### PR TITLE
Added edm::stream::Watch* to SimTracker modules

### DIFF
--- a/SimTracker/TrackTriggerAssociation/plugins/StubAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/StubAssociator.cc
@@ -30,7 +30,7 @@ namespace tt {
    *  \author Thomas Schuh
    *  \date   2020, Apr
    */
-  class StubAssociator : public edm::stream::EDProducer<> {
+  class StubAssociator : public edm::stream::EDProducer<edm::stream::WatchRuns> {
   public:
     explicit StubAssociator(const edm::ParameterSet&);
     ~StubAssociator() override = default;

--- a/SimTracker/TrackerHitAssociation/plugins/SimDoubletsProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/SimDoubletsProducer.cc
@@ -69,7 +69,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void beginRun(const edm::Run&, const edm::EventSetup&) override;
 
 private:
   TrackingParticleSelector trackingParticleSelector;
@@ -210,9 +209,6 @@ void SimDoubletsProducer<pixelTopology::Phase2>::fillDescriptions(edm::Configura
 
   descriptions.addWithDefaultLabel(desc);
 }
-
-template <typename TrackerTraits>
-void SimDoubletsProducer<TrackerTraits>::beginRun(const edm::Run& run, const edm::EventSetup& eventSetup) {}
 
 template <typename TrackerTraits>
 void SimDoubletsProducer<TrackerTraits>::produce(edm::Event& event, const edm::EventSetup& eventSetup) {


### PR DESCRIPTION
#### PR description:

This is part of a campaign to add the attributes to modules which need them.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2100