### PR TITLE
[16.0.X] switch off `usePixelQualityFlag` in `TrackerTrackHitFilter` in presence of the `PixelCPEGeneric` modifier

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli0T_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli0T_cff.py
@@ -122,6 +122,9 @@ SiPixelAliTrackerTrackHitFilter = HitFilter.TrackerTrackHitFilter.clone(
     usePixelQualityFlag = True #False
     )
 
+from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
+PixelCPEGeneric.toModify(SiPixelAliTrackerTrackHitFilter,usePixelQualityFlag = False)
+
 # Ingredient: SiPixelAliSiPixelAliTrackFitter
 import RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cff as fitWithMaterial
 SiPixelAliTrackFitter = fitWithMaterial.ctfWithMaterialTracks.clone(

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
@@ -120,6 +120,9 @@ SiPixelAliTrackerTrackHitFilter = HitFilter.TrackerTrackHitFilter.clone(
     usePixelQualityFlag = True #False
     )
 
+from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
+PixelCPEGeneric.toModify(SiPixelAliTrackerTrackHitFilter, usePixelQualityFlag = False)
+
 # Ingredient: SiPixelAliSiPixelAliTrackFitter
 import RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cff as fitWithMaterial
 SiPixelAliTrackFitter = fitWithMaterial.ctfWithMaterialTracks.clone(

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlCosmics0T_Skimmed_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlCosmics0T_Skimmed_cff.py
@@ -67,6 +67,9 @@ AlignmentHitFilterCTF=RecoTracker.FinalTrackSelectors.TrackerTrackHitFilter_cff.
     PxlCorrClusterChargeCut=10000.0
     )
 
+from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
+PixelCPEGeneric.toModify(AlignmentHitFilterCTF, usePixelQualityFlag = False)
+
 # 3: produce track after NEW track hit filter
 
 import RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_Skimmed_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_Skimmed_cff.py
@@ -68,6 +68,9 @@ AlignmentHitFilterCTF=RecoTracker.FinalTrackSelectors.TrackerTrackHitFilter_cff.
     PxlCorrClusterChargeCut=10000.0
     )
 
+from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
+PixelCPEGeneric.toModify(AlignmentHitFilterCTF, usePixelQualityFlag = False)
+
 # 3: produce track after NEW track hit filter
 
 import RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cff

--- a/DPGAnalysis/SiStripTools/python/tkAlTrackRefitSequence_cff.py
+++ b/DPGAnalysis/SiStripTools/python/tkAlTrackRefitSequence_cff.py
@@ -21,6 +21,9 @@ TrackerTrackHitFilter.rejectLowAngleHits= True
 TrackerTrackHitFilter.TrackAngleCut= 0.35 # in rads, starting from the module surface
 TrackerTrackHitFilter.usePixelQualityFlag= True
 
+from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
+PixelCPEGeneric.toModify(TrackerTrackHitFilter, usePixelQualityFlag = False)
+
 ################################################################################################
 #TRACK PRODUCER
 #now we give the TrackCandidate coming out of the TrackerTrackHitFilter to the track producer

--- a/DQM/TrackingMonitorSource/python/shortTrackResolution_cff.py
+++ b/DQM/TrackingMonitorSource/python/shortTrackResolution_cff.py
@@ -10,6 +10,9 @@ ShortTrackCandidates = _trackerTrackHitFilter.clone(src = "SingleLongTrackProduc
                                                     rejectBadStoNHits = True,
                                                     usePixelQualityFlag = True)
 
+from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
+PixelCPEGeneric.toModify(ShortTrackCandidates, usePixelQualityFlag = False)
+
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(ShortTrackCandidates,
                         isPhase2 = True)

--- a/RecoTracker/FinalTrackSelectors/python/TrackerTrackHitFilter_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/TrackerTrackHitFilter_cff.py
@@ -44,3 +44,6 @@ TrackerTrackHitFilter = _trackerTrackHitFilter.clone(
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(TrackerTrackHitFilter,
                         isPhase2 = True)
+
+from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
+PixelCPEGeneric.toModify(TrackerTrackHitFilter, usePixelQualityFlag = False)


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50616

#### PR description:

This PR is a follow-up to https://github.com/cms-sw/cmssw/pull/50480. 
In that PR the default CPE for track fitting in the 2026 Era was moved to the CPE generic.
Unfortunately this has a knock-on effect on  the `TrackerTrackHitFilter` which has a flag (`usePixelQualityFlag`) which relies on the template fit information to do hit rejection:

https://github.com/cms-sw/cmssw/blob/0733146428f160a0208f28fa49d1c10025355d66/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc#L976-L997

This is of course not available when the template fit is not run.
This has lead to missing alignment PCL results (see e.g. https://cern.ch/wygsf) and potentially wrong DQM results.

#### PR validation:

I've re-run the following command (previously failing in `CMSSW_16_0_4_patch2`):

```bash
#!/bin/bash -ex

dasgoclient --limit 0 --query 'file dataset=/StreamExpress/Run2026C-TkAlMinBias-Express-v1/ALCARECO run=402536' | sort -u > input_files.txt
echo '{"402536": [[1, 116]]}' > step1_lumiRanges.txt

cmsDriver.py ReAlCaHLT \
  -s ALCA:PromptCalibProdSiPixelAli \
  --conditions 160X_dataRun3_Express_v1 \
  --scenario pp \
  --data \
  --era Run3_2026 \
  --datatier ALCARECO \
  --eventcontent ALCARECO \
  --process RECO \
  --processName ReAlCa \
  --filein filelist:input_files.txt \
  --lumiToProcess step1_lumiRanges.txt \
  -n 1000 >& ReAlCa.log

cmsDriver.py ALCAHARVDSIPIXELALI \
  -s ALCAHARVEST:SiPixelAli \
  --conditions 160X_dataRun3_Express_v1 \
  --scenario pp \
  --era Run3_2026 \
  --data \
  -n -1 \
  --filein file:PromptCalibProdSiPixelAli.root \
  --customise Alignment/CommonAlignmentProducer/customizeLSNumberFilterForRelVals.lowerHitsPerStructure >& Harvesting.log
```

and verfied the alignment PCL works correctly.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/50616 to the 2026 data-taking release.