### PR TITLE
Moved FWCore/TestProcessor to catch2

### DIFF
--- a/FWCore/TestProcessor/test/BuildFile.xml
+++ b/FWCore/TestProcessor/test/BuildFile.xml
@@ -1,6 +1,6 @@
 <bin name="testFWCoreTestProcessor" file="testprocessor_t.cppunit.cc,testsourceprocessor_t.cppunit.cc">
   <use name="boost"/>
-  <use name="cppunit"/>
+  <use name="catch2"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/TestProcessor"/>
   <use name="FWCore/Integration"/>

--- a/FWCore/TestProcessor/test/testprocessor_t.cppunit.cc
+++ b/FWCore/TestProcessor/test/testprocessor_t.cppunit.cc
@@ -15,7 +15,7 @@
 #include "FWCore/Integration/interface/ESTestData.h"
 #include "FWCore/Integration/interface/ESTestRecords.h"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "catch2/catch_all.hpp"
 
 #include <memory>
 
@@ -27,274 +27,225 @@
 #include <algorithm>
 #include <set>
 
-class testTestProcessor : public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(testTestProcessor);
-  CPPUNIT_TEST(simpleProcessTest);
-  CPPUNIT_TEST(addProductTest);
-  CPPUNIT_TEST(missingProductTest);
-  CPPUNIT_TEST(filterTest);
-  CPPUNIT_TEST(outputModuleTest);
-  CPPUNIT_TEST(extraProcessTest);
-  CPPUNIT_TEST(eventSetupTest);
-  CPPUNIT_TEST(eventSetupPutTest);
-  CPPUNIT_TEST(lumiTest);
-  CPPUNIT_TEST(taskTest);
-  CPPUNIT_TEST(emptyProcessBlockTest);
-  CPPUNIT_TEST(emptyRunTest);
-  CPPUNIT_TEST(emptyLumiTest);
-  CPPUNIT_TEST(processBlockProductTest);
-  CPPUNIT_TEST(processBlockEndProductTest);
-  CPPUNIT_TEST(runProductTest);
-  CPPUNIT_TEST(lumiProductTest);
-  CPPUNIT_TEST(runStreamAnalyzerTest);
-  CPPUNIT_TEST(lumiStreamAnalyzerTest);
+TEST_CASE("TestProcessor tests", "[TestProcessor]") {
+  SECTION("simple process test") {
+    char const* kTest =
+        "from FWCore.TestProcessor.TestProcess import *\n"
+        "process = TestProcess()\n"
+        "process.foo = cms.EDProducer('IntProducer', ivalue=cms.int32(1))\n"
+        "process.moduleToTest(process.foo)\n";
+    edm::test::TestProcessor::Config config(kTest);
+    edm::test::TestProcessor tester(config);
+    REQUIRE(tester.labelOfTestModule() == "foo");
 
-  CPPUNIT_TEST_SUITE_END();
+    auto event = tester.test();
 
-public:
-  void setUp() {}
-  void tearDown() {}
-  void simpleProcessTest();
-  void addProductTest();
-  void missingProductTest();
-  void filterTest();
-  void outputModuleTest();
-  void extraProcessTest();
-  void eventSetupTest();
-  void eventSetupPutTest();
-  void lumiTest();
-  void taskTest();
-  void emptyProcessBlockTest();
-  void emptyRunTest();
-  void emptyLumiTest();
-  void processBlockProductTest();
-  void processBlockEndProductTest();
-  void runProductTest();
-  void lumiProductTest();
-  void runStreamAnalyzerTest();
-  void lumiStreamAnalyzerTest();
+    REQUIRE(event.get<edmtest::IntProduct>()->value == 1);
 
-private:
-};
-
-///registration of the test so that the runner can find it
-CPPUNIT_TEST_SUITE_REGISTRATION(testTestProcessor);
-
-void testTestProcessor::simpleProcessTest() {
-  char const* kTest =
-      "from FWCore.TestProcessor.TestProcess import *\n"
-      "process = TestProcess()\n"
-      "process.foo = cms.EDProducer('IntProducer', ivalue=cms.int32(1))\n"
-      "process.moduleToTest(process.foo)\n";
-  edm::test::TestProcessor::Config config(kTest);
-  edm::test::TestProcessor tester(config);
-  CPPUNIT_ASSERT(tester.labelOfTestModule() == "foo");
-
-  auto event = tester.test();
-
-  CPPUNIT_ASSERT(event.get<edmtest::IntProduct>()->value == 1);
-
-  CPPUNIT_ASSERT(not event.get<edmtest::IntProduct>("doesNotExist"));
-  CPPUNIT_ASSERT_THROW(*event.get<edmtest::IntProduct>("doesNotExist"), cms::Exception);
-}
-
-void testTestProcessor::addProductTest() {
-  char const* kTest =
-      "from FWCore.TestProcessor.TestProcess import *\n"
-      "process = TestProcess()\n"
-      "process.add = cms.EDProducer('AddIntsProducer', labels=cms.VInputTag('in'))\n"
-      "process.moduleToTest(process.add)\n";
-  edm::test::TestProcessor::Config config(kTest);
-  auto token = config.produces<edmtest::IntProduct>("in");
-
-  edm::test::TestProcessor tester(config);
-
-  {
-    auto event = tester.test(std::make_pair(token, std::make_unique<edmtest::IntProduct>(1)));
-
-    CPPUNIT_ASSERT(event.get<edmtest::IntProduct>()->value == 1);
+    REQUIRE(not event.get<edmtest::IntProduct>("doesNotExist"));
+    REQUIRE_THROWS_AS(*event.get<edmtest::IntProduct>("doesNotExist"), cms::Exception);
   }
 
-  {
-    auto event = tester.test(std::make_pair(token, std::make_unique<edmtest::IntProduct>(2)));
+  SECTION("add product test") {
+    char const* kTest =
+        "from FWCore.TestProcessor.TestProcess import *\n"
+        "process = TestProcess()\n"
+        "process.add = cms.EDProducer('AddIntsProducer', labels=cms.VInputTag('in'))\n"
+        "process.moduleToTest(process.add)\n";
+    edm::test::TestProcessor::Config config(kTest);
+    auto token = config.produces<edmtest::IntProduct>("in");
 
-    CPPUNIT_ASSERT(event.get<edmtest::IntProduct>()->value == 2);
+    edm::test::TestProcessor tester(config);
+
+    {
+      auto event = tester.test(std::make_pair(token, std::make_unique<edmtest::IntProduct>(1)));
+
+      REQUIRE(event.get<edmtest::IntProduct>()->value == 1);
+    }
+
+    {
+      auto event = tester.test(std::make_pair(token, std::make_unique<edmtest::IntProduct>(2)));
+
+      REQUIRE(event.get<edmtest::IntProduct>()->value == 2);
+    }
+
+    //Check that event gets reset so the data product is not available
+    REQUIRE_THROWS_AS(tester.test(), cms::Exception);
   }
 
-  //Check that event gets reset so the data product is not available
-  CPPUNIT_ASSERT_THROW(tester.test(), cms::Exception);
-}
+  SECTION("missing product test") {
+    char const* kTest =
+        "from FWCore.TestProcessor.TestProcess import *\n"
+        "process = TestProcess()\n"
+        "process.add = cms.EDProducer('AddIntsProducer', labels=cms.VInputTag('in'))\n"
+        "process.moduleToTest(process.add)\n";
+    edm::test::TestProcessor::Config config(kTest);
 
-void testTestProcessor::missingProductTest() {
-  char const* kTest =
-      "from FWCore.TestProcessor.TestProcess import *\n"
-      "process = TestProcess()\n"
-      "process.add = cms.EDProducer('AddIntsProducer', labels=cms.VInputTag('in'))\n"
-      "process.moduleToTest(process.add)\n";
-  edm::test::TestProcessor::Config config(kTest);
+    edm::test::TestProcessor tester(config);
 
-  edm::test::TestProcessor tester(config);
-
-  CPPUNIT_ASSERT_THROW(tester.test(), cms::Exception);
-}
-
-void testTestProcessor::filterTest() {
-  char const* kTest =
-      "from FWCore.TestProcessor.TestProcess import *\n"
-      "process = TestProcess()\n"
-      "process.foo = cms.EDFilter('TestFilterModule', acceptValue=cms.untracked.int32(2),\n"
-      "   onlyOne = cms.untracked.bool(True))\n"
-      "process.moduleToTest(process.foo)\n";
-  edm::test::TestProcessor::Config config(kTest);
-  edm::test::TestProcessor tester(config);
-  CPPUNIT_ASSERT(tester.labelOfTestModule() == "foo");
-
-  CPPUNIT_ASSERT(not tester.test().modulePassed());
-  CPPUNIT_ASSERT(tester.test().modulePassed());
-  CPPUNIT_ASSERT(not tester.test().modulePassed());
-  CPPUNIT_ASSERT(tester.test().modulePassed());
-}
-
-void testTestProcessor::outputModuleTest() {
-  char const* kTest =
-      "from FWCore.TestProcessor.TestProcess import *\n"
-      "process = TestProcess()\n"
-      "process.MessageLogger.cerr.INFO.limit=10000\n"
-      "process.foo = cms.OutputModule('GetProductCheckerOutputModule', verbose=cms.untracked.bool(True),"
-      " outputCommands = cms.untracked.vstring('drop *','keep edmtestIntProduct_in__TEST'),\n"
-      " crosscheck = cms.untracked.vstring('edmtestIntProduct_in__TEST'))\n"
-      "process.moduleToTest(process.foo)\n";
-  edm::test::TestProcessor::Config config(kTest);
-  auto token = config.produces<edmtest::IntProduct>("in");
-  edm::test::TestProcessor tester(config);
-  tester.test(std::make_pair(token, std::make_unique<edmtest::IntProduct>(1)));
-}
-void testTestProcessor::extraProcessTest() {
-  char const* kTest =
-      "from FWCore.TestProcessor.TestProcess import *\n"
-      "process = TestProcess()\n"
-      "process.add = cms.EDProducer('AddIntsProducer', labels=cms.VInputTag('in'))\n"
-      "process.moduleToTest(process.add)\n";
-  edm::test::TestProcessor::Config config(kTest);
-  auto processToken = config.addExtraProcess("HLT");
-  auto token = config.produces<edmtest::IntProduct>("in", "", processToken);
-
-  edm::test::TestProcessor tester(config);
-
-  {
-    auto event = tester.test(std::make_pair(token, std::make_unique<edmtest::IntProduct>(1)));
-
-    CPPUNIT_ASSERT(event.get<edmtest::IntProduct>()->value == 1);
+    REQUIRE_THROWS_AS(tester.test(), cms::Exception);
   }
-}
 
-void testTestProcessor::eventSetupTest() {
-  char const* kTest =
-      "from FWCore.TestProcessor.TestProcess import *\n"
-      "process = TestProcess()\n"
-      "process.emptyESSourceA1 = cms.ESSource('EmptyESSource',"
-      "recordName = cms.string('ESTestRecordA'),"
-      "firstValid = cms.vuint32(1,2),"
-      "iovIsRunNotTime = cms.bool(True)"
-      ")\n"
+  SECTION("filter test") {
+    char const* kTest =
+        "from FWCore.TestProcessor.TestProcess import *\n"
+        "process = TestProcess()\n"
+        "process.foo = cms.EDFilter('TestFilterModule', acceptValue=cms.untracked.int32(2),\n"
+        "   onlyOne = cms.untracked.bool(True))\n"
+        "process.moduleToTest(process.foo)\n";
+    edm::test::TestProcessor::Config config(kTest);
+    edm::test::TestProcessor tester(config);
+    REQUIRE(tester.labelOfTestModule() == "foo");
 
-      "process.add_(cms.ESProducer('ESTestProducerA') )\n"
-      "process.add = cms.EDAnalyzer('ESTestAnalyzerA', runsToGetDataFor = cms.vint32(1,2), "
-      "expectedValues=cms.untracked.vint32(1,2))\n"
-      "process.moduleToTest(process.add)\n";
-  edm::test::TestProcessor::Config config(kTest);
+    REQUIRE(not tester.test().modulePassed());
+    REQUIRE(tester.test().modulePassed());
+    REQUIRE(not tester.test().modulePassed());
+    REQUIRE(tester.test().modulePassed());
+  }
 
-  edm::test::TestProcessor tester(config);
+  SECTION("output module test") {
+    char const* kTest =
+        "from FWCore.TestProcessor.TestProcess import *\n"
+        "process = TestProcess()\n"
+        "process.MessageLogger.cerr.INFO.limit=10000\n"
+        "process.foo = cms.OutputModule('GetProductCheckerOutputModule', verbose=cms.untracked.bool(True),"
+        " outputCommands = cms.untracked.vstring('drop *','keep edmtestIntProduct_in__TEST'),\n"
+        " crosscheck = cms.untracked.vstring('edmtestIntProduct_in__TEST'))\n"
+        "process.moduleToTest(process.foo)\n";
+    edm::test::TestProcessor::Config config(kTest);
+    auto token = config.produces<edmtest::IntProduct>("in");
+    edm::test::TestProcessor tester(config);
+    tester.test(std::make_pair(token, std::make_unique<edmtest::IntProduct>(1)));
+  }
 
-  (void)tester.test();
+  SECTION("extra process test") {
+    char const* kTest =
+        "from FWCore.TestProcessor.TestProcess import *\n"
+        "process = TestProcess()\n"
+        "process.add = cms.EDProducer('AddIntsProducer', labels=cms.VInputTag('in'))\n"
+        "process.moduleToTest(process.add)\n";
+    edm::test::TestProcessor::Config config(kTest);
+    auto processToken = config.addExtraProcess("HLT");
+    auto token = config.produces<edmtest::IntProduct>("in", "", processToken);
 
-  tester.setRunNumber(2);
-  (void)tester.test();
-}
+    edm::test::TestProcessor tester(config);
 
-void testTestProcessor::eventSetupPutTest() {
-  char const* kTest =
-      "from FWCore.TestProcessor.TestProcess import *\n"
-      "process = TestProcess()\n"
-      "process.add = cms.EDAnalyzer('ESTestAnalyzerA', runsToGetDataFor = cms.vint32(1,2,3), "
-      "expectedValues=cms.untracked.vint32(1,2,2))\n"
-      "process.moduleToTest(process.add)\n";
-  edm::test::TestProcessor::Config config(kTest);
-  auto estoken = config.esProduces<ESTestRecordA, edmtest::ESTestDataA>();
+    {
+      auto event = tester.test(std::make_pair(token, std::make_unique<edmtest::IntProduct>(1)));
 
-  edm::test::TestProcessor tester(config);
+      REQUIRE(event.get<edmtest::IntProduct>()->value == 1);
+    }
+  }
 
-  (void)tester.test(std::make_pair(estoken, std::make_unique<edmtest::ESTestDataA>(1)));
+  SECTION("event setup test") {
+    char const* kTest =
+        "from FWCore.TestProcessor.TestProcess import *\n"
+        "process = TestProcess()\n"
+        "process.emptyESSourceA1 = cms.ESSource('EmptyESSource',"
+        "recordName = cms.string('ESTestRecordA'),"
+        "firstValid = cms.vuint32(1,2),"
+        "iovIsRunNotTime = cms.bool(True)"
+        ")\n"
 
-  tester.setRunNumber(2);
-  (void)tester.test(std::make_pair(estoken, std::make_unique<edmtest::ESTestDataA>(2)));
+        "process.add_(cms.ESProducer('ESTestProducerA') )\n"
+        "process.add = cms.EDAnalyzer('ESTestAnalyzerA', runsToGetDataFor = cms.vint32(1,2), "
+        "expectedValues=cms.untracked.vint32(1,2))\n"
+        "process.moduleToTest(process.add)\n";
+    edm::test::TestProcessor::Config config(kTest);
 
-  tester.setRunNumber(3);
-  CPPUNIT_ASSERT_THROW(tester.test(), cms::Exception);
-}
+    edm::test::TestProcessor tester(config);
 
-void testTestProcessor::lumiTest() {
-  auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
+    (void)tester.test();
+
+    tester.setRunNumber(2);
+    (void)tester.test();
+  }
+
+  SECTION("event setup put test") {
+    char const* kTest =
+        "from FWCore.TestProcessor.TestProcess import *\n"
+        "process = TestProcess()\n"
+        "process.add = cms.EDAnalyzer('ESTestAnalyzerA', runsToGetDataFor = cms.vint32(1,2,3), "
+        "expectedValues=cms.untracked.vint32(1,2,2))\n"
+        "process.moduleToTest(process.add)\n";
+    edm::test::TestProcessor::Config config(kTest);
+    auto estoken = config.esProduces<ESTestRecordA, edmtest::ESTestDataA>();
+
+    edm::test::TestProcessor tester(config);
+
+    (void)tester.test(std::make_pair(estoken, std::make_unique<edmtest::ESTestDataA>(1)));
+
+    tester.setRunNumber(2);
+    (void)tester.test(std::make_pair(estoken, std::make_unique<edmtest::ESTestDataA>(2)));
+
+    tester.setRunNumber(3);
+    REQUIRE_THROWS_AS(tester.test(), cms::Exception);
+  }
+
+  SECTION("lumi test") {
+    auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
 process = TestProcess()
 process.toTest = cms.EDProducer('ThingProducer')
 process.moduleToTest(process.toTest)
 )_";
-  edm::test::TestProcessor::Config config(kTest);
+    edm::test::TestProcessor::Config config(kTest);
 
-  edm::test::TestProcessor tester(config);
-  (void)tester.test();
-  tester.setLuminosityBlockNumber(2);
-  (void)tester.test();
-}
-
-void testTestProcessor::taskTest() {
-  char const* kTest =
-      "from FWCore.TestProcessor.TestProcess import *\n"
-      "process = TestProcess()\n"
-      "process.mid = cms.EDProducer('AddIntsProducer', labels=cms.VInputTag('in'))\n"
-      "process.add = cms.EDProducer('AddIntsProducer', labels=cms.VInputTag('mid','in'))\n"
-      "process.moduleToTest(process.add,cms.Task(process.mid))\n";
-  edm::test::TestProcessor::Config config(kTest);
-  auto token = config.produces<edmtest::IntProduct>("in");
-
-  edm::test::TestProcessor tester(config);
-
-  {
-    auto event = tester.test(std::make_pair(token, std::make_unique<edmtest::IntProduct>(1)));
-
-    CPPUNIT_ASSERT(event.get<edmtest::IntProduct>()->value == 2);
+    edm::test::TestProcessor tester(config);
+    (void)tester.test();
+    tester.setLuminosityBlockNumber(2);
+    (void)tester.test();
   }
-}
 
-void testTestProcessor::emptyProcessBlockTest() {
-  auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
+  SECTION("task test") {
+    char const* kTest =
+        "from FWCore.TestProcessor.TestProcess import *\n"
+        "process = TestProcess()\n"
+        "process.mid = cms.EDProducer('AddIntsProducer', labels=cms.VInputTag('in'))\n"
+        "process.add = cms.EDProducer('AddIntsProducer', labels=cms.VInputTag('mid','in'))\n"
+        "process.moduleToTest(process.add,cms.Task(process.mid))\n";
+    edm::test::TestProcessor::Config config(kTest);
+    auto token = config.produces<edmtest::IntProduct>("in");
+
+    edm::test::TestProcessor tester(config);
+
+    {
+      auto event = tester.test(std::make_pair(token, std::make_unique<edmtest::IntProduct>(1)));
+
+      REQUIRE(event.get<edmtest::IntProduct>()->value == 2);
+    }
+  }
+
+  SECTION("empty process block test") {
+    auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
 process = TestProcess()
 process.toTest = cms.EDAnalyzer('RunLumiEventChecker',
         eventSequence = cms.untracked.VEventID()
                                 )
 process.moduleToTest(process.toTest)
 )_";
-  edm::test::TestProcessor::Config config(kTest);
-  edm::test::TestProcessor tester(config);
+    edm::test::TestProcessor::Config config(kTest);
+    edm::test::TestProcessor tester(config);
 
-  tester.testWithNoRuns();
-}
-void testTestProcessor::emptyRunTest() {
-  auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
+    tester.testWithNoRuns();
+  }
+
+  SECTION("empty run test") {
+    auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
 process = TestProcess()
 process.toTest = cms.EDAnalyzer('RunLumiEventChecker',
         eventSequence = cms.untracked.VEventID(cms.EventID(1,0,0), cms.EventID(1,0,0))
                                 )
 process.moduleToTest(process.toTest)
 )_";
-  edm::test::TestProcessor::Config config(kTest);
+    edm::test::TestProcessor::Config config(kTest);
 
-  edm::test::TestProcessor tester(config);
+    edm::test::TestProcessor tester(config);
 
-  tester.testRunWithNoLuminosityBlocks();
-}
-void testTestProcessor::emptyLumiTest() {
-  auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
+    tester.testRunWithNoLuminosityBlocks();
+  }
+
+  SECTION("empty lumi test") {
+    auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
 process = TestProcess()
 process.toTest = cms.EDAnalyzer('RunLumiEventChecker',
                                   eventSequence = cms.untracked.VEventID(cms.EventID(1,0,0), cms.EventID(1,1,0),
@@ -302,105 +253,105 @@ process.toTest = cms.EDAnalyzer('RunLumiEventChecker',
                                   )
 process.moduleToTest(process.toTest)
 )_";
-  edm::test::TestProcessor::Config config(kTest);
+    edm::test::TestProcessor::Config config(kTest);
 
-  edm::test::TestProcessor tester(config);
+    edm::test::TestProcessor tester(config);
 
-  tester.testLuminosityBlockWithNoEvents();
-}
+    tester.testLuminosityBlockWithNoEvents();
+  }
 
-void testTestProcessor::processBlockProductTest() {
-  auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
+  SECTION("process block product test") {
+    auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
 process = TestProcess()
 process.intProducerBeginProcessBlock = cms.EDProducer("IntProducerBeginProcessBlock", ivalue = cms.int32(10000))
 process.moduleToTest(process.intProducerBeginProcessBlock)
 )_";
-  edm::test::TestProcessor::Config config(kTest);
+    edm::test::TestProcessor::Config config(kTest);
 
-  edm::test::TestProcessor tester(config);
-  {
-    auto processBlock = tester.testBeginProcessBlock();
-    CPPUNIT_ASSERT(processBlock.get<edmtest::IntProduct>()->value == 10000);
+    edm::test::TestProcessor tester(config);
+    {
+      auto processBlock = tester.testBeginProcessBlock();
+      REQUIRE(processBlock.get<edmtest::IntProduct>()->value == 10000);
+    }
+    {
+      auto processBlock = tester.testEndProcessBlock();
+      REQUIRE(processBlock.get<edmtest::IntProduct>()->value == 10000);
+    }
   }
-  {
-    auto processBlock = tester.testEndProcessBlock();
-    CPPUNIT_ASSERT(processBlock.get<edmtest::IntProduct>()->value == 10000);
-  }
-}
 
-void testTestProcessor::processBlockEndProductTest() {
-  auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
+  SECTION("process block end product test") {
+    auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
 process = TestProcess()
 process.intProducerEndProcessBlock = cms.EDProducer("IntProducerEndProcessBlock", ivalue = cms.int32(10001))
 process.moduleToTest(process.intProducerEndProcessBlock)
 )_";
-  edm::test::TestProcessor::Config config(kTest);
+    edm::test::TestProcessor::Config config(kTest);
 
-  edm::test::TestProcessor tester(config);
-  {
-    auto processBlock = tester.testBeginProcessBlock();
-    CPPUNIT_ASSERT_THROW(*processBlock.get<edmtest::IntProduct>(), cms::Exception);
+    edm::test::TestProcessor tester(config);
+    {
+      auto processBlock = tester.testBeginProcessBlock();
+      REQUIRE_THROWS_AS(*processBlock.get<edmtest::IntProduct>(), cms::Exception);
+    }
+    {
+      auto processBlock = tester.testEndProcessBlock();
+      REQUIRE(processBlock.get<edmtest::IntProduct>()->value == 10001);
+    }
   }
-  {
-    auto processBlock = tester.testEndProcessBlock();
-    CPPUNIT_ASSERT(processBlock.get<edmtest::IntProduct>()->value == 10001);
-  }
-}
 
-void testTestProcessor::runProductTest() {
-  auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
+  SECTION("run product test") {
+    auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
 process = TestProcess()
 process.toTest = cms.EDProducer('ThingProducer')
 process.moduleToTest(process.toTest)
 )_";
-  edm::test::TestProcessor::Config config(kTest);
+    edm::test::TestProcessor::Config config(kTest);
 
-  edm::test::TestProcessor tester(config);
-  {
-    auto run = tester.testBeginRun(1);
-    CPPUNIT_ASSERT(run.get<edmtest::ThingCollection>("beginRun")->size() == 20);
+    edm::test::TestProcessor tester(config);
+    {
+      auto run = tester.testBeginRun(1);
+      REQUIRE(run.get<edmtest::ThingCollection>("beginRun")->size() == 20);
+    }
+
+    {
+      auto run = tester.testEndRun();
+      REQUIRE(run.get<edmtest::ThingCollection>("beginRun")->size() == 20);
+      REQUIRE(run.get<edmtest::ThingCollection>("endRun")->size() == 20);
+    }
+
+    {
+      auto run = tester.testBeginRun(2);
+      REQUIRE(run.get<edmtest::ThingCollection>("beginRun")->size() == 20);
+    }
   }
 
-  {
-    auto run = tester.testEndRun();
-    CPPUNIT_ASSERT(run.get<edmtest::ThingCollection>("beginRun")->size() == 20);
-    CPPUNIT_ASSERT(run.get<edmtest::ThingCollection>("endRun")->size() == 20);
-  }
-
-  {
-    auto run = tester.testBeginRun(2);
-    CPPUNIT_ASSERT(run.get<edmtest::ThingCollection>("beginRun")->size() == 20);
-  }
-}
-
-void testTestProcessor::lumiProductTest() {
-  auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
+  SECTION("lumi product test") {
+    auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
 process = TestProcess()
 process.toTest = cms.EDProducer('ThingProducer')
 process.moduleToTest(process.toTest)
 )_";
-  edm::test::TestProcessor::Config config(kTest);
+    edm::test::TestProcessor::Config config(kTest);
 
-  edm::test::TestProcessor tester(config);
-  {
-    auto lumi = tester.testBeginLuminosityBlock(1);
-    CPPUNIT_ASSERT(lumi.get<edmtest::ThingCollection>("beginLumi")->size() == 20);
+    edm::test::TestProcessor tester(config);
+    {
+      auto lumi = tester.testBeginLuminosityBlock(1);
+      REQUIRE(lumi.get<edmtest::ThingCollection>("beginLumi")->size() == 20);
+    }
+
+    {
+      auto lumi = tester.testEndLuminosityBlock();
+      REQUIRE(lumi.get<edmtest::ThingCollection>("beginLumi")->size() == 20);
+      REQUIRE(lumi.get<edmtest::ThingCollection>("endLumi")->size() == 20);
+    }
+
+    {
+      auto lumi = tester.testBeginLuminosityBlock(2);
+      REQUIRE(lumi.get<edmtest::ThingCollection>("beginLumi")->size() == 20);
+    }
   }
 
-  {
-    auto lumi = tester.testEndLuminosityBlock();
-    CPPUNIT_ASSERT(lumi.get<edmtest::ThingCollection>("beginLumi")->size() == 20);
-    CPPUNIT_ASSERT(lumi.get<edmtest::ThingCollection>("endLumi")->size() == 20);
-  }
-
-  {
-    auto lumi = tester.testBeginLuminosityBlock(2);
-    CPPUNIT_ASSERT(lumi.get<edmtest::ThingCollection>("beginLumi")->size() == 20);
-  }
-}
-
-void testTestProcessor::runStreamAnalyzerTest() {
-  auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
+  SECTION("run stream analyzer test") {
+    auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
 process = TestProcess()
 process.toTest = cms.EDAnalyzer('edmtest::stream::RunIntAnalyzer',
     transitions = cms.int32(2)
@@ -409,15 +360,15 @@ process.toTest = cms.EDAnalyzer('edmtest::stream::RunIntAnalyzer',
 
 process.moduleToTest(process.toTest)
 )_";
-  edm::test::TestProcessor::Config config(kTest);
-  edm::test::TestProcessor tester(config);
-  tester.testBeginLuminosityBlock(1);
-  tester.testEndLuminosityBlock();
-  tester.testBeginLuminosityBlock(2);
-}
+    edm::test::TestProcessor::Config config(kTest);
+    edm::test::TestProcessor tester(config);
+    tester.testBeginLuminosityBlock(1);
+    tester.testEndLuminosityBlock();
+    tester.testBeginLuminosityBlock(2);
+  }
 
-void testTestProcessor::lumiStreamAnalyzerTest() {
-  auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
+  SECTION("lumi stream analyzer test") {
+    auto const kTest = R"_(from FWCore.TestProcessor.TestProcess import *
 process = TestProcess()
 process.toTest = cms.EDAnalyzer('edmtest::stream::LumiIntAnalyzer',
     transitions = cms.int32(4)
@@ -427,11 +378,10 @@ process.toTest = cms.EDAnalyzer('edmtest::stream::LumiIntAnalyzer',
 
 process.moduleToTest(process.toTest)
 )_";
-  edm::test::TestProcessor::Config config(kTest);
-  edm::test::TestProcessor tester(config);
-  tester.testBeginLuminosityBlock(1);
-  tester.testEndLuminosityBlock();
-  tester.testBeginLuminosityBlock(2);
+    edm::test::TestProcessor::Config config(kTest);
+    edm::test::TestProcessor tester(config);
+    tester.testBeginLuminosityBlock(1);
+    tester.testEndLuminosityBlock();
+    tester.testBeginLuminosityBlock(2);
+  }
 }
-
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>

--- a/FWCore/TestProcessor/test/testsourceprocessor_t.cppunit.cc
+++ b/FWCore/TestProcessor/test/testsourceprocessor_t.cppunit.cc
@@ -1,113 +1,98 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/TestProcessor/interface/TestSourceProcessor.h"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "catch2/catch_all.hpp"
 
-class testTestSourceProcessor : public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(testTestSourceProcessor);
-  CPPUNIT_TEST(simpleTest);
+TEST_CASE("TestSourceProcessor tests", "[TestSourceProcessor]") {
+  SECTION("simple test") {
+    char const* kTest =
+        "from FWCore.TestProcessor.TestSourceProcess import *\n"
+        "process = TestSourceProcess()\n"
+        "process.source = cms.Source('TestSource',"
+        "transitions = cms.untracked.VPSet(\n"
+        "cms.PSet(type = cms.untracked.string('IsFile'),\n"
+        "         id = cms.untracked.EventID(0,0,0)),\n"
+        "cms.PSet(type = cms.untracked.string('IsRun'),\n"
+        "         id = cms.untracked.EventID(1,0,0)),\n"
+        "cms.PSet(type = cms.untracked.string('IsLumi'),\n"
+        "         id = cms.untracked.EventID(1,1,0)),\n"
+        "cms.PSet(type = cms.untracked.string('IsEvent'),\n"
+        "         id = cms.untracked.EventID(1,1,1)),\n"
+        "cms.PSet(type = cms.untracked.string('IsEvent'),\n"
+        "         id = cms.untracked.EventID(1,1,2)),\n"
+        "cms.PSet(type = cms.untracked.string('IsEvent'),\n"
+        "         id = cms.untracked.EventID(1,1,3)),\n"
+        "cms.PSet(type = cms.untracked.string('IsEvent'),\n"
+        "         id = cms.untracked.EventID(1,1,4)),\n"
+        "cms.PSet(type = cms.untracked.string('IsEvent'),\n"
+        "         id = cms.untracked.EventID(1,1,5)),\n"
+        "cms.PSet(type = cms.untracked.string('IsStop'),\n"
+        "         id = cms.untracked.EventID(0,0,0))\n"
+        "))\n";
+    edm::test::TestSourceProcessor tester(kTest);
 
-  CPPUNIT_TEST_SUITE_END();
-
-public:
-  void setUp() {}
-  void tearDown() {}
-  void simpleTest();
-
-private:
-};
-
-///registration of the test so that the runner can find it
-CPPUNIT_TEST_SUITE_REGISTRATION(testTestSourceProcessor);
-
-void testTestSourceProcessor::simpleTest() {
-  char const* kTest =
-      "from FWCore.TestProcessor.TestSourceProcess import *\n"
-      "process = TestSourceProcess()\n"
-      "process.source = cms.Source('TestSource',"
-      "transitions = cms.untracked.VPSet(\n"
-      "cms.PSet(type = cms.untracked.string('IsFile'),\n"
-      "         id = cms.untracked.EventID(0,0,0)),\n"
-      "cms.PSet(type = cms.untracked.string('IsRun'),\n"
-      "         id = cms.untracked.EventID(1,0,0)),\n"
-      "cms.PSet(type = cms.untracked.string('IsLumi'),\n"
-      "         id = cms.untracked.EventID(1,1,0)),\n"
-      "cms.PSet(type = cms.untracked.string('IsEvent'),\n"
-      "         id = cms.untracked.EventID(1,1,1)),\n"
-      "cms.PSet(type = cms.untracked.string('IsEvent'),\n"
-      "         id = cms.untracked.EventID(1,1,2)),\n"
-      "cms.PSet(type = cms.untracked.string('IsEvent'),\n"
-      "         id = cms.untracked.EventID(1,1,3)),\n"
-      "cms.PSet(type = cms.untracked.string('IsEvent'),\n"
-      "         id = cms.untracked.EventID(1,1,4)),\n"
-      "cms.PSet(type = cms.untracked.string('IsEvent'),\n"
-      "         id = cms.untracked.EventID(1,1,5)),\n"
-      "cms.PSet(type = cms.untracked.string('IsStop'),\n"
-      "         id = cms.untracked.EventID(0,0,0))\n"
-      "))\n";
-  edm::test::TestSourceProcessor tester(kTest);
-
-  {
-    auto n = tester.findNextTransition();
-    CPPUNIT_ASSERT(n == edm::InputSource::ItemType::IsFile);
-    auto f = tester.openFile();
-    CPPUNIT_ASSERT(bool(f));
-  }
-  {
-    auto n = tester.findNextTransition();
-    CPPUNIT_ASSERT(n == edm::InputSource::ItemType::IsRun);
-    auto r = tester.readRun();
-    CPPUNIT_ASSERT(r.run() == 1);
-  }
-  {
-    auto n = tester.findNextTransition();
-    CPPUNIT_ASSERT(n == edm::InputSource::ItemType::IsLumi);
-    auto r = tester.readLuminosityBlock();
-    CPPUNIT_ASSERT(r.run() == 1);
-    CPPUNIT_ASSERT(r.luminosityBlock() == 1);
-  }
-  {
-    auto n = tester.findNextTransition();
-    CPPUNIT_ASSERT(n == edm::InputSource::ItemType::IsEvent);
-    auto r = tester.readEvent();
-    CPPUNIT_ASSERT(r.run() == 1);
-    CPPUNIT_ASSERT(r.luminosityBlock() == 1);
-    CPPUNIT_ASSERT(r.event() == 1);
-  }
-  {
-    auto n = tester.findNextTransition();
-    CPPUNIT_ASSERT(n == edm::InputSource::ItemType::IsEvent);
-    auto r = tester.readEvent();
-    CPPUNIT_ASSERT(r.run() == 1);
-    CPPUNIT_ASSERT(r.luminosityBlock() == 1);
-    CPPUNIT_ASSERT(r.event() == 2);
-  }
-  {
-    auto n = tester.findNextTransition();
-    CPPUNIT_ASSERT(n == edm::InputSource::ItemType::IsEvent);
-    auto r = tester.readEvent();
-    CPPUNIT_ASSERT(r.run() == 1);
-    CPPUNIT_ASSERT(r.luminosityBlock() == 1);
-    CPPUNIT_ASSERT(r.event() == 3);
-  }
-  {
-    auto n = tester.findNextTransition();
-    CPPUNIT_ASSERT(n == edm::InputSource::ItemType::IsEvent);
-    auto r = tester.readEvent();
-    CPPUNIT_ASSERT(r.run() == 1);
-    CPPUNIT_ASSERT(r.luminosityBlock() == 1);
-    CPPUNIT_ASSERT(r.event() == 4);
-  }
-  {
-    auto n = tester.findNextTransition();
-    CPPUNIT_ASSERT(n == edm::InputSource::ItemType::IsEvent);
-    auto r = tester.readEvent();
-    CPPUNIT_ASSERT(r.run() == 1);
-    CPPUNIT_ASSERT(r.luminosityBlock() == 1);
-    CPPUNIT_ASSERT(r.event() == 5);
-  }
-  {
-    auto n = tester.findNextTransition();
-    CPPUNIT_ASSERT(n == edm::InputSource::ItemType::IsStop);
+    {
+      auto n = tester.findNextTransition();
+      REQUIRE(n == edm::InputSource::ItemType::IsFile);
+      auto f = tester.openFile();
+      REQUIRE(bool(f));
+    }
+    {
+      auto n = tester.findNextTransition();
+      REQUIRE(n == edm::InputSource::ItemType::IsRun);
+      auto r = tester.readRun();
+      REQUIRE(r.run() == 1);
+    }
+    {
+      auto n = tester.findNextTransition();
+      REQUIRE(n == edm::InputSource::ItemType::IsLumi);
+      auto r = tester.readLuminosityBlock();
+      REQUIRE(r.run() == 1);
+      REQUIRE(r.luminosityBlock() == 1);
+    }
+    {
+      auto n = tester.findNextTransition();
+      REQUIRE(n == edm::InputSource::ItemType::IsEvent);
+      auto r = tester.readEvent();
+      REQUIRE(r.run() == 1);
+      REQUIRE(r.luminosityBlock() == 1);
+      REQUIRE(r.event() == 1);
+    }
+    {
+      auto n = tester.findNextTransition();
+      REQUIRE(n == edm::InputSource::ItemType::IsEvent);
+      auto r = tester.readEvent();
+      REQUIRE(r.run() == 1);
+      REQUIRE(r.luminosityBlock() == 1);
+      REQUIRE(r.event() == 2);
+    }
+    {
+      auto n = tester.findNextTransition();
+      REQUIRE(n == edm::InputSource::ItemType::IsEvent);
+      auto r = tester.readEvent();
+      REQUIRE(r.run() == 1);
+      REQUIRE(r.luminosityBlock() == 1);
+      REQUIRE(r.event() == 3);
+    }
+    {
+      auto n = tester.findNextTransition();
+      REQUIRE(n == edm::InputSource::ItemType::IsEvent);
+      auto r = tester.readEvent();
+      REQUIRE(r.run() == 1);
+      REQUIRE(r.luminosityBlock() == 1);
+      REQUIRE(r.event() == 4);
+    }
+    {
+      auto n = tester.findNextTransition();
+      REQUIRE(n == edm::InputSource::ItemType::IsEvent);
+      auto r = tester.readEvent();
+      REQUIRE(r.run() == 1);
+      REQUIRE(r.luminosityBlock() == 1);
+      REQUIRE(r.event() == 5);
+    }
+    {
+      auto n = tester.findNextTransition();
+      REQUIRE(n == edm::InputSource::ItemType::IsStop);
+    }
   }
 }


### PR DESCRIPTION
#### PR description:

Part of a campaign to reduce FWCore dependencies.

#### PR validation:

Code compiles, unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/2123