### PR TITLE
Introduce shared memory check for `multiBlockPrefixScan` kernel launch

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/OneToManyAssoc.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/OneToManyAssoc.h
@@ -262,6 +262,7 @@ namespace cms::alpakatools {
         auto nthreads = 1024;
         auto nblocks = (nOnes + nthreads - 1) / nthreads;
         auto workDiv = cms::alpakatools::make_workdiv<TAcc>(nblocks, nthreads);
+        cms::alpakatools::checkSharedMemoryPrefixScan<TAcc>(nOnes, nblocks, alpaka::getDev(queue));
         alpaka::exec<TAcc>(queue,
                            workDiv,
                            multiBlockPrefixScan<Counter>(),
@@ -279,4 +280,4 @@ namespace cms::alpakatools {
 
 }  // namespace cms::alpakatools
 
-#endif  // HeterogeneousCore_CUDAUtilities_interface_HistoContainer_h
+#endif  //HeterogeneousCore_AlpakaInterface_interface_OneToManyAssoc_h

--- a/HeterogeneousCore/AlpakaInterface/interface/prefixScan.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/prefixScan.h
@@ -133,7 +133,25 @@ namespace cms::alpakatools {
     }
   }
 
-  // in principle not limited....
+  // Throws an exception with a message containing the shared memory requirements and limit.
+  void throwSharedMemoryLimitExceeded(size_t nElements,
+                                      uint32_t nBlocks,
+                                      size_t requiredSharedMem,
+                                      size_t sharedMemLimit);
+
+  // Verify shared memory requirements
+  template <alpaka::concepts::Acc TAcc, typename TSize>
+  ALPAKA_FN_INLINE static void checkSharedMemoryPrefixScan(TSize nElements,
+                                                           uint32_t nBlocks,
+                                                           alpaka::Dev<TAcc> const& device) {
+    auto requiredSharedMem = (nBlocks + alpaka::getPreferredWarpSize(device)) * sizeof(TSize);
+    auto sharedMemLimit = alpaka::getAccDevProps<TAcc>(device).m_sharedMemSizeBytes;
+    if (requiredSharedMem > sharedMemLimit) {
+      throwSharedMemoryLimitExceeded(static_cast<size_t>(nElements), nBlocks, requiredSharedMem, sharedMemLimit);
+    }
+  }
+
+  // in principle not limited.... in practice limited by shared memory size and occupancy.
   template <typename T>
   struct multiBlockPrefixScan {
     template <alpaka::concepts::Acc TAcc>

--- a/HeterogeneousCore/AlpakaInterface/src/prefixScan.cc
+++ b/HeterogeneousCore/AlpakaInterface/src/prefixScan.cc
@@ -1,0 +1,17 @@
+#include <alpaka/alpaka.hpp>
+#include <cstdint>
+
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/prefixScan.h"
+
+namespace cms::alpakatools {
+  void throwSharedMemoryLimitExceeded(const size_t nElements,
+                                      const uint32_t nBlocks,
+                                      const size_t requiredSharedMem,
+                                      const size_t sharedMemLimit) {
+    throw cms::Exception("SharedMemoryLimitExceeded")
+        << "OneToManyAssoc: Shared memory limit exceeded for prefix scan of " << nElements << " elements in " << nBlocks
+        << " blocks. Required shared memory: " << requiredSharedMem << " bytes. Shared memory limit: " << sharedMemLimit
+        << " bytes.";
+  }
+}  // namespace cms::alpakatools

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -624,6 +624,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         auto bCounter = cms::alpakatools::make_device_buffer<int32_t>(queue);
         alpaka::memset(queue, bCounter, 0);
 
+        cms::alpakatools::checkSharedMemoryPrefixScan<Acc1D>(
+            TrackerTraits::numberOfModules, blocksPrefixScan, alpaka::getDev(queue));
         alpaka::exec<Acc1D>(queue,
                             workDivPrefixScan,
                             cms::alpakatools::multiBlockPrefixScan<uint32_t>(),
@@ -734,6 +736,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto bCounter = cms::alpakatools::make_device_buffer<int32_t>(queue);
       alpaka::memset(queue, bCounter, 0);
 
+      cms::alpakatools::checkSharedMemoryPrefixScan<Acc1D>(
+          TrackerTraits::numberOfModules, blocksPrefixScan, alpaka::getDev(queue));
       alpaka::exec<Acc1D>(queue,
                           workDivPrefixScan,
                           cms::alpakatools::multiBlockPrefixScan<uint32_t>(),

--- a/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToClusterAlgo.dev.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToClusterAlgo.dev.cc
@@ -719,13 +719,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::sistrip {
     const auto workDivMultiBlock = make_workdiv<Acc1D>(nBlocks, threads);
     auto blockCounter_d = make_device_buffer<int32_t>(queue);
     alpaka::memset(queue, blockCounter_d, 0);
+
+    cms::alpakatools::checkSharedMemoryPrefixScan<Acc1D>(
+        static_cast<uint32_t>(stripMapping_d_->view().metadata().size()), nBlocks, alpaka::getDev(queue));
     alpaka::exec<Acc1D>(queue,
                         workDivMultiBlock,
                         multiBlockPrefixScan<uint32_t>(),
                         stripMapping_d_->const_view().fedChStripsN().data(),
                         stripMapping_d_->view().fedChStripsN().data(),
-                        (uint32_t)stripMapping_d_->view().metadata().size(),
-                        (int32_t)nBlocks,
+                        static_cast<uint32_t>(stripMapping_d_->view().metadata().size()),
+                        nBlocks,
                         blockCounter_d.data(),
                         alpaka::getPreferredWarpSize(alpaka::getDev(queue)));
 
@@ -801,6 +804,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::sistrip {
     const int32_t nBlocks = divide_up_by(nStrips, nThreads);
     auto blockCounter_d = make_device_buffer<int32_t>(queue);
     alpaka::memset(queue, blockCounter_d, 0);
+
+    cms::alpakatools::checkSharedMemoryPrefixScan<Acc1D>(nStrips, nBlocks, alpaka::getDev(queue));
     alpaka::exec<Acc1D>(queue,
                         make_workdiv<Acc1D>(nBlocks, nThreads),
                         multiBlockPrefixScan<uint32_t>(),
@@ -865,6 +870,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::sistrip {
     const int32_t nBlocks = divide_up_by(kMaxSeedStrips_, nThreads);
     auto blockCounter_d = make_device_buffer<int32_t>(queue);
     alpaka::memset(queue, blockCounter_d, 0);
+
+    cms::alpakatools::checkSharedMemoryPrefixScan<Acc1D>(kMaxSeedStrips_, nBlocks, alpaka::getDev(queue));
     alpaka::exec<Acc1D>(queue,
                         make_workdiv<Acc1D>(nBlocks, nThreads),
                         multiBlockPrefixScan<uint32_t>(),


### PR DESCRIPTION
#### PR description:

This PR implements a first check on the required dynamic shared memory needed by the [`multiBlockPrefixScan`](https://github.com/Parsifal-2045/cmssw/blob/a8a0be07cf733c297800282bffcd4749450f88a6/HeterogeneousCore/AlpakaInterface/interface/prefixScan.h#L138) required in the [`launchFinalize`](https://github.com/Parsifal-2045/cmssw/blob/a8a0be07cf733c297800282bffcd4749450f88a6/HeterogeneousCore/AlpakaInterface/interface/OneToManyAssoc.h#L234) function of the Alpaka `OneToManyAssoc`.
Details are documented in #50376 and in the GPU meeting on 23/03, this is a first band-aid implementation for a clearer error message.

#### PR validation:

The code compiles and runs, producing the expected error when using a configurations with too many "ones". A simple way to trigger the error is to double the `maxNumberOfDoublets` parameter in [`hltPhase2PixelTracksSoA`](https://github.com/Parsifal-2045/cmssw/blob/a8a0be07cf733c297800282bffcd4749450f88a6/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksSoA_cfi.py#L229). Before this change would produce the following output:
```bash
----- Begin Fatal Exception 10-Mar-2026 11:04:58 CET-----------------------
An exception of category 'StdException' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 1 stream: 0
   [1] Running path 'MC_Ele5_Open_Unseeded'
   [2] Calling method for module CAHitNtupletAlpakaPhase2OT@alpaka/'hltPhase2PixelTracksSoA'
Exception Message:
A std::exception was thrown.
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02931/el9_amd64_gcc13/external/alpaka/2.1.1-3caaac8d71f39d400ab2511b2403675a/include/alpaka/queueccuda-hip/QueueUniformCudaHipRt.hpp(199) 'TApi::streamSynchronize(queue.getNativeHandle())' A previous API call (not this one) set the error  : 'cudaErrorInvalidValue': 'invalid argument'!
----- End Fatal Exception -------------------------------------------------
```
while now it produces a readable error report:
```bash
----- Begin Fatal Exception 26-Mar-2026 16:31:43 CET-----------------------
An exception of category 'SharedMemoryLimitExceeded' occurred while
   [0] Processing  Event run: 1 lumi: 67 event: 6601 stream: 0
   [1] Running path 'HLT_PFPuppiMETTypeOne140_PFPuppiMHT140'
   [2] Calling method for module CAHitNtupletAlpakaPhase2OT@alpaka/'hltPhase2PixelTracksSoA'
Exception Message:
OneToManyAssocRandomAccess::launchFinalize requested a multiBlockPrefixScan for 12582913 ones, using 12289 blocks.
Shared memory requirement (49284 bytes) exceeds device limit (49152 bytes).
----- End Fatal Exception -------------------------------------------------
```
The same code runs without issues on CPU as there is no shared memory limit.

Since this condition is never triggered in release, all existing workflows run without issues: this is purely a technical change.