### PR TITLE
Tight TOBTEC iteration cuts for heavy-ions

### DIFF
--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -423,7 +423,7 @@ trackdnn.toReplaceWith(tobTecStep, trackTfClassifier.clone(
 ))
 (trackdnn & fastSim).toModify(tobTecStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
-pp_on_AA.toModify(tobTecStep, qualityCuts = [-0.6,-0.3,0.7])
+pp_on_AA.toModify(tobTecStep, qualityCuts = [0.7,0.8,0.96])
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 trackingLowPU.toReplaceWith(tobTecStep, RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(


### PR DESCRIPTION
#### PR description:
Dear All,
We tighten the cuts for the TOBTEC tracking iteration for heavy ion eras. 
The reason is to reduce fake tracks at high-pT. In slide 30, we show that with the new cuts we could reduced fake tracks (and multiple reconstruction) considerably, while maintaining the same efficiency. The performance is for high-purity working point. 
https://indico.cern.ch/event/1662429/contributions/6989327/attachments/3236989/5787095/slides_report_tracking_25022026_v2.pdf
Thank you!

#### PR validation:

Tested with wf 163

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport will be needed.

@mandrenguyen @icali @sayanchatterjee38 @RAGHUMATAPITA