### PR TITLE
Support for a 6-bit slope in the CSC OTMB emulator

### DIFF
--- a/CalibMuon/CSCCalibration/python/CSCCustomizeBendingAngle_cfi.py
+++ b/CalibMuon/CSCCalibration/python/CSCCustomizeBendingAngle_cfi.py
@@ -1,14 +1,14 @@
 def set_6bit_gemcsc_bending_LUTs(process):
   process.CSCL1TPLookupTableEP.esDiffToSlopeME11bFiles = [
-    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11b_even_GEMlayer1_6bit.txt",
-    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11b_odd_GEMlayer1_6bit.txt",
-    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11b_even_GEMlayer2_6bit.txt",
-    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11b_odd_GEMlayer2_6bit.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1b_even_layer1.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1b_odd_layer1.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1b_even_layer2.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1b_odd_layer2.txt",
   ]
   process.CSCL1TPLookupTableEP.esDiffToSlopeME11aFiles = [
-    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11a_even_GEMlayer1_6bit.txt",
-    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11a_odd_GEMlayer1_6bit.txt",
-    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11a_even_GEMlayer2_6bit.txt",
-    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11a_odd_GEMlayer2_6bit.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1a_even_layer1.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1a_odd_layer1.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1a_even_layer2.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1a_odd_layer2.txt",
   ]
   return process

--- a/CalibMuon/CSCCalibration/python/CSCCustomizeBendingAngle_cfi.py
+++ b/CalibMuon/CSCCalibration/python/CSCCustomizeBendingAngle_cfi.py
@@ -1,0 +1,14 @@
+def set_6bit_gemcsc_bending_LUTs(process):
+  process.CSCL1TPLookupTableEP.esDiffToSlopeME11bFiles = [
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11b_even_GEMlayer1_6bit.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11b_odd_GEMlayer1_6bit.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11b_even_GEMlayer2_6bit.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11b_odd_GEMlayer2_6bit.txt",
+  ]
+  process.CSCL1TPLookupTableEP.esDiffToSlopeME11aFiles = [
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11a_even_GEMlayer1_6bit.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11a_odd_GEMlayer1_6bit.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11a_even_GEMlayer2_6bit.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/SlopeAmendment_ME11a_odd_GEMlayer2_6bit.txt",
+  ]
+  return process

--- a/CondFormats/CSCObjects/interface/CSCL1TPLookupTableME11ILT.h
+++ b/CondFormats/CSCObjects/interface/CSCL1TPLookupTableME11ILT.h
@@ -4,16 +4,17 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <vector>
 
-#define DECLARE_CSCL1TP_LUT(NAME) \
-  private: \
-    std::vector<unsigned> NAME##_; \
-  public: \
-    void set_##NAME(t_lut lut); \
-    unsigned NAME(unsigned idx) const; \
-    unsigned NAME##_bit_width() const
+#define DECLARE_CSCL1TP_LUT(NAME)    \
+private:                             \
+  std::vector<unsigned> NAME##_;     \
+                                     \
+public:                              \
+  void set_##NAME(t_lut lut);        \
+  unsigned NAME(unsigned idx) const; \
+  unsigned NAME##_bit_width() const
 
-#define DEFINE_CSCL1TP_LUT(CLASS, NAME) \
-  void CLASS::set_##NAME(t_lut lut) { NAME##_ = std::move(lut); } \
+#define DEFINE_CSCL1TP_LUT(CLASS, NAME)                                \
+  void CLASS::set_##NAME(t_lut lut) { NAME##_ = std::move(lut); }      \
   unsigned CLASS::NAME(unsigned idx) const { return NAME##_.at(idx); } \
   unsigned CLASS::NAME##_bit_width() const { return CSCL1TPLookupTableUtils::get_lut_bit_width(NAME##_); }
 
@@ -21,7 +22,8 @@ struct CSCL1TPLookupTableUtils {
   using t_lut = std::vector<unsigned>;
 
   static unsigned get_lut_bit_width(const t_lut& lut);
-  static unsigned get_common_lut_bit_width(std::initializer_list<unsigned> luts_bit_width, std::string_view lut_group_name);
+  static unsigned get_common_lut_bit_width(std::initializer_list<unsigned> luts_bit_width,
+                                           std::string_view lut_group_name);
 };
 
 class CSCL1TPLookupTableME11ILT {

--- a/CondFormats/CSCObjects/interface/CSCL1TPLookupTableME11ILT.h
+++ b/CondFormats/CSCObjects/interface/CSCL1TPLookupTableME11ILT.h
@@ -4,148 +4,74 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <vector>
 
+#define DECLARE_CSCL1TP_LUT(NAME) \
+  private: \
+    std::vector<unsigned> NAME##_; \
+  public: \
+    void set_##NAME(t_lut lut); \
+    unsigned NAME(unsigned idx) const; \
+    unsigned NAME##_bit_width() const
+
+#define DEFINE_CSCL1TP_LUT(CLASS, NAME) \
+  void CLASS::set_##NAME(t_lut lut) { NAME##_ = std::move(lut); } \
+  unsigned CLASS::NAME(unsigned idx) const { return NAME##_.at(idx); } \
+  unsigned CLASS::NAME##_bit_width() const { return CSCL1TPLookupTableUtils::get_lut_bit_width(NAME##_); }
+
+struct CSCL1TPLookupTableUtils {
+  using t_lut = std::vector<unsigned>;
+
+  static unsigned get_lut_bit_width(const t_lut& lut);
+  static unsigned get_common_lut_bit_width(std::initializer_list<unsigned> luts_bit_width, std::string_view lut_group_name);
+};
+
 class CSCL1TPLookupTableME11ILT {
 public:
-  CSCL1TPLookupTableME11ILT();
+  using t_lut = CSCL1TPLookupTableUtils::t_lut;
 
-  ~CSCL1TPLookupTableME11ILT() {}
+  DECLARE_CSCL1TP_LUT(GEM_pad_CSC_es_ME11b_even);
+  DECLARE_CSCL1TP_LUT(GEM_pad_CSC_es_ME11a_even);
+  DECLARE_CSCL1TP_LUT(GEM_pad_CSC_es_ME11b_odd);
+  DECLARE_CSCL1TP_LUT(GEM_pad_CSC_es_ME11a_odd);
 
-  typedef std::vector<unsigned> t_lut;
+  DECLARE_CSCL1TP_LUT(GEM_roll_CSC_min_wg_ME11_even);
+  DECLARE_CSCL1TP_LUT(GEM_roll_CSC_max_wg_ME11_even);
+  DECLARE_CSCL1TP_LUT(GEM_roll_CSC_min_wg_ME11_odd);
+  DECLARE_CSCL1TP_LUT(GEM_roll_CSC_max_wg_ME11_odd);
 
-  // setters
-  void set_GEM_pad_CSC_es_ME11b_even(t_lut lut);
-  void set_GEM_pad_CSC_es_ME11a_even(t_lut lut);
-  void set_GEM_pad_CSC_es_ME11b_odd(t_lut lut);
-  void set_GEM_pad_CSC_es_ME11a_odd(t_lut lut);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_2to1_L1_ME11a_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_2to1_L1_ME11a_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_3to1_L1_ME11a_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_3to1_L1_ME11a_odd);
 
-  void set_GEM_roll_CSC_min_wg_ME11_even(t_lut lut);
-  void set_GEM_roll_CSC_max_wg_ME11_even(t_lut lut);
-  void set_GEM_roll_CSC_min_wg_ME11_odd(t_lut lut);
-  void set_GEM_roll_CSC_max_wg_ME11_odd(t_lut lut);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_2to1_L1_ME11b_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_2to1_L1_ME11b_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_3to1_L1_ME11b_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_3to1_L1_ME11b_odd);
 
-  // GEM-CSC trigger: slope correction
-  void set_CSC_slope_cosi_2to1_L1_ME11a_even(t_lut lut);
-  void set_CSC_slope_cosi_2to1_L1_ME11a_odd(t_lut lut);
-  void set_CSC_slope_cosi_3to1_L1_ME11a_even(t_lut lut);
-  void set_CSC_slope_cosi_3to1_L1_ME11a_odd(t_lut lut);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_corr_L1_ME11a_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_corr_L1_ME11b_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_corr_L1_ME11a_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_corr_L1_ME11b_odd);
 
-  void set_CSC_slope_cosi_2to1_L1_ME11b_even(t_lut lut);
-  void set_CSC_slope_cosi_2to1_L1_ME11b_odd(t_lut lut);
-  void set_CSC_slope_cosi_3to1_L1_ME11b_even(t_lut lut);
-  void set_CSC_slope_cosi_3to1_L1_ME11b_odd(t_lut lut);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L1_ME11a_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L1_ME11b_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L1_ME11a_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L1_ME11b_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L2_ME11a_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L2_ME11b_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L2_ME11a_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L2_ME11b_odd);
 
-  void set_CSC_slope_cosi_corr_L1_ME11a_even(t_lut lut);
-  void set_CSC_slope_cosi_corr_L1_ME11b_even(t_lut lut);
-  void set_CSC_slope_cosi_corr_L1_ME11a_odd(t_lut lut);
-  void set_CSC_slope_cosi_corr_L1_ME11b_odd(t_lut lut);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L1_ME11a_even);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L1_ME11a_odd);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L1_ME11b_even);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L1_ME11b_odd);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L2_ME11a_even);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L2_ME11a_odd);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L2_ME11b_even);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L2_ME11b_odd);
 
-  void set_CSC_slope_corr_L1_ME11a_even(t_lut lut);
-  void set_CSC_slope_corr_L1_ME11b_even(t_lut lut);
-  void set_CSC_slope_corr_L1_ME11a_odd(t_lut lut);
-  void set_CSC_slope_corr_L1_ME11b_odd(t_lut lut);
-  void set_CSC_slope_corr_L2_ME11a_even(t_lut lut);
-  void set_CSC_slope_corr_L2_ME11b_even(t_lut lut);
-  void set_CSC_slope_corr_L2_ME11a_odd(t_lut lut);
-  void set_CSC_slope_corr_L2_ME11b_odd(t_lut lut);
-
-  void set_es_diff_slope_L1_ME11a_even(t_lut lut);
-  void set_es_diff_slope_L1_ME11a_odd(t_lut lut);
-  void set_es_diff_slope_L1_ME11b_even(t_lut lut);
-  void set_es_diff_slope_L1_ME11b_odd(t_lut lut);
-  void set_es_diff_slope_L2_ME11a_even(t_lut lut);
-  void set_es_diff_slope_L2_ME11a_odd(t_lut lut);
-  void set_es_diff_slope_L2_ME11b_even(t_lut lut);
-  void set_es_diff_slope_L2_ME11b_odd(t_lut lut);
-
-  // getters
-  unsigned GEM_pad_CSC_es_ME11b_even(unsigned pad) const;
-  unsigned GEM_pad_CSC_es_ME11a_even(unsigned pad) const;
-  unsigned GEM_pad_CSC_es_ME11b_odd(unsigned pad) const;
-  unsigned GEM_pad_CSC_es_ME11a_odd(unsigned pad) const;
-
-  unsigned GEM_roll_CSC_min_wg_ME11_even(unsigned roll) const;
-  unsigned GEM_roll_CSC_max_wg_ME11_even(unsigned roll) const;
-  unsigned GEM_roll_CSC_min_wg_ME11_odd(unsigned roll) const;
-  unsigned GEM_roll_CSC_max_wg_ME11_odd(unsigned roll) const;
-
-  // GEM-CSC trigger: slope correction
-  unsigned CSC_slope_cosi_2to1_L1_ME11a_even(unsigned channel) const;
-  unsigned CSC_slope_cosi_2to1_L1_ME11a_odd(unsigned channel) const;
-  unsigned CSC_slope_cosi_3to1_L1_ME11a_even(unsigned channel) const;
-  unsigned CSC_slope_cosi_3to1_L1_ME11a_odd(unsigned channel) const;
-
-  unsigned CSC_slope_cosi_2to1_L1_ME11b_even(unsigned channel) const;
-  unsigned CSC_slope_cosi_2to1_L1_ME11b_odd(unsigned channel) const;
-  unsigned CSC_slope_cosi_3to1_L1_ME11b_even(unsigned channel) const;
-  unsigned CSC_slope_cosi_3to1_L1_ME11b_odd(unsigned channel) const;
-
-  unsigned CSC_slope_cosi_corr_L1_ME11a_even(unsigned channel) const;
-  unsigned CSC_slope_cosi_corr_L1_ME11b_even(unsigned channel) const;
-  unsigned CSC_slope_cosi_corr_L1_ME11a_odd(unsigned channel) const;
-  unsigned CSC_slope_cosi_corr_L1_ME11b_odd(unsigned channel) const;
-
-  unsigned CSC_slope_corr_L1_ME11a_even(unsigned channel) const;
-  unsigned CSC_slope_corr_L1_ME11b_even(unsigned channel) const;
-  unsigned CSC_slope_corr_L1_ME11a_odd(unsigned channel) const;
-  unsigned CSC_slope_corr_L1_ME11b_odd(unsigned channel) const;
-  unsigned CSC_slope_corr_L2_ME11a_even(unsigned channel) const;
-  unsigned CSC_slope_corr_L2_ME11b_even(unsigned channel) const;
-  unsigned CSC_slope_corr_L2_ME11a_odd(unsigned channel) const;
-  unsigned CSC_slope_corr_L2_ME11b_odd(unsigned channel) const;
-
-  // GEM-CSC trigger: 1/8-strip difference to slope
-  unsigned es_diff_slope_L1_ME11a_even(unsigned es_diff) const;
-  unsigned es_diff_slope_L1_ME11a_odd(unsigned es_diff) const;
-  unsigned es_diff_slope_L1_ME11b_even(unsigned es_diff) const;
-  unsigned es_diff_slope_L1_ME11b_odd(unsigned es_diff) const;
-  unsigned es_diff_slope_L2_ME11a_even(unsigned es_diff) const;
-  unsigned es_diff_slope_L2_ME11a_odd(unsigned es_diff) const;
-  unsigned es_diff_slope_L2_ME11b_even(unsigned es_diff) const;
-  unsigned es_diff_slope_L2_ME11b_odd(unsigned es_diff) const;
-
-private:
-  t_lut GEM_pad_CSC_es_ME11b_even_;
-  t_lut GEM_pad_CSC_es_ME11a_even_;
-  t_lut GEM_pad_CSC_es_ME11b_odd_;
-  t_lut GEM_pad_CSC_es_ME11a_odd_;
-
-  t_lut GEM_roll_CSC_min_wg_ME11_even_;
-  t_lut GEM_roll_CSC_max_wg_ME11_even_;
-  t_lut GEM_roll_CSC_min_wg_ME11_odd_;
-  t_lut GEM_roll_CSC_max_wg_ME11_odd_;
-
-  t_lut CSC_slope_cosi_2to1_L1_ME11a_even_;
-  t_lut CSC_slope_cosi_2to1_L1_ME11a_odd_;
-  t_lut CSC_slope_cosi_3to1_L1_ME11a_even_;
-  t_lut CSC_slope_cosi_3to1_L1_ME11a_odd_;
-
-  t_lut CSC_slope_cosi_2to1_L1_ME11b_even_;
-  t_lut CSC_slope_cosi_2to1_L1_ME11b_odd_;
-  t_lut CSC_slope_cosi_3to1_L1_ME11b_even_;
-  t_lut CSC_slope_cosi_3to1_L1_ME11b_odd_;
-
-  t_lut CSC_slope_cosi_corr_L1_ME11a_even_;
-  t_lut CSC_slope_cosi_corr_L1_ME11b_even_;
-  t_lut CSC_slope_cosi_corr_L1_ME11a_odd_;
-  t_lut CSC_slope_cosi_corr_L1_ME11b_odd_;
-
-  t_lut CSC_slope_corr_L1_ME11a_even_;
-  t_lut CSC_slope_corr_L1_ME11b_even_;
-  t_lut CSC_slope_corr_L1_ME11a_odd_;
-  t_lut CSC_slope_corr_L1_ME11b_odd_;
-  t_lut CSC_slope_corr_L2_ME11a_even_;
-  t_lut CSC_slope_corr_L2_ME11b_even_;
-  t_lut CSC_slope_corr_L2_ME11a_odd_;
-  t_lut CSC_slope_corr_L2_ME11b_odd_;
-
-  t_lut es_diff_slope_L1_ME11a_even_;
-  t_lut es_diff_slope_L1_ME11a_odd_;
-  t_lut es_diff_slope_L1_ME11b_even_;
-  t_lut es_diff_slope_L1_ME11b_odd_;
-  t_lut es_diff_slope_L2_ME11a_even_;
-  t_lut es_diff_slope_L2_ME11a_odd_;
-  t_lut es_diff_slope_L2_ME11b_even_;
-  t_lut es_diff_slope_L2_ME11b_odd_;
+  unsigned es_diff_slope_bit_width() const;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/CSCObjects/interface/CSCL1TPLookupTableME11ILT.h
+++ b/CondFormats/CSCObjects/interface/CSCL1TPLookupTableME11ILT.h
@@ -3,6 +3,9 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <vector>
+#include <string_view>
+#include <initializer_list>
+#include <utility>
 
 #define DECLARE_CSCL1TP_LUT(NAME)    \
 private:                             \

--- a/CondFormats/CSCObjects/interface/CSCL1TPLookupTableME21ILT.h
+++ b/CondFormats/CSCObjects/interface/CSCL1TPLookupTableME21ILT.h
@@ -1,113 +1,38 @@
 #ifndef CondFormats_CSCObjects_CSCL1TPLookupTableME21ILT_h
 #define CondFormats_CSCObjects_CSCL1TPLookupTableME21ILT_h
 
-#include "CondFormats/Serialization/interface/Serializable.h"
-#include <vector>
+#include "CSCL1TPLookupTableME11ILT.h"
 
 class CSCL1TPLookupTableME21ILT {
 public:
-  CSCL1TPLookupTableME21ILT();
+  using t_lut = CSCL1TPLookupTableUtils::t_lut;
 
-  ~CSCL1TPLookupTableME21ILT() {}
+  DECLARE_CSCL1TP_LUT(GEM_pad_CSC_es_ME21_even);
+  DECLARE_CSCL1TP_LUT(GEM_pad_CSC_es_ME21_odd);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L1_CSC_min_wg_ME21_even);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L1_CSC_max_wg_ME21_even);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L1_CSC_min_wg_ME21_odd);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L1_CSC_max_wg_ME21_odd);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L2_CSC_min_wg_ME21_even);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L2_CSC_max_wg_ME21_even);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L2_CSC_min_wg_ME21_odd);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L2_CSC_max_wg_ME21_odd);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L1_ME21_even);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L1_ME21_odd);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L2_ME21_even);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L2_ME21_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_2to1_L1_ME21_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_2to1_L1_ME21_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_3to1_L1_ME21_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_3to1_L1_ME21_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_corr_L1_ME21_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_corr_L1_ME21_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L1_ME21_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L1_ME21_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L2_ME21_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L2_ME21_odd);
 
-  typedef std::vector<unsigned> t_lut;
-
-  // setters
-  void set_GEM_pad_CSC_es_ME21_even(t_lut lut);
-  void set_GEM_pad_CSC_es_ME21_odd(t_lut lut);
-
-  void set_GEM_roll_L1_CSC_min_wg_ME21_even(t_lut lut);
-  void set_GEM_roll_L1_CSC_max_wg_ME21_even(t_lut lut);
-  void set_GEM_roll_L1_CSC_min_wg_ME21_odd(t_lut lut);
-  void set_GEM_roll_L1_CSC_max_wg_ME21_odd(t_lut lut);
-
-  void set_GEM_roll_L2_CSC_min_wg_ME21_even(t_lut lut);
-  void set_GEM_roll_L2_CSC_max_wg_ME21_even(t_lut lut);
-  void set_GEM_roll_L2_CSC_min_wg_ME21_odd(t_lut lut);
-  void set_GEM_roll_L2_CSC_max_wg_ME21_odd(t_lut lut);
-
-  void set_es_diff_slope_L1_ME21_even(t_lut lut);
-  void set_es_diff_slope_L1_ME21_odd(t_lut lut);
-  void set_es_diff_slope_L2_ME21_even(t_lut lut);
-  void set_es_diff_slope_L2_ME21_odd(t_lut lut);
-
-  void set_CSC_slope_cosi_2to1_L1_ME21_even(t_lut lut);
-  void set_CSC_slope_cosi_2to1_L1_ME21_odd(t_lut lut);
-  void set_CSC_slope_cosi_3to1_L1_ME21_even(t_lut lut);
-  void set_CSC_slope_cosi_3to1_L1_ME21_odd(t_lut lut);
-
-  void set_CSC_slope_cosi_corr_L1_ME21_even(t_lut lut);
-  void set_CSC_slope_cosi_corr_L1_ME21_odd(t_lut lut);
-
-  void set_CSC_slope_corr_L1_ME21_even(t_lut lut);
-  void set_CSC_slope_corr_L1_ME21_odd(t_lut lut);
-  void set_CSC_slope_corr_L2_ME21_even(t_lut lut);
-  void set_CSC_slope_corr_L2_ME21_odd(t_lut lut);
-
-  // getters
-  unsigned GEM_pad_CSC_es_ME21_even(unsigned pad) const;
-  unsigned GEM_pad_CSC_es_ME21_odd(unsigned pad) const;
-
-  unsigned GEM_roll_L1_CSC_min_wg_ME21_even(unsigned roll) const;
-  unsigned GEM_roll_L1_CSC_max_wg_ME21_even(unsigned roll) const;
-  unsigned GEM_roll_L1_CSC_min_wg_ME21_odd(unsigned roll) const;
-  unsigned GEM_roll_L1_CSC_max_wg_ME21_odd(unsigned roll) const;
-
-  unsigned GEM_roll_L2_CSC_min_wg_ME21_even(unsigned roll) const;
-  unsigned GEM_roll_L2_CSC_max_wg_ME21_even(unsigned roll) const;
-  unsigned GEM_roll_L2_CSC_min_wg_ME21_odd(unsigned roll) const;
-  unsigned GEM_roll_L2_CSC_max_wg_ME21_odd(unsigned roll) const;
-
-  unsigned CSC_slope_cosi_2to1_L1_ME21_even(unsigned slope) const;
-  unsigned CSC_slope_cosi_2to1_L1_ME21_odd(unsigned slope) const;
-  unsigned CSC_slope_cosi_3to1_L1_ME21_even(unsigned slope) const;
-  unsigned CSC_slope_cosi_3to1_L1_ME21_odd(unsigned slope) const;
-
-  unsigned CSC_slope_cosi_corr_L1_ME21_even(unsigned slope) const;
-  unsigned CSC_slope_cosi_corr_L1_ME21_odd(unsigned slope) const;
-
-  unsigned CSC_slope_corr_L1_ME21_even(unsigned slope) const;
-  unsigned CSC_slope_corr_L1_ME21_odd(unsigned slope) const;
-  unsigned CSC_slope_corr_L2_ME21_even(unsigned slope) const;
-  unsigned CSC_slope_corr_L2_ME21_odd(unsigned slope) const;
-
-  // GEM-CSC trigger: 1/8-strip difference to slope
-  unsigned es_diff_slope_L1_ME21_even(unsigned es_diff) const;
-  unsigned es_diff_slope_L1_ME21_odd(unsigned es_diff) const;
-  unsigned es_diff_slope_L2_ME21_even(unsigned es_diff) const;
-  unsigned es_diff_slope_L2_ME21_odd(unsigned es_diff) const;
-
-private:
-  std::vector<unsigned> GEM_pad_CSC_es_ME21_even_;
-  std::vector<unsigned> GEM_pad_CSC_es_ME21_odd_;
-
-  std::vector<unsigned> GEM_roll_L1_CSC_min_wg_ME21_even_;
-  std::vector<unsigned> GEM_roll_L1_CSC_max_wg_ME21_even_;
-  std::vector<unsigned> GEM_roll_L1_CSC_min_wg_ME21_odd_;
-  std::vector<unsigned> GEM_roll_L1_CSC_max_wg_ME21_odd_;
-
-  std::vector<unsigned> GEM_roll_L2_CSC_min_wg_ME21_even_;
-  std::vector<unsigned> GEM_roll_L2_CSC_max_wg_ME21_even_;
-  std::vector<unsigned> GEM_roll_L2_CSC_min_wg_ME21_odd_;
-  std::vector<unsigned> GEM_roll_L2_CSC_max_wg_ME21_odd_;
-
-  std::vector<unsigned> CSC_slope_cosi_2to1_L1_ME21_even_;
-  std::vector<unsigned> CSC_slope_cosi_2to1_L1_ME21_odd_;
-  std::vector<unsigned> CSC_slope_cosi_3to1_L1_ME21_even_;
-  std::vector<unsigned> CSC_slope_cosi_3to1_L1_ME21_odd_;
-
-  std::vector<unsigned> CSC_slope_cosi_corr_L1_ME21_even_;
-  std::vector<unsigned> CSC_slope_cosi_corr_L1_ME21_odd_;
-
-  std::vector<unsigned> CSC_slope_corr_L1_ME21_even_;
-  std::vector<unsigned> CSC_slope_corr_L1_ME21_odd_;
-  std::vector<unsigned> CSC_slope_corr_L2_ME21_even_;
-  std::vector<unsigned> CSC_slope_corr_L2_ME21_odd_;
-
-  std::vector<unsigned> es_diff_slope_L1_ME21_even_;
-  std::vector<unsigned> es_diff_slope_L1_ME21_odd_;
-  std::vector<unsigned> es_diff_slope_L2_ME21_even_;
-  std::vector<unsigned> es_diff_slope_L2_ME21_odd_;
+  unsigned es_diff_slope_bit_width() const;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/CSCObjects/src/CSCL1TPLookupTableME11ILT.cc
+++ b/CondFormats/CSCObjects/src/CSCL1TPLookupTableME11ILT.cc
@@ -1,333 +1,77 @@
 #include "CondFormats/CSCObjects/interface/CSCL1TPLookupTableME11ILT.h"
-
-CSCL1TPLookupTableME11ILT::CSCL1TPLookupTableME11ILT()
-    : GEM_pad_CSC_es_ME11b_even_(0),
-      GEM_pad_CSC_es_ME11a_even_(0),
-      GEM_pad_CSC_es_ME11b_odd_(0),
-      GEM_pad_CSC_es_ME11a_odd_(0),
-
-      GEM_roll_CSC_min_wg_ME11_even_(0),
-      GEM_roll_CSC_max_wg_ME11_even_(0),
-      GEM_roll_CSC_min_wg_ME11_odd_(0),
-      GEM_roll_CSC_max_wg_ME11_odd_(0),
-
-      CSC_slope_cosi_2to1_L1_ME11a_even_(0),
-      CSC_slope_cosi_2to1_L1_ME11a_odd_(0),
-      CSC_slope_cosi_3to1_L1_ME11a_even_(0),
-      CSC_slope_cosi_3to1_L1_ME11a_odd_(0),
-
-      CSC_slope_cosi_2to1_L1_ME11b_even_(0),
-      CSC_slope_cosi_2to1_L1_ME11b_odd_(0),
-      CSC_slope_cosi_3to1_L1_ME11b_even_(0),
-      CSC_slope_cosi_3to1_L1_ME11b_odd_(0),
-
-      CSC_slope_cosi_corr_L1_ME11a_even_(0),
-      CSC_slope_cosi_corr_L1_ME11b_even_(0),
-      CSC_slope_cosi_corr_L1_ME11a_odd_(0),
-      CSC_slope_cosi_corr_L1_ME11b_odd_(0),
-
-      CSC_slope_corr_L1_ME11a_even_(0),
-      CSC_slope_corr_L1_ME11b_even_(0),
-      CSC_slope_corr_L1_ME11a_odd_(0),
-      CSC_slope_corr_L1_ME11b_odd_(0),
-      CSC_slope_corr_L2_ME11a_even_(0),
-      CSC_slope_corr_L2_ME11b_even_(0),
-      CSC_slope_corr_L2_ME11a_odd_(0),
-      CSC_slope_corr_L2_ME11b_odd_(0),
-
-      es_diff_slope_L1_ME11a_even_(0),
-      es_diff_slope_L1_ME11a_odd_(0),
-      es_diff_slope_L1_ME11b_even_(0),
-      es_diff_slope_L1_ME11b_odd_(0),
-      es_diff_slope_L2_ME11a_even_(0),
-      es_diff_slope_L2_ME11a_odd_(0),
-      es_diff_slope_L2_ME11b_even_(0),
-      es_diff_slope_L2_ME11b_odd_(0) {}
-
-// GEM-CSC trigger: coordinate conversion
-void CSCL1TPLookupTableME11ILT::set_GEM_pad_CSC_es_ME11b_even(t_lut lut) {
-  GEM_pad_CSC_es_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_GEM_pad_CSC_es_ME11a_even(t_lut lut) {
-  GEM_pad_CSC_es_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_GEM_pad_CSC_es_ME11b_odd(t_lut lut) { GEM_pad_CSC_es_ME11b_odd_ = std::move(lut); }
-
-void CSCL1TPLookupTableME11ILT::set_GEM_pad_CSC_es_ME11a_odd(t_lut lut) { GEM_pad_CSC_es_ME11a_odd_ = std::move(lut); }
-
-void CSCL1TPLookupTableME11ILT::set_GEM_roll_CSC_min_wg_ME11_even(t_lut lut) {
-  GEM_roll_CSC_min_wg_ME11_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_GEM_roll_CSC_max_wg_ME11_even(t_lut lut) {
-  GEM_roll_CSC_max_wg_ME11_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_GEM_roll_CSC_min_wg_ME11_odd(t_lut lut) {
-  GEM_roll_CSC_min_wg_ME11_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_GEM_roll_CSC_max_wg_ME11_odd(t_lut lut) {
-  GEM_roll_CSC_max_wg_ME11_odd_ = std::move(lut);
-}
-
-// GEM-CSC trigger: slope correction
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_2to1_L1_ME11a_even(t_lut lut) {
-  CSC_slope_cosi_2to1_L1_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_2to1_L1_ME11b_even(t_lut lut) {
-  CSC_slope_cosi_2to1_L1_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_2to1_L1_ME11a_odd(t_lut lut) {
-  CSC_slope_cosi_2to1_L1_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_2to1_L1_ME11b_odd(t_lut lut) {
-  CSC_slope_cosi_2to1_L1_ME11b_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_3to1_L1_ME11a_even(t_lut lut) {
-  CSC_slope_cosi_3to1_L1_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_3to1_L1_ME11b_even(t_lut lut) {
-  CSC_slope_cosi_3to1_L1_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_3to1_L1_ME11a_odd(t_lut lut) {
-  CSC_slope_cosi_3to1_L1_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_3to1_L1_ME11b_odd(t_lut lut) {
-  CSC_slope_cosi_3to1_L1_ME11b_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_corr_L1_ME11a_even(t_lut lut) {
-  CSC_slope_cosi_corr_L1_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_corr_L1_ME11b_even(t_lut lut) {
-  CSC_slope_cosi_corr_L1_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_corr_L1_ME11a_odd(t_lut lut) {
-  CSC_slope_cosi_corr_L1_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_corr_L1_ME11b_odd(t_lut lut) {
-  CSC_slope_cosi_corr_L1_ME11b_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L1_ME11a_even(t_lut lut) {
-  CSC_slope_corr_L1_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L1_ME11b_even(t_lut lut) {
-  CSC_slope_corr_L1_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L1_ME11a_odd(t_lut lut) {
-  CSC_slope_corr_L1_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L1_ME11b_odd(t_lut lut) {
-  CSC_slope_corr_L1_ME11b_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L1_ME11a_even(t_lut lut) {
-  es_diff_slope_L1_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L1_ME11a_odd(t_lut lut) {
-  es_diff_slope_L1_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L1_ME11b_even(t_lut lut) {
-  es_diff_slope_L1_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L1_ME11b_odd(t_lut lut) {
-  es_diff_slope_L1_ME11b_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L2_ME11a_even(t_lut lut) {
-  CSC_slope_corr_L2_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L2_ME11b_even(t_lut lut) {
-  CSC_slope_corr_L2_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L2_ME11a_odd(t_lut lut) {
-  CSC_slope_corr_L2_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L2_ME11b_odd(t_lut lut) {
-  CSC_slope_corr_L2_ME11b_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L2_ME11a_even(t_lut lut) {
-  es_diff_slope_L2_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L2_ME11a_odd(t_lut lut) {
-  es_diff_slope_L2_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L2_ME11b_even(t_lut lut) {
-  es_diff_slope_L2_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L2_ME11b_odd(t_lut lut) {
-  es_diff_slope_L2_ME11b_odd_ = std::move(lut);
-}
-
-// GEM-CSC trigger: coordinate conversion
-unsigned CSCL1TPLookupTableME11ILT::GEM_pad_CSC_es_ME11b_even(unsigned pad) const {
-  return GEM_pad_CSC_es_ME11b_even_.at(pad);
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_pad_CSC_es_ME11a_even(unsigned pad) const {
-  return GEM_pad_CSC_es_ME11a_even_.at(pad);
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_pad_CSC_es_ME11b_odd(unsigned pad) const {
-  return GEM_pad_CSC_es_ME11b_odd_.at(pad);
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_pad_CSC_es_ME11a_odd(unsigned pad) const {
-  return GEM_pad_CSC_es_ME11a_odd_.at(pad);
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_roll_CSC_min_wg_ME11_even(unsigned roll) const {
-  return GEM_roll_CSC_min_wg_ME11_even_[roll];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_roll_CSC_max_wg_ME11_even(unsigned roll) const {
-  return GEM_roll_CSC_max_wg_ME11_even_[roll];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_roll_CSC_min_wg_ME11_odd(unsigned roll) const {
-  return GEM_roll_CSC_min_wg_ME11_odd_[roll];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_roll_CSC_max_wg_ME11_odd(unsigned roll) const {
-  return GEM_roll_CSC_max_wg_ME11_odd_[roll];
-}
-
-// GEM-CSC trigger: slope correction
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_2to1_L1_ME11a_even(unsigned slope) const {
-  return CSC_slope_cosi_2to1_L1_ME11a_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_2to1_L1_ME11b_even(unsigned slope) const {
-  return CSC_slope_cosi_2to1_L1_ME11b_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_2to1_L1_ME11a_odd(unsigned slope) const {
-  return CSC_slope_cosi_2to1_L1_ME11a_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_2to1_L1_ME11b_odd(unsigned slope) const {
-  return CSC_slope_cosi_2to1_L1_ME11b_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_3to1_L1_ME11a_even(unsigned slope) const {
-  return CSC_slope_cosi_3to1_L1_ME11a_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_3to1_L1_ME11b_even(unsigned slope) const {
-  return CSC_slope_cosi_3to1_L1_ME11b_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_3to1_L1_ME11a_odd(unsigned slope) const {
-  return CSC_slope_cosi_3to1_L1_ME11a_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_3to1_L1_ME11b_odd(unsigned slope) const {
-  return CSC_slope_cosi_3to1_L1_ME11b_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_corr_L1_ME11a_even(unsigned slope) const {
-  return CSC_slope_cosi_corr_L1_ME11a_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_corr_L1_ME11b_even(unsigned slope) const {
-  return CSC_slope_cosi_corr_L1_ME11b_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_corr_L1_ME11a_odd(unsigned slope) const {
-  return CSC_slope_cosi_corr_L1_ME11a_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_corr_L1_ME11b_odd(unsigned slope) const {
-  return CSC_slope_cosi_corr_L1_ME11b_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L1_ME11a_even(unsigned slope) const {
-  return CSC_slope_corr_L1_ME11a_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L1_ME11b_even(unsigned slope) const {
-  return CSC_slope_corr_L1_ME11b_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L1_ME11a_odd(unsigned slope) const {
-  return CSC_slope_corr_L1_ME11a_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L1_ME11b_odd(unsigned slope) const {
-  return CSC_slope_corr_L1_ME11b_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L1_ME11a_even(unsigned es_diff) const {
-  return es_diff_slope_L1_ME11a_even_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L1_ME11a_odd(unsigned es_diff) const {
-  return es_diff_slope_L1_ME11a_odd_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L1_ME11b_even(unsigned es_diff) const {
-  return es_diff_slope_L1_ME11b_even_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L1_ME11b_odd(unsigned es_diff) const {
-  return es_diff_slope_L1_ME11b_odd_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L2_ME11a_even(unsigned slope) const {
-  return CSC_slope_corr_L2_ME11a_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L2_ME11b_even(unsigned slope) const {
-  return CSC_slope_corr_L2_ME11b_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L2_ME11a_odd(unsigned slope) const {
-  return CSC_slope_corr_L2_ME11a_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L2_ME11b_odd(unsigned slope) const {
-  return CSC_slope_corr_L2_ME11b_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L2_ME11a_even(unsigned es_diff) const {
-  return es_diff_slope_L2_ME11a_even_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L2_ME11a_odd(unsigned es_diff) const {
-  return es_diff_slope_L2_ME11a_odd_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L2_ME11b_even(unsigned es_diff) const {
-  return es_diff_slope_L2_ME11b_even_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L2_ME11b_odd(unsigned es_diff) const {
-  return es_diff_slope_L2_ME11b_odd_[es_diff];
-}
+#include "FWCore/Utilities/interface/Exception.h"
+#include <algorithm>
+
+unsigned CSCL1TPLookupTableUtils::get_lut_bit_width(const std::vector<unsigned>& lut) {
+  const auto iter = std::max_element(lut.begin(), lut.end());
+  return iter == lut.end() || *iter == 0 ? 0 : std::bit_width(*iter);
+}
+
+unsigned CSCL1TPLookupTableUtils::get_common_lut_bit_width(std::initializer_list<unsigned> luts_bit_width,
+                                                           std::string_view lut_group_name) {
+  const auto min_max = std::minmax(luts_bit_width);
+  if (min_max.first != min_max.second)
+    throw cms::Exception("InvalidLookupTable") << "Inconsistent bit widths among " << lut_group_name << " LUTs: "
+      << min_max.first << " vs " << min_max.second;
+  return min_max.first;
+}
+
+#define DEFINE_LUT(NAME) DEFINE_CSCL1TP_LUT(CSCL1TPLookupTableME11ILT, NAME)
+
+DEFINE_LUT(GEM_pad_CSC_es_ME11b_even);
+DEFINE_LUT(GEM_pad_CSC_es_ME11a_even);
+DEFINE_LUT(GEM_pad_CSC_es_ME11b_odd);
+DEFINE_LUT(GEM_pad_CSC_es_ME11a_odd);
+
+DEFINE_LUT(GEM_roll_CSC_min_wg_ME11_even);
+DEFINE_LUT(GEM_roll_CSC_max_wg_ME11_even);
+DEFINE_LUT(GEM_roll_CSC_min_wg_ME11_odd);
+DEFINE_LUT(GEM_roll_CSC_max_wg_ME11_odd);
+
+DEFINE_LUT(CSC_slope_cosi_2to1_L1_ME11a_even);
+DEFINE_LUT(CSC_slope_cosi_2to1_L1_ME11a_odd);
+DEFINE_LUT(CSC_slope_cosi_3to1_L1_ME11a_even);
+DEFINE_LUT(CSC_slope_cosi_3to1_L1_ME11a_odd);
+
+DEFINE_LUT(CSC_slope_cosi_2to1_L1_ME11b_even);
+DEFINE_LUT(CSC_slope_cosi_2to1_L1_ME11b_odd);
+DEFINE_LUT(CSC_slope_cosi_3to1_L1_ME11b_even);
+DEFINE_LUT(CSC_slope_cosi_3to1_L1_ME11b_odd);
+
+DEFINE_LUT(CSC_slope_cosi_corr_L1_ME11a_even);
+DEFINE_LUT(CSC_slope_cosi_corr_L1_ME11b_even);
+DEFINE_LUT(CSC_slope_cosi_corr_L1_ME11a_odd);
+DEFINE_LUT(CSC_slope_cosi_corr_L1_ME11b_odd);
+
+DEFINE_LUT(CSC_slope_corr_L1_ME11a_even);
+DEFINE_LUT(CSC_slope_corr_L1_ME11b_even);
+DEFINE_LUT(CSC_slope_corr_L1_ME11a_odd);
+DEFINE_LUT(CSC_slope_corr_L1_ME11b_odd);
+DEFINE_LUT(CSC_slope_corr_L2_ME11a_even);
+DEFINE_LUT(CSC_slope_corr_L2_ME11b_even);
+DEFINE_LUT(CSC_slope_corr_L2_ME11a_odd);
+DEFINE_LUT(CSC_slope_corr_L2_ME11b_odd);
+
+DEFINE_LUT(es_diff_slope_L1_ME11a_even);
+DEFINE_LUT(es_diff_slope_L1_ME11a_odd);
+DEFINE_LUT(es_diff_slope_L1_ME11b_even);
+DEFINE_LUT(es_diff_slope_L1_ME11b_odd);
+DEFINE_LUT(es_diff_slope_L2_ME11a_even);
+DEFINE_LUT(es_diff_slope_L2_ME11a_odd);
+DEFINE_LUT(es_diff_slope_L2_ME11b_even);
+DEFINE_LUT(es_diff_slope_L2_ME11b_odd);
+
+unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_bit_width() const {
+  return CSCL1TPLookupTableUtils::get_common_lut_bit_width({
+      es_diff_slope_L1_ME11a_even_bit_width(),
+      es_diff_slope_L1_ME11a_odd_bit_width(),
+      es_diff_slope_L1_ME11b_even_bit_width(),
+      es_diff_slope_L1_ME11b_odd_bit_width(),
+      es_diff_slope_L2_ME11a_even_bit_width(),
+      es_diff_slope_L2_ME11a_odd_bit_width(),
+      es_diff_slope_L2_ME11b_even_bit_width(),
+      es_diff_slope_L2_ME11b_odd_bit_width(),
+  }, "es_diff_slope");
+}
+
+#undef DEFINE_LUT

--- a/CondFormats/CSCObjects/src/CSCL1TPLookupTableME11ILT.cc
+++ b/CondFormats/CSCObjects/src/CSCL1TPLookupTableME11ILT.cc
@@ -11,8 +11,8 @@ unsigned CSCL1TPLookupTableUtils::get_common_lut_bit_width(std::initializer_list
                                                            std::string_view lut_group_name) {
   const auto min_max = std::minmax(luts_bit_width);
   if (min_max.first != min_max.second)
-    throw cms::Exception("InvalidLookupTable") << "Inconsistent bit widths among " << lut_group_name << " LUTs: "
-      << min_max.first << " vs " << min_max.second;
+    throw cms::Exception("InvalidLookupTable")
+        << "Inconsistent bit widths among " << lut_group_name << " LUTs: " << min_max.first << " vs " << min_max.second;
   return min_max.first;
 }
 
@@ -62,16 +62,18 @@ DEFINE_LUT(es_diff_slope_L2_ME11b_even);
 DEFINE_LUT(es_diff_slope_L2_ME11b_odd);
 
 unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_bit_width() const {
-  return CSCL1TPLookupTableUtils::get_common_lut_bit_width({
-      es_diff_slope_L1_ME11a_even_bit_width(),
-      es_diff_slope_L1_ME11a_odd_bit_width(),
-      es_diff_slope_L1_ME11b_even_bit_width(),
-      es_diff_slope_L1_ME11b_odd_bit_width(),
-      es_diff_slope_L2_ME11a_even_bit_width(),
-      es_diff_slope_L2_ME11a_odd_bit_width(),
-      es_diff_slope_L2_ME11b_even_bit_width(),
-      es_diff_slope_L2_ME11b_odd_bit_width(),
-  }, "es_diff_slope");
+  return CSCL1TPLookupTableUtils::get_common_lut_bit_width(
+      {
+          es_diff_slope_L1_ME11a_even_bit_width(),
+          es_diff_slope_L1_ME11a_odd_bit_width(),
+          es_diff_slope_L1_ME11b_even_bit_width(),
+          es_diff_slope_L1_ME11b_odd_bit_width(),
+          es_diff_slope_L2_ME11a_even_bit_width(),
+          es_diff_slope_L2_ME11a_odd_bit_width(),
+          es_diff_slope_L2_ME11b_even_bit_width(),
+          es_diff_slope_L2_ME11b_odd_bit_width(),
+      },
+      "es_diff_slope");
 }
 
 #undef DEFINE_LUT

--- a/CondFormats/CSCObjects/src/CSCL1TPLookupTableME21ILT.cc
+++ b/CondFormats/CSCObjects/src/CSCL1TPLookupTableME21ILT.cc
@@ -1,221 +1,39 @@
 #include "CondFormats/CSCObjects/interface/CSCL1TPLookupTableME21ILT.h"
 
-CSCL1TPLookupTableME21ILT::CSCL1TPLookupTableME21ILT()
-    : GEM_pad_CSC_es_ME21_even_(0),
-      GEM_pad_CSC_es_ME21_odd_(0),
+#define DEFINE_LUT(NAME) DEFINE_CSCL1TP_LUT(CSCL1TPLookupTableME21ILT, NAME)
 
-      GEM_roll_L1_CSC_min_wg_ME21_even_(0),
-      GEM_roll_L1_CSC_max_wg_ME21_even_(0),
-      GEM_roll_L1_CSC_min_wg_ME21_odd_(0),
-      GEM_roll_L1_CSC_max_wg_ME21_odd_(0),
+DEFINE_LUT(GEM_pad_CSC_es_ME21_even);
+DEFINE_LUT(GEM_pad_CSC_es_ME21_odd);
+DEFINE_LUT(GEM_roll_L1_CSC_min_wg_ME21_even);
+DEFINE_LUT(GEM_roll_L1_CSC_max_wg_ME21_even);
+DEFINE_LUT(GEM_roll_L1_CSC_min_wg_ME21_odd);
+DEFINE_LUT(GEM_roll_L1_CSC_max_wg_ME21_odd);
+DEFINE_LUT(GEM_roll_L2_CSC_min_wg_ME21_even);
+DEFINE_LUT(GEM_roll_L2_CSC_max_wg_ME21_even);
+DEFINE_LUT(GEM_roll_L2_CSC_min_wg_ME21_odd);
+DEFINE_LUT(GEM_roll_L2_CSC_max_wg_ME21_odd);
+DEFINE_LUT(es_diff_slope_L1_ME21_even);
+DEFINE_LUT(es_diff_slope_L1_ME21_odd);
+DEFINE_LUT(es_diff_slope_L2_ME21_even);
+DEFINE_LUT(es_diff_slope_L2_ME21_odd);
+DEFINE_LUT(CSC_slope_cosi_2to1_L1_ME21_even);
+DEFINE_LUT(CSC_slope_cosi_2to1_L1_ME21_odd);
+DEFINE_LUT(CSC_slope_cosi_3to1_L1_ME21_even);
+DEFINE_LUT(CSC_slope_cosi_3to1_L1_ME21_odd);
+DEFINE_LUT(CSC_slope_cosi_corr_L1_ME21_even);
+DEFINE_LUT(CSC_slope_cosi_corr_L1_ME21_odd);
+DEFINE_LUT(CSC_slope_corr_L1_ME21_even);
+DEFINE_LUT(CSC_slope_corr_L1_ME21_odd);
+DEFINE_LUT(CSC_slope_corr_L2_ME21_even);
+DEFINE_LUT(CSC_slope_corr_L2_ME21_odd);
 
-      GEM_roll_L2_CSC_min_wg_ME21_even_(0),
-      GEM_roll_L2_CSC_max_wg_ME21_even_(0),
-      GEM_roll_L2_CSC_min_wg_ME21_odd_(0),
-      GEM_roll_L2_CSC_max_wg_ME21_odd_(0),
-
-      CSC_slope_cosi_2to1_L1_ME21_even_(0),
-      CSC_slope_cosi_2to1_L1_ME21_odd_(0),
-      CSC_slope_cosi_3to1_L1_ME21_even_(0),
-      CSC_slope_cosi_3to1_L1_ME21_odd_(0),
-
-      CSC_slope_cosi_corr_L1_ME21_even_(0),
-      CSC_slope_cosi_corr_L1_ME21_odd_(0),
-
-      CSC_slope_corr_L1_ME21_even_(0),
-      CSC_slope_corr_L1_ME21_odd_(0),
-      CSC_slope_corr_L2_ME21_even_(0),
-      CSC_slope_corr_L2_ME21_odd_(0),
-
-      es_diff_slope_L1_ME21_even_(0),
-      es_diff_slope_L1_ME21_odd_(0),
-      es_diff_slope_L2_ME21_even_(0),
-      es_diff_slope_L2_ME21_odd_(0) {}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_pad_CSC_es_ME21_even(t_lut lut) { GEM_pad_CSC_es_ME21_even_ = std::move(lut); }
-
-void CSCL1TPLookupTableME21ILT::set_GEM_pad_CSC_es_ME21_odd(t_lut lut) { GEM_pad_CSC_es_ME21_odd_ = std::move(lut); }
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L1_CSC_min_wg_ME21_even(t_lut lut) {
-  GEM_roll_L1_CSC_min_wg_ME21_even_ = std::move(lut);
+unsigned CSCL1TPLookupTableME21ILT::es_diff_slope_bit_width() const {
+  return CSCL1TPLookupTableUtils::get_common_lut_bit_width({
+      es_diff_slope_L1_ME21_even_bit_width(),
+      es_diff_slope_L1_ME21_odd_bit_width(),
+      es_diff_slope_L2_ME21_even_bit_width(),
+      es_diff_slope_L2_ME21_odd_bit_width(),
+  }, "es_diff_slope");
 }
 
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L1_CSC_max_wg_ME21_even(t_lut lut) {
-  GEM_roll_L1_CSC_max_wg_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L1_CSC_min_wg_ME21_odd(t_lut lut) {
-  GEM_roll_L1_CSC_min_wg_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L1_CSC_max_wg_ME21_odd(t_lut lut) {
-  GEM_roll_L1_CSC_max_wg_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L2_CSC_min_wg_ME21_even(t_lut lut) {
-  GEM_roll_L2_CSC_min_wg_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L2_CSC_max_wg_ME21_even(t_lut lut) {
-  GEM_roll_L2_CSC_max_wg_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L2_CSC_min_wg_ME21_odd(t_lut lut) {
-  GEM_roll_L2_CSC_min_wg_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L2_CSC_max_wg_ME21_odd(t_lut lut) {
-  GEM_roll_L2_CSC_max_wg_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_cosi_2to1_L1_ME21_even(t_lut lut) {
-  CSC_slope_cosi_2to1_L1_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_cosi_2to1_L1_ME21_odd(t_lut lut) {
-  CSC_slope_cosi_2to1_L1_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_cosi_3to1_L1_ME21_even(t_lut lut) {
-  CSC_slope_cosi_3to1_L1_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_cosi_3to1_L1_ME21_odd(t_lut lut) {
-  CSC_slope_cosi_3to1_L1_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_cosi_corr_L1_ME21_even(t_lut lut) {
-  CSC_slope_cosi_corr_L1_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_cosi_corr_L1_ME21_odd(t_lut lut) {
-  CSC_slope_cosi_corr_L1_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_corr_L1_ME21_even(t_lut lut) {
-  CSC_slope_corr_L1_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_corr_L1_ME21_odd(t_lut lut) {
-  CSC_slope_corr_L1_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_es_diff_slope_L1_ME21_even(t_lut lut) {
-  es_diff_slope_L1_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_es_diff_slope_L1_ME21_odd(t_lut lut) {
-  es_diff_slope_L1_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_corr_L2_ME21_even(t_lut lut) {
-  CSC_slope_corr_L2_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_corr_L2_ME21_odd(t_lut lut) {
-  CSC_slope_corr_L2_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_es_diff_slope_L2_ME21_even(t_lut lut) {
-  es_diff_slope_L2_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_es_diff_slope_L2_ME21_odd(t_lut lut) {
-  es_diff_slope_L2_ME21_odd_ = std::move(lut);
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_pad_CSC_es_ME21_even(unsigned pad) const {
-  return GEM_pad_CSC_es_ME21_even_[pad];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_pad_CSC_es_ME21_odd(unsigned pad) const {
-  return GEM_pad_CSC_es_ME21_odd_[pad];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L1_CSC_min_wg_ME21_even(unsigned roll) const {
-  return GEM_roll_L1_CSC_min_wg_ME21_even_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L1_CSC_max_wg_ME21_even(unsigned roll) const {
-  return GEM_roll_L1_CSC_max_wg_ME21_even_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L1_CSC_min_wg_ME21_odd(unsigned roll) const {
-  return GEM_roll_L1_CSC_min_wg_ME21_odd_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L1_CSC_max_wg_ME21_odd(unsigned roll) const {
-  return GEM_roll_L1_CSC_max_wg_ME21_odd_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L2_CSC_min_wg_ME21_even(unsigned roll) const {
-  return GEM_roll_L2_CSC_min_wg_ME21_even_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L2_CSC_max_wg_ME21_even(unsigned roll) const {
-  return GEM_roll_L2_CSC_max_wg_ME21_even_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L2_CSC_min_wg_ME21_odd(unsigned roll) const {
-  return GEM_roll_L2_CSC_min_wg_ME21_odd_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L2_CSC_max_wg_ME21_odd(unsigned roll) const {
-  return GEM_roll_L2_CSC_max_wg_ME21_odd_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_cosi_2to1_L1_ME21_even(unsigned slope) const {
-  return CSC_slope_cosi_2to1_L1_ME21_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_cosi_2to1_L1_ME21_odd(unsigned slope) const {
-  return CSC_slope_cosi_2to1_L1_ME21_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_cosi_3to1_L1_ME21_even(unsigned slope) const {
-  return CSC_slope_cosi_3to1_L1_ME21_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_cosi_3to1_L1_ME21_odd(unsigned slope) const {
-  return CSC_slope_cosi_3to1_L1_ME21_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_cosi_corr_L1_ME21_even(unsigned slope) const {
-  return CSC_slope_cosi_corr_L1_ME21_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_cosi_corr_L1_ME21_odd(unsigned slope) const {
-  return CSC_slope_cosi_corr_L1_ME21_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_corr_L1_ME21_even(unsigned slope) const {
-  return CSC_slope_corr_L1_ME21_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_corr_L1_ME21_odd(unsigned slope) const {
-  return CSC_slope_corr_L1_ME21_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::es_diff_slope_L1_ME21_even(unsigned es_diff) const {
-  return es_diff_slope_L1_ME21_even_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::es_diff_slope_L1_ME21_odd(unsigned es_diff) const {
-  return es_diff_slope_L1_ME21_odd_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_corr_L2_ME21_even(unsigned slope) const {
-  return CSC_slope_corr_L2_ME21_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_corr_L2_ME21_odd(unsigned slope) const {
-  return CSC_slope_corr_L2_ME21_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::es_diff_slope_L2_ME21_even(unsigned es_diff) const {
-  return es_diff_slope_L2_ME21_even_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::es_diff_slope_L2_ME21_odd(unsigned es_diff) const {
-  return es_diff_slope_L2_ME21_odd_[es_diff];
-}
+#undef DEFINE_LUT

--- a/CondFormats/CSCObjects/src/CSCL1TPLookupTableME21ILT.cc
+++ b/CondFormats/CSCObjects/src/CSCL1TPLookupTableME21ILT.cc
@@ -28,12 +28,14 @@ DEFINE_LUT(CSC_slope_corr_L2_ME21_even);
 DEFINE_LUT(CSC_slope_corr_L2_ME21_odd);
 
 unsigned CSCL1TPLookupTableME21ILT::es_diff_slope_bit_width() const {
-  return CSCL1TPLookupTableUtils::get_common_lut_bit_width({
-      es_diff_slope_L1_ME21_even_bit_width(),
-      es_diff_slope_L1_ME21_odd_bit_width(),
-      es_diff_slope_L2_ME21_even_bit_width(),
-      es_diff_slope_L2_ME21_odd_bit_width(),
-  }, "es_diff_slope");
+  return CSCL1TPLookupTableUtils::get_common_lut_bit_width(
+      {
+          es_diff_slope_L1_ME21_even_bit_width(),
+          es_diff_slope_L1_ME21_odd_bit_width(),
+          es_diff_slope_L2_ME21_even_bit_width(),
+          es_diff_slope_L2_ME21_odd_bit_width(),
+      },
+      "es_diff_slope");
 }
 
 #undef DEFINE_LUT

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -116,7 +116,7 @@ public:
   /// return the slope
   uint16_t getSlope() const;
   // return the slope with extended resolution. The raw slope resolution is 4 bits for Legacy and Run3, and 6 bits for Run3HR. If resolution=0, return raw slope value with the full resolution.
-  uint16_t getSlopeEx(uint16_t resolution=0) const;
+  uint16_t getSlopeEx(uint16_t resolution = 0) const;
   uint16_t getRawSlopeResolution() const { return version_ == Version::Run3HR ? 6 : 4; }
 
   /// slope in number of half-strips/layer

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -18,7 +18,7 @@
 
 class CSCCorrelatedLCTDigi {
 public:
-  enum class Version { Legacy = 0, Run3 };
+  enum class Version { Legacy = 0, Run3, Run3HR };
   // for data vs emulator studies
   enum LCTBXMask { kBXDataMask = 0x1 };
 
@@ -114,7 +114,10 @@ public:
   uint16_t getRun3Pattern() const { return run3_pattern_; }
 
   /// return the slope
-  uint16_t getSlope() const { return run3_slope_; }
+  uint16_t getSlope() const;
+  // return the slope with extended resolution. The raw slope resolution is 4 bits for Legacy and Run3, and 6 bits for Run3HR. If resolution=0, return raw slope value with the full resolution.
+  uint16_t getSlopeEx(uint16_t resolution=0) const;
+  uint16_t getRawSlopeResolution() const { return version_ == Version::Run3HR ? 6 : 4; }
 
   /// slope in number of half-strips/layer
   /// negative means left-bending
@@ -207,7 +210,7 @@ public:
   /// Distinguish Run-1/2 from Run-3
   bool isRun3() const { return version_ == Version::Run3; }
 
-  void setRun3(const bool isRun3);
+  void setVersion(const Version version) { version_ = version; }
 
   int getType() const { return type_; }
 

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -113,7 +113,7 @@ public:
   /// return the Run-3 pattern ID
   uint16_t getRun3Pattern() const { return run3_pattern_; }
 
-  /// return the slope
+  /// return the slope with the 4 bits resolution (for backward compatibility).
   uint16_t getSlope() const;
   // return the slope with extended resolution. The raw slope resolution is 4 bits for Legacy and Run3, and 6 bits for Run3HR. If resolution=0, return raw slope value with the full resolution.
   uint16_t getSlopeEx(uint16_t resolution = 0) const;
@@ -208,8 +208,9 @@ public:
   void setHMT(const uint16_t h);
 
   /// Distinguish Run-1/2 from Run-3
-  bool isRun3() const { return version_ == Version::Run3; }
+  bool isRun3() const { return version_ == Version::Run3 || version_ == Version::Run3HR; }
 
+  Version getVersion() const { return version_; }
   void setVersion(const Version version) { version_ = version; }
 
   int getType() const { return type_; }

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -140,10 +140,10 @@ uint16_t CSCCorrelatedLCTDigi::getSlope() const {
 
 uint16_t CSCCorrelatedLCTDigi::getSlopeEx(uint16_t resolution) const {
   if (resolution > 16)
-    throw cms::Exception("InvalidSlopeResolution") << "Requested slope resolution " << resolution
-                                           << " is larger than 16 bits, which is not supported.";
+    throw cms::Exception("InvalidSlopeResolution")
+        << "Requested slope resolution " << resolution << " is larger than 16 bits, which is not supported.";
   const uint16_t rawResolution = getRawSlopeResolution();
-  if(resolution == 0 || resolution == rawResolution)
+  if (resolution == 0 || resolution == rawResolution)
     return run3_slope_;
   if (resolution > rawResolution)
     return run3_slope_ << (resolution - rawResolution);
@@ -177,8 +177,7 @@ std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi) {
              << " Run-2 Pattern = " << digi.getPattern() << " Run-3 Pattern = " << digi.getRun3Pattern()
              << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend() << " Slope = " << digi.getSlope()
              << " Slope resolution = " << digi.getRawSlopeResolution() << " bits"
-             << " GemLayer = " << digi.getGemLayerUsedForSlopeComputation()
-             << "\n"
+             << " GemLayer = " << digi.getGemLayerUsedForSlopeComputation() << "\n"
              << " KeyHalfStrip = " << digi.getStrip() << " KeyQuartStrip = " << digi.getStrip(4)
              << " KeyEighthStrip = " << digi.getStrip(8) << " KeyWireGroup = " << digi.getKeyWG()
              << " Type (SIM) = " << digi.getType() << " MPC Link = " << digi.getMPCLink();

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -134,7 +134,21 @@ uint16_t CSCCorrelatedLCTDigi::getHMT() const { return (isRun3() ? hmt : std::nu
 
 void CSCCorrelatedLCTDigi::setHMT(const uint16_t h) { hmt = isRun3() ? h : std::numeric_limits<uint16_t>::max(); }
 
-void CSCCorrelatedLCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
+uint16_t CSCCorrelatedLCTDigi::getSlope() const {
+  return version_ == Version::Run3HR ? (run3_slope_ >> 2) : run3_slope_;
+}
+
+uint16_t CSCCorrelatedLCTDigi::getSlopeEx(uint16_t resolution) const {
+  if (resolution > 16)
+    throw cms::Exception("InvalidSlopeResolution") << "Requested slope resolution " << resolution
+                                           << " is larger than 16 bits, which is not supported.";
+  const uint16_t rawResolution = getRawSlopeResolution();
+  if(resolution == 0 || resolution == rawResolution)
+    return run3_slope_;
+  if (resolution > rawResolution)
+    return run3_slope_ << (resolution - rawResolution);
+  return run3_slope_ >> (rawResolution - resolution);
+}
 
 /// Comparison
 bool CSCCorrelatedLCTDigi::operator==(const CSCCorrelatedLCTDigi& rhs) const {
@@ -161,7 +175,9 @@ std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi) {
   if (digi.isRun3())
     return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
              << " Run-2 Pattern = " << digi.getPattern() << " Run-3 Pattern = " << digi.getRun3Pattern()
-             << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend() << " Slope = " << digi.getSlope() << " GemLayer = " << digi.getGemLayerUsedForSlopeComputation()
+             << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend() << " Slope = " << digi.getSlope()
+             << " Slope resolution = " << digi.getRawSlopeResolution() << " bits"
+             << " GemLayer = " << digi.getGemLayerUsedForSlopeComputation()
              << "\n"
              << " KeyHalfStrip = " << digi.getStrip() << " KeyQuartStrip = " << digi.getStrip(4)
              << " KeyEighthStrip = " << digi.getStrip(8) << " KeyWireGroup = " << digi.getKeyWG()

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -175,7 +175,7 @@ std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi) {
   if (digi.isRun3())
     return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
              << " Run-2 Pattern = " << digi.getPattern() << " Run-3 Pattern = " << digi.getRun3Pattern()
-             << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend() << " Slope = " << digi.getSlope()
+             << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend() << " Slope = " << digi.getSlopeEx()
              << " Slope resolution = " << digi.getRawSlopeResolution() << " bits"
              << " GemLayer = " << digi.getGemLayerUsedForSlopeComputation() << "\n"
              << " KeyHalfStrip = " << digi.getStrip() << " KeyQuartStrip = " << digi.getStrip(4)

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -161,7 +161,7 @@ std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi) {
   if (digi.isRun3())
     return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
              << " Run-2 Pattern = " << digi.getPattern() << " Run-3 Pattern = " << digi.getRun3Pattern()
-             << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend() << " Slope = " << digi.getSlope()
+             << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend() << " Slope = " << digi.getSlope() << " GemLayer = " << digi.getGemLayerUsedForSlopeComputation()
              << "\n"
              << " KeyHalfStrip = " << digi.getStrip() << " KeyQuartStrip = " << digi.getStrip(4)
              << " KeyEighthStrip = " << digi.getStrip(8) << " KeyWireGroup = " << digi.getKeyWG()

--- a/DataFormats/L1TMuon/src/EMTFHit.cc
+++ b/DataFormats/L1TMuon/src/EMTFHit.cc
@@ -92,7 +92,7 @@ namespace l1t {
     lct.setEighthStripBit(eighth_bit);
     lct.setSlope(slope);
     lct.setRun3Pattern(pattern_run3);
-    lct.setRun3(isRun3);
+    lct.setVersion(isRun3 ? CSCCorrelatedLCTDigi::Version::Run3 : CSCCorrelatedLCTDigi::Version::Legacy);
 
     return lct;
     // Added Run 3 parameters - EY 04.07.22

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
@@ -114,6 +114,13 @@ private:
   // Construct LCT from CSC and GEM information. ALCT+2GEM
   void constructLCTsGEM(const CSCALCTDigi& alct, const GEMInternalCluster& gem, CSCCorrelatedLCTDigi& lct) const;
 
+  void fillBaseInfo(CSCCorrelatedLCTDigi& lct) const;
+  void fillCCLUTInfo(CSCCorrelatedLCTDigi& lct,
+                      const CSCCLCTDigi* clct,
+                                       const GEMInternalCluster* gem,
+                                       const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                                       const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) const;
+
   // LCTs are sorted by quality. If there are two with the same quality,
   // then the sorting is done by the slope
   void sortLCTs(std::vector<CSCCorrelatedLCTDigi>& lcts) const;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
@@ -116,10 +116,10 @@ private:
 
   void fillBaseInfo(CSCCorrelatedLCTDigi& lct) const;
   void fillCCLUTInfo(CSCCorrelatedLCTDigi& lct,
-                      const CSCCLCTDigi* clct,
-                                       const GEMInternalCluster* gem,
-                                       const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
-                                       const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) const;
+                     const CSCCLCTDigi* clct,
+                     const GEMInternalCluster* gem,
+                     const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                     const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) const;
 
   // LCTs are sorted by quality. If there are two with the same quality,
   // then the sorting is done by the slope

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMatcher.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMatcher.cc
@@ -249,13 +249,7 @@ int CSCGEMMatcher::matchedClusterDistES(const CSCCLCTDigi& clct,
 
   int cl_es = isME1a ? cl.getKeyStripME1a(8, isLayer2) : cl.getKeyStrip(8, isLayer2);
 
-  int alignCorrection = 0;
-  // Here will be some magic to load the alignment correction from LUTs
-  if (config_useAlignment) {
-    std::cout << "Magic" << std::endl;
-  }
-
-  int eighthStripDiff = cl_es + alignCorrection - clct.getKeyStrip(8);
+  int eighthStripDiff = cl_es - clct.getKeyStrip(8);
 
   if (matchCLCTpropagation_ and !ForceTotal) {  //modification of DeltaStrip by CLCT slope
     int SlopeShift = 0;
@@ -501,12 +495,6 @@ int CSCGEMMatcher::calculateGEMCSCBending(const CSCCLCTDigi& clct,
       }
     }
   }
-
-  // Konstantin, do we need to keep the old method in emulator?
-  // To explain, previously, the above "eighthStripDiff" was fed into a LUT that returned a 4-bit slope
-  // Now, we are directly returning eighthStripDiff as a capped 6 bit number
-  // Also, do we want to do the 6-bit capping here, or in CSCGEMMotherboard?
-  slopeShift = eighthStripDiff <= 62 ? eighthStripDiff : 63;
 
   //account for the sign of the difference
   slopeShift *= pow(-1, std::signbit(SignedEighthStripDiff));

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMatcher.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMatcher.cc
@@ -249,7 +249,13 @@ int CSCGEMMatcher::matchedClusterDistES(const CSCCLCTDigi& clct,
 
   int cl_es = isME1a ? cl.getKeyStripME1a(8, isLayer2) : cl.getKeyStrip(8, isLayer2);
 
-  int eighthStripDiff = cl_es - clct.getKeyStrip(8);
+  int alignCorrection = 0;
+  // Here will be some magic to load the alignment correction from LUTs
+  if (config_useAlignment) {
+    std::cout << "Magic" << std::endl;
+  }
+
+  int eighthStripDiff = cl_es + alignCorrection - clct.getKeyStrip(8);
 
   if (matchCLCTpropagation_ and !ForceTotal) {  //modification of DeltaStrip by CLCT slope
     int SlopeShift = 0;
@@ -495,6 +501,12 @@ int CSCGEMMatcher::calculateGEMCSCBending(const CSCCLCTDigi& clct,
       }
     }
   }
+
+  // Konstantin, do we need to keep the old method in emulator?
+  // To explain, previously, the above "eighthStripDiff" was fed into a LUT that returned a 4-bit slope
+  // Now, we are directly returning eighthStripDiff as a capped 6 bit number
+  // Also, do we want to do the 6-bit capping here, or in CSCGEMMotherboard?
+  slopeShift = eighthStripDiff <= 62 ? eighthStripDiff : 63;
 
   //account for the sign of the difference
   slopeShift *= pow(-1, std::signbit(SignedEighthStripDiff));

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -504,27 +504,33 @@ void CSCGEMMotherboard::fillBaseInfo(CSCCorrelatedLCTDigi& thisLCT) const {
 }
 
 void CSCGEMMotherboard::fillCCLUTInfo(CSCCorrelatedLCTDigi& thisLCT,
-                                       const CSCCLCTDigi* clct,
-                                       const GEMInternalCluster* gem,
-                                       const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
-                                       const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) const {
-  if (!runCCLUT_) return;
+                                      const CSCCLCTDigi* clct,
+                                      const GEMInternalCluster* gem,
+                                      const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                                      const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) const {
+  if (!runCCLUT_)
+    return;
   CSCCorrelatedLCTDigi::Version version = CSCCorrelatedLCTDigi::Version::Run3;
-  if(lookupTableME11ILT || lookupTableME21ILT) {
-    const auto me11_n_bits = lookupTableME11ILT ? std::make_optional(lookupTableME11ILT->es_diff_slope_bit_width()) : std::nullopt;
-    const auto me21_n_bits = lookupTableME21ILT ? std::make_optional(lookupTableME21ILT->es_diff_slope_bit_width()) : std::nullopt;
+  if (lookupTableME11ILT || lookupTableME21ILT) {
+    const auto me11_n_bits =
+        lookupTableME11ILT ? std::make_optional(lookupTableME11ILT->es_diff_slope_bit_width()) : std::nullopt;
+    const auto me21_n_bits =
+        lookupTableME21ILT ? std::make_optional(lookupTableME21ILT->es_diff_slope_bit_width()) : std::nullopt;
     if (me11_n_bits.has_value() && me21_n_bits.has_value() && me11_n_bits != me21_n_bits) {
-      throw cms::Exception("CSCGEMMotherboard") << "Mismatch in ES diff slope bit width between ME11 and ME21 LUTs! ME11: " << *me11_n_bits << " bits, ME21: " << *me21_n_bits << " bits. This may lead to incorrect slope and pattern assignment.";
+      throw cms::Exception("CSCGEMMotherboard")
+          << "Mismatch in ES diff slope bit width between ME11 and ME21 LUTs! ME11: " << *me11_n_bits
+          << " bits, ME21: " << *me21_n_bits << " bits. This may lead to incorrect slope and pattern assignment.";
     }
     const unsigned n_bits = me11_n_bits.has_value() ? *me11_n_bits : *me21_n_bits;
-    if(n_bits != 4 && n_bits != 6) {
-      throw cms::Exception("CSCGEMMotherboard") << "Unsupported ES diff slope bit width in LUTs! Expected 4 or 6 bits, but got " << n_bits << " bits.";
+    if (n_bits != 4 && n_bits != 6) {
+      throw cms::Exception("CSCGEMMotherboard")
+          << "Unsupported ES diff slope bit width in LUTs! Expected 4 or 6 bits, but got " << n_bits << " bits.";
     }
     if (n_bits == 6)
       version = CSCCorrelatedLCTDigi::Version::Run3HR;
   }
   thisLCT.setVersion(version);
-  if(clct) {
+  if (clct) {
     if (assign_gem_csc_bending_ && gem && gem->isValid()) {
       //calculate new slope from strip difference between CLCT and associated GEM
       const int slope = cscGEMMatcher_->calculateGEMCSCBending(*clct, *gem, lookupTableME11ILT, lookupTableME21ILT);

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <algorithm>
 
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h"
 CSCGEMMotherboard::CSCGEMMotherboard(unsigned endcap,
@@ -493,6 +494,63 @@ void CSCGEMMotherboard::correlateLCTsGEM(const CSCALCTDigi& ALCT,
   }
 }
 
+void CSCGEMMotherboard::fillBaseInfo(CSCCorrelatedLCTDigi& thisLCT) const {
+  thisLCT.setValid(true);
+  thisLCT.setMPCLink(0);
+  thisLCT.setBX0(0);
+  thisLCT.setSyncErr(0);
+  thisLCT.setCSCID(theTrigChamber);
+  thisLCT.setTrknmb(0);  // will be set later after sorting
+}
+
+void CSCGEMMotherboard::fillCCLUTInfo(CSCCorrelatedLCTDigi& thisLCT,
+                                       const CSCCLCTDigi* clct,
+                                       const GEMInternalCluster* gem,
+                                       const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                                       const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) const {
+  if (!runCCLUT_) return;
+  CSCCorrelatedLCTDigi::Version version = CSCCorrelatedLCTDigi::Version::Run3;
+  if(lookupTableME11ILT || lookupTableME21ILT) {
+    const auto me11_n_bits = lookupTableME11ILT ? std::make_optional(lookupTableME11ILT->es_diff_slope_bit_width()) : std::nullopt;
+    const auto me21_n_bits = lookupTableME21ILT ? std::make_optional(lookupTableME21ILT->es_diff_slope_bit_width()) : std::nullopt;
+    if (me11_n_bits.has_value() && me21_n_bits.has_value() && me11_n_bits != me21_n_bits) {
+      throw cms::Exception("CSCGEMMotherboard") << "Mismatch in ES diff slope bit width between ME11 and ME21 LUTs! ME11: " << *me11_n_bits << " bits, ME21: " << *me21_n_bits << " bits. This may lead to incorrect slope and pattern assignment.";
+    }
+    const unsigned n_bits = me11_n_bits.has_value() ? *me11_n_bits : *me21_n_bits;
+    if(n_bits != 4 && n_bits != 6) {
+      throw cms::Exception("CSCGEMMotherboard") << "Unsupported ES diff slope bit width in LUTs! Expected 4 or 6 bits, but got " << n_bits << " bits.";
+    }
+    if (n_bits == 6)
+      version = CSCCorrelatedLCTDigi::Version::Run3HR;
+  }
+  thisLCT.setVersion(version);
+  if(clct) {
+    if (assign_gem_csc_bending_ && gem && gem->isValid()) {
+      //calculate new slope from strip difference between CLCT and associated GEM
+      const int slope = cscGEMMatcher_->calculateGEMCSCBending(*clct, *gem, lookupTableME11ILT, lookupTableME21ILT);
+      const int gemLayer = gem->isMatchingLayer1() ? 1 : (gem->isMatchingLayer2() ? 2 : 0);
+      thisLCT.setGemLayerUsedForSlopeComputation(gemLayer);
+      thisLCT.setSlope(abs(slope));
+      thisLCT.setBend(std::signbit(slope));
+      thisLCT.setPattern(Run2PatternConverter(slope));
+    } else {
+      unsigned clct_slope = clct->getSlope();
+      if (version == CSCCorrelatedLCTDigi::Version::Run3HR)
+        clct_slope *= 4;
+      thisLCT.setSlope(clct_slope);
+    }
+    thisLCT.setQuartStripBit(clct->getQuartStripBit());
+    thisLCT.setEighthStripBit(clct->getEighthStripBit());
+    thisLCT.setRun3Pattern(clct->getRun3Pattern());
+  } else {
+    thisLCT.setSlope(0);
+    thisLCT.setQuartStripBit(false);
+    thisLCT.setEighthStripBit(false);
+    // ALCT-2GEM type LCTs do not bend in the chamber
+    thisLCT.setRun3Pattern(4);
+  }
+}
+
 // Construct LCT from CSC and GEM information. Option ALCT-CLCT-GEM
 void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct,
                                          const CSCCLCTDigi& clct,
@@ -500,7 +558,7 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct,
                                          const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
                                          const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
                                          CSCCorrelatedLCTDigi& thisLCT) const {
-  thisLCT.setValid(true);
+  fillBaseInfo(thisLCT);
   if (gem.isCoincidence())
     thisLCT.setType(CSCCorrelatedLCTDigi::ALCTCLCT2GEM);
   else if (gem.isValid())
@@ -512,60 +570,29 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct,
   thisLCT.setGEM1(gem.mid1());
   thisLCT.setGEM2(gem.mid2());
   thisLCT.setPattern(encodePattern(clct.getPattern()));
-  thisLCT.setMPCLink(0);
-  thisLCT.setBX0(0);
-  thisLCT.setSyncErr(0);
-  thisLCT.setCSCID(theTrigChamber);
-  thisLCT.setTrknmb(0);  // will be set later after sorting
   thisLCT.setWireGroup(alct.getKeyWG());
   thisLCT.setStrip(clct.getKeyStrip());
   thisLCT.setBend(clct.getBend());
   thisLCT.setBX(alct.getBX());
-  if (runCCLUT_) {
-    thisLCT.setRun3(true);
-    if (assign_gem_csc_bending_ &&
-        gem.isValid()) {  //calculate new slope from strip difference between CLCT and associated GEM
-      int slope = cscGEMMatcher_->calculateGEMCSCBending(clct, gem, lookupTableME11ILT, lookupTableME21ILT);
-      int gemLayer = gem.isMatchingLayer1() ? 1 : (gem.isMatchingLayer2() ? 2 : 0);
-      thisLCT.setGemLayerUsedForSlopeComputation(gemLayer);
-      thisLCT.setSlope(abs(slope));
-      thisLCT.setBend(std::signbit(slope));
-      thisLCT.setPattern(Run2PatternConverter(slope));
-    } else
-      thisLCT.setSlope(clct.getSlope()*4);
-    thisLCT.setQuartStripBit(clct.getQuartStripBit());
-    thisLCT.setEighthStripBit(clct.getEighthStripBit());
-    thisLCT.setRun3Pattern(clct.getRun3Pattern());
-  }
+
+  fillCCLUTInfo(thisLCT, &clct, &gem, lookupTableME11ILT, lookupTableME21ILT);
 }
 
 // Construct LCT from CSC and GEM information. Option ALCT-CLCT
 void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& aLCT,
                                          const CSCCLCTDigi& cLCT,
                                          CSCCorrelatedLCTDigi& thisLCT) const {
-  thisLCT.setValid(true);
+  fillBaseInfo(thisLCT);
   thisLCT.setType(CSCCorrelatedLCTDigi::ALCTCLCT);
   thisLCT.setALCT(getBXShiftedALCT(aLCT));
   thisLCT.setCLCT(getBXShiftedCLCT(cLCT));
   thisLCT.setPattern(encodePattern(cLCT.getPattern()));
-  thisLCT.setMPCLink(0);
-  thisLCT.setBX0(0);
-  thisLCT.setSyncErr(0);
-  thisLCT.setCSCID(theTrigChamber);
-  thisLCT.setTrknmb(0);  // will be set later after sorting
   thisLCT.setWireGroup(aLCT.getKeyWG());
   thisLCT.setStrip(cLCT.getKeyStrip());
   thisLCT.setBend(cLCT.getBend());
   thisLCT.setBX(aLCT.getBX());
   thisLCT.setQuality(qualityAssignment_->findQuality(aLCT, cLCT));
-  if (runCCLUT_) {
-    thisLCT.setRun3(true);
-    // 4-bit slope value derived with the CCLUT algorithm
-    thisLCT.setSlope(cLCT.getSlope()*4);
-    thisLCT.setQuartStripBit(cLCT.getQuartStripBit());
-    thisLCT.setEighthStripBit(cLCT.getEighthStripBit());
-    thisLCT.setRun3Pattern(cLCT.getRun3Pattern());
-  }
+  fillCCLUTInfo(thisLCT, &cLCT, nullptr, nullptr, nullptr);
 }
 
 // Construct LCT from CSC and GEM information. Option CLCT-2GEM
@@ -574,78 +601,43 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCCLCTDigi& clct,
                                          const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
                                          const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
                                          CSCCorrelatedLCTDigi& thisLCT) const {
-  thisLCT.setValid(true);
+  fillBaseInfo(thisLCT);
   thisLCT.setType(CSCCorrelatedLCTDigi::CLCT2GEM);
   thisLCT.setQuality(qualityAssignment_->findQuality(clct, gem));
   thisLCT.setCLCT(getBXShiftedCLCT(clct));
   thisLCT.setGEM1(gem.mid1());
   thisLCT.setGEM2(gem.mid2());
   thisLCT.setPattern(encodePattern(clct.getPattern()));
-  thisLCT.setMPCLink(0);
-  thisLCT.setBX0(0);
-  thisLCT.setSyncErr(0);
-  thisLCT.setCSCID(theTrigChamber);
-  thisLCT.setTrknmb(0);  // will be set later after sorting
   thisLCT.setWireGroup(gem.getKeyWG());
   thisLCT.setStrip(clct.getKeyStrip());
   thisLCT.setBend(clct.getBend());
   thisLCT.setBX(gem.bx());
-  if (runCCLUT_) {
-    thisLCT.setRun3(true);
-    if (assign_gem_csc_bending_ &&
-        gem.isValid()) {  //calculate new slope from strip difference between CLCT and associated GEM
-      int slope = cscGEMMatcher_->calculateGEMCSCBending(clct, gem, lookupTableME11ILT, lookupTableME21ILT);
-      int gemLayer = gem.isMatchingLayer1() ? 1 : (gem.isMatchingLayer2() ? 2 : 0);
-      thisLCT.setGemLayerUsedForSlopeComputation(gemLayer);
-      thisLCT.setSlope(abs(slope));
-      thisLCT.setBend(pow(-1, std::signbit(slope)));
-      thisLCT.setPattern(Run2PatternConverter(slope));
-    } else
-      thisLCT.setSlope(clct.getSlope()*4);
-    thisLCT.setQuartStripBit(clct.getQuartStripBit());
-    thisLCT.setEighthStripBit(clct.getEighthStripBit());
-    thisLCT.setRun3Pattern(clct.getRun3Pattern());
-  }
+  fillCCLUTInfo(thisLCT, &clct, &gem, lookupTableME11ILT, lookupTableME21ILT);
 }
 
 // Construct LCT from CSC and GEM information. Option ALCT-2GEM
 void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct,
                                          const GEMInternalCluster& gem,
                                          CSCCorrelatedLCTDigi& thisLCT) const {
-  thisLCT.setValid(true);
+  fillBaseInfo(thisLCT);
   thisLCT.setType(CSCCorrelatedLCTDigi::ALCT2GEM);
   thisLCT.setQuality(qualityAssignment_->findQuality(alct, gem));
   thisLCT.setALCT(getBXShiftedALCT(alct));
   thisLCT.setGEM1(gem.mid1());
   thisLCT.setGEM2(gem.mid2());
   thisLCT.setPattern(10);
-  thisLCT.setMPCLink(0);
-  thisLCT.setBX0(0);
-  thisLCT.setSyncErr(0);
-  thisLCT.setCSCID(theTrigChamber);
-  thisLCT.setTrknmb(0);  // will be set later after sorting
   thisLCT.setWireGroup(alct.getKeyWG());
   thisLCT.setStrip(gem.getKeyStrip());
   thisLCT.setBend(0);
   thisLCT.setBX(alct.getBX());
-  if (runCCLUT_) {
-    thisLCT.setRun3(true);
-    thisLCT.setSlope(0);
-    thisLCT.setQuartStripBit(false);
-    thisLCT.setEighthStripBit(false);
-    // ALCT-2GEM type LCTs do not bend in the chamber
-    thisLCT.setRun3Pattern(4);
-  }
+  fillCCLUTInfo(thisLCT, nullptr, &gem, nullptr, nullptr);
 }
 
 void CSCGEMMotherboard::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& lcts) const {
   // LCTs are sorted by quality. If there are two with the same quality, then the sorting is done by the slope
   std::sort(lcts.begin(), lcts.end(), [](const CSCCorrelatedLCTDigi& lct1, const CSCCorrelatedLCTDigi& lct2) -> bool {
-    if (lct1.getQuality() > lct2.getQuality())
-      return lct1.getQuality() > lct2.getQuality();
-    else if (lct1.getQuality() == lct2.getQuality())
-      return lct1.getSlope() < lct2.getSlope();
-    else
-      return false;
+    if (lct1.getQuality() == lct2.getQuality())
+      return lct1.getSlopeEx() < lct2.getSlopeEx();
+    return lct1.getQuality() > lct2.getQuality();
   });
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -526,6 +526,8 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct,
     if (assign_gem_csc_bending_ &&
         gem.isValid()) {  //calculate new slope from strip difference between CLCT and associated GEM
       int slope = cscGEMMatcher_->calculateGEMCSCBending(clct, gem, lookupTableME11ILT, lookupTableME21ILT);
+      // Does gem.layer() work? Or do I have to use "!gem.isMatchingLayer1() and gem.isMatchingLayer2()"
+      thisLCT.setGemLayerUsedForSlopeComputation(gem.layer());
       thisLCT.setSlope(abs(slope));
       thisLCT.setBend(std::signbit(slope));
       thisLCT.setPattern(Run2PatternConverter(slope));
@@ -593,6 +595,8 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCCLCTDigi& clct,
     if (assign_gem_csc_bending_ &&
         gem.isValid()) {  //calculate new slope from strip difference between CLCT and associated GEM
       int slope = cscGEMMatcher_->calculateGEMCSCBending(clct, gem, lookupTableME11ILT, lookupTableME21ILT);
+      // Does gem.layer() work? Or do I have to use "!gem.isMatchingLayer1() and gem.isMatchingLayer2()"
+      thisLCT.setGemLayerUsedForSlopeComputation(gem.layer());
       thisLCT.setSlope(abs(slope));
       thisLCT.setBend(pow(-1, std::signbit(slope)));
       thisLCT.setPattern(Run2PatternConverter(slope));

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -526,8 +526,8 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct,
     if (assign_gem_csc_bending_ &&
         gem.isValid()) {  //calculate new slope from strip difference between CLCT and associated GEM
       int slope = cscGEMMatcher_->calculateGEMCSCBending(clct, gem, lookupTableME11ILT, lookupTableME21ILT);
-      // Does gem.layer() work? Or do I have to use "!gem.isMatchingLayer1() and gem.isMatchingLayer2()"
-      thisLCT.setGemLayerUsedForSlopeComputation(gem.layer());
+      int gemLayer = gem.isMatchingLayer1() ? 1 : (gem.isMatchingLayer2() ? 2 : 0);
+      thisLCT.setGemLayerUsedForSlopeComputation(gemLayer);
       thisLCT.setSlope(abs(slope));
       thisLCT.setBend(std::signbit(slope));
       thisLCT.setPattern(Run2PatternConverter(slope));
@@ -595,8 +595,8 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCCLCTDigi& clct,
     if (assign_gem_csc_bending_ &&
         gem.isValid()) {  //calculate new slope from strip difference between CLCT and associated GEM
       int slope = cscGEMMatcher_->calculateGEMCSCBending(clct, gem, lookupTableME11ILT, lookupTableME21ILT);
-      // Does gem.layer() work? Or do I have to use "!gem.isMatchingLayer1() and gem.isMatchingLayer2()"
-      thisLCT.setGemLayerUsedForSlopeComputation(gem.layer());
+      int gemLayer = gem.isMatchingLayer1() ? 1 : (gem.isMatchingLayer2() ? 2 : 0);
+      thisLCT.setGemLayerUsedForSlopeComputation(gemLayer);
       thisLCT.setSlope(abs(slope));
       thisLCT.setBend(pow(-1, std::signbit(slope)));
       thisLCT.setPattern(Run2PatternConverter(slope));

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -532,7 +532,7 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct,
       thisLCT.setBend(std::signbit(slope));
       thisLCT.setPattern(Run2PatternConverter(slope));
     } else
-      thisLCT.setSlope(clct.getSlope());
+      thisLCT.setSlope(clct.getSlope()*4);
     thisLCT.setQuartStripBit(clct.getQuartStripBit());
     thisLCT.setEighthStripBit(clct.getEighthStripBit());
     thisLCT.setRun3Pattern(clct.getRun3Pattern());
@@ -561,7 +561,7 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& aLCT,
   if (runCCLUT_) {
     thisLCT.setRun3(true);
     // 4-bit slope value derived with the CCLUT algorithm
-    thisLCT.setSlope(cLCT.getSlope());
+    thisLCT.setSlope(cLCT.getSlope()*4);
     thisLCT.setQuartStripBit(cLCT.getQuartStripBit());
     thisLCT.setEighthStripBit(cLCT.getEighthStripBit());
     thisLCT.setRun3Pattern(cLCT.getRun3Pattern());
@@ -601,7 +601,7 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCCLCTDigi& clct,
       thisLCT.setBend(pow(-1, std::signbit(slope)));
       thisLCT.setPattern(Run2PatternConverter(slope));
     } else
-      thisLCT.setSlope(clct.getSlope());
+      thisLCT.setSlope(clct.getSlope()*4);
     thisLCT.setQuartStripBit(clct.getQuartStripBit());
     thisLCT.setEighthStripBit(clct.getEighthStripBit());
     thisLCT.setRun3Pattern(clct.getRun3Pattern());

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -48,7 +48,7 @@ void CSCGEMMotherboard::clear() { clusterProc_->clear(); }
 //function to convert GEM-CSC amended signed slope into Run2 legacy pattern number
 uint16_t CSCGEMMotherboard::Run2PatternConverter(const int slope) const {
   unsigned sign = std::signbit(slope);
-  unsigned slope_ = abs(slope);
+  unsigned slope_ = std::abs(slope);
   uint16_t Run2Pattern = 0;
 
   if (slope_ < 3)
@@ -536,7 +536,7 @@ void CSCGEMMotherboard::fillCCLUTInfo(CSCCorrelatedLCTDigi& thisLCT,
       const int slope = cscGEMMatcher_->calculateGEMCSCBending(*clct, *gem, lookupTableME11ILT, lookupTableME21ILT);
       const int gemLayer = gem->isMatchingLayer1() ? 1 : (gem->isMatchingLayer2() ? 2 : 0);
       thisLCT.setGemLayerUsedForSlopeComputation(gemLayer);
-      thisLCT.setSlope(abs(slope));
+      thisLCT.setSlope(std::abs(slope));
       thisLCT.setBend(std::signbit(slope));
       thisLCT.setPattern(Run2PatternConverter(slope));
     } else {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -521,7 +521,7 @@ void CSCMotherboard::constructLCTs(
   thisLCT.setBX(bx);
   thisLCT.setQuality(qualityAssignment_->findQuality(aLCT, cLCT));
   if (runCCLUT_) {
-    thisLCT.setRun3(true);
+    thisLCT.setVersion(CSCCorrelatedLCTDigi::Version::Run3);
     // 4-bit slope value derived with the CCLUT algorithm
     thisLCT.setSlope(cLCT.getSlope());
     thisLCT.setQuartStripBit(cLCT.getQuartStripBit());

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
@@ -59,8 +59,8 @@ options.register("dropNonMuonCollections", True, VarParsing.multiplicity.singlet
                  "Option to drop most non-muon collections generally considered unnecessary for GEM/CSC analysis")
 options.register("dqmOutputFile", "step_DQM.root", VarParsing.multiplicity.singleton, VarParsing.varType.string,
                  "Name of the DQM output file. Default: step_DQM.root")
-options.register("useGEMCSCAlignment", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
-                 "Set to True if you want to use alignment-corrected LUTs for the GEM-CSC bending angle correction in the CSCGEMMatcher.")
+options.register("use6BitGEMCSCBendingAngle", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True if you want to use 6 bit LUTs for the GEM-CSC bending angle in the CSCGEMMatcher.")
 options.parseArguments()
 
 process_era = Run3
@@ -84,7 +84,7 @@ process.load("DQM.L1TMonitor.L1TdeCSCTPG_cfi")
 process.load("DQM.L1TMonitor.L1TdeGEMTPG_cfi")
 
 
-if options.useGEMCSCAlignment:
+if options.use6BitGEMCSCBendingAngle:
       process = set_6bit_gemcsc_bending_LUTs(process)
 
 

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing
 from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+from CalibMuon.CSCCalibration.CSCCustomizeBendingAngle_cfi import set_6bit_gemcsc_bending_LUTs
 
 options = VarParsing('analysis')
 options.register("unpack", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
@@ -58,6 +59,8 @@ options.register("dropNonMuonCollections", True, VarParsing.multiplicity.singlet
                  "Option to drop most non-muon collections generally considered unnecessary for GEM/CSC analysis")
 options.register("dqmOutputFile", "step_DQM.root", VarParsing.multiplicity.singleton, VarParsing.varType.string,
                  "Name of the DQM output file. Default: step_DQM.root")
+options.register("useGEMCSCAlignment", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True if you want to use alignment-corrected LUTs for the GEM-CSC bending angle correction in the CSCGEMMatcher.")
 options.parseArguments()
 
 process_era = Run3
@@ -79,6 +82,11 @@ process.load("CalibMuon.CSCCalibration.CSCL1TPLookupTableEP_cff")
 process.load('L1Trigger.L1TGEM.simGEMDigis_cff')
 process.load("DQM.L1TMonitor.L1TdeCSCTPG_cfi")
 process.load("DQM.L1TMonitor.L1TdeGEMTPG_cfi")
+
+
+if options.useGEMCSCAlignment:
+      process = set_6bit_gemcsc_bending_LUTs(process)
+
 
 process.maxEvents = cms.untracked.PSet(
       input = cms.untracked.int32(options.maxEvents)


### PR DESCRIPTION
#### PR description:

Following https://github.com/cms-sw/cmssw/pull/50116, this PR adds support for a 6-bit slope to the CSC OTMB emulator code. The default behavior remains unchanged (4-bit slope), and a customization function is provided to switch to the new format for R&D purposes. The changes are in line with the new proposed OTMB LCT data format discussed [here](https://indico.cern.ch/event/1491198/#sc-3-6-gem-csc-bending-angle-o). The changes to the unpacker are planned as a separate PR.

To test 6-bit customization, LUTs from https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives/pull/14 are required.

#### PR validation:

Private muon gun production to test that the default emulator behavior does not change, and when applying `set_6bit_gemcsc_bending_LUTs` customization function, `CSCCorrelatedLCTDigi` objects contain 6-bit slopes.
