### PR TITLE
Add filter efficiency monitoring to NGT client

### DIFF
--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -89,6 +89,12 @@ process.dqmcommon = cms.Sequence(process.dqmEnv
 from PhysicsTools.Scouting.Run3ScoutingElectronBestTrackProducer_cfi import Run3ScoutingElectronBestTrackProducer as _Run3ScoutingElectronBestTrackProducer
 process.run3ScoutingElectronBestTrack =  _Run3ScoutingElectronBestTrackProducer.clone()
 
+# Metadata monitoring
+process.load("DQMOffline.Trigger.dqmHLTFiltersDQMonitor_cfi")
+process.dqmHLTFiltersDQMonitor.triggerEvent = 'hltTriggerSummaryAOD::HLT'
+process.dqmHLTFiltersDQMonitor.triggerResults = 'TriggerResults::HLT'
+process.dqmHLTFiltersDQMonitor.folderName = "NGT/Filters"
+
 process.p = cms.Path(process.dqmcommon *
                      process.hltOnlineBeamSpot *
                      process.run3ScoutingElectronBestTrack *
@@ -96,7 +102,8 @@ process.p = cms.Path(process.dqmcommon *
                      process.ScoutingRecHitsMonitoring *
                      process.ScoutingDileptonMonitorOnline *
                      process.ScoutingMuonPropertiesMonitorOnline *
-                     process.ScoutingPi0MonitorOnline)
+                     process.ScoutingPi0MonitorOnline *
+                     process.dqmHLTFiltersDQMonitor)
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -94,6 +94,7 @@ process.load("DQMOffline.Trigger.dqmHLTFiltersDQMonitor_cfi")
 process.dqmHLTFiltersDQMonitor.triggerEvent = 'hltTriggerSummaryAOD::HLT'
 process.dqmHLTFiltersDQMonitor.triggerResults = 'TriggerResults::HLT'
 process.dqmHLTFiltersDQMonitor.folderName = "NGT/Filters"
+process.dqmHLTFiltersDQMonitor.lightMonitor = True
 
 process.p = cms.Path(process.dqmcommon *
                      process.hltOnlineBeamSpot *

--- a/DQMOffline/Trigger/plugins/HLTFiltersDQMonitor.cc
+++ b/DQMOffline/Trigger/plugins/HLTFiltersDQMonitor.cc
@@ -40,6 +40,7 @@ private:
   std::string processName_;
   bool initFailed_;
   bool skipRun_;
+  bool lightMonitor_;  // in case triggerEvent is missing from EventContent
 
   MonitorElement* meMenu_;
   std::unordered_map<std::string, MonitorElement*> meDatasetMap_;
@@ -61,6 +62,7 @@ HLTFiltersDQMonitor::HLTFiltersDQMonitor(const edm::ParameterSet& iConfig)
       processName_(""),
       initFailed_(false),
       skipRun_(false),
+      lightMonitor_(iConfig.getParameter<bool>("lightMonitor")),
       meMenu_(nullptr) {
   auto const& triggerResultsInputTag = iConfig.getParameter<edm::InputTag>("triggerResults");
 
@@ -172,6 +174,10 @@ void HLTFiltersDQMonitor::bookHistograms(DQMStore::IBooker& iBooker,
   for (size_t idx = 0; idx < triggerNames.size(); ++idx) {
     binIndexMap_[triggerNames[idx]] = idx + 1;
   }
+
+  // in case it's light monitoring, return here
+  if (lightMonitor_)
+    return;
 
   LogTrace("HLTFiltersDQMonitor") << "[HLTFiltersDQMonitor::bookHistograms] HLTConfigProvider::size() = "
                                   << hltConfigProvider_.size()
@@ -331,6 +337,10 @@ void HLTFiltersDQMonitor::analyze(const edm::Event& iEvent, const edm::EventSetu
                                            << iPathName << "\", bin_index=" << ibin;
     }
   }
+
+  // if it's light Monitoring do not do further work
+  if (lightMonitor_)
+    return;
 
   auto const& triggerEventHandle = iEvent.getHandle(triggerEventToken_);
   edm::Handle<trigger::TriggerEventWithRefs> triggerEventWithRefs;
@@ -536,6 +546,7 @@ void HLTFiltersDQMonitor::fillDescriptions(edm::ConfigurationDescriptions& descr
   edm::ParameterSetDescription desc;
   desc.add<std::string>("folderName", "HLT/Filters");
   desc.add<std::string>("efficPlotNamePrefix", "effic_");
+  desc.add<bool>("lightMonitor", false);
   desc.add<edm::InputTag>("triggerResults", edm::InputTag("TriggerResults::HLT"));
   desc.add<edm::InputTag>("triggerEvent", edm::InputTag("hltTriggerSummaryAOD::HLT"));
   desc.add<edm::InputTag>("triggerEventWithRefs", edm::InputTag("hltTriggerSummaryRAW::HLT"));


### PR DESCRIPTION
#### PR description:

Title says it all.

#### PR validation:

` scram b runtests_TestDQMOnlineClient-ngt_dqm_sourceclient ` runs fine.
I get the following plot of it:

<img width="1382" height="957" alt="image" src="https://github.com/user-attachments/assets/be1a19b6-4ce9-40ca-b4d8-aa428cff1701" />

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will be backported to CMSSW_16_0_X for 2026 NGT demonstrator purposes.