### PR TITLE
[GCC15] Added missing header for std::variant

### DIFF
--- a/RecoTracker/DeDx/interface/DeDxTools.h
+++ b/RecoTracker/DeDx/interface/DeDxTools.h
@@ -2,7 +2,7 @@
 #define DeDxTools_H
 
 #include <vector>
-
+#include <variant>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"


### PR DESCRIPTION
This PR fixes the GCC15 build errors [a] which due to missing `variant` include

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el10_amd64_gcc15/CMSSW_16_1_X_2026-03-24-2300/RecoTracker/DeDx
```
In file included from src/RecoTracker/DeDx/src/DeDxTools.cc:4:
  [src/RecoTracker/DeDx/interface/DeDxTools.h:54](https://github.com/cms-sw/cmssw/blob/CMSSW_16_1_X_2026-03-24-2300/RecoTracker/DeDx/interface/DeDxTools.h#L54):38: error: 'variant' in namespace 'std' does not name a template type
    54 |   using ESGetTokenH3DDVariant = std::variant<edm::ESGetToken<H3DD, SiStripDeDxMip_3D_Rcd>,
      |                                      ^~~~~~~
src/RecoTracker/DeDx/interface/DeDxTools.h:40:1: note: 'std::variant' is defined in header '<variant>'; this is probably fixable by adding '#include <variant>'
   39 | #include "TH3F.h"
  +++ |+#include <variant>
```
