### PR TITLE
Implement `stream::FixedQueueEDProducer`

### DIFF
--- a/HeterogeneousCore/AlpakaCore/README.md
+++ b/HeterogeneousCore/AlpakaCore/README.md
@@ -21,6 +21,7 @@ The `BuildFile.xml` must contain `<flags ALPAKA_BACKENDS="1"/>` to enable the be
     * For few objects consider using [`edm::StreamCache<T>`](https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedFrameworkGlobalModuleInterface#edm_StreamCacheT) with the global module, or
     * Use `stream::EDProducer`
   * If you need to transfer some data back to host, use `stream::SynchronizingEDProducer`
+  * If you need a fixed association of GPU queues and framework streams, use `stream::FixedQueueEDProcucer`
 * All code using `ALPAKA_ACCELERATOR_NAMESPACE` should be placed in `Package/SubPackage/{interface,src,plugins,test}/alpaka` directory
   * `ALPAKA_ACCELERATOR_NAMESPACE` should be used for Alpaka-backend-specific code that is not separated from other backends by other means
     * Some examples when to enclose code in `ALPAKA_ACCELERATOR_NAMESPACE`
@@ -159,6 +160,8 @@ The Alpaka-based EDModules should use one of the following base classes (that ar
 * `stream::SynchronizingEDProducer<...>` (`#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h"`)
    * A [stream EDProducer](https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedFrameworkStreamModuleInterface) that may launch (possibly) asynchronous work, and synchronizes the asynchronous work on the device with the host
       * The base class uses the [`edm::ExternalWork`](https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedFrameworkStreamModuleInterface#edm_ExternalWork) for the non-blocking synchronization
+* `stream::FixedQueueEDProcucer<...>` (`#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/FixedQueueEDProcucer.h"`)
+   * A [stream EDProducer](https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedFrameworkStreamModuleInterface) that launches (possibly) asynchronous work, with a fixed association of device queues to framework streams
 
 The `...` can in principle be any of the module abilities listed in the linked TWiki pages, except the `edm::ExternalWork`. The majority of the Alpaka EDProducers should be `global::EDProducer` or `stream::EDProducer`, with `stream::SynchronizingEDProducer` used only in cases where some data to be copied from the device to the host, that requires synchronization, for different reason than copying an Event data product from the device to the host.
 

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/FixedQueueEDProducer.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/FixedQueueEDProducer.h
@@ -1,0 +1,61 @@
+#ifndef HeterogeneousCore_AlpakaCore_interface_alpaka_stream_FixedQueueEDProducer_h
+#define HeterogeneousCore_AlpakaCore_interface_alpaka_stream_FixedQueueEDProducer_h
+
+#include <memory>
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadataSentry.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/chooseDevice.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::stream {
+
+  template <typename... Args>
+  class FixedQueueEDProducer : public ProducerBase<edm::stream::EDProducer, Args...> {
+    static_assert(not edm::CheckAbility<edm::module::Abilities::kExternalWork, Args...>::kHasIt,
+                  "ALPAKA_ACCELERATOR_NAMESPACE::stream::FixedQueueEDProducer may not be used with ExternalWork "
+                  "ability. Please request this functionality to the Heterogeneous or Core Software developers.");
+    using Base = ProducerBase<edm::stream::EDProducer, Args...>;
+
+  protected:
+    FixedQueueEDProducer(edm::ParameterSet const iConfig) : Base(iConfig) {}
+
+  public:
+    void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) final {
+      // Use the FixedQueueEDProducer queue for the Event metadata.
+      detail::EDMetadataSentry sentry(queue_, this->synchronize());
+      device::Event ev(iEvent, sentry.metadata());
+      device::EventSetup const es(iSetup, ev.device());
+      produce(ev, es);
+      this->putBackend(iEvent);
+      sentry.finish(ev.wasQueueUsed());
+    }
+
+    void beginStream(edm::StreamID sid) final {
+      queue_ = std::make_shared<Queue>(detail::chooseDevice(sid));
+      this->beginStream(sid, *queue_);
+    }
+
+    void endStream() final {
+      this->endStream(*queue_);
+      queue_.reset();
+    }
+
+    virtual void produce(device::Event& iEvent, device::EventSetup const& iSetup) = 0;
+
+    // "queue" cannot be passed by const reference, because submitting any work to a queue is a non-const operation.
+    // Passing it by non-const reference would be unsafe, as the user code could reset or modify the queue itself.
+    // Since Queue objects have a shared_ptr semantic, it can safely be passed by value.
+    virtual void beginStream(edm::StreamID sid, Queue queue) {}
+    virtual void endStream(Queue queue) {}
+
+  private:
+    std::shared_ptr<Queue> queue_;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::stream
+
+#endif  // HeterogeneousCore_AlpakaCore_interface_alpaka_stream_FixedQueueEDProducer_h

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamFixedQueueProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamFixedQueueProducer.cc
@@ -1,0 +1,111 @@
+#include <cassert>
+#include <optional>
+
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDPutToken.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESGetToken.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/FixedQueueEDProducer.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaTest/interface/AlpakaESTestRecords.h"
+#include "HeterogeneousCore/AlpakaTest/interface/AlpakaESTestData.h"
+
+#include "TestAlgo.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  /**
+   * This class demonstrates a stream FixedQueueEDProducer that
+   * - consumes a host EDProduct
+   * - consumes a device ESProduct
+   * - produces a device EDProduct (that gets transferred to host automatically if needed)
+   * - optionally uses a product instance label
+   *
+   * Unlike stream::EDProducer, that uses a random device queue for every event,
+   * stream::FixedQueueEDProducer always uses the same device queue for all the events
+   * processed by a given framework stream.
+   *
+   * This module tests that the queue being used is always the same, when no device
+   * products are consumed.
+   */
+  class TestAlpakaStreamFixedQueueProducer : public stream::FixedQueueEDProducer<> {
+  public:
+    TestAlpakaStreamFixedQueueProducer(edm::ParameterSet const& config)
+        : FixedQueueEDProducer<>(config),
+          size_{config.getParameter<edm::ParameterSet>("size").getParameter<int32_t>(
+              EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE))},
+          size2_{config.getParameter<edm::ParameterSet>("size").getParameter<int32_t>(
+              EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE))},
+          size3_{config.getParameter<edm::ParameterSet>("size").getParameter<int32_t>(
+              EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE))} {
+      getToken_ = consumes(config.getParameter<edm::InputTag>("source"));
+      esToken_ = esConsumes(config.getParameter<edm::ESInputTag>("eventSetupSource"));
+      devicePutToken_ = produces(config.getParameter<std::string>("productInstanceName"));
+      devicePutTokenMulti2_ = produces(config.getParameter<std::string>("productInstanceName"));
+      devicePutTokenMulti3_ = produces(config.getParameter<std::string>("productInstanceName"));
+    }
+
+    void beginStream(edm::StreamID sid, Queue queue) override { queue_ = queue; }
+
+    void endStream(Queue queue) override { queue_.reset(); }
+
+    void produce(device::Event& iEvent, device::EventSetup const& iSetup) override {
+      [[maybe_unused]] auto inpData = iEvent.getHandle(getToken_);
+      [[maybe_unused]] auto const& esData = iSetup.getData(esToken_);
+
+      auto deviceProduct = std::make_unique<portabletest::TestDeviceCollection>(iEvent.queue(), size_);
+      auto deviceProductMulti2 = std::make_unique<portabletest::TestDeviceCollection2>(iEvent.queue(), size_, size2_);
+      auto deviceProductMulti3 =
+          std::make_unique<portabletest::TestDeviceCollection3>(iEvent.queue(), size_, size2_, size3_);
+
+      // run the algorithm, potentially asynchronously
+      algo_.fill(iEvent.queue(), *deviceProduct);
+      algo_.fillMulti2(iEvent.queue(), *deviceProductMulti2);
+      algo_.fillMulti3(iEvent.queue(), *deviceProductMulti3);
+
+      iEvent.put(devicePutToken_, std::move(deviceProduct));
+      iEvent.put(devicePutTokenMulti2_, std::move(deviceProductMulti2));
+      iEvent.put(devicePutTokenMulti3_, std::move(deviceProductMulti3));
+
+      assert(iEvent.queue() == *queue_);
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<edm::InputTag>("source");
+      desc.add("eventSetupSource", edm::ESInputTag{});
+      desc.add<std::string>("productInstanceName", "");
+
+      edm::ParameterSetDescription psetSize;
+      psetSize.add<int32_t>("alpaka_serial_sync");
+      psetSize.add<int32_t>("alpaka_cuda_async");
+      psetSize.add<int32_t>("alpaka_rocm_async");
+      desc.add("size", psetSize);
+
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+  private:
+    edm::EDGetTokenT<edmtest::IntProduct> getToken_;
+    device::ESGetToken<cms::alpakatest::AlpakaESTestDataB<Device>, AlpakaESTestRecordB> esToken_;
+    device::EDPutToken<portabletest::TestDeviceCollection> devicePutToken_;
+    device::EDPutToken<portabletest::TestDeviceCollection2> devicePutTokenMulti2_;
+    device::EDPutToken<portabletest::TestDeviceCollection3> devicePutTokenMulti3_;
+    const int32_t size_;
+    const int32_t size2_;
+    const int32_t size3_;
+
+    // implementation of the algorithm
+    TestAlgo algo_;
+
+    // validation of the queue logic
+    std::optional<Queue> queue_;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(TestAlpakaStreamFixedQueueProducer);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamFixedQueueProducerE.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamFixedQueueProducerE.cc
@@ -1,0 +1,90 @@
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/FixedQueueEDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDPutToken.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESGetToken.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaTest/interface/AlpakaESTestRecords.h"
+#include "HeterogeneousCore/AlpakaTest/interface/alpaka/AlpakaESTestData.h"
+
+#include "TestAlgo.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  /**
+   * This class demonstrates a stream FixedQueueEDProducer that
+   * - consumes a device ESProduct
+   * - consumes a device EDProduct
+   * - produces a device EDProduct (that can get transferred to host automatically)
+   *
+   * Unlike stream::EDProducer, that uses a random device queue for every event,
+   * stream::FixedQueueEDProducer always uses the same device queue for all the events
+   * processed by a given framework stream.
+   *
+   * This module tests that the queue being used is always the same, even if a device
+   * product with a reusable queue is consumed first.
+   */
+  class TestAlpakaStreamFixedQueueProducerE : public stream::FixedQueueEDProducer<> {
+  public:
+    TestAlpakaStreamFixedQueueProducerE(edm::ParameterSet const& config)
+        : FixedQueueEDProducer<>(config),
+          esToken_(esConsumes(config.getParameter<edm::ESInputTag>("eventSetupSource"))),
+          getToken_(consumes(config.getParameter<edm::InputTag>("source"))),
+          getTokenMulti2_(consumes(config.getParameter<edm::InputTag>("source"))),
+          getTokenMulti3_(consumes(config.getParameter<edm::InputTag>("source"))),
+          putToken_{produces()},
+          putTokenMulti2_{produces()},
+          putTokenMulti3_{produces()} {}
+
+    void beginStream(edm::StreamID sid, Queue queue) override { queue_ = queue; }
+
+    void endStream(Queue queue) override { queue_.reset(); }
+
+    void produce(device::Event& iEvent, device::EventSetup const& iSetup) override {
+      auto const& esData = iSetup.getData(esToken_);
+      auto const& input = iEvent.get(getToken_);
+      auto const& inputMulti2 = iEvent.get(getTokenMulti2_);
+      auto const& inputMulti3 = iEvent.get(getTokenMulti3_);
+
+      // run the algorithm, potentially asynchronously
+      auto deviceProduct = algo_.update(iEvent.queue(), input, esData);
+      auto deviceProductMulti2 = algo_.updateMulti2(iEvent.queue(), inputMulti2, esData);
+      auto deviceProductMulti3 = algo_.updateMulti3(iEvent.queue(), inputMulti3, esData);
+
+      iEvent.emplace(putToken_, std::move(deviceProduct));
+      iEvent.emplace(putTokenMulti2_, std::move(deviceProductMulti2));
+      iEvent.emplace(putTokenMulti3_, std::move(deviceProductMulti3));
+
+      assert(iEvent.queue() == *queue_);
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add("eventSetupSource", edm::ESInputTag{});
+      desc.add("source", edm::InputTag{});
+
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+  private:
+    const device::ESGetToken<AlpakaESTestDataEDevice, AlpakaESTestRecordC> esToken_;
+    const device::EDGetToken<portabletest::TestDeviceCollection> getToken_;
+    const device::EDGetToken<portabletest::TestDeviceCollection2> getTokenMulti2_;
+    const device::EDGetToken<portabletest::TestDeviceCollection3> getTokenMulti3_;
+    const device::EDPutToken<portabletest::TestDeviceCollection> putToken_;
+    const device::EDPutToken<portabletest::TestDeviceCollection2> putTokenMulti2_;
+    const device::EDPutToken<portabletest::TestDeviceCollection3> putTokenMulti3_;
+
+    // implementation of the algorithm
+    TestAlgo algo_;
+
+    // validation of the queue logic
+    std::optional<Queue> queue_;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(TestAlpakaStreamFixedQueueProducerE);

--- a/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
+++ b/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
@@ -80,6 +80,9 @@ process.alpakaGlobalProducer = testAlpakaGlobalProducer.clone(
 process.alpakaGlobalProducerE = cms.EDProducer("TestAlpakaGlobalProducerE@alpaka",
     source = cms.InputTag("alpakaGlobalProducer")
 )
+process.alpakaStreamFixedQueueProducerE = cms.EDProducer("TestAlpakaStreamFixedQueueProducerE@alpaka",
+    source = cms.InputTag("alpakaGlobalProducer")
+)
 process.alpakaGlobalProducerCopyToDeviceCache = cms.EDProducer("TestAlpakaGlobalProducerCopyToDeviceCache@alpaka",
     source = cms.InputTag("alpakaGlobalProducer"),
     x = cms.int32(3),
@@ -122,6 +125,15 @@ process.alpakaStreamSynchronizingProducerToDevice = cms.EDProducer("TestAlpakaSt
         alpaka_serial_sync = cms.int32(1),
         alpaka_cuda_async = cms.int32(2),
         alpaka_rocm_async = cms.int32(3),
+    )
+)
+process.alpakaStreamFixedQueueProducer = cms.EDProducer("TestAlpakaStreamFixedQueueProducer@alpaka",
+    source = cms.InputTag("intProduct"),
+    eventSetupSource = cms.ESInputTag("alpakaESProducerB", "explicitLabel"),
+    size = cms.PSet(
+        alpaka_serial_sync = cms.int32(5),
+        alpaka_cuda_async = cms.int32(25),
+        alpaka_rocm_async = cms.int32(125),
     )
 )
 
@@ -177,6 +189,12 @@ process.alpakaStreamSynchronizingProducerToDeviceDeviceConsumer2 = process.alpak
 process.alpakaNullESConsumer = cms.EDProducer("TestAlpakaGlobalProducerNullES@alpaka",
     eventSetupSource = cms.ESInputTag("", "null")
 )
+process.alpakaStreamFixedQueueProducerDeviceConsumer = process.alpakaGlobalDeviceConsumer.clone(
+    source = "alpakaStreamFixedQueueProducer"
+)
+process.alpakaStreamFixedQueueProducerGlobalConsumerE = process.alpakaGlobalConsumerE.clone(
+    source = "alpakaStreamFixedQueueProducerE"
+)
 
 _postfixes = ["ESProducerA", "ESProducerB", "ESProducerC", "ESProducerD", "ESProducerE", "ESProducerBlocks",
               "ESProducerNull",
@@ -188,6 +206,8 @@ _postfixes = ["ESProducerA", "ESProducerB", "ESProducerC", "ESProducerD", "ESPro
               "GlobalConsumerImplicitCopyToDevice", "GlobalConsumerImplicitCopyToDeviceInstance",
               "GlobalDeviceConsumer", "StreamDeviceConsumer",
               "StreamSynchronizingProducerToDeviceDeviceConsumer1", "StreamSynchronizingProducerToDeviceDeviceConsumer2",
+              "StreamFixedQueueProducer", "StreamFixedQueueProducerDeviceConsumer",
+              "StreamFixedQueueProducerE",
               "NullESConsumer"]
 alpakaModules = ["alpaka"+x for x in _postfixes]
 if args.processAcceleratorBackend != "":
@@ -209,6 +229,8 @@ if args.expectBackend == "cuda_async":
     setExpect(process.alpakaStreamConsumer, size=25)
     setExpect(process.alpakaStreamInstanceConsumer, size=36)
     setExpect(process.alpakaStreamSynchronizingConsumer, size=20)
+    setExpect(process.alpakaStreamFixedQueueProducerGlobalConsumerE, size=20)
+    process.alpakaStreamFixedQueueProducerGlobalConsumerE.expectXvalues.extend([0]*(20-10))
 elif args.expectBackend == "rocm_async":
     def setExpect(m, size):
         m.expectSize = size
@@ -223,6 +245,8 @@ elif args.expectBackend == "rocm_async":
     setExpect(process.alpakaStreamConsumer, size = 125)
     setExpect(process.alpakaStreamInstanceConsumer, size = 216)
     setExpect(process.alpakaStreamSynchronizingConsumer, size = 30)
+    setExpect(process.alpakaStreamFixedQueueProducerGlobalConsumerE, size=30)
+    process.alpakaStreamFixedQueueProducerGlobalConsumerE.expectXvalues.extend([0]*(30-10))
 
 if args.processAcceleratorSynchronize:
     process.ProcessAcceleratorAlpaka.setSynchronize(True)
@@ -254,7 +278,9 @@ process.t = cms.Task(
     process.alpakaStreamProducer,
     process.alpakaStreamInstanceProducer,
     process.alpakaStreamSynchronizingProducer,
-    process.alpakaStreamSynchronizingProducerToDevice
+    process.alpakaStreamSynchronizingProducerToDevice,
+    process.alpakaStreamFixedQueueProducer,
+    process.alpakaStreamFixedQueueProducerE,
 )
 process.p = cms.Path(
     process.alpakaGlobalConsumer+
@@ -270,6 +296,8 @@ process.p = cms.Path(
     process.alpakaStreamSynchronizingConsumer+
     process.alpakaStreamSynchronizingProducerToDeviceDeviceConsumer1+
     process.alpakaStreamSynchronizingProducerToDeviceDeviceConsumer2+
+    process.alpakaStreamFixedQueueProducerDeviceConsumer+
+    process.alpakaStreamFixedQueueProducerGlobalConsumerE+
     process.alpakaNullESConsumer,
     process.t
 )

--- a/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/DataSource.cc
+++ b/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/DataSource.cc
@@ -7,17 +7,17 @@
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
-#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/FixedQueueEDProducer.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "PhysicsTools/PyTorchAlpakaTest/interface/Environment.h"
 #include "PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/CommonKernels.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
-  class DataSource : public stream::EDProducer<> {
+  class DataSource : public stream::FixedQueueEDProducer<> {
   public:
     DataSource(const edm::ParameterSet &params)
-        : EDProducer<>(params),
+        : FixedQueueEDProducer<>(params),
           particles_token_{produces()},
           images_token_{produces()},
           batch_size_(params.getParameter<uint32_t>("batchSize")),

--- a/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/MaskedNet.cc
+++ b/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/MaskedNet.cc
@@ -9,7 +9,7 @@
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
-#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/FixedQueueEDProducer.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "PhysicsTools/PyTorchAlpaka/interface/TensorCollection.h"
 #include "PhysicsTools/PyTorchAlpaka/interface/alpaka/AlpakaModel.h"
@@ -18,10 +18,10 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
-  class MaskedNet : public stream::EDProducer<> {
+  class MaskedNet : public stream::FixedQueueEDProducer<> {
   public:
     MaskedNet(const edm::ParameterSet &params)
-        : EDProducer<>(params),
+        : FixedQueueEDProducer<>(params),
           particles_token_(consumes(params.getParameter<edm::InputTag>("particles"))),
           masked_net_token_{produces()},
           model_(params.getParameter<edm::FileInPath>("model").fullPath()),

--- a/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/MultiHeadNet.cc
+++ b/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/MultiHeadNet.cc
@@ -8,7 +8,7 @@
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
-#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/FixedQueueEDProducer.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "PhysicsTools/PyTorchAlpaka/interface/TensorCollection.h"
 #include "PhysicsTools/PyTorchAlpaka/interface/alpaka/AlpakaModel.h"
@@ -16,10 +16,10 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
-  class MultiHeadNet : public stream::EDProducer<> {
+  class MultiHeadNet : public stream::FixedQueueEDProducer<> {
   public:
     MultiHeadNet(const edm::ParameterSet &params)
-        : EDProducer<>(params),
+        : FixedQueueEDProducer<>(params),
           particles_token_(consumes(params.getParameter<edm::InputTag>("particles"))),
           multi_head_net_token_{produces()},
           model_(params.getParameter<edm::FileInPath>("model").fullPath()),

--- a/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/SimpleNet.cc
+++ b/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/SimpleNet.cc
@@ -8,7 +8,7 @@
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
-#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/FixedQueueEDProducer.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "PhysicsTools/PyTorchAlpaka/interface/TensorCollection.h"
 #include "PhysicsTools/PyTorchAlpaka/interface/alpaka/AlpakaModel.h"
@@ -16,10 +16,10 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
-  class SimpleNet : public stream::EDProducer<> {
+  class SimpleNet : public stream::FixedQueueEDProducer<> {
   public:
     SimpleNet(const edm::ParameterSet &params)
-        : EDProducer<>(params),
+        : FixedQueueEDProducer<>(params),
           particles_token_(consumes(params.getParameter<edm::InputTag>("particles"))),
           simple_net_token_{produces()},
           model_(params.getParameter<edm::FileInPath>("model").fullPath()),

--- a/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/TinyResNet.cc
+++ b/PhysicsTools/PyTorchAlpakaTest/plugins/alpaka/TinyResNet.cc
@@ -8,7 +8,7 @@
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
-#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/FixedQueueEDProducer.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "PhysicsTools/PyTorchAlpaka/interface/TensorCollection.h"
 #include "PhysicsTools/PyTorchAlpaka/interface/alpaka/AlpakaModel.h"
@@ -16,10 +16,10 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::torchtest {
 
-  class TinyResNet : public stream::EDProducer<> {
+  class TinyResNet : public stream::FixedQueueEDProducer<> {
   public:
     TinyResNet(const edm::ParameterSet &params)
-        : EDProducer<>(params),
+        : FixedQueueEDProducer<>(params),
           images_token_(consumes(params.getParameter<edm::InputTag>("images"))),
           logits_token_{produces()},
           model_(params.getParameter<edm::FileInPath>("model").fullPath()),


### PR DESCRIPTION
#### PR description:

This PR builds on top of #50675.

Implement a new kind of alpaka `stream::EDProducer` with a fixed association of device queues (_e.g._ CUDA streams) to framework streams.

This is useful for using external software that associates resources to the device queues, for example the PyTorch device memory caching allocator.

Migrating the PyTorch alpaka modules from `stream::EDProducer` to `stream::FixedQueueEDProducer` ensures that PyTorch sees only a limited number of device queues, reducing the overall device memory utilisation.

For more background information see the presentation [ML inference on GPUs in CMSSW with PyTorch](https://indico.cern.ch/event/1667896/#6-ml-inference-on-gpus-in-cmss) by @EmanueleCoradin at the [CMS developments with GPUs](https://indico.cern.ch/event/1667896/) on March 30th, 2026.


#### PR validation:

All unit tests pass.