### PR TITLE
[16.0.X] Fixing preallocated histogram binning for lowPU

### DIFF
--- a/DQMOffline/Lumi/python/ZCounting_cfi.py
+++ b/DQMOffline/Lumi/python/ZCounting_cfi.py
@@ -31,9 +31,9 @@ ZCounting = DQMEDAnalyzer('ZCounting',
                           MassMin=cms.untracked.double(50.0),
                           MassMax=cms.untracked.double(130.0),
 
-                          LumiBin=cms.untracked.int32(2500),
+                          LumiBin=cms.untracked.int32(10000),
                           LumiMin=cms.untracked.double(0.5),
-                          LumiMax=cms.untracked.double(2500.5),
+                          LumiMax=cms.untracked.double(10000.5),
 
                           PVBin=cms.untracked.int32(100),
                           PVMin=cms.untracked.double(0.5),


### PR DESCRIPTION
(cherry picked from commit 35d636c4b9f9ab842d7c578a401c4af89e2087e2)

Backport of https://github.com/cms-sw/cmssw/pull/50475

#### PR description:

Change in the config to increase the number of LS bins in ZCounting histograms for BRIL Lumi module. With the increased duration of Run, especially expected for lowPU running some of the fills record incomplete data. Typical size of histograms is kB per run. Since the processor works with AOD, we propose to change it to avoid rerunning heavy datasets.

#### PR validation:

Tested offline, PR is transparent

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

https://github.com/cms-sw/cmssw/pull/50475
