### PR TITLE
Move DataFormats/FEDRawData tests to catch2

### DIFF
--- a/DataFormats/FEDRawData/test/BuildFile.xml
+++ b/DataFormats/FEDRawData/test/BuildFile.xml
@@ -22,7 +22,7 @@
 
 
 <bin name="testFEDRawData" file="FEDRawData_t.cpp,FEDRawDataProduct_t.cc, FEDNumbering_t.cpp">
-  <use name="cppunit"/>
+  <use name="catch2"/>
 </bin>
 
 <library name="testDumpFEDRawDataProduct" file="DumpFEDRawDataProduct.cc">

--- a/DataFormats/FEDRawData/test/FEDNumbering_t.cpp
+++ b/DataFormats/FEDRawData/test/FEDNumbering_t.cpp
@@ -6,110 +6,95 @@
    \date 28 Jun 2005
 */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "catch2/catch_all.hpp"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
-class testFEDNumbering : public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(testFEDNumbering);
-
-  CPPUNIT_TEST(test_inRange);
-
-  CPPUNIT_TEST_SUITE_END();
-
-public:
-  void setUp() {}
-  void tearDown() {}
-  void test_inRange();
-  void test_fromDet();
-};
-
-///registration of the test so that the runner can find it
-CPPUNIT_TEST_SUITE_REGISTRATION(testFEDNumbering);
-
-void testFEDNumbering::test_inRange() {
-  int i = 0;
-  for (i = FEDNumbering::MINSiPixelFEDID; i <= FEDNumbering::MAXSiPixelFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MAXSiPixelFEDID + 1; i <= FEDNumbering::MINSiStripFEDID - 1; i++) {
-    CPPUNIT_ASSERT(not FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINSiStripFEDID; i <= FEDNumbering::MAXSiStripFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINPreShowerFEDID; i <= FEDNumbering::MAXPreShowerFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINECALFEDID; i <= FEDNumbering::MAXECALFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINCASTORFEDID; i <= FEDNumbering::MAXCASTORFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINHCALFEDID; i <= FEDNumbering::MAXHCALFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINLUMISCALERSFEDID; i <= FEDNumbering::MAXLUMISCALERSFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINCSCFEDID; i <= FEDNumbering::MAXCSCFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINCSCTFFEDID; i <= FEDNumbering::MAXCSCTFFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINDTFEDID; i <= FEDNumbering::MAXDTFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINDTTFFEDID; i <= FEDNumbering::MAXDTTFFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINRPCFEDID; i <= FEDNumbering::MAXRPCFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINTriggerGTPFEDID; i <= FEDNumbering::MAXTriggerGTPFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINTriggerEGTPFEDID; i <= FEDNumbering::MAXTriggerEGTPFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINTriggerGCTFEDID; i <= FEDNumbering::MAXTriggerGCTFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINTriggerLTCFEDID; i <= FEDNumbering::MAXTriggerLTCFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINTriggerLTCmtccFEDID; i <= FEDNumbering::MAXTriggerLTCmtccFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINCSCDDUFEDID; i <= FEDNumbering::MAXCSCDDUFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINCSCContingencyFEDID; i <= FEDNumbering::MAXCSCContingencyFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINCSCTFSPFEDID; i <= FEDNumbering::MAXCSCTFSPFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINDAQeFEDFEDID; i <= FEDNumbering::MAXDAQeFEDFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINDAQmFEDFEDID; i <= FEDNumbering::MAXDAQmFEDFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINTCDSuTCAFEDID; i <= FEDNumbering::MAXTCDSuTCAFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINHCALuTCAFEDID; i <= FEDNumbering::MAXHCALuTCAFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINSiPixeluTCAFEDID; i <= FEDNumbering::MAXSiPixeluTCAFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINDTUROSFEDID; i <= FEDNumbering::MAXDTUROSFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
-  }
-  for (i = FEDNumbering::MINTriggerUpgradeFEDID; i <= FEDNumbering::MAXTriggerUpgradeFEDID; i++) {
-    CPPUNIT_ASSERT(FEDNumbering::inRange(i));
+TEST_CASE("FEDNumbering", "[FEDRawData]") {
+  SECTION("test_inRange") {
+    int i = 0;
+    for (i = FEDNumbering::MINSiPixelFEDID; i <= FEDNumbering::MAXSiPixelFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MAXSiPixelFEDID + 1; i <= FEDNumbering::MINSiStripFEDID - 1; i++) {
+      REQUIRE(not FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINSiStripFEDID; i <= FEDNumbering::MAXSiStripFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINPreShowerFEDID; i <= FEDNumbering::MAXPreShowerFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINECALFEDID; i <= FEDNumbering::MAXECALFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINCASTORFEDID; i <= FEDNumbering::MAXCASTORFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINHCALFEDID; i <= FEDNumbering::MAXHCALFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINLUMISCALERSFEDID; i <= FEDNumbering::MAXLUMISCALERSFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINCSCFEDID; i <= FEDNumbering::MAXCSCFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINCSCTFFEDID; i <= FEDNumbering::MAXCSCTFFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINDTFEDID; i <= FEDNumbering::MAXDTFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINDTTFFEDID; i <= FEDNumbering::MAXDTTFFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINRPCFEDID; i <= FEDNumbering::MAXRPCFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINTriggerGTPFEDID; i <= FEDNumbering::MAXTriggerGTPFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINTriggerEGTPFEDID; i <= FEDNumbering::MAXTriggerEGTPFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINTriggerGCTFEDID; i <= FEDNumbering::MAXTriggerGCTFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINTriggerLTCFEDID; i <= FEDNumbering::MAXTriggerLTCFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINTriggerLTCmtccFEDID; i <= FEDNumbering::MAXTriggerLTCmtccFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINCSCDDUFEDID; i <= FEDNumbering::MAXCSCDDUFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINCSCContingencyFEDID; i <= FEDNumbering::MAXCSCContingencyFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINCSCTFSPFEDID; i <= FEDNumbering::MAXCSCTFSPFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINDAQeFEDFEDID; i <= FEDNumbering::MAXDAQeFEDFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINDAQmFEDFEDID; i <= FEDNumbering::MAXDAQmFEDFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINTCDSuTCAFEDID; i <= FEDNumbering::MAXTCDSuTCAFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINHCALuTCAFEDID; i <= FEDNumbering::MAXHCALuTCAFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINSiPixeluTCAFEDID; i <= FEDNumbering::MAXSiPixeluTCAFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINDTUROSFEDID; i <= FEDNumbering::MAXDTUROSFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
+    for (i = FEDNumbering::MINTriggerUpgradeFEDID; i <= FEDNumbering::MAXTriggerUpgradeFEDID; i++) {
+      REQUIRE(FEDNumbering::inRange(i));
+    }
   }
 }

--- a/DataFormats/FEDRawData/test/FEDRawDataProduct_t.cc
+++ b/DataFormats/FEDRawData/test/FEDRawDataProduct_t.cc
@@ -6,42 +6,28 @@
    \date 28 Jun 2005
 */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "catch2/catch_all.hpp"
 #include <DataFormats/FEDRawData/interface/FEDRawData.h>
 #include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h>
 
-class testFEDRawDataProduct : public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(testFEDRawDataProduct);
+TEST_CASE("FEDRawDataProduct", "[FEDRawData]") {
+  SECTION("testInsertAndReadBack") {
+    FEDRawData f1(16);
+    f1.data()[0] = 'a';
+    f1.data()[1] = 'b';
 
-  CPPUNIT_TEST(testInsertAndReadBack);
+    FEDRawData f2(24);
+    f2.data()[0] = 'd';
+    f2.data()[1] = 'e';
 
-  CPPUNIT_TEST_SUITE_END();
+    FEDRawDataCollection fp;
+    fp.FEDData(12) = f1;
+    fp.FEDData(121) = f2;
 
-public:
-  void setUp() {}
-  void tearDown() {}
-  void testInsertAndReadBack();
-};
+    REQUIRE(fp.FEDData(12).data()[0] == 'a');
+    REQUIRE(fp.FEDData(12).data()[1] == 'b');
 
-///registration of the test so that the runner can find it
-CPPUNIT_TEST_SUITE_REGISTRATION(testFEDRawDataProduct);
-
-void testFEDRawDataProduct::testInsertAndReadBack() {
-  FEDRawData f1(16);
-  f1.data()[0] = 'a';
-  f1.data()[1] = 'b';
-
-  FEDRawData f2(24);
-  f2.data()[0] = 'd';
-  f2.data()[1] = 'e';
-
-  FEDRawDataCollection fp;
-  fp.FEDData(12) = f1;
-  fp.FEDData(121) = f2;
-
-  CPPUNIT_ASSERT(fp.FEDData(12).data()[0] == 'a');
-  CPPUNIT_ASSERT(fp.FEDData(12).data()[1] == 'b');
-
-  CPPUNIT_ASSERT(fp.FEDData(121).data()[0] == 'd');
-  CPPUNIT_ASSERT(fp.FEDData(121).data()[1] == 'e');
+    REQUIRE(fp.FEDData(121).data()[0] == 'd');
+    REQUIRE(fp.FEDData(121).data()[1] == 'e');
+  }
 }

--- a/DataFormats/FEDRawData/test/FEDRawData_t.cpp
+++ b/DataFormats/FEDRawData/test/FEDRawData_t.cpp
@@ -6,48 +6,30 @@
    \date 28 Jun 2005
 */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "catch2/catch_all.hpp"
 #include <DataFormats/FEDRawData/interface/FEDRawData.h>
 
 #include <iostream>
 
-class testFEDRawData : public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(testFEDRawData);
+TEST_CASE("FEDRawData", "[FEDRawData]") {
+  SECTION("testCtor") {
+    FEDRawData f;
+    REQUIRE(f.size() == 0);
 
-  CPPUNIT_TEST(testCtor);
-  CPPUNIT_TEST(testdata);
+    FEDRawData f2(24);
+    REQUIRE(f2.size() == size_t(24));
+  }
 
-  CPPUNIT_TEST_SUITE_END();
+  SECTION("testdata") {
+    FEDRawData f(48);
+    f.data()[0] = 'a';
+    f.data()[1] = 'b';
+    f.data()[47] = 'c';
 
-public:
-  void setUp() {}
-  void tearDown() {}
-  void testCtor();
-  void testdata();
-};
+    const unsigned char* buf = f.data();
 
-///registration of the test so that the runner can find it
-CPPUNIT_TEST_SUITE_REGISTRATION(testFEDRawData);
-
-void testFEDRawData::testCtor() {
-  FEDRawData f;
-  CPPUNIT_ASSERT(f.size() == 0);
-
-  FEDRawData f2(24);
-  CPPUNIT_ASSERT(f2.size() == size_t(24));
+    REQUIRE(buf[0] == 'a');
+    REQUIRE(buf[1] == 'b');
+    REQUIRE(buf[47] == 'c');
+  }
 }
-
-void testFEDRawData::testdata() {
-  FEDRawData f(48);
-  f.data()[0] = 'a';
-  f.data()[1] = 'b';
-  f.data()[47] = 'c';
-
-  const unsigned char* buf = f.data();
-
-  CPPUNIT_ASSERT(buf[0] == 'a');
-  CPPUNIT_ASSERT(buf[1] == 'b');
-  CPPUNIT_ASSERT(buf[47] == 'c');
-}
-
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>

--- a/DataFormats/FEDRawData/test/RawDataBufferProduct_t.cc
+++ b/DataFormats/FEDRawData/test/RawDataBufferProduct_t.cc
@@ -6,42 +6,28 @@
    \date 28 Jun 2005
 */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "catch2/catch_all.hpp"
 #include <DataFormats/FEDRawData/interface/FEDRawData.h>
 #include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h>
 
-class testFEDRawDataProduct : public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(testFEDRawDataProduct);
+TEST_CASE("RawDataBufferProduct", "[FEDRawData]") {
+  SECTION("testInsertAndReadBack") {
+    FEDRawData f1(16);
+    f1.data()[0] = 'a';
+    f1.data()[1] = 'b';
 
-  CPPUNIT_TEST(testInsertAndReadBack);
+    FEDRawData f2(24);
+    f2.data()[0] = 'd';
+    f2.data()[1] = 'e';
 
-  CPPUNIT_TEST_SUITE_END();
+    FEDRawDataCollection fp;
+    fp.FEDData(12) = f1;
+    fp.FEDData(121) = f2;
 
-public:
-  void setUp() {}
-  void tearDown() {}
-  void testInsertAndReadBack();
-};
+    REQUIRE(fp.FEDData(12).data()[0] == 'a');
+    REQUIRE(fp.FEDData(12).data()[1] == 'b');
 
-///registration of the test so that the runner can find it
-CPPUNIT_TEST_SUITE_REGISTRATION(testFEDRawDataProduct);
-
-void testFEDRawDataProduct::testInsertAndReadBack() {
-  FEDRawData f1(16);
-  f1.data()[0] = 'a';
-  f1.data()[1] = 'b';
-
-  FEDRawData f2(24);
-  f2.data()[0] = 'd';
-  f2.data()[1] = 'e';
-
-  FEDRawDataCollection fp;
-  fp.FEDData(12) = f1;
-  fp.FEDData(121) = f2;
-
-  CPPUNIT_ASSERT(fp.FEDData(12).data()[0] == 'a');
-  CPPUNIT_ASSERT(fp.FEDData(12).data()[1] == 'b');
-
-  CPPUNIT_ASSERT(fp.FEDData(121).data()[0] == 'd');
-  CPPUNIT_ASSERT(fp.FEDData(121).data()[1] == 'e');
+    REQUIRE(fp.FEDData(121).data()[0] == 'd');
+    REQUIRE(fp.FEDData(121).data()[1] == 'e');
+  }
 }


### PR DESCRIPTION
#### PR description:

Part of a campaign to decrease dependencies for Core packages.

#### PR validation:

Code compiles, unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/2136