### PR TITLE
Use RNTupleReader::RActiveEntryToken

### DIFF
--- a/FWIO/RNTupleTempInput/src/RootRNTuple.cc
+++ b/FWIO/RNTupleTempInput/src/RootRNTuple.cc
@@ -84,6 +84,12 @@ namespace edm::rntuple_temp {
           << "\n This is either not an edm RNTuple ROOT file or is one that has been corrupted.";
     }
     entries_ = reader_->GetNEntries();
+    activeEntryTokens_.reserve(entryNumberForIndex_->size());
+    {
+      for (size_t i = 0; i < entryNumberForIndex_->size(); ++i) {
+        activeEntryTokens_.push_back(reader_->CreateActiveEntryToken());
+      }
+    }
   }
 
   RootRNTuple::~RootRNTuple() {}
@@ -104,6 +110,7 @@ namespace edm::rntuple_temp {
   void RootRNTuple::insertEntryForIndex(unsigned int index) {
     assert(index < entryNumberForIndex_->size());
     (*entryNumberForIndex_)[index] = entryNumber();
+    activeEntryTokens_[index].SetEntryNumber(entryNumber());
   }
 
   bool RootRNTuple::isValid() const {

--- a/FWIO/RNTupleTempInput/src/RootRNTuple.h
+++ b/FWIO/RNTupleTempInput/src/RootRNTuple.h
@@ -206,6 +206,7 @@ namespace edm::rntuple_temp {
     std::unique_ptr<std::vector<EntryNumber>> entryNumberForIndex_;
     std::vector<std::string> branchNames_;
     ProductMap branches_;
+    std::vector<ROOT::RNTupleReader::RActiveEntryToken> activeEntryTokens_;
     unsigned int cacheSize_ = 0;
     unsigned long treeAutoFlush_ = 0;
     bool promptRead_;


### PR DESCRIPTION

#### PR description:

This is meant to avoid having a cluster go away before all data from it has been read.

#### PR validation:

Code compiles in a new enough version of ROOT.