### PR TITLE
fix CustomPhysics BuildFile to include pythia8 external directly

### DIFF
--- a/SimG4Core/CustomPhysics/BuildFile.xml
+++ b/SimG4Core/CustomPhysics/BuildFile.xml
@@ -7,7 +7,7 @@
 <use name="SimG4Core/Physics"/>
 <use name="SimG4Core/PhysicsLists"/>
 <use name="SimG4Core/Watcher"/>
-<use name="GeneratorInterface/Pythia8Interface"/>
+<use name="pythia8"/>
 <use name="geant4core"/>
 <use name="clhep"/>
 <use name="boost"/>


### PR DESCRIPTION
#### PR description:

Attempt to resolve IB compilation issue:
```
lto-wrapper: warning: Extra option to '-Xassembler': --compress-debug-sections, dropping all '-Xassembler' and '-Wa' options.
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `Pythia8::HelicityMatrixElement::~HelicityMatrixElement()':
<artificial>:(.text+0x243): undefined reference to `vtable for Pythia8::HelicityMatrixElement'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `Pythia8::HelicityParticle::~HelicityParticle()':
<artificial>:(.text+0x4094): undefined reference to `vtable for Pythia8::Particle'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `Pythia8::HelicityParticle::~HelicityParticle()':
<artificial>:(.text+0x4244): undefined reference to `vtable for Pythia8::Particle'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `Pythia8::TauDecays::~TauDecays()':
<artificial>:(.text+0x443c): undefined reference to `vtable for Pythia8::Particle'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x47a8): undefined reference to `vtable for Pythia8::HMETauDecay'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x47ed): undefined reference to `vtable for Pythia8::HMETau2TwoPionsGamma'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x48b9): undefined reference to `vtable for Pythia8::HMETau2ThreeMesonsGeneric'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x4a27): undefined reference to `vtable for Pythia8::HMETau2ThreeMesonsWithKaons'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x4c88): undefined reference to `vtable for Pythia8::HMETau2ThreePions'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x4d8a): undefined reference to `vtable for Pythia8::HMETau2TwoMesonsViaVectorScalar'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x4ec2): undefined reference to `vtable for Pythia8::HMETau2TwoMesonsViaVector'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x4f98): undefined reference to `vtable for Pythia8::HMEHiggs2TwoFermions'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x4fb6): undefined reference to `vtable for Pythia8::HMEX2TwoFermions'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x4ffa): undefined reference to `vtable for Pythia8::HMETwoGammas2TwoFermions'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x5018): undefined reference to `vtable for Pythia8::HMETwoFermions2GammaZ2TwoFermions'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x5036): undefined reference to `vtable for Pythia8::HMETwoFermions2W2TwoFermions'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `Pythia8::JunctionSplitting::onInitInfoPtr()':
<artificial>:(.text+0xa684): undefined reference to `Pythia8::PhysicsBase::registerSubObject(Pythia8::PhysicsBase&)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0xa693): undefined reference to `Pythia8::PhysicsBase::registerSubObject(Pythia8::PhysicsBase&)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0xa6a2): undefined reference to `Pythia8::PhysicsBase::registerSubObject(Pythia8::PhysicsBase&)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `Pythia8::HadronLevel::onInitInfoPtr()':
<artificial>:(.text+0xa6e4): undefined reference to `Pythia8::PhysicsBase::registerSubObject(Pythia8::PhysicsBase&)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0xa6f3): undefined reference to `Pythia8::PhysicsBase::registerSubObject(Pythia8::PhysicsBase&)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o:<artificial>:(.text+0xa702): more undefined references to `Pythia8::PhysicsBase::registerSubObject(Pythia8::PhysicsBase&)' follow
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `Pythia8::StringFragmentation::~StringFragmentation()':
<artificial>:(.text+0xbb64): undefined reference to `vtable for Pythia8::StringFragmentation'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `RHadronPythiaDecayer::fillParticle(G4Track const&, Pythia8::Event&) const':
<artificial>:(.text+0xfd33): undefined reference to `vtable for Pythia8::Particle'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0xfdea): undefined reference to `Pythia8::Particle::setPDEPtr(std::shared_ptr<Pythia8::ParticleDataEntry>)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0xff52): undefined reference to `Pythia8::Particle::setPDEPtr(std::shared_ptr<Pythia8::ParticleDataEntry>)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x10040): undefined reference to `vtable for Pythia8::Particle'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `RHadronPythiaDecayer::fromIdWithSquark(int) const':
<artificial>:(.text+0x1068f): undefined reference to `Pythia8::Settings::mode(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x106e9): undefined reference to `Pythia8::Settings::mode(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `RHadronPythiaDecayer::fromIdWithGluino(int, Pythia8::Rndm*) const':
<artificial>:(.text+0x10991): undefined reference to `Pythia8::Rndm::flat()'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x109c0): undefined reference to `Pythia8::Rndm::flat()'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x109f4): undefined reference to `Pythia8::Rndm::flat()'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x10a77): undefined reference to `Pythia8::Rndm::flat()'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x10ac9): undefined reference to `Pythia8::Rndm::flat()'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `RHadronPythiaDecayer::RHadronToConstituents(Pythia8::Event&)':
<artificial>:(.text+0x10c68): undefined reference to `Pythia8::Settings::mode(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x10cc4): undefined reference to `Pythia8::Settings::mode(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x10d2d): undefined reference to `Pythia8::Settings::mode(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x10eb6): undefined reference to `Pythia8::ParticleDataEntry::mSel() const'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x111ad): undefined reference to `Pythia8::ParticleDataEntry::mSel() const'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x11592): undefined reference to `Pythia8::ParticleDataEntry::mSel() const'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x11659): undefined reference to `Pythia8::ParticleDataEntry::mSel() const'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `Pythia8::Pythia::~Pythia()':
<artificial>:(.text+0x124ea): undefined reference to `Pythia8::ProcessLevel::~ProcessLevel()'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x12b78): undefined reference to `vtable for Pythia8::WeightsBase'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x12c08): undefined reference to `Pythia8::WeightsFragmentation::~WeightsFragmentation()'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x12c0f): undefined reference to `vtable for Pythia8::WeightsMerging'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x12cbb): undefined reference to `vtable for Pythia8::WeightsBase'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x12d43): undefined reference to `vtable for Pythia8::WeightsSimpleShower'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x13121): undefined reference to `vtable for Pythia8::WeightsBase'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x131ab): undefined reference to `vtable for Pythia8::WeightsLHEF'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x131d0): undefined reference to `vtable for Pythia8::WeightsBase'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `RHadronPythiaDecayer::RHadronPythiaDecayer(edm::ParameterSet const&)':
<artificial>:(.text+0x141aa): undefined reference to `Pythia8::Pythia::Pythia(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x14988): undefined reference to `Pythia8::Settings::readString(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, int)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x149fd): undefined reference to `Pythia8::Pythia::init()'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0x14d12): undefined reference to `Pythia8::Settings::readString(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, int)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `RHadronPythiaDecayer::pythiaDecay(G4Track const&, std::vector<G4DynamicParticle*, std::allocator<G4DynamicParticle*> >&)':
<artificial>:(.text+0x15283): undefined reference to `Pythia8::Pythia::next(int)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `Pythia8::JunctionSplitting::onInitInfoPtr()':
<artificial>:(.text+0xa6b6): undefined reference to `Pythia8::PhysicsBase::registerSubObject(Pythia8::PhysicsBase&)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `Pythia8::ParticleDecays::onInitInfoPtr()':
<artificial>:(.text+0xa6c8): undefined reference to `Pythia8::PhysicsBase::registerSubObject(Pythia8::PhysicsBase&)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `Pythia8::HadronLevel::onInitInfoPtr()':
<artificial>:(.text+0xa752): undefined reference to `Pythia8::PhysicsBase::registerSubObject(Pythia8::PhysicsBase&)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `Pythia8::BeamRemnants::onInitInfoPtr()':
<artificial>:(.text+0xa768): undefined reference to `Pythia8::PhysicsBase::registerSubObject(Pythia8::PhysicsBase&)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o: in function `Pythia8::PartonLevel::onInitInfoPtr()':
<artificial>:(.text+0xa801): undefined reference to `Pythia8::PhysicsBase::registerSubObject(Pythia8::PhysicsBase&)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o:<artificial>:(.text+0xa892): more undefined references to `Pythia8::PhysicsBase::registerSubObject(Pythia8::PhysicsBase&)' follow
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans24.ltrans.o:(.data.rel.ro+0x208): undefined reference to `typeinfo for Pythia8::Particle'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: /tmp/ccoDSBBP.ltrans124.ltrans.o: in function `Pythia8::Event::append(int, int, int, int, int, int, int, int, Pythia8::Vec4, double, double, double) [clone .constprop.0] [clone .isra.0]':
<artificial>:(.text+0xd84a): undefined reference to `vtable for Pythia8::Particle'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0xd90b): undefined reference to `Pythia8::Particle::setPDEPtr(std::shared_ptr<Pythia8::ParticleDataEntry>)'
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/bin/../lib/gcc/x86_64-redhat-linux-gnu/13.4.0/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: <artificial>:(.text+0xda10): undefined reference to `vtable for Pythia8::Particle'
collect2: error: ld returned 1 exit status
gmake: *** [tmp/el8_amd64_gcc13/src/BigProducts/Simulation/pluginSimulation.so] Error 1
>> Leaving Package src/BigProducts/Simulation
>> Package src/BigProducts/Simulation built
```

possibly related to #49414

#### PR validation:

Build succeeds with this PR (though build also succeeds just by checking out `SimG4Core/CustomPhysics` without this PR)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
