### PR TITLE
SA: Ignore system header in FunctionChecker

### DIFF
--- a/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
@@ -73,7 +73,17 @@ namespace clangcms {
     if (support::isSafeClassName(D->getCanonicalDecl()->getQualifiedNameAsString()))
       return;
 
-    const char *sfile = BR.getSourceManager().getPresumedLoc(D->getLocation()).getFilename();
+    const auto &SM = BR.getSourceManager();
+
+    // Normalize to where the code is actually defined
+    clang::SourceLocation loc = SM.getSpellingLoc(D->getLocation());
+
+    // Ignore anything coming from system headers (via -isystem)
+    if (SM.isInSystemHeader(loc)) {
+      return;
+    }
+
+    const char *sfile = SM.getPresumedLoc(loc).getFilename();
     std::string fname(sfile);
     if (!support::isInterestingLocation(fname))
       return;


### PR DESCRIPTION
This PR proposes that we ignore code from system headers (e.g. inlined code) for `cms.FunctionChecker` . This should allow to not report warnings like following (coming from root headers)

- https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_16_1_X_2026-04-01-1100/el8_amd64_gcc13/build-logs/MuonAnalysis/MomentumScaleCalibration/log.html
```
In file included from src/MuonAnalysis/MomentumScaleCalibration/bin/MuScleFitTreeProvenance.cc:13:
  src/MuonAnalysis/MomentumScaleCalibration/interface/MuScleFitProvenance.h:18:3: warning: function 'MuScleFitProvenance::CheckTObjectHashConsistency' accesses or modifies non-const static member data variable 'fgHashConsistency'.
  [cms.FunctionChecker]
   18 |   ClassDef(MuScleFitProvenance, 1)
      |   ^
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/lcg/root/6.36.11-c9684ba7622be6ba003c6d1250a79c91/include/Rtypes.h:343:4: note: expanded from macro 'ClassDef'
  343 |    _ClassDefOutline_(name,id,virtual,)               \
      |    ^
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/lcg/root/6.36.11-c9684ba7622be6ba003c6d1250a79c91/include/Rtypes.h:309:4: note: expanded from macro '_ClassDefOutline_'
  309 |    _ClassDefBase_(name,id, virtual_keyword, overrd)                                                             \
      |    ^
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02935/el8_amd64_gcc13/lcg/root/6.36.11-c9684ba7622be6ba003c6d1250a79c91/include/Rtypes.h:284:17: note: expanded from macro '_ClassDefBase_'
  284 |          return ::ROOT::Internal::THashConsistencyHolder<decltype(*this)>::fgHashConsistency;                   \
      |                 ^
```