### PR TITLE
"Condition Validation"-Like Workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -618,9 +618,11 @@ def addFixedEventsTestingWfs(years, pds, eras):
 
             wf_number = round(float(y) + offset_pd * pds.index(pd) + fixed_events_offset, 7)
             step_name = 'Run' + pd.replace('ParkingDouble','Park2') + y + era + "_10k"
-
+            
+            # With PAT, standard reconstruction
             workflows[wf_number] = ['',[step_name,'HLTDR3_' + y,'RECONANORUN3_reHLT_' + y,'HARVESTRUN3_' + suff + y]]
-
+            # No PAT, for condition validation
+            workflows[round(wf_number + 1e-7,7)] = ['',[step_name,'HLTDR3_' + y,'RECODR3_reHLT_' + y,'HARVESTRUN3_' + suff + y]]
 ## 2025 
 pds  = ['ZeroBias', 'JetMET0', 'EGamma0']
 eras = ['B','C','D']

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -129,7 +129,7 @@ if __name__ == '__main__':
             2024.0070001,      # Run2024I Tau
 
             # 2025
-            2025.0000001,     # Run2025B ZeroBias
+            2025.0000002,     # Run2025B ZeroBias                       noPAT
             2025.0010001,     # Run2025C JetMET0
         ],
 


### PR DESCRIPTION
Triggered by the failures in [CMSALCA-359](https://its.cern.ch/jira/projects/CMSALCA/issues/CMSALCA-359?filter=allopenissues) and also the further discussion in https://github.com/cms-sw/cmssw/issues/50548 this PR proposes to have a couple of extra data wfs exercising the standar condition validation workflows used for Full Track Validations.

A backport to 16_0_X would be needed to be really useful.