### PR TITLE
Added edm::stream::Watch* to RecoParticleFlow modules

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -10,7 +10,7 @@
 #include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 #include <memory>
 
-class PFClusterProducer : public edm::stream::EDProducer<> {
+class PFClusterProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
   typedef RecHitTopologicalCleanerBase RHCB;
   typedef InitialClusteringStepBase ICSB;
   typedef PFClusterBuilderBase PFCBB;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeSelector.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeSelector.cc
@@ -17,8 +17,6 @@ public:
   explicit PFClusterTimeSelector(const edm::ParameterSet&);
   ~PFClusterTimeSelector() override;
 
-  void beginRun(const edm::Run& run, const edm::EventSetup& es) override;
-
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -214,6 +212,3 @@ void PFClusterTimeSelector::produce(edm::Event& iEvent, const edm::EventSetup& i
 }
 
 PFClusterTimeSelector::~PFClusterTimeSelector() = default;
-
-// ------------ method called once each job just before starting event loop  ------------
-void PFClusterTimeSelector::beginRun(const edm::Run& run, const EventSetup& es) {}

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-class PFMultiDepthClusterProducer : public edm::stream::EDProducer<> {
+class PFMultiDepthClusterProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
   typedef InitialClusteringStepBase ICSB;
   typedef PFClusterBuilderBase PFCBB;
   typedef PFCPositionCalculatorBase PosCalc;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
@@ -13,7 +13,7 @@
 // class declaration
 //
 
-class PFRecHitProducer final : public edm::stream::EDProducer<> {
+class PFRecHitProducer final : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   explicit PFRecHitProducer(const edm::ParameterSet& iConfig);
   ~PFRecHitProducer() override;

--- a/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.cc
@@ -18,7 +18,7 @@ flow blocks This is done at a later stage, see PFProducer and PFAlgo.
 
 class FSimEvent;
 
-class PFBlockProducer : public edm::stream::EDProducer<> {
+class PFBlockProducer : public edm::stream::EDProducer<edm::stream::WatchLuminosityBlocks> {
 public:
   explicit PFBlockProducer(const edm::ParameterSet&);
 

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
@@ -34,7 +34,7 @@ This producer makes use of PFAlgo, the particle flow algorithm.
 \date   July 2006
 */
 
-class PFProducer : public edm::stream::EDProducer<> {
+class PFProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   explicit PFProducer(const edm::ParameterSet&);
 

--- a/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
@@ -17,7 +17,7 @@
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
-class LegacyPFRecHitProducer : public edm::stream::EDProducer<> {
+class LegacyPFRecHitProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   LegacyPFRecHitProducer(edm::ParameterSet const& config)
       : alpakaPfRecHitsToken_(consumes(config.getParameter<edm::InputTag>("src"))),

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
@@ -51,7 +51,7 @@
 
 #include <memory>
 
-class ConvBremSeedProducer : public edm::stream::EDProducer<> {
+class ConvBremSeedProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   explicit ConvBremSeedProducer(const edm::ParameterSet&);
 
@@ -88,8 +88,8 @@ private:
   const TrackerGeometry* tracker_;
   const MagneticField* magfield_;
   const MagneticFieldMap* fieldMap_;
-  const PropagatorWithMaterial* propagator_;
-  const KFUpdator* kfUpdator_;
+  std::unique_ptr<const PropagatorWithMaterial> propagator_;
+  std::unique_ptr<const KFUpdator> kfUpdator_;
   const TransientTrackingRecHitBuilder* hitBuilder_;
   std::vector<const DetLayer*> layerMap_;
   int negLayerOffset_;
@@ -434,13 +434,13 @@ void ConvBremSeedProducer::beginRun(const edm::Run& run, const EventSetup& iSetu
 
   hitBuilder_ = &iSetup.getData(hitBuilderToken_);
 
-  propagator_ = new PropagatorWithMaterial(alongMomentum, 0.0005, magfield_);
-  kfUpdator_ = new KFUpdator();
+  propagator_ = std::make_unique<PropagatorWithMaterial>(alongMomentum, 0.0005, magfield_);
+  kfUpdator_ = std::make_unique<KFUpdator>();
 }
 
 void ConvBremSeedProducer::endRun(const edm::Run& run, const EventSetup& iSetup) {
-  delete propagator_;
-  delete kfUpdator_;
+  propagator_.reset();
+  kfUpdator_.reset();
 }
 
 void ConvBremSeedProducer::initializeLayerMap() {

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -65,7 +65,8 @@ namespace goodseedhelpers {
   };
 }  // namespace goodseedhelpers
 
-class GoodSeedProducer final : public edm::stream::EDProducer<edm::GlobalCache<goodseedhelpers::HeavyObjectCache>> {
+class GoodSeedProducer final
+    : public edm::stream::EDProducer<edm::GlobalCache<goodseedhelpers::HeavyObjectCache>, edm::stream::WatchRuns> {
   typedef TrajectoryStateOnSurface TSOS;
 
 public:

--- a/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/HGCalTrackCollectionProducer.cc
@@ -36,7 +36,7 @@
 #include <memory>
 #include <unordered_map>
 
-class HGCalTrackCollectionProducer : public edm::stream::EDProducer<> {
+class HGCalTrackCollectionProducer : public edm::stream::EDProducer<edm::stream::WatchLuminosityBlocks> {
 public:
   HGCalTrackCollectionProducer(const edm::ParameterSet&);
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);

--- a/RecoParticleFlow/PFTracking/plugins/LightPFTrackProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/LightPFTrackProducer.cc
@@ -11,13 +11,12 @@
 #include "RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 
-class LightPFTrackProducer : public edm::stream::EDProducer<> {
+#include <memory>
+
+class LightPFTrackProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   ///Constructor
   explicit LightPFTrackProducer(const edm::ParameterSet&);
-
-  ///Destructor
-  ~LightPFTrackProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -29,7 +28,7 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   ///PFTrackTransformer
-  PFTrackTransformer* pfTransformer_;
+  std::unique_ptr<PFTrackTransformer> pfTransformer_;
   std::vector<edm::EDGetTokenT<reco::TrackCollection>> tracksContainers_;
 
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
@@ -65,8 +64,6 @@ LightPFTrackProducer::LightPFTrackProducer(const ParameterSet& iConfig)
   trackQuality_ = reco::TrackBase::qualityByName(iConfig.getParameter<std::string>("TrackQuality"));
 }
 
-LightPFTrackProducer::~LightPFTrackProducer() { delete pfTransformer_; }
-
 void LightPFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   //create the empty collections
   auto PfTrColl = std::make_unique<reco::PFRecTrackCollection>();
@@ -94,12 +91,9 @@ void LightPFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup) {
 // ------------ method called once each job just before starting event loop  ------------
 void LightPFTrackProducer::beginRun(const edm::Run& run, const EventSetup& iSetup) {
   auto const& magneticField = &iSetup.getData(magneticFieldToken_);
-  pfTransformer_ = new PFTrackTransformer(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
+  pfTransformer_ = std::make_unique<PFTrackTransformer>(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
   pfTransformer_->OnlyProp();
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void LightPFTrackProducer::endRun(const edm::Run& run, const EventSetup& iSetup) {
-  delete pfTransformer_;
-  pfTransformer_ = nullptr;
-}
+void LightPFTrackProducer::endRun(const edm::Run& run, const EventSetup& iSetup) { pfTransformer_.reset(); }

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
@@ -14,13 +14,10 @@
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
-class PFConversionProducer : public edm::stream::EDProducer<> {
+class PFConversionProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   ///Constructor
   explicit PFConversionProducer(const edm::ParameterSet&);
-
-  ///Destructor
-  ~PFConversionProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -32,7 +29,7 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   ///PFTrackTransformer
-  PFTrackTransformer* pfTransformer_;
+  std::unique_ptr<PFTrackTransformer> pfTransformer_;
   edm::EDGetTokenT<reco::ConversionCollection> pfConversionContainer_;
   edm::EDGetTokenT<reco::VertexCollection> vtx_h;
 
@@ -65,8 +62,6 @@ PFConversionProducer::PFConversionProducer(const ParameterSet& iConfig)
 
   vtx_h = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("PrimaryVertexLabel"));
 }
-
-PFConversionProducer::~PFConversionProducer() { delete pfTransformer_; }
 
 void PFConversionProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   //create the empty collections
@@ -205,12 +200,9 @@ void PFConversionProducer::produce(Event& iEvent, const EventSetup& iSetup) {
 // ------------ method called once each job just before starting event loop  ------------
 void PFConversionProducer::beginRun(const edm::Run& run, const EventSetup& iSetup) {
   auto const& magneticField = &iSetup.getData(magneticFieldToken_);
-  pfTransformer_ = new PFTrackTransformer(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
+  pfTransformer_ = std::make_unique<PFTrackTransformer>(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
   pfTransformer_->OnlyProp();
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void PFConversionProducer::endRun(const edm::Run& run, const EventSetup& iSetup) {
-  delete pfTransformer_;
-  pfTransformer_ = nullptr;
-}
+void PFConversionProducer::endRun(const edm::Run& run, const EventSetup& iSetup) { pfTransformer_.reset(); }

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.cc
@@ -8,13 +8,11 @@
 #include "RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 
-class PFDisplacedTrackerVertexProducer : public edm::stream::EDProducer<> {
+#include <memory>
+class PFDisplacedTrackerVertexProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   ///Constructor
   explicit PFDisplacedTrackerVertexProducer(const edm::ParameterSet&);
-
-  ///Destructor
-  ~PFDisplacedTrackerVertexProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -26,7 +24,7 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   ///PFTrackTransformer
-  PFTrackTransformer* pfTransformer_;
+  std::unique_ptr<PFTrackTransformer> pfTransformer_;
   edm::EDGetTokenT<reco::PFDisplacedVertexCollection> pfDisplacedVertexContainer_;
   edm::EDGetTokenT<reco::TrackCollection> pfTrackContainer_;
 
@@ -46,7 +44,7 @@ void PFDisplacedTrackerVertexProducer::fillDescriptions(edm::ConfigurationDescri
 using namespace std;
 using namespace edm;
 PFDisplacedTrackerVertexProducer::PFDisplacedTrackerVertexProducer(const ParameterSet& iConfig)
-    : pfTransformer_(nullptr), magneticFieldToken_(esConsumes<edm::Transition::BeginRun>()) {
+    : pfTransformer_(), magneticFieldToken_(esConsumes<edm::Transition::BeginRun>()) {
   produces<reco::PFRecTrackCollection>();
   produces<reco::PFDisplacedTrackerVertexCollection>();
 
@@ -55,8 +53,6 @@ PFDisplacedTrackerVertexProducer::PFDisplacedTrackerVertexProducer(const Paramet
 
   pfTrackContainer_ = consumes<reco::TrackCollection>(iConfig.getParameter<InputTag>("trackColl"));
 }
-
-PFDisplacedTrackerVertexProducer::~PFDisplacedTrackerVertexProducer() { delete pfTransformer_; }
 
 void PFDisplacedTrackerVertexProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   //create the empty collections
@@ -116,12 +112,9 @@ void PFDisplacedTrackerVertexProducer::produce(Event& iEvent, const EventSetup& 
 // ------------ method called once each job just before starting event loop  ------------
 void PFDisplacedTrackerVertexProducer::beginRun(const edm::Run& run, const EventSetup& iSetup) {
   auto const& magneticField = &iSetup.getData(magneticFieldToken_);
-  pfTransformer_ = new PFTrackTransformer(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
+  pfTransformer_ = std::make_unique<PFTrackTransformer>(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
   pfTransformer_->OnlyProp();
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void PFDisplacedTrackerVertexProducer::endRun(const edm::Run& run, const EventSetup& iSetup) {
-  delete pfTransformer_;
-  pfTransformer_ = nullptr;
-}
+void PFDisplacedTrackerVertexProducer::endRun(const edm::Run& run, const EventSetup& iSetup) { pfTransformer_.reset(); }

--- a/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFElecTkProducer.cc
@@ -59,7 +59,8 @@ namespace {
 
 }  // namespace
 
-class PFElecTkProducer final : public edm::stream::EDProducer<edm::GlobalCache<convbremhelpers::HeavyObjectCache> > {
+class PFElecTkProducer final
+    : public edm::stream::EDProducer<edm::GlobalCache<convbremhelpers::HeavyObjectCache>, edm::stream::WatchRuns> {
 public:
   ///Constructor
   explicit PFElecTkProducer(const edm::ParameterSet&, const convbremhelpers::HeavyObjectCache*);

--- a/RecoParticleFlow/PFTracking/plugins/PFNuclearProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFNuclearProducer.cc
@@ -8,13 +8,12 @@
 #include "RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 
-class PFNuclearProducer : public edm::stream::EDProducer<> {
+#include <memory>
+
+class PFNuclearProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   ///Constructor
   explicit PFNuclearProducer(const edm::ParameterSet&);
-
-  ///Destructor
-  ~PFNuclearProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -26,7 +25,7 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   ///PFTrackTransformer
-  PFTrackTransformer* pfTransformer_;
+  std::unique_ptr<PFTrackTransformer> pfTransformer_;
   double likelihoodCut_;
   std::vector<edm::EDGetTokenT<reco::NuclearInteractionCollection>> nuclearContainers_;
 
@@ -58,8 +57,6 @@ PFNuclearProducer::PFNuclearProducer(const ParameterSet& iConfig)
 
   likelihoodCut_ = iConfig.getParameter<double>("likelihoodCut");
 }
-
-PFNuclearProducer::~PFNuclearProducer() { delete pfTransformer_; }
 
 void PFNuclearProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   typedef reco::NuclearInteraction::trackRef_iterator trackRef_iterator;
@@ -107,12 +104,9 @@ void PFNuclearProducer::produce(Event& iEvent, const EventSetup& iSetup) {
 // ------------ method called once each job just before starting event loop  ------------
 void PFNuclearProducer::beginRun(const edm::Run& run, const EventSetup& iSetup) {
   auto const& magneticField = &iSetup.getData(magneticFieldToken_);
-  pfTransformer_ = new PFTrackTransformer(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
+  pfTransformer_ = std::make_unique<PFTrackTransformer>(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
   pfTransformer_->OnlyProp();
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void PFNuclearProducer::endRun(const edm::Run& run, const EventSetup& iSetup) {
-  delete pfTransformer_;
-  pfTransformer_ = nullptr;
-}
+void PFNuclearProducer::endRun(const edm::Run& run, const EventSetup& iSetup) { pfTransformer_.reset(); }

--- a/RecoParticleFlow/PFTracking/plugins/PFTrackProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFTrackProducer.cc
@@ -25,7 +25,7 @@
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
-class PFTrackProducer : public edm::stream::EDProducer<> {
+class PFTrackProducer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   ///Constructor
   explicit PFTrackProducer(const edm::ParameterSet&);

--- a/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
@@ -10,7 +10,8 @@
 #include "RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 
-class PFV0Producer : public edm::stream::EDProducer<> {
+#include <memory>
+class PFV0Producer : public edm::stream::EDProducer<edm::stream::WatchRuns> {
 public:
   ///Constructor
   explicit PFV0Producer(const edm::ParameterSet&);
@@ -28,7 +29,7 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   ///PFTrackTransformer
-  PFTrackTransformer* pfTransformer_;
+  std::unique_ptr<PFTrackTransformer> pfTransformer_;
   std::vector<edm::EDGetTokenT<reco::VertexCompositeCandidateCollection>> V0list_;
 
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
@@ -48,7 +49,7 @@ using namespace std;
 using namespace edm;
 using namespace reco;
 PFV0Producer::PFV0Producer(const ParameterSet& iConfig)
-    : pfTransformer_(nullptr), magneticFieldToken_(esConsumes<edm::Transition::BeginRun>()) {
+    : pfTransformer_(), magneticFieldToken_(esConsumes<edm::Transition::BeginRun>()) {
   produces<reco::PFV0Collection>();
   produces<reco::PFRecTrackCollection>();
 
@@ -58,7 +59,7 @@ PFV0Producer::PFV0Producer(const ParameterSet& iConfig)
     V0list_.push_back(consumes<reco::VertexCompositeCandidateCollection>(tags[i]));
 }
 
-PFV0Producer::~PFV0Producer() { delete pfTransformer_; }
+PFV0Producer::~PFV0Producer() {}
 
 void PFV0Producer::produce(Event& iEvent, const EventSetup& iSetup) {
   LogDebug("PFV0Producer") << "START event: " << iEvent.id().event() << " in run " << iEvent.id().run();
@@ -104,12 +105,9 @@ void PFV0Producer::produce(Event& iEvent, const EventSetup& iSetup) {
 // ------------ method called once each job just before starting event loop  ------------
 void PFV0Producer::beginRun(const edm::Run& run, const EventSetup& iSetup) {
   auto const& magneticField = &iSetup.getData(magneticFieldToken_);
-  pfTransformer_ = new PFTrackTransformer(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
+  pfTransformer_ = std::make_unique<PFTrackTransformer>(math::XYZVector(magneticField->inTesla(GlobalPoint(0, 0, 0))));
   pfTransformer_->OnlyProp();
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void PFV0Producer::endRun(const edm::Run& run, const EventSetup& iSetup) {
-  delete pfTransformer_;
-  pfTransformer_ = nullptr;
-}
+void PFV0Producer::endRun(const edm::Run& run, const EventSetup& iSetup) { pfTransformer_.reset(); }


### PR DESCRIPTION
#### PR description:

This is part of a campaign to add the attributes to modules which need them.

Also took the opportunity to switch to std::unique_ptr for memory management.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2093