### PR TITLE
Update the beam spot tag in the Oflline data GT in autoCond - [CMSSW_16_0_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -37,8 +37,8 @@ autoCond = {
     'run3_data_express'            :    '160X_dataRun3_Express_frozen260223_v1',
     # GlobalTag for Run3 data relvals (prompt GT): same as 160X_dataRun3_Prompt_v1 but with snapshot at 2026-02-23 14:53:19 (UTC)
     'run3_data_prompt'             :    '160X_dataRun3_Prompt_frozen260223_v1',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2026-03-17 08:48:50 (UTC)
-    'run3_data'                    :    '150X_dataRun3_v7',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2026-03-30 15:14:30 (UTC)
+    'run3_data'                    :    '150X_dataRun3_v8',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-05-31 08:53:25 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)


### PR DESCRIPTION
#### PR description:

Beam spot in the Offline data GT was updated with the payloads corresponding to the latest inserted tracker alignment tags,, as requested in [cmsTalk](https://cms-talk.web.cern.ch/t/gt-offline-new-offline-gt-with-updated-tracker-alignment-conditions/141387/5)  The offline BeamSpot tag [BeamSpotObjects_Run3_LumiBased_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/BeamSpotObjects_Run3_LumiBased_v3) was updated by appending to it the payloads taken from the prompt tag ([BeamSpotObjects_PCL_byLumi_v0_prompt](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/BeamSpotObjects_PCL_byLumi_v0_prompt)).

The newly appended payloads cover conditions up to the end of era Run2025G (run 398903, included).

The latest offline data GT is [150X_dataRun3_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_dataRun3_v8) and its difference with respect to _v7 is  [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_dataRun3_v8/150X_dataRun3_v7).

#### PR validation:

Rely on tests made for the master version of this PR

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #50592