### PR TITLE
[AllocMonitorPlugin][GCC15] Link stdc++exp for gcc14 abd above

### DIFF
--- a/PerfTools/AllocMonitor/plugins/BuildFile.xml
+++ b/PerfTools/AllocMonitor/plugins/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities" source_only="1"/>
 <use name="PerfTools/AllocMonitor"/>
-<!-- Needed by monitors that use std::stacktrace, presently available only in CPP23 builds -->
-<ifrelease name="CPP23">
+<!-- Needed by monitors that use std::stacktrace, presently available only in GCC14 and above builds -->
+<iftool name="gcc-cxxcompiler" version="^1[4-9]">
   <lib name="stdc++exp"/>
-</ifrelease>
+</iftool>


### PR DESCRIPTION
This fixes the link issue [a] we get in GCC 15 IB. GCC 15 IBs are built with c++23 and this PR suggets to explicitly link stdc++exp for GCC 14 and above. `CPP23_X`  IBs built for `GCC14` to this change should work for `CPP23_X` IBs too


[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc15/CMSSW_16_1_X_2026-03-24-2300/PerfTools/AllocMonitor
```
  <artificial>:(.text+0x90f): undefined reference to `std::__stacktrace_impl::_S_current(int (*)(void*, unsigned long), void*, int)'
 /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-c6197a2919ecf1f2d0282333cd56ba08/x86_64-vendor-linux/bin/ld.bfd: tmp/el9_amd64_gcc15/src/PerfTools/AllocMonitor/plugins/PerfToolsAllocMonitorAuto/scram_x86-64-v2/ccUCSFWx.ltrans2.ltrans.o: in function `std::basic_stacktrace<std::allocator<std::stacktrace_entry> >::current(unsigned short, std::allocator<std::stacktrace_entry> const&) [clone .constprop.0]':
  <artificial>:(.text+0x9a2): undefined reference to `std::__stacktrace_impl::_S_current(int (*)(void*, unsigned long), void*, int)'
 /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-c6197a2919ecf1f2d0282333cd56ba08/x86_64-vendor-linux/bin/ld.bfd: tmp/el9_amd64_gcc15/src/PerfTools/AllocMonitor/plugins/PerfToolsAllocMonitorAuto/scram_x86-64-v2/ccUCSFWx.ltrans2.ltrans.o: in function `(anonymous namespace)::MonitorAdaptor::startOnThread(std::basic_string_view<char, std::char_traits<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool)':
  <artificial>:(.text+0x2c6b): undefined reference to `std::stacktrace_entry::_Info::_M_populate(unsigned long)'
   /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-c6197a2919ecf1f2d0282333cd56ba08/x86_64-vendor-linux/bin/ld.bfd: <artificial>:(.text+0x2d87): undefined reference to `std::stacktrace_entry::_Info::_M_populate(unsigned long)'
   /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc15/external/gcc/15.2.1-c6197a2919ecf1f2d0282333cd56ba08/x86_64-vendor-linux/bin/ld.bfd: <artificial>:(.text+0x2e80): undefined reference to `std::stacktrace_entry::_Info::_M_populate(unsigned long)'
```