### PR TITLE
Made BaseEvtVtxGenerator a template to allow edm::stream::Watch*

### DIFF
--- a/IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h
@@ -22,11 +22,12 @@ namespace edm {
   class HepMC3Product;
 }  // namespace edm
 
-class BaseEvtVtxGenerator : public edm::stream::EDProducer<> {
+template <typename... T>
+class BaseEvtVtxGeneratorT : public edm::stream::EDProducer<T...> {
 public:
   // ctor & dtor
-  explicit BaseEvtVtxGenerator(const edm::ParameterSet&);
-  ~BaseEvtVtxGenerator() override;
+  explicit BaseEvtVtxGeneratorT(const edm::ParameterSet&);
+  ~BaseEvtVtxGeneratorT() override;
 
   void produce(edm::Event&, const edm::EventSetup&) override;
 
@@ -38,5 +39,8 @@ private:
   edm::EDGetTokenT<edm::HepMCProduct> sourceToken;
   edm::EDGetTokenT<edm::HepMC3Product> sourceToken3;
 };
+
+using BaseEvtVtxGenerator = BaseEvtVtxGeneratorT<>;
+using BaseEvtVtxGeneratorWithLumi = BaseEvtVtxGeneratorT<edm::stream::WatchLuminosityBlocks>;
 
 #endif

--- a/IOMC/EventVertexGenerators/interface/BetafuncEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BetafuncEvtVtxGenerator.h
@@ -29,7 +29,7 @@ namespace CLHEP {
   class HepRandomEngine;
 }
 
-class BetafuncEvtVtxGenerator : public BaseEvtVtxGenerator {
+class BetafuncEvtVtxGenerator : public BaseEvtVtxGeneratorWithLumi {
 public:
   BetafuncEvtVtxGenerator(const edm::ParameterSet& p);
   /** Copy constructor */

--- a/IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h
@@ -18,7 +18,7 @@ namespace CLHEP {
   class HepRandomEngine;
 }
 
-class GaussEvtVtxGenerator : public BaseEvtVtxGenerator {
+class GaussEvtVtxGenerator : public BaseEvtVtxGeneratorWithLumi {
 public:
   GaussEvtVtxGenerator(const edm::ParameterSet& p);
   /** Copy constructor */

--- a/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
@@ -27,7 +27,7 @@ namespace edm {
   class ConfigurationDescriptions;
 }
 
-class HLLHCEvtVtxGenerator : public BaseEvtVtxGenerator {
+class HLLHCEvtVtxGenerator : public BaseEvtVtxGeneratorWithLumi {
 public:
   HLLHCEvtVtxGenerator(const edm::ParameterSet& p);
 

--- a/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BaseEvtVtxGenerator.cc
@@ -20,7 +20,8 @@
 using namespace edm;
 using namespace CLHEP;
 
-BaseEvtVtxGenerator::BaseEvtVtxGenerator(const ParameterSet& pset) {
+template <typename... T>
+BaseEvtVtxGeneratorT<T...>::BaseEvtVtxGeneratorT(const ParameterSet& pset) {
   Service<RandomNumberGenerator> rng;
   if (!rng.isAvailable()) {
     throw cms::Exception("Configuration") << "The BaseEvtVtxGenerator requires the RandomNumberGeneratorService\n"
@@ -29,15 +30,17 @@ BaseEvtVtxGenerator::BaseEvtVtxGenerator(const ParameterSet& pset) {
                                              "in the configuration file or remove the modules that require it.";
   }
 
-  sourceToken3 = consumes<edm::HepMC3Product>(pset.getParameter<edm::InputTag>("src"));
-  sourceToken = consumes<edm::HepMCProduct>(pset.getParameter<edm::InputTag>("src"));
-  produces<edm::HepMC3Product>();
-  produces<edm::HepMCProduct>();
+  sourceToken3 = this->template consumes<edm::HepMC3Product>(pset.getParameter<edm::InputTag>("src"));
+  sourceToken = this->template consumes<edm::HepMCProduct>(pset.getParameter<edm::InputTag>("src"));
+  this->template produces<edm::HepMC3Product>();
+  this->template produces<edm::HepMCProduct>();
 }
 
-BaseEvtVtxGenerator::~BaseEvtVtxGenerator() {}
+template <typename... T>
+BaseEvtVtxGeneratorT<T...>::~BaseEvtVtxGeneratorT() {}
 
-void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
+template <typename... T>
+void BaseEvtVtxGeneratorT<T...>::produce(Event& evt, const EventSetup&) {
   edm::Service<edm::RandomNumberGenerator> rng;
   CLHEP::HepRandomEngine* engine = &rng->getEngine(evt.streamID());
 
@@ -96,3 +99,6 @@ void BaseEvtVtxGenerator::produce(Event& evt, const EventSetup&) {
 
   return;
 }
+
+template class BaseEvtVtxGeneratorT<>;
+template class BaseEvtVtxGeneratorT<edm::stream::WatchLuminosityBlocks>;

--- a/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
@@ -29,7 +29,8 @@ using CLHEP::cm;
 using CLHEP::ns;
 using CLHEP::radian;
 
-BetafuncEvtVtxGenerator::BetafuncEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVtxGenerator(p), boost_(4, 4) {
+BetafuncEvtVtxGenerator::BetafuncEvtVtxGenerator(const edm::ParameterSet& p)
+    : BaseEvtVtxGeneratorWithLumi(p), boost_(4, 4) {
   readDB_ = p.getParameter<bool>("readDB");
   if (!readDB_) {
     fX0 = p.getParameter<double>("X0") * cm;

--- a/IOMC/EventVertexGenerators/src/GaussEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/GaussEvtVtxGenerator.cc
@@ -9,7 +9,7 @@
 using CLHEP::cm;
 using CLHEP::ns;
 
-GaussEvtVtxGenerator::GaussEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVtxGenerator(p) {
+GaussEvtVtxGenerator::GaussEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVtxGeneratorWithLumi(p) {
   readDB_ = p.getParameter<bool>("readDB");
   if (!readDB_) {
     fMeanX = p.getParameter<double>("MeanX") * cm;

--- a/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
@@ -46,7 +46,7 @@ void HLLHCEvtVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions& desc
   descriptions.add("HLLHCEvtVtxGenerator", desc);
 }
 
-HLLHCEvtVtxGenerator::HLLHCEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVtxGenerator(p) {
+HLLHCEvtVtxGenerator::HLLHCEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVtxGeneratorWithLumi(p) {
   readDB_ = p.getParameter<bool>("readDB");
   if (!readDB_) {
     // Read configurable parameters


### PR DESCRIPTION
#### PR description:

Only some of the classes inheriting from BaseEvtVtxGenerator need to watch LuminosityBlocks. Switching to a template allows both types to use the same base code.

#### PR validation:

resolves https://github.com/cms-sw/framework-team/issues/2080