### PR TITLE
MTD validation: add multiplicty plots for tracks selected for PV reconstruction

### DIFF
--- a/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
@@ -165,6 +165,10 @@ void Primary4DVertexHarvester::incrementME(MonitorElement* base, MonitorElement*
 // ------------ endjob tasks ----------------------------
 void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& igetter) {
   // --- Get the monitoring histograms
+  MonitorElement* meSelVtxTrk = igetter.get(folder_ + "SelVtxTrk");
+  MonitorElement* meSelVtxTrkwTime = igetter.get(folder_ + "SelVtxTrkwTime");
+  MonitorElement* meSelVtxTrkvsEta = igetter.get(folder_ + "SelVtxTrkvsEta");
+  MonitorElement* meSelVtxTrkwTimevsEta = igetter.get(folder_ + "SelVtxTrkwTimevsEta");
   MonitorElement* meTrackEffPtTot = igetter.get(folder_ + "EffPtTot");
   MonitorElement* meTrackMatchedTPEffPtTot = igetter.get(folder_ + "MatchedTPEffPtTot");
   MonitorElement* meTrackMatchedTPEffPtMtd = igetter.get(folder_ + "MatchedTPEffPtMtd");
@@ -178,15 +182,27 @@ void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGe
   MonitorElement* meSimVerZ = igetter.get(folder_ + "simPVZ");
   MonitorElement* meSimVerT = igetter.get(folder_ + "simPVT");
 
-  if (!meTrackEffPtTot || !meTrackMatchedTPEffPtTot || !meTrackMatchedTPEffPtMtd || !meTrackEffEtaTot ||
-      !meTrackMatchedTPEffEtaTot || !meTrackMatchedTPEffEtaMtd || !meRecSelVerNumber || !meRecVerZ || !meRecVerT ||
-      !meSimVerNumber || !meSimVerZ || !meSimVerT) {
+  if (!meSelVtxTrk || !meSelVtxTrkwTime || !meSelVtxTrkvsEta || !meSelVtxTrkwTimevsEta || !meTrackEffPtTot ||
+      !meTrackMatchedTPEffPtTot || !meTrackMatchedTPEffPtMtd || !meTrackEffEtaTot || !meTrackMatchedTPEffEtaTot ||
+      !meTrackMatchedTPEffEtaMtd || !meRecSelVerNumber || !meRecVerZ || !meRecVerT || !meSimVerNumber || !meSimVerZ ||
+      !meSimVerT) {
     edm::LogError("Primary4DVertexHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
 
+  // Normalize selected track distribution vs eta
+  double scale = meSelVtxTrk->getTH1F()->Integral();
+  scale = (scale > 0.) ? 1. / scale : 0.;
+  if (scale > 0.) {
+    scaleby(meSelVtxTrkvsEta, scale);
+  }
+  scale = meSelVtxTrkwTime->getTH1F()->Integral();
+  scale = (scale > 0.) ? 1. / scale : 0.;
+  if (scale > 0.) {
+    scaleby(meSelVtxTrkwTimevsEta, scale);
+  }
   // Normalize z,time multiplicty plots to get correct line densities
-  double scale = meRecSelVerNumber->getTH1F()->Integral();
+  scale = meRecSelVerNumber->getTH1F()->Integral();
   scale = (scale > 0.) ? 1. / scale : 0.;
   if (scale > 0.) {
     scaleby(meRecVerZ, scale);

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -333,6 +333,10 @@ private:
   edm::ESGetToken<HepPDT::ParticleDataTable, edm::DefaultRecord> pdtToken_;
 
   // histogram declaration
+  MonitorElement* meSelVtxTrk_;
+  MonitorElement* meSelVtxTrkwTime_;
+  MonitorElement* meSelVtxTrkvsEta_;
+  MonitorElement* meSelVtxTrkwTimevsEta_;
   MonitorElement* meUnAssocTracks_;
   MonitorElement* meUnAssocTracksFake_;
   MonitorElement* meFractionUnAssocTracks_;
@@ -643,6 +647,12 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
                                                edm::EventSetup const& iSetup) {
   ibook.setCurrentFolder(folder_);
   // --- histograms booking
+  meSelVtxTrk_ = ibook.book1D("SelVtxTrk", "Log10 of Multiplicity of tracks selected for PV", 80, 0., 4.);
+  meSelVtxTrkwTime_ =
+      ibook.book1D("SelVtxTrkwTime", "Log10 of Multiplicity of tracks selected for PV with MTD time", 80, 0., 4.);
+  meSelVtxTrkvsEta_ = ibook.book1D("SelVtxTrkvsEta", "Eta distribution of tracks selected for PV", 80, -4., 4.);
+  meSelVtxTrkwTimevsEta_ =
+      ibook.book1D("SelVtxTrkwTimevsEta", "Eta distribution of tracks selected for PV with MTD time", 80, -4., 4.);
   meUnAssocTracks_ = ibook.book1D("UnAssocTracks", "Log10(Unassociated tracks)", 160, 0.5, 4.5);
   meUnAssocTracksFake_ = ibook.book1D("UnAssocTracksFake", "Log10(Unassociated fake tracks)", 160, 0.5, 4.5);
   meFractionUnAssocTracks_ = ibook.book1D("FractionUnAssocTracks", "Fraction Unassociated tracks", 160, 0.0, 1.);
@@ -2327,7 +2337,13 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
 
   int unassociatedCount = 0;
   int unassociatedCountFake = 0;
+  size_t trkwTime(0);
   for (std::vector<reco::TransientTrack>::const_iterator itk = seltks.begin(); itk != seltks.end(); itk++) {
+    meSelVtxTrkvsEta_->Fill(itk->track().eta());
+    if (itk->dtErrorExt() < TransientTrackBuilder::defaultInvalidTrackTimeReso) {
+      trkwTime++;
+      meSelVtxTrkwTimevsEta_->Fill(itk->track().eta());
+    }
     reco::TrackBaseRef trackref = (*itk).trackBaseRef();
     bool isAssociated = false;
     for (unsigned int iv = 0; iv < recopv.size(); iv++) {
@@ -2349,6 +2365,8 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
         unassociatedCountFake++;
     }
   }
+  meSelVtxTrk_->Fill(log10(seltks.size()));
+  meSelVtxTrkwTime_->Fill(log10(trkwTime));
   double fraction = double(unassociatedCount) / (seltks.size());
   meUnAssocTracks_->Fill(log10(unassociatedCount));
   meFractionUnAssocTracks_->Fill(fraction);

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -68,7 +68,6 @@ etlValidation = cms.Sequence(process.etlSimHitsValid + process.etlDigiHitsValid 
 
 # --- Global Validation
 process.load("Validation.MtdValidation.mtdTracksValid_cfi")
-process.load("Validation.MtdValidation.mtdEleIsoValid_cfi")
 process.load("Validation.MtdValidation.vertices4DValid_cff")
 
 # process.btlSimHitsValid.optionalPlots = True
@@ -79,7 +78,7 @@ process.load("Validation.MtdValidation.vertices4DValid_cff")
 # process.mtdTracksValid.optionalPlots = True
 # process.vertices4DValid.optionalPlots = True
 
-process.validation = cms.Sequence(btlValidation + etlValidation + process.mtdTracksValid + process.mtdEleIsoValid + process.vertices4DValid)
+process.validation = cms.Sequence(btlValidation + etlValidation + process.mtdTracksValid + process.vertices4DValid)
 
 process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
     dataset = cms.untracked.PSet(


### PR DESCRIPTION
#### PR description:

Plots for the multiplicity of tracks selected for PV reconstruction, inclusive and with MTD information, inclusive and vs eta, are added to ```Primary4DVertexValidation```.

#### PR validation:

code runs on RelVal samples and produces the desired histograms.