### PR TITLE
[16_0_X]  HcalDQM: Add calibration monitoring to offline sequence 

### DIFF
--- a/DQM/HcalCommon/src/DQClient.cc
+++ b/DQM/HcalCommon/src/DQClient.cc
@@ -1,6 +1,7 @@
 #include "DQM/HcalCommon/interface/DQClient.h"
 
 namespace hcaldqm {
+  using namespace hcaldqm;
   using namespace constants;
   DQClient::DQClient(std::string const &name,
                      std::string const &taskname,
@@ -73,6 +74,18 @@ namespace hcaldqm {
       std::map<int, uint32_t> crateHashMap = utilities::getCrateHashMap(_emap);
       for (auto &it_crate : _vCrates) {
         _vhashCrates.push_back(crateHashMap[it_crate]);
+      }
+
+      _vFEDs = utilities::getFEDList(_emap);
+      std::vector<int> vFEDsVME = utilities::getFEDVMEList(_emap);
+      std::vector<int> vFEDsuTCA = utilities::getFEDuTCAList(_emap);
+      for (std::vector<int>::const_iterator it = vFEDsVME.begin(); it != vFEDsVME.end(); ++it)
+        _vhashFEDs.push_back(
+            HcalElectronicsId(constants::FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN, (*it) - FED_VME_MIN).rawId());
+      for (std::vector<int>::const_iterator it = vFEDsuTCA.begin(); it != vFEDsuTCA.end(); ++it) {
+        std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(*it);
+        _vhashFEDs.push_back(
+            HcalElectronicsId(cspair.first, cspair.second, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
       }
     }
 

--- a/DQM/HcalCommon/src/DQClient.cc
+++ b/DQM/HcalCommon/src/DQClient.cc
@@ -1,7 +1,6 @@
 #include "DQM/HcalCommon/interface/DQClient.h"
 
 namespace hcaldqm {
-  using namespace hcaldqm;
   using namespace constants;
   DQClient::DQClient(std::string const &name,
                      std::string const &taskname,

--- a/DQM/HcalCommon/src/DQClient.cc
+++ b/DQM/HcalCommon/src/DQClient.cc
@@ -25,6 +25,7 @@ namespace hcaldqm {
   void DQClient::beginRun(edm::Run const &r, edm::EventSetup const &es) {
     //	TEMPORARY
     _vhashFEDs.clear();
+    _vFEDs.clear();
     _vcdaqEids.clear();
     _vhashCrates.clear();
 
@@ -76,14 +77,22 @@ namespace hcaldqm {
         _vhashCrates.push_back(crateHashMap[it_crate]);
       }
 
-      _vFEDs = utilities::getFEDList(_emap);
       std::vector<int> vFEDsVME = utilities::getFEDVMEList(_emap);
       std::vector<int> vFEDsuTCA = utilities::getFEDuTCAList(_emap);
-      for (std::vector<int>::const_iterator it = vFEDsVME.begin(); it != vFEDsVME.end(); ++it)
+      for (std::vector<int>::const_iterator it = vFEDsVME.begin(); it != vFEDsVME.end(); ++it) {
+        if (*it <= 0)
+          continue;
+        _vFEDs.push_back(*it);
         _vhashFEDs.push_back(
             HcalElectronicsId(constants::FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN, (*it) - FED_VME_MIN).rawId());
+      }
       for (std::vector<int>::const_iterator it = vFEDsuTCA.begin(); it != vFEDsuTCA.end(); ++it) {
+        if (*it <= 0)
+          continue;
         std::pair<uint16_t, uint16_t> cspair = utilities::fed2crate(*it);
+        if (cspair.first == 0)
+          continue;
+        _vFEDs.push_back(*it);
         _vhashFEDs.push_back(
             HcalElectronicsId(cspair.first, cspair.second, FIBER_uTCA_MIN1, FIBERCH_MIN, false).rawId());
       }

--- a/DQM/HcalCommon/src/DQTask.cc
+++ b/DQM/HcalCommon/src/DQTask.cc
@@ -58,7 +58,7 @@ namespace hcaldqm {
     //	get the run info FEDs - FEDs registered at cDAQ
     //	and determine if there are any HCAL FEDs in.
     //	push them as ElectronicsIds into the vector
-    //    _vcdaqEids.clear();
+    _vcdaqEids.clear();
     if (auto runInfoRec = es.tryToGet<RunInfoRcd>()) {
       const RunInfo &runInfo = es.getData(runInfoToken_);
       std::vector<int> vfeds = runInfo.m_fed_in;

--- a/DQM/HcalCommon/src/DQTask.cc
+++ b/DQM/HcalCommon/src/DQTask.cc
@@ -58,6 +58,7 @@ namespace hcaldqm {
     //	get the run info FEDs - FEDs registered at cDAQ
     //	and determine if there are any HCAL FEDs in.
     //	push them as ElectronicsIds into the vector
+    //    _vcdaqEids.clear();
     if (auto runInfoRec = es.tryToGet<RunInfoRcd>()) {
       const RunInfo &runInfo = es.getData(runInfoToken_);
       std::vector<int> vfeds = runInfo.m_fed_in;

--- a/DQM/HcalTasks/interface/DigiRunSummary.h
+++ b/DQM/HcalTasks/interface/DigiRunSummary.h
@@ -43,10 +43,13 @@ namespace hcaldqm {
       fNChsHF = 1,
       fUnknownIds = 2,
       fLED = 3,
-      nLSFlags = 4,  // defines the boundary between lumi-based and run-based flags
-      fUniHF = 5,
-      fDead = 6,
-      nDigiFlag = 7
+      fRADDAM = 4,
+      fLASER = 5,
+      fPinDiode = 6,
+      nLSFlags = 7,  // defines the boundary between lumi-based and run-based flags
+      fUniHF = 8,
+      fDead = 9,
+      nDigiFlag = 10
     };
   };
 }  // namespace hcaldqm

--- a/DQM/HcalTasks/interface/DigiRunSummary.h
+++ b/DQM/HcalTasks/interface/DigiRunSummary.h
@@ -22,6 +22,7 @@ namespace hcaldqm {
     std::vector<LSSummary> _vflagsLS;
 
     double _thresh_unihf;
+    double _thresh_pindiode;
 
     electronicsmap::ElectronicsMap _ehashmap;
 

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -156,7 +156,6 @@ protected:
   hcaldqm::ContainerProf1D _cOccupancyBadCapidvsLS_Subdet;
   hcaldqm::Container2D _cOccupancyBadCapidvsLS_depth;
   //	#Time Samples for a digi. Used for Summary generation
-  hcaldqm::Container1D _cDigiSize_Crate;
   hcaldqm::Container1D _cDigiSize_FED;
   hcaldqm::ContainerProf1D _cDigiSizevsLS_FED;     // online only
   hcaldqm::ContainerXXX<uint32_t> _xDigiSize;      // online only
@@ -206,18 +205,21 @@ protected:
   // CU LED monitoring stuff
   double _thresh_led;
   std::map<HcalSubdetector, std::vector<HcalDetId> > _ledCalibrationChannels;
-  hcaldqm::Container1D _LED_CUCountvsLS_Subdet;       // Misfire count vs LS
-  hcaldqm::Container1D _LED_CUCountvsLSmod60_Subdet;  // Misfire count vs LS
+  hcaldqm::Container1D _LED_CUCountvsLSmod60_Subdet;  // Misfire count vs LS (per subdet)
+  hcaldqm::Container1D _LED_CUCountvsLS_FED;          // Misfire count vs LS (per FED)
   hcaldqm::Container2D _LED_ADCvsBX_Subdet;           // Pin diode amplitude vs BX
   hcaldqm::Container2D _LED_ADCvsTS_Subdet;           // Pin diode amplitude vs TS for online DQM
 
   // CU laser monitoring stuff
   double _thresh_laser;
   std::map<HcalSubdetector, std::vector<HcalDetId> > _laserCalibrationChannels;
-  hcaldqm::Container1D _LASER_CUCountvsLS_Subdet;       // Misfire count vs LS
-  hcaldqm::Container1D _LASER_CUCountvsLSmod60_Subdet;  // Misfire count vs LS
+  hcaldqm::Container1D _LASER_CUCountvsLSmod60_Subdet;  // Misfire count vs LS (per subdet)
+  hcaldqm::Container1D _LASER_CUCountvsLS_FED;          // Misfire count vs LS (per FED)
   hcaldqm::Container2D _LASER_ADCvsBX_Subdet;           // Pin diode amplitude vs BX
   hcaldqm::Container2D _LASER_ADCvsTS_Subdet;           // Pin diode amplitude vs TS for online DQM
+
+  // Map from calibration channel DetId to its HcalElectronicsId (for per-FED CU fill)
+  std::map<uint32_t, HcalElectronicsId> _calibDetId2Eid;
 
   // CU Raddam monitoring stuff
   double _thresh_raddam;

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -41,6 +41,9 @@ protected:
   void _process(edm::Event const &, edm::EventSetup const &) override;
   void _resetMonitors(hcaldqm::UpdateFreq) override;
 
+  /// Fill per-FED CU count vs LS when a detRawId is in _calibDetId2Eid (LED/Laser blocks).
+  void _fillCUFEDCountVsLS(hcaldqm::Container1D &hist, uint32_t detRawId);
+
   edm::InputTag _tagQIE11;
   edm::InputTag _tagHO;
   edm::InputTag _tagQIE10;
@@ -230,6 +233,7 @@ protected:
   hcaldqm::ContainerSingle2D _Raddam_ADCvsTS;           // Raddam amplitude vs TS for online DQM
 
   // Laser monitoring for pin diode channel (0, 31, 0)
+  double _thresh_pindiode;
   hcaldqm::ContainerSingleProf1D _cSumQvsBX_PinDiode;
   hcaldqm::ContainerSingleProf1D _cSumQvsLS_PinDiode;
   hcaldqm::ContainerSingle2D _cADCvsTS_PinDiode;

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -566,7 +566,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
     _filter_FEDHF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fFED, vFEDHF);
 
     //	push the rawIds of each fed into the vector...
-    //    _vhashFEDs.clear();
+    _vhashFEDs.clear();
     for (std::vector<int>::const_iterator it = vFEDsVME.begin(); it != vFEDsVME.end(); ++it)
       _vhashFEDs.push_back(
           HcalElectronicsId(constants::FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN, (*it) - FED_VME_MIN).rawId());

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -113,9 +113,11 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
 
         if (isLED) {
           _ledCalibrationChannels[this_subdet].push_back(HcalDetId(id.rawId()));
+          _calibDetId2Eid[id.rawId()] = eid;
         }
         if (isLAS) {
           _laserCalibrationChannels[this_subdet].push_back(HcalDetId(id.rawId()));
+          _calibDetId2Eid[id.rawId()] = eid;
         }
         if (isRAD) {
           _raddamCalibrationChannels[this_subdet].push_back(HcalDetId(id.rawId()));
@@ -311,13 +313,13 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
                                   0);
 
-  // Digi size
-  _cDigiSize_Crate.initialize(_name,
-                              "DigiSize",
-                              hcaldqm::hashfunctions::fCrate,
-                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDigiSize),
-                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
-                              0);
+  // Digi size (per FED: online, offline/local)
+  _cDigiSize_FED.initialize(_name,
+                            "DigiSize",
+                            hcaldqm::hashfunctions::fFED,
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDigiSize),
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                            0);
   _cADCvsTS_SubdetPM.initialize(_name,
                                 "ADCvsTS",
                                 hcaldqm::hashfunctions::fSubdetPM,
@@ -633,13 +635,6 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
                                               0);
 
-    _cDigiSize_FED.initialize(_name,
-                              "DigiSize",
-                              hcaldqm::hashfunctions::fFED,
-                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fDigiSize),
-                              new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
-                              0);
-
     if (_ptype == fOnline) {
       _cSummaryvsLS_FED.initialize(_name,
                                    "SummaryvsLS",
@@ -680,12 +675,12 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
                                    0);
 
-    _LED_CUCountvsLS_Subdet.initialize(_name + "/CU_LED",
-                                       "CU_LED_CUCountvsLS",
-                                       hcaldqm::hashfunctions::fSubdet,
-                                       new hcaldqm::quantity::LumiSection(_maxLS),
-                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
-                                       0);
+    _LED_CUCountvsLS_FED.initialize(_name + "/CU_LED",
+                                    "CU_LED_CUCountvsLS",
+                                    hcaldqm::hashfunctions::fFED,
+                                    new hcaldqm::quantity::LumiSection(_maxLS),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                    0);
     if (_ptype == fOnline) {
       _LED_CUCountvsLSmod60_Subdet.initialize(_name + "/CU_LED",
                                               "CU_LED_CUCountvsLSmod60",
@@ -709,12 +704,12 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
                                      0);
-    _LASER_CUCountvsLS_Subdet.initialize(_name + "/CU_Laser",
-                                         "CU_LASER_CUCountvsLS",
-                                         hcaldqm::hashfunctions::fSubdet,
-                                         new hcaldqm::quantity::LumiSection(_maxLS),
-                                         new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
-                                         0);
+    _LASER_CUCountvsLS_FED.initialize(_name + "/CU_Laser",
+                                      "CU_LASER_CUCountvsLS",
+                                      hcaldqm::hashfunctions::fFED,
+                                      new hcaldqm::quantity::LumiSection(_maxLS),
+                                      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                      0);
     if (_ptype == fOnline) {
       _LASER_CUCountvsLSmod60_Subdet.initialize(_name + "/CU_Laser",
                                                 "CU_LASER_CUCountvsLSmod60",
@@ -806,7 +801,6 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
     _cDigiSize_FED.book(ib, _emap, _subsystem);
   }
   if (_ptype != fOffline) {  // else book per-lumi later.
-    _cDigiSize_Crate.book(ib, _emap, _subsystem);
     _cOccupancy_depth.book(ib, _emap, _subsystem);
   }
 
@@ -846,14 +840,14 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   if (_ptype != fLocal) {
     _LED_ADCvsBX_Subdet.book(ib, _emap, _subsystem);
     _LED_ADCvsTS_Subdet.book(ib, _emap, _subsystem);
-    _LED_CUCountvsLS_Subdet.book(ib, _emap, _subsystem);
+    _LED_CUCountvsLS_FED.book(ib, _emap, _subsystem);
     if (_ptype == fOnline) {
       _LED_CUCountvsLSmod60_Subdet.book(ib, _emap, _subsystem);
     }
     // Book laser monitoring containers
     _LASER_ADCvsBX_Subdet.book(ib, _emap, _subsystem);
     _LASER_ADCvsTS_Subdet.book(ib, _emap, _subsystem);
-    _LASER_CUCountvsLS_Subdet.book(ib, _emap, _subsystem);
+    _LASER_CUCountvsLS_FED.book(ib, _emap, _subsystem);
     if (_ptype == fOnline) {
       _LASER_CUCountvsLSmod60_Subdet.book(ib, _emap, _subsystem);
     }
@@ -932,7 +926,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
     auto scope = DQMStore::IBooker::UseLumiScope(ib);
     if (_ptype == fOffline) {
       //_cDigiSize_FED.setLumiFlag();
-      _cDigiSize_Crate.book(ib, _emap, _subsystem);
+      _cDigiSize_FED.book(ib, _emap, _subsystem);
       _cOccupancy_depth.book(ib, _emap, _subsystem);
     }
 
@@ -1054,7 +1048,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                 }
               }
               if (channelLEDSignalPresent) {
-                _LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS);
+                auto it_eid = _calibDetId2Eid.find(did.rawId());
+                if (it_eid != _calibDetId2Eid.end())
+                  _LED_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
                 if (_ptype == fOnline) {
                   _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS % 60);
                 }
@@ -1073,7 +1069,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                 }
               }
               if (channelLEDSignalPresent) {
-                _LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), _currentLS);
+                auto it_eid = _calibDetId2Eid.find(did.rawId());
+                if (it_eid != _calibDetId2Eid.end())
+                  _LED_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
                 if (_ptype == fOnline) {
                   _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), _currentLS % 60);
                 }
@@ -1092,7 +1090,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                 }
               }
               if (channelLASERSignalPresent) {
-                _LASER_CUCountvsLS_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS);
+                auto it_eid = _calibDetId2Eid.find(did.rawId());
+                if (it_eid != _calibDetId2Eid.end())
+                  _LASER_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
                 if (_ptype == fOnline) {
                   _LASER_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS % 60);
                 }
@@ -1109,7 +1109,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                 }
               }
               if (channelLASERSignalPresent) {
-                _LASER_CUCountvsLS_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), _currentLS);
+                auto it_eid = _calibDetId2Eid.find(did.rawId());
+                if (it_eid != _calibDetId2Eid.end())
+                  _LASER_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
                 if (_ptype == fOnline) {
                   _LASER_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), _currentLS % 60);
                 }
@@ -1195,9 +1197,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
       _cOccupancyvsiphi_SubdetPM.fill(did);
       _cOccupancyvsieta_Subdet.fill(did);
     }
-    _cDigiSize_Crate.fill(eid, digi.samples());
+    _cDigiSize_FED.fill(eid, digi.samples());
     if (_ptype != fOffline) {  // hidefed2crate
-      _cDigiSize_FED.fill(eid, digi.samples());
       if (!eid.isVMEid()) {
         _cOccupancy_FEDuTCA.fill(eid);
         _cOccupancy_ElectronicsuTCA.fill(eid);
@@ -1339,7 +1340,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                 }
               }
               if (channelLEDSignalPresent) {
-                _LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), _currentLS);
+                auto it_eid = _calibDetId2Eid.find(did.rawId());
+                if (it_eid != _calibDetId2Eid.end())
+                  _LED_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
                 if (_ptype == fOnline) {
                   _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), _currentLS % 60);
                 }
@@ -1358,7 +1361,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                 }
               }
               if (channelLASERSignalPresent) {
-                _LASER_CUCountvsLS_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), _currentLS);
+                auto it_eid = _calibDetId2Eid.find(did.rawId());
+                if (it_eid != _calibDetId2Eid.end())
+                  _LASER_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
                 if (_ptype == fOnline) {
                   _LASER_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), _currentLS % 60);
                 }
@@ -1427,9 +1432,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
       _cOccupancyvsiphi_SubdetPM.fill(did);
       _cOccupancyvsieta_Subdet.fill(did);
     }
-    _cDigiSize_Crate.fill(eid, it->size());
+    _cDigiSize_FED.fill(eid, it->size());
     if (_ptype != fOffline) {  // hidefed2crate
-      _cDigiSize_FED.fill(eid, it->size());
       if (!eid.isVMEid()) {
         _cOccupancy_FEDuTCA.fill(eid);
         _cOccupancy_ElectronicsuTCA.fill(eid);
@@ -1532,7 +1536,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                   }
                 }
                 if (channelLEDSignalPresent) {
-                  _LED_CUCountvsLS_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), _currentLS);
+                  auto it_eid = _calibDetId2Eid.find(did.rawId());
+                  if (it_eid != _calibDetId2Eid.end())
+                    _LED_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
                   if (_ptype == fOnline) {
                     _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), _currentLS % 60);
                   }
@@ -1551,7 +1557,9 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                   }
                 }
                 if (channelLASERSignalPresent) {
-                  _LASER_CUCountvsLS_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), _currentLS);
+                  auto it_eid = _calibDetId2Eid.find(did.rawId());
+                  if (it_eid != _calibDetId2Eid.end())
+                    _LASER_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
                   if (_ptype == fOnline) {
                     _LASER_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), _currentLS % 60);
                   }
@@ -1650,9 +1658,8 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
         _cOccupancyvsiphi_SubdetPM.fill(did);
         _cOccupancyvsieta_Subdet.fill(did);
       }
-      _cDigiSize_Crate.fill(eid, digi.samples());
+      _cDigiSize_FED.fill(eid, digi.samples());
       if (_ptype != fOffline) {  // hidefed2crate
-        _cDigiSize_FED.fill(eid, digi.samples());
         if (!eid.isVMEid()) {
           _cOccupancy_FEDuTCA.fill(eid);
           _cOccupancy_ElectronicsuTCA.fill(eid);
@@ -1844,61 +1851,23 @@ std::shared_ptr<hcaldqm::Cache> DigiTask::globalBeginLuminosityBlock(edm::Lumino
       else
         _vflags[fUnknownIds]._state = hcaldqm::flag::fGOOD;
 
-      // LED misfires
+      // LED/Laser/PinDiode/Raddam misfires per-FED granularity
       if (_ptype != fLocal) {
-        if (hcaldqm::utilities::isFEDHBHE(eid)) {
-          HcalDetId did_hb(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalBarrel, 1, 1, 1)));
-          HcalDetId did_he(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalEndcap, 16, 1, 1)));
+        if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHF(eid) ||
+            hcaldqm::utilities::isFEDHO(eid)) {
+          _vflags[fLED]._state =
+              (_LED_CUCountvsLS_FED.getBinContent(eid, _currentLS) > 0) ? hcaldqm::flag::fBAD : hcaldqm::flag::fGOOD;
 
-          if (_LED_CUCountvsLS_Subdet.getBinContent(did_hb, _currentLS) > 0 ||
-              _LED_CUCountvsLS_Subdet.getBinContent(did_he, _currentLS) > 0) {
-            _vflags[fLED]._state = hcaldqm::flag::fBAD;
-          } else {
-            _vflags[fLED]._state = hcaldqm::flag::fGOOD;
-          }
-          // Laser misfires
-          if (_LASER_CUCountvsLS_Subdet.getBinContent(did_hb, _currentLS) > 0 ||
-              _LASER_CUCountvsLS_Subdet.getBinContent(did_he, _currentLS) > 0) {
-            _vflags[fLASER]._state = hcaldqm::flag::fBAD;
-          } else {
-            _vflags[fLASER]._state = hcaldqm::flag::fGOOD;
-          }
-          // Pin diode misfires
-          if (_cSumQvsLS_PinDiode.getBinContent(_currentLS) >
-              2000) {  // 2000 fC is the hardcoded threshold for pin diode misfires, this is a temporary fix
-            _vflags[fPinDiode]._state = hcaldqm::flag::fBAD;
-          } else {
-            _vflags[fPinDiode]._state = hcaldqm::flag::fGOOD;
-          }
-        } else if (hcaldqm::utilities::isFEDHF(eid)) {
-          HcalDetId did_hf(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalForward, 29, 1, 1)));
-          if (_LED_CUCountvsLS_Subdet.getBinContent(did_hf, _currentLS) > 0) {
-            _vflags[fLED]._state = hcaldqm::flag::fBAD;
-          } else {
-            _vflags[fLED]._state = hcaldqm::flag::fGOOD;
-          }
-          if (_LASER_CUCountvsLS_Subdet.getBinContent(did_hf, _currentLS) > 0) {
-            _vflags[fLASER]._state = hcaldqm::flag::fBAD;
-          } else {
-            _vflags[fLASER]._state = hcaldqm::flag::fGOOD;
-          }
-          if (_Raddam_CUCountvsLS.getBinContent(_currentLS) > 0) {
-            _vflags[fRADDAM]._state = hcaldqm::flag::fBAD;
-          } else {
-            _vflags[fRADDAM]._state = hcaldqm::flag::fGOOD;
-          }
-        } else if (hcaldqm::utilities::isFEDHO(eid)) {
-          HcalDetId did_ho(hcaldqm::hashfunctions::hash_Subdet(HcalDetId(HcalOuter, 1, 1, 1)));
-          if (_LED_CUCountvsLS_Subdet.getBinContent(did_ho, _currentLS) > 0) {
-            _vflags[fLED]._state = hcaldqm::flag::fBAD;
-          } else {
-            _vflags[fLED]._state = hcaldqm::flag::fGOOD;
-          }
-          if (_LASER_CUCountvsLS_Subdet.getBinContent(did_ho, _currentLS) > 0) {
-            _vflags[fLASER]._state = hcaldqm::flag::fBAD;
-          } else {
-            _vflags[fLASER]._state = hcaldqm::flag::fGOOD;
-          }
+          _vflags[fLASER]._state =
+              (_LASER_CUCountvsLS_FED.getBinContent(eid, _currentLS) > 0) ? hcaldqm::flag::fBAD : hcaldqm::flag::fGOOD;
+        }
+        if (hcaldqm::utilities::isFEDHBHE(eid)) {
+          _vflags[fPinDiode]._state =
+              (_cSumQvsLS_PinDiode.getBinContent(_currentLS) > 2000) ? hcaldqm::flag::fBAD : hcaldqm::flag::fGOOD;
+        }
+        if (hcaldqm::utilities::isFEDHF(eid)) {
+          _vflags[fRADDAM]._state =
+              (_Raddam_CUCountvsLS.getBinContent(_currentLS) > 0) ? hcaldqm::flag::fBAD : hcaldqm::flag::fGOOD;
         }
       }
 

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -566,6 +566,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
     _filter_FEDHF.initialize(filter::fPreserver, hcaldqm::hashfunctions::fFED, vFEDHF);
 
     //	push the rawIds of each fed into the vector...
+    //    _vhashFEDs.clear();
     for (std::vector<int>::const_iterator it = vFEDsVME.begin(); it != vFEDsVME.end(); ++it)
       _vhashFEDs.push_back(
           HcalElectronicsId(constants::FIBERCH_MIN, FIBER_VME_MIN, SPIGOT_MIN, (*it) - FED_VME_MIN).rawId());

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -24,6 +24,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   _thresh_led = ps.getUntrackedParameter<double>("thresh_led", 20);
   _thresh_laser = ps.getUntrackedParameter<double>("thresh_laser", 20);
   _thresh_raddam = ps.getUntrackedParameter<double>("thresh_raddam", 20);
+  _thresh_pindiode = ps.getUntrackedParameter<double>("thresh_pindiode", 2000);
 
   _vflags.resize(nDigiFlag);
   _vflags[fUni] = hcaldqm::flag::Flag("UniSlotHF");
@@ -50,6 +51,12 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
   _capidmbx[HcalEndcap] = 1;
   _capidmbx[HcalOuter] = 1;
   _capidmbx[HcalForward] = 1;
+}
+
+void DigiTask::_fillCUFEDCountVsLS(hcaldqm::Container1D& hist, uint32_t detRawId) {
+  auto it = _calibDetId2Eid.find(detRawId);
+  if (it != _calibDetId2Eid.end())
+    hist.fill(it->second, _currentLS);
 }
 
 /* virtual */ void DigiTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
@@ -1048,9 +1055,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                 }
               }
               if (channelLEDSignalPresent) {
-                auto it_eid = _calibDetId2Eid.find(did.rawId());
-                if (it_eid != _calibDetId2Eid.end())
-                  _LED_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
+                _fillCUFEDCountVsLS(_LED_CUCountvsLS_FED, did.rawId());
                 if (_ptype == fOnline) {
                   _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS % 60);
                 }
@@ -1069,9 +1074,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                 }
               }
               if (channelLEDSignalPresent) {
-                auto it_eid = _calibDetId2Eid.find(did.rawId());
-                if (it_eid != _calibDetId2Eid.end())
-                  _LED_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
+                _fillCUFEDCountVsLS(_LED_CUCountvsLS_FED, did.rawId());
                 if (_ptype == fOnline) {
                   _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), _currentLS % 60);
                 }
@@ -1090,9 +1093,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                 }
               }
               if (channelLASERSignalPresent) {
-                auto it_eid = _calibDetId2Eid.find(did.rawId());
-                if (it_eid != _calibDetId2Eid.end())
-                  _LASER_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
+                _fillCUFEDCountVsLS(_LASER_CUCountvsLS_FED, did.rawId());
                 if (_ptype == fOnline) {
                   _LASER_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalEndcap, 16, 1, 1), _currentLS % 60);
                 }
@@ -1109,9 +1110,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                 }
               }
               if (channelLASERSignalPresent) {
-                auto it_eid = _calibDetId2Eid.find(did.rawId());
-                if (it_eid != _calibDetId2Eid.end())
-                  _LASER_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
+                _fillCUFEDCountVsLS(_LASER_CUCountvsLS_FED, did.rawId());
                 if (_ptype == fOnline) {
                   _LASER_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), _currentLS % 60);
                 }
@@ -1340,9 +1339,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                 }
               }
               if (channelLEDSignalPresent) {
-                auto it_eid = _calibDetId2Eid.find(did.rawId());
-                if (it_eid != _calibDetId2Eid.end())
-                  _LED_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
+                _fillCUFEDCountVsLS(_LED_CUCountvsLS_FED, did.rawId());
                 if (_ptype == fOnline) {
                   _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), _currentLS % 60);
                 }
@@ -1361,9 +1358,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                 }
               }
               if (channelLASERSignalPresent) {
-                auto it_eid = _calibDetId2Eid.find(did.rawId());
-                if (it_eid != _calibDetId2Eid.end())
-                  _LASER_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
+                _fillCUFEDCountVsLS(_LASER_CUCountvsLS_FED, did.rawId());
                 if (_ptype == fOnline) {
                   _LASER_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 4), _currentLS % 60);
                 }
@@ -1536,9 +1531,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                   }
                 }
                 if (channelLEDSignalPresent) {
-                  auto it_eid = _calibDetId2Eid.find(did.rawId());
-                  if (it_eid != _calibDetId2Eid.end())
-                    _LED_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
+                  _fillCUFEDCountVsLS(_LED_CUCountvsLS_FED, did.rawId());
                   if (_ptype == fOnline) {
                     _LED_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), _currentLS % 60);
                   }
@@ -1557,9 +1550,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                   }
                 }
                 if (channelLASERSignalPresent) {
-                  auto it_eid = _calibDetId2Eid.find(did.rawId());
-                  if (it_eid != _calibDetId2Eid.end())
-                    _LASER_CUCountvsLS_FED.fill(it_eid->second, _currentLS);
+                  _fillCUFEDCountVsLS(_LASER_CUCountvsLS_FED, did.rawId());
                   if (_ptype == fOnline) {
                     _LASER_CUCountvsLSmod60_Subdet.fill(HcalDetId(HcalForward, 29, 1, 1), _currentLS % 60);
                   }
@@ -1862,8 +1853,9 @@ std::shared_ptr<hcaldqm::Cache> DigiTask::globalBeginLuminosityBlock(edm::Lumino
               (_LASER_CUCountvsLS_FED.getBinContent(eid, _currentLS) > 0) ? hcaldqm::flag::fBAD : hcaldqm::flag::fGOOD;
         }
         if (hcaldqm::utilities::isFEDHBHE(eid)) {
-          _vflags[fPinDiode]._state =
-              (_cSumQvsLS_PinDiode.getBinContent(_currentLS) > 2000) ? hcaldqm::flag::fBAD : hcaldqm::flag::fGOOD;
+          _vflags[fPinDiode]._state = (_cSumQvsLS_PinDiode.getBinContent(_currentLS) > _thresh_pindiode)
+                                          ? hcaldqm::flag::fBAD
+                                          : hcaldqm::flag::fGOOD;
         }
         if (hcaldqm::utilities::isFEDHF(eid)) {
           _vflags[fRADDAM]._state =

--- a/DQM/HcalTasks/python/DigiTask_cfi.py
+++ b/DQM/HcalTasks/python/DigiTask_cfi.py
@@ -29,7 +29,7 @@ digiTask = DQMEDAnalyzer(
 
 	#	ratio thresholds
 	thresh_unifh = cms.untracked.double(0.2),
-	thresh_led = cms.untracked.double(20),
+	thresh_led = cms.untracked.double(60),
     thresh_laser = cms.untracked.double(60),
 	thresh_raddam = cms.untracked.double(20),
 

--- a/DQM/HcalTasks/python/DigiTask_cfi.py
+++ b/DQM/HcalTasks/python/DigiTask_cfi.py
@@ -29,7 +29,7 @@ digiTask = DQMEDAnalyzer(
 
 	#	ratio thresholds
 	thresh_unifh = cms.untracked.double(0.2),
-	thresh_led = cms.untracked.double(60),
+	thresh_led = cms.untracked.double(20),
     thresh_laser = cms.untracked.double(60),
 	thresh_raddam = cms.untracked.double(20),
 

--- a/DQM/HcalTasks/python/DigiTask_cfi.py
+++ b/DQM/HcalTasks/python/DigiTask_cfi.py
@@ -28,10 +28,11 @@ digiTask = DQMEDAnalyzer(
 	cutSumQ_HF = cms.untracked.double(20),
 
 	#	ratio thresholds
-	thresh_unifh = cms.untracked.double(0.2),
+	thresh_unihf = cms.untracked.double(0.2),
 	thresh_led = cms.untracked.double(60),
     thresh_laser = cms.untracked.double(60),
 	thresh_raddam = cms.untracked.double(20),
+	thresh_pindiode = cms.untracked.double(2000), #units in fC, currently an adequate approximation to cut off pedestals
 
 	qie10InConditions = cms.untracked.bool(False),
 

--- a/DQM/HcalTasks/python/HcalOfflineHarvesting_cfi.py
+++ b/DQM/HcalTasks/python/HcalOfflineHarvesting_cfi.py
@@ -18,6 +18,7 @@ hcalOfflineHarvesting = DQMEDHarvester(
 	thresh_FGMsmRate_high = cms.untracked.double(0.2),
 	thresh_FGMsmRate_low = cms.untracked.double(0.1),
 	thresh_unihf = cms.untracked.double(0.2),
+	thresh_pindiode = cms.untracked.double(2000),
 	thresh_tcds = cms.untracked.double(1.5),
 	refDigiSize = digiTask.refDigiSize,
 )

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -93,13 +93,13 @@ namespace hcaldqm {
     _xNChs.reset();
 
     //	INITIALIZE LUMI BASED HISTOGRAMS
-    Container2D cDigiSize_Crate, cOccupancy_depth;
-    cDigiSize_Crate.initialize(_taskname,
-                               "DigiSize",
-                               hashfunctions::fCrate,
-                               new quantity::ValueQuantity(quantity::fDigiSize),
-                               new quantity::ValueQuantity(quantity::fN),
-                               0);
+    Container2D cDigiSize_FED, cOccupancy_depth;
+    cDigiSize_FED.initialize(_taskname,
+                             "DigiSize",
+                             hashfunctions::fFED,
+                             new quantity::ValueQuantity(quantity::fDigiSize),
+                             new quantity::ValueQuantity(quantity::fN),
+                             0);
     cOccupancy_depth.initialize(_taskname,
                                 "Occupancy",
                                 hashfunctions::fdepth,
@@ -110,7 +110,7 @@ namespace hcaldqm {
 
     //	LOAD LUMI BASED HISTOGRAMS
     cOccupancy_depth.load(ig, _emap, _subsystem);
-    cDigiSize_Crate.load(ig, _emap, _subsystem);
+    cDigiSize_FED.load(ig, _emap, _subsystem);
     MonitorElement* meNumEvents = ig.get(_subsystem + "/RunInfo/NumberOfEvents");
     int numEvents = meNumEvents->getBinContent(1);
     bool unknownIdsPresent = ig.get(_subsystem + "/" + _taskname + "/UnknownIds")->getBinContent(1) > 0;
@@ -138,8 +138,8 @@ namespace hcaldqm {
       cOccupancy_depth.getBinContent(did) > 0 ? _xNChs.get(eid)++ : _xNChs.get(eid) += 0;
       _cOccupancy_depth.fill(did, cOccupancy_depth.getBinContent(did));
       //	digi size
-      cDigiSize_Crate.getMean(eid) != _refDigiSize[did.subdet()] ? _xDigiSize.get(eid)++ : _xDigiSize.get(eid) += 0;
-      cDigiSize_Crate.getRMS(eid) != 0 ? _xDigiSize.get(eid)++ : _xDigiSize.get(eid) += 0;
+      cDigiSize_FED.getMean(eid) != _refDigiSize[did.subdet()] ? _xDigiSize.get(eid)++ : _xDigiSize.get(eid) += 0;
+      cDigiSize_FED.getRMS(eid) != 0 ? _xDigiSize.get(eid)++ : _xDigiSize.get(eid) += 0;
     }
 
     //	GENERATE SUMMARY AND STORE IT
@@ -153,112 +153,7 @@ namespace hcaldqm {
     vtmpflags[fLASER] = flag::Flag("LaserMonCU");
     vtmpflags[fPinDiode] = flag::Flag("LaserMon");
 
-    for (std::vector<uint32_t>::const_iterator it = _vhashCrates.begin(); it != _vhashCrates.end(); ++it) {
-      HcalElectronicsId eid(*it);
-
-      // ZDC: skip detailed monitoring (consistent with FED loop)
-      if (utilities::isFEDZDC(eid)) {
-        for (std::vector<flag::Flag>::iterator ft = vtmpflags.begin(); ft != vtmpflags.end(); ++ft)
-          ft->reset();
-        lssum._vflags.push_back(vtmpflags);
-        continue;
-      }
-
-      for (std::vector<flag::Flag>::iterator ft = vtmpflags.begin(); ft != vtmpflags.end(); ++ft)
-        ft->reset();
-
-      if (_xDigiSize.get(eid) > 0)
-        vtmpflags[fDigiSize]._state = flag::fBAD;
-      else
-        vtmpflags[fDigiSize]._state = flag::fGOOD;
-
-      if (utilities::isFEDHF(eid)) {
-        if (_xNChs.get(eid) != _xNChsNominal.get(eid))
-          vtmpflags[fNChsHF]._state = flag::fBAD;
-        else
-          vtmpflags[fNChsHF]._state = flag::fGOOD;
-      } else {
-        vtmpflags[fNChsHF]._state = flag::fNA;
-      }
-      if (unknownIdsPresent)
-        vtmpflags[fUnknownIds]._state = flag::fBAD;
-      else
-        vtmpflags[fUnknownIds]._state = flag::fGOOD;
-
-      const bool isHBHE = utilities::isFEDHBHE(eid);
-      const bool isHF = utilities::isFEDHF(eid);
-      const bool isHO = utilities::isFEDHO(eid) || eid.isVMEid();
-
-      if (isHBHE || isHF || isHO) {
-        const std::string ledBase = _subsystem + "/" + _taskname + "/CU_LED/CU_LED_CUCountvsLS/Subdet/";
-        const std::string laserBase = _subsystem + "/" + _taskname + "/CU_Laser/CU_LASER_CUCountvsLS/Subdet/";
-
-        // LED CU — HBHE checks both HB and HE
-        if (isHBHE) {
-          MonitorElement* ledHB = ig.get(ledBase + "HB");
-          MonitorElement* ledHE = ig.get(ledBase + "HE");
-          if (ledHB || ledHE) {
-            bool signal =
-                (ledHB && ledHB->getBinContent(_currentLS) > 0) || (ledHE && ledHE->getBinContent(_currentLS) > 0);
-            vtmpflags[fLED]._state = signal ? flag::fBAD : flag::fGOOD;
-          } else {
-            vtmpflags[fLED]._state = flag::fNA;
-          }
-        } else {
-          const std::string subdet = isHF ? "HF" : "HO";
-          MonitorElement* ledHist = ig.get(ledBase + subdet);
-          vtmpflags[fLED]._state =
-              ledHist ? ((ledHist->getBinContent(_currentLS) > 0) ? flag::fBAD : flag::fGOOD) : flag::fNA;
-        }
-
-        // Laser CU — HBHE checks both HB and HE
-        if (isHBHE) {
-          MonitorElement* laserHB = ig.get(laserBase + "HB");
-          MonitorElement* laserHE = ig.get(laserBase + "HE");
-          if (laserHB || laserHE) {
-            bool signal = (laserHB && laserHB->getBinContent(_currentLS) > 0) ||
-                          (laserHE && laserHE->getBinContent(_currentLS) > 0);
-            vtmpflags[fLASER]._state = signal ? flag::fBAD : flag::fGOOD;
-          } else {
-            vtmpflags[fLASER]._state = flag::fNA;
-          }
-        } else {
-          const std::string subdet = isHF ? "HF" : "HO";
-          MonitorElement* laserHist = ig.get(laserBase + subdet);
-          vtmpflags[fLASER]._state =
-              laserHist ? ((laserHist->getBinContent(_currentLS) > 0) ? flag::fBAD : flag::fGOOD) : flag::fNA;
-        }
-
-        // Pin Diode (LaserMon) — HBHE only
-        if (isHBHE) {
-          MonitorElement* pinDiodeHist = ig.get(_subsystem + "/" + _taskname + "/PinDiodeMon/sumQvsLS/sumQvsLS");
-          vtmpflags[fPinDiode]._state =
-              pinDiodeHist ? ((pinDiodeHist->getBinContent(_currentLS) > 2000) ? flag::fBAD : flag::fGOOD) : flag::fNA;
-        } else {
-          vtmpflags[fPinDiode]._state = flag::fNA;
-        }
-
-        // Raddam CU — HF only
-        if (isHF) {
-          MonitorElement* raddamHist =
-              ig.get(_subsystem + "/" + _taskname + "/CU_Raddam/CU_Raddam_CUCountvsLS/CU_Raddam_CUCountvsLS");
-          vtmpflags[fRADDAM]._state =
-              raddamHist ? ((raddamHist->getBinContent(_currentLS) > 0) ? flag::fBAD : flag::fGOOD) : flag::fNA;
-        } else {
-          vtmpflags[fRADDAM]._state = flag::fNA;
-        }
-      } else {
-        vtmpflags[fLED]._state = flag::fNA;
-        vtmpflags[fLASER]._state = flag::fNA;
-        vtmpflags[fPinDiode]._state = flag::fNA;
-        vtmpflags[fRADDAM]._state = flag::fNA;
-      }
-
-      // push all the flags for this crate
-      lssum._vflags.push_back(vtmpflags);
-    }
-
-    // In addition to crate flags, also push FED-based flags for this LS
+    // Push FED-based flags for this LS
     for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
       HcalElectronicsId eid(*it);
 
@@ -293,7 +188,7 @@ namespace hcaldqm {
       else
         vtmpflags[fUnknownIds]._state = flag::fGOOD;
 
-      // Determine subdetector category directly from FED number — no emap lookup.
+      // Determine subdetector category directly from FED number - no emap lookup.
       // crateListHF = {22,29,32}, crateListHO = {23,26,27,38}, VME crates are HO.
       // HBHE crates serve both HB and HE: check both subdet histograms and OR the results.
       const bool isHBHE = utilities::isFEDHBHE(eid);
@@ -301,46 +196,24 @@ namespace hcaldqm {
       const bool isHO = utilities::isFEDHO(eid) || eid.isVMEid();
 
       if (isHBHE || isHF || isHO) {
-        const std::string ledBase = _subsystem + "/" + _taskname + "/CU_LED/CU_LED_CUCountvsLS/Subdet/";
-        const std::string laserBase = _subsystem + "/" + _taskname + "/CU_Laser/CU_LASER_CUCountvsLS/Subdet/";
+        int fed =
+            eid.isVMEid() ? eid.dccid() + constants::FED_VME_MIN : utilities::crate2fed(eid.crateId(), eid.slot());
+        char fedName[20];
+        sprintf(fedName, "FED%d", fed);
+        std::string ledFEDPath = _subsystem + "/" + _taskname + "/CU_LED/CU_LED_CUCountvsLS/FED/" + fedName;
+        std::string laserFEDPath = _subsystem + "/" + _taskname + "/CU_Laser/CU_LASER_CUCountvsLS/FED/" + fedName;
 
-        // LED CU — per-subdetector; HBHE checks both HB and HE
-        if (isHBHE) {
-          MonitorElement* ledHB = ig.get(ledBase + "HB");
-          MonitorElement* ledHE = ig.get(ledBase + "HE");
-          if (ledHB || ledHE) {
-            bool signal =
-                (ledHB && ledHB->getBinContent(_currentLS) > 0) || (ledHE && ledHE->getBinContent(_currentLS) > 0);
-            vtmpflags[fLED]._state = signal ? flag::fBAD : flag::fGOOD;
-          } else {
-            vtmpflags[fLED]._state = flag::fNA;
-          }
-        } else {
-          const std::string subdet = isHF ? "HF" : "HO";
-          MonitorElement* ledHist = ig.get(ledBase + subdet);
-          vtmpflags[fLED]._state =
-              ledHist ? ((ledHist->getBinContent(_currentLS) > 0) ? flag::fBAD : flag::fGOOD) : flag::fNA;
-        }
+        // LED CU - per-FED
+        MonitorElement* ledFED = ig.get(ledFEDPath);
+        vtmpflags[fLED]._state =
+            ledFED ? ((ledFED->getBinContent(_currentLS) > 0) ? flag::fBAD : flag::fGOOD) : flag::fNA;
 
-        // Laser CU — per-subdetector; HBHE checks both HB and HE
-        if (isHBHE) {
-          MonitorElement* laserHB = ig.get(laserBase + "HB");
-          MonitorElement* laserHE = ig.get(laserBase + "HE");
-          if (laserHB || laserHE) {
-            bool signal = (laserHB && laserHB->getBinContent(_currentLS) > 0) ||
-                          (laserHE && laserHE->getBinContent(_currentLS) > 0);
-            vtmpflags[fLASER]._state = signal ? flag::fBAD : flag::fGOOD;
-          } else {
-            vtmpflags[fLASER]._state = flag::fNA;
-          }
-        } else {
-          const std::string subdet = isHF ? "HF" : "HO";
-          MonitorElement* laserHist = ig.get(laserBase + subdet);
-          vtmpflags[fLASER]._state =
-              laserHist ? ((laserHist->getBinContent(_currentLS) > 0) ? flag::fBAD : flag::fGOOD) : flag::fNA;
-        }
+        // Laser CU - per-FED
+        MonitorElement* laserFED = ig.get(laserFEDPath);
+        vtmpflags[fLASER]._state =
+            laserFED ? ((laserFED->getBinContent(_currentLS) > 0) ? flag::fBAD : flag::fGOOD) : flag::fNA;
 
-        // Pin Diode (LaserMon) — HBHE only
+        // Pin Diode (LaserMon) - HBHE only
         if (isHBHE) {
           MonitorElement* pinDiodeHist = ig.get(_subsystem + "/" + _taskname + "/PinDiodeMon/sumQvsLS/sumQvsLS");
           vtmpflags[fPinDiode]._state =
@@ -349,7 +222,7 @@ namespace hcaldqm {
           vtmpflags[fPinDiode]._state = flag::fNA;
         }
 
-        // Raddam CU — HF only
+        // Raddam CU - HF only
         if (isHF) {
           MonitorElement* raddamHist =
               ig.get(_subsystem + "/" + _taskname + "/CU_Raddam/CU_Raddam_CUCountvsLS/CU_Raddam_CUCountvsLS");
@@ -371,7 +244,7 @@ namespace hcaldqm {
 
     //	push all the flags for all FEDs for this LS
     _vflagsLS.push_back(lssum);
-    cDigiSize_Crate.reset();
+    cDigiSize_FED.reset();
     cOccupancy_depth.reset();
   }
 
@@ -386,11 +259,9 @@ namespace hcaldqm {
     _xUniHF.reset();
     _xUni.reset();
 
-    //	PREPARE LS AND RUN BASED FLAGS TO USE IT FOR BOOKING
+    //	PREPARE LS-BASED FLAGS FOR BOOKING
     std::vector<flag::Flag> vflagsPerLS;
-    std::vector<flag::Flag> vflagsPerRun;
     vflagsPerLS.resize(nLSFlags);
-    vflagsPerRun.resize(nDigiFlag - nLSFlags + 1);
     vflagsPerLS[fDigiSize] = flag::Flag("DigiSize");
     vflagsPerLS[fNChsHF] = flag::Flag("NChsHF");
     vflagsPerLS[fUnknownIds] = flag::Flag("UnknownIds");
@@ -398,31 +269,8 @@ namespace hcaldqm {
     vflagsPerLS[fRADDAM] = flag::Flag("RaddamMon");
     vflagsPerLS[fLASER] = flag::Flag("LaserMonCU");
     vflagsPerLS[fPinDiode] = flag::Flag("LaserMon");
-    vflagsPerRun[fDigiSize] = flag::Flag("DigiSize");
-    vflagsPerRun[fNChsHF] = flag::Flag("NChsHF");
-    vflagsPerRun[fUniHF - nLSFlags + 1] = flag::Flag("UniSlotHF");
-    vflagsPerRun[fDead - nLSFlags + 1] = flag::Flag("Dead");
 
-    //	INITIALIZE SUMMARY CONTAINERS
-    ContainerSingle2D cSummaryvsLS;
-    Container2D cSummaryvsLS_Crate;
-    cSummaryvsLS.initialize(_name,
-                            "SummaryvsLS",
-                            new quantity::LumiSection(_maxProcessedLS),
-                            new quantity::CrateQuantity(_emap),
-                            new quantity::ValueQuantity(quantity::fState),
-                            0);
-    cSummaryvsLS.book(ib, _subsystem);
-    cSummaryvsLS_Crate.initialize(_name,
-                                  "SummaryvsLS",
-                                  hashfunctions::fCrate,
-                                  new quantity::LumiSection(_maxProcessedLS),
-                                  new quantity::FlagQuantity(vflagsPerLS),
-                                  new quantity::ValueQuantity(quantity::fState),
-                                  0);
-    cSummaryvsLS_Crate.book(ib, _emap, _subsystem);
-
-    // Also initialize FED-based Summary vs LS containers
+    //	INITIALIZE SUMMARY CONTAINERS (FED-based)
     ContainerSingle2D cSummaryvsLS_FEDSummary;
     Container2D cSummaryvsLS_FED;
     cSummaryvsLS_FEDSummary.initialize(_name,
@@ -506,51 +354,42 @@ namespace hcaldqm {
       }
     }
 
-    /*
-		 *	Iterate over each crate
-		 *		Iterate over each LS Summary
-		 *			Iterate over all flags
-		 *				set...
-		 */
-    //	iterate over all crates
+    // Iterate over each FED: fill per-LS histograms and accumulate the per-run summary flag
     std::vector<flag::Flag> sumflags;
-    int icrate = 0;
-    for (auto& it_crate : _vhashCrates) {
-      flag::Flag fSumRun("DIGI");  // summary flag for this FED
+    int ifed = 0;
+    for (auto& it_fed : _vhashFEDs) {
+      HcalElectronicsId eid(it_fed);
+      flag::Flag fSumRun("DIGI");
       flag::Flag ffDead("Dead");
       flag::Flag ffUniSlotHF("UniSlotHF");
-      HcalElectronicsId eid(it_crate);
 
-      // skip monitoring for ZDC crate for now (Oct. 1 2023), the Hcal DQM group need to discuss with the ZDC group on the monitoring flags settings.
-      if (HcalGenericDetId(_emap->lookup(eid)).isHcalZDCDetId()) {
+      if (utilities::isFEDZDC(eid)) {
         sumflags.push_back(fSumRun);
-        icrate++;
+        ifed++;
         continue;
       }
 
-      HcalDetId did = HcalDetId(_emap->lookup(eid));
-
-      //	ITERATE OVER EACH LS
+      // Per-LS flag histograms
       for (std::vector<LSSummary>::const_iterator itls = _vflagsLS.begin(); itls != _vflagsLS.end(); ++itls) {
         int iflag = 0;
         flag::Flag fSumLS("DIGI");
-        for (std::vector<flag::Flag>::const_iterator ft = itls->_vflags[icrate].begin();
-             ft != itls->_vflags[icrate].end();
+        for (std::vector<flag::Flag>::const_iterator ft = itls->_vflags[ifed].begin(); ft != itls->_vflags[ifed].end();
              ++ft) {
-          cSummaryvsLS_Crate.setBinContent(eid, itls->_LS, int(iflag), ft->_state);
+          cSummaryvsLS_FED.setBinContent(eid, itls->_LS, int(iflag), ft->_state);
           fSumLS += (*ft);
           iflag++;
         }
-        cSummaryvsLS.setBinContent(eid, itls->_LS, fSumLS._state);
+        cSummaryvsLS_FEDSummary.setBinContent(eid, itls->_LS, fSumLS._state);
         fSumRun += fSumLS;
       }
 
-      //	EVALUATE RUN BASED FLAGS
+      // Run-based flags: dead channels and HF slot uniformity
       if (_xDead.get(eid) > 0)
         ffDead._state = flag::fBAD;
       else
         ffDead._state = flag::fGOOD;
-      if (did.subdet() == HcalForward) {
+
+      if (utilities::isFEDHF(eid)) {
         if (_xUni.get(eid) > 0)
           ffUniSlotHF._state = flag::fBAD;
         else
@@ -558,32 +397,7 @@ namespace hcaldqm {
       }
       fSumRun += ffDead + ffUniSlotHF;
 
-      // push the summary flag for this FED for the Whole Run
       sumflags.push_back(fSumRun);
-
-      //	 increment fed
-      icrate++;
-    }
-
-    // Additionally, fill FED-based Summary vs LS using the FED flags appended after crates per LS
-    const int numCrates = static_cast<int>(_vhashCrates.size());
-    int ifed = 0;
-    for (auto& it_fed : _vhashFEDs) {
-      HcalElectronicsId eid(it_fed);
-
-      // Iterate over each LS and fill per-flag and single-state FED summaries
-      for (std::vector<LSSummary>::const_iterator itls = _vflagsLS.begin(); itls != _vflagsLS.end(); ++itls) {
-        int iflag = 0;
-        flag::Flag fSumLS("DIGI");
-        const int idx = numCrates + ifed;  // FED flags were appended after crate flags
-        for (std::vector<flag::Flag>::const_iterator ft = itls->_vflags[idx].begin(); ft != itls->_vflags[idx].end();
-             ++ft) {
-          cSummaryvsLS_FED.setBinContent(eid, itls->_LS, int(iflag), ft->_state);
-          fSumLS += (*ft);
-          iflag++;
-        }
-        cSummaryvsLS_FEDSummary.setBinContent(eid, itls->_LS, fSumLS._state);
-      }
       ifed++;
     }
 

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -148,22 +148,22 @@ namespace hcaldqm {
     vtmpflags[fDigiSize] = flag::Flag("DigiSize");
     vtmpflags[fNChsHF] = flag::Flag("NChsHF");
     vtmpflags[fUnknownIds] = flag::Flag("UnknownIds");
-    vtmpflags[fLED] = flag::Flag("LEDMisfire");
+    vtmpflags[fLED] = flag::Flag("LedMonCU");
+    vtmpflags[fRADDAM] = flag::Flag("RaddamMon");
+    vtmpflags[fLASER] = flag::Flag("LaserMonCU");
+    vtmpflags[fPinDiode] = flag::Flag("LaserMon");
+
     for (std::vector<uint32_t>::const_iterator it = _vhashCrates.begin(); it != _vhashCrates.end(); ++it) {
       HcalElectronicsId eid(*it);
 
-      // skip monitoring for ZDC crate for now (Oct. 1 2023), the Hcal DQM group need to discuss with the ZDC group on the monitoring flags settings.
-      if (HcalGenericDetId(_emap->lookup(eid)).isHcalZDCDetId()) {
+      // ZDC: skip detailed monitoring (consistent with FED loop)
+      if (utilities::isFEDZDC(eid)) {
         for (std::vector<flag::Flag>::iterator ft = vtmpflags.begin(); ft != vtmpflags.end(); ++ft)
           ft->reset();
         lssum._vflags.push_back(vtmpflags);
         continue;
       }
 
-      HcalDetId did = HcalDetId(_emap->lookup(eid));
-
-      //	reset all the tmp flags to fNA
-      //	MUST DO IT NOW! AS NCDAQ MIGHT OVERWRITE IT!
       for (std::vector<flag::Flag>::iterator ft = vtmpflags.begin(); ft != vtmpflags.end(); ++ft)
         ft->reset();
 
@@ -172,7 +172,7 @@ namespace hcaldqm {
       else
         vtmpflags[fDigiSize]._state = flag::fGOOD;
 
-      if (did.subdet() == HcalForward) {
+      if (utilities::isFEDHF(eid)) {
         if (_xNChs.get(eid) != _xNChsNominal.get(eid))
           vtmpflags[fNChsHF]._state = flag::fBAD;
         else
@@ -185,33 +185,187 @@ namespace hcaldqm {
       else
         vtmpflags[fUnknownIds]._state = flag::fGOOD;
 
-      if ((did.subdet() == HcalBarrel) || (did.subdet() == HcalEndcap) || (did.subdet() == HcalOuter) ||
-          (did.subdet() == HcalForward)) {
-        std::string ledHistName = _subsystem + "/" + _taskname + "/CU_LED/CU_LED_CUCountvsLS/Subdet/";
-        if (did.subdet() == HcalBarrel) {
-          ledHistName += "HB";
-        } else if (did.subdet() == HcalEndcap) {
-          ledHistName += "HE";
-        } else if (did.subdet() == HcalOuter) {
-          ledHistName += "HO";
-        } else if (did.subdet() == HcalForward) {
-          ledHistName += "HF";
-        }
-        MonitorElement* ledHist = ig.get(ledHistName);
-        if (ledHist) {
-          bool ledSignalPresent = (ledHist->getEntries() > 0);
-          if (ledSignalPresent)
-            vtmpflags[fLED]._state = flag::fBAD;
-          else
-            vtmpflags[fLED]._state = flag::fGOOD;
+      const bool isHBHE = utilities::isFEDHBHE(eid);
+      const bool isHF = utilities::isFEDHF(eid);
+      const bool isHO = utilities::isFEDHO(eid) || eid.isVMEid();
+
+      if (isHBHE || isHF || isHO) {
+        const std::string ledBase = _subsystem + "/" + _taskname + "/CU_LED/CU_LED_CUCountvsLS/Subdet/";
+        const std::string laserBase = _subsystem + "/" + _taskname + "/CU_Laser/CU_LASER_CUCountvsLS/Subdet/";
+
+        // LED CU — HBHE checks both HB and HE
+        if (isHBHE) {
+          MonitorElement* ledHB = ig.get(ledBase + "HB");
+          MonitorElement* ledHE = ig.get(ledBase + "HE");
+          if (ledHB || ledHE) {
+            bool signal =
+                (ledHB && ledHB->getBinContent(_currentLS) > 0) || (ledHE && ledHE->getBinContent(_currentLS) > 0);
+            vtmpflags[fLED]._state = signal ? flag::fBAD : flag::fGOOD;
+          } else {
+            vtmpflags[fLED]._state = flag::fNA;
+          }
         } else {
-          vtmpflags[fLED]._state = flag::fNA;
+          const std::string subdet = isHF ? "HF" : "HO";
+          MonitorElement* ledHist = ig.get(ledBase + subdet);
+          vtmpflags[fLED]._state =
+              ledHist ? ((ledHist->getBinContent(_currentLS) > 0) ? flag::fBAD : flag::fGOOD) : flag::fNA;
+        }
+
+        // Laser CU — HBHE checks both HB and HE
+        if (isHBHE) {
+          MonitorElement* laserHB = ig.get(laserBase + "HB");
+          MonitorElement* laserHE = ig.get(laserBase + "HE");
+          if (laserHB || laserHE) {
+            bool signal = (laserHB && laserHB->getBinContent(_currentLS) > 0) ||
+                          (laserHE && laserHE->getBinContent(_currentLS) > 0);
+            vtmpflags[fLASER]._state = signal ? flag::fBAD : flag::fGOOD;
+          } else {
+            vtmpflags[fLASER]._state = flag::fNA;
+          }
+        } else {
+          const std::string subdet = isHF ? "HF" : "HO";
+          MonitorElement* laserHist = ig.get(laserBase + subdet);
+          vtmpflags[fLASER]._state =
+              laserHist ? ((laserHist->getBinContent(_currentLS) > 0) ? flag::fBAD : flag::fGOOD) : flag::fNA;
+        }
+
+        // Pin Diode (LaserMon) — HBHE only
+        if (isHBHE) {
+          MonitorElement* pinDiodeHist = ig.get(_subsystem + "/" + _taskname + "/PinDiodeMon/sumQvsLS/sumQvsLS");
+          vtmpflags[fPinDiode]._state =
+              pinDiodeHist ? ((pinDiodeHist->getBinContent(_currentLS) > 2000) ? flag::fBAD : flag::fGOOD) : flag::fNA;
+        } else {
+          vtmpflags[fPinDiode]._state = flag::fNA;
+        }
+
+        // Raddam CU — HF only
+        if (isHF) {
+          MonitorElement* raddamHist =
+              ig.get(_subsystem + "/" + _taskname + "/CU_Raddam/CU_Raddam_CUCountvsLS/CU_Raddam_CUCountvsLS");
+          vtmpflags[fRADDAM]._state =
+              raddamHist ? ((raddamHist->getBinContent(_currentLS) > 0) ? flag::fBAD : flag::fGOOD) : flag::fNA;
+        } else {
+          vtmpflags[fRADDAM]._state = flag::fNA;
         }
       } else {
         vtmpflags[fLED]._state = flag::fNA;
+        vtmpflags[fLASER]._state = flag::fNA;
+        vtmpflags[fPinDiode]._state = flag::fNA;
+        vtmpflags[fRADDAM]._state = flag::fNA;
       }
 
       // push all the flags for this crate
+      lssum._vflags.push_back(vtmpflags);
+    }
+
+    // In addition to crate flags, also push FED-based flags for this LS
+    for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
+      HcalElectronicsId eid(*it);
+
+      // ZDC: skip detailed monitoring entirely (crate2fed-based, no emap lookup)
+      if (utilities::isFEDZDC(eid)) {
+        for (std::vector<flag::Flag>::iterator ft = vtmpflags.begin(); ft != vtmpflags.end(); ++ft)
+          ft->reset();
+        lssum._vflags.push_back(vtmpflags);
+        continue;
+      }
+
+      // reset flags to NA
+      for (std::vector<flag::Flag>::iterator ft = vtmpflags.begin(); ft != vtmpflags.end(); ++ft)
+        ft->reset();
+
+      if (_xDigiSize.get(eid) > 0)
+        vtmpflags[fDigiSize]._state = flag::fBAD;
+      else
+        vtmpflags[fDigiSize]._state = flag::fGOOD;
+
+      // NChsHF is only relevant for HF FEDs
+      if (utilities::isFEDHF(eid)) {
+        if (_xNChs.get(eid) != _xNChsNominal.get(eid))
+          vtmpflags[fNChsHF]._state = flag::fBAD;
+        else
+          vtmpflags[fNChsHF]._state = flag::fGOOD;
+      } else {
+        vtmpflags[fNChsHF]._state = flag::fNA;
+      }
+      if (unknownIdsPresent)
+        vtmpflags[fUnknownIds]._state = flag::fBAD;
+      else
+        vtmpflags[fUnknownIds]._state = flag::fGOOD;
+
+      // Determine subdetector category directly from FED number — no emap lookup.
+      // crateListHF = {22,29,32}, crateListHO = {23,26,27,38}, VME crates are HO.
+      // HBHE crates serve both HB and HE: check both subdet histograms and OR the results.
+      const bool isHBHE = utilities::isFEDHBHE(eid);
+      const bool isHF = utilities::isFEDHF(eid);
+      const bool isHO = utilities::isFEDHO(eid) || eid.isVMEid();
+
+      if (isHBHE || isHF || isHO) {
+        const std::string ledBase = _subsystem + "/" + _taskname + "/CU_LED/CU_LED_CUCountvsLS/Subdet/";
+        const std::string laserBase = _subsystem + "/" + _taskname + "/CU_Laser/CU_LASER_CUCountvsLS/Subdet/";
+
+        // LED CU — per-subdetector; HBHE checks both HB and HE
+        if (isHBHE) {
+          MonitorElement* ledHB = ig.get(ledBase + "HB");
+          MonitorElement* ledHE = ig.get(ledBase + "HE");
+          if (ledHB || ledHE) {
+            bool signal =
+                (ledHB && ledHB->getBinContent(_currentLS) > 0) || (ledHE && ledHE->getBinContent(_currentLS) > 0);
+            vtmpflags[fLED]._state = signal ? flag::fBAD : flag::fGOOD;
+          } else {
+            vtmpflags[fLED]._state = flag::fNA;
+          }
+        } else {
+          const std::string subdet = isHF ? "HF" : "HO";
+          MonitorElement* ledHist = ig.get(ledBase + subdet);
+          vtmpflags[fLED]._state =
+              ledHist ? ((ledHist->getBinContent(_currentLS) > 0) ? flag::fBAD : flag::fGOOD) : flag::fNA;
+        }
+
+        // Laser CU — per-subdetector; HBHE checks both HB and HE
+        if (isHBHE) {
+          MonitorElement* laserHB = ig.get(laserBase + "HB");
+          MonitorElement* laserHE = ig.get(laserBase + "HE");
+          if (laserHB || laserHE) {
+            bool signal = (laserHB && laserHB->getBinContent(_currentLS) > 0) ||
+                          (laserHE && laserHE->getBinContent(_currentLS) > 0);
+            vtmpflags[fLASER]._state = signal ? flag::fBAD : flag::fGOOD;
+          } else {
+            vtmpflags[fLASER]._state = flag::fNA;
+          }
+        } else {
+          const std::string subdet = isHF ? "HF" : "HO";
+          MonitorElement* laserHist = ig.get(laserBase + subdet);
+          vtmpflags[fLASER]._state =
+              laserHist ? ((laserHist->getBinContent(_currentLS) > 0) ? flag::fBAD : flag::fGOOD) : flag::fNA;
+        }
+
+        // Pin Diode (LaserMon) — HBHE only
+        if (isHBHE) {
+          MonitorElement* pinDiodeHist = ig.get(_subsystem + "/" + _taskname + "/PinDiodeMon/sumQvsLS/sumQvsLS");
+          vtmpflags[fPinDiode]._state =
+              pinDiodeHist ? ((pinDiodeHist->getBinContent(_currentLS) > 2000) ? flag::fBAD : flag::fGOOD) : flag::fNA;
+        } else {
+          vtmpflags[fPinDiode]._state = flag::fNA;
+        }
+
+        // Raddam CU — HF only
+        if (isHF) {
+          MonitorElement* raddamHist =
+              ig.get(_subsystem + "/" + _taskname + "/CU_Raddam/CU_Raddam_CUCountvsLS/CU_Raddam_CUCountvsLS");
+          vtmpflags[fRADDAM]._state =
+              raddamHist ? ((raddamHist->getBinContent(_currentLS) > 0) ? flag::fBAD : flag::fGOOD) : flag::fNA;
+        } else {
+          vtmpflags[fRADDAM]._state = flag::fNA;
+        }
+      } else {
+        vtmpflags[fLED]._state = flag::fNA;
+        vtmpflags[fLASER]._state = flag::fNA;
+        vtmpflags[fPinDiode]._state = flag::fNA;
+        vtmpflags[fRADDAM]._state = flag::fNA;
+      }
+
+      // push all the flags for this FED
       lssum._vflags.push_back(vtmpflags);
     }
 
@@ -240,7 +394,10 @@ namespace hcaldqm {
     vflagsPerLS[fDigiSize] = flag::Flag("DigiSize");
     vflagsPerLS[fNChsHF] = flag::Flag("NChsHF");
     vflagsPerLS[fUnknownIds] = flag::Flag("UnknownIds");
-    vflagsPerLS[fLED] = flag::Flag("LEDMisfire");
+    vflagsPerLS[fLED] = flag::Flag("LedMonCU");
+    vflagsPerLS[fRADDAM] = flag::Flag("RaddamMon");
+    vflagsPerLS[fLASER] = flag::Flag("LaserMonCU");
+    vflagsPerLS[fPinDiode] = flag::Flag("LaserMon");
     vflagsPerRun[fDigiSize] = flag::Flag("DigiSize");
     vflagsPerRun[fNChsHF] = flag::Flag("NChsHF");
     vflagsPerRun[fUniHF - nLSFlags + 1] = flag::Flag("UniSlotHF");
@@ -264,6 +421,25 @@ namespace hcaldqm {
                                   new quantity::ValueQuantity(quantity::fState),
                                   0);
     cSummaryvsLS_Crate.book(ib, _emap, _subsystem);
+
+    // Also initialize FED-based Summary vs LS containers
+    ContainerSingle2D cSummaryvsLS_FEDSummary;
+    Container2D cSummaryvsLS_FED;
+    cSummaryvsLS_FEDSummary.initialize(_name,
+                                       "SummaryvsLS_FED",
+                                       new quantity::LumiSection(_maxProcessedLS),
+                                       new quantity::FEDQuantity(_vFEDs),
+                                       new quantity::ValueQuantity(quantity::fState),
+                                       0);
+    cSummaryvsLS_FED.initialize(_name,
+                                "SummaryvsLS_FED",
+                                hashfunctions::fFED,
+                                new quantity::LumiSection(_maxProcessedLS),
+                                new quantity::FlagQuantity(vflagsPerLS),
+                                new quantity::ValueQuantity(quantity::fState),
+                                0);
+    cSummaryvsLS_FED.book(ib, _emap, _subsystem);
+    cSummaryvsLS_FEDSummary.book(ib, _subsystem);
 
     // INITIALIZE CONTAINERS WE NEED TO LOAD or BOOK
     Container2D cOccupancyCut_depth;
@@ -348,6 +524,7 @@ namespace hcaldqm {
       // skip monitoring for ZDC crate for now (Oct. 1 2023), the Hcal DQM group need to discuss with the ZDC group on the monitoring flags settings.
       if (HcalGenericDetId(_emap->lookup(eid)).isHcalZDCDetId()) {
         sumflags.push_back(fSumRun);
+        icrate++;
         continue;
       }
 
@@ -386,6 +563,28 @@ namespace hcaldqm {
 
       //	 increment fed
       icrate++;
+    }
+
+    // Additionally, fill FED-based Summary vs LS using the FED flags appended after crates per LS
+    const int numCrates = static_cast<int>(_vhashCrates.size());
+    int ifed = 0;
+    for (auto& it_fed : _vhashFEDs) {
+      HcalElectronicsId eid(it_fed);
+
+      // Iterate over each LS and fill per-flag and single-state FED summaries
+      for (std::vector<LSSummary>::const_iterator itls = _vflagsLS.begin(); itls != _vflagsLS.end(); ++itls) {
+        int iflag = 0;
+        flag::Flag fSumLS("DIGI");
+        const int idx = numCrates + ifed;  // FED flags were appended after crate flags
+        for (std::vector<flag::Flag>::const_iterator ft = itls->_vflags[idx].begin(); ft != itls->_vflags[idx].end();
+             ++ft) {
+          cSummaryvsLS_FED.setBinContent(eid, itls->_LS, int(iflag), ft->_state);
+          fSumLS += (*ft);
+          iflag++;
+        }
+        cSummaryvsLS_FEDSummary.setBinContent(eid, itls->_LS, fSumLS._state);
+      }
+      ifed++;
     }
 
     return sumflags;

--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -9,6 +9,7 @@ namespace hcaldqm {
                                  edm::ConsumesCollector& iC)
       : DQClient(name, taskname, ps, iC), _booked(false) {
     _thresh_unihf = ps.getUntrackedParameter<double>("thresh_unihf", 0.2);
+    _thresh_pindiode = ps.getUntrackedParameter<double>("thresh_pindiode", 2000);
 
     std::vector<uint32_t> vrefDigiSize = ps.getUntrackedParameter<std::vector<uint32_t>>("refDigiSize");
     _refDigiSize[HcalBarrel] = vrefDigiSize[0];
@@ -198,8 +199,7 @@ namespace hcaldqm {
       if (isHBHE || isHF || isHO) {
         int fed =
             eid.isVMEid() ? eid.dccid() + constants::FED_VME_MIN : utilities::crate2fed(eid.crateId(), eid.slot());
-        char fedName[20];
-        sprintf(fedName, "FED%d", fed);
+        std::string const fedName = "FED" + std::to_string(fed);
         std::string ledFEDPath = _subsystem + "/" + _taskname + "/CU_LED/CU_LED_CUCountvsLS/FED/" + fedName;
         std::string laserFEDPath = _subsystem + "/" + _taskname + "/CU_Laser/CU_LASER_CUCountvsLS/FED/" + fedName;
 
@@ -217,7 +217,8 @@ namespace hcaldqm {
         if (isHBHE) {
           MonitorElement* pinDiodeHist = ig.get(_subsystem + "/" + _taskname + "/PinDiodeMon/sumQvsLS/sumQvsLS");
           vtmpflags[fPinDiode]._state =
-              pinDiodeHist ? ((pinDiodeHist->getBinContent(_currentLS) > 2000) ? flag::fBAD : flag::fGOOD) : flag::fNA;
+              pinDiodeHist ? ((pinDiodeHist->getBinContent(_currentLS) > _thresh_pindiode) ? flag::fBAD : flag::fGOOD)
+                           : flag::fNA;
         } else {
           vtmpflags[fPinDiode]._state = flag::fNA;
         }
@@ -375,7 +376,7 @@ namespace hcaldqm {
         flag::Flag fSumLS("DIGI");
         for (std::vector<flag::Flag>::const_iterator ft = itls->_vflags[ifed].begin(); ft != itls->_vflags[ifed].end();
              ++ft) {
-          cSummaryvsLS_FED.setBinContent(eid, itls->_LS, int(iflag), ft->_state);
+          cSummaryvsLS_FED.setBinContent(eid, itls->_LS, static_cast<int>(iflag), ft->_state);
           fSumLS += (*ft);
           iflag++;
         }


### PR DESCRIPTION
#### PR description:

In PR #48510 and PR #48679 we added monitoring of hcal calibration units for online sequence, this PR will sync the same monitoring to the offline hcal dqm sequence, adding FED based summary plots for DigiRunSummary folder.

#### PR validation:
Developed and tested on top of CMSSW_16_0_4_patch1. A recent run 402560 is processed with offline code with plots [shown in local hcal DQM gui](https://cmsweb.cern.ch/dqm/hcal-online/start?runnr=402560;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=HCAL;size=M;root=Hcal/DigiRunHarvesting/SummaryvsLS_FED;focus=Hcal/DigiRunHarvesting/SummaryvsLS_FED/SummaryvsLS_FED;zoom=yes;), and compare it with the [central online GUI](https://cern.ch/z83tj), all looks in consistency, except for the NchsHF in FED 1118 and 1120, that is [another issue](https://gitlab.cern.ch/cmshcal/docs/-/issues/307) currently under investigation by Hcal group

