### PR TITLE
[Backport] JME Offline DQM: adding trigger efficiency for scouting jets

### DIFF
--- a/DQM/HLTEvF/python/ScoutingJetMonitoring_cff.py
+++ b/DQM/HLTEvF/python/ScoutingJetMonitoring_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 ## See DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
 
 from DQMOffline.JetMET.jetMETDQMOfflineSource_cff import *
+from DQMOffline.Trigger.JetMETPromptMonitor_cff import *
 
 jetDQMOnlineAnalyzerAk4ScoutingCleaned = jetDQMAnalyzerAk4ScoutingCleaned.clone(
     JetType='scoutingOnline',
@@ -23,6 +24,85 @@ dqmAk4PFScoutingL1FastL2L3ResidualCorrectorChain = cms.Sequence(dqmAk4PFScouting
 jetDQMOnlineAnalyzerSequenceScouting = cms.Sequence(jetDQMOnlineAnalyzerAk4ScoutingUncleaned*
                                                     jetDQMOnlineAnalyzerAk4ScoutingCleaned)
 
+
+######### Scouitng Trigger and L1 seeds #########
+#PFScoutingJetHT
+PFScoutingJetHT_Online_Prommonitoring = PFScoutingJetHT_Prommonitoring.clone(
+    FolderName = 'HLT/ScoutingOnline/Jet/PFScoutingJetHT/'
+)
+
+# L1_HTT200er
+L1HTT200_Online_Prommonitoring = L1HTT200_Prommonitoring.clone(
+    FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT200er/'
+)
+
+
+# L1_HTT255er
+L1HTT255_Online_Prommonitoring = L1HTT255_Prommonitoring.clone(
+    FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT255er/'
+)
+
+
+# L1_HTT280er
+L1HTT280_Online_Prommonitoring = L1HTT280_Prommonitoring.clone(
+    FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT280er/'
+)
+
+
+#  L1_HTT320er
+L1HTT320_Online_Prommonitoring = L1HTT320_Prommonitoring.clone(
+    FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT320er/'
+)
+
+
+# L1_HTT360er
+L1HTT360_Online_Prommonitoring = L1HTT360_Prommonitoring.clone(
+    FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT360er/'
+)
+
+# L1_HTT400er
+L1HTT400_Online_Prommonitoring = L1HTT400_Prommonitoring.clone(
+    FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT400er/'
+)
+
+
+# L1_HTT450er
+L1HTT450_Online_Prommonitoring = L1HTT450_Prommonitoring.clone(
+    FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT450er/'
+)
+
+
+# L1_SingleJet180
+L1SingleJet180_Online_Prommonitoring = L1SingleJet180_Prommonitoring.clone(
+    FolderName = 'HLT/ScoutingOnline/Jet/L1_SingleJet180/'
+)
+
+
+# L1_SingleJet200
+L1SingleJet200_Online_Prommonitoring = L1SingleJet200_Prommonitoring.clone(
+    FolderName = 'HLT/ScoutingOnline/Jet/L1_SingleJet200/'
+)
+
+HLTScoutingJetOnlinemonitoring = cms.Sequence(
+    ak4PFScoutL1FastL2L3ResidualCorrectorChain
+    *PFScoutingJetHT_Online_Prommonitoring
+    *L1HTT200_Online_Prommonitoring
+    *L1HTT255_Online_Prommonitoring
+    *L1HTT280_Online_Prommonitoring
+    *L1HTT320_Online_Prommonitoring
+    *L1HTT360_Online_Prommonitoring
+    *L1HTT400_Online_Prommonitoring
+    *L1HTT450_Online_Prommonitoring
+    *L1SingleJet180_Online_Prommonitoring
+    *L1SingleJet200_Online_Prommonitoring
+)
+
+jetmetScoutingOnlineMonitorHLT = cms.Sequence(
+    HLTScoutingJetOnlinemonitoring
+)
+
+
 ScoutingJetMonitoring = cms.Sequence(jetPreDQMSeqScouting*
                                      dqmAk4PFScoutingL1FastL2L3ResidualCorrectorChain*
-                                     jetDQMOnlineAnalyzerSequenceScouting)
+                                     jetDQMOnlineAnalyzerSequenceScouting*
+                                     jetmetScoutingOnlineMonitorHLT)

--- a/DQM/HLTEvF/python/ScoutingJetMonitoring_cff.py
+++ b/DQM/HLTEvF/python/ScoutingJetMonitoring_cff.py
@@ -27,74 +27,74 @@ jetDQMOnlineAnalyzerSequenceScouting = cms.Sequence(jetDQMOnlineAnalyzerAk4Scout
 
 ######### Scouitng Trigger and L1 seeds #########
 #PFScoutingJetHT
-PFScoutingJetHT_Online_Prommonitoring = PFScoutingJetHT_Prommonitoring.clone(
+PFScoutingJetHT_Onlinemonitoring = PFScoutingJetHT_Prommonitoring.clone(
     FolderName = 'HLT/ScoutingOnline/Jet/PFScoutingJetHT/'
 )
 
 # L1_HTT200er
-L1HTT200_Online_Prommonitoring = L1HTT200_Prommonitoring.clone(
+L1HTT200_Onlinemonitoring = L1HTT200_Prommonitoring.clone(
     FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT200er/'
 )
 
 
 # L1_HTT255er
-L1HTT255_Online_Prommonitoring = L1HTT255_Prommonitoring.clone(
+L1HTT255_Onlinemonitoring = L1HTT255_Prommonitoring.clone(
     FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT255er/'
 )
 
 
 # L1_HTT280er
-L1HTT280_Online_Prommonitoring = L1HTT280_Prommonitoring.clone(
+L1HTT280_Onlinemonitoring = L1HTT280_Prommonitoring.clone(
     FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT280er/'
 )
 
 
 #  L1_HTT320er
-L1HTT320_Online_Prommonitoring = L1HTT320_Prommonitoring.clone(
+L1HTT320_Onlinemonitoring = L1HTT320_Prommonitoring.clone(
     FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT320er/'
 )
 
 
 # L1_HTT360er
-L1HTT360_Online_Prommonitoring = L1HTT360_Prommonitoring.clone(
+L1HTT360_Onlinemonitoring = L1HTT360_Prommonitoring.clone(
     FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT360er/'
 )
 
 # L1_HTT400er
-L1HTT400_Online_Prommonitoring = L1HTT400_Prommonitoring.clone(
+L1HTT400_Onlinemonitoring = L1HTT400_Prommonitoring.clone(
     FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT400er/'
 )
 
 
 # L1_HTT450er
-L1HTT450_Online_Prommonitoring = L1HTT450_Prommonitoring.clone(
+L1HTT450_Onlinemonitoring = L1HTT450_Prommonitoring.clone(
     FolderName = 'HLT/ScoutingOnline/Jet/L1_HTT450er/'
 )
 
 
 # L1_SingleJet180
-L1SingleJet180_Online_Prommonitoring = L1SingleJet180_Prommonitoring.clone(
+L1SingleJet180_Onlinemonitoring = L1SingleJet180_Prommonitoring.clone(
     FolderName = 'HLT/ScoutingOnline/Jet/L1_SingleJet180/'
 )
 
 
 # L1_SingleJet200
-L1SingleJet200_Online_Prommonitoring = L1SingleJet200_Prommonitoring.clone(
+L1SingleJet200_Onlinemonitoring = L1SingleJet200_Prommonitoring.clone(
     FolderName = 'HLT/ScoutingOnline/Jet/L1_SingleJet200/'
 )
 
 HLTScoutingJetOnlinemonitoring = cms.Sequence(
     ak4PFScoutL1FastL2L3ResidualCorrectorChain
-    *PFScoutingJetHT_Online_Prommonitoring
-    *L1HTT200_Online_Prommonitoring
-    *L1HTT255_Online_Prommonitoring
-    *L1HTT280_Online_Prommonitoring
-    *L1HTT320_Online_Prommonitoring
-    *L1HTT360_Online_Prommonitoring
-    *L1HTT400_Online_Prommonitoring
-    *L1HTT450_Online_Prommonitoring
-    *L1SingleJet180_Online_Prommonitoring
-    *L1SingleJet200_Online_Prommonitoring
+    *PFScoutingJetHT_Onlinemonitoring
+    *L1HTT200_Onlinemonitoring
+    *L1HTT255_Onlinemonitoring
+    *L1HTT280_Onlinemonitoring
+    *L1HTT320_Onlinemonitoring
+    *L1HTT360_Onlinemonitoring
+    *L1HTT400_Onlinemonitoring
+    *L1HTT450_Onlinemonitoring
+    *L1SingleJet180_Onlinemonitoring
+    *L1SingleJet200_Onlinemonitoring
 )
 
 jetmetScoutingOnlineMonitorHLT = cms.Sequence(

--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -56,7 +56,6 @@ hltScoutingDqmOffline = cms.Sequence(hltScoutingMuonDqmOffline +
                                      run3ScoutingElectronBestTrack +
                                      hltScoutingDileptonMonitor +
                                      hltScoutingPi0Monitor +
-                                     jetmetScoutingMonitorHLT +
                                      hltScoutingCollectionMonitor)
 
 ## Add the scouting rechits monitoring (only for 2025, integrated in menu GRun 2025 V1.3)

--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -17,6 +17,7 @@ from HLTriggerOffline.Scouting.HLTScoutingEGammaDqmOffline_cff import *
 
 ### Jets Monitoring
 from DQMOffline.JetMET.jetMETDQMOfflineSource_cff import *
+from DQMOffline.Trigger.JetMETPromptMonitor_cff import *
 
 ### Electron best track producer
 from PhysicsTools.Scouting.Run3ScoutingElectronBestTrackProducer_cfi import Run3ScoutingElectronBestTrackProducer as run3ScoutingElectronBestTrack
@@ -41,7 +42,8 @@ hltScoutingMuonDqmOffline = cms.Sequence(scoutingMonitoringTagProbeMuonNoVtx *
 
 hltScoutingJetDqmOffline = cms.Sequence(jetMETDQMOfflineSourceScouting)
 ## remove corrector to not schedule the run of the corrector modules which crash if scouting objects are missing
-hltScoutingJetDqmOfflineForRelVals = cms.Sequence(jetMETDQMOfflineSourceScoutingNoCorrection)
+hltScoutingJetDqmOfflineForRelVals = cms.Sequence(jetMETDQMOfflineSourceScoutingNoCorrection +
+                                                  jetmetScoutingNoJECsMonitorHLT)
 
 hltScoutingCollectionMonitor = cms.Sequence(scoutingCollectionMonitor)
 hltScoutingDileptonMonitor = cms.Sequence(ScoutingDileptonMonitor)
@@ -54,6 +56,7 @@ hltScoutingDqmOffline = cms.Sequence(hltScoutingMuonDqmOffline +
                                      hltScoutingDileptonMonitor +
                                      hltScoutingPi0Monitor +
                                      run3ScoutingElectronBestTrack +
+                                     jetmetScoutingMonitorHLT +
                                      hltScoutingCollectionMonitor)
 
 ## Add the scouting rechits monitoring (only for 2025, integrated in menu GRun 2025 V1.3)

--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -40,7 +40,8 @@ hltScoutingMuonDqmOffline = cms.Sequence(scoutingMonitoringTagProbeMuonNoVtx *
                                          scoutingMonitoringTriggerMuon_SingleMu *
                                          ScoutingMuonPropertiesMonitor )
 
-hltScoutingJetDqmOffline = cms.Sequence(jetMETDQMOfflineSourceScouting)
+hltScoutingJetDqmOffline = cms.Sequence(jetMETDQMOfflineSourceScouting +
+                                        jetmetScoutingMonitorHLT)
 ## remove corrector to not schedule the run of the corrector modules which crash if scouting objects are missing
 hltScoutingJetDqmOfflineForRelVals = cms.Sequence(jetMETDQMOfflineSourceScoutingNoCorrection +
                                                   jetmetScoutingNoJECsMonitorHLT)
@@ -55,7 +56,6 @@ hltScoutingDqmOffline = cms.Sequence(hltScoutingMuonDqmOffline +
                                      run3ScoutingElectronBestTrack +
                                      hltScoutingDileptonMonitor +
                                      hltScoutingPi0Monitor +
-                                     run3ScoutingElectronBestTrack +
                                      jetmetScoutingMonitorHLT +
                                      hltScoutingCollectionMonitor)
 

--- a/DQMOffline/Trigger/plugins/JetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/JetMonitor.cc
@@ -642,16 +642,12 @@ bool JetMonitor::isCleanJet(double JetEta, double JetPhi, const std::vector<reco
 }
 
 bool JetMonitor::isGoodScoutingMuon(Run3ScoutingMuon const& scoutingMuon) {
-  if (scoutingMuon.pt() > 1
-      && abs(scoutingMuon.eta()) < 0.8
-      && abs(scoutingMuon.trk_dxy()) < 0.2
+  if (scoutingMuon.pt() > 1 && abs(scoutingMuon.eta()) < 0.8 &&
+      abs(scoutingMuon.trk_dxy()) < 0.2
       /////&& abs(scoutingMuon.trackIso()) < 0.15 //removed
-      && abs(scoutingMuon.trk_dz()) < 0.5
-      && scoutingMuon.normalizedChi2() < 3
-      && scoutingMuon.nValidRecoMuonHits() > 0
-      && scoutingMuon.nRecoMuonMatchedStations() > 1
-      && scoutingMuon.nValidPixelHits() > 0
-      && scoutingMuon.nTrackerLayersWithMeasurement() > 5) {
+      && abs(scoutingMuon.trk_dz()) < 0.5 && scoutingMuon.normalizedChi2() < 3 &&
+      scoutingMuon.nValidRecoMuonHits() > 0 && scoutingMuon.nRecoMuonMatchedStations() > 1 &&
+      scoutingMuon.nValidPixelHits() > 0 && scoutingMuon.nTrackerLayersWithMeasurement() > 5) {
     return true;
   } else {
     return false;

--- a/DQMOffline/Trigger/plugins/JetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/JetMonitor.cc
@@ -642,12 +642,16 @@ bool JetMonitor::isCleanJet(double JetEta, double JetPhi, const std::vector<reco
 }
 
 bool JetMonitor::isGoodScoutingMuon(Run3ScoutingMuon const& scoutingMuon) {
-  if (scoutingMuon.pt() > 10 && abs(scoutingMuon.eta()) < 0.8 &&
-      abs(scoutingMuon.trk_dxy()) < 0.2
+  if (scoutingMuon.pt() > 1
+      && abs(scoutingMuon.eta()) < 0.8
+      && abs(scoutingMuon.trk_dxy()) < 0.2
       /////&& abs(scoutingMuon.trackIso()) < 0.15 //removed
-      && abs(scoutingMuon.trk_dz()) < 0.5 && scoutingMuon.normalizedChi2() < 3 &&
-      scoutingMuon.nValidRecoMuonHits() > 0 && scoutingMuon.nRecoMuonMatchedStations() > 1 &&
-      scoutingMuon.nValidPixelHits() > 0 && scoutingMuon.nTrackerLayersWithMeasurement() > 5) {
+      && abs(scoutingMuon.trk_dz()) < 0.5
+      && scoutingMuon.normalizedChi2() < 3
+      && scoutingMuon.nValidRecoMuonHits() > 0
+      && scoutingMuon.nRecoMuonMatchedStations() > 1
+      && scoutingMuon.nValidPixelHits() > 0
+      && scoutingMuon.nTrackerLayersWithMeasurement() > 5) {
     return true;
   } else {
     return false;

--- a/DQMOffline/Trigger/plugins/JetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/JetMonitor.cc
@@ -22,7 +22,13 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingPFJet.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingMuon.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingVertex.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingTrack.h"
+#include "PhysicsTools/SelectorUtils/interface/Run3ScoutingPFJetIDSelectionFunctor.h"
 #include "DataFormats/Math/interface/deltaR.h"
+#include "TLorentzVector.h"
 
 class JetMonitor : public DQMEDAnalyzer, public TriggerDQMBase {
 public:
@@ -54,6 +60,8 @@ protected:
 
   bool passTightJetID(const correctedPFJets& jet);
   bool isCleanJet(double JetEta, double JetPhi, const std::vector<reco::Muon>& muons, double dr2Cut);
+  bool isGoodScoutingMuon(Run3ScoutingMuon const &scoutingMuon);
+  bool isCleanScoutingJet(double ScoutingJetEta, double ScoutingJetPhi, const std::vector<Run3ScoutingMuon>& scoutingMuons, double dr2Cut);
   bool isBarrel(double eta);
   bool isEndCapP(double eta);
   bool isEndCapM(double eta);
@@ -91,17 +99,31 @@ private:
   bool isPFJetTrig;
   bool isCaloJetTrig;
   bool isPuppiJet;
+  bool isScoutingPFJetTrig;
   double dr2cut_;
+  bool doVariableBinning;
+  
+  int verbose_;
+  std::string JetIDQuality_;
+  std::string JetIDVersion_;
+  Run3ScoutingPFJetIDSelectionFunctor::Quality_t run3scoutingpfjetidquality;
+  Run3ScoutingPFJetIDSelectionFunctor::Version_t run3scoutingpfjetidversion;
+  Run3ScoutingPFJetIDSelectionFunctor run3scoutingpfjetIDFunctor;
+  
   const bool enableFullMonitoring_;
 
   edm::InputTag muoInputTag_;
   edm::InputTag vtxInputTag_;
+  edm::InputTag scoutingMuonInputTag_;
 
   const edm::EDGetTokenT<reco::MuonCollection> muoToken_;
   const edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
   const edm::EDGetTokenT<reco::PFJetCollection> jetSrc_;
   const edm::EDGetTokenT<reco::JetCorrector> correctorToken_;
   const edm::EDGetTokenT<reco::CaloJetCollection> calojetToken_;
+  
+  edm::EDGetTokenT<std::vector<Run3ScoutingMuon> > scoutingMuonToken_;
+  edm::EDGetTokenT<std::vector<Run3ScoutingPFJet> > scoutjetSrc_;
 
   std::unique_ptr<GenericTriggerEventFlag> num_genTriggerEventFlag_;
   std::unique_ptr<GenericTriggerEventFlag> den_genTriggerEventFlag_;
@@ -109,6 +131,8 @@ private:
   StringCutObjectSelector<reco::Muon, true> muoSelection_;
 
   unsigned nmuons_;
+
+  std::vector<double> jetPt_variable_binning_;
 
   MEbinning jetpt_binning_;
   MEbinning jetptThr_binning_;
@@ -120,6 +144,13 @@ private:
   ObjME a_ME_HF[7];
   ObjME a_ME_HE_p[7];
   ObjME a_ME_HE_m[7];
+  
+  struct correctedScoutingJets {
+    double pt;
+    double eta;
+    double phi;
+  };
+  std::vector<correctedScoutingJets> corrected_scoutingjets;
 
   struct correctedCaloJets {
     double pt;
@@ -141,21 +172,30 @@ JetMonitor::JetMonitor(const edm::ParameterSet& iConfig)
       isPFJetTrig(iConfig.getParameter<bool>("ispfjettrg")),
       isCaloJetTrig(iConfig.getParameter<bool>("iscalojettrg")),
       isPuppiJet(iConfig.getParameter<bool>("ispuppijet")),
+      isScoutingPFJetTrig(iConfig.getParameter<bool>("isscoutingpfjettrg")),
       dr2cut_(iConfig.getParameter<double>("dr2cut")),
+      doVariableBinning(iConfig.getParameter<bool>("doVariablebinning")),
+      JetIDQuality_(iConfig.getParameter<std::string>("JetIDQuality")),
+      JetIDVersion_(iConfig.getParameter<std::string>("JetIDVersion")),
       enableFullMonitoring_(iConfig.getParameter<bool>("enableFullMonitoring")),
       muoInputTag_(iConfig.getParameter<edm::InputTag>("muons")),
       vtxInputTag_(iConfig.getParameter<edm::InputTag>("vertices")),
+      scoutingMuonInputTag_(iConfig.getParameter<edm::InputTag>("muons")),
       muoToken_(mayConsume<reco::MuonCollection>(muoInputTag_)),
       vtxToken_(mayConsume<reco::VertexCollection>(vtxInputTag_)),
       jetSrc_(mayConsume<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("jetSrc"))),
       correctorToken_(mayConsume<reco::JetCorrector>(iConfig.getParameter<edm::InputTag>("corrector"))),
       calojetToken_(mayConsume<reco::CaloJetCollection>(iConfig.getParameter<edm::InputTag>("jetSrc"))),
+      scoutingMuonToken_(mayConsume<std::vector<Run3ScoutingMuon> >(scoutingMuonInputTag_)),
+      scoutjetSrc_(mayConsume<std::vector<Run3ScoutingPFJet> >(iConfig.getParameter<edm::InputTag>("jetSrc"))),
       num_genTriggerEventFlag_(new GenericTriggerEventFlag(
           iConfig.getParameter<edm::ParameterSet>("numGenericTriggerEventPSet"), consumesCollector(), *this)),
       den_genTriggerEventFlag_(new GenericTriggerEventFlag(
           iConfig.getParameter<edm::ParameterSet>("denGenericTriggerEventPSet"), consumesCollector(), *this)),
       muoSelection_(iConfig.getParameter<std::string>("muoSelection")),
       nmuons_(iConfig.getParameter<unsigned>("nmuons")),
+      jetPt_variable_binning_(
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetptBinning")),
       jetpt_binning_(getHistoPSet(
           iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("jetPSet"))),
       jetptThr_binning_(getHistoPSet(
@@ -209,6 +249,9 @@ void JetMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
   } else if (isCaloJetTrig) {
     hist_obtag = "calojet";
     histtitle_obtag = "CaloJet";
+  } else if (isScoutingPFJetTrig) {
+    hist_obtag = "scoutingpfjet";
+    histtitle_obtag = "ScoutingPfJet";
   } else {
     hist_obtag = "pfpuppijet";
     histtitle_obtag = "PFPuppi Jet";
@@ -296,63 +339,100 @@ void JetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
   //--------- access vrtx -----------
   reco::Vertex vtx;
   edm::Handle<reco::VertexCollection> vtxHandle;
-  iEvent.getByToken(vtxToken_, vtxHandle);
-  if (vtxHandle.isValid()) {
-    for (auto const& v : *vtxHandle) {
-      bool isFake = v.isFake();
+  if (!isScoutingPFJetTrig) {
+    iEvent.getByToken(vtxToken_, vtxHandle);
+    if (vtxHandle.isValid()) {
+      for (auto const& v : *vtxHandle) {
+        bool isFake = v.isFake();
 
-      if (!isFake) {
-        vtx = v;
-        break;
+        if (!isFake) {
+          vtx = v;
+          break;
+        }
       }
+    } else {
+      if (vtxInputTag_.label().empty())
+        edm::LogWarning("JetMonitor") << "VertexCollection is not set";
+      else
+        edm::LogWarning("JetMonitor") << "skipping events because the collection " << vtxInputTag_.label().c_str()
+                                      << " is not available";
+      if (!vtxInputTag_.label().empty())
+        return;
     }
-  } else {
-    if (vtxInputTag_.label().empty())
-      edm::LogWarning("JetMonitor") << "VertexCollection is not set";
-    else
-      edm::LogWarning("JetMonitor") << "skipping events because the collection " << vtxInputTag_.label().c_str()
-                                    << " is not available";
-    if (!vtxInputTag_.label().empty())
-      return;
   }
   // -------- muons ----------
   std::vector<reco::Muon> muons;
   edm::Handle<reco::MuonCollection> muoHandle;
-  iEvent.getByToken(muoToken_, muoHandle);
-  if (muoHandle.isValid()) {
-    if (muoHandle->size() < nmuons_)
-      return;
-    for (auto const& m : *muoHandle) {
-      bool istightID = m.isGlobalMuon() && m.isPFMuon() && m.globalTrack()->normalizedChi2() < 10. &&
-                       m.globalTrack()->hitPattern().numberOfValidMuonHits() > 0 && m.numberOfMatchedStations() > 1 &&
-                       fabs(m.muonBestTrack()->dxy(vtx.position())) < 0.2 &&
-                       fabs(m.muonBestTrack()->dz(vtx.position())) < 0.5 &&
-                       m.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 &&
-                       m.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5;
-      if (muoSelection_(m) && istightID) {
-        muons.push_back(m);
+  
+  std::vector<Run3ScoutingMuon> scoutingmuons;
+  edm::Handle<std::vector<Run3ScoutingMuon>> ScoutingMuonHandle;
+  
+  if (isScoutingPFJetTrig) {
+    iEvent.getByToken(scoutingMuonToken_, ScoutingMuonHandle);
+    if (ScoutingMuonHandle.isValid()) {
+      if (ScoutingMuonHandle->size() < nmuons_) {
+        //edm::LogWarning("JetMonitor") << "Run3ScoutingMuon collection not valid.";
+        return;
       }
+      for (auto const& iscoutmuon : *ScoutingMuonHandle) {
+        //std::cout << "scouting muon pT: " << iscoutmuon.pt() << std::endl;
+        //std::cout << "scouting muon eta: " << iscoutmuon.eta() << std::endl;
+        if (isGoodScoutingMuon(iscoutmuon)) {
+          scoutingmuons.push_back(iscoutmuon);
+        }
+      }
+      if (scoutingmuons.size() < nmuons_) { // require 1 tight scouting muon if orthogonal method, else nmuons_ is 0
+        return;
+      }
+    } else {
+      if (scoutingMuonInputTag_.label().empty()) {
+        edm::LogWarning("JetMonitor") << "Scouting muon collection not valid \n";
+      }
+      else {
+        edm::LogWarning("JetMonitor") << "skipping events because the collection " <<  scoutingMuonInputTag_.label().c_str() << " is not available \n";
+      }
+        return;
     }
-    if (muons.size() < nmuons_)  // require 1 tight muon if orthogonal method, else nmuons_ is 0
-      return;
   } else {
-    if (muoInputTag_.label().empty())
-      edm::LogWarning("JetMonitor") << "MuonCollection not set";
-    else
-      edm::LogWarning("JetMonitor") << "skipping events because the collection " << muoInputTag_.label().c_str()
-                                    << " is not available";
-    if (!muoInputTag_.label().empty())
-      return;
+    iEvent.getByToken(muoToken_, muoHandle);
+    if (muoHandle.isValid()) {
+      if (muoHandle->size() < nmuons_)
+        return;
+      for (auto const& m : *muoHandle) {
+        bool istightID = m.isGlobalMuon() && m.isPFMuon() && m.globalTrack()->normalizedChi2() < 10. &&
+                        m.globalTrack()->hitPattern().numberOfValidMuonHits() > 0 && m.numberOfMatchedStations() > 1 &&
+                        fabs(m.muonBestTrack()->dxy(vtx.position())) < 0.2 &&
+                        fabs(m.muonBestTrack()->dz(vtx.position())) < 0.5 &&
+                        m.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 &&
+                        m.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5;
+        if (muoSelection_(m) && istightID) {
+          muons.push_back(m);
+        }
+      }
+      if (muons.size() < nmuons_)  // require 1 tight muon if orthogonal method, else nmuons_ is 0
+        return;
+    } else {
+      if (muoInputTag_.label().empty())
+        edm::LogWarning("JetMonitor") << "MuonCollection not set";
+      else
+        edm::LogWarning("JetMonitor") << "skipping events because the collection " << muoInputTag_.label().c_str()
+                                      << " is not available";
+      if (!muoInputTag_.label().empty())
+        return;
+    }
   }
   // ------------- Jets ------------
   corrected_jets.clear();
   corrected_calojets.clear();
+  corrected_scoutingjets.clear();
 
   edm::Handle<reco::PFJetCollection> PFjetHandle;
   edm::Handle<reco::CaloJetCollection> calojetHandle;
+  edm::Handle<std::vector<Run3ScoutingPFJet>> ScoutingJetHandle;
 
   edm::Handle<reco::JetCorrector> Corrector;
   iEvent.getByToken(correctorToken_, Corrector);
+  
   if (isPFJetTrig) {  // if pfjet
     iEvent.getByToken(jetSrc_, PFjetHandle);
     if (!PFjetHandle.isValid()) {
@@ -417,15 +497,70 @@ void JetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
 
   }  // end if Calo Jets
 
-  double jetpt_ = (isPFJetTrig && !corrected_jets.empty())         ? corrected_jets[0].pt
-                  : (isCaloJetTrig && !corrected_calojets.empty()) ? corrected_calojets[0].pt
-                                                                   : -99.;
-  double jeteta_ = (isPFJetTrig && !corrected_jets.empty())         ? corrected_jets[0].eta
-                   : (isCaloJetTrig && !corrected_calojets.empty()) ? corrected_calojets[0].eta
-                                                                    : 99;
-  double jetphi_ = (isPFJetTrig && !corrected_jets.empty())         ? corrected_jets[0].phi
-                   : (isCaloJetTrig && !corrected_calojets.empty()) ? corrected_calojets[0].phi
-                                                                    : 99;
+  if (isScoutingPFJetTrig) { //if scouting pf jets
+    iEvent.getByToken(scoutjetSrc_, ScoutingJetHandle);
+    if (!ScoutingJetHandle.isValid()) {
+      edm::LogWarning("JetMonitor") << "Scouting jet handle not valid \n";
+      return;
+    }
+    
+    if (JetIDVersion_ == "RUN3Scouting") {
+      run3scoutingpfjetidversion = Run3ScoutingPFJetIDSelectionFunctor::RUN3Scouting;
+    } else {
+      if (verbose_)
+        std::cout << "no valid scouting Run3ScoutinPF JetID version given" << std::endl;
+    }
+    if (JetIDQuality_ == "TIGHT") {
+      run3scoutingpfjetidquality = Run3ScoutingPFJetIDSelectionFunctor::TIGHT;
+    } else if (JetIDQuality_ == "TIGHTLEPVETO") {
+      run3scoutingpfjetidquality = Run3ScoutingPFJetIDSelectionFunctor::TIGHTLEPVETO;
+    } else {
+      if (verbose_)
+        std::cout << "no Valid scouting Run3ScoutinPF JetID quality given" << std::endl;
+    }
+    run3scoutingpfjetIDFunctor = Run3ScoutingPFJetIDSelectionFunctor(run3scoutingpfjetidversion, run3scoutingpfjetidquality);
+    for (auto const& iscoutjet : *ScoutingJetHandle) {
+      bool passScoutjetID = false;
+      passScoutjetID = run3scoutingpfjetIDFunctor(iscoutjet);
+      if (!passScoutjetID) continue;
+      if (!isCleanScoutingJet(iscoutjet.eta(), iscoutjet.phi(), scoutingmuons, dr2cut_)) continue;
+      
+      reco::PFJet dummy_scoutingpfjet;
+      reco::Particle::PolarLorentzVector dummy_scoutingpfjetP4(iscoutjet.pt(),
+                                                               iscoutjet.eta(),
+                                                               iscoutjet.phi(),
+                                                               iscoutjet.m());
+      dummy_scoutingpfjet.setP4(dummy_scoutingpfjetP4);
+      dummy_scoutingpfjet.setJetArea(iscoutjet.jetArea());
+
+      // apply corrections on the fly
+      double jec = Corrector.isValid() ? Corrector->correction(dummy_scoutingpfjet) : 1.0;
+      //std::cout << "Jet Pt: "<< iscoutjet.pt() << " JEC: " << jec << std::endl;
+      
+      double corjet = jec*iscoutjet.pt();  /////------> iscoutjet or dummy_...jet ?????
+      if (corjet < ptcut_) {
+        continue;
+      }
+      corrected_scoutingjets.push_back({corjet, iscoutjet.eta(), iscoutjet.phi()});
+    } // end for loop over jets
+    std::sort(corrected_scoutingjets.begin(), corrected_scoutingjets.end(),[](const auto& a, const auto& b){return a.pt > b.pt;});
+    if (corrected_scoutingjets.empty())
+      return;
+  } //end if scouting pf jets
+  
+  
+  double jetpt_ = (isPFJetTrig && !corrected_jets.empty())                   ? corrected_jets[0].pt
+                  : (isCaloJetTrig && !corrected_calojets.empty())           ? corrected_calojets[0].pt
+                  : (isScoutingPFJetTrig && !corrected_scoutingjets.empty()) ? corrected_scoutingjets[0].pt
+                                                                             : -99.;
+  double jeteta_ = (isPFJetTrig && !corrected_jets.empty())                   ? corrected_jets[0].eta
+                   : (isCaloJetTrig && !corrected_calojets.empty())           ? corrected_calojets[0].eta
+                   : (isScoutingPFJetTrig && !corrected_scoutingjets.empty()) ? corrected_scoutingjets[0].eta
+                                                                              : 99;
+  double jetphi_ = (isPFJetTrig && !corrected_jets.empty())                   ? corrected_jets[0].phi
+                   : (isCaloJetTrig && !corrected_calojets.empty())           ? corrected_calojets[0].phi
+                   : (isScoutingPFJetTrig && !corrected_scoutingjets.empty()) ? corrected_scoutingjets[0].phi
+                                                                              : 99;
 
   FillME(a_ME, jetpt_, jetphi_, jeteta_, ls, "denominator");
   if (isBarrel(jeteta_)) {
@@ -500,6 +635,38 @@ bool JetMonitor::isCleanJet(double JetEta, double JetPhi, const std::vector<reco
   }
   return true;
 }
+
+
+bool JetMonitor::isGoodScoutingMuon(Run3ScoutingMuon const &scoutingMuon) {
+  //if (scoutingMuon.pt() > 30
+  //if (scoutingMuon.pt() > 10
+  if (scoutingMuon.pt() > 1
+      //&& abs(scoutingMuon.eta()) < 0.8
+      //&& abs(scoutingMuon.trk_dxy()) < 0.2 //
+      /////&& abs(scoutingMuon.trackIso()) < 0.15 //removed
+      //&& abs(scoutingMuon.trk_dz()) < 0.5 //
+      //&& scoutingMuon.normalizedChi2() < 3
+      && scoutingMuon.nValidRecoMuonHits() > 0) {
+      //&& scoutingMuon.nRecoMuonMatchedStations() > 1
+      //&& scoutingMuon.nValidPixelHits() > 0
+      //&& scoutingMuon.nTrackerLayersWithMeasurement() > 5) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool JetMonitor::isCleanScoutingJet(double ScoutingJetEta, double ScoutingJetPhi, const std::vector<Run3ScoutingMuon>& scoutingMuons, double dr2Cut) {
+  for (const auto& scoutingMuon : scoutingMuons) {
+  	double ScoutingdR2 = deltaR2(ScoutingJetEta, ScoutingJetPhi, scoutingMuon.eta(),  scoutingMuon.phi());
+  	if (ScoutingdR2 < dr2Cut) {
+    		return false;
+    }
+  }
+  return true;
+}
+
+
 bool JetMonitor::isBarrel(double eta) {
   bool output = false;
   if (fabs(eta) <= 1.3)
@@ -596,10 +763,17 @@ void JetMonitor::bookMESub(DQMStore::IBooker& Ibooker,
   double maxbin_eta = jet_eta_binning_.xmax;
   double minbin_eta = jet_eta_binning_.xmin;
 
-  hName = h_Name + "pT" + hSubN;
-  hTitle = h_Title + " pT " + hSubT;
-  bookME(Ibooker, a_me[0], hName, hTitle, jetpt_binning_.nbins, jetpt_binning_.xmin, jetpt_binning_.xmax);
-  setMETitle(a_me[0], h_Title + " pT [GeV]", "events / [GeV]");
+  if (doVariableBinning) {
+    hName = h_Name + "pT" + hSubN;
+    hTitle = h_Title + " pT " + hSubT;
+    bookME(Ibooker, a_me[0], hName, hTitle, jetPt_variable_binning_);
+    setMETitle(a_me[0], h_Title + " pT [GeV]", "events / [GeV]");
+  } else {
+    hName = h_Name + "pT" + hSubN;
+    hTitle = h_Title + " pT " + hSubT;
+    bookME(Ibooker, a_me[0], hName, hTitle, jetpt_binning_.nbins, jetpt_binning_.xmin, jetpt_binning_.xmax);
+    setMETitle(a_me[0], h_Title + " pT [GeV]", "events / [GeV]");
+  }
 
   hName = h_Name + "pT_pTThresh" + hSubN;
   hTitle = h_Title + " pT " + hSubT;
@@ -673,6 +847,12 @@ void JetMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   desc.add<bool>("iscalojettrg", false);
   desc.add<bool>("ispuppijet", false);
   desc.add<double>("dr2cut", 0.16);
+
+  desc.add<bool>("isscoutingpfjettrg", false);
+  desc.add<bool>("doVariablebinning", false);
+  
+  desc.add<std::string>("JetIDQuality", "TIGHT");
+  desc.add<std::string>("JetIDVersion", "RUN3Scouting");
 
   desc.add<bool>("enableFullMonitoring", true);
   desc.add<std::string>("muoSelection", "pt > 30");

--- a/DQMOffline/Trigger/plugins/JetMonitor.cc
+++ b/DQMOffline/Trigger/plugins/JetMonitor.cc
@@ -60,8 +60,11 @@ protected:
 
   bool passTightJetID(const correctedPFJets& jet);
   bool isCleanJet(double JetEta, double JetPhi, const std::vector<reco::Muon>& muons, double dr2Cut);
-  bool isGoodScoutingMuon(Run3ScoutingMuon const &scoutingMuon);
-  bool isCleanScoutingJet(double ScoutingJetEta, double ScoutingJetPhi, const std::vector<Run3ScoutingMuon>& scoutingMuons, double dr2Cut);
+  bool isGoodScoutingMuon(Run3ScoutingMuon const& scoutingMuon);
+  bool isCleanScoutingJet(double ScoutingJetEta,
+                          double ScoutingJetPhi,
+                          const std::vector<Run3ScoutingMuon>& scoutingMuons,
+                          double dr2Cut);
   bool isBarrel(double eta);
   bool isEndCapP(double eta);
   bool isEndCapM(double eta);
@@ -102,14 +105,14 @@ private:
   bool isScoutingPFJetTrig;
   double dr2cut_;
   bool doVariableBinning;
-  
+
   int verbose_;
   std::string JetIDQuality_;
   std::string JetIDVersion_;
   Run3ScoutingPFJetIDSelectionFunctor::Quality_t run3scoutingpfjetidquality;
   Run3ScoutingPFJetIDSelectionFunctor::Version_t run3scoutingpfjetidversion;
   Run3ScoutingPFJetIDSelectionFunctor run3scoutingpfjetIDFunctor;
-  
+
   const bool enableFullMonitoring_;
 
   edm::InputTag muoInputTag_;
@@ -121,9 +124,9 @@ private:
   const edm::EDGetTokenT<reco::PFJetCollection> jetSrc_;
   const edm::EDGetTokenT<reco::JetCorrector> correctorToken_;
   const edm::EDGetTokenT<reco::CaloJetCollection> calojetToken_;
-  
-  edm::EDGetTokenT<std::vector<Run3ScoutingMuon> > scoutingMuonToken_;
-  edm::EDGetTokenT<std::vector<Run3ScoutingPFJet> > scoutjetSrc_;
+
+  edm::EDGetTokenT<std::vector<Run3ScoutingMuon>> scoutingMuonToken_;
+  edm::EDGetTokenT<std::vector<Run3ScoutingPFJet>> scoutjetSrc_;
 
   std::unique_ptr<GenericTriggerEventFlag> num_genTriggerEventFlag_;
   std::unique_ptr<GenericTriggerEventFlag> den_genTriggerEventFlag_;
@@ -144,7 +147,7 @@ private:
   ObjME a_ME_HF[7];
   ObjME a_ME_HE_p[7];
   ObjME a_ME_HE_m[7];
-  
+
   struct correctedScoutingJets {
     double pt;
     double eta;
@@ -186,8 +189,8 @@ JetMonitor::JetMonitor(const edm::ParameterSet& iConfig)
       jetSrc_(mayConsume<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("jetSrc"))),
       correctorToken_(mayConsume<reco::JetCorrector>(iConfig.getParameter<edm::InputTag>("corrector"))),
       calojetToken_(mayConsume<reco::CaloJetCollection>(iConfig.getParameter<edm::InputTag>("jetSrc"))),
-      scoutingMuonToken_(mayConsume<std::vector<Run3ScoutingMuon> >(scoutingMuonInputTag_)),
-      scoutjetSrc_(mayConsume<std::vector<Run3ScoutingPFJet> >(iConfig.getParameter<edm::InputTag>("jetSrc"))),
+      scoutingMuonToken_(mayConsume<std::vector<Run3ScoutingMuon>>(scoutingMuonInputTag_)),
+      scoutjetSrc_(mayConsume<std::vector<Run3ScoutingPFJet>>(iConfig.getParameter<edm::InputTag>("jetSrc"))),
       num_genTriggerEventFlag_(new GenericTriggerEventFlag(
           iConfig.getParameter<edm::ParameterSet>("numGenericTriggerEventPSet"), consumesCollector(), *this)),
       den_genTriggerEventFlag_(new GenericTriggerEventFlag(
@@ -195,7 +198,7 @@ JetMonitor::JetMonitor(const edm::ParameterSet& iConfig)
       muoSelection_(iConfig.getParameter<std::string>("muoSelection")),
       nmuons_(iConfig.getParameter<unsigned>("nmuons")),
       jetPt_variable_binning_(
-          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("jetptBinning")),
+          iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double>>("jetptBinning")),
       jetpt_binning_(getHistoPSet(
           iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<edm::ParameterSet>("jetPSet"))),
       jetptThr_binning_(getHistoPSet(
@@ -363,10 +366,10 @@ void JetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
   // -------- muons ----------
   std::vector<reco::Muon> muons;
   edm::Handle<reco::MuonCollection> muoHandle;
-  
+
   std::vector<Run3ScoutingMuon> scoutingmuons;
   edm::Handle<std::vector<Run3ScoutingMuon>> ScoutingMuonHandle;
-  
+
   if (isScoutingPFJetTrig) {
     iEvent.getByToken(scoutingMuonToken_, ScoutingMuonHandle);
     if (ScoutingMuonHandle.isValid()) {
@@ -381,17 +384,17 @@ void JetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
           scoutingmuons.push_back(iscoutmuon);
         }
       }
-      if (scoutingmuons.size() < nmuons_) { // require 1 tight scouting muon if orthogonal method, else nmuons_ is 0
+      if (scoutingmuons.size() < nmuons_) {  // require 1 tight scouting muon if orthogonal method, else nmuons_ is 0
         return;
       }
     } else {
       if (scoutingMuonInputTag_.label().empty()) {
         edm::LogWarning("JetMonitor") << "Scouting muon collection not valid \n";
+      } else {
+        edm::LogWarning("JetMonitor") << "skipping events because the collection "
+                                      << scoutingMuonInputTag_.label().c_str() << " is not available \n";
       }
-      else {
-        edm::LogWarning("JetMonitor") << "skipping events because the collection " <<  scoutingMuonInputTag_.label().c_str() << " is not available \n";
-      }
-        return;
+      return;
     }
   } else {
     iEvent.getByToken(muoToken_, muoHandle);
@@ -400,11 +403,11 @@ void JetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
         return;
       for (auto const& m : *muoHandle) {
         bool istightID = m.isGlobalMuon() && m.isPFMuon() && m.globalTrack()->normalizedChi2() < 10. &&
-                        m.globalTrack()->hitPattern().numberOfValidMuonHits() > 0 && m.numberOfMatchedStations() > 1 &&
-                        fabs(m.muonBestTrack()->dxy(vtx.position())) < 0.2 &&
-                        fabs(m.muonBestTrack()->dz(vtx.position())) < 0.5 &&
-                        m.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 &&
-                        m.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5;
+                         m.globalTrack()->hitPattern().numberOfValidMuonHits() > 0 && m.numberOfMatchedStations() > 1 &&
+                         fabs(m.muonBestTrack()->dxy(vtx.position())) < 0.2 &&
+                         fabs(m.muonBestTrack()->dz(vtx.position())) < 0.5 &&
+                         m.innerTrack()->hitPattern().numberOfValidPixelHits() > 0 &&
+                         m.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5;
         if (muoSelection_(m) && istightID) {
           muons.push_back(m);
         }
@@ -432,7 +435,7 @@ void JetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
 
   edm::Handle<reco::JetCorrector> Corrector;
   iEvent.getByToken(correctorToken_, Corrector);
-  
+
   if (isPFJetTrig) {  // if pfjet
     iEvent.getByToken(jetSrc_, PFjetHandle);
     if (!PFjetHandle.isValid()) {
@@ -497,13 +500,13 @@ void JetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
 
   }  // end if Calo Jets
 
-  if (isScoutingPFJetTrig) { //if scouting pf jets
+  if (isScoutingPFJetTrig) {  //if scouting pf jets
     iEvent.getByToken(scoutjetSrc_, ScoutingJetHandle);
     if (!ScoutingJetHandle.isValid()) {
       edm::LogWarning("JetMonitor") << "Scouting jet handle not valid \n";
       return;
     }
-    
+
     if (JetIDVersion_ == "RUN3Scouting") {
       run3scoutingpfjetidversion = Run3ScoutingPFJetIDSelectionFunctor::RUN3Scouting;
     } else {
@@ -518,37 +521,39 @@ void JetMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup
       if (verbose_)
         std::cout << "no Valid scouting Run3ScoutinPF JetID quality given" << std::endl;
     }
-    run3scoutingpfjetIDFunctor = Run3ScoutingPFJetIDSelectionFunctor(run3scoutingpfjetidversion, run3scoutingpfjetidquality);
+    run3scoutingpfjetIDFunctor =
+        Run3ScoutingPFJetIDSelectionFunctor(run3scoutingpfjetidversion, run3scoutingpfjetidquality);
     for (auto const& iscoutjet : *ScoutingJetHandle) {
       bool passScoutjetID = false;
       passScoutjetID = run3scoutingpfjetIDFunctor(iscoutjet);
-      if (!passScoutjetID) continue;
-      if (!isCleanScoutingJet(iscoutjet.eta(), iscoutjet.phi(), scoutingmuons, dr2cut_)) continue;
-      
+      if (!passScoutjetID)
+        continue;
+      if (!isCleanScoutingJet(iscoutjet.eta(), iscoutjet.phi(), scoutingmuons, dr2cut_))
+        continue;
+
       reco::PFJet dummy_scoutingpfjet;
-      reco::Particle::PolarLorentzVector dummy_scoutingpfjetP4(iscoutjet.pt(),
-                                                               iscoutjet.eta(),
-                                                               iscoutjet.phi(),
-                                                               iscoutjet.m());
+      reco::Particle::PolarLorentzVector dummy_scoutingpfjetP4(
+          iscoutjet.pt(), iscoutjet.eta(), iscoutjet.phi(), iscoutjet.m());
       dummy_scoutingpfjet.setP4(dummy_scoutingpfjetP4);
       dummy_scoutingpfjet.setJetArea(iscoutjet.jetArea());
 
       // apply corrections on the fly
       double jec = Corrector.isValid() ? Corrector->correction(dummy_scoutingpfjet) : 1.0;
       //std::cout << "Jet Pt: "<< iscoutjet.pt() << " JEC: " << jec << std::endl;
-      
-      double corjet = jec*iscoutjet.pt();  /////------> iscoutjet or dummy_...jet ?????
+
+      double corjet = jec * iscoutjet.pt();  /////------> iscoutjet or dummy_...jet ?????
       if (corjet < ptcut_) {
         continue;
       }
       corrected_scoutingjets.push_back({corjet, iscoutjet.eta(), iscoutjet.phi()});
-    } // end for loop over jets
-    std::sort(corrected_scoutingjets.begin(), corrected_scoutingjets.end(),[](const auto& a, const auto& b){return a.pt > b.pt;});
+    }  // end for loop over jets
+    std::sort(corrected_scoutingjets.begin(), corrected_scoutingjets.end(), [](const auto& a, const auto& b) {
+      return a.pt > b.pt;
+    });
     if (corrected_scoutingjets.empty())
       return;
-  } //end if scouting pf jets
-  
-  
+  }  //end if scouting pf jets
+
   double jetpt_ = (isPFJetTrig && !corrected_jets.empty())                   ? corrected_jets[0].pt
                   : (isCaloJetTrig && !corrected_calojets.empty())           ? corrected_calojets[0].pt
                   : (isScoutingPFJetTrig && !corrected_scoutingjets.empty()) ? corrected_scoutingjets[0].pt
@@ -636,36 +641,31 @@ bool JetMonitor::isCleanJet(double JetEta, double JetPhi, const std::vector<reco
   return true;
 }
 
-
-bool JetMonitor::isGoodScoutingMuon(Run3ScoutingMuon const &scoutingMuon) {
-  //if (scoutingMuon.pt() > 30
-  //if (scoutingMuon.pt() > 10
-  if (scoutingMuon.pt() > 1
-      //&& abs(scoutingMuon.eta()) < 0.8
-      //&& abs(scoutingMuon.trk_dxy()) < 0.2 //
+bool JetMonitor::isGoodScoutingMuon(Run3ScoutingMuon const& scoutingMuon) {
+  if (scoutingMuon.pt() > 10 && abs(scoutingMuon.eta()) < 0.8 &&
+      abs(scoutingMuon.trk_dxy()) < 0.2
       /////&& abs(scoutingMuon.trackIso()) < 0.15 //removed
-      //&& abs(scoutingMuon.trk_dz()) < 0.5 //
-      //&& scoutingMuon.normalizedChi2() < 3
-      && scoutingMuon.nValidRecoMuonHits() > 0) {
-      //&& scoutingMuon.nRecoMuonMatchedStations() > 1
-      //&& scoutingMuon.nValidPixelHits() > 0
-      //&& scoutingMuon.nTrackerLayersWithMeasurement() > 5) {
+      && abs(scoutingMuon.trk_dz()) < 0.5 && scoutingMuon.normalizedChi2() < 3 &&
+      scoutingMuon.nValidRecoMuonHits() > 0 && scoutingMuon.nRecoMuonMatchedStations() > 1 &&
+      scoutingMuon.nValidPixelHits() > 0 && scoutingMuon.nTrackerLayersWithMeasurement() > 5) {
     return true;
   } else {
     return false;
   }
 }
 
-bool JetMonitor::isCleanScoutingJet(double ScoutingJetEta, double ScoutingJetPhi, const std::vector<Run3ScoutingMuon>& scoutingMuons, double dr2Cut) {
+bool JetMonitor::isCleanScoutingJet(double ScoutingJetEta,
+                                    double ScoutingJetPhi,
+                                    const std::vector<Run3ScoutingMuon>& scoutingMuons,
+                                    double dr2Cut) {
   for (const auto& scoutingMuon : scoutingMuons) {
-  	double ScoutingdR2 = deltaR2(ScoutingJetEta, ScoutingJetPhi, scoutingMuon.eta(),  scoutingMuon.phi());
-  	if (ScoutingdR2 < dr2Cut) {
-    		return false;
+    double ScoutingdR2 = deltaR2(ScoutingJetEta, ScoutingJetPhi, scoutingMuon.eta(), scoutingMuon.phi());
+    if (ScoutingdR2 < dr2Cut) {
+      return false;
     }
   }
   return true;
 }
-
 
 bool JetMonitor::isBarrel(double eta) {
   bool output = false;
@@ -850,7 +850,7 @@ void JetMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
 
   desc.add<bool>("isscoutingpfjettrg", false);
   desc.add<bool>("doVariablebinning", false);
-  
+
   desc.add<std::string>("JetIDQuality", "TIGHT");
   desc.add<std::string>("JetIDVersion", "RUN3Scouting");
 
@@ -871,9 +871,9 @@ void JetMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   fillHistoPSetDescription(jetPtThrPSet);
   histoPSet.add<edm::ParameterSetDescription>("jetPSet", jetPSet);
   histoPSet.add<edm::ParameterSetDescription>("jetPtThrPSet", jetPtThrPSet);
-  histoPSet.add<std::vector<double> >("jetptBinning",
-                                      {0.,   20.,  40.,  60.,  80.,  90.,  100., 110., 120., 130., 140., 150., 160.,
-                                       170., 180., 190., 200., 220., 240., 260., 280., 300., 350., 400., 450., 1000.});
+  histoPSet.add<std::vector<double>>("jetptBinning",
+                                     {0.,   20.,  40.,  60.,  80.,  90.,  100., 110., 120., 130., 140., 150., 160.,
+                                      170., 180., 190., 200., 220., 240., 260., 280., 300., 350., 400., 450., 1000.});
 
   edm::ParameterSetDescription lsPSet;
   fillHistoLSPSetDescription(lsPSet);

--- a/DQMOffline/Trigger/python/JetMETPromptMonitor_cff.py
+++ b/DQMOffline/Trigger/python/JetMETPromptMonitor_cff.py
@@ -11,5 +11,13 @@ jetmetMonitorHLT = cms.Sequence(
     * HLTZGammaJetmonitoring
 )
 
+jetmetScoutingMonitorHLT = cms.Sequence(
+    HLTScoutingJetmonitoring
+)
+
+jetmetScoutingNoJECsMonitorHLT = cms.Sequence(
+    HLTScoutingJetnoJECsmonitoring
+)
+
 jmeHLTDQMSourceExtra = cms.Sequence(
 )

--- a/DQMOffline/Trigger/python/JetMETPromptMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/JetMETPromptMonitoring_Client_cff.py
@@ -178,6 +178,63 @@ ZJetsEfficiency = DQMEDHarvester("DQMGenericClient",
         "effic_HLTJetPt320_HEOuter  'HLT Jet (cut=320GeV) efficiency [HEOuter] vs HLT Z Pt [GeV];  HLT Z (pT) [GeV]; efficiency'  ZpT_for_JetpT_over320_HEOuter_numerator  ZpT_HEOuter_numerator",
         ),
     )
+ 
+
+scoutingpfjetEfficiency = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/JME/*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_scoutingpfjetpT          'Jet pT turnON;            ScoutingPFJet(pT) [GeV]; efficiency'     scoutingpfjetpT_numerator          scoutingpfjetpT_denominator",
+        "effic_scoutingpfjetpT_pTThresh 'Jet pT turnON;            PFJet(pT) [GeV]; efficiency'     scoutingpfjetpT_pTThresh_numerator scoutingpfjetpT_pTThresh_denominator",
+        "effic_scoutingpfjetphi       'Jet efficiency vs #phi; Scouting PF Jet #phi [rad]; efficiency' scoutingpfjetphi_numerator       scoutingpfjetphi_denominator",
+        "effic_scoutingpfjeteta       'Jet efficiency vs #eta; Scouting PF Jet #eta; efficiency' scoutingpfjeteta_numerator       scoutingpfjeteta_denominator",
+        ## HB
+        "effic_scoutingpfjetpT_HB          'Jet pT turnON (HB);            ScoutingPFJet(pT) [GeV]; efficiency'     scoutingpfjetpT_HB_numerator          scoutingpfjetpT_HB_denominator",
+        "effic_scoutingpfjetpT_HB_pTThresh 'Jet pT turnON (HB);            ScoutingPFJet(pT) [GeV]; efficiency'     scoutingpfjetpT_pTThresh_HB_numerator scoutingpfjetpT_pTThresh_HB_denominator",
+        "effic_scoutingpfjetphi_HB       'Jet efficiency vs #phi (HB); Scouting PF Jet #phi [rad]; efficiency' pfjetphi_HB_numerator       pfjetphi_HB_denominator",
+        "effic_scoutingpfjeteta_HB       'Jet efficiency vs #eta (HB); Scouting PF Jet #eta; efficiency' pfjeteta_HB_numerator       pfjeteta_HB_denominator",
+        ## HE
+        "effic_scoutingpfjetpT_HE          'Jet pT turnON (HE);            ScoutingPFJet(pT) [GeV]; efficiency'     scoutingpfjetpT_HE_numerator          scoutingpfjetpT_HE_denominator",
+        "effic_scoutingpfjetpT_HE_pTThresh 'Jet pT turnON (HE);            ScoutingPFJet(pT) [GeV]; efficiency'     scoutingpfjetpT_pTThresh_HE_numerator scoutingpfjetpT_pTThresh_HE_denominator",
+        "effic_scoutingpfjetphi_HE       'Jet efficiency vs #phi (HE); Scouting PF Jet #phi [rad]; efficiency' scoutingpfjetphi_HE_numerator       scoutingpfjetphi_HE_denominator",
+        "effic_scoutingpfjeteta_HE       'Jet efficiency vs #eta (HE); Scouting PF Jet #eta; efficiency' scoutingpfjeteta_HE_numerator       scoutingpfjeteta_HE_denominator",
+         ## HE_p
+        "effic_scoutingpfjetpT_HE_p          'Jet pT turnON (HEP);            ScoutingPFJet(pT) [GeV]; efficiency'     scoutingpfjetpT_HE_p_numerator          scoutingpfjetpT_HE_p_denominator",
+        "effic_scoutingpfjetpT_HE_p_pTThresh 'Jet pT turnON (HEP);            ScoutingPFJet(pT) [GeV]; efficiency'     scoutingpfjetpT_pTThresh_HE_p_numerator scoutingpfjetpT_pTThresh_HE_p_denominator",
+        "effic_scoutingpfjetphi_HE_p       'Jet efficiency vs #phi (HEP); Scouting PF Jet #phi [rad]; efficiency' scoutingpfjetphi_HE_p_numerator       scoutingpfjetphi_HE_p_denominator",
+        "effic_scoutingpfjeteta_HE_p       'Jet efficiency vs #eta (HEP); Scouting PF Jet #eta; efficiency' scoutingpfjeteta_HE_p_numerator       scoutingpfjeteta_HE_p_denominator",
+        ## HE_m
+        "effic_scoutingpfjetpT_HE_m          'Jet pT turnON (HEM);            ScoutingPFJet(pT) [GeV]; efficiency'     scoutingpfjetpT_HE_m_numerator          scoutingpfjetpT_HE_m_denominator",
+        "effic_scoutingpfjetpT_HE_m_pTThresh 'Jet pT turnON (HEM);            ScoutingPFJet(pT) [GeV]; efficiency'     scoutingpfjetpT_pTThresh_HE_m_numerator scoutingpfjetpT_pTThresh_HE_m_denominator",
+        "effic_scoutingpfjetphi_HE_m       'Jet efficiency vs #phi (HEM); Scouting PF Jet #phi [rad]; efficiency' scoutingpfjetphi_HE_m_numerator       scoutingpfjetphi_HE_m_denominator",
+        "effic_scoutingpfjeteta_HE_m       'Jet efficiency vs #eta (HEM); Scouting PF Jet #eta; efficiency' scoutingpfjeteta_HE_m_numerator       scoutingpfjeteta_HE_m_denominator",
+        ## HF
+        "effic_scoutingpfjetpT_HF          'Jet pT turnON (HF);            ScoutingPFJet(pT) [GeV]; efficiency'     scoutingpfjetpT_HF_numerator          scoutingpfjetpT_HF_denominator",
+        "effic_scoutingpfjetpT_HF_pTThresh 'Jet pT turnON (HF);            ScoutingPFJet(pT) [GeV]; efficiency'     scoutingpfjetpT_pTThresh_HF_numerator scoutingpfjetpT_pTThresh_HF_denominator",
+        "effic_scoutingpfjetphi_HF       'Jet efficiency vs #phi (HF); Scouting PF Jet #phi [rad]; efficiency' scoutingpfjetphi_HF_numerator       scoutingpfjetphi_HF_denominator",
+        "effic_scoutingpfjeteta_HF       'Jet efficiency vs #eta (HF); Scouting PF Jet #eta; efficiency' scoutingpfjeteta_HF_numerator       scoutingpfjeteta_HF_denominator",
+        ## 2D Eff
+        "effic_scoutingpfjetEtaVsPhi       'Jet efficiency vs #eta and #phi; Scouting PF Jet #eta; #phi' scoutingpfjetEtaVsPhi_numerator       scoutingpfjetEtaVsPhi_denominator",
+        "effic_scoutingpfjetEtaVsPhi_HB    'Jet efficiency vs #eta and #phi(HB); Scouting PF Jet #eta; #phi' scoutingpfjetEtaVsPhi_HB_numerator       scoutingpfjetEtaVsPhi_HB_denominator",
+        "effic_scoutingpfjetEtaVsPhi_HE    'Jet efficiency vs #eta and #phi(HE); Scouting PF Jet #eta; #phi' scoutingpfjetEtaVsPhi_HE_numerator       scoutingpfjetEtaVsPhi_HE_denominator",
+        "effic_scoutingpfjetEtaVsPhi_HF    'Jet efficiency vs #eta and #phi(HF); Scouting PF Jet #eta; #phi' scoutingpfjetEtaVsPhi_HF_numerator       scoutingpfjetEtaVsPhi_HF_denominator",
+
+        "effic_scoutingpfjetEtaVsPhi_HE_p 'Jet efficiency vs #eta and #phi(HE_p); Scouting PF Jet #eta; #phi' scoutingpfjetEtaVsPhi_HE_p_numerator       scoutingpfjetEtaVsPhi_HE_p_denominator",
+        "effic_scoutingpfjetEtaVsPhi_HE_m 'Jet efficiency vs #eta and #phi(HE_m); Scouting PF Jet #eta; #phi' scoutingpfjetEtaVsPhi_HE_m_numerator       scoutingpfjetEtaVsPhi_HE_m_denominator",
+
+        "effic_scoutingpfjetEtaVspT        'Jet efficiency #eta vs Pt;     Scouting PF Jet #eta; Pt' scoutingpfjetEtaVspT_numerator          scoutingpfjetEtaVspT_denominator",
+        "effic_scoutingpfjetEtaVspT_HB     'Jet efficiency #eta vs Pt(HB); Scouting PF Jet #eta; Pt' scoutingpfjetEtaVspT_HB_numerator       scoutingpfjetEtaVspT_HB_denominator",
+        "effic_scoutingpfjetEtaVspT_HE     'Jet efficiency #eta vs Pt(HE); Scouting PF Jet #eta; Pt' scoutingpfjetEtaVspT_HE_numerator       scoutingpfjetEtaVspT_HE_denominator",
+        "effic_scoutingpfjetEtaVspT_HF     'Jet efficiency #eta vs Pt(HF); Scouting PF Jet #eta; Pt' scoutingpfjetEtaVspT_HF_numerator       scoutingpfjetEtaVspT_HF_denominator",
+
+        "effic_scoutingpfjetEtaVspT_HE_p   'Jet efficiency #eta vs Pt(HE_p); Scouting PF Jet #eta; Pt' scoutingpfjetEtaVspT_HE_p_numerator       scoutingpfjetEtaVspT_HE_p_denominator",
+        "effic_scoutingpfjetEtaVspT_HE_m   'Jet efficiency #eta vs Pt(HE_m); ScoutingPF Jet #eta; Pt' scoutingpfjetEtaVspT_HE_m_numerator       scoutingpfjetEtaVspT_HE_m_denominator"
+    ),
+    efficiencyProfile = cms.untracked.vstring(
+        "effic_scoutingpfjetpT_vs_LS 'JET efficiency vs LS; LS; Scouting PF JET efficiency' scoutingpfjetpTVsLS_numerator scoutingpfjetpTVsLS_denominator",
+    ),
+  )
 
 #-----------------------------
 
@@ -186,4 +243,5 @@ JetMetPromClient = cms.Sequence(
     *calojetEfficiency
     *GammaJetsEfficiency
     *ZJetsEfficiency
+    *scoutingpfjetEfficiency
 )

--- a/DQMOffline/Trigger/python/JetMonitor_cff.py
+++ b/DQMOffline/Trigger/python/JetMonitor_cff.py
@@ -743,7 +743,7 @@ CaloJet500_NoJetID_Orthogonal_Prommonitoring = hltJetMETmonitoring.clone(
 )
 
 
-### Scouitng Trigger and L1 seeds ###
+######### Scouitng Trigger and L1 seeds #########
 # DST_PFScouting_JetHT_v
 PFScoutingJetHT_Prommonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/JME/Jets/AK4/ScoutingPF/PFScoutingJetHT/',
@@ -1021,6 +1021,63 @@ L1SingleJet200_Prommonitoring = hltJetMETmonitoring.clone(
 )
 
 
+### --------- No JECs --------- ###
+PFScoutingJetHT_NoJECs_Prommonitoring = PFScoutingJetHT_Prommonitoring.clone(
+    corrector = ""
+)
+
+# L1_HTT200er
+L1HTT200_NoJECs_Prommonitoring = L1HTT200_Prommonitoring.clone(
+    corrector = ""
+)
+
+
+# L1_HTT255er
+L1HTT255_NoJECs_Prommonitoring = L1HTT255_Prommonitoring.clone(
+    corrector = ""
+)
+
+
+# L1_HTT280er
+L1HTT280_NoJECs_Prommonitoring = L1HTT280_Prommonitoring.clone(
+    corrector = ""
+)
+
+
+#  L1_HTT320er
+L1HTT320_NoJECs_Prommonitoring = L1HTT320_Prommonitoring.clone(
+    corrector = ""
+)
+
+
+# L1_HTT360er
+L1HTT360_NoJECs_Prommonitoring = L1HTT360_Prommonitoring.clone(
+    corrector = ""
+)
+
+# L1_HTT400er
+L1HTT400_NoJECs_Prommonitoring = L1HTT400_Prommonitoring.clone(
+    corrector = ""
+)
+
+
+# L1_HTT450er
+L1HTT450_NoJECs_Prommonitoring = L1HTT450_Prommonitoring.clone(
+    corrector = ""
+)
+
+
+# L1_SingleJet180
+L1SingleJet180_NoJECs_Prommonitoring = L1SingleJet180_Prommonitoring.clone(
+    corrector = ""
+)
+
+
+# L1_SingleJet200
+L1SingleJet200_NoJECs_Prommonitoring = L1SingleJet200_Prommonitoring.clone(
+    corrector = ""
+)
+
 HLTJetmonitoring = cms.Sequence(    
     ak4PFPuppiL1FastL2L3ResidualCorrectorChain
     *PFJet500_Orthogonal_Prommonitoring
@@ -1069,7 +1126,11 @@ HLTJetmonitoring = cms.Sequence(
     *ak4CaloL1FastL2L3ResidualCorrectorChain
     *CaloJet500_NoJetID_Prommonitoring
     *CaloJet500_NoJetID_Orthogonal_Prommonitoring
-    *ak4PFScoutL1FastL2L3ResidualCorrectorChain
+)
+
+
+HLTScoutingJetmonitoring = cms.Sequence(
+    ak4PFScoutL1FastL2L3ResidualCorrectorChain
     *PFScoutingJetHT_Prommonitoring
     *L1HTT200_Prommonitoring
     *L1HTT255_Prommonitoring
@@ -1080,4 +1141,17 @@ HLTJetmonitoring = cms.Sequence(
     *L1HTT450_Prommonitoring
     *L1SingleJet180_Prommonitoring
     *L1SingleJet200_Prommonitoring
+)
+
+HLTScoutingJetnoJECsmonitoring = cms.Sequence(
+    PFScoutingJetHT_NoJECs_Prommonitoring
+    *L1HTT200_NoJECs_Prommonitoring
+    *L1HTT255_NoJECs_Prommonitoring
+    *L1HTT280_NoJECs_Prommonitoring
+    *L1HTT320_NoJECs_Prommonitoring
+    *L1HTT360_NoJECs_Prommonitoring
+    *L1HTT400_NoJECs_Prommonitoring
+    *L1HTT450_NoJECs_Prommonitoring
+    *L1SingleJet180_NoJECs_Prommonitoring
+    *L1SingleJet200_NoJECs_Prommonitoring
 )

--- a/DQMOffline/Trigger/python/JetMonitor_cff.py
+++ b/DQMOffline/Trigger/python/JetMonitor_cff.py
@@ -4,6 +4,36 @@ from DQMOffline.Trigger.JetMonitor_cfi import hltJetMETmonitoring
 from JetMETCorrections.Configuration.JetCorrectors_cff import *
 from DQMOffline.Trigger.ZGammaplusJetsMonitor_cff import *
 
+###################     Scouting JECs    #################
+ak4PFScoutL1FastjetCorrector = ak4PFL1FastjetCorrector.clone(
+    algorithm   = cms.string('AK4PFHLT'),
+    srcRho = cms.InputTag("hltScoutingPFPacker","rho")
+    )
+    
+ak4PFScoutL2RelativeCorrector = ak4PFL2RelativeCorrector.clone( 
+    algorithm = cms.string('AK4PFHLT'),
+    )
+
+ak4PFScoutL3AbsoluteCorrector = ak4PFL3AbsoluteCorrector.clone( 
+    algorithm = cms.string('AK4PFHLT'),
+    )
+
+ak4PFScoutResidualCorrector  = ak4PFResidualCorrector.clone( 
+    algorithm = cms.string('AK4PFHLT'),
+    )
+
+ak4PFScoutL1FastL2L3ResidualCorrector = cms.EDProducer(
+    'ChainedJetCorrectorProducer',
+    correctors = cms.VInputTag('ak4PFScoutL1FastjetCorrector','ak4PFScoutL2RelativeCorrector','ak4PFScoutL3AbsoluteCorrector','ak4PFScoutResidualCorrector')
+    )
+    
+ak4PFScoutL1FastL2L3ResidualCorrectorTask = cms.Task(
+    ak4PFScoutL1FastjetCorrector, ak4PFScoutL2RelativeCorrector, ak4PFScoutL3AbsoluteCorrector, ak4PFScoutResidualCorrector, ak4PFScoutL1FastL2L3ResidualCorrector
+)
+ak4PFScoutL1FastL2L3ResidualCorrectorChain = cms.Sequence(ak4PFScoutL1FastL2L3ResidualCorrectorTask)
+
+
+
 ### HLT_PFJet Triggers ###
 # HLT_PFJet450
 PFJet450_Prommonitoring = hltJetMETmonitoring.clone(
@@ -713,6 +743,284 @@ CaloJet500_NoJetID_Orthogonal_Prommonitoring = hltJetMETmonitoring.clone(
 )
 
 
+### Scouitng Trigger and L1 seeds ###
+# DST_PFScouting_JetHT_v
+PFScoutingJetHT_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/ScoutingPF/PFScoutingJetHT/',
+    jetSrc = "hltScoutingPFPacker",
+    muons = "hltScoutingMuonPackerVtx",
+    vertices = "hltScoutingPrimaryVertexPacker",
+    corrector = "ak4PFScoutL1FastL2L3ResidualCorrector",
+    ispfjettrg = False,
+    isscoutingpfjettrg = True,
+    doVariablebinning = True,
+    JetIDQuality = "TIGHT",
+    JetIDVersion = "RUN3Scouting",
+    dr2cut = 0.16,
+    nmuons = 1,
+    histoPSet = dict(jetptBinning = [0., 20., 40., 50., 60., 70., 80., 90., 100., 110.,
+                120., 130., 140., 150., 160., 170., 180., 190., 200., 210.,
+                220., 230., 240., 250., 260., 280., 300., 320., 340., 360.,
+                380., 400., 450., 500., 600., 800., 1000.]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["DST_PFScouting_JetHT_v*"]),
+    denGenericTriggerEventPSet = dict(
+        andOrHlt = False, # True:=OR; False:=AND (default)
+        hltPaths = ["HLT_TriggersForScoutingPFMonitor_PS1000_v*","DST_PFScouting_SingleMuon_v*"])
+)
+
+# L1_HTT200er
+L1HTT200_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/ScoutingPF/L1_HTT200er/',
+    jetSrc = "hltScoutingPFPacker",
+    muons = "hltScoutingMuonPackerVtx",
+    vertices = "hltScoutingPrimaryVertexPacker",
+    corrector = "ak4PFScoutL1FastL2L3ResidualCorrector",
+    ispfjettrg = False,
+    isscoutingpfjettrg = True,
+    doVariablebinning = True,
+    JetIDQuality = "TIGHT",
+    JetIDVersion = "RUN3Scouting",
+    dr2cut = 0.16,
+    nmuons = 1,
+    histoPSet = dict(jetptBinning = [0., 20., 40., 50., 60., 70., 80., 90., 100., 110.,
+                120., 130., 140., 150., 160., 170., 180., 190., 200., 210.,
+                220., 230., 240., 250., 260., 280., 300., 320., 340., 360.,
+                380., 400., 450., 500., 600., 800., 1000.]),
+    numGenericTriggerEventPSet = dict(
+        hltPaths          = cms.vstring(),
+        stage2 = cms.bool(True),
+        l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+        l1Algorithms      = cms.vstring("L1_HTT200er")),
+    denGenericTriggerEventPSet = dict(
+        andOrHlt = False, # True:=OR; False:=AND (default)
+        hltPaths = ["HLT_TriggersForScoutingPFMonitor_PS1000_v*","DST_PFScouting_SingleMuon_v*"])
+)
+
+
+# L1_HTT255er
+L1HTT255_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/ScoutingPF/L1_HTT255er/',
+    jetSrc = "hltScoutingPFPacker",
+    muons = "hltScoutingMuonPackerVtx",
+    vertices = "hltScoutingPrimaryVertexPacker",
+    corrector = "ak4PFScoutL1FastL2L3ResidualCorrector",
+    ispfjettrg = False,
+    isscoutingpfjettrg = True,
+    doVariablebinning = True,
+    JetIDQuality = "TIGHT",
+    JetIDVersion = "RUN3Scouting",
+    dr2cut = 0.16,
+    nmuons = 1,
+    histoPSet = dict(jetptBinning = [0., 20., 40., 50., 60., 70., 80., 90., 100., 110.,
+                120., 130., 140., 150., 160., 170., 180., 190., 200., 210.,
+                220., 230., 240., 250., 260., 280., 300., 320., 340., 360.,
+                380., 400., 450., 500., 600., 800., 1000.]),
+    numGenericTriggerEventPSet = dict(
+        hltPaths          = cms.vstring(),
+        l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+        l1Algorithms      = cms.vstring("L1_HTT255er")),
+    denGenericTriggerEventPSet = dict(
+        andOrHlt = False, # True:=OR; False:=AND (default)
+        hltPaths = ["HLT_TriggersForScoutingPFMonitor_PS1000_v*","DST_PFScouting_SingleMuon_v*"])
+)
+
+
+# L1_HTT280er 
+L1HTT280_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/ScoutingPF/L1_HTT280er/',
+    jetSrc = "hltScoutingPFPacker",
+    muons = "hltScoutingMuonPackerVtx",
+    vertices = "hltScoutingPrimaryVertexPacker",
+    corrector = "ak4PFScoutL1FastL2L3ResidualCorrector",
+    ispfjettrg = False,
+    isscoutingpfjettrg = True,
+    doVariablebinning = True,
+    JetIDQuality = "TIGHT",
+    JetIDVersion = "RUN3Scouting",
+    dr2cut = 0.16,
+    nmuons = 1,
+    histoPSet = dict(jetptBinning = [0., 20., 40., 50., 60., 70., 80., 90., 100., 110.,
+                120., 130., 140., 150., 160., 170., 180., 190., 200., 210.,
+                220., 230., 240., 250., 260., 280., 300., 320., 340., 360.,
+                380., 400., 450., 500., 600., 800., 1000.]),
+    numGenericTriggerEventPSet = dict(
+        hltPaths          = cms.vstring(),
+        l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+        l1Algorithms      = cms.vstring("L1_HTT280er")),
+    denGenericTriggerEventPSet = dict(
+        andOrHlt = False, # True:=OR; False:=AND (default)
+        hltPaths = ["HLT_TriggersForScoutingPFMonitor_PS1000_v*","DST_PFScouting_SingleMuon_v*"])
+)
+
+
+#  L1_HTT320er
+L1HTT320_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/ScoutingPF/L1_HTT320er/',
+    jetSrc = "hltScoutingPFPacker",
+    muons = "hltScoutingMuonPackerVtx",
+    vertices = "hltScoutingPrimaryVertexPacker",
+    corrector = "ak4PFScoutL1FastL2L3ResidualCorrector",
+    ispfjettrg = False,
+    isscoutingpfjettrg = True,
+    doVariablebinning = True,
+    JetIDQuality = "TIGHT",
+    JetIDVersion = "RUN3Scouting",
+    dr2cut = 0.16,
+    nmuons = 1,
+    histoPSet = dict(jetptBinning = [0., 20., 40., 50., 60., 70., 80., 90., 100., 110.,
+                120., 130., 140., 150., 160., 170., 180., 190., 200., 210.,
+                220., 230., 240., 250., 260., 280., 300., 320., 340., 360.,
+                380., 400., 450., 500., 600., 800., 1000.]),
+    numGenericTriggerEventPSet = dict(
+        hltPaths          = cms.vstring(),
+        l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+        l1Algorithms      = cms.vstring("L1_HTT320er")),
+    denGenericTriggerEventPSet = dict(
+        andOrHlt = False, # True:=OR; False:=AND (default)
+        hltPaths = ["HLT_TriggersForScoutingPFMonitor_PS1000_v*","DST_PFScouting_SingleMuon_v*"])
+)
+
+
+# L1_HTT360er
+L1HTT360_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/ScoutingPF/L1_HTT360er/',
+    jetSrc = "hltScoutingPFPacker",
+    muons = "hltScoutingMuonPackerVtx",
+    vertices = "hltScoutingPrimaryVertexPacker",
+    corrector = "ak4PFScoutL1FastL2L3ResidualCorrector",
+    ispfjettrg = False,
+    isscoutingpfjettrg = True,
+    doVariablebinning = True,
+    JetIDQuality = "TIGHT",
+    JetIDVersion = "RUN3Scouting",
+    dr2cut = 0.16,
+    nmuons = 1,
+    histoPSet = dict(jetptBinning = [0., 20., 40., 50., 60., 70., 80., 90., 100., 110.,
+                120., 130., 140., 150., 160., 170., 180., 190., 200., 210.,
+                220., 230., 240., 250., 260., 280., 300., 320., 340., 360.,
+                380., 400., 450., 500., 600., 800., 1000.]),
+    numGenericTriggerEventPSet = dict(
+        stage2 = cms.bool(True),
+        hltPaths          = cms.vstring(),
+        l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+        l1Algorithms      = cms.vstring("L1_HTT360er")),
+    denGenericTriggerEventPSet = dict(
+        andOrHlt = False, # True:=OR; False:=AND (default)
+        hltPaths = ["HLT_TriggersForScoutingPFMonitor_PS1000_v*","DST_PFScouting_SingleMuon_v*"])
+)
+
+# L1_HTT400er
+L1HTT400_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/ScoutingPF/L1_HTT400er/',
+    jetSrc = "hltScoutingPFPacker",
+    muons = "hltScoutingMuonPackerVtx",
+    vertices = "hltScoutingPrimaryVertexPacker",
+    corrector = "ak4PFScoutL1FastL2L3ResidualCorrector",
+    ispfjettrg = False,
+    isscoutingpfjettrg = True,
+    doVariablebinning = True,
+    JetIDQuality = "TIGHT",
+    JetIDVersion = "RUN3Scouting",
+    dr2cut = 0.16,
+    nmuons = 1,
+    histoPSet = dict(jetptBinning = [0., 20., 40., 50., 60., 70., 80., 90., 100., 110.,
+                120., 130., 140., 150., 160., 170., 180., 190., 200., 210.,
+                220., 230., 240., 250., 260., 280., 300., 320., 340., 360.,
+                380., 400., 450., 500., 600., 800., 1000.]),
+    numGenericTriggerEventPSet = dict(
+        hltPaths          = cms.vstring(),
+        l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+        l1Algorithms      = cms.vstring("L1_HTT400er")),
+    denGenericTriggerEventPSet = dict(
+        andOrHlt = False, # True:=OR; False:=AND (default)
+        hltPaths = ["HLT_TriggersForScoutingPFMonitor_PS1000_v*","DST_PFScouting_SingleMuon_v*"])
+)
+
+
+# L1_HTT450er
+L1HTT450_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/ScoutingPF/L1_HTT450er/',
+    jetSrc = "hltScoutingPFPacker",
+    muons = "hltScoutingMuonPackerVtx",
+    vertices = "hltScoutingPrimaryVertexPacker",
+    corrector = "ak4PFScoutL1FastL2L3ResidualCorrector",
+    ispfjettrg = False,
+    isscoutingpfjettrg = True,
+    doVariablebinning = True,
+    JetIDQuality = "TIGHT",
+    JetIDVersion = "RUN3Scouting",
+    dr2cut = 0.16,
+    nmuons = 1,
+    histoPSet = dict(jetptBinning = [0., 20., 40., 50., 60., 70., 80., 90., 100., 110.,
+                120., 130., 140., 150., 160., 170., 180., 190., 200., 210.,
+                220., 230., 240., 250., 260., 280., 300., 320., 340., 360.,
+                380., 400., 450., 500., 600., 800., 1000.]),
+    numGenericTriggerEventPSet = dict(
+        hltPaths          = cms.vstring(),
+        l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+        l1Algorithms      = cms.vstring("L1_HTT450er")),
+    denGenericTriggerEventPSet = dict(
+        andOrHlt = False, # True:=OR; False:=AND (default)
+        hltPaths = ["HLT_TriggersForScoutingPFMonitor_PS1000_v*","DST_PFScouting_SingleMuon_v*"])
+)
+
+
+# L1_SingleJet180
+L1SingleJet180_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/ScoutingPF/L1_SingleJet180/',
+    jetSrc = "hltScoutingPFPacker",
+    muons = "hltScoutingMuonPackerVtx",
+    vertices = "hltScoutingPrimaryVertexPacker",
+    corrector = "ak4PFScoutL1FastL2L3ResidualCorrector",
+    ispfjettrg = False,
+    isscoutingpfjettrg = True,
+    doVariablebinning = True,
+    JetIDQuality = "TIGHT",
+    JetIDVersion = "RUN3Scouting",
+    dr2cut = 0.16,
+    nmuons = 1,
+    histoPSet = dict(jetptBinning = [0., 20., 40., 50., 60., 70., 80., 90., 100., 110.,
+                120., 130., 140., 150., 160., 170., 180., 190., 200., 210.,
+                220., 230., 240., 250., 260., 280., 300., 320., 340., 360.,
+                380., 400., 450., 500., 600., 800., 1000.]),
+    numGenericTriggerEventPSet = dict(
+        hltPaths          = cms.vstring(),
+        l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+        l1Algorithms      = cms.vstring("L1_SingleJet180")),
+    denGenericTriggerEventPSet = dict(
+        andOrHlt = False, # True:=OR; False:=AND (default)
+        hltPaths = ["HLT_TriggersForScoutingPFMonitor_PS1000_v*","DST_PFScouting_SingleMuon_v*"])
+)
+
+
+# L1_SingleJet200
+L1SingleJet200_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/ScoutingPF/L1_SingleJet200/',
+    jetSrc = "hltScoutingPFPacker",
+    muons = "hltScoutingMuonPackerVtx",
+    vertices = "hltScoutingPrimaryVertexPacker",
+    corrector = "ak4PFScoutL1FastL2L3ResidualCorrector",
+    ispfjettrg = False,
+    isscoutingpfjettrg = True,
+    doVariablebinning = True,
+    JetIDQuality = "TIGHT",
+    JetIDVersion = "RUN3Scouting",
+    dr2cut = 0.16,
+    nmuons = 1,
+    histoPSet = dict(jetptBinning = [0., 20., 40., 50., 60., 70., 80., 90., 100., 110.,
+                120., 130., 140., 150., 160., 170., 180., 190., 200., 210.,
+                220., 230., 240., 250., 260., 280., 300., 320., 340., 360.,
+                380., 400., 450., 500., 600., 800., 1000.]),
+    numGenericTriggerEventPSet = dict(
+        hltPaths          = cms.vstring(),
+        l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
+        l1Algorithms      = cms.vstring("L1_SingleJet200")),
+    denGenericTriggerEventPSet = dict(
+        andOrHlt = False, # True:=OR; False:=AND (default)
+        hltPaths = ["HLT_TriggersForScoutingPFMonitor_PS1000_v*","DST_PFScouting_SingleMuon_v*"])
+)
+
+
 HLTJetmonitoring = cms.Sequence(    
     ak4PFPuppiL1FastL2L3ResidualCorrectorChain
     *PFJet500_Orthogonal_Prommonitoring
@@ -761,4 +1069,15 @@ HLTJetmonitoring = cms.Sequence(
     *ak4CaloL1FastL2L3ResidualCorrectorChain
     *CaloJet500_NoJetID_Prommonitoring
     *CaloJet500_NoJetID_Orthogonal_Prommonitoring
+    *ak4PFScoutL1FastL2L3ResidualCorrectorChain
+    *PFScoutingJetHT_Prommonitoring
+    *L1HTT200_Prommonitoring
+    *L1HTT255_Prommonitoring
+    *L1HTT280_Prommonitoring
+    *L1HTT320_Prommonitoring
+    *L1HTT360_Prommonitoring
+    *L1HTT400_Prommonitoring
+    *L1HTT450_Prommonitoring
+    *L1SingleJet180_Prommonitoring
+    *L1SingleJet200_Prommonitoring
 )

--- a/DQMOffline/Trigger/python/JetMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/JetMonitor_cfi.py
@@ -23,6 +23,10 @@ hltJetMETmonitoring = jetMonitoring.clone(
     ptcut = 30.,
     ispfjettrg = True, # is PFJet Trigger ?
     iscalojettrg = False, # is CaloJet Trigger ?
+    isscoutingpfjettrg = False, # is ScoutingPFJet Trigger ?
+    doVariablebinning = False,
+    JetIDQuality = 'TIGHT',
+    JetIDVersion = 'RUN3Scouting',  #maybe put a pfpuppi version, but need to define it in the relevant if above
 
     numGenericTriggerEventPSet = dict(
         andOr         =  False,

--- a/PhysicsTools/SelectorUtils/interface/Run3ScoutingPFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/Run3ScoutingPFJetIDSelectionFunctor.h
@@ -160,6 +160,8 @@ public:  // interface
 
 private:  // member variables
   int nConstituents_ = 0;
+  int nNeutrals_TR_ = 0;
+  int nNeutrals_EC_ = 0;
   double CHF_ = 0.0;
   double NHF_ = 0.0;
   double NEF_ = 0.0;
@@ -174,27 +176,30 @@ private:  // member variables
     if (quality_ == TIGHT) {
       if (version_ == RUN3Scouting) {
         nConstituents_ = 1;
-        CHF_ = 0.01;
+        //CHF_ = 0.01;
         NHF_ = 0.99;
         NEF_ = 0.9;
         NCH_ = 0.0;
-        NEF_TR_ = 0.9;
-        NEF_EC_ = 0.9;
-        NEF_FW_ = 0.2;
+        NEF_TR_ = 0.99;
+        NEF_EC_ = 0.99;
+        NEF_FW_ = 0.1;
+        nNeutrals_TR_ = 1;
+        nNeutrals_EC_ = 1;
       }
     } else if (quality_ == TIGHTLEPVETO) {
       if (version_ == RUN3Scouting) {
-        CHF_ = 0.01;
         nConstituents_ = 1;
-        CHF_ = 0.01;
+        //CHF_ = 0.01;
         NHF_ = 0.99;
         NEF_ = 0.9;
         NCH_ = 0.0;
         MUF_ = 0.8;
-        NEF_TR_ = 0.9;
+        NEF_TR_ = 0.99;
         MUF_TR_ = 0.8;
-        NEF_EC_ = 0.9;
-        NEF_FW_ = 0.2;
+        NEF_EC_ = 0.99;
+        NEF_FW_ = 0.1;
+        nNeutrals_TR_ = 1;
+        nNeutrals_EC_ = 1;
       }
     }
   }


### PR DESCRIPTION
#### PR description:

This PR summarises changes in the [cmssw/DQMOffline/Trigger/](https://github.com/cms-sw/cmssw/tree/master/DQMOffline/Trigger) framework in order to include trigger efficiency calculations for scouting jets for offline monitoring. The relevant modules run only with online and offline scouting DQM with scouting datasets, to avoid crash due to missing scouting objects (specifically rho) from other datasets. Also, modules w/o JECs have been created in order to avoid similar crash in RelVals. (Issues thoroughly described in https://github.com/cms-sw/cmssw/issues/49377 and https://github.com/cms-sw/cmssw/pull/49358).

Relevant reports about the development and validation of this work can be found in:

- [Scouting meeting on 6 February 2026](https://docs.google.com/document/d/1Ap5cgokuxh-ExencGMSr-5I30tjvijl52dr6XxWqOgE/edit?tab=t.0#heading=h.xk7gvf6fxiv8)
- [Scouting meeting on 30 January 2026](https://docs.google.com/document/d/1Ap5cgokuxh-ExencGMSr-5I30tjvijl52dr6XxWqOgE/edit?tab=t.0#heading=h.sgoebh7ccqxc)
- [Scouting meeting on 14 November 2025](https://docs.google.com/document/d/1Ap5cgokuxh-ExencGMSr-5I30tjvijl52dr6XxWqOgE/edit?tab=t.0#heading=h.k4l0b2gqpvu)
- [Scouting meeting on 24 October 2025](https://docs.google.com/document/d/1Ap5cgokuxh-ExencGMSr-5I30tjvijl52dr6XxWqOgE/edit?tab=t.0#heading=h.3gsukd9w8bcs)
- [Scouting meeting on 14 October 2025](https://docs.google.com/document/d/1Ap5cgokuxh-ExencGMSr-5I30tjvijl52dr6XxWqOgE/edit?tab=t.0#heading=h.k4l0b2gqpvu)

cc: @silviodonato @patinkaew

#### PR validation:

This PR has been prepared starting from:

cmsrel CMSSW_16_1_X_2026-02-15-2300
cd CMSSW_16_1_X_2026-02-15-2300/src
cmsenv
git cms-init
git cms-addpkg DQMOffline/HLTScouting DQMOffline/Trigger DQMOffline/Configuration DQMOffline/JetMET  PhysicsTools/SelectorUtils DQM/HLTEvF
scram b
scram build code-checks
scram build code-format

[1]: input: ScoutingPFMonitor/AOD/PromptReco-v1/ dataset (specifically testing with files from era 2025G, run 398827)
[2]: cmsDriver.py step2 -s DQM:jetmetScoutingMonitorHLT--conditions 150X_dataRun3_Prompt_v1 --datatier DQMIO -n -1 --eventcontent DQM --geometry DB:Extended --era Run3 --filein /store/data/Run2025G/ScoutingPFMonitor/AOD/PromptReco-v1/000/398/827/00000/1b30ead2-bc1f-42c3-87ca-dba7b395d525.root --fileout file:stepDQM.root --python_filename DQM_cfg.py --data --scenario pp --no_exec (or cmsDriver.py step2 -s DQM:jetmetScoutingNoJECsMonitorHLT--conditions 150X_dataRun3_Prompt_v1 --datatier DQMIO -n -1 --eventcontent DQM --geometry DB:Extended --era Run3 --filein /store/data/Run2025G/ScoutingPFMonitor/AOD/PromptReco-v1/000/398/827/00000/1b30ead2-bc1f-42c3-87ca-dba7b395d525.root --fileout file:stepDQM.root --python_filename DQM_cfg.py --data --scenario pp --no_exec)
[3]: cmsRun DQM_cfg.py
[4]: cmsDriver.py step3 -s HARVESTING:hltOfflineDQMClient --harvesting AtRunEnd --filein file:stepDQM.root --python_filename harvesting_cfg.py --conditions 150X_dataRun3_Prompt_v1 --data --filetype DQM --scenario pp --era Run3 --geometry DB:Extended -n -1 --no_exec
[5]: cmsRun harvesting_cfg.py

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of the original [#50188](https://github.com/cms-sw/cmssw/pull/50188). The reason of the backport is that the updates are intended for monitoring of jme objects during 2026 data taking.