### PR TITLE
Prevent potential null pointer dereference in TrackletEventProcessor

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -17,13 +17,15 @@
 using namespace trklet;
 using namespace std;
 
-TrackletEventProcessor::TrackletEventProcessor() : settings_(nullptr) {}
+TrackletEventProcessor::TrackletEventProcessor() : settings_(nullptr), sector_(nullptr), histbase_(nullptr) {}
 
 TrackletEventProcessor::~TrackletEventProcessor() {
   if (settings_ && settings_->bookHistos()) {
-    histbase_->close();
+    if (histbase_)
+      histbase_->close();
   }
-  sector_->clean();
+  if (sector_)
+    sector_->clean();
 }
 
 void TrackletEventProcessor::init(Settings const& theSettings, const tt::Setup* setup) {


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/50489

#### PR description:

As per https://github.com/cms-sw/cmssw/issues/50489#issuecomment-4112964567

#### PR validation:

Running a workflow like e.g.: `34634.0` **without** having a valid proxy certificate (or using `--ibeos` option), one gets now:

```
----- Begin Fatal Exception 23-Mar-2026 19:52:45 CET-----------------------
An exception of category 'NoSecondaryFiles' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing module: class=MixingModule label='mix'
Exception Message:
RootEmbeddedFileSequence no input files specified for secondary input source.
----- End Fatal Exception -------------------------------------------------
```

instead of the segfault reported in the issue.  

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A