### PR TITLE
Moved FWCore/PluginManager tests to catch2

### DIFF
--- a/FWCore/PluginManager/test/BuildFile.xml
+++ b/FWCore/PluginManager/test/BuildFile.xml
@@ -1,25 +1,25 @@
 <bin name="TestFWCorePluginManagerPluginFactoryManager" file="pluginfactorymanager_t.cc">
   <use name="boost"/>
-  <use name="cppunit"/>
+  <use name="catch2"/>
   <use name="FWCore/PluginManager"/>
 </bin>
 
 <bin name="TestFWCorePluginManagerPluginManager" file="pluginmanager_t.cc">
   <use name="boost"/>
-  <use name="cppunit"/>
+  <use name="catch2"/>
   <use name="FWCore/PluginManager"/>
   <lib name="TestFWCorePluginManagerDummyFactory"/>
 </bin>
 
 <bin name="TestFWCorePluginManagerCacheParser" file="cacheparser_t.cc">
   <use name="boost"/>
-  <use name="cppunit"/>
+  <use name="catch2"/>
   <use name="FWCore/PluginManager"/>
 </bin>
 
 <bin name="TestFWCorePluginManagerPluginFactory" file="pluginfactory_t.cc">
   <use name="boost"/>
-  <use name="cppunit"/>
+  <use name="catch2"/>
   <use name="FWCore/PluginManager"/>
 </bin>
 

--- a/FWCore/PluginManager/test/cacheparser_t.cc
+++ b/FWCore/PluginManager/test/cacheparser_t.cc
@@ -11,92 +11,90 @@
 //
 
 // system include files
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
-#include <cppunit/extensions/HelperMacros.h>
+#include "catch2/catch_all.hpp"
 #include <iostream>
 #include <sstream>
 
 // user include files
 #include "FWCore/PluginManager/interface/CacheParser.h"
-
-class TestCacheParser : public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(TestCacheParser);
-  CPPUNIT_TEST(testSpace);
-  CPPUNIT_TEST(testReadWrite);
-  CPPUNIT_TEST_SUITE_END();
-
+class TestCacheParser {
 public:
-  void testSpace();
-  void testReadWrite();
-  void setUp() {}
-  void tearDown() {}
+  static std::string replaceSpaces(std::string& iString) { return edmplugin::CacheParser::replaceSpaces(iString); }
+  static std::string restoreSpaces(std::string& iString) { return edmplugin::CacheParser::restoreSpaces(iString); }
+  static void write(const std::map<std::string, std::vector<edmplugin::PluginInfo> >& iIn, std::ostream& oOut) {
+    edmplugin::CacheParser::write(iIn, oOut);
+  }
+  static void read(std::istream& iIn,
+                   const std::filesystem::path& iDirectory,
+                   std::map<std::string, std::vector<edmplugin::PluginInfo> >& oOut) {
+    edmplugin::CacheParser::read(iIn, iDirectory, oOut);
+  }
 };
 
-///registration of the test so that the runner can find it
-CPPUNIT_TEST_SUITE_REGISTRATION(TestCacheParser);
+TEST_CASE("CacheParser", "[PluginManager]") {
+  SECTION("space") {
+    using namespace edmplugin;
 
-void TestCacheParser::testSpace() {
-  using namespace edmplugin;
+    const std::string kNoSpace("abcDefla");
+    std::string unchanged(kNoSpace);
 
-  const std::string kNoSpace("abcDefla");
-  std::string unchanged(kNoSpace);
+    REQUIRE(kNoSpace == TestCacheParser::replaceSpaces(unchanged));
+    REQUIRE(kNoSpace == unchanged);
+    REQUIRE(kNoSpace == TestCacheParser::restoreSpaces(unchanged));
+    REQUIRE(kNoSpace == unchanged);
 
-  CPPUNIT_ASSERT(kNoSpace == CacheParser::replaceSpaces(unchanged));
-  CPPUNIT_ASSERT(kNoSpace == unchanged);
-  CPPUNIT_ASSERT(kNoSpace == CacheParser::restoreSpaces(unchanged));
-  CPPUNIT_ASSERT(kNoSpace == unchanged);
+    const std::string kWithSpace("abc Def");
+    std::string changed(kWithSpace);
 
-  const std::string kWithSpace("abc Def");
-  std::string changed(kWithSpace);
+    const std::string kSpaceReplaced("abc%Def");
+    REQUIRE(kSpaceReplaced == TestCacheParser::replaceSpaces(changed));
+    REQUIRE(kSpaceReplaced == changed);
 
-  const std::string kSpaceReplaced("abc%Def");
-  CPPUNIT_ASSERT(kSpaceReplaced == CacheParser::replaceSpaces(changed));
-  CPPUNIT_ASSERT(kSpaceReplaced == changed);
-
-  CPPUNIT_ASSERT(kWithSpace == CacheParser::restoreSpaces(changed));
-  CPPUNIT_ASSERT(kWithSpace == changed);
-}
-
-void TestCacheParser::testReadWrite() {
-  using namespace edmplugin;
-  std::map<std::string, std::vector<PluginInfo> > categoryToInfos;
-  PluginInfo info;
-  info.loadable_ = "pluginA.so";
-  info.name_ = "AlphaClass";
-  categoryToInfos["Cat One"].push_back(info);
-  info.name_ = "BetaClass<Itl >";
-  categoryToInfos["Cat Two"].push_back(info);
-
-  const std::string match("pluginA.so AlphaClass Cat%One\npluginA.so BetaClass<Itl%> Cat%Two\n");
-  {
-    std::stringstream ss;
-    CacheParser::write(categoryToInfos, ss);
-    CPPUNIT_ASSERT(match == ss.str());
+    REQUIRE(kWithSpace == TestCacheParser::restoreSpaces(changed));
+    REQUIRE(kWithSpace == changed);
   }
 
-  //check that the path is removed
-  categoryToInfos.clear();
+  SECTION("readWrite") {
+    using namespace edmplugin;
+    std::map<std::string, std::vector<PluginInfo> > categoryToInfos;
+    PluginInfo info;
+    info.loadable_ = "pluginA.so";
+    info.name_ = "AlphaClass";
+    categoryToInfos["Cat One"].push_back(info);
+    info.name_ = "BetaClass<Itl >";
+    categoryToInfos["Cat Two"].push_back(info);
 
-  info.loadable_ = "/enee/menee/minee/mo/pluginA.so";
-  info.name_ = "AlphaClass";
-  categoryToInfos["Cat One"].push_back(info);
-  info.name_ = "BetaClass<Itl >";
-  categoryToInfos["Cat Two"].push_back(info);
+    const std::string match("pluginA.so AlphaClass Cat%One\npluginA.so BetaClass<Itl%> Cat%Two\n");
+    {
+      std::stringstream ss;
+      TestCacheParser::write(categoryToInfos, ss);
+      REQUIRE(match == ss.str());
+    }
 
-  {
-    std::stringstream ss;
-    CacheParser::write(categoryToInfos, ss);
-    CPPUNIT_ASSERT(match == ss.str());
+    //check that the path is removed
+    categoryToInfos.clear();
 
-    std::map<std::string, std::vector<PluginInfo> > readValues;
-    CacheParser::read(ss, "/enee/menee/minee/mo", readValues);
-    CPPUNIT_ASSERT(categoryToInfos.size() == readValues.size());
+    info.loadable_ = "/enee/menee/minee/mo/pluginA.so";
+    info.name_ = "AlphaClass";
+    categoryToInfos["Cat One"].push_back(info);
+    info.name_ = "BetaClass<Itl >";
+    categoryToInfos["Cat Two"].push_back(info);
 
     {
-      std::stringstream ssFinalWrite;
-      CacheParser::write(readValues, ssFinalWrite);
-      std::cout << ssFinalWrite.str() << std::endl;
-      CPPUNIT_ASSERT(match == ssFinalWrite.str());
+      std::stringstream ss;
+      TestCacheParser::write(categoryToInfos, ss);
+      REQUIRE(match == ss.str());
+
+      std::map<std::string, std::vector<PluginInfo> > readValues;
+      TestCacheParser::read(ss, "/enee/menee/minee/mo", readValues);
+      REQUIRE(categoryToInfos.size() == readValues.size());
+
+      {
+        std::stringstream ssFinalWrite;
+        TestCacheParser::write(readValues, ssFinalWrite);
+        std::cout << ssFinalWrite.str() << std::endl;
+        REQUIRE(match == ssFinalWrite.str());
+      }
     }
   }
 }

--- a/FWCore/PluginManager/test/pluginfactory_t.cc
+++ b/FWCore/PluginManager/test/pluginfactory_t.cc
@@ -11,8 +11,7 @@
 //
 
 // system include files
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
-#include <cppunit/extensions/HelperMacros.h>
+#include "catch2/catch_all.hpp"
 #include <iostream>
 #include <sstream>
 
@@ -21,30 +20,6 @@
 #include "FWCore/PluginManager/interface/standard.h"
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-
-class TestPluginFactory : public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(TestPluginFactory);
-  CPPUNIT_TEST(test);
-  CPPUNIT_TEST(testTry);
-  CPPUNIT_TEST_SUITE_END();
-
-public:
-  void test();
-  void testTry();
-  void setUp() {
-    if (!alreadySetup_) {
-      alreadySetup_ = true;
-      edmplugin::PluginManager::configure(edmplugin::standard::config());
-    }
-  }
-  void tearDown() {}
-  static bool alreadySetup_;
-};
-
-bool TestPluginFactory::alreadySetup_ = false;
-
-///registration of the test so that the runner can find it
-CPPUNIT_TEST_SUITE_REGISTRATION(TestPluginFactory);
 
 namespace edmplugintest {
   struct DummyBase {};
@@ -57,17 +32,25 @@ EDM_REGISTER_PLUGINFACTORY(FactoryType, "Test Dummy");
 
 DEFINE_EDM_PLUGIN(FactoryType, edmplugintest::Dummy, "Dummy");
 
-void TestPluginFactory::test() {
-  using namespace edmplugin;
+TEST_CASE("PluginFactory", "[PluginManager]") {
+  static bool alreadySetup = false;
+  if (!alreadySetup) {
+    alreadySetup = true;
+    edmplugin::PluginManager::configure(edmplugin::standard::config());
+  }
 
-  std::unique_ptr<edmplugintest::DummyBase> p(FactoryType::get()->create("Dummy"));
-  CPPUNIT_ASSERT(0 != p.get());
-}
+  SECTION("test") {
+    using namespace edmplugin;
 
-void TestPluginFactory::testTry() {
-  using namespace edmplugin;
-  CPPUNIT_ASSERT(0 == FactoryType::get()->tryToCreate("ThisDoesNotExist"));
+    std::unique_ptr<edmplugintest::DummyBase> p(FactoryType::get()->create("Dummy"));
+    REQUIRE(nullptr != p.get());
+  }
 
-  std::unique_ptr<edmplugintest::DummyBase> p(FactoryType::get()->tryToCreate("Dummy"));
-  CPPUNIT_ASSERT(0 != p.get());
+  SECTION("tryToCreate") {
+    using namespace edmplugin;
+    REQUIRE(nullptr == FactoryType::get()->tryToCreate("ThisDoesNotExist").get());
+
+    std::unique_ptr<edmplugintest::DummyBase> p(FactoryType::get()->tryToCreate("Dummy"));
+    REQUIRE(nullptr != p.get());
+  }
 }

--- a/FWCore/PluginManager/test/pluginfactorymanager_t.cc
+++ b/FWCore/PluginManager/test/pluginfactorymanager_t.cc
@@ -11,28 +11,13 @@
 //
 
 // system include files
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
-#include <cppunit/extensions/HelperMacros.h>
+#include "catch2/catch_all.hpp"
 #include <functional>
 #include <iostream>
 
 // user include files
 #include "FWCore/PluginManager/interface/PluginFactoryManager.h"
 #include "FWCore/PluginManager/interface/PluginFactoryBase.h"
-
-class TestPluginFactoryManager : public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(TestPluginFactoryManager);
-  CPPUNIT_TEST(test);
-  CPPUNIT_TEST_SUITE_END();
-
-public:
-  void test();
-  void setUp() {}
-  void tearDown() {}
-};
-
-///registration of the test so that the runner can find it
-CPPUNIT_TEST_SUITE_REGISTRATION(TestPluginFactoryManager);
 
 class DummyTestPlugin : public edmplugin::PluginFactoryBase {
 public:
@@ -48,16 +33,18 @@ struct Catcher {
   void catchIt(const edmplugin::PluginFactoryBase* iFactory) { lastSeen_ = iFactory->category(); }
 };
 
-void TestPluginFactoryManager::test() {
-  using namespace edmplugin;
-  using std::placeholders::_1;
-  PluginFactoryManager& pfm = *(PluginFactoryManager::get());
-  CPPUNIT_ASSERT(pfm.begin() == pfm.end());
+TEST_CASE("PluginFactoryManager", "[PluginManager]") {
+  SECTION("test") {
+    using namespace edmplugin;
+    using std::placeholders::_1;
+    PluginFactoryManager& pfm = *(PluginFactoryManager::get());
+    REQUIRE(pfm.begin() == pfm.end());
 
-  Catcher catcher;
-  pfm.newFactory_.connect(std::bind(std::mem_fn(&Catcher::catchIt), &catcher, _1));
+    Catcher catcher;
+    pfm.newFactory_.connect(std::bind(std::mem_fn(&Catcher::catchIt), &catcher, _1));
 
-  DummyTestPlugin one("one");
-  CPPUNIT_ASSERT((pfm.begin() != pfm.end()));
-  CPPUNIT_ASSERT(catcher.lastSeen_ == std::string("one"));
+    DummyTestPlugin one("one");
+    REQUIRE((pfm.begin() != pfm.end()));
+    REQUIRE(catcher.lastSeen_ == std::string("one"));
+  }
 }

--- a/FWCore/PluginManager/test/pluginmanager_t.cc
+++ b/FWCore/PluginManager/test/pluginmanager_t.cc
@@ -11,8 +11,7 @@
 //
 
 // system include files
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
-#include <cppunit/extensions/HelperMacros.h>
+#include "catch2/catch_all.hpp"
 #include <iostream>
 
 // user include files
@@ -22,20 +21,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "FWCore/PluginManager/test/DummyFactory.h"
-
-class TestPluginManager : public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(TestPluginManager);
-  CPPUNIT_TEST(test);
-  CPPUNIT_TEST_SUITE_END();
-
-public:
-  void test();
-  void setUp() {}
-  void tearDown() {}
-};
-
-///registration of the test so that the runner can find it
-CPPUNIT_TEST_SUITE_REGISTRATION(TestPluginManager);
 
 class DummyTestPlugin : public edmplugin::PluginFactoryBase {
 public:
@@ -62,52 +47,54 @@ namespace testedmplugin {
 
 DEFINE_EDM_PLUGIN(testedmplugin::DummyFactory, testedmplugin::DummyThree, "DummyThree");
 
-void TestPluginManager::test() {
-  using namespace edmplugin;
-  using namespace testedmplugin;
-  CPPUNIT_ASSERT_THROW(PluginManager::get(), cms::Exception);
+TEST_CASE("PluginManager", "[PluginManager]") {
+  SECTION("test") {
+    using namespace edmplugin;
+    using namespace testedmplugin;
+    REQUIRE_THROWS_AS(PluginManager::get(), cms::Exception);
 
-  PluginManager::Config config;
-  CPPUNIT_ASSERT_THROW(PluginManager::configure(config), cms::Exception);
+    PluginManager::Config config;
+    REQUIRE_THROWS_AS(PluginManager::configure(config), cms::Exception);
 
-  edmplugin::PluginManager& db = edmplugin::PluginManager::configure(edmplugin::standard::config());
+    edmplugin::PluginManager& db = edmplugin::PluginManager::configure(edmplugin::standard::config());
 
-  std::string toLoadCategory("Test Dummy");
-  std::string toLoadPlugin;
-  unsigned int nTimesAsked = 0;
+    std::string toLoadCategory("Test Dummy");
+    std::string toLoadPlugin;
+    unsigned int nTimesAsked = 0;
 
-  edmplugin::PluginManager::get()->askedToLoadCategoryWithPlugin_.connect(
-      [&](std::string const& iCategory, std::string const& iPlugin) {
-        //std::cout <<iCategory<<" "<<iPlugin<<std::endl;
-        CPPUNIT_ASSERT(toLoadCategory == iCategory);
-        CPPUNIT_ASSERT(toLoadPlugin == iPlugin);
-        ++nTimesAsked;
-      });
+    edmplugin::PluginManager::get()->askedToLoadCategoryWithPlugin_.connect(
+        [&](std::string const& iCategory, std::string const& iPlugin) {
+          //std::cout <<iCategory<<" "<<iPlugin<<std::endl;
+          REQUIRE(toLoadCategory == iCategory);
+          REQUIRE(toLoadPlugin == iPlugin);
+          ++nTimesAsked;
+        });
 
-  unsigned int nTimesGoingToLoad = 0;
-  edmplugin::PluginManager::get()->goingToLoad_.connect(
-      [&nTimesGoingToLoad](const std::filesystem::path&) { ++nTimesGoingToLoad; });
+    unsigned int nTimesGoingToLoad = 0;
+    edmplugin::PluginManager::get()->goingToLoad_.connect(
+        [&nTimesGoingToLoad](const std::filesystem::path&) { ++nTimesGoingToLoad; });
 
-  unsigned int nTimesLoaded = 0;
-  edmplugin::PluginManager::get()->justLoaded_.connect(
-      [&nTimesLoaded](const edmplugin::SharedLibrary&) { ++nTimesLoaded; });
+    unsigned int nTimesLoaded = 0;
+    edmplugin::PluginManager::get()->justLoaded_.connect(
+        [&nTimesLoaded](const edmplugin::SharedLibrary&) { ++nTimesLoaded; });
 
-  toLoadPlugin = "DummyOne";
-  std::unique_ptr<DummyBase> ptr(DummyFactory::get()->create("DummyOne"));
-  CPPUNIT_ASSERT(1 == ptr->value());
-  CPPUNIT_ASSERT(nTimesAsked == 1);
-  CPPUNIT_ASSERT(nTimesGoingToLoad == 1);
-  CPPUNIT_ASSERT(nTimesLoaded == 1);
-  CPPUNIT_ASSERT(db.loadableFor("Test Dummy", "DummyThree") == "static");
-  std::unique_ptr<DummyBase> ptr2(DummyFactory::get()->create("DummyThree"));
-  CPPUNIT_ASSERT(3 == ptr2->value());
-  CPPUNIT_ASSERT(nTimesAsked == 1);  //no request to load
-  CPPUNIT_ASSERT(nTimesGoingToLoad == 1);
-  CPPUNIT_ASSERT(nTimesLoaded == 1);
+    toLoadPlugin = "DummyOne";
+    std::unique_ptr<DummyBase> ptr(DummyFactory::get()->create("DummyOne"));
+    REQUIRE(1 == ptr->value());
+    REQUIRE(nTimesAsked == 1);
+    REQUIRE(nTimesGoingToLoad == 1);
+    REQUIRE(nTimesLoaded == 1);
+    REQUIRE(db.loadableFor("Test Dummy", "DummyThree") == "static");
+    std::unique_ptr<DummyBase> ptr2(DummyFactory::get()->create("DummyThree"));
+    REQUIRE(3 == ptr2->value());
+    REQUIRE(nTimesAsked == 1);  //no request to load
+    REQUIRE(nTimesGoingToLoad == 1);
+    REQUIRE(nTimesLoaded == 1);
 
-  toLoadPlugin = "DoesNotExist";
-  CPPUNIT_ASSERT_THROW(DummyFactory::get()->create("DoesNotExist"), cms::Exception);
-  CPPUNIT_ASSERT(nTimesAsked == 2);  //request happens even though it failed
-  CPPUNIT_ASSERT(nTimesGoingToLoad == 1);
-  CPPUNIT_ASSERT(nTimesLoaded == 1);
+    toLoadPlugin = "DoesNotExist";
+    REQUIRE_THROWS_AS(DummyFactory::get()->create("DoesNotExist"), cms::Exception);
+    REQUIRE(nTimesAsked == 2);  //request happens even though it failed
+    REQUIRE(nTimesGoingToLoad == 1);
+    REQUIRE(nTimesLoaded == 1);
+  }
 }


### PR DESCRIPTION
#### PR description:

Part of a campaign to reduce dependencies in FWCore.

#### PR validation:

Code compiles, unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/2127