### PR TITLE
Removed unused typedefs in FWCore

### DIFF
--- a/FWCore/Concurrency/interface/SerialTaskQueueChain.h
+++ b/FWCore/Concurrency/interface/SerialTaskQueueChain.h
@@ -100,7 +100,6 @@ namespace edm {
   template <typename T>
   void SerialTaskQueueChain::actionToRun(T&& iAction) {
     //even if an exception happens we will resume the queues.
-    using Queues = std::vector<std::shared_ptr<SerialTaskQueue>>;
     auto sentryAction = [](SerialTaskQueueChain* iChain) {
       auto& vec = iChain->m_queues;
       for (auto it = vec.rbegin() + 1; it != vec.rend(); ++it) {

--- a/FWCore/Framework/src/ExceptionActions.cc
+++ b/FWCore/Framework/src/ExceptionActions.cc
@@ -25,8 +25,6 @@ namespace edm {
     inline void install(exception_actions::ActionCodes code,
                         ExceptionToActionTable::ActionMap& out,
                         ParameterSet const& pset) {
-      typedef std::vector<std::string> vstring;
-
       // we cannot have parameters in the main process section so look
       // for an untracked (optional) ParameterSet called "options" for
       // now.  Notice that all exceptions (most actally) throw

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -762,7 +762,6 @@ namespace edm {
 
       msg << "\n<LumiSections>";
       msg << "\n<Inputs>";
-      typedef std::vector<JobReport::Token>::iterator iterator;
       for (auto const& iInput : f.contributingInputs) {
         addInputElement(impl_->inputFiles_[iInput], f.fastCopyingInputs, msg);
       }


### PR DESCRIPTION
#### PR description:

These were found while compiling the framework using an alternative method which had set the compiler directive `-Wall`.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2114#issue-4159625066