### PR TITLE
Moved DataFormats/TestObjects test to catch2

### DIFF
--- a/DataFormats/TestObjects/test/BuildFile.xml
+++ b/DataFormats/TestObjects/test/BuildFile.xml
@@ -1,5 +1,5 @@
-<use name="cppunit"/>
-<use name="DataFormats/TestObjects"/>
 <bin file="Enum_t.cpp">
+  <use name="catch2"/>
+  <use name="DataFormats/TestObjects"/>
   <use name="FWCore/Reflection"/>
 </bin>

--- a/DataFormats/TestObjects/test/Enum_t.cpp
+++ b/DataFormats/TestObjects/test/Enum_t.cpp
@@ -3,70 +3,11 @@
 #include "FWCore/Utilities/interface/TypeDemangler.h"
 #include "FWCore/Reflection/interface/TypeWithDict.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
-#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 
-#include "cppunit/extensions/HelperMacros.h"
+#include <catch2/catch_all.hpp>
 
 #include <typeinfo>
 #include <vector>
-
-class TestDictionaries : public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(TestDictionaries);
-  CPPUNIT_TEST(enum_is_valid);
-  CPPUNIT_TEST(enum_by_name_is_valid);
-  CPPUNIT_TEST(enum_member_is_valid);
-  CPPUNIT_TEST(array_member_is_valid);
-  CPPUNIT_TEST(demangling);
-  CPPUNIT_TEST_SUITE_END();
-
-public:
-  TestDictionaries() {}
-  ~TestDictionaries() {}
-  void setUp() {}
-  void tearDown() {}
-
-  void enum_is_valid();
-  void enum_by_name_is_valid();
-  void enum_member_is_valid();
-  void array_member_is_valid();
-  void demangling();
-
-private:
-};
-
-CPPUNIT_TEST_SUITE_REGISTRATION(TestDictionaries);
-
-void TestDictionaries::enum_is_valid() {
-  edm::TypeWithDict t(typeid(edmtest::EnumProduct::TheEnumProduct));
-  CPPUNIT_ASSERT(t);
-}
-
-void TestDictionaries::enum_by_name_is_valid() {
-  edm::TypeWithDict t = edm::TypeWithDict::byName("edmtest::EnumProduct::TheEnumProduct");
-  CPPUNIT_ASSERT(t);
-}
-
-void TestDictionaries::enum_member_is_valid() {
-  edm::TypeWithDict t = edm::TypeWithDict::byName("edmtest::EnumProduct");
-  edm::MemberWithDict m = t.dataMemberByName("value");
-  edm::TypeWithDict t2 = m.typeOf();
-  edm::TypeWithDict t3 = edm::TypeWithDict::byName("edmtest::EnumProduct::TheEnumProduct");
-  CPPUNIT_ASSERT(t2);
-  CPPUNIT_ASSERT(t3);
-  CPPUNIT_ASSERT(t2 == t3);
-}
-
-void TestDictionaries::array_member_is_valid() {
-  edm::TypeWithDict t = edm::TypeWithDict::byName("edmtest::ArrayProduct");
-  edm::MemberWithDict m = t.dataMemberByName("value");
-  CPPUNIT_ASSERT(m.isArray());
-  edm::TypeWithDict t2 = m.typeOf();
-  edm::TypeWithDict t3 = edm::TypeWithDict::byName("int[1]");
-  CPPUNIT_ASSERT(t2);
-  CPPUNIT_ASSERT(t3);
-  CPPUNIT_ASSERT(t2.qualifiedName() == "int[1]");
-  CPPUNIT_ASSERT(t2 == t3);
-}
 
 namespace {
   template <typename T>
@@ -75,7 +16,7 @@ namespace {
     // Test only if class has dictionary
     if (bool(type)) {
       std::string demangledName(edm::typeDemangle(typeid(T).name()));
-      CPPUNIT_ASSERT(type.name() == demangledName);
+      REQUIRE(type.name() == demangledName);
     }
   }
 
@@ -86,4 +27,38 @@ namespace {
   }
 }  // namespace
 
-void TestDictionaries::demangling() { checkDemangling<edmtest::EnumProduct::TheEnumProduct>(); }
+TEST_CASE("Dictionaries", "[Enum_t]") {
+  SECTION("enum_is_valid") {
+    edm::TypeWithDict t(typeid(edmtest::EnumProduct::TheEnumProduct));
+    REQUIRE(t);
+  }
+
+  SECTION("enum_by_name_is_valid") {
+    edm::TypeWithDict t = edm::TypeWithDict::byName("edmtest::EnumProduct::TheEnumProduct");
+    REQUIRE(t);
+  }
+
+  SECTION("enum_member_is_valid") {
+    edm::TypeWithDict t = edm::TypeWithDict::byName("edmtest::EnumProduct");
+    edm::MemberWithDict m = t.dataMemberByName("value");
+    edm::TypeWithDict t2 = m.typeOf();
+    edm::TypeWithDict t3 = edm::TypeWithDict::byName("edmtest::EnumProduct::TheEnumProduct");
+    REQUIRE(t2);
+    REQUIRE(t3);
+    REQUIRE(t2 == t3);
+  }
+
+  SECTION("array_member_is_valid") {
+    edm::TypeWithDict t = edm::TypeWithDict::byName("edmtest::ArrayProduct");
+    edm::MemberWithDict m = t.dataMemberByName("value");
+    REQUIRE(m.isArray());
+    edm::TypeWithDict t2 = m.typeOf();
+    edm::TypeWithDict t3 = edm::TypeWithDict::byName("int[1]");
+    REQUIRE(t2);
+    REQUIRE(t3);
+    REQUIRE(t2.qualifiedName() == "int[1]");
+    REQUIRE(t2 == t3);
+  }
+
+  SECTION("demangling") { checkDemangling<edmtest::EnumProduct::TheEnumProduct>(); }
+}


### PR DESCRIPTION
#### PR description:

Part of a campaign to reduce the dependencies needed for FWCore.

#### PR validation:

Code compiles, unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/2122