### PR TITLE
[16.0.X] `FourVectorHLT`: add to the list of monitored filters, the filters used for E/gamma T&P

### DIFF
--- a/DQM/HLTEvF/plugins/FourVectorHLT.cc
+++ b/DQM/HLTEvF/plugins/FourVectorHLT.cc
@@ -326,6 +326,7 @@ void FourVectorHLT::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
 void FourVectorHLT::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.addUntracked<bool>("plotAll", false);
+  desc.addUntracked<bool>("debug", false);
   desc.addUntracked<unsigned int>("Nbins", 50);
   desc.addUntracked<double>("ptMin", 0.);
   desc.addUntracked<double>("ptMax", 200.);

--- a/DQM/HLTEvF/python/FourVectorHLT_cfi.py
+++ b/DQM/HLTEvF/python/FourVectorHLT_cfi.py
@@ -5,6 +5,7 @@ from DQM.HLTEvF.listOfFilters_cff import filters as _filters
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 hltResults = DQMEDAnalyzer("FourVectorHLT",
      plotAll = cms.untracked.bool(False),
+     debug =  cms.untracked.bool(False),
      ptMax = cms.untracked.double(100.0),
      ptMin = cms.untracked.double(0.0),
      filters = _filters,

--- a/DQM/HLTEvF/python/listOfFilters_cff.py
+++ b/DQM/HLTEvF/python/listOfFilters_cff.py
@@ -1261,4 +1261,70 @@ filters = cms.VPSet(
         ptMin = cms.untracked.double(0),
         ptMax = cms.untracked.double(200)
       ),
+  cms.PSet(
+      name = cms.string('hltEle32WPTightClusterShapeFilter'),
+      type = cms.int32(0),
+      ptMin = cms.untracked.double(0),
+      ptMax = cms.untracked.double(200)
+  ),
+  cms.PSet(
+      name = cms.string('hltEle32WPTightHEFilter'),
+      type = cms.int32(0),
+      ptMin = cms.untracked.double(0),
+      ptMax = cms.untracked.double(200)
+  ),
+  cms.PSet(
+      name = cms.string('hltEle32WPTightEcalIsoFilter'),
+      type = cms.int32(0),
+      ptMin = cms.untracked.double(0),
+      ptMax = cms.untracked.double(200)
+  ),
+  cms.PSet(
+      name = cms.string('hltEle32WPTightHcalIsoFilter'),
+      type = cms.int32(0),
+      ptMin = cms.untracked.double(0),
+      ptMax = cms.untracked.double(200)
+  ),
+  cms.PSet(
+      name = cms.string('hltEle32WPTightPixelMatchFilter'),
+      type = cms.int32(0),
+      ptMin = cms.untracked.double(0),
+      ptMax = cms.untracked.double(200)
+  ),
+  cms.PSet(
+      name = cms.string('hltEle32WPTightPMS2Filter'),
+      type = cms.int32(0),
+      ptMin = cms.untracked.double(0),
+      ptMax = cms.untracked.double(200)
+  ),
+  cms.PSet(
+      name = cms.string('hltEle32WPTightGsfOneOEMinusOneOPFilter'),
+      type = cms.int32(0),
+      ptMin = cms.untracked.double(0),
+      ptMax = cms.untracked.double(200)
+  ),
+  cms.PSet(
+      name = cms.string('hltEle32WPTightGsfMissingHitsFilter'),
+      type = cms.int32(0),
+      ptMin = cms.untracked.double(0),
+      ptMax = cms.untracked.double(200)
+  ),
+  cms.PSet(
+      name = cms.string('hltEle32WPTightGsfDetaFilter'),
+      type = cms.int32(0),
+      ptMin = cms.untracked.double(0),
+      ptMax = cms.untracked.double(200)
+  ),
+  cms.PSet(
+      name = cms.string('hltEle32WPTightGsfDphiFilter'),
+      type = cms.int32(0),
+      ptMin = cms.untracked.double(0),
+      ptMax = cms.untracked.double(200)
+  ),
+  cms.PSet(
+      name = cms.string('hltEle32WPTightGsfTrackIsoFilter'),
+      type = cms.int32(0),
+      ptMin = cms.untracked.double(0),
+      ptMax = cms.untracked.double(200)
+  )
 )


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50637

#### PR description:

This is a follow-up to https://github.com/cms-sw/cmssw/pull/49610.
I just add to the list of monitored filters the ones used for the e/gamma T&P, see:

https://github.com/cms-sw/cmssw/blob/d07df709859de98eae791f183ca0713beed60430/DQM/HLTEvF/python/trigObjTnPSource_cfi.py#L77-L88

I profit to add to the `fillDescriptions` of the module a missed parameter in the original implementation.

#### PR validation:


The module compiles cleanly within the current CMSSW release. 
I generated an input file for testing via the following script:

```bash
#!/bin/bash -ex

# cmsrel CMSSW_16_1_X_2026-04-01-2300
# cd CMSSW_16_1_X_2026-04-01-2300/src
# cmsenv
# scram b -j 20

hltGetConfiguration /dev/CMSSW_15_1_0/GRun \
            --globaltag 151X_dataRun3_HLT_v1 \
            --data \
            --unprescale \
            --output minimal \
            --max-events -1 \
            --eras Run3_2025 --l1-emulator uGT --l1 L1Menu_Collisions2025_v1_3_0_xml \
            --input /store/data/Run2025G/EphemeralHLTPhysics0/RAW/v1/000/398/183/00000/002bbd0c-b9ed-4758-b7a6-e2e13149ca34.root  \
            > hltData.py

edmConfigDump hltData.py > dump.py

cmsRun dump.py >& hltData.log
```

and then analyzed it with:

```
cmsRun DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py inputFiles=file:output.root
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/50637 to the 2026 data-taking release.