### PR TITLE
[HCAL-DQM] Add LS-normalized HCAL LED and pedestal trend plots; set CapID_BadvsLS binning to 1 LS

### DIFF
--- a/DQM/HcalTasks/interface/LEDTask.h
+++ b/DQM/HcalTasks/interface/LEDTask.h
@@ -25,6 +25,7 @@ public:
   ~LEDTask() override {}
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   void dqmEndRun(edm::Run const& r, edm::EventSetup const&) override {
     if (_ptype == hcaldqm::fLocal)
       if (r.runAuxiliary().run() == 1)
@@ -84,15 +85,37 @@ protected:
   hcaldqm::ContainerProf2D _cSignalRMS_depth;
   hcaldqm::ContainerProf2D _cTimingMean_depth;
   hcaldqm::ContainerProf2D _cTimingRMS_depth;
+  hcaldqm::ContainerProf2D _cChargeCorr_depth;
+  hcaldqm::ContainerProf2D _cCWTCorr_depth;
+  hcaldqm::ContainerProf2D _cChargeNormLS2_depth;
+  hcaldqm::ContainerProf2D _cCWTNormLS2_depth;
+  hcaldqm::ContainerProf2D _cChargeAbs_depth;
+  hcaldqm::ContainerProf2D _cCWTAbs_depth;
 
   hcaldqm::ContainerProf2D _cSignalMean_FEDuTCA;
   hcaldqm::ContainerProf2D _cTimingMean_FEDuTCA;
   hcaldqm::ContainerProf2D _cSignalRMS_FEDuTCA;
   hcaldqm::ContainerProf2D _cTimingRMS_FEDuTCA;
 
+  hcaldqm::Container2D _cChargeNormvsLS_SubdetPM;
+  hcaldqm::Container2D _cCWTNormvsLS_SubdetPM;
+
   //	Bad Quality and Missing Channels
   hcaldqm::Container2D _cMissing_depth;
   hcaldqm::Container2D _cMissing_FEDuTCA;
+
+  // LS-to-LS pedestal and LS2 references
+  hcaldqm::ContainerXXX<double> _xPedestalChargeSumLS;
+  hcaldqm::ContainerXXX<int> _xPedestalChargeEntriesLS;
+  hcaldqm::ContainerXXX<double> _xPedestalChargePrevLS;
+  hcaldqm::ContainerXXX<double> _xChargeRefLS2;
+  hcaldqm::ContainerXXX<double> _xCWTRefLS2;
+  hcaldqm::ContainerXXX<int> _xChargeRefLS2Entries;
+  hcaldqm::ContainerXXX<int> _xCWTRefLS2Entries;
+  hcaldqm::ContainerXXX<double> _xChargeNormSumLS;
+  hcaldqm::ContainerXXX<double> _xCWTNormSumLS;
+  hcaldqm::ContainerXXX<int> _xChargeNormEntriesLS;
+  hcaldqm::ContainerXXX<int> _xCWTNormEntriesLS;
 
   // For hcalcalib online LED
   hcaldqm::Container2D _cADCvsTS_SubdetPM;

--- a/DQM/HcalTasks/interface/PedestalTask.h
+++ b/DQM/HcalTasks/interface/PedestalTask.h
@@ -69,9 +69,12 @@ protected:
   hcaldqm::ContainerXXX<double> _xPedSum1LS;
   hcaldqm::ContainerXXX<double> _xPedSum21LS;
   hcaldqm::ContainerXXX<int> _xPedEntries1LS;
+  hcaldqm::ContainerXXX<double> _xChargeSum1LS;
   hcaldqm::ContainerXXX<double> _xPedSumTotal;
   hcaldqm::ContainerXXX<double> _xPedSum2Total;
   hcaldqm::ContainerXXX<int> _xPedEntriesTotal;
+  hcaldqm::ContainerXXX<double> _xChargeRefLS1;
+  hcaldqm::ContainerXXX<int> _xChargeRefLS1Entries;
   hcaldqm::ContainerXXX<int> _xNChs;     // number of channels per FED as in emap
   hcaldqm::ContainerXXX<int> _xNMsn1LS;  // #missing for 1LS per FED
   hcaldqm::ContainerXXX<int> _xNBadMean1LS, _xNBadRMS1LS;
@@ -120,6 +123,7 @@ protected:
 
   //	averaging per event
   hcaldqm::ContainerProf1D _cOccupancyEAvsLS_Subdet;
+  hcaldqm::Container2D _cChargeNormvsLS_SubdetPM;
 
   //	map of missing channels
   hcaldqm::Container2D _cMissing1LS_depth;

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -538,7 +538,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
                                              0);
     _cCapid_BadvsFEDvsLS.initialize(_name,
                                     "CapID",
-                                    new hcaldqm::quantity::LumiSectionCoarse(_maxLS, 10),
+                                    new hcaldqm::quantity::LumiSection(_maxLS),
                                     new hcaldqm::quantity::FEDQuantity(vFEDs),
                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
                                     0);

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -1,9 +1,25 @@
 
 #include "DQM/HcalTasks/interface/LEDTask.h"
+#include <algorithm>
+#include <cmath>
 
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
 using namespace hcaldqm::filter;
+
+namespace {
+  constexpr double kTiny = 1e-9;
+
+  class FineTimingDiffNs : public hcaldqm::quantity::ValueQuantity {
+  public:
+    FineTimingDiffNs() : ValueQuantity(hcaldqm::quantity::fTimingDiff_ns) {}
+
+    FineTimingDiffNs* makeCopy() override { return new FineTimingDiffNs(); }
+    int nbins() override { return 100; }
+    double min() override { return -50.; }
+    double max() override { return 50.; }
+  };
+}  // namespace
 
 LEDTask::LEDTask(edm::ParameterSet const& ps)
     : DQTask(ps), hcalDbServiceToken_(esConsumes<HcalDbService, HcalDbRecord, edm::Transition::BeginRun>()) {
@@ -184,6 +200,48 @@ LEDTask::LEDTask(edm::ParameterSet const& ps)
                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
                                0);
+  _cChargeCorr_depth.initialize(_name,
+                                "ChargeCorrected",
+                                hcaldqm::hashfunctions::fdepth,
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_400000),
+                                0);
+  _cCWTCorr_depth.initialize(_name,
+                             "CWTCorrected",
+                             hcaldqm::hashfunctions::fdepth,
+                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                             new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                             0);
+  _cChargeNormLS2_depth.initialize(_name,
+                                   "ChargeNormLS2",
+                                   hcaldqm::hashfunctions::fdepth,
+                                   new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                   new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                   new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),
+                                   0);
+  _cCWTNormLS2_depth.initialize(_name,
+                                "CWTNormLS2",
+                                hcaldqm::hashfunctions::fdepth,
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                                new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTimingDiff_ns),
+                                0);
+  _cChargeAbs_depth.initialize(_name,
+                               "ChargeAbs",
+                               hcaldqm::hashfunctions::fdepth,
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                               new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                               new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::ffC_generic_400000),
+                               0);
+  _cCWTAbs_depth.initialize(_name,
+                            "CWTAbs",
+                            hcaldqm::hashfunctions::fdepth,
+                            new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fieta),
+                            new hcaldqm::quantity::DetectorQuantity(hcaldqm::quantity::fiphi),
+                            new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS200),
+                            0);
 
   _cMissing_depth.initialize(_name,
                              "Missing",
@@ -201,6 +259,20 @@ LEDTask::LEDTask(edm::ParameterSet const& ps)
                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
                                  0);
   }
+  _cChargeNormvsLS_SubdetPM.initialize(_name,
+                                       "ChargeNormvsLS",
+                                       hcaldqm::hashfunctions::fSubdetPM,
+                                       new hcaldqm::quantity::LumiSection(_maxLS),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                       0);
+  _cCWTNormvsLS_SubdetPM.initialize(_name,
+                                    "CWTNormvsLS",
+                                    hcaldqm::hashfunctions::fSubdetPM,
+                                    new hcaldqm::quantity::LumiSection(_maxLS),
+                                    new FineTimingDiffNs(),
+                                    new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                    0);
 
   // Plots for LED in global
   if (_ptype == fOnline || _ptype == fLocal) {
@@ -261,6 +333,17 @@ LEDTask::LEDTask(edm::ParameterSet const& ps)
   _xTimingSum.initialize(hcaldqm::hashfunctions::fDChannel);
   _xTimingSum2.initialize(hcaldqm::hashfunctions::fDChannel);
   _xEntries.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xPedestalChargeSumLS.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xPedestalChargeEntriesLS.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xPedestalChargePrevLS.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xChargeRefLS2.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xCWTRefLS2.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xChargeRefLS2Entries.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xCWTRefLS2Entries.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xChargeNormSumLS.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xCWTNormSumLS.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xChargeNormEntriesLS.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xCWTNormEntriesLS.initialize(hcaldqm::hashfunctions::fDChannel);
 
   //	BOOK
   _cSignalMean_Subdet.book(ib, _emap, _subsystem);
@@ -272,6 +355,14 @@ LEDTask::LEDTask(edm::ParameterSet const& ps)
   _cSignalRMS_depth.book(ib, _emap, _subsystem);
   _cTimingMean_depth.book(ib, _emap, _subsystem);
   _cTimingRMS_depth.book(ib, _emap, _subsystem);
+  _cChargeCorr_depth.book(ib, _emap, _subsystem);
+  _cCWTCorr_depth.book(ib, _emap, _subsystem);
+  _cChargeNormLS2_depth.book(ib, _emap, _subsystem);
+  _cCWTNormLS2_depth.book(ib, _emap, _subsystem);
+  _cChargeAbs_depth.book(ib, _emap, _subsystem);
+  _cCWTAbs_depth.book(ib, _emap, _subsystem);
+  _cChargeNormvsLS_SubdetPM.book(ib, _emap, _subsystem);
+  _cCWTNormvsLS_SubdetPM.book(ib, _emap, _subsystem);
 
   _cMissing_depth.book(ib, _emap, _subsystem);
   if (_ptype == fLocal) {  // hidefed2crate
@@ -303,6 +394,17 @@ LEDTask::LEDTask(edm::ParameterSet const& ps)
   _xEntries.book(_emap);
   _xTimingSum.book(_emap);
   _xTimingSum2.book(_emap);
+  _xPedestalChargeSumLS.book(_emap);
+  _xPedestalChargeEntriesLS.book(_emap);
+  _xPedestalChargePrevLS.book(_emap);
+  _xChargeRefLS2.book(_emap);
+  _xCWTRefLS2.book(_emap);
+  _xChargeRefLS2Entries.book(_emap);
+  _xCWTRefLS2Entries.book(_emap);
+  _xChargeNormSumLS.book(_emap);
+  _xCWTNormSumLS.book(_emap);
+  _xChargeNormEntriesLS.book(_emap);
+  _xCWTNormEntriesLS.book(_emap);
 
   _ehashmap.initialize(_emap, electronicsmap::fD2EHashMap);
 }
@@ -366,6 +468,40 @@ LEDTask::LEDTask(edm::ParameterSet const& ps)
   }
 }
 
+/* virtual */ void LEDTask::globalEndLuminosityBlock(edm::LuminosityBlock const& lb, edm::EventSetup const& es) {
+  auto lumiCache = luminosityBlockCache(lb.index());
+  _currentLS = lumiCache->currentLS;
+
+  if (_emap) {
+    std::vector<HcalGenericDetId> dids = _emap->allPrecisionId();
+    for (std::vector<HcalGenericDetId>::const_iterator it = dids.begin(); it != dids.end(); ++it) {
+      if (!it->isHcalDetId())
+        continue;
+      HcalDetId did(it->rawId());
+      int nChargeNorm = _xChargeNormEntriesLS.get(did);
+      if (nChargeNorm > 0) {
+        _cChargeNormvsLS_SubdetPM.fill(did, _currentLS, _xChargeNormSumLS.get(did) / nChargeNorm);
+      }
+      int nCWTNorm = _xCWTNormEntriesLS.get(did);
+      if (nCWTNorm > 0) {
+        _cCWTNormvsLS_SubdetPM.fill(did, _currentLS, _xCWTNormSumLS.get(did) / nCWTNorm);
+      }
+      int nPed = _xPedestalChargeEntriesLS.get(did);
+      if (nPed > 0) {
+        _xPedestalChargePrevLS.set(did, _xPedestalChargeSumLS.get(did) / nPed);
+      }
+    }
+  }
+  _xChargeNormSumLS.reset();
+  _xCWTNormSumLS.reset();
+  _xChargeNormEntriesLS.reset();
+  _xCWTNormEntriesLS.reset();
+  _xPedestalChargeSumLS.reset();
+  _xPedestalChargeEntriesLS.reset();
+
+  DQTask::globalEndLuminosityBlock(lb, es);
+}
+
 /* virtual */ void LEDTask::_process(edm::Event const& e, edm::EventSetup const& es) {
   edm::Handle<HODigiCollection> c_ho;
   edm::Handle<QIE10DigiCollection> c_QIE10;
@@ -380,7 +516,8 @@ LEDTask::LEDTask(edm::ParameterSet const& ps)
     _logger.dqmthrow("Collection QIE11DigiCollection isn't available " + _tagQIE11.label() + " " +
                      _tagQIE11.instance());
 
-  //	int currentEvent = e.eventAuxiliary().id().event();
+  auto lumiCache = luminosityBlockCache(e.getLuminosityBlock().index());
+  _currentLS = lumiCache->currentLS;
 
   for (QIE11DigiCollection::const_iterator it = c_QIE11->begin(); it != c_QIE11->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
@@ -432,6 +569,21 @@ LEDTask::LEDTask(edm::ParameterSet const& ps)
     CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
     //double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(digi, 2.5, 0, digi.samples()-1);
     double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
+    int const nSamples = digi.samples();
+    if (nSamples <= 0)
+      continue;
+    double rawCharge = 0;
+    double pedestalChargeEvent = 0;
+    for (int i = 0; i < nSamples; ++i) {
+      rawCharge += digi_fC[i];
+    }
+    int nPedestalTS = 1;
+    for (int i = 0; i < nPedestalTS; ++i)
+      pedestalChargeEvent += digi_fC[i];
+    pedestalChargeEvent = (nPedestalTS > 0 ? pedestalChargeEvent * nSamples / nPedestalTS : 0);
+    _xPedestalChargeSumLS.get(did) += pedestalChargeEvent;
+    _xPedestalChargeEntriesLS.get(did)++;
+
     if (sumQ >= _lowHBHE) {
       //double aveTS = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
       double aveTS = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
@@ -441,6 +593,56 @@ LEDTask::LEDTask(edm::ParameterSet const& ps)
       _xTimingSum.get(did) += aveTS;
       _xTimingSum2.get(did) += aveTS * aveTS;
       _xEntries.get(did)++;
+
+      double pedestalPrevLS = _xPedestalChargePrevLS.get(did);
+      if (pedestalPrevLS <= 0)
+        pedestalPrevLS = pedestalChargeEvent;
+      double pedestalPerTS = pedestalPrevLS / nSamples;
+      double chargeAbs = rawCharge - pedestalPrevLS;
+      double cwtDenom = 0;
+      double cwtNumer = 0;
+      for (int i = 0; i < nSamples; ++i) {
+        double const qCorr = digi_fC[i] - pedestalPerTS;
+        cwtDenom += qCorr;
+        cwtNumer += i * qCorr;
+      }
+      double cwtCorr = (cwtDenom > 0 ? cwtNumer / cwtDenom : constants::GARBAGE_VALUE);
+
+      _cChargeCorr_depth.fill(did, chargeAbs);
+      _cChargeAbs_depth.fill(did, chargeAbs);
+      if (cwtCorr != constants::GARBAGE_VALUE) {
+        _cCWTCorr_depth.fill(did, cwtCorr);
+        _cCWTAbs_depth.fill(did, cwtCorr);
+      }
+
+      if (_currentLS == 2) {
+        int nChargeRef = _xChargeRefLS2Entries.get(did);
+        double chargeRef = _xChargeRefLS2.get(did);
+        _xChargeRefLS2.set(did, (chargeRef * nChargeRef + chargeAbs) / (nChargeRef + 1));
+        _xChargeRefLS2Entries.get(did)++;
+        if (cwtCorr != constants::GARBAGE_VALUE) {
+          int nCWTRef = _xCWTRefLS2Entries.get(did);
+          double cwtRef = _xCWTRefLS2.get(did);
+          _xCWTRefLS2.set(did, (cwtRef * nCWTRef + cwtCorr) / (nCWTRef + 1));
+          _xCWTRefLS2Entries.get(did)++;
+        }
+      }
+
+      if (_xChargeRefLS2Entries.get(did) > 0) {
+        double chargeRef = _xChargeRefLS2.get(did);
+        if (std::abs(chargeRef) > kTiny) {
+          double chargeNorm = chargeAbs / chargeRef;
+          _cChargeNormLS2_depth.fill(did, chargeNorm);
+          _xChargeNormSumLS.get(did) += chargeNorm;
+          _xChargeNormEntriesLS.get(did)++;
+        }
+      }
+      if (cwtCorr != constants::GARBAGE_VALUE && _xCWTRefLS2Entries.get(did) > 0) {
+        double cwtNormNS = (cwtCorr - _xCWTRefLS2.get(did)) * 25.;
+        _cCWTNormLS2_depth.fill(did, cwtNormNS);
+        _xCWTNormSumLS.get(did) += cwtNormNS;
+        _xCWTNormEntriesLS.get(did)++;
+      }
 
       if (_ptype == fLocal) {  // hidefed2crate
         for (int i = 0; i < digi.samples(); i++) {
@@ -505,6 +707,21 @@ LEDTask::LEDTask(edm::ParameterSet const& ps)
     //double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(digi, 8.5, 0, digi.size()-1);
     CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HODataFrame>(_dbService, did, digi);
     double sumQ = hcaldqm::utilities::sumQDB<HODataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
+    int const nSamples = digi.size();
+    if (nSamples <= 0)
+      continue;
+    double rawCharge = 0;
+    double pedestalChargeEvent = 0;
+    for (int i = 0; i < nSamples; ++i) {
+      rawCharge += digi_fC[i];
+    }
+    int nPedestalTS = 1;
+    for (int i = 0; i < nPedestalTS; ++i)
+      pedestalChargeEvent += digi_fC[i];
+    pedestalChargeEvent = (nPedestalTS > 0 ? pedestalChargeEvent * nSamples / nPedestalTS : 0);
+    _xPedestalChargeSumLS.get(did) += pedestalChargeEvent;
+    _xPedestalChargeEntriesLS.get(did)++;
+
     if (sumQ >= _lowHO) {
       //double aveTS = hcaldqm::utilities::aveTS<HODataFrame>(digi, 8.5, 0, digi.size()-1);
       double aveTS = hcaldqm::utilities::aveTSDB<HODataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
@@ -514,6 +731,56 @@ LEDTask::LEDTask(edm::ParameterSet const& ps)
       _xTimingSum.get(did) += aveTS;
       _xTimingSum2.get(did) += aveTS * aveTS;
       _xEntries.get(did)++;
+
+      double pedestalPrevLS = _xPedestalChargePrevLS.get(did);
+      if (pedestalPrevLS <= 0)
+        pedestalPrevLS = pedestalChargeEvent;
+      double pedestalPerTS = pedestalPrevLS / nSamples;
+      double chargeAbs = rawCharge - pedestalPrevLS;
+      double cwtDenom = 0;
+      double cwtNumer = 0;
+      for (int i = 0; i < nSamples; ++i) {
+        double const qCorr = digi_fC[i] - pedestalPerTS;
+        cwtDenom += qCorr;
+        cwtNumer += i * qCorr;
+      }
+      double cwtCorr = (cwtDenom > 0 ? cwtNumer / cwtDenom : constants::GARBAGE_VALUE);
+
+      _cChargeCorr_depth.fill(did, chargeAbs);
+      _cChargeAbs_depth.fill(did, chargeAbs);
+      if (cwtCorr != constants::GARBAGE_VALUE) {
+        _cCWTCorr_depth.fill(did, cwtCorr);
+        _cCWTAbs_depth.fill(did, cwtCorr);
+      }
+
+      if (_currentLS == 2) {
+        int nChargeRef = _xChargeRefLS2Entries.get(did);
+        double chargeRef = _xChargeRefLS2.get(did);
+        _xChargeRefLS2.set(did, (chargeRef * nChargeRef + chargeAbs) / (nChargeRef + 1));
+        _xChargeRefLS2Entries.get(did)++;
+        if (cwtCorr != constants::GARBAGE_VALUE) {
+          int nCWTRef = _xCWTRefLS2Entries.get(did);
+          double cwtRef = _xCWTRefLS2.get(did);
+          _xCWTRefLS2.set(did, (cwtRef * nCWTRef + cwtCorr) / (nCWTRef + 1));
+          _xCWTRefLS2Entries.get(did)++;
+        }
+      }
+
+      if (_xChargeRefLS2Entries.get(did) > 0) {
+        double chargeRef = _xChargeRefLS2.get(did);
+        if (std::abs(chargeRef) > kTiny) {
+          double chargeNorm = chargeAbs / chargeRef;
+          _cChargeNormLS2_depth.fill(did, chargeNorm);
+          _xChargeNormSumLS.get(did) += chargeNorm;
+          _xChargeNormEntriesLS.get(did)++;
+        }
+      }
+      if (cwtCorr != constants::GARBAGE_VALUE && _xCWTRefLS2Entries.get(did) > 0) {
+        double cwtNormNS = (cwtCorr - _xCWTRefLS2.get(did)) * 25.;
+        _cCWTNormLS2_depth.fill(did, cwtNormNS);
+        _xCWTNormSumLS.get(did) += cwtNormNS;
+        _xCWTNormEntriesLS.get(did)++;
+      }
 
       if (_ptype == fLocal) {  // hidefed2crate
         for (int i = 0; i < digi.size(); i++) {
@@ -561,6 +828,21 @@ LEDTask::LEDTask(edm::ParameterSet const& ps)
     //double sumQ = hcaldqm::utilities::sumQ_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
     CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, digi);
     double sumQ = hcaldqm::utilities::sumQDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
+    int const nSamples = digi.samples();
+    if (nSamples <= 0)
+      continue;
+    double rawCharge = 0;
+    double pedestalChargeEvent = 0;
+    for (int i = 0; i < nSamples; ++i) {
+      rawCharge += digi_fC[i];
+    }
+    int nPedestalTS = 1;
+    for (int i = 0; i < nPedestalTS; ++i)
+      pedestalChargeEvent += digi_fC[i];
+    pedestalChargeEvent = (nPedestalTS > 0 ? pedestalChargeEvent * nSamples / nPedestalTS : 0);
+    _xPedestalChargeSumLS.get(did) += pedestalChargeEvent;
+    _xPedestalChargeEntriesLS.get(did)++;
+
     if (sumQ >= _lowHF) {
       //double aveTS = hcaldqm::utilities::aveTS_v10<QIE10DataFrame>(digi, 2.5, 0, digi.samples()-1);
       double aveTS = hcaldqm::utilities::aveTSDB<QIE10DataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
@@ -570,6 +852,56 @@ LEDTask::LEDTask(edm::ParameterSet const& ps)
       _xTimingSum.get(did) += aveTS;
       _xTimingSum2.get(did) += aveTS * aveTS;
       _xEntries.get(did)++;
+
+      double pedestalPrevLS = _xPedestalChargePrevLS.get(did);
+      if (pedestalPrevLS <= 0)
+        pedestalPrevLS = pedestalChargeEvent;
+      double pedestalPerTS = pedestalPrevLS / nSamples;
+      double chargeAbs = rawCharge - pedestalPrevLS;
+      double cwtDenom = 0;
+      double cwtNumer = 0;
+      for (int i = 0; i < nSamples; ++i) {
+        double const qCorr = digi_fC[i] - pedestalPerTS;
+        cwtDenom += qCorr;
+        cwtNumer += i * qCorr;
+      }
+      double cwtCorr = (cwtDenom > 0 ? cwtNumer / cwtDenom : constants::GARBAGE_VALUE);
+
+      _cChargeCorr_depth.fill(did, chargeAbs);
+      _cChargeAbs_depth.fill(did, chargeAbs);
+      if (cwtCorr != constants::GARBAGE_VALUE) {
+        _cCWTCorr_depth.fill(did, cwtCorr);
+        _cCWTAbs_depth.fill(did, cwtCorr);
+      }
+
+      if (_currentLS == 2) {
+        int nChargeRef = _xChargeRefLS2Entries.get(did);
+        double chargeRef = _xChargeRefLS2.get(did);
+        _xChargeRefLS2.set(did, (chargeRef * nChargeRef + chargeAbs) / (nChargeRef + 1));
+        _xChargeRefLS2Entries.get(did)++;
+        if (cwtCorr != constants::GARBAGE_VALUE) {
+          int nCWTRef = _xCWTRefLS2Entries.get(did);
+          double cwtRef = _xCWTRefLS2.get(did);
+          _xCWTRefLS2.set(did, (cwtRef * nCWTRef + cwtCorr) / (nCWTRef + 1));
+          _xCWTRefLS2Entries.get(did)++;
+        }
+      }
+
+      if (_xChargeRefLS2Entries.get(did) > 0) {
+        double chargeRef = _xChargeRefLS2.get(did);
+        if (std::abs(chargeRef) > kTiny) {
+          double chargeNorm = chargeAbs / chargeRef;
+          _cChargeNormLS2_depth.fill(did, chargeNorm);
+          _xChargeNormSumLS.get(did) += chargeNorm;
+          _xChargeNormEntriesLS.get(did)++;
+        }
+      }
+      if (cwtCorr != constants::GARBAGE_VALUE && _xCWTRefLS2Entries.get(did) > 0) {
+        double cwtNormNS = (cwtCorr - _xCWTRefLS2.get(did)) * 25.;
+        _cCWTNormLS2_depth.fill(did, cwtNormNS);
+        _xCWTNormSumLS.get(did) += cwtNormNS;
+        _xCWTNormEntriesLS.get(did)++;
+      }
 
       if (_ptype == fLocal) {  // hidefed2crate
         for (int i = 0; i < digi.samples(); ++i) {

--- a/DQM/HcalTasks/plugins/PedestalTask.cc
+++ b/DQM/HcalTasks/plugins/PedestalTask.cc
@@ -3,6 +3,11 @@
 
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
+
+namespace {
+  constexpr double kTiny = 1e-9;
+}
+
 PedestalTask::PedestalTask(edm::ParameterSet const& ps)
     : DQTask(ps), hcalDbServiceToken_(esConsumes<HcalDbService, HcalDbRecord, edm::Transition::BeginRun>()) {
   //	tags
@@ -53,9 +58,12 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps)
   _xPedSum1LS.initialize(hcaldqm::hashfunctions::fDChannel);
   _xPedSum21LS.initialize(hcaldqm::hashfunctions::fDChannel);
   _xPedEntries1LS.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xChargeSum1LS.initialize(hcaldqm::hashfunctions::fDChannel);
   _xPedSumTotal.initialize(hcaldqm::hashfunctions::fDChannel);
   _xPedSum2Total.initialize(hcaldqm::hashfunctions::fDChannel);
   _xPedEntriesTotal.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xChargeRefLS1.initialize(hcaldqm::hashfunctions::fDChannel);
+  _xChargeRefLS1Entries.initialize(hcaldqm::hashfunctions::fDChannel);
 
 #ifndef HIDE_PEDESTAL_CONDITIONS
   _xPedRefMean.initialize(hcaldqm::hashfunctions::fDChannel);
@@ -205,6 +213,13 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps)
                                       new hcaldqm::quantity::LumiSection(_maxLS),
                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN_to8000),
                                       0);
+  _cChargeNormvsLS_SubdetPM.initialize(_name,
+                                       "ChargeNormvsLS",
+                                       hcaldqm::hashfunctions::fSubdetPM,
+                                       new hcaldqm::quantity::LumiSection(_maxLS),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fRatio_0to2),
+                                       new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                       0);
   _cNBadMeanvsLS_Subdet.initialize(_name,
                                    "NBadMeanvsLS",
                                    hcaldqm::hashfunctions::fSubdet,
@@ -431,6 +446,7 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps)
   _cMissingvsLS_Subdet.book(ib, _emap, _subsystem);
   _cOccupancyvsLS_Subdet.book(ib, _emap, _subsystem);
   _cOccupancyEAvsLS_Subdet.book(ib, _emap, _subsystem);
+  _cChargeNormvsLS_SubdetPM.book(ib, _emap, _subsystem);
   _cNBadMeanvsLS_Subdet.book(ib, _emap, _subsystem);
   _cNBadRMSvsLS_Subdet.book(ib, _emap, _subsystem);
   if (_ptype != fOffline) {  // hidefed2crate
@@ -442,9 +458,12 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps)
   _xPedSum1LS.book(_emap);
   _xPedSum21LS.book(_emap);
   _xPedEntries1LS.book(_emap);
+  _xChargeSum1LS.book(_emap);
   _xPedSumTotal.book(_emap);
   _xPedSum2Total.book(_emap);
   _xPedEntriesTotal.book(_emap);
+  _xChargeRefLS1.book(_emap);
+  _xChargeRefLS1Entries.book(_emap);
 
 #ifndef HIDE_PEDESTAL_CONDITIONS
   _xPedRefMean.book(_emap);
@@ -588,6 +607,7 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps)
 
     HcalDetId did = HcalDetId(it->rawId());
     double sum1LS = _xPedSum1LS.get(did);
+    double sumCharge1LS = _xChargeSum1LS.get(did);
 #ifndef HIDE_PEDESTAL_CONDITIONS
     double refm = _xPedRefMean.get(did);
 #endif
@@ -630,7 +650,19 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps)
 
     //	compute the means and diffs for this LS
     sum1LS /= n1LS;
+    double meanCharge1LS = sumCharge1LS / n1LS;
     double rms1LS = sqrt(sum21LS / n1LS - sum1LS * sum1LS);
+    if (_currentLS == 1) {
+      _xChargeRefLS1.set(did, meanCharge1LS);
+      _xChargeRefLS1Entries.get(did) = 1;
+    }
+    if (_xChargeRefLS1Entries.get(did) > 0) {
+      double chargeRefLS1 = _xChargeRefLS1.get(did);
+      if (fabs(chargeRefLS1) > kTiny) {
+        double chargeNorm = meanCharge1LS / chargeRefLS1;
+        _cChargeNormvsLS_SubdetPM.fill(did, _currentLS, chargeNorm);
+      }
+    }
 #ifndef HIDE_PEDESTAL_CONDITIONS
     double diffm1LS = sum1LS - refm;
     double diffr1LS = rms1LS - refr;
@@ -778,6 +810,7 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps)
   _xPedSum1LS.reset();
   _xPedSum21LS.reset();
   _xPedEntries1LS.reset();
+  _xChargeSum1LS.reset();
 }
 
 std::shared_ptr<hcaldqm::Cache> PedestalTask::globalBeginLuminosityBlock(edm::LuminosityBlock const& lb,
@@ -831,6 +864,7 @@ std::shared_ptr<hcaldqm::Cache> PedestalTask::globalBeginLuminosityBlock(edm::Lu
     if ((did.subdet() != HcalEndcap) && (did.subdet() != HcalBarrel)) {
       continue;
     }
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
     int digiSizeToUse = floor(digi.samples() / constants::CAPS_NUM) * constants::CAPS_NUM - 1;
     did.subdet() == HcalBarrel ? nHB++ : nHE++;
 
@@ -840,6 +874,7 @@ std::shared_ptr<hcaldqm::Cache> PedestalTask::globalBeginLuminosityBlock(edm::Lu
       _xPedSum1LS.get(did) += digi[i].adc();
       _xPedSum21LS.get(did) += digi[i].adc() * digi[i].adc();
       _xPedEntries1LS.get(did)++;
+      _xChargeSum1LS.get(did) += digi_fC[i];
 
       _xPedSumTotal.get(did) += digi[i].adc();
       _xPedSum2Total.get(did) += digi[i].adc() * digi[i].adc();
@@ -853,6 +888,7 @@ std::shared_ptr<hcaldqm::Cache> PedestalTask::globalBeginLuminosityBlock(edm::Lu
   for (HODigiCollection::const_iterator it = c_ho->begin(); it != c_ho->end(); ++it) {
     const HODataFrame digi = (const HODataFrame)(*it);
     HcalDetId did = digi.id();
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HODataFrame>(_dbService, did, digi);
     int digiSizeToUse = floor(digi.size() / constants::CAPS_NUM) * constants::CAPS_NUM - 1;
     nHO++;
     for (int i = 0; i < digiSizeToUse; i++) {
@@ -861,6 +897,7 @@ std::shared_ptr<hcaldqm::Cache> PedestalTask::globalBeginLuminosityBlock(edm::Lu
       _xPedSum1LS.get(did) += it->sample(i).adc();
       _xPedSum21LS.get(did) += it->sample(i).adc() * it->sample(i).adc();
       _xPedEntries1LS.get(did)++;
+      _xChargeSum1LS.get(did) += digi_fC[i];
 
       _xPedSumTotal.get(did) += it->sample(i).adc();
       _xPedSum2Total.get(did) += it->sample(i).adc() * it->sample(i).adc();
@@ -875,6 +912,7 @@ std::shared_ptr<hcaldqm::Cache> PedestalTask::globalBeginLuminosityBlock(edm::Lu
     if (did.subdet() != HcalForward) {
       continue;
     }
+    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(_dbService, did, digi);
     // HF has 3 samples in global, so impossible to make divisible by 4
     int digiSizeToUse =
         (digi.samples() >= 4 ? floor(digi.samples() / constants::CAPS_NUM) * constants::CAPS_NUM - 1 : digi.samples());
@@ -885,6 +923,7 @@ std::shared_ptr<hcaldqm::Cache> PedestalTask::globalBeginLuminosityBlock(edm::Lu
       _xPedSum1LS.get(did) += digi[i].adc();
       _xPedSum21LS.get(did) += digi[i].adc() * digi[i].adc();
       _xPedEntries1LS.get(did)++;
+      _xChargeSum1LS.get(did) += digi_fC[i];
 
       _xPedSumTotal.get(did) += digi[i].adc();
       _xPedSum2Total.get(did) += digi[i].adc() * digi[i].adc();


### PR DESCRIPTION
#### PR description:

This PR adds LS-based normalized trend plots for HCAL DQM.

  In `LEDTask`: 
 - adds LS2-referenced charge and CWT normalized monitoring
- fills `ChargeNormvsLS` and `CWTNormvsLS` using LS-averaged values per channel
-  uses 1 TS pedestal estimate
- sets `CWTNormvsLS` to 1 ns/bin in the range [-50, 50] ns
 
In `PedestalTask`:
- adds charge-based LS trend monitoring normalized to LS1
- computes the per-channel LS average charge and fills `ChargeNormvsLS`
 
In `DigiTask`: 
- set CapID_BadvsLS binning to 1 LS

#### PR validation:

runTheMatrix test is done
#### Backport :

This is not a backport PR.