### PR TITLE
TestObjects: Added missing dependency to fix the failing unit test

### DIFF
--- a/DataFormats/TestObjects/test/BuildFile.xml
+++ b/DataFormats/TestObjects/test/BuildFile.xml
@@ -1,4 +1,5 @@
 <bin file="Enum_t.cpp">
   <use name="catch2"/>
+  <use name="DataFormats/TestObjects"/>
   <use name="FWCore/Reflection"/>
 </bin>

--- a/DataFormats/TestObjects/test/BuildFile.xml
+++ b/DataFormats/TestObjects/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <bin file="Enum_t.cpp">
   <use name="catch2"/>
-  <use name="DataFormats/TestObjects"/>
   <use name="FWCore/Reflection"/>
 </bin>

--- a/DataFormats/TestObjects/test/BuildFile_extra.xml
+++ b/DataFormats/TestObjects/test/BuildFile_extra.xml
@@ -1,9 +1,11 @@
 <library file="" name="DataFormatsTestObjectsParent1">
   <flags LCG_DICT_HEADER="classes.h"/>
   <flags LCG_DICT_XML="classes_def_parent1.xml"/>
+  <use name="DataFormats/TestObjects"/>
 </library>
 
 <library file="" name="DataFormatsTestObjectsParent2">
   <flags LCG_DICT_HEADER="classes.h"/>
   <flags LCG_DICT_XML="classes_def_parent2.xml"/>
+  <use name="DataFormats/TestObjects"/>
 </library>


### PR DESCRIPTION
This should fix the failing unit test `TestIOPoolInputNoParentDictionary` in 16.1.X IBs. This PR proposes to add the missing dependency on `DataFormats/TestObjects` for the extra dictionaries build by the unit test.

This dependency was removed in https://github.com/cms-sw/cmssw/pull/50609 ( as a part of cleanup) but it was actually needed by the extra dictionaries build by the unit test. 

Local build and tests are successful
```
Creating test log file logs/el8_amd64_gcc13/testing.log
Pass    3s ... DataFormats/TestObjects/Enum_t
Pass    5s ... IOPool/Input/TestFileOpenErrorExitCode
Pass   47s ... IOPool/Input/TestIOPoolInputNoParentDictionary
Pass   10s ... IOPool/Input/TestIOPoolInputReducedProcessHistoryHardwareResources
Pass   30s ... IOPool/Input/TestIOPoolInputReducedProcessHistoryVersion
Pass    8s ... IOPool/Input/TestIOPoolInputRefProductIDMetadataConsistency
Pass    4s ... IOPool/Input/TestIOPoolInputRepeating
Pass   22s ... IOPool/Input/TestIOPoolInputSchemaEvolution
Pass   36s ... IOPool/Input/TestPoolInput
Pass    5s ... IOPool/Input/TestPoolInputMergeHeterogeneousFiles
Pass    3s ... IOPool/Input/TestPoolInputMultiLumi
Pass   74s ... IOPool/Input/TestPoolInputOldFormat
Pass    4s ... IOPool/Input/TestPoolInputOverlappingLumis
Pass   23s ... IOPool/Input/TestPoolInputRunPerLumi

```