### PR TITLE
Require Watchs attributes for stream modules

### DIFF
--- a/FWCore/Framework/interface/stream/AbilityChecker.h
+++ b/FWCore/Framework/interface/stream/AbilityChecker.h
@@ -141,8 +141,8 @@ namespace edm {
         static constexpr bool kExternalWork = false;
         static constexpr bool kAccumulator = false;
         static constexpr bool kTransformer = false;
-        static constexpr bool kWatchLuminosityBlocks = true;
-        static constexpr bool kWatchRuns = true;
+        static constexpr bool kWatchLuminosityBlocks = false;
+        static constexpr bool kWatchRuns = false;
       };
     }  // namespace impl
     template <typename... T>

--- a/FWCore/Framework/interface/stream/EDAnalyzer.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzer.h
@@ -23,6 +23,7 @@
 #include "FWCore/Framework/interface/stream/Contexts.h"
 #include "FWCore/Framework/interface/stream/AbilityChecker.h"
 #include "FWCore/Framework/interface/stream/EDAnalyzerBase.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h"
 
 namespace edm {
   namespace stream {

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -31,6 +31,8 @@
 #include "FWCore/Framework/interface/stream/callAbilities.h"
 #include "FWCore/Framework/interface/stream/dummy_helpers.h"
 #include "FWCore/Framework/interface/stream/makeGlobal.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzerBase.h"
+#include "FWCore/Framework/interface/stream/implementors.h"
 #include "FWCore/Framework/interface/maker/MakeModuleHelper.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
@@ -75,11 +77,16 @@ namespace edm {
       bool wantsGlobalRuns() const noexcept final {
         return T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache;
       }
-      bool wantsStreamRuns() const noexcept final { return T::HasAbility::kWatchRuns; }
+      bool wantsStreamRuns() const noexcept final {
+        return T::HasAbility::kWatchRuns or T::HasAbility::kRunSummaryCache or T::HasAbility::kRunCache;
+      }
       bool wantsGlobalLuminosityBlocks() const noexcept final {
         return T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache;
       }
-      bool wantsStreamLuminosityBlocks() const noexcept final { return T::HasAbility::kWatchLuminosityBlocks; }
+      bool wantsStreamLuminosityBlocks() const noexcept final {
+        return T::HasAbility::kWatchLuminosityBlocks or T::HasAbility::kLuminosityBlockSummaryCache or
+               T::HasAbility::kLuminosityBlockCache;
+      }
 
     private:
       using MyGlobal = CallGlobal<T>;
@@ -111,14 +118,87 @@ namespace edm {
 
       void doBeginJob() final { MyGlobal::beginJob(m_global.get()); }
       void doEndJob() final { MyGlobal::endJob(m_global.get()); }
-      void setupRun(EDAnalyzerBase* iProd, RunIndex iIndex) final { MyGlobalRun::set(iProd, m_runs[iIndex].get()); }
+      void setupRun(EDAnalyzerBase* iProd, RunIndex iIndex) { MyGlobalRun::set(iProd, m_runs[iIndex].get()); }
+      void streamBeginRun(EDAnalyzerBase* mod, RunTransitionInfo const& info, ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kWatchRuns or T::HasAbility::kRunSummaryCache or T::HasAbility::kRunCache) {
+          RunPrincipal const& rp = info.principal();
+          setupRun(mod, rp.index());
+
+          if constexpr (T::HasAbility::kWatchRuns) {
+            Run r(rp, moduleDescription(), mcc, false);
+            ESParentContext parentC(mcc);
+            const EventSetup c{info,
+                               static_cast<unsigned int>(Transition::BeginRun),
+                               mod->esGetTokenIndices(Transition::BeginRun),
+                               parentC};
+            r.setConsumer(mod);
+            static_cast<impl::WatchRuns*>(static_cast<T*>(mod))->beginRun(r, c);
+          }
+        }
+      }
+
+      void streamEndRun(EDAnalyzerBase* mod, RunTransitionInfo const& info, ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kWatchRuns or T::HasAbility::kRunSummaryCache) {
+          Run r(info, moduleDescription(), mcc, true);
+          r.setConsumer(mod);
+          ESParentContext parentC(mcc);
+          const EventSetup c{
+              info, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), parentC};
+          if constexpr (T::HasAbility::kWatchRuns) {
+            static_cast<impl::WatchRuns*>(static_cast<T*>(mod))->endRun(r, c);
+          }
+          if constexpr (T::HasAbility::kRunSummaryCache) {
+            streamEndRunSummary(mod, r, c);
+          }
+        }
+      }
+
+      void streamBeginLuminosityBlock(EDAnalyzerBase* mod,
+                                      LumiTransitionInfo const& info,
+                                      ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kWatchLuminosityBlocks or T::HasAbility::kLuminosityBlockSummaryCache or
+                      T::HasAbility::kLuminosityBlockCache) {
+          LuminosityBlockPrincipal const& lbp = info.principal();
+          setupLuminosityBlock(mod, lbp.index());
+
+          if constexpr (T::HasAbility::kWatchLuminosityBlocks) {
+            LuminosityBlock lb(lbp, moduleDescription(), mcc, false);
+            lb.setConsumer(mod);
+            ESParentContext parentC(mcc);
+            const EventSetup c{info,
+                               static_cast<unsigned int>(Transition::BeginLuminosityBlock),
+                               mod->esGetTokenIndices(Transition::BeginLuminosityBlock),
+                               parentC};
+            static_cast<impl::WatchLuminosityBlocks*>(static_cast<T*>(mod))->beginLuminosityBlock(lb, c);
+          }
+        }
+      }
+      void streamEndLuminosityBlock(EDAnalyzerBase* mod,
+                                    LumiTransitionInfo const& info,
+                                    ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kWatchLuminosityBlocks or T::HasAbility::kLuminosityBlockSummaryCache) {
+          LuminosityBlock lb(info, moduleDescription(), mcc, true);
+          lb.setConsumer(mod);
+          ESParentContext parentC(mcc);
+          const EventSetup c{info,
+                             static_cast<unsigned int>(Transition::EndLuminosityBlock),
+                             mod->esGetTokenIndices(Transition::EndLuminosityBlock),
+                             parentC};
+          if constexpr (T::HasAbility::kWatchLuminosityBlocks) {
+            static_cast<impl::WatchLuminosityBlocks*>(static_cast<T*>(mod))->endLuminosityBlock(lb, c);
+          }
+          if constexpr (T::HasAbility::kLuminosityBlockSummaryCache) {
+            streamEndLuminosityBlockSummary(mod, lb, c);
+          }
+        }
+      }
       void streamEndRunSummary(EDAnalyzerBase* iProd, edm::Run const& iRun, edm::EventSetup const& iES) final {
         auto s = m_runSummaries[iRun.index()].get();
         std::lock_guard<decltype(m_runSummaryLock)> guard(m_runSummaryLock);
         MyGlobalRunSummary::streamEndRunSummary(iProd, iRun, iES, s);
       }
 
-      void setupLuminosityBlock(EDAnalyzerBase* iProd, LuminosityBlockIndex iIndex) final {
+      void setupLuminosityBlock(EDAnalyzerBase* iProd, LuminosityBlockIndex iIndex) {
         MyGlobalLuminosityBlock::set(iProd, m_lumis[iIndex].get());
       }
       void streamEndLuminosityBlockSummary(EDAnalyzerBase* iProd,

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -143,13 +143,19 @@ namespace edm {
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
       void doStreamBeginRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
-      virtual void setupRun(EDAnalyzerBase*, RunIndex) = 0;
+      virtual void streamBeginRun(EDAnalyzerBase*, edm::RunTransitionInfo const&, ModuleCallingContext const*) = 0;
       void doStreamEndRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      virtual void streamEndRun(EDAnalyzerBase*, edm::RunTransitionInfo const&, ModuleCallingContext const*) = 0;
       virtual void streamEndRunSummary(EDAnalyzerBase*, edm::Run const&, edm::EventSetup const&) = 0;
 
       void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
-      virtual void setupLuminosityBlock(EDAnalyzerBase*, LuminosityBlockIndex) = 0;
+      virtual void streamBeginLuminosityBlock(EDAnalyzerBase*,
+                                              LumiTransitionInfo const&,
+                                              ModuleCallingContext const*) = 0;
       void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
+      virtual void streamEndLuminosityBlock(EDAnalyzerBase*,
+                                            LumiTransitionInfo const&,
+                                            ModuleCallingContext const*) = 0;
       virtual void streamEndLuminosityBlockSummary(EDAnalyzerBase*,
                                                    edm::LuminosityBlock const&,
                                                    edm::EventSetup const&) = 0;

--- a/FWCore/Framework/interface/stream/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerBase.h
@@ -23,12 +23,13 @@
 // user include files
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 // forward declarations
 namespace edm {
+  class SignallingProductRegistryFiller;
   namespace stream {
     class EDAnalyzerAdaptorBase;
 
@@ -57,11 +58,7 @@ namespace edm {
       void registerProductsAndCallbacks(EDAnalyzerBase const*, SignallingProductRegistryFiller* reg);
 
       virtual void beginStream(StreamID) {}
-      virtual void beginRun(edm::Run const&, edm::EventSetup const&) {}
-      virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
       virtual void analyze(Event const&, EventSetup const&) = 0;
-      virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
-      virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
       virtual void endStream() {}
 
       void setModuleDescriptionPtr(ModuleDescription const* iDesc) { moduleDescriptionPtr_ = iDesc; }

--- a/FWCore/Framework/interface/stream/EDFilter.h
+++ b/FWCore/Framework/interface/stream/EDFilter.h
@@ -24,6 +24,7 @@
 #include "FWCore/Framework/interface/stream/Contexts.h"
 #include "FWCore/Framework/interface/stream/AbilityChecker.h"
 #include "FWCore/Framework/interface/stream/EDFilterBase.h"
+#include "FWCore/Framework/interface/stream/EDFilterAdaptor.h"
 #include "FWCore/Framework/interface/stream/ProducingModuleHelper.h"
 
 namespace edm {

--- a/FWCore/Framework/interface/stream/EDFilterBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterBase.h
@@ -24,14 +24,16 @@
 #include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDFilterAdaptor.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "DataFormats/Provenance/interface/ParentageID.h"
+#include "DataFormats/Provenance/interface/BranchID.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
-
+#include "FWCore/Utilities/interface/StreamID.h"
 // forward declarations
 namespace edm {
 
   class ProductRegistry;
+  class WaitingTaskHolder;
 
   namespace stream {
     class EDFilterAdaptorBase;
@@ -60,11 +62,7 @@ namespace edm {
 
     private:
       virtual void beginStream(StreamID) {}
-      virtual void beginRun(edm::Run const&, edm::EventSetup const&) {}
-      virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
       virtual bool filter(Event&, EventSetup const&) = 0;
-      virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
-      virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
       virtual void endStream() {}
 
       virtual void doAcquire_(Event const&, EventSetup const&, WaitingTaskHolder&&) = 0;

--- a/FWCore/Framework/interface/stream/EDProducer.h
+++ b/FWCore/Framework/interface/stream/EDProducer.h
@@ -24,6 +24,7 @@
 #include "FWCore/Framework/interface/stream/Contexts.h"
 #include "FWCore/Framework/interface/stream/AbilityChecker.h"
 #include "FWCore/Framework/interface/stream/EDProducerBase.h"
+#include "FWCore/Framework/interface/stream/EDProducerAdaptor.h"
 #include "FWCore/Framework/interface/stream/ProducingModuleHelper.h"
 
 namespace edm {

--- a/FWCore/Framework/interface/stream/EDProducerBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerBase.h
@@ -24,10 +24,11 @@
 #include "FWCore/Framework/interface/ProducerBase.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducerAdaptor.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "DataFormats/Provenance/interface/ParentageID.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Utilities/interface/ProductResolverIndex.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 
 // forward declarations
 namespace edm {
@@ -35,6 +36,8 @@ namespace edm {
   class WorkerT;
   class ProductRegistry;
   class EventForTransformer;
+  class WaitingTaskHolder;
+  class ServiceWeakToken;
 
   namespace stream {
     class EDProducerAdaptorBase;
@@ -63,11 +66,7 @@ namespace edm {
 
     private:
       virtual void beginStream(StreamID) {}
-      virtual void beginRun(edm::Run const&, edm::EventSetup const&) {}
-      virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
       virtual void produce(Event&, EventSetup const&) = 0;
-      virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
-      virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
       virtual void endStream() {}
 
       virtual void doAcquire_(Event const&, EventSetup const&, WaitingTaskHolder&&) = 0;
@@ -89,5 +88,4 @@ namespace edm {
 
   }  // namespace stream
 }  // namespace edm
-
 #endif

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -30,6 +30,7 @@
 #include "FWCore/Framework/interface/stream/callAbilities.h"
 #include "FWCore/Framework/interface/stream/dummy_helpers.h"
 #include "FWCore/Framework/interface/stream/makeGlobal.h"
+#include "FWCore/Framework/interface/stream/implementors.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 // forward declarations
@@ -67,13 +68,18 @@ namespace edm {
         return T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kBeginRunProducer or
                T::HasAbility::kEndRunProducer;
       }
-      bool wantsStreamRuns() const noexcept final { return T::HasAbility::kWatchRuns; }
+      bool wantsStreamRuns() const noexcept final {
+        return T::HasAbility::kWatchRuns or T::HasAbility::kRunSummaryCache or T::HasAbility::kRunCache;
+      }
 
       bool wantsGlobalLuminosityBlocks() const noexcept final {
         return T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache or
                T::HasAbility::kBeginLuminosityBlockProducer or T::HasAbility::kEndLuminosityBlockProducer;
       }
-      bool wantsStreamLuminosityBlocks() const noexcept final { return T::HasAbility::kWatchLuminosityBlocks; }
+      bool wantsStreamLuminosityBlocks() const noexcept final {
+        return T::HasAbility::kWatchLuminosityBlocks or T::HasAbility::kLuminosityBlockSummaryCache or
+               T::HasAbility::kLuminosityBlockCache;
+      }
 
       bool hasAcquire() const noexcept final { return T::HasAbility::kExternalWork; }
 
@@ -114,14 +120,95 @@ namespace edm {
       }
       void doBeginJob() final { MyGlobal::beginJob(m_global.get()); }
       void doEndJob() final { MyGlobal::endJob(m_global.get()); }
-      void setupRun(M* iProd, RunIndex iIndex) final { MyGlobalRun::set(iProd, m_runs[iIndex].get()); }
+      void setupRun(M* iProd, RunIndex iIndex) { MyGlobalRun::set(iProd, m_runs[iIndex].get()); }
+      void streamBeginRun(M* mod, RunTransitionInfo const& info, ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kWatchRuns or T::HasAbility::kRunSummaryCache or T::HasAbility::kRunCache) {
+          RunPrincipal const& rp = info.principal();
+          setupRun(mod, rp.index());
+
+          if constexpr (T::HasAbility::kWatchRuns) {
+            Run r(rp, this->moduleDescription(), mcc, false);
+            r.setConsumer(mod);
+            ESParentContext parentC(mcc);
+            const EventSetup c{info,
+                               static_cast<unsigned int>(Transition::BeginRun),
+                               mod->esGetTokenIndices(Transition::BeginRun),
+                               parentC};
+            static_assert(std::is_base_of_v<impl::WatchRuns, T>,
+                          "Should be impossible to have WatchRuns ability without M deriving from WatchRuns");
+            static_cast<impl::WatchRuns*>(static_cast<T*>(mod))->beginRun(r, c);
+          }
+        }
+      }
+
+      void streamEndRun(M* mod, RunTransitionInfo const& info, ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kWatchRuns or T::HasAbility::kRunSummaryCache) {
+          Run r(info, this->moduleDescription(), mcc, true);
+          r.setConsumer(mod);
+          ESParentContext parentC(mcc);
+          const EventSetup c{
+              info, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), parentC};
+          if constexpr (T::HasAbility::kWatchRuns) {
+            static_assert(std::is_base_of_v<impl::WatchRuns, T>,
+                          "Should be impossible to have WatchRuns ability without M deriving from WatchRuns");
+            static_cast<impl::WatchRuns*>(static_cast<T*>(mod))->endRun(r, c);
+          }
+          if constexpr (T::HasAbility::kRunSummaryCache) {
+            streamEndRunSummary(mod, r, c);
+          }
+        }
+      }
+
+      void streamBeginLuminosityBlock(M* mod, LumiTransitionInfo const& info, ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kWatchLuminosityBlocks or T::HasAbility::kLuminosityBlockSummaryCache or
+                      T::HasAbility::kLuminosityBlockCache) {
+          LuminosityBlockPrincipal const& lbp = info.principal();
+          setupLuminosityBlock(mod, lbp.index());
+
+          if constexpr (T::HasAbility::kWatchLuminosityBlocks) {
+            LuminosityBlock lb(lbp, this->moduleDescription(), mcc, false);
+            lb.setConsumer(mod);
+            ESParentContext parentC(mcc);
+            const EventSetup c{info,
+                               static_cast<unsigned int>(Transition::BeginLuminosityBlock),
+                               mod->esGetTokenIndices(Transition::BeginLuminosityBlock),
+                               parentC};
+            static_assert(std::is_base_of_v<impl::WatchLuminosityBlocks, T>,
+                          "Should be impossible to have WatchLuminosityBlocks ability without M deriving from "
+                          "WatchLuminosityBlocks");
+
+            static_cast<impl::WatchLuminosityBlocks*>(static_cast<T*>(mod))->beginLuminosityBlock(lb, c);
+          }
+        }
+      }
+
+      void streamEndLuminosityBlock(M* mod, LumiTransitionInfo const& info, ModuleCallingContext const* mcc) final {
+        if constexpr (T::HasAbility::kWatchLuminosityBlocks or T::HasAbility::kLuminosityBlockSummaryCache) {
+          LuminosityBlock lb(info, this->moduleDescription(), mcc, true);
+          lb.setConsumer(mod);
+          ESParentContext parentC(mcc);
+          const EventSetup c{info,
+                             static_cast<unsigned int>(Transition::EndLuminosityBlock),
+                             mod->esGetTokenIndices(Transition::EndLuminosityBlock),
+                             parentC};
+          if constexpr (T::HasAbility::kWatchLuminosityBlocks) {
+            static_assert(std::is_base_of_v<impl::WatchLuminosityBlocks, T>,
+                          "Should be impossible to have WatchLuminosityBlocks ability without M deriving from "
+                          "WatchLuminosityBlocks");
+            static_cast<impl::WatchLuminosityBlocks*>(static_cast<T*>(mod))->endLuminosityBlock(lb, c);
+          }
+          if constexpr (T::HasAbility::kLuminosityBlockSummaryCache) {
+            streamEndLuminosityBlockSummary(mod, lb, c);
+          }
+        }
+      }
       void streamEndRunSummary(M* iProd, edm::Run const& iRun, edm::EventSetup const& iES) final {
         auto s = m_runSummaries[iRun.index()].get();
         std::lock_guard<decltype(m_runSummaryLock)> guard(m_runSummaryLock);
         MyGlobalRunSummary::streamEndRunSummary(iProd, iRun, iES, s);
       }
 
-      void setupLuminosityBlock(M* iProd, LuminosityBlockIndex iIndex) final {
+      void setupLuminosityBlock(M* iProd, LuminosityBlockIndex iIndex) {
         MyGlobalLuminosityBlock::set(iProd, m_lumis[iIndex].get());
       }
       void streamEndLuminosityBlockSummary(M* iProd,

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -173,13 +173,15 @@ namespace edm {
       void doBeginStream(StreamID);
       void doEndStream(StreamID);
       void doStreamBeginRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
-      virtual void setupRun(T*, RunIndex) = 0;
+      virtual void streamBeginRun(T*, edm::RunTransitionInfo const&, ModuleCallingContext const*) = 0;
       void doStreamEndRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      virtual void streamEndRun(T*, edm::RunTransitionInfo const&, ModuleCallingContext const*) = 0;
       virtual void streamEndRunSummary(T*, edm::Run const&, edm::EventSetup const&) = 0;
 
       void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
-      virtual void setupLuminosityBlock(T*, LuminosityBlockIndex) = 0;
+      virtual void streamBeginLuminosityBlock(T*, LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
       void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
+      virtual void streamEndLuminosityBlock(T*, LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
       virtual void streamEndLuminosityBlockSummary(T*, edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
 
       virtual void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;

--- a/FWCore/Framework/interface/stream/implementors.h
+++ b/FWCore/Framework/interface/stream/implementors.h
@@ -33,6 +33,7 @@
 #include "FWCore/Framework/interface/InputProcessBlockCacheImpl.h"
 #include "FWCore/Framework/interface/TransformerBase.h"
 #include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/StreamID.h"
@@ -46,6 +47,8 @@ namespace edm {
   class WaitingTaskWithArenaHolder;
 
   namespace stream {
+    template <typename T, bool, bool>
+    struct CallInputProcessBlockImpl;
     namespace impl {
       class EmptyType {};
 
@@ -298,8 +301,8 @@ namespace edm {
         WatchLuminosityBlocks& operator=(WatchLuminosityBlocks const&) = delete;
         virtual ~WatchLuminosityBlocks() noexcept(false) {}
 
-        // virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
-        // virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
+        virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
+        virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
       };
 
       class WatchRuns {
@@ -309,8 +312,8 @@ namespace edm {
         WatchRuns& operator=(WatchRuns const&) = delete;
         virtual ~WatchRuns() noexcept(false) {}
 
-        // virtual void beginRun(edm::Run const&, edm::EventSetup const&) = 0;
-        // virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
+        virtual void beginRun(edm::Run const&, edm::EventSetup const&) = 0;
+        virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
       };
       class Transformer : private TransformerBase, public EDProducerBase {
       public:

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -176,60 +176,24 @@ void EDAnalyzerAdaptorBase::doEndStream(StreamID id) { m_streamModules[id]->endS
 void EDAnalyzerAdaptorBase::doStreamBeginRun(StreamID id,
                                              RunTransitionInfo const& info,
                                              ModuleCallingContext const* mcc) {
-  RunPrincipal const& rp = info.principal();
-  auto mod = m_streamModules[id];
-  setupRun(mod, rp.index());
-
-  Run r(rp, moduleDescription_, mcc, false);
-  ESParentContext parentC(mcc);
-  const EventSetup c{
-      info, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun), parentC};
-  r.setConsumer(mod);
-  mod->beginRun(r, c);
+  streamBeginRun(m_streamModules[id], info, mcc);
 }
 
 void EDAnalyzerAdaptorBase::doStreamEndRun(StreamID id,
                                            RunTransitionInfo const& info,
                                            ModuleCallingContext const* mcc) {
-  auto mod = m_streamModules[id];
-  Run r(info, moduleDescription_, mcc, true);
-  r.setConsumer(mod);
-  ESParentContext parentC(mcc);
-  const EventSetup c{
-      info, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), parentC};
-  mod->endRun(r, c);
-  streamEndRunSummary(mod, r, c);
+  streamEndRun(m_streamModules[id], info, mcc);
 }
 
 void EDAnalyzerAdaptorBase::doStreamBeginLuminosityBlock(StreamID id,
                                                          LumiTransitionInfo const& info,
                                                          ModuleCallingContext const* mcc) {
-  LuminosityBlockPrincipal const& lbp = info.principal();
-  auto mod = m_streamModules[id];
-  setupLuminosityBlock(mod, lbp.index());
-
-  LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
-  lb.setConsumer(mod);
-  ESParentContext parentC(mcc);
-  const EventSetup c{info,
-                     static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                     mod->esGetTokenIndices(Transition::BeginLuminosityBlock),
-                     parentC};
-  mod->beginLuminosityBlock(lb, c);
+  streamBeginLuminosityBlock(m_streamModules[id], info, mcc);
 }
 void EDAnalyzerAdaptorBase::doStreamEndLuminosityBlock(StreamID id,
                                                        LumiTransitionInfo const& info,
                                                        ModuleCallingContext const* mcc) {
-  auto mod = m_streamModules[id];
-  LuminosityBlock lb(info, moduleDescription_, mcc, true);
-  lb.setConsumer(mod);
-  ESParentContext parentC(mcc);
-  const EventSetup c{info,
-                     static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                     mod->esGetTokenIndices(Transition::EndLuminosityBlock),
-                     parentC};
-  mod->endLuminosityBlock(lb, c);
-  streamEndLuminosityBlockSummary(mod, lb, c);
+  streamEndLuminosityBlock(m_streamModules[id], info, mcc);
 }
 
 void EDAnalyzerAdaptorBase::setModuleDescriptionPtr(EDAnalyzerBase* m) {

--- a/FWCore/Framework/src/stream/EDProducerBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerBase.cc
@@ -19,6 +19,10 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+
+#include "DataFormats/Provenance/interface/BranchID.h"
+
 using namespace edm::stream;
 //
 // constants, enums and typedefs

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -214,64 +214,28 @@ namespace edm {
     void ProducingModuleAdaptorBase<T>::doStreamBeginRun(StreamID id,
                                                          RunTransitionInfo const& info,
                                                          ModuleCallingContext const* mcc) {
-      RunPrincipal const& rp = info.principal();
-      auto mod = m_streamModules[id];
-      setupRun(mod, rp.index());
-
-      Run r(rp, moduleDescription_, mcc, false);
-      r.setConsumer(mod);
-      ESParentContext parentC(mcc);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun), parentC};
-      mod->beginRun(r, c);
+      streamBeginRun(m_streamModules[id], info, mcc);
     }
 
     template <typename T>
     void ProducingModuleAdaptorBase<T>::doStreamEndRun(StreamID id,
                                                        RunTransitionInfo const& info,
                                                        ModuleCallingContext const* mcc) {
-      auto mod = m_streamModules[id];
-      Run r(info, moduleDescription_, mcc, true);
-      r.setConsumer(mod);
-      ESParentContext parentC(mcc);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), parentC};
-      mod->endRun(r, c);
-      streamEndRunSummary(mod, r, c);
+      streamEndRun(m_streamModules[id], info, mcc);
     }
 
     template <typename T>
     void ProducingModuleAdaptorBase<T>::doStreamBeginLuminosityBlock(StreamID id,
                                                                      LumiTransitionInfo const& info,
                                                                      ModuleCallingContext const* mcc) {
-      LuminosityBlockPrincipal const& lbp = info.principal();
-      auto mod = m_streamModules[id];
-      setupLuminosityBlock(mod, lbp.index());
-
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
-      lb.setConsumer(mod);
-      ESParentContext parentC(mcc);
-      const EventSetup c{info,
-                         static_cast<unsigned int>(Transition::BeginLuminosityBlock),
-                         mod->esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         parentC};
-      mod->beginLuminosityBlock(lb, c);
+      streamBeginLuminosityBlock(m_streamModules[id], info, mcc);
     }
 
     template <typename T>
     void ProducingModuleAdaptorBase<T>::doStreamEndLuminosityBlock(StreamID id,
                                                                    LumiTransitionInfo const& info,
                                                                    ModuleCallingContext const* mcc) {
-      auto mod = m_streamModules[id];
-      LuminosityBlock lb(info, moduleDescription_, mcc, true);
-      lb.setConsumer(mod);
-      ESParentContext parentC(mcc);
-      const EventSetup c{info,
-                         static_cast<unsigned int>(Transition::EndLuminosityBlock),
-                         mod->esGetTokenIndices(Transition::EndLuminosityBlock),
-                         parentC};
-      mod->endLuminosityBlock(lb, c);
-      streamEndLuminosityBlockSummary(mod, lb, c);
+      streamEndLuminosityBlock(m_streamModules[id], info, mcc);
     }
   }  // namespace stream
 }  // namespace edm

--- a/FWCore/Framework/test/stubs/TestStreamProducers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamProducers.cc
@@ -120,6 +120,9 @@ namespace edmtest {
 
       void produce(edm::Event&, edm::EventSetup const&) override {
         ++m_count;
+        if (not runCache()) {
+          throw cms::Exception("runCache not set");
+        }
         ++(runCache()->value);
       }
 
@@ -255,6 +258,9 @@ namespace edmtest {
 
       void produce(edm::Event&, edm::EventSetup const&) override {
         ++m_count;
+        if (not runCache()) {
+          throw cms::Exception("runCache not set");
+        }
         ++(runCache()->value);
         ++valueAccumulatedForStream_;
       }
@@ -677,10 +683,16 @@ namespace edmtest {
         gbr = true;
         ger = false;
         gbrp = false;
-        return std::shared_ptr<bool>{};
+        return std::make_shared<bool>(true);
       }
 
       void produce(edm::Event&, edm::EventSetup const&) override {
+        if (not runCache()) {
+          throw cms::Exception("runCache not set");
+        }
+        if (not *runCache()) {
+          throw cms::Exception("runCache wrong value");
+        }
         if (!gbrp) {
           throw cms::Exception("out of sequence") << "produce before globalBeginRunProduce";
         }
@@ -722,7 +734,7 @@ namespace edmtest {
         gbr = true;
         ger = false;
         p = false;
-        return std::shared_ptr<bool>{};
+        return std::make_shared<bool>(true);
       }
 
       TestEndRunProducer(edm::ParameterSet const& p) {
@@ -732,7 +744,15 @@ namespace edmtest {
         produces<unsigned int, edm::Transition::EndRun>("a");
       }
 
-      void produce(edm::Event&, edm::EventSetup const&) override { p = true; }
+      void produce(edm::Event&, edm::EventSetup const&) override {
+        p = true;
+        if (not runCache()) {
+          throw cms::Exception("runCache not set");
+        }
+        if (not *runCache()) {
+          throw cms::Exception("runCache has wrong value");
+        }
+      }
 
       static void globalEndRunProduce(edm::Run& iRun, edm::EventSetup const&, RunContext const*) {
         ++m_count;
@@ -780,6 +800,12 @@ namespace edmtest {
         if (!gblp) {
           throw cms::Exception("begin out of sequence") << "produce seen before globalBeginLumiBlockProduce";
         }
+        if (not luminosityBlockCache()) {
+          throw cms::Exception("luminosityBlockCache not set");
+        }
+        if (not *luminosityBlockCache()) {
+          throw cms::Exception("luminosityBlockCache has wrong value");
+        }
       }
 
       static void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&,
@@ -799,7 +825,7 @@ namespace edmtest {
         gbl = true;
         gel = false;
         gblp = false;
-        return std::shared_ptr<bool>();
+        return std::make_shared<bool>(true);
       }
 
       static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB,
@@ -838,7 +864,15 @@ namespace edmtest {
         produces<unsigned int, edm::Transition::EndLuminosityBlock>("a");
       }
 
-      void produce(edm::Event&, edm::EventSetup const&) override { p = true; }
+      void produce(edm::Event&, edm::EventSetup const&) override {
+        p = true;
+        if (not luminosityBlockCache()) {
+          throw cms::Exception("luminosityBlockCache not set");
+        }
+        if (not *luminosityBlockCache()) {
+          throw cms::Exception("luminosityBlockCache has wrong value");
+        }
+      }
 
       static void globalEndLuminosityBlockProduce(edm::LuminosityBlock&,
                                                   edm::EventSetup const&,
@@ -855,7 +889,7 @@ namespace edmtest {
         gbl = true;
         gel = false;
         p = false;
-        return std::shared_ptr<bool>{};
+        return std::make_shared<bool>(true);
       }
 
       static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB,

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -96,30 +96,6 @@ ModuleCallingContext state = Running
 ++++ starting: global begin run 1 : time = 1000000
 ++++ finished: global begin run 1 : time = 1000000
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
-++++++ starting: begin run for module: stream = 0 label = 'one' id = 4
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=dd3aecb8f6531b74585c9fe89286679e
-    StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-
-++++++ finished: begin run for module: stream = 0 label = 'one' id = 4
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=dd3aecb8f6531b74585c9fe89286679e
-    StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
 ++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
@@ -129,30 +105,6 @@ ModuleCallingContext state = Running
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
-++++++ starting: begin lumi for module: stream = 0 label = 'one' id = 4
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=dd3aecb8f6531b74585c9fe89286679e
-    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-
-++++++ finished: begin lumi for module: stream = 0 label = 'one' id = 4
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=dd3aecb8f6531b74585c9fe89286679e
-    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
 ++++ starting: source event
 ++++ finished: source event
@@ -500,60 +452,12 @@ ModuleCallingContext state = Running
 ++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
-++++++ starting: end lumi for module: stream = 0 label = 'one' id = 4
-StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=dd3aecb8f6531b74585c9fe89286679e
-    StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-
-++++++ finished: end lumi for module: stream = 0 label = 'one' id = 4
-StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=dd3aecb8f6531b74585c9fe89286679e
-    StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
-++++++ starting: end run for module: stream = 0 label = 'one' id = 4
-StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=dd3aecb8f6531b74585c9fe89286679e
-    StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-
-++++++ finished: end run for module: stream = 0 label = 'one' id = 4
-StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=dd3aecb8f6531b74585c9fe89286679e
-    StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
-    ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
-
 ++++ finished: end run: stream = 0 run = 1 time = 1000030
 ++++ starting: global end run 1 : time = 1000030
 ++++ finished: global end run 1 : time = 1000030

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -64,10 +64,6 @@
 ++++ starting: global begin run 1 : time = 1000000
 ++++ finished: global begin run 1 : time = 1000000
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
-++++++ starting: begin run for module: stream = 0 label = 'one' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'one' id = 3
-++++++ starting: begin run for module: stream = 0 label = 'two' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'two' id = 5
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
 ++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
@@ -77,10 +73,6 @@
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
-++++++ starting: begin lumi for module: stream = 0 label = 'one' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'one' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'two' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'two' id = 5
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
 ++++ starting: source event
 ++++ finished: source event
@@ -164,20 +156,12 @@
 ++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
-++++++ starting: end lumi for module: stream = 0 label = 'one' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'one' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'two' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'two' id = 5
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
-++++++ starting: end run for module: stream = 0 label = 'one' id = 3
-++++++ finished: end run for module: stream = 0 label = 'one' id = 3
-++++++ starting: end run for module: stream = 0 label = 'two' id = 5
-++++++ finished: end run for module: stream = 0 label = 'two' id = 5
 ++++ finished: end run: stream = 0 run = 1 time = 1000030
 ++++ starting: global end run 1 : time = 1000030
 ++++ finished: global end run 1 : time = 1000030

--- a/FWCore/Services/test/AsyncServiceTester.cc
+++ b/FWCore/Services/test/AsyncServiceTester.cc
@@ -266,6 +266,7 @@ namespace edmtest {
       }
     }
 
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) final {}
     void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) final {
       if (edm::Service<AsyncServiceTesterService>()->stillWaiting() and *streamId_ != throwingStream_) {
         throw cms::Exception("Assert") << "In endLuminosityBlock for stream " << *streamId_
@@ -274,6 +275,7 @@ namespace edmtest {
       }
     }
 
+    void beginRun(edm::Run const&, edm::EventSetup const&) final {}
     void endRun(edm::Run const&, edm::EventSetup const&) final {
       if (edm::Service<AsyncServiceTesterService>()->stillWaiting() and *streamId_ != throwingStream_) {
         throw cms::Exception("Assert") << "In endRun for stream " << *streamId_

--- a/FWIO/RNTupleTempTests/test/unit_test_outputs/testGetBy1.log
+++ b/FWIO/RNTupleTempTests/test/unit_test_outputs/testGetBy1.log
@@ -305,36 +305,6 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 3
-++++++ starting: begin run for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ finished: begin run for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ starting: begin run for module: stream = 0 label = 'intProducerB' id = 9
-++++++ finished: begin run for module: stream = 0 label = 'intProducerB' id = 9
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 12
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 12
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -420,36 +390,6 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerB' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerB' id = 9
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 12
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -1095,36 +1035,6 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerB' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerB' id = 9
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 12
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -1219,36 +1129,6 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 3
-++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 3
-++++++ starting: end run for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ finished: end run for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ starting: end run for module: stream = 0 label = 'intProducerB' id = 9
-++++++ finished: end run for module: stream = 0 label = 'intProducerB' id = 9
-++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 12
-++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 12
 ++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0

--- a/FWIO/RNTupleTempTests/test/unit_test_outputs/testGetBy2.log
+++ b/FWIO/RNTupleTempTests/test/unit_test_outputs/testGetBy2.log
@@ -147,32 +147,6 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-
-++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -202,32 +176,6 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -681,32 +629,6 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-
-++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -745,32 +667,6 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
 
-++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-
-++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 2383b6183d2bd58762047deda96e12f0
-
-++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 5
-++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0

--- a/IOPool/Tests/test/unit_test_outputs/testGetBy1.log
+++ b/IOPool/Tests/test/unit_test_outputs/testGetBy1.log
@@ -305,36 +305,6 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 3
-++++++ starting: begin run for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ finished: begin run for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ starting: begin run for module: stream = 0 label = 'intProducerB' id = 9
-++++++ finished: begin run for module: stream = 0 label = 'intProducerB' id = 9
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 12
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 12
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -420,36 +390,6 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 3
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerB' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerB' id = 9
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 12
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -1095,36 +1035,6 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 3
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerB' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerB' id = 9
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 12
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -1219,36 +1129,6 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 3
-++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 3
-++++++ starting: end run for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ finished: end run for module: stream = 0 label = 'intProducerA' id = 8
-StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-    StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
-
-++++++ starting: end run for module: stream = 0 label = 'intProducerB' id = 9
-++++++ finished: end run for module: stream = 0 label = 'intProducerB' id = 9
-++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 12
-++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 12
 ++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0

--- a/IOPool/Tests/test/unit_test_outputs/testGetBy2.log
+++ b/IOPool/Tests/test/unit_test_outputs/testGetBy2.log
@@ -147,32 +147,6 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-
-++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -202,32 +176,6 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -681,32 +629,6 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-
-++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = EndLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -745,32 +667,6 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-
-++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 3
-StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-    StreamContext: StreamID = 0 transition = EndRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
-
-++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 5
-++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0


### PR DESCRIPTION
#### PR description:

- Require that if a module wants to see Run or LuminosityBlock transitions the code must use the appropriate stream::Watchs* template attribute.

#### PR validation:

Code compiles. Framework unit tests pass.

Separate pull requests have been made to change modules in CMSSW which need to use the edm::stream::Watch* attributes.

resolves https://github.com/cms-sw/framework-team/issues/813