### PR TITLE
Add optional auto parsing printout to InitRootHandlers

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -785,6 +785,12 @@ namespace edm {
           }
         });
       }
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 39, 0)
+      auto const printAutoParsed = pset.getUntrackedParameter<bool>("PrintAutoParsed");
+      if (printAutoParsed) {
+        iReg.watchPostEndJob([]() { gInterpreter->Print("autoparsed"); });
+      }
+#endif
 
       if (unloadSigHandler_) {
         // Deactivate all the Root signal handlers and restore the system defaults
@@ -920,6 +926,10 @@ namespace edm {
               "missing is disable during module construction. The current implementation of disabling the parsing is "
               "fragile, and may work only in a single-thread job that does not use reco::parser::cutParser() or "
               "reco::parser::expressionParser() (and it certainly does not work on multiple threads).");
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 39, 0)
+      desc.addUntracked<bool>("PrintAutoParsed", false)
+          ->setComment("If True, ask ROOT to print at the end of the job all classes for which headers were parsed");
+#endif
       desc.addUntracked<bool>("LoadAllDictionaries", false)->setComment("If True, loads all ROOT dictionaries.");
       desc.addUntracked<bool>("EnableIMT", true)->setComment("If True, calls ROOT::EnableImplicitMT().");
       desc.addUntracked<bool>("AbortOnSignal", true)


### PR DESCRIPTION
#### PR description:

This PR makes use of the new facility added to ROOT master in https://github.com/root-project/root/pull/18402 to optionally print out the auto-parsed classes from `InitRootHandlers`. Since the feature is only available in ROOT master, the related code is enclosed in `#if` on ROOT version.

Context https://github.com/cms-sw/cmssw/issues/49458

Resolves https://github.com/cms-sw/framework-team/issues/2132

#### PR validation:

This printout was useful for https://github.com/cms-sw/cmssw/issues/49949#issuecomment-4170888141 and https://github.com/cms-sw/cmssw/issues/50580#issuecomment-4171097559