### PR TITLE
Update the TK alignment and beam spot tags in the Oflline data GT in autoCond - [CMSSW_15_0_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -37,8 +37,8 @@ autoCond = {
     'run3_data_express'            :    '150X_dataRun3_Express_frozen250613_v1',
     # GlobalTag for Run3 data relvals (prompt GT): same as 150X_dataRun3_Prompt_v1 but with snapshot at 2025-06-13 05:06:05 (UTC)
     'run3_data_prompt'             :    '150X_dataRun3_Prompt_frozen250613_v1',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2025-11-11 14:11:48 (UTC)
-    'run3_data'                    :    '150X_dataRun3_v6',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2026-03-30 15:14:30 (UTC)
+    'run3_data'                    :    '150X_dataRun3_v8',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-05-31 08:53:25 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)


### PR DESCRIPTION
#### PR description:

Update the Run3 data GT, in order to allow the most recent Tracker Alignment payloads listed in https://cms-talk.web.cern.ch/t/gt-offline-new-offline-gt-with-updated-tracker-alignment-conditions/141387

Beam spot in the Offline data GT was also updated with the payloads corresponding to those latest inserted tracker alignment tags,, as requested in [cmsTalk](https://cms-talk.web.cern.ch/t/gt-offline-new-offline-gt-with-updated-tracker-alignment-conditions/141387/5)  The offline BeamSpot tag [BeamSpotObjects_Run3_LumiBased_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/BeamSpotObjects_Run3_LumiBased_v3) was updated by appending to it the payloads taken from the prompt tag ([BeamSpotObjects_PCL_byLumi_v0_prompt](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/BeamSpotObjects_PCL_byLumi_v0_prompt)).

The newly appended payloads cover conditions up to the end of era Run2025G (run 398903, included).

The latest offline data GT is [150X_dataRun3_v8](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/150X_dataRun3_v8) and its difference with respect to previous in autoCond _v6 is  [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/150X_dataRun3_v8/150X_dataRun3_v6).

#### PR validation:

Rely on tests made for the master versions of this PR

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #50592 and #50443