### PR TITLE
Phase2-hgx365X Allow creation of scintillator SimHits in the V19 version of the HGCal geometry

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -183,6 +183,10 @@ public:
     return ((mode_ == HGCalGeometryMode::TrapezoidFile) || (mode_ == HGCalGeometryMode::TrapezoidModule) ||
             (mode_ == HGCalGeometryMode::TrapezoidCassette) || (mode_ == HGCalGeometryMode::TrapezoidFineCell));
   }
+  inline bool trapezoidModule() const {
+    return ((mode_ == HGCalGeometryMode::TrapezoidModule) || (mode_ == HGCalGeometryMode::TrapezoidCassette) ||
+            (mode_ == HGCalGeometryMode::TrapezoidFineCell));
+  }
   inline bool v16OrLess() const { return (mode_ < HGCalGeometryMode::Hexagon8Cassette); }
   inline bool v17OrLess() const { return (mode_ < HGCalGeometryMode::Hexagon8CalibCell); }
   inline bool v18OrLess() const { return (mode_ < HGCalGeometryMode::Hexagon8FineCell); }

--- a/SimG4CMS/Calo/plugins/HGCalTestScintHits.cc
+++ b/SimG4CMS/Calo/plugins/HGCalTestScintHits.cc
@@ -30,7 +30,7 @@
 class HGCalTestScintHits : public edm::one::EDAnalyzer<> {
 public:
   HGCalTestScintHits(const edm::ParameterSet& ps);
-  ~HGCalTestScintHits() override = default;
+  ~HGCalTestScintHits() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
@@ -43,6 +43,7 @@ private:
   const edm::EDGetTokenT<edm::PCaloHitContainer> tok_calo_;
   const edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
   std::vector<int> tiles_;
+  int32_t nEvents_, nHits_;
 };
 
 HGCalTestScintHits::HGCalTestScintHits(const edm::ParameterSet& ps)
@@ -51,7 +52,8 @@ HGCalTestScintHits::HGCalTestScintHits(const edm::ParameterSet& ps)
       nameSense_(ps.getParameter<std::string>("nameSense")),
       tileFileName_(ps.getParameter<std::string>("tileFileName")),
       tok_calo_(consumes<edm::PCaloHitContainer>(edm::InputTag(g4Label_, caloHitSource_))),
-      geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_})) {
+      geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_})),
+      nEvents_(0), nHits_(0) {
   edm::LogVerbatim("HGCalSim") << "Test Hit ID using SimHits for " << nameSense_ << " with module Label: " << g4Label_
                                << "   Hits: " << caloHitSource_ << " Tile file " << tileFileName_;
   if (!tileFileName_.empty()) {
@@ -77,6 +79,10 @@ HGCalTestScintHits::HGCalTestScintHits(const edm::ParameterSet& ps)
   }
 }
 
+HGCalTestScintHits::~HGCalTestScintHits() {
+  edm::LogVerbatim("HGCalSim") << "Reads " << nHits_ << " hits in " << nEvents_ << " events";
+}
+
 void HGCalTestScintHits::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<std::string>("moduleLabel", "g4SimHits");
@@ -87,6 +93,7 @@ void HGCalTestScintHits::fillDescriptions(edm::ConfigurationDescriptions& descri
 }
 
 void HGCalTestScintHits::analyze(const edm::Event& e, const edm::EventSetup& iS) {
+  ++nEvents_;
   // get hcalGeometry
   const HGCalGeometry* geom = &iS.getData(geomToken_);
   const HGCalDDDConstants& hgc = geom->topology().dddConstants();
@@ -103,6 +110,7 @@ void HGCalTestScintHits::analyze(const edm::Event& e, const edm::EventSetup& iS)
     std::vector<PCaloHit> hits;
     hits.insert(hits.end(), hitsCalo->begin(), hitsCalo->end());
     if (!hits.empty()) {
+      ++nHits_;
       // Loop over all hits
       for (auto hit : hits) {
         ++all;

--- a/SimG4CMS/Calo/plugins/HGCalTestScintHits.cc
+++ b/SimG4CMS/Calo/plugins/HGCalTestScintHits.cc
@@ -53,7 +53,8 @@ HGCalTestScintHits::HGCalTestScintHits(const edm::ParameterSet& ps)
       tileFileName_(ps.getParameter<std::string>("tileFileName")),
       tok_calo_(consumes<edm::PCaloHitContainer>(edm::InputTag(g4Label_, caloHitSource_))),
       geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_})),
-      nEvents_(0), nHits_(0) {
+      nEvents_(0),
+      nHits_(0) {
   edm::LogVerbatim("HGCalSim") << "Test Hit ID using SimHits for " << nameSense_ << " with module Label: " << g4Label_
                                << "   Hits: " << caloHitSource_ << " Tile file " << tileFileName_;
   if (!tileFileName_.empty()) {

--- a/SimG4CMS/Calo/src/HGCScintSD.cc
+++ b/SimG4CMS/Calo/src/HGCScintSD.cc
@@ -26,7 +26,7 @@
 #include <iostream>
 #include <memory>
 
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 HGCScintSD::HGCScintSD(const std::string& name,
                        const HGCalDDDConstants* hgc,

--- a/SimG4CMS/Calo/src/HGCScintSD.cc
+++ b/SimG4CMS/Calo/src/HGCScintSD.cc
@@ -26,7 +26,7 @@
 #include <iostream>
 #include <memory>
 
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 
 HGCScintSD::HGCScintSD(const std::string& name,
                        const HGCalDDDConstants* hgc,
@@ -161,7 +161,7 @@ uint32_t HGCScintSD::setDetUnitId(const G4Step* aStep) {
   int iz(globalZ > 0 ? 1 : -1);
 
   int layer(0), module(-1), cell(-1);
-  if ((geom_mode_ == HGCalGeometryMode::TrapezoidModule) || (geom_mode_ == HGCalGeometryMode::TrapezoidCassette)) {
+  if (hgcons_->trapezoidModule()) {
     layer = touch->GetReplicaNumber(1);
   } else if ((touch->GetHistoryDepth() == levelT1_) || (touch->GetHistoryDepth() == levelT2_)) {
     layer = touch->GetReplicaNumber(0);

--- a/SimG4CMS/Calo/test/python/minbiasRun4_cfg.py
+++ b/SimG4CMS/Calo/test/python/minbiasRun4_cfg.py
@@ -61,7 +61,7 @@ process.load('Configuration.StandardSequences.SimIdeal_cff')
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T35', '')
 
 if 'MessageLogger' in process.__dict__:
     process.MessageLogger.G4cerr=dict()

--- a/SimG4CMS/Calo/test/python/runHGC1_cfg.py
+++ b/SimG4CMS/Calo/test/python/runHGC1_cfg.py
@@ -47,7 +47,7 @@ process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.EventContent.EventContent_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T35', '')
 
 if hasattr(process,'MessageLogger'):
     process.MessageLogger.G4cout = dict()

--- a/SimG4CMS/Calo/test/python/runHGC8_cfg.py
+++ b/SimG4CMS/Calo/test/python/runHGC8_cfg.py
@@ -1,8 +1,33 @@
+###############################################################################
+# Way to use this:
+#   cmsRun runHGC8_cfg.py geomName=Run4D120
+#   Options for geomName: Run4D120, Run4D121, Run4D122, Run4D123
+# 
+###############################################################################
 import FWCore.ParameterSet.Config as cms
 import os, sys, importlib, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
-geomName = "Run4D121"
+####################################################################
+### SETUP OPTIONS
+options = VarParsing.VarParsing('standard')
+options.register('geomName',
+                 "Run4D121",
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "geometry of operations: Run4D120, Run4D121, Run4D122, Run4D123")
+
+### get and parse the command line arguments
+ 
+options.parseArguments()
+print(options)
+
+####################################################################
+geomName = options.geomName
+import FWCore.ParameterSet.Config as cms
+import os, sys, importlib, re
+import FWCore.ParameterSet.VarParsing as VarParsing
+
 geomFile = "Configuration.Geometry.GeometryExtended" + geomName + "Reco_cff"
 import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
 GLOBAL_TAG, ERA = _settings.get_era_and_conditions(geomName)


### PR DESCRIPTION
#### PR description:

Allow creation of scintillator SimHits in the V19 version of the HGCal geometry

#### PR validation:

Tested using scripts in SimG4CMS/Calo/test/python

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special