### PR TITLE
Add `TestProcessor` based unit tests to `HLTriggerOffline/Scouting`

### DIFF
--- a/HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/PatElectronTagProbeAnalyzer.cc
@@ -214,7 +214,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   edm::Handle<edm::View<pat::Electron>> patEls;
   iEvent.getByToken(electronCollection_, patEls);
   if (patEls.failedToGet()) {
-    edm::LogWarning("ScoutingMonitoring") << "pat::Electron collection not found.";
+    edm::LogWarning("PatElectronTagProbeAnalyzer") << "pat::Electron collection not found.";
     return;
   }
 
@@ -222,7 +222,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   edm::Handle<std::vector<Run3ScoutingElectron>> sctEls;
   iEvent.getByToken(scoutingElectronCollection_, sctEls);
   if (sctEls.failedToGet()) {
-    edm::LogWarning("ScoutingMonitoring") << "Run3ScoutingElectron collection not found.";
+    edm::LogWarning("PatElectronTagProbeAnalyzer") << "Run3ScoutingElectron collection not found.";
     return;
   }
 
@@ -230,8 +230,8 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   edm::Handle<edm::ValueMap<bool>> tight_ele_id_decisions;
   iEvent.getByToken(eleIdMapTightToken_, tight_ele_id_decisions);
 
-  edm::LogInfo("ScoutingMonitoring") << "Process pat::Electrons: " << patEls->size();
-  edm::LogInfo("ScoutingMonitoring") << "Process Run3ScoutingElectrons: " << sctEls->size();
+  edm::LogInfo("PatElectronTagProbeAnalyzer") << "Process pat::Electrons: " << patEls->size();
+  edm::LogInfo("PatElectronTagProbeAnalyzer") << "Process Run3ScoutingElectrons: " << sctEls->size();
 
   // Trigger
   edm::Handle<edm::TriggerResults> triggerResults;
@@ -243,7 +243,7 @@ void PatElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
 
   // Trigger result
   if (triggerResults.failedToGet()) {
-    edm::LogWarning("ScoutingEGammaCollectionMonitoring") << "Trgger Results not found.";
+    edm::LogWarning("PatElectronTagProbeAnalyzer") << "Trgger Results not found.";
     return;
   }
 

--- a/HLTriggerOffline/Scouting/plugins/ScoutingElectronTagProbeAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingElectronTagProbeAnalyzer.cc
@@ -157,7 +157,7 @@ void ScoutingElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   edm::Handle<std::vector<Run3ScoutingElectron>> sctEls;
   iEvent.getByToken(scoutingElectronCollection_, sctEls);
   if (sctEls.failedToGet()) {
-    edm::LogWarning("ScoutingMonitoring") << "Run3ScoutingElectron collection not found.";
+    edm::LogWarning("ScoutingElectronTagProbeAnalyzer") << "Run3ScoutingElectron collection not found.";
     return;
   }
 
@@ -167,7 +167,7 @@ void ScoutingElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
 
   // Trigger result
   if (triggerResults.failedToGet()) {
-    edm::LogWarning("ScoutingEGammaCollectionMonitoring") << "Trgger Results not found.";
+    edm::LogWarning("ScoutingElectronTagProbeAnalyzer") << "Trgger Results not found.";
     return;
   }
   int nTriggers = triggerResults->size();
@@ -211,7 +211,7 @@ void ScoutingElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
     }
   }
 
-  edm::LogInfo("ScoutingMonitoring") << "Process Run3ScoutingElectrons: " << sctEls->size();
+  edm::LogInfo("ScoutingElectronTagProbeAnalyzer") << "Process Run3ScoutingElectrons: " << sctEls->size();
 
   // Pt ordered sct electron collection
 
@@ -243,7 +243,7 @@ void ScoutingElectronTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
       math::PtEtaPhiMLorentzVector probe_sct_el(
           sct_el_second.pt(), sct_el_second.eta(), sct_el_second.phi(), sct_el_second.m());
       float invMass = (tag_sct_el + probe_sct_el).mass();
-      edm::LogInfo("ScoutingMonitoring") << "Inv Mass: " << invMass;
+      edm::LogInfo("ScoutingElectronTagProbeAnalyzer") << "Inv Mass: " << invMass;
       if ((80 < invMass) && (invMass < 100)) {
         fillHistograms_resonance(
             histos.resonanceZ, sct_el_second, invMass, legObjects, passBaseDST, second_sct_pt_order);

--- a/HLTriggerOffline/Scouting/plugins/ScoutingMuonTagProbeAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingMuonTagProbeAnalyzer.cc
@@ -144,7 +144,7 @@ void ScoutingMuonTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   edm::Handle<std::vector<Run3ScoutingMuon>> sctMuons;
   iEvent.getByToken(scoutingMuonCollection_, sctMuons);
   if (sctMuons.failedToGet()) {
-    edm::LogWarning("ScoutingMonitoring") << "Run3ScoutingMuon collection not found.";
+    edm::LogWarning("ScoutingMuonTagProbeAnalyzer") << "Run3ScoutingMuon collection not found.";
     return;
   }
 
@@ -152,13 +152,13 @@ void ScoutingMuonTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
   edm::Handle<std::vector<Run3ScoutingVertex>> sctVertex;
   iEvent.getByToken(scoutingVtxCollection_, sctVertex);
   if (sctVertex.failedToGet()) {
-    edm::LogWarning("ScoutingMonitoring") << "Run3ScoutingVertex collection not found.";
+    edm::LogWarning("ScoutingMuonTagProbeAnalyzer") << "Run3ScoutingVertex collection not found.";
     return;
   }
 
-  edm::LogInfo("ScoutingMonitoring") << "Process Run3ScoutingMuons: " << sctMuons->size();
+  edm::LogInfo("ScoutingMuonTagProbeAnalyzer") << "Process Run3ScoutingMuons: " << sctMuons->size();
 
-  edm::LogInfo("ScoutingMonitoring") << "Process Run3ScoutingVertex: " << sctVertex->size();
+  edm::LogInfo("ScoutingMuonTagProbeAnalyzer") << "Process Run3ScoutingVertex: " << sctVertex->size();
 
   // Core of Tag and Probe implementation
   bool foundTag = false;
@@ -182,7 +182,7 @@ void ScoutingMuonTagProbeAnalyzer::dqmAnalyze(edm::Event const& iEvent,
       const std::vector<int>& vtxIndx_probe = sct_mu_second.vtxIndx();
 
       float invMass = (tag_sct_mu + probe_sct_mu).mass();
-      edm::LogInfo("ScoutingMonitoring") << "Inv Mass: " << invMass;
+      edm::LogInfo("ScoutingMuonTagProbeAnalyzer") << "Inv Mass: " << invMass;
       // If dimuon system comes from J/Psi, process event
       if ((2.4 < invMass && invMass < 3.8)) {
         // Boolean added because hltScoutingMuonPackerVtx collection doesn't

--- a/HLTriggerOffline/Scouting/plugins/ScoutingMuonTriggerAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingMuonTriggerAnalyzer.cc
@@ -298,10 +298,16 @@ void ScoutingMuonTriggerAnalyzer::fillDescriptions(edm::ConfigurationDescription
   desc.add<edm::InputTag>("l1tAlgBlkInputTag", edm::InputTag("gtStage2Digis"));
   desc.add<edm::InputTag>("l1tExtBlkInputTag", edm::InputTag("gtStage2Digis"));
   desc.add<bool>("ReadPrescalesFromFile", false);
+  desc.add<std::string>("muonSelection", "");
+
   edm::ParameterSetDescription triggerConfig;
-  desc.add<std::string>("muonSelection");
-  triggerConfig.setAllowAnything();
+  triggerConfig.add<edm::InputTag>("hltResults", edm::InputTag("TriggerResults", "", "HLT"));
+  triggerConfig.add<edm::InputTag>("l1tResults", edm::InputTag(""));
+  triggerConfig.add<bool>("l1tIgnoreMaskAndPrescale", false);
+  triggerConfig.add<bool>("throw", true);
+  triggerConfig.add<bool>("usePathStatus", false);
   desc.add<edm::ParameterSetDescription>("triggerConfiguration", triggerConfig);
+
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/HLTriggerOffline/Scouting/plugins/ScoutingMuonTriggerAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingMuonTriggerAnalyzer.cc
@@ -157,7 +157,7 @@ void ScoutingMuonTriggerAnalyzer::analyze(edm::Event const& iEvent, edm::EventSe
   edm::Handle<std::vector<Run3ScoutingMuon>> sctMuons;
   iEvent.getByToken(scoutingMuonCollection_, sctMuons);
   if (sctMuons.failedToGet()) {
-    edm::LogWarning("ScoutingMonitoring") << "Run3ScoutingMuon collection not found.";
+    edm::LogWarning("ScoutingMuonTriggerAnalyzer") << "Run3ScoutingMuon collection not found.";
     return;
   }
   //Apply cuts specified in config file

--- a/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
@@ -141,6 +141,16 @@ ScoutingRecHitAnalyzer<RecHitType>::ScoutingRecHitAnalyzer(const edm::ParameterS
     triggers_.push_back(trigger);
     trigger_names_.push_back(trigger_name);
   }
+  const size_t n = trigger_names_.size();
+  number_histograms_.reserve(n);
+  energy_histograms_.reserve(n);
+  time_histograms_.reserve(n);
+  ieta_iphi_histograms_.reserve(n);
+  eta_phi_histograms_.reserve(n);
+  energy_time_histograms_.reserve(n);
+  ieta_iphi_energy_profiles_.reserve(n);
+  eta_phi_energy_profiles_.reserve(n);
+  ieta_iphi_time_profiles_.reserve(n);
 }
 
 template <typename RecHitType>
@@ -185,19 +195,24 @@ void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibook
   ibooker.setCurrentFolder(topFolderName_);
   for (auto const& trigger_name : trigger_names_) {
     ibooker.setCurrentFolder(topFolderName_ + "/" + trigger_name);
+
+    auto n = [&](const std::string& base) { return (base + "_" + trigger_name); };
+
     if constexpr (std::is_same<RecHitType, Run3ScoutingEBRecHit>()) {
       // 1D histograms
-      number_histograms_.push_back(ibooker.book1D("number", "Number or RecHits;RecHits Number;Events", 100, 0., 1000.));
+      number_histograms_.push_back(
+          ibooker.book1D(n("number"), "Number or RecHits;RecHits Number;Events", 100, 0., 1000.));
       energy_histograms_.push_back(
-          ibooker.book1DD("energy", "Energy of RecHits;RecHit Energy (GeV);RecHits", 100, 0., 20.));
-      time_histograms_.push_back(ibooker.book1DD("time", "Time of RecHits;RecHit Time (ns);RecHits", 200, -100., 100.));
+          ibooker.book1DD(n("energy"), "Energy of RecHits;RecHit Energy (GeV);RecHits", 100, 0., 20.));
+      time_histograms_.push_back(
+          ibooker.book1DD(n("time"), "Time of RecHits;RecHit Time (ns);RecHits", 200, -100., 100.));
 
       // 2D histograms
       energy_time_histograms_.push_back(book2D(
-          "energy_time", "RecHit Time vs Energy;Energy (GeV);Time (ns);Entries", 100, 0., 20., 100, -100., 100.));
+          n("energy_time"), "RecHit Time vs Energy;Energy (GeV);Time (ns);Entries", 100, 0., 20., 100, -100., 100.));
       ieta_iphi_histograms_.push_back(
-          book2D("ieta_iphi", "RecHit i#phi vs i#eta;i#eta;i#phi;Entries", 171, -85.5, 85.5, 360, 0.5, 360.5));
-      eta_phi_histograms_.push_back(book2D("eta_phi",
+          book2D(n("ieta_iphi"), "RecHit i#phi vs i#eta;i#eta;i#phi;Entries", 171, -85.5, 85.5, 360, 0.5, 360.5));
+      eta_phi_histograms_.push_back(book2D(n("eta_phi"),
                                            "RecHit #phi vs #eta;#eta;#phi (rad);Entries",
                                            170,
                                            -85 * kDegToRad,
@@ -208,8 +223,8 @@ void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibook
 
       // 2D profiles
       ieta_iphi_energy_profiles_.push_back(bookProfile2D(
-          "ieta_iphi_energy", "mean RecHit Energy;i#eta;i#phi;mean Energy", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
-      eta_phi_energy_profiles_.push_back(bookProfile2D("eta_phi_energy",
+          n("ieta_iphi_energy"), "mean RecHit Energy;i#eta;i#phi;mean Energy", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
+      eta_phi_energy_profiles_.push_back(bookProfile2D(n("eta_phi_energy"),
                                                        "mean RecHit Energy;#eta;#phi (rad);mean Energy",
                                                        170,
                                                        -85 * kDegToRad,
@@ -221,8 +236,8 @@ void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibook
                                                        20));
 
       ieta_iphi_time_profiles_.push_back(bookProfile2D(
-          "ieta_iphi_time", "Mean RecHit time;i#eta;i#phi;mean Time", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
-      eta_phi_time_profiles_.push_back(bookProfile2D("eta_phi_time",
+          n("ieta_iphi_time"), "Mean RecHit time;i#eta;i#phi;mean Time", 171, -85.5, 85.5, 360, 0.5, 360.5, 0, 20));
+      eta_phi_time_profiles_.push_back(bookProfile2D(n("eta_phi_time"),
                                                      "Mean RecHit time;#eta;#phi (rad);mean Time",
                                                      170,
                                                      -85 * kDegToRad,
@@ -257,44 +272,47 @@ void ScoutingRecHitAnalyzer<RecHitType>::bookHistograms(DQMStore::IBooker& ibook
         return phiMin + i * dphi;
       });
 
+      auto n = [&](const std::string& base) { return (base + "_" + trigger_name); };
+
       // 1D histograms
-      number_histograms_.push_back(ibooker.book1D("number", "Number of RecHits;RecHits Number;Events", 100, 0., 2000.));
+      number_histograms_.push_back(
+          ibooker.book1D(n("number"), "Number of RecHits;RecHits Number;Events", 100, 0., 2000.));
       energy_histograms_.push_back(
-          ibooker.book1DD("energy", "Energy of RecHits;RecHit Energy (GeV);RecHits", 100, 0., 20.));
-      time_histograms_.push_back(ibooker.book1DD("time", "Time of RecHits;RecHit Time (ns);RecHits", 100, 0., 30.));
+          ibooker.book1DD(n("energy"), "Energy of RecHits;RecHit Energy (GeV);RecHits", 100, 0., 20.));
+      time_histograms_.push_back(ibooker.book1DD(n("time"), "Time of RecHits;RecHit Time (ns);RecHits", 100, 0., 30.));
 
       // 2D histograms
-      energy_time_histograms_.push_back(
-          book2D("energy_time", "RecHit Time vs Energy;Energy (GeV);Time (ns);Entries", 100., 0., 50., 100., 0, 30.));
+      energy_time_histograms_.push_back(book2D(
+          n("energy_time"), "RecHit Time vs Energy;Energy (GeV);Time (ns);Entries", 100., 0., 50., 100., 0, 30.));
 
       ieta_iphi_histograms_.push_back(
-          book2D("ieta_iphi", "RecHit i#phi vs i#eta;i#eta;i#phi;Entries", 59, -29.5, 29.5, 72, 0.5, 72.5));
+          book2D(n("ieta_iphi"), "RecHit i#phi vs i#eta;i#eta;i#phi;Entries", 59, -29.5, 29.5, 72, 0.5, 72.5));
 
       // 2D profiles
       ieta_iphi_energy_profiles_.push_back(bookProfile2D(
-          "ieta_iphi_energy", "mean RecHit Energy;i#eta;i#phi;mean Energy", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 100.));
+          n("ieta_iphi_energy"), "mean RecHit Energy;i#eta;i#phi;mean Energy", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 100.));
 
       ieta_iphi_time_profiles_.push_back(bookProfile2D(
-          "ieta_iphi_time", "mean RecHit time;i#eta;i#phi;mean Time", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 30.));
+          n("ieta_iphi_time"), "mean RecHit time;i#eta;i#phi;mean Time", 59, -29.5, 29.5, 72, 0.5, 72.5, 0, 30.));
 
       // demote edges from double to float
       std::vector<float> eta_edges_f(eta_edges.begin(), eta_edges.end());
       std::vector<float> phi_edges_f(phi_edges.begin(), phi_edges.end());
-      eta_phi_histograms_.push_back(book2D("eta_phi",
+      eta_phi_histograms_.push_back(book2D(n("eta_phi"),
                                            "RecHit #phi vs #eta;#eta;#phi (rad);Entries",
                                            eta_edges_f.size() - 1,
                                            eta_edges_f.data(),
                                            phi_edges_f.size() - 1,
                                            phi_edges_f.data()));
 
-      eta_phi_energy_profiles_.push_back(bookProfile2D("eta_phi_energy",
+      eta_phi_energy_profiles_.push_back(bookProfile2D(n("eta_phi_energy"),
                                                        "mean RecHit Energy;#eta;#phi (rad);mean Energy",
                                                        eta_edges.size() - 1,
                                                        eta_edges.data(),
                                                        phi_edges.size() - 1,
                                                        phi_edges.data()));
 
-      eta_phi_time_profiles_.push_back(bookProfile2D("eta_phi_time",
+      eta_phi_time_profiles_.push_back(bookProfile2D(n("eta_phi_time"),
                                                      "mean RecHit Time;#eta;#phi (rad);mean Time",
                                                      eta_edges.size() - 1,
                                                      eta_edges.data(),
@@ -308,13 +326,13 @@ template <typename RecHitType>
 void ScoutingRecHitAnalyzer<RecHitType>::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const auto& l1TriggerResults_handle = iEvent.getHandle(l1TriggerResults_token_);
   if (!l1TriggerResults_handle.isValid()) {
-    edm::LogWarning("Handle") << "L1 TriggerResults is invalid";
+    edm::LogWarning("ScoutingRecHitAnalyzer") << "L1 TriggerResults is invalid";
     return;
   }
 
   const auto& hltTriggerResults_handle = iEvent.getHandle(hltTriggerResults_token_);
   if (!hltTriggerResults_handle.isValid()) {
-    edm::LogWarning("Handle") << "HLT TriggerResults is invalid";
+    edm::LogWarning("ScoutingRecHitAnalyzer") << "HLT TriggerResults is invalid";
     return;
   }
 
@@ -322,7 +340,7 @@ void ScoutingRecHitAnalyzer<RecHitType>::analyze(const edm::Event& iEvent, const
 
   const auto& rechit_collection_handle = iEvent.getHandle(rechit_collection_token_);
   if (!rechit_collection_handle.isValid()) {
-    edm::LogWarning("Handle") << "rechit is invalid";
+    edm::LogWarning("ScoutingRecHitAnalyzer") << "rechit is invalid";
     return;
   }
 

--- a/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingRecHitAnalyzer.cc
@@ -146,7 +146,7 @@ ScoutingRecHitAnalyzer<RecHitType>::ScoutingRecHitAnalyzer(const edm::ParameterS
 template <typename RecHitType>
 void ScoutingRecHitAnalyzer<RecHitType>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("src");
+  desc.add<edm::InputTag>("src", edm::InputTag(""));
   desc.add<std::string>("topFolderName", "HLT/ScoutingOffline/CaloRecHits");
   desc.add<edm::InputTag>("L1TriggerResults", edm::InputTag("l1bits"));
   desc.add<edm::InputTag>("HLTTriggerResults", edm::InputTag("TriggerResults", "", "HLT"));

--- a/HLTriggerOffline/Scouting/test/BuildFile.xml
+++ b/HLTriggerOffline/Scouting/test/BuildFile.xml
@@ -1,0 +1,6 @@
+<environment>
+  <bin file="testHLTScoutingDQMAnalyzers.cc" name="testHLTScoutingDQMAnalyzers">
+    <use name="FWCore/TestProcessor"/>
+    <use name="catch2"/>
+  </bin>
+</environment>

--- a/HLTriggerOffline/Scouting/test/testHLTScoutingDQMAnalyzers.cc
+++ b/HLTriggerOffline/Scouting/test/testHLTScoutingDQMAnalyzers.cc
@@ -1,0 +1,142 @@
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include <format>
+#include <iostream>
+#include "TROOT.h"
+
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch_all.hpp"
+
+//Function to run the catch2 tests
+//___________________________________________________________________________________________
+void runTestForAnalyzer(const std::string& baseConfig, const std::string& analyzerName) {
+  edm::test::TestProcessor::Config config{baseConfig};
+
+  SECTION(analyzerName + " base configuration is OK") {
+    gROOT->GetList()->Delete();  // to get rid of duplicated ME warnings
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(edm::test::TestProcessor(config));
+  }
+
+  SECTION(analyzerName + " No Runs data") {
+    gROOT->GetList()->Delete();  // to get rid of duplicated ME warnings
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testWithNoRuns());
+  }
+
+  SECTION(analyzerName + " beginJob and endJob only") {
+    gROOT->GetList()->Delete();  // to get rid of duplicated ME warnings
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  SECTION(analyzerName + " No event data") {
+    gROOT->GetList()->Delete();  // to get rid of duplicated ME warnings
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.test());
+  }
+
+  SECTION(analyzerName + " Run with no LuminosityBlocks") {
+    gROOT->GetList()->Delete();  // to get rid of duplicated ME warnings
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+
+  SECTION(analyzerName + " LuminosityBlock with no Events") {
+    gROOT->GetList()->Delete();  // to get rid of duplicated ME warnings
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  }
+}
+
+// Function to generate base configuration string
+//___________________________________________________________________________________________
+std::string generateBaseConfig(const std::string& analyzerName) {
+  // Define a raw string literal
+  constexpr const char* rawString = R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+process.load("MagneticField.Engine.uniformMagneticField_cfi")
+process.load("Configuration.Geometry.GeometryExtended2024Reco_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2024_design', '')
+from HLTriggerOffline.Scouting.{}_cfi import {}
+process.dqmAnalyzer = {}
+process.moduleToTest(process.dqmAnalyzer)
+process.add_(cms.Service('DQMStore'))
+process.add_(cms.Service('MessageLogger'))
+process.add_(cms.Service('JobReportService'))
+process.add_(cms.Service('SiteLocalConfigService'))
+    )_";
+
+  // Format the raw string literal using std::format
+  return std::format(rawString, analyzerName, analyzerName, analyzerName);
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ScoutingDileptonMonitor tests", "[ScoutingDileptonMonitor]") {
+  const std::string baseConfig = generateBaseConfig("scoutingDileptonMonitor");
+  runTestForAnalyzer(baseConfig, "ScoutingDileptonMonitor");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ScoutingPi0Analyzer tests", "[ScoutingPi0Analyzer]") {
+  const std::string baseConfig = generateBaseConfig("scoutingPi0Analyzer");
+  runTestForAnalyzer(baseConfig, "ScoutingPi0Analyzer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ElectronEfficiencyPlotter tests", "[ElectronEfficiencyPlotter]") {
+  const std::string baseConfig = generateBaseConfig("electronEfficiencyPlotter");
+  runTestForAnalyzer(baseConfig, "ElectronEfficiencyPlotter");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("PatElectronTagProbeAnalyzer tests", "[PatElectronTagProbeAnalyzer]") {
+  const std::string baseConfig = generateBaseConfig("patElectronTagProbeAnalyzer");
+  runTestForAnalyzer(baseConfig, "PatElectronTagProbeAnalyzer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ScoutingEBRecHitAnalyzer tests", "[ScoutingEBRecHitAnalyzer]") {
+  const std::string baseConfig = generateBaseConfig("scoutingEBRecHitAnalyzer");
+  runTestForAnalyzer(baseConfig, "ScoutingEBRecHitAnalyzer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ScoutingEGammaCollectionMonitoring tests", "[ScoutingEGammaCollectionMonitoring]") {
+  const std::string baseConfig = generateBaseConfig("scoutingEGammaCollectionMonitoring");
+  runTestForAnalyzer(baseConfig, "ScoutingEGammaCollectionMonitoring");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ScoutingElectronTagProbeAnalyzer tests", "[ScoutingElectronTagProbeAnalyzer]") {
+  const std::string baseConfig = generateBaseConfig("scoutingElectronTagProbeAnalyzer");
+  runTestForAnalyzer(baseConfig, "ScoutingElectronTagProbeAnalyzer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ScoutingHBHERecHitAnalyzer tests", "[ScoutingHBHERecHitAnalyzer]") {
+  const std::string baseConfig = generateBaseConfig("scoutingHBHERecHitAnalyzer");
+  runTestForAnalyzer(baseConfig, "ScoutingHBHERecHitAnalyzer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ScoutingMuonPropertiesAnalyzer tests", "[ScoutingMuonPropertiesAnalyzer]") {
+  const std::string baseConfig = generateBaseConfig("scoutingMuonPropertiesAnalyzer");
+  runTestForAnalyzer(baseConfig, "ScoutingMuonPropertiesAnalyzer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ScoutingMuonTagProbeAnalyzer tests", "[ScoutingMuonTagProbeAnalyzer]") {
+  const std::string baseConfig = generateBaseConfig("scoutingMuonTagProbeAnalyzer");
+  runTestForAnalyzer(baseConfig, "ScoutingMuonTagProbeAnalyzer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("ScoutingMuonTriggerAnalyzer tests", "[ScoutingMuonTriggerAnalyzer]") {
+  const std::string baseConfig = generateBaseConfig("scoutingMuonTriggerAnalyzer");
+  runTestForAnalyzer(baseConfig, "ScoutingMuonTriggerAnalyzer");
+}


### PR DESCRIPTION
#### PR description:

Inspired by the discussion at https://github.com/cms-sw/cmssw/issues/50548#issuecomment-4129506187 I provide `TestProcessor`-based tests that make sure there are no crashes when we run with missing input.
I profit to make some light modifications to improve the code where possible.

#### PR validation:

Run successfully the following unit tests:

```
scram b runtests_testHLTScoutingDQMAnalyzers
scram b runtests_TestDQMOnlineClient-scouting_dqm_sourceclient
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will be backported to CMSSW_16_0_X for 2026 production.