### PR TITLE
Phase2-hgx365W7 Bug fix to find the missing hits in the scintillators for the V19 version of HGCal - backport of #50659

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -179,11 +179,15 @@ public:
             (mode_ == HGCalGeometryMode::TrapezoidFineCell));
   }
   std::pair<int, int> tileType(int layer, int ring, int phi) const;
+  bool tileTrapezoidCassette() const {
+    return ((mode_ == HGCalGeometryMode::TrapezoidCassette) || (mode_ == HGCalGeometryMode::TrapezoidFineCell));
+  }
   inline bool trapezoidFile() const {
     return ((mode_ == HGCalGeometryMode::TrapezoidFile) || (mode_ == HGCalGeometryMode::TrapezoidModule) ||
             (mode_ == HGCalGeometryMode::TrapezoidCassette) || (mode_ == HGCalGeometryMode::TrapezoidFineCell));
   }
-  inline bool trapezoidModule() const {
+  inline bool trapeoidFine() const { return (mode_ == HGCalGeometryMode::Hexagon8FineCell); }
+  bool tileTrapezoidModule() const {
     return ((mode_ == HGCalGeometryMode::TrapezoidModule) || (mode_ == HGCalGeometryMode::TrapezoidCassette) ||
             (mode_ == HGCalGeometryMode::TrapezoidFineCell));
   }

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -312,6 +312,9 @@ std::array<int, 3> HGCalDDDConstants::assignCellTrap(float x, float y, float z, 
 #endif
     }
   }
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeomT") << "assignCellTrap:irad " << irad << " iphi " << iphi << " type " << type;
+#endif
   return std::array<int, 3>{{irad, iphi, type}};
 }
 

--- a/SimG4CMS/Calo/src/HGCScintSD.cc
+++ b/SimG4CMS/Calo/src/HGCScintSD.cc
@@ -24,6 +24,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <memory>
 
 //#define EDM_ML_DEBUG
@@ -161,7 +162,9 @@ uint32_t HGCScintSD::setDetUnitId(const G4Step* aStep) {
   int iz(globalZ > 0 ? 1 : -1);
 
   int layer(0), module(-1), cell(-1);
-  if (hgcons_->trapezoidModule()) {
+  if (hgcons_->trapeoidFine()) {
+    layer = touch->GetReplicaNumber(0);
+  } else if (hgcons_->tileTrapezoidModule()) {
     layer = touch->GetReplicaNumber(1);
   } else if ((touch->GetHistoryDepth() == levelT1_) || (touch->GetHistoryDepth() == levelT2_)) {
     layer = touch->GetReplicaNumber(0);
@@ -233,6 +236,13 @@ uint32_t HGCScintSD::setDetUnitId(const G4Step* aStep) {
                           << xy.second << ") distance " << diff << " Valid " << valid
                           << " Rho = " << hitPoint.perp() / CLHEP::cm;
   }
+#ifdef EDM_ML_DEBUG
+  std::ostringstream st1;
+  st1 << "HGCScintSD::Final ID " << std::hex << id << std::dec;
+  if (id != 0)
+    st1 << " " << HGCScintillatorDetId(id);
+  edm::LogVerbatim("HGCSim") << st1.str();
+#endif
   return id;
 }
 


### PR DESCRIPTION
#### PR description:

Bug fix to find the missing hits in the scintillators for the V19 version of HGCal - backport of #50659

#### PR validation:

Tested the bug-fix in CMSSW version 17_0_X

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport bof #50659