### PR TITLE
[L1T] Propagate CTL2 Electron ID discriminator output to GT object (Phase-2)

### DIFF
--- a/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2GTtables_cff.py
+++ b/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2GTtables_cff.py
@@ -88,6 +88,7 @@ gtTkEleTable = gtTkPhoTable.clone(
 gtTkEleTable.variables.z0 = Var("vz",float)
 gtTkEleTable.variables.charge = Var("charge", int, doc="charge id")
 gtTkEleTable.variables.hwZ0 = Var("hwZ0_toInt()",int)
+gtTkEleTable.variables.hwQualityScore = Var("hwQualityScore_toInt()",int)
 
 ## GT gmtTkMuons
 gtTkMuTable = gtTkEleTable.clone(

--- a/DataFormats/L1TParticleFlow/interface/egamma.h
+++ b/DataFormats/L1TParticleFlow/interface/egamma.h
@@ -171,6 +171,7 @@ namespace l1ct {
       ele.charge = (!hwCharge) & ele.valid;
       ele.z0(l1ct::z0_t::width - 1, 0) = hwZ0(l1ct::z0_t::width - 1, 0);
       ele.isolationPT = hwIso;
+      ele.idScore = l1ct::CTtoGT_idProba(hwIDScore);
       return ele;
     }
   };

--- a/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
@@ -362,6 +362,7 @@ namespace l1gt {
     ap_uint<1> charge;
     z0_t z0;
     iso_t isolationPT;
+    id_proba_t idScore;
 
     static const int BITWIDTH = 96;
     inline ap_uint<BITWIDTH> pack() const {
@@ -373,6 +374,7 @@ namespace l1gt {
       pack_into_bits(ret, start, isolationPT);
       pack_into_bits(ret, start, charge);
       pack_into_bits(ret, start, z0);
+      pack_into_bits(ret, start, idScore);
       return ret;
     }
 
@@ -386,6 +388,7 @@ namespace l1gt {
       unpack_from_bits(src, start, isolationPT);
       unpack_from_bits(src, start, charge);
       unpack_from_bits(src, start, z0);
+      unpack_from_bits(src, start, idScore);
     }
 
     inline static Electron unpack_ap(const ap_uint<BITWIDTH> &src) {
@@ -481,6 +484,13 @@ namespace l1ct {
 
   inline l1gt::mass2_t CTtoGT_massSq(mass2_t x) { return (l1gt::mass2_t)x; }
 
+  inline l1gt::id_proba_t CTtoGT_idProba(id_score_t x) {
+    // l1ct::id_score_t is [-1, 1-LSB] with LSB = 1/512,
+    // l1gt::id_proba_t is [0, 1] with LSB = 1/128 although datatype can represent [0, 2-LSB]
+    typedef ap_fixed<id_score_t::width + 1, id_score_t::iwidth + 1, AP_RND_CONV, AP_SAT> id_score_ext_t;
+    id_score_ext_t x_ext = x;
+    return l1gt::id_proba_t((x_ext + id_score_ext_t(1)) >> 1);
+  }
 }  // namespace l1ct
 
 #endif

--- a/L1Trigger/Phase2L1GT/plugins/L1GTProducer.cc
+++ b/L1Trigger/Phase2L1GT/plugins/L1GTProducer.cc
@@ -453,6 +453,7 @@ namespace l1t {
       gtObj.hwZ0_ = hwZ0;
       gtObj.hwIsolationPT_ = gtElectron.isolationPT.V.to_int();
       gtObj.hwQualityFlags_ = gtElectron.qualityFlags.V.to_int();
+      gtObj.hwQualityScore_ = gtElectron.idScore.V.to_int();
       gtObj.hwCharge_ = gtElectron.charge.V.to_int();
       gtObj.objectType_ = P2GTCandidate::CL2Electrons;
 


### PR DESCRIPTION
#### PR description:

This PR adds the electron ID discriminator value to the electron object that is sent to the global trigger.

For uniformity with other discriminator values in the GT, the score is converted from the signed value by CTL2 (range [-1,1]) to an unsigned in the range `[0,1]` encoded with 8 bits (LSB = 1/128, slightly wasteful representation but ensuring that that both 0 and 1 are exactly representable).

When the CTL2 electron object is converted to the unified GT object in the GT emulator, the score is extended to 10 bits.

The variable is also added to the GT TkEle table in DPGAnalysis/Phase2L1TNanoAOD

There's no dataformat change in the CMSSW sense, since the CTL2 object and GT object already had the variables to store that content, they were just not filled.

#### PR validation:

* tested in 15_1_X (https://github.com/p2l1pfp/cmssw/pull/154) comparing the score before and after the packing for GT
* code-format, code-checks
* `runTheMatrix.py  -l 34434.759`, i.e. `TTbar_14TeV+Run4D121_HLTPhase2WithNano` which includes the L1TrackTrigger,L1,L1P2GT steps
 * `L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py`

@cerminar 

@RobertJWard @artlbv let me know if the P2GT changes look ok to you