### PR TITLE
HD full module readout corrected

### DIFF
--- a/CondFormats/HGCalObjects/interface/HGCalConfiguration.h
+++ b/CondFormats/HGCalObjects/interface/HGCalConfiguration.h
@@ -10,7 +10,7 @@
 // @short configuration for ECON eRX (one half of HGROC)
 struct HGCalROCConfig {
   uint32_t charMode;  // characterization mode; determines data fields in ROC dataframe
-  uint32_t muxMode;  // multiplexing mode; determines routing of eRx between the ROCs and ECON-Ds
+  uint32_t muxMode;   // multiplexing mode; determines routing of eRx between the ROCs and ECON-Ds
   COND_SERIALIZABLE;
 };
 

--- a/CondFormats/HGCalObjects/interface/HGCalConfiguration.h
+++ b/CondFormats/HGCalObjects/interface/HGCalConfiguration.h
@@ -10,6 +10,7 @@
 // @short configuration for ECON eRX (one half of HGROC)
 struct HGCalROCConfig {
   uint32_t charMode;  // characterization mode; determines data fields in ROC dataframe
+  uint32_t muxMode;  // multiplexing mode; determines routing of eRx between the ROCs and ECON-Ds
   COND_SERIALIZABLE;
 };
 

--- a/CondFormats/HGCalObjects/interface/HGCalConfiguration.h
+++ b/CondFormats/HGCalObjects/interface/HGCalConfiguration.h
@@ -10,7 +10,7 @@
 // @short configuration for ECON eRX (one half of HGROC)
 struct HGCalROCConfig {
   uint32_t charMode;  // characterization mode; determines data fields in ROC dataframe
-  int32_t muxMode;   // multiplexing mode; determines routing of eRx between the ROCs and ECON-Ds
+  int32_t muxMode;    // multiplexing mode; determines routing of eRx between the ROCs and ECON-Ds
   COND_SERIALIZABLE;
 };
 

--- a/CondFormats/HGCalObjects/interface/HGCalConfiguration.h
+++ b/CondFormats/HGCalObjects/interface/HGCalConfiguration.h
@@ -10,7 +10,7 @@
 // @short configuration for ECON eRX (one half of HGROC)
 struct HGCalROCConfig {
   uint32_t charMode;  // characterization mode; determines data fields in ROC dataframe
-  uint32_t muxMode;   // multiplexing mode; determines routing of eRx between the ROCs and ECON-Ds
+  int32_t muxMode;   // multiplexing mode; determines routing of eRx between the ROCs and ECON-Ds
   COND_SERIALIZABLE;
 };
 

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -324,12 +324,11 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
                                       << erxHeader << ", cmSum = " << std::dec << cmSum;
           iword += 2;
 
-	  const auto mux    = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
+          const auto mux = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
+          uint32_t delta = (mux - erxIdx) * 37;
           // parse erx body (channel data)
           uint32_t iBit = 0;
           for (uint32_t channelIdx = 0; channelIdx < HGCalMappingCellIndexer::maxChPerErx_; channelIdx++) {
-            
-	    uint32_t delta =  (mux - erxIdx)*37;
             uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx) + delta;
 
             // check if the channel has data
@@ -399,12 +398,11 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
                                       << erxHeader << ", cmSum = " << std::dec << cmSum;
           iword += 2;
 
-	  const auto mux    = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
+          const auto mux = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
+          uint32_t delta = (mux - erxIdx) * 37;
 
           // parse erx body (channel data)
           for (uint32_t channelIdx = 0; channelIdx < HGCalMappingCellIndexer::maxChPerErx_; channelIdx++) {
-
-	    uint32_t delta =  (mux - erxIdx)*37;
             uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx) + delta;
 
             // check if the channel has data

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -324,10 +324,13 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
                                       << erxHeader << ", cmSum = " << std::dec << cmSum;
           iword += 2;
 
+	  const auto mux    = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
           // parse erx body (channel data)
           uint32_t iBit = 0;
           for (uint32_t channelIdx = 0; channelIdx < HGCalMappingCellIndexer::maxChPerErx_; channelIdx++) {
-            uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx);
+            
+	    uint32_t delta =  (mux - erxIdx)*37;
+            uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx) + delta;
 
             // check if the channel has data
             if (((erxHeader >> channelIdx) & 1) == 0) {
@@ -396,9 +399,13 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
                                       << erxHeader << ", cmSum = " << std::dec << cmSum;
           iword += 2;
 
+	  const auto mux    = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
+
           // parse erx body (channel data)
           for (uint32_t channelIdx = 0; channelIdx < HGCalMappingCellIndexer::maxChPerErx_; channelIdx++) {
-            uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx);
+
+	    uint32_t delta =  (mux - erxIdx)*37;
+            uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx) + delta;
 
             // check if the channel has data
             if (((erxHeader >> channelIdx) & 1) == 0) {

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -325,7 +325,7 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
           iword += 2;
 
           const int32_t mux = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
-          int32_t delta = (mux == -1) ? 0 : (mux - erxIdx) * 37;
+          int32_t delta = (mux == -1) ? 0 : (mux - static_cast<int>(erxIdx)) * 37;
 
           // parse erx body (channel data)
           uint32_t iBit = 0;
@@ -399,7 +399,7 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
           iword += 2;
 
           const int32_t mux = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
-          int32_t delta = (mux == -1) ? 0 : (mux - erxIdx) * 37;
+          int32_t delta = (mux == -1) ? 0 : (mux - static_cast<int>(erxIdx)) * 37;
 
           // parse erx body (channel data)
           for (uint32_t channelIdx = 0; channelIdx < HGCalMappingCellIndexer::maxChPerErx_; channelIdx++) {

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -324,8 +324,8 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
                                       << erxHeader << ", cmSum = " << std::dec << cmSum;
           iword += 2;
 
-          const auto mux = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
-          int32_t delta = (static_cast<int>(mux) == -1) ? 0 : (static_cast<int>(mux) - static_cast<int>(erxIdx)) * 37;
+          const int32_t mux = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
+          int32_t delta = (mux == -1) ? 0 : (mux - erxIdx) * 37;
 
           // parse erx body (channel data)
           uint32_t iBit = 0;
@@ -398,8 +398,8 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
                                       << erxHeader << ", cmSum = " << std::dec << cmSum;
           iword += 2;
 
-          const auto mux = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
-          int32_t delta = (static_cast<int>(mux) == -1) ? 0 : (static_cast<int>(mux) - static_cast<int>(erxIdx)) * 37;
+          const int32_t mux = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
+          int32_t delta = (mux == -1) ? 0 : (mux - erxIdx) * 37;
 
           // parse erx body (channel data)
           for (uint32_t channelIdx = 0; channelIdx < HGCalMappingCellIndexer::maxChPerErx_; channelIdx++) {

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -325,9 +325,9 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
           iword += 2;
 
           const auto mux = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
-	  int32_t delta = (static_cast<int>(mux) == -1) ? 0 : (static_cast<int>(mux) - static_cast<int>(erxIdx)) * 37;
+          int32_t delta = (static_cast<int>(mux) == -1) ? 0 : (static_cast<int>(mux) - static_cast<int>(erxIdx)) * 37;
 
-	  // parse erx body (channel data)
+          // parse erx body (channel data)
           uint32_t iBit = 0;
           for (uint32_t channelIdx = 0; channelIdx < HGCalMappingCellIndexer::maxChPerErx_; channelIdx++) {
             uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx) + delta;
@@ -400,8 +400,8 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
 
           const auto mux = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
           int32_t delta = (static_cast<int>(mux) == -1) ? 0 : (static_cast<int>(mux) - static_cast<int>(erxIdx)) * 37;
-	  
-	  // parse erx body (channel data)
+
+          // parse erx body (channel data)
           for (uint32_t channelIdx = 0; channelIdx < HGCalMappingCellIndexer::maxChPerErx_; channelIdx++) {
             uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx) + delta;
             // check if the channel has data

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -325,12 +325,12 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
           iword += 2;
 
           const auto mux = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
-          uint32_t delta = (mux - erxIdx) * 37;
-          // parse erx body (channel data)
+	  int32_t delta = (static_cast<int>(mux) == -1) ? 0 : (static_cast<int>(mux) - static_cast<int>(erxIdx)) * 37;
+
+	  // parse erx body (channel data)
           uint32_t iBit = 0;
           for (uint32_t channelIdx = 0; channelIdx < HGCalMappingCellIndexer::maxChPerErx_; channelIdx++) {
             uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx) + delta;
-
             // check if the channel has data
             if (((erxHeader >> channelIdx) & 1) == 0) {
               continue;
@@ -399,17 +399,15 @@ uint16_t HGCalUnpacker::parseFEDData(unsigned fedId,
           iword += 2;
 
           const auto mux = fedConfig.econds[globalECONDIdx].rocs[erxIdx].muxMode;
-          uint32_t delta = (mux - erxIdx) * 37;
-
-          // parse erx body (channel data)
+          int32_t delta = (static_cast<int>(mux) == -1) ? 0 : (static_cast<int>(mux) - static_cast<int>(erxIdx)) * 37;
+	  
+	  // parse erx body (channel data)
           for (uint32_t channelIdx = 0; channelIdx < HGCalMappingCellIndexer::maxChPerErx_; channelIdx++) {
             uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx) + delta;
-
             // check if the channel has data
             if (((erxHeader >> channelIdx) & 1) == 0) {
               continue;
             }
-
             // check if in characterization mode
             if (fedConfig.econds[globalECONDIdx].rocs[erxIdx / 2].charMode) {
               //characterization mode

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
@@ -87,7 +87,7 @@ public:
     uint32_t nfeds = moduleMap.numFEDs();
     uint32_t ntot_mods = 0, ntot_rocs = 0;
     const std::vector<std::string> fedkeys = {"mismatchPassthroughMode", "cbHeaderMarker", "slinkHeaderMarker"};
-    const std::vector<std::string> modkeys = {"headerMarker", "CalibrationSC"};
+    const std::vector<std::string> modkeys = {"headerMarker", "CalibrationSC" , "MultiPlex"};
     if (nfeds != fed_config_data.size())
       edm::LogWarning("HGCalConfigurationESProducer")
           << "Total number of FEDs found in JSON file " << fedjsonurl << " (" << fed_config_data.size()
@@ -157,6 +157,7 @@ public:
           ntot_rocs++;
           HGCalROCConfig roc;
           roc.charMode = getint(mod_config_data[modkey]["CalibrationSC"][iroc], charMode_);
+	  roc.muxMode  = getint(mod_config_data[modkey]["MultiPlex"][iroc],-1);
           mod.rocs[iroc] = roc;  // add to ECON-D's vector<HGCalROCConfig> of eRx half-ROCs
         }
         fed.econds[imod] = mod;  // add to FED's vector<HGCalECONDConfig> of ECON-D modules

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
@@ -87,7 +87,7 @@ public:
     uint32_t nfeds = moduleMap.numFEDs();
     uint32_t ntot_mods = 0, ntot_rocs = 0;
     const std::vector<std::string> fedkeys = {"mismatchPassthroughMode", "cbHeaderMarker", "slinkHeaderMarker"};
-    const std::vector<std::string> modkeys = {"headerMarker", "CalibrationSC" , "MultiPlex"};
+    const std::vector<std::string> modkeys = {"headerMarker", "CalibrationSC", "MultiPlex"};
     if (nfeds != fed_config_data.size())
       edm::LogWarning("HGCalConfigurationESProducer")
           << "Total number of FEDs found in JSON file " << fedjsonurl << " (" << fed_config_data.size()
@@ -157,7 +157,7 @@ public:
           ntot_rocs++;
           HGCalROCConfig roc;
           roc.charMode = getint(mod_config_data[modkey]["CalibrationSC"][iroc], charMode_);
-	  roc.muxMode  = getint(mod_config_data[modkey]["MultiPlex"][iroc],-1);
+          roc.muxMode = getint(mod_config_data[modkey]["MultiPlex"][iroc], -1);
           mod.rocs[iroc] = roc;  // add to ECON-D's vector<HGCalROCConfig> of eRx half-ROCs
         }
         fed.econds[imod] = mod;  // add to FED's vector<HGCalECONDConfig> of ECON-D modules

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
@@ -25,9 +25,9 @@
 class HGCalConfigurationESProducer : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   explicit HGCalConfigurationESProducer(const edm::ParameterSet& iConfig)
-      :  //edm::ESProducer(iConfig),
-        fedjson_(iConfig.getParameter<edm::FileInPath>("fedjson")),
-        modjson_(iConfig.getParameter<edm::FileInPath>("modjson")) {
+    :  //edm::ESProducer(iConfig),
+    fedjson_(iConfig.getParameter<edm::FileInPath>("fedjson")),
+    modjson_(iConfig.getParameter<edm::FileInPath>("modjson")) {
     if (iConfig.exists("bePassthroughMode"))
       bePassthroughMode_ = iConfig.getParameter<int32_t>("bePassthroughMode");
     if (iConfig.exists("cbHeaderMarker"))
@@ -45,17 +45,17 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     desc.add<edm::ESInputTag>("indexSource", edm::ESInputTag(""))
-        ->setComment("Label for module indexer to set SoA size");
+      ->setComment("Label for module indexer to set SoA size");
     desc.add<edm::FileInPath>("fedjson")->setComment("JSON file with FED configuration parameters");
     desc.add<edm::FileInPath>("modjson")->setComment("JSON file with ECOND configuration parameters");
     desc.addOptional<int32_t>("bePassthroughMode", -1)
-        ->setComment("Manual override for mismatch passthrough mode in the BE");
+      ->setComment("Manual override for mismatch passthrough mode in the BE");
     desc.addOptional<int32_t>("cbHeaderMarker", -1)
-        ->setComment("Manual override for capture block header marker (BEO, e.g 0x7f)");
+      ->setComment("Manual override for capture block header marker (BEO, e.g 0x7f)");
     desc.addOptional<int32_t>("slinkHeaderMarker", -1)
-        ->setComment("Manual override for S-link header marker (BEO, e.g 0x55)");
+      ->setComment("Manual override for S-link header marker (BEO, e.g 0x55)");
     desc.addOptional<int32_t>("econdHeaderMarker", -1)
-        ->setComment("Manual override for ECON-D header marker (BEO, e.g 0x154)");
+      ->setComment("Manual override for ECON-D header marker (BEO, e.g 0x154)");
     desc.addOptional<int32_t>("charMode", -1)->setComment("Manual override for ROC characterization mode");
     descriptions.addWithDefaultLabel(desc);
   }
@@ -73,7 +73,7 @@ public:
   std::unique_ptr<HGCalConfiguration> produce(const HGCalModuleConfigurationRcd& iRecord) {
     auto const& moduleMap = iRecord.get(indexToken_);
     edm::LogInfo("HGCalConfigurationESProducer")
-        << "produce: fedjson_=" << fedjson_ << ",\n         modjson_=" << modjson_;
+      << "produce: fedjson_=" << fedjson_ << ",\n         modjson_=" << modjson_;
 
     // retrieve values from custom JSON format (see HGCalCalibrationESProducer)
     std::string fedjsonurl(fedjson_.fullPath());
@@ -87,11 +87,11 @@ public:
     uint32_t nfeds = moduleMap.numFEDs();
     uint32_t ntot_mods = 0, ntot_rocs = 0;
     const std::vector<std::string> fedkeys = {"mismatchPassthroughMode", "cbHeaderMarker", "slinkHeaderMarker"};
-    const std::vector<std::string> modkeys = {"headerMarker", "CalibrationSC", "MultiPlex"};
+    const std::vector<std::string> modkeys = {"headerMarker", "CalibrationSC"};
     if (nfeds != fed_config_data.size())
       edm::LogWarning("HGCalConfigurationESProducer")
-          << "Total number of FEDs found in JSON file " << fedjsonurl << " (" << fed_config_data.size()
-          << ") does not match indexer (" << nfeds << ")";
+	<< "Total number of FEDs found in JSON file " << fedjsonurl << " (" << fed_config_data.size()
+	<< ") does not match indexer (" << nfeds << ")";
 
     // loop over FEDs in indexer & fill configuration structs: FED > ECON-D > eRx
     // follow indexing by HGCalMappingModuleIndexer
@@ -104,7 +104,7 @@ public:
         continue;                                                                    // skip non-existent FED
       const auto fedkey = hgcal::search_fedkey(fedid, fed_config_data, fedjsonurl);  // search matching key
       hgcal::check_keys(
-          fed_config_data, fedkey, fedkeys, fedjsonurl);  // check required keys are in the JSON, warn otherwise
+			fed_config_data, fedkey, fedkeys, fedjsonurl);  // check required keys are in the JSON, warn otherwise
 
       // fill FED configurations
       HGCalFedConfig fed;
@@ -125,8 +125,16 @@ public:
         ntot_mods++;
         const auto modkey = hgcal::search_modkey(typecode, mod_config_data, modjsonurl);  // search matching key
         hgcal::check_keys(
-            mod_config_data, modkey, modkeys, modjsonurl);  // check required keys are in the JSON, warn otherwise
-        if (imod >= fed.econds.size())
+			  mod_config_data, modkey, modkeys, modjsonurl);  // check required keys are in the JSON, warn otherwise
+       
+	if (mod_config_data[modkey].count("MultiPlex") == 0) {
+	  edm::LogWarning("HGCalConfigurationESProducer")
+	    << "Missing MultiPlex key for module " << typecode
+	    << " in " << modjsonurl
+	    << ". Setting muxMode = -1 for all ROCs.";
+	}
+
+       	if (imod >= fed.econds.size())
           fed.econds.resize(imod + 1);
 
         // fill ECON-D configuration
@@ -139,9 +147,9 @@ public:
         uint32_t nrocs2 = mod_config_data[modkey]["CalibrationSC"].size();
         if (nrocs != nrocs2)
           edm::LogWarning("HGCalConfigurationESProducer")
-              << " Number of eRx ROCs for ECON-D " << typecode << " in " << fedjsonurl << " (" << nrocs2
-              << ") does not match that of the indexer for fedid" << fedid << " & imod=" << imod << " (" << nrocs
-              << ")!";
+	    << " Number of eRx ROCs for ECON-D " << typecode << " in " << fedjsonurl << " (" << nrocs2
+	    << ") does not match that of the indexer for fedid" << fedid << " & imod=" << imod << " (" << nrocs
+	    << ")!";
         mod.rocs.resize(nrocs);
 
         //by default are enabled except if configured otherwise
@@ -157,7 +165,11 @@ public:
           ntot_rocs++;
           HGCalROCConfig roc;
           roc.charMode = getint(mod_config_data[modkey]["CalibrationSC"][iroc], charMode_);
-          roc.muxMode = getint(mod_config_data[modkey]["MultiPlex"][iroc], -1);
+          roc.muxMode = -1;
+	  if (mod_config_data[modkey].count("MultiPlex") > 0 &&
+	      iroc < mod_config_data[modkey]["MultiPlex"].size()) {
+	    roc.muxMode = getint(mod_config_data[modkey]["MultiPlex"][iroc], -1);
+	  }
           mod.rocs[iroc] = roc;  // add to ECON-D's vector<HGCalROCConfig> of eRx half-ROCs
         }
         fed.econds[imod] = mod;  // add to FED's vector<HGCalECONDConfig> of ECON-D modules
@@ -169,12 +181,12 @@ public:
     // consistency check
     if (ntot_mods != moduleMap.maxModulesCount())
       edm::LogWarning("HGCalConfigurationESProducer")
-          << "Total number of ECON-D modules found in JSON file " << modjson_ << " (" << ntot_mods
-          << ") does not match indexer (" << moduleMap.maxModulesCount() << ")";
+	<< "Total number of ECON-D modules found in JSON file " << modjson_ << " (" << ntot_mods
+	<< ") does not match indexer (" << moduleMap.maxModulesCount() << ")";
     if (ntot_rocs != moduleMap.maxERxSize())
       edm::LogWarning("HGCalConfigurationESProducer")
-          << "Total number of eRx half-ROCs found in JSON file " << modjson_ << " (" << ntot_rocs
-          << ") does not match indexer (" << moduleMap.maxERxSize() << ")";
+	<< "Total number of eRx half-ROCs found in JSON file " << modjson_ << " (" << ntot_rocs
+	<< ") does not match indexer (" << moduleMap.maxERxSize() << ")";
 
     return config_;
   }  // end of produce()

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/HGCalConfigurationESProducer.cc
@@ -25,9 +25,9 @@
 class HGCalConfigurationESProducer : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   explicit HGCalConfigurationESProducer(const edm::ParameterSet& iConfig)
-    :  //edm::ESProducer(iConfig),
-    fedjson_(iConfig.getParameter<edm::FileInPath>("fedjson")),
-    modjson_(iConfig.getParameter<edm::FileInPath>("modjson")) {
+      :  //edm::ESProducer(iConfig),
+        fedjson_(iConfig.getParameter<edm::FileInPath>("fedjson")),
+        modjson_(iConfig.getParameter<edm::FileInPath>("modjson")) {
     if (iConfig.exists("bePassthroughMode"))
       bePassthroughMode_ = iConfig.getParameter<int32_t>("bePassthroughMode");
     if (iConfig.exists("cbHeaderMarker"))
@@ -45,17 +45,17 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     desc.add<edm::ESInputTag>("indexSource", edm::ESInputTag(""))
-      ->setComment("Label for module indexer to set SoA size");
+        ->setComment("Label for module indexer to set SoA size");
     desc.add<edm::FileInPath>("fedjson")->setComment("JSON file with FED configuration parameters");
     desc.add<edm::FileInPath>("modjson")->setComment("JSON file with ECOND configuration parameters");
     desc.addOptional<int32_t>("bePassthroughMode", -1)
-      ->setComment("Manual override for mismatch passthrough mode in the BE");
+        ->setComment("Manual override for mismatch passthrough mode in the BE");
     desc.addOptional<int32_t>("cbHeaderMarker", -1)
-      ->setComment("Manual override for capture block header marker (BEO, e.g 0x7f)");
+        ->setComment("Manual override for capture block header marker (BEO, e.g 0x7f)");
     desc.addOptional<int32_t>("slinkHeaderMarker", -1)
-      ->setComment("Manual override for S-link header marker (BEO, e.g 0x55)");
+        ->setComment("Manual override for S-link header marker (BEO, e.g 0x55)");
     desc.addOptional<int32_t>("econdHeaderMarker", -1)
-      ->setComment("Manual override for ECON-D header marker (BEO, e.g 0x154)");
+        ->setComment("Manual override for ECON-D header marker (BEO, e.g 0x154)");
     desc.addOptional<int32_t>("charMode", -1)->setComment("Manual override for ROC characterization mode");
     descriptions.addWithDefaultLabel(desc);
   }
@@ -73,7 +73,7 @@ public:
   std::unique_ptr<HGCalConfiguration> produce(const HGCalModuleConfigurationRcd& iRecord) {
     auto const& moduleMap = iRecord.get(indexToken_);
     edm::LogInfo("HGCalConfigurationESProducer")
-      << "produce: fedjson_=" << fedjson_ << ",\n         modjson_=" << modjson_;
+        << "produce: fedjson_=" << fedjson_ << ",\n         modjson_=" << modjson_;
 
     // retrieve values from custom JSON format (see HGCalCalibrationESProducer)
     std::string fedjsonurl(fedjson_.fullPath());
@@ -90,8 +90,8 @@ public:
     const std::vector<std::string> modkeys = {"headerMarker", "CalibrationSC"};
     if (nfeds != fed_config_data.size())
       edm::LogWarning("HGCalConfigurationESProducer")
-	<< "Total number of FEDs found in JSON file " << fedjsonurl << " (" << fed_config_data.size()
-	<< ") does not match indexer (" << nfeds << ")";
+          << "Total number of FEDs found in JSON file " << fedjsonurl << " (" << fed_config_data.size()
+          << ") does not match indexer (" << nfeds << ")";
 
     // loop over FEDs in indexer & fill configuration structs: FED > ECON-D > eRx
     // follow indexing by HGCalMappingModuleIndexer
@@ -104,7 +104,7 @@ public:
         continue;                                                                    // skip non-existent FED
       const auto fedkey = hgcal::search_fedkey(fedid, fed_config_data, fedjsonurl);  // search matching key
       hgcal::check_keys(
-			fed_config_data, fedkey, fedkeys, fedjsonurl);  // check required keys are in the JSON, warn otherwise
+          fed_config_data, fedkey, fedkeys, fedjsonurl);  // check required keys are in the JSON, warn otherwise
 
       // fill FED configurations
       HGCalFedConfig fed;
@@ -125,16 +125,14 @@ public:
         ntot_mods++;
         const auto modkey = hgcal::search_modkey(typecode, mod_config_data, modjsonurl);  // search matching key
         hgcal::check_keys(
-			  mod_config_data, modkey, modkeys, modjsonurl);  // check required keys are in the JSON, warn otherwise
-       
-	if (mod_config_data[modkey].count("MultiPlex") == 0) {
-	  edm::LogWarning("HGCalConfigurationESProducer")
-	    << "Missing MultiPlex key for module " << typecode
-	    << " in " << modjsonurl
-	    << ". Setting muxMode = -1 for all ROCs.";
-	}
+            mod_config_data, modkey, modkeys, modjsonurl);  // check required keys are in the JSON, warn otherwise
 
-       	if (imod >= fed.econds.size())
+        if (mod_config_data[modkey].count("MultiPlex") == 0) {
+          edm::LogWarning("HGCalConfigurationESProducer") << "Missing MultiPlex key for module " << typecode << " in "
+                                                          << modjsonurl << ". Setting muxMode = -1 for all ROCs.";
+        }
+
+        if (imod >= fed.econds.size())
           fed.econds.resize(imod + 1);
 
         // fill ECON-D configuration
@@ -147,9 +145,9 @@ public:
         uint32_t nrocs2 = mod_config_data[modkey]["CalibrationSC"].size();
         if (nrocs != nrocs2)
           edm::LogWarning("HGCalConfigurationESProducer")
-	    << " Number of eRx ROCs for ECON-D " << typecode << " in " << fedjsonurl << " (" << nrocs2
-	    << ") does not match that of the indexer for fedid" << fedid << " & imod=" << imod << " (" << nrocs
-	    << ")!";
+              << " Number of eRx ROCs for ECON-D " << typecode << " in " << fedjsonurl << " (" << nrocs2
+              << ") does not match that of the indexer for fedid" << fedid << " & imod=" << imod << " (" << nrocs
+              << ")!";
         mod.rocs.resize(nrocs);
 
         //by default are enabled except if configured otherwise
@@ -166,10 +164,9 @@ public:
           HGCalROCConfig roc;
           roc.charMode = getint(mod_config_data[modkey]["CalibrationSC"][iroc], charMode_);
           roc.muxMode = -1;
-	  if (mod_config_data[modkey].count("MultiPlex") > 0 &&
-	      iroc < mod_config_data[modkey]["MultiPlex"].size()) {
-	    roc.muxMode = getint(mod_config_data[modkey]["MultiPlex"][iroc], -1);
-	  }
+          if (mod_config_data[modkey].count("MultiPlex") > 0 && iroc < mod_config_data[modkey]["MultiPlex"].size()) {
+            roc.muxMode = getint(mod_config_data[modkey]["MultiPlex"][iroc], -1);
+          }
           mod.rocs[iroc] = roc;  // add to ECON-D's vector<HGCalROCConfig> of eRx half-ROCs
         }
         fed.econds[imod] = mod;  // add to FED's vector<HGCalECONDConfig> of ECON-D modules
@@ -181,12 +178,12 @@ public:
     // consistency check
     if (ntot_mods != moduleMap.maxModulesCount())
       edm::LogWarning("HGCalConfigurationESProducer")
-	<< "Total number of ECON-D modules found in JSON file " << modjson_ << " (" << ntot_mods
-	<< ") does not match indexer (" << moduleMap.maxModulesCount() << ")";
+          << "Total number of ECON-D modules found in JSON file " << modjson_ << " (" << ntot_mods
+          << ") does not match indexer (" << moduleMap.maxModulesCount() << ")";
     if (ntot_rocs != moduleMap.maxERxSize())
       edm::LogWarning("HGCalConfigurationESProducer")
-	<< "Total number of eRx half-ROCs found in JSON file " << modjson_ << " (" << ntot_rocs
-	<< ") does not match indexer (" << moduleMap.maxERxSize() << ")";
+          << "Total number of eRx half-ROCs found in JSON file " << modjson_ << " (" << ntot_rocs
+          << ") does not match indexer (" << moduleMap.maxERxSize() << ")";
 
     return config_;
   }  // end of produce()


### PR DESCRIPTION
#### PR description:

This PR updates the unpacking of HD full module ECON-D data by adding the offset of +/- 37 indices. 
The following changes were made. 
- `muxMode` field is introduced in`HGCalROCConfig` in `HGCalConfiguration.h` 
- It was populated from the JSON `MultiPlex` configuration file in `HGCalConfigurationESProducer`
- In `HGCalUnpacker`, the dense channel index is shifted by `(muxMode - erxIdx) * 37`, so channel data are unpacked into the correct routing position. 

**Link to the issue created on HGCAL-DPG**
https://gitlab.cern.ch/hgcal-dpg/hgcal-comm/-/issues/84

#### PR validation:
Plot shows the run taken with fixed ADC for one of the high density module and   appears reasonable. 
<img width="1123" height="726" alt="Screenshot from 2026-04-02 13-34-27" src="https://github.com/user-attachments/assets/bbff3d8c-186e-44a3-b105-389f9564c0b9" />

assign hgcal-dpg
