### PR TITLE
Add safeguard in final step of Alpaka PF multi-depth clustering when 0 clusters are present

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/LegacyMultiDepthPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LegacyMultiDepthPFClusterProducer.cc
@@ -149,45 +149,49 @@ void LegacyMultiDepthPFClusterProducer::produce(edm::Event& event, const edm::Ev
 
   auto const rechitsHandle = event.getHandle(recHitsLabel_);
 
-  // Build PFClusters in legacy format
+  int sizePFC = pfClusterSoA.metadata().size();
 
-  std::unordered_map<int, int> nTopoSeeds;
-  nTopoSeeds.reserve(pfClusterSoA.nSeeds());
+  if (sizePFC != 0) {
+    // Build PFClusters in legacy format
 
-  for (int i = 0; i < pfClusterSoA.nSeeds(); ++i)
-    nTopoSeeds[pfClusterSoA[i].topoId()]++;
+    std::unordered_map<int, int> nTopoSeeds;
+    nTopoSeeds.reserve(pfClusterSoA.nSeeds());
 
-  // Looping over SoA PFClusters to produce legacy PFCluster collection
-  auto const& recHits = *rechitsHandle;
+    for (int i = 0; i < pfClusterSoA.nSeeds(); ++i)
+      nTopoSeeds[pfClusterSoA[i].topoId()]++;
 
-  for (int i = 0; i < pfClusterSoA.nSeeds(); i++) {
-    unsigned int seedIdx = pfClusterSoA[i].seedRHIdx();
+    // Looping over SoA PFClusters to produce legacy PFCluster collection
+    auto const& recHits = *rechitsHandle;
 
-    if (seedIdx >= static_cast<unsigned>(nRH))
-      continue;
+    for (int i = 0; i < pfClusterSoA.nSeeds(); i++) {
+      unsigned int seedIdx = pfClusterSoA[i].seedRHIdx();
 
-    reco::PFCluster temp;
+      if (seedIdx >= static_cast<unsigned>(nRH))
+        continue;
 
-    temp.setSeed(recHits[seedIdx].detId());
+      reco::PFCluster temp;
 
-    int const offset = pfClusterSoA[i].rhfracOffset();
-    int const size = pfClusterSoA[i].rhfracSize();
+      temp.setSeed(recHits[seedIdx].detId());
 
-    for (int k = offset; k < (offset + size); k++) {  // Looping over PFRecHits in the same topo cluster
-      if (pfRecHitFractionSoA[k].pfrhIdx() < nRH && pfRecHitFractionSoA[k].pfrhIdx() > -1 &&
-          pfRecHitFractionSoA[k].frac() > 0.0f) {
-        const reco::PFRecHitRef& refhit = reco::PFRecHitRef(rechitsHandle, pfRecHitFractionSoA[k].pfrhIdx());
-        temp.addRecHitFraction(reco::PFRecHitFraction(refhit, pfRecHitFractionSoA[k].frac()));
+      int const offset = pfClusterSoA[i].rhfracOffset();
+      int const size = pfClusterSoA[i].rhfracSize();
+
+      for (int k = offset; k < (offset + size); k++) {  // Looping over PFRecHits in the same topo cluster
+        if (pfRecHitFractionSoA[k].pfrhIdx() < nRH && pfRecHitFractionSoA[k].pfrhIdx() > -1 &&
+            pfRecHitFractionSoA[k].frac() > 0.0f) {
+          const reco::PFRecHitRef& refhit = reco::PFRecHitRef(rechitsHandle, pfRecHitFractionSoA[k].pfrhIdx());
+          temp.addRecHitFraction(reco::PFRecHitFraction(refhit, pfRecHitFractionSoA[k].frac()));
+        }
       }
-    }
 
-    // Now PFRecHitFraction of this PFCluster is set. Now compute calculateAndSetPosition (energy, position etc)
-    if (nTopoSeeds[pfClusterSoA[i].topoId()] == 1 && allCellsPositionCalc_) {
-      allCellsPositionCalc_->calculateAndSetPosition(temp, paramPF);
-    } else {
-      positionCalc_->calculateAndSetPosition(temp, paramPF);
+      // Now PFRecHitFraction of this PFCluster is set. Now compute calculateAndSetPosition (energy, position etc)
+      if (nTopoSeeds[pfClusterSoA[i].topoId()] == 1 && allCellsPositionCalc_) {
+        allCellsPositionCalc_->calculateAndSetPosition(temp, paramPF);
+      } else {
+        positionCalc_->calculateAndSetPosition(temp, paramPF);
+      }
+      out.emplace_back(std::move(temp));
     }
-    out.emplace_back(std::move(temp));
   }
 
   event.emplace(legacyPfClustersToken_, std::move(out));

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterSoAProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterSoAProducer.cc
@@ -163,7 +163,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         *pfcl_size_);
     } else {
       outPFClusters = std::make_unique<reco::PFClusterDeviceCollection>(event.queue(), 0);
+      outPFClusters->zeroInitialise(event.queue());
       outPFRHFractions = std::make_unique<reco::PFRecHitFractionDeviceCollection>(event.queue(), 0);
+      outPFRHFractions->zeroInitialise(event.queue());
     }
 
     event.emplace(outputPFClusterSoA_Token_, std::move(*outPFClusters));


### PR DESCRIPTION
#### PR description:

This PR prevents a crash in the final step of Alpaka PF multi-depth clustering under the special case of 0 clusters which would occur when there are 0 valid rechits in an event. The implementation is similar to that of the layer clustering. 

#### PR validation:

PR was validated using a customized HLT menu running on error stream data that contained a special event.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.

@alexstrel @fwyzard 
