### PR TITLE
fix missing ToF offset of Phase-2 cosmic pixel digi

### DIFF
--- a/SimGeneral/MixingModule/python/digitizersCosmics_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizersCosmics_cfi.py
@@ -14,6 +14,11 @@ pixelDigitizer.TofLowerCut=cms.double(18.5)
 pixelDigitizer.TofUpperCut=cms.double(43.5)
 stripDigitizer.CosmicDelayShift = cms.untracked.double(31)
 
+# Phase-2: Propagate cosmic time offset to all algorithms
+phase2_tracker.toModify(pixelDigitizer, AlgorithmCommon = dict(
+  CosmicDelayShift = cms.double(31)
+))
+
 ecalDigitizer.cosmicsPhase = cms.bool(True)
 ecalDigitizer.cosmicsShift = cms.double(1.)
 

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -106,6 +106,7 @@ Phase2TrackerDigitizerAlgorithm::Phase2TrackerDigitizerAlgorithm(const edm::Para
       // theTofCut 12.5, cut in particle TOD +/- 12.5ns
       theTofLowerCut_(conf_specific.getParameter<double>("TofLowerCut")),
       theTofUpperCut_(conf_specific.getParameter<double>("TofUpperCut")),
+      cosmicShift_(conf_common.getParameter<double>("CosmicDelayShift")),
 
       // Get the Lorentz angle from the cfg file:
       tanLorentzAnglePerTesla_Endcap_(
@@ -193,7 +194,7 @@ void Phase2TrackerDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::co
                                          << hit.detUnitId() << hit.entryPoint() << " " << hit.exitPoint();
     double signalScale = 1.0;
     // fill collection_points for this SimHit, indpendent of topology
-    if (select_hit(hit, (pixdet->surface().toGlobal(hit.localPosition()).mag() * c_inv), signalScale)) {
+    if (select_hit(hit, (pixdet->surface().toGlobal(hit.localPosition()).mag() * c_inv) + cosmicShift_, signalScale)) {
       const auto& ionization_points = primary_ionization(hit);  // fills ionization_points
 
       // transforms ionization_points -> collection_points

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
@@ -151,6 +151,7 @@ protected:
 
   const float theTofLowerCut_;                  // Cut on the particle TOF
   const float theTofUpperCut_;                  // Cut on the particle TOF
+  const float cosmicShift_;                     // Cosmic shift to apply before the ToF cut.
   const float tanLorentzAnglePerTesla_Endcap_;  //FPix Lorentz angle tangent per Tesla
   const float tanLorentzAnglePerTesla_Barrel_;  //BPix Lorentz angle tangent per Tesla
 

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -80,6 +80,7 @@ phase2TrackerDigitizer = cms.PSet(
     AlgorithmCommon = cms.PSet(
       DeltaProductionCut = cms.double(0.03),
       makeDigiSimLinks = cms.untracked.bool(True),
+      CosmicDelayShift = cms.double(0.)
     ),
 # Specific parameters
 #Pixel Digitizer Algorithm


### PR DESCRIPTION
#### PR description:

The current Phase-2 cosmic digitisation for the strip system has a bug - the time offset between the cosmic muon production and the arrival in the tracker (around 31 ns) was not being accounted for.

As a result, Phase-2 cosmics MC workflows would not contain any digis / reco-level hits, as all SimHits would be rejected by the initial time window check. 

This PR fixes the bug by re-introducing an offset of the timing window as done for the Phase-1 strip system (and equivalent to the symmetric shift of the window edges applied to the phase-1 pixel system). 
It is added to a common configuration block for all the (four) phase-2 digitizers, to minimise the amount of domain knowledge required at the `mixingModule` level. 

Changes were discussed with @boudoul and @suchandradutta. Once the initial functionality is (re)established, detailed validation studies of the cosmic digitisation can be performed to reproduce more closely what is expected to happen in the real, timed-in detector at point 5. 

#### PR validation:

Tested effect of the fix: 
- Before fix, almost zero digis / cluster / recoHits in the Phase-2 tracker for WF 7.5. 
- After fix, ~every SimHit matched by digis / clusters / recoHits in WF 7.5 
<img width="250" height="250" alt="image" src="https://github.com/user-attachments/assets/c752b0d9-af81-43c6-b5cf-6ae53edd59e2" />
before fix - no blue / orange entries (indicating reco-level measurements) matching the red SimHit locations


<img width="250" height="250" alt="image" src="https://github.com/user-attachments/assets/c327bf91-7474-481b-96e6-648ae3b2d8b0" />
after fix -  blue / orange entries indicating reco-level measurements for all red SimHit locations

Ran standard tests:
- unit tests passing
- limited runTheMatrix payload passing 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

no backport planned. 