### PR TITLE
[GEM][Backport] Introducing GE21 rechit container for Run 3

### DIFF
--- a/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
@@ -42,7 +42,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
 process.muonGEMDigis.useDBEMap = True
 process.muonGEMDigis.keepDAQStatus = True
 
-process.gemRecHits.ge21Off = cms.bool(False)
+process.gemRecHits.ge21Container = cms.bool(False)
 
 process.GEMDigiSource.runType = "online"
 process.GEMRecHitSource.runType = "online"

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -199,6 +199,14 @@ def customizeHLTfor49436(process):
 
     return process
 
+def customizeHLTfor49476(process):
+
+    for prod in producers_by_type(process, "GEMRecHitProducer"):
+        if hasattr(prod,"ge21Off") : delattr(prod,"ge21Off")
+        prod.ge21Container = cms.bool( True )
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -207,5 +215,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # process = customiseFor12718(process)
 
     # process = customizeHLTfor49436(process)
+    process = customizeHLTfor49476(process)
 
     return process

--- a/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitProducer.cc
+++ b/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitProducer.cc
@@ -29,8 +29,12 @@ GEMRecHitProducer::GEMRecHitProducer(const ParameterSet& config)
       gemGeomToken_(esConsumes<GEMGeometry, MuonGeometryRecord, edm::Transition::BeginRun>()) {
   produces<GEMRecHitCollection>();
 
-  // Turns off GE2/1 demonstrator reconstruction in Run3
-  ge21Off_ = config.getParameter<bool>("ge21Off");
+  // GE2/1 rec hits are saved in a separate container in Run 3
+  // So they are dropped off from the muon reconstruction
+  ge21Container_ = config.getParameter<bool>("ge21Container");
+  if (ge21Container_)
+    produces<GEMRecHitCollection>("GE21");
+
   // Get masked- and dead-strip information from file
   applyMasking_ = config.getParameter<bool>("applyMasking");
   if (applyMasking_) {
@@ -83,7 +87,7 @@ void GEMRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<std::string>("recAlgo", "GEMRecHitStandardAlgo");
   desc.add<edm::InputTag>("gemDigiLabel", edm::InputTag("muonGEMDigis"));
   desc.add<bool>("applyMasking", false);
-  desc.add<bool>("ge21Off", false);
+  desc.add<bool>("ge21Container", false);
   desc.addOptional<edm::FileInPath>("maskFile");
   desc.addOptional<edm::FileInPath>("deadFile");
   descriptions.add("gemRecHitsDef", desc);
@@ -108,9 +112,6 @@ void GEMRecHitProducer::beginRun(const edm::Run& r, const edm::EventSetup& setup
     for (auto gems : gemGeom_->etaPartitions()) {
       // Getting the EtaPartitionMask mask, that includes dead strips, for the given GEMDet
       GEMDetId gemId = gems->id();
-      if (ge21Off_ && gemId.station() == 2) {
-        continue;
-      }
       EtaPartitionMask mask;
       const int rawId = gemId.rawId();
       for (const auto& tomask : theGEMMaskedStripsObj->getMaskVec()) {
@@ -143,14 +144,15 @@ void GEMRecHitProducer::produce(Event& event, const EventSetup& setup) {
 
   // Create the pointer to the collection which will store the rechits
   auto recHitCollection = std::make_unique<GEMRecHitCollection>();
+  unique_ptr<GEMRecHitCollection> recHitCollection_ge21;
+
+  if (ge21Container_)
+    recHitCollection_ge21 = std::make_unique<GEMRecHitCollection>();
 
   // Iterate through all digi collections ordered by LayerId
   for (auto gemdgIt = digis->begin(); gemdgIt != digis->end(); ++gemdgIt) {
     // The layerId
     const GEMDetId& gemId = (*gemdgIt).first;
-    if (ge21Off_ && gemId.station() == 2) {
-      continue;
-    }
 
     // Get the GeomDet from the setup
     const GEMEtaPartition* roll = gemGeom_->etaPartition(gemId);
@@ -173,9 +175,14 @@ void GEMRecHitProducer::produce(Event& event, const EventSetup& setup) {
     // Call the reconstruction algorithm
     OwnVector<GEMRecHit> recHits = theAlgo->reconstruct(*roll, gemId, range, mask);
 
-    if (!recHits.empty())  //FIXME: is it really needed?
+    if (ge21Container_ && gemId.station() == 2) {
+      recHitCollection_ge21->put(gemId, recHits.begin(), recHits.end());
+    } else {
       recHitCollection->put(gemId, recHits.begin(), recHits.end());
+    }
   }
 
-  event.put(std::move(recHitCollection));
+  event.put(std::move(recHitCollection), "");
+  if (ge21Container_)
+    event.put(std::move(recHitCollection_ge21), "GE21");
 }

--- a/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitProducer.h
+++ b/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitProducer.h
@@ -65,6 +65,6 @@ private:
   std::map<GEMDetId, EtaPartitionMask> gemMask_;
 
   bool applyMasking_;
-  bool ge21Off_;
+  bool ge21Container_;
 };
 #endif

--- a/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
+++ b/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
@@ -15,6 +15,6 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_run3_GEM_2025_cff import run3_GEM_2025
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
-run3_GEM.toModify(gemRecHits, ge21Off=True, applyMasking=False)
-run3_GEM_2025.toModify(gemRecHits, ge21Off=True, applyMasking=True)
-phase2_GEM.toModify(gemRecHits, ge21Off=False, applyMasking=False)
+run3_GEM.toModify(gemRecHits, ge21Container=True, applyMasking=False)
+run3_GEM_2025.toModify(gemRecHits, ge21Container=True, applyMasking=True)
+phase2_GEM.toModify(gemRecHits, ge21Container=False, applyMasking=False)


### PR DESCRIPTION
#### PR description:

* This PR enables saving the GEMRecHits from GE21 chambers, which are installed for testing purposes.
Currently, we are not saving them because of the possibility of interruption in the muon reconstruction performance.
However, several groups studying GE21 performance continue to ask if we can save them.
For this reason, GEM DPG decides to save them in a separate rechit container, which does not propagate to the muon reco system.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

* The original PR for the master is #49476 and #50556
* The backport is needed for using the feature during the 2026 data taking