### PR TITLE
Run3-gex212 Update the scripts for test beam by splitting the content of common_beam_direction_parameters.py

### DIFF
--- a/Geometry/HcalTestBeamData/test/python/testHcalTBParameterDD4hep_cfg.py
+++ b/Geometry/HcalTestBeamData/test/python/testHcalTBParameterDD4hep_cfg.py
@@ -42,13 +42,17 @@ process.common_beam_direction_parameters = cms.PSet(
     MinEta       = cms.double(0.5655),
     MaxEta       = cms.double(0.5655),
     MinPhi       = cms.double(-0.1309),
-    MaxPhi       = cms.double(-0.1309),
+    MaxPhi       = cms.double(-0.1309)
+)
+
+process.common_beam_position_parameters = cms.PSet(
     BeamPosition = cms.double(-521.5)
 )
 
 from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
 process.VtxSmeared = cms.EDProducer("BeamProfileVtxGenerator",
     process.common_beam_direction_parameters,
+    process.common_beam_position_parameters,
     VtxSmearedCommon,
     BeamMeanX       = cms.double(0.0),
     BeamMeanY       = cms.double(0.0),

--- a/Geometry/HcalTestBeamData/test/python/testHcalTBParameterDDD_cfg.py
+++ b/Geometry/HcalTestBeamData/test/python/testHcalTBParameterDDD_cfg.py
@@ -33,13 +33,17 @@ process.common_beam_direction_parameters = cms.PSet(
     MinEta       = cms.double(0.5655),
     MaxEta       = cms.double(0.5655),
     MinPhi       = cms.double(-0.1309),
-    MaxPhi       = cms.double(-0.1309),
+    MaxPhi       = cms.double(-0.1309)
+)
+
+process.common_beam_position_parameters = cms.PSet(
     BeamPosition = cms.double(-521.5)
 )
 
 from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
 process.VtxSmeared = cms.EDProducer("BeamProfileVtxGenerator",
     process.common_beam_direction_parameters,
+    process.common_beam_position_parameters,
     VtxSmearedCommon,
     BeamMeanX       = cms.double(0.0),
     BeamMeanY       = cms.double(0.0),

--- a/SimG4CMS/HcalTestBeam/python/TB06Analysis_cfi.py
+++ b/SimG4CMS/HcalTestBeam/python/TB06Analysis_cfi.py
@@ -5,6 +5,7 @@ from SimG4CMS.HcalTestBeam.TBDirectionParameters_cfi import *
 
 testbeam = cms.EDAnalyzer("HcalTB06Analysis",
                           common_beam_direction_parameters,
+                          common_beam_position_parameters,
                           ECAL = cms.bool(True),
                           TestBeamAnalysis = cms.PSet(
         Verbose = cms.untracked.bool(False),

--- a/SimG4CMS/HcalTestBeam/python/TBDirectionParameters_cfi.py
+++ b/SimG4CMS/HcalTestBeam/python/TBDirectionParameters_cfi.py
@@ -12,4 +12,4 @@ common_beam_direction_parameters = cms.PSet(
 
 common_beam_position_parameters = cms.PSet(
     BeamPosition = cms.double(-800.0)
-}
+)

--- a/SimG4CMS/HcalTestBeam/python/TBDirectionParameters_cfi.py
+++ b/SimG4CMS/HcalTestBeam/python/TBDirectionParameters_cfi.py
@@ -7,6 +7,9 @@ common_beam_direction_parameters = cms.PSet(
     MinEta       = cms.double(0.2175),
     MaxEta       = cms.double(0.2175),
     MinPhi       = cms.double(-0.1309),
-    MaxPhi       = cms.double(-0.1309),
+    MaxPhi       = cms.double(-0.1309)
+)
+
+common_beam_position_parameters = cms.PSet(
     BeamPosition = cms.double(-800.0)
-    )
+}

--- a/SimG4CMS/HcalTestBeam/python/TBVtxSmeared_cfi.py
+++ b/SimG4CMS/HcalTestBeam/python/TBVtxSmeared_cfi.py
@@ -5,6 +5,7 @@ from SimG4CMS.HcalTestBeam.TBDirectionParameters_cfi import *
 
 VtxSmeared = cms.EDProducer("BeamProfileVtxGenerator",
                             common_beam_direction_parameters,
+                            common_beam_position_parameters,
                             VtxSmearedCommon,
                             BeamMeanX       = cms.double(0.0),
                             BeamMeanY       = cms.double(0.0),

--- a/SimG4CMS/HcalTestBeam/test/python/anal_tb06_cfg.py
+++ b/SimG4CMS/HcalTestBeam/test/python/anal_tb06_cfg.py
@@ -28,7 +28,7 @@ process.VtxSmeared.PartID = process.common_beam_direction_parameters.PartID
 process.testbeam.MinE = process.common_beam_direction_parameters.MinE
 process.testbeam.MaxE = process.common_beam_direction_parameters.MaxE
 process.testbeam.PartID = process.common_beam_direction_parameters.PartID
-process.g4SimHits.CaloSD.BeamPosition = process.common_beam_direction_parameters.BeamPosition
+process.g4SimHits.CaloSD.BeamPosition = process.common_beam_position_parameters.BeamPosition
 
 process.testbeam.TestBeamAnalysis.EcalFactor = cms.double(1.)
 process.testbeam.TestBeamAnalysis.HcalFactor = cms.double(100.)

--- a/SimG4CMS/HcalTestBeam/test/python/run2003_cfg.py
+++ b/SimG4CMS/HcalTestBeam/test/python/run2003_cfg.py
@@ -110,6 +110,7 @@ process.g4SimHits.HCalSD.ForTBH2 = True
 #process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
 #    HcalTB04Analysis = cms.PSet(
 #        process.common_beam_direction_parameters,
+#        process.common_beam_position_parameters,
 #        HcalOnly  = cms.bool(False),
 #        Type      = cms.int32(2),
 #        Mode      = cms.int32(1),


### PR DESCRIPTION
#### PR description:

Update the scripts for test beam by splitting the content of common_beam_direction_parameters.py

#### PR validation:

This avoids the call to the generator action that does not have a parameter named "position"

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

May need backporting to 16_1_X