### PR TITLE
Fix LST warning for Track Candidate allocation

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
@@ -768,7 +768,7 @@ void LSTEvent::createTrackCandidates(bool no_pls_dupclean, bool tc_pls_triplets)
   alpaka::wait(queue_);  // wait to get the value before using it
 
   auto nTrackCandidatesTotal = *nTrackCanTotalHost_buf.data();
-  if (nTrackCandidatesTotal >= nTotal) {
+  if (nTrackCandidatesTotal > nMaxTC) {
     lstWarning(
         "\
         ****************************************************************************************************\n\


### PR DESCRIPTION
This PR fixes the warning triggered during Track Candidate (TC) allocation in events with a small number of TCs. Currently, the warning is thrown whenever the dynamic memory allocation for TCs is exactly equal to the required number, which can happen especially in no-pileup events. This update refines the check so that the warning is issued only when the allocation exceeds the static maximum number of TCs (nMaxTC).

FYI @GNiendorf @slava77


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport
