### PR TITLE
Extend `edmMpiSplitConfig` for multiple controllers

### DIFF
--- a/HeterogeneousCore/MPICore/plugins/MPIController.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIController.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/EmptyGroupDescription.h"
@@ -99,34 +100,34 @@ MPIController::MPIController(edm::ParameterSet const& config)
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-    // Determine the rank of the other process.
-    auto followers = config.getUntrackedParameter<std::vector<int32_t>>("followers");
+    edm::LogInfo("MPI") << "MPIController sees world size " << size;
+
+    // Determine the ranks of the follower processes.
+    auto follower_name = config.getParameter<std::string>("followerProcessName");
+    if (follower_name.empty()) {
+      throw edm::Exception(edm::errors::Configuration)
+          << "ERROR: Follower process name cannot be empty. Aborting MPIController...";
+    }
+
+    edm::Service<edm::service::TriggerNamesService> tns;
+    std::string const& this_process_name = tns->getProcessName();
+    if (follower_name == this_process_name) {
+      throw edm::Exception(edm::errors::Configuration)
+          << "ERROR: controller and follower processes cannot have the same name. Aborting MPIController...";
+    }
+
+    edm::Service<MPIService> mpiservice;
+    auto followers = mpiservice->getRanksByProcessName(follower_name);
     if (followers.empty()) {
-      // When there are only two proccesses, we can assume the ranks to be 0 and 1,
-      // and we can infer the other process rank from our own.
-      if (size == 2) {
-        followers = {1 - rank};
-      } else {
-        throw edm::Exception(edm::errors::Configuration)
-            << "An empty list of remote processes is valid only where there are exactly two processes.";
-      }
-    }
-    if (followers.size() >= static_cast<size_t>(size)) {
       throw edm::Exception(edm::errors::Configuration)
-          << "The number of remote processes is invalid. Please specify at most " << size - 1 << "remote processes.";
+          << "ERROR: No follower process with name " << follower_name << " found. Aborting...";
     }
-    std::vector<int32_t> invalid;
-    for (int follower : followers) {
-      if (follower < 0 or follower >= size) {
-        invalid.push_back(follower);
-      }
-    }
-    if (invalid.size() == 1) {
+
+    if (followers.size() == static_cast<size_t>(size)) {
       throw edm::Exception(edm::errors::Configuration)
-          << fmt::format("The remote process {} is invalid. Valid ranks are 0 to {}.", invalid.front(), size - 1);
-    } else if (invalid.size() > 1) {
-      throw edm::Exception(edm::errors::Configuration) << fmt::format(
-          "The remote processes {} are invalid. Valid ranks are 0 to {}.", fmt::join(invalid, ", "), size - 1);
+          << "The number of found followers equals to the world size. "
+          << "Possible reason could be process names' hash collision. "
+          << "Please check process names in follower and controller. Aborting...";
     }
 
     for (int follower : followers) {
@@ -354,15 +355,12 @@ void MPIController::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.ifValue(
           edm::ParameterDescription<std::string>("mode", "CommWorld", false),
           ModeDescription[kCommWorld] >>
-                  edm::ParameterDescription<std::vector<int32_t>>(
-                      "followers",
-                      {},
-                      false,
-                      edm::Comment("Ranks of the remote \"follower\" processes.\n"
-                                   "When there are two or more follower processes, framework streams are associated to "
-                                   "each follower in a round-robin fashion.\n"
-                                   "When there is only one remote process, pass an empty list to autodetect its rank "
-                                   "based on the rank of the current process.")) or
+                  edm::ParameterDescription<std::string>(
+                      "followerProcessName",
+                      "",
+                      true,
+                      edm::Comment("All processes with this process name should act as followers, "
+                                   "and should be configured with an MPISource that follows this controller.")) or
               ModeDescription[kIntercommunicator] >> edm::ParameterDescription<std::string>("name", "server", false))
       ->setComment(
           "Valid modes are CommWorld (use MPI_COMM_WORLD) and Intercommunicator (use an MPI name server to setup an "

--- a/HeterogeneousCore/MPICore/plugins/MPISource.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISource.cc
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/interface/InputSourceDescription.h"
 #include "FWCore/Framework/interface/InputSourceMacros.h"
 #include "FWCore/Framework/interface/ProductProvenanceRetriever.h"
+#include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/MessageLogger/interface/ErrorObj.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -29,6 +30,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Sources/interface/ProducerSourceBase.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/StreamID.h"
@@ -101,21 +103,36 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-    // Determine the rank of the other process.
-    int remote = config.getUntrackedParameter<int>("controller");
-    if (remote == -1) {
-      // When there are only two proccesses, we can assume the ranks to be 0 and 1,
-      // and we can infer the other process rank from our own.
-      if (size == 2) {
-        remote = 1 - rank;
-      } else {
-        throw edm::Exception(edm::errors::Configuration)
-            << "Setting the remote rank to -1 is valid only where there are exactly two processes.";
-      }
-    }
-    if (remote < 0 or remote >= size) {
+    edm::LogInfo("MPI") << "MPIController Comm World size: " << size;
+
+    // All processes exchange the hashes of their names.
+    // One follower process has to make one communication channel with the controller process
+    // If controller process is not unique, error is thrown
+    auto controller_name = config.getParameter<std::string>("controllerProcessName");
+    if (controller_name.empty()) {
       throw edm::Exception(edm::errors::Configuration)
-          << "The rank of the remote process (" << remote << ") is invalid. Valid ranks are 0 to " << size - 1 << ".";
+          << "ERROR: Controller process name cannot be empty. Aborting MPISource...";
+    }
+
+    edm::Service<edm::service::TriggerNamesService> tns;
+    std::string const& this_process_name = tns->getProcessName();
+    if (controller_name == this_process_name) {
+      throw edm::Exception(edm::errors::Configuration)
+          << "ERROR: controller and follower processes cannot have the same name. Aborting MPISource...";
+    }
+
+    edm::Service<MPIService> mpiservice;
+    std::vector<int> controller_indices = mpiservice->getRanksByProcessName(controller_name);
+    int remote = -1;
+    if (controller_indices.empty()) {
+      throw edm::Exception(edm::errors::Configuration)
+          << "ERROR: No controller process with name " << controller_name << " found. Aborting...";
+    } else if (controller_indices.size() == 1) {
+      remote = controller_indices[0];
+    } else {
+      throw edm::Exception(edm::errors::Configuration)
+          << "ERROR: Multiple controller processes with name " << controller_name
+          << " were found. Currently, only one controller process is supported. Aborting...";
     }
 
     // Create a new communicator that spans only this process and the one with the given remote rank.
@@ -126,7 +143,7 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
     MPI_Comm_create_group(MPI_COMM_WORLD, comm_group, 0, &comm_);
     MPI_Group_free(&world_group);
     MPI_Group_free(&comm_group);
-    edm::LogAbsolute("MPI") << "The remote process and MPISource have ranks " << remote << ", " << rank
+    edm::LogAbsolute("MPI") << "The MPIController process and MPISource have ranks " << remote << ", " << rank
                             << " in MPI_COMM_WORLD, mapped to ranks 0, 1 in their private communicator.";
     // The remote process always has rank 0 in the new communicator.
     remote = 0;
@@ -364,13 +381,12 @@ void MPISource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   desc.ifValue(
           edm::ParameterDescription<std::string>("mode", "CommWorld", false),
           ModeDescription[kCommWorld] >>
-                  edm::ParameterDescription<int>(
-                      "controller",
-                      -1,
-                      false,
-                      edm::Comment("Rank of the remote \"controller\" process.\n"
-                                   "When there are only two processes, pass -1 to autodetect the rank of the remote "
-                                   "process based on the rank of the current process.")) or
+                  edm::ParameterDescription<std::string>(
+                      "controllerProcessName",
+                      "",
+                      true,
+                      edm::Comment("Process name of the controller process corresponding to this MPISource.\n"
+                                   "Only one process with this name is expected.\n")) or
               ModeDescription[kIntercommunicator] >> edm::ParameterDescription<std::string>("name", "server", false))
       ->setComment(
           "Valid modes are CommWorld (use MPI_COMM_WORLD) and Intercommunicator (use an MPI name server to setup an "

--- a/HeterogeneousCore/MPICore/python/configuration_splitter/editor_functions.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/editor_functions.py
@@ -5,12 +5,17 @@ import FWCore.ParameterSet.Config as cms
 from HLTrigger.Configuration.common import *
 from HeterogeneousCore.MPICore.modules import *
 
-def add_controller_to_local(process):
+
+def add_controller_to_local(process, remote_name):
     process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
     process.MPIService.pmix_server_uri = "file:server.uri"
-    process.mpiController = MPIController()
+    controller_name = f"mpiController{remote_name.title()}"
+    controller = cms.EDProducer("MPIController",
+                               followerProcessName = cms.string(remote_name))
+    setattr(process, controller_name, controller)
     # Multiple luminocity blocks are currently unsupported
     process.options.numberOfConcurrentLuminosityBlocks = 1
+    return controller_name
 
 
 def clone_module_from_process(dst, src, name):
@@ -23,8 +28,8 @@ def clone_module_from_process(dst, src, name):
     setattr(dst, name, getattr(src, name).clone())
 
 
-def create_remote_process(local_process, modules_to_run):
-    remote_process = cms.Process("REMOTE")
+def create_remote_process(local_process, modules_to_run, remote_process_name, local_process_name):
+    remote_process = cms.Process(remote_process_name)
     remote_process.load("Configuration.StandardSequences.Accelerators_cff")
 
     # load the global psets and event setup modules
@@ -39,9 +44,11 @@ def create_remote_process(local_process, modules_to_run):
     remote_process.MPIService.pmix_server_uri = "file:server.uri"
 
     # where do i get this firstRun parameter from?
-    remote_process.source = cms.Source("MPISource")
+    remote_process.source = MPISource(
     #     firstRun = cms.untracked.uint32(process.Source)
-    # )
+        mode = 'CommWorld',
+        controllerProcessName = local_process_name
+    )
     remote_process.maxEvents.input = -1
 
     for module in modules_to_run:

--- a/HeterogeneousCore/MPICore/python/configuration_splitter/multiple_remotes_option_parser.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/multiple_remotes_option_parser.py
@@ -1,0 +1,205 @@
+import argparse
+import pathlib
+import sys
+
+
+def build_global_parser():
+    parser = argparse.ArgumentParser(add_help=False)
+
+    parser.add_argument(
+        "config",
+        metavar="config.py",
+        type=pathlib.Path,
+        help="python configuration file to be split"
+    )
+    parser.add_argument("-c", "--reuse-cpp-names", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument(
+        "-l",
+        "--output-local",
+        type=pathlib.Path,
+        default=pathlib.Path("local.py"),
+    )
+
+    return parser
+
+
+def build_process_parser():
+    parser = argparse.ArgumentParser(add_help=False)
+
+    parser.add_argument("-m", "--remote-modules", nargs="+", default=None)
+    parser.add_argument("-r", "--output-remote", type=pathlib.Path, default=None)
+    parser.add_argument("-d", "--duplicate-modules", nargs="+", default=None)
+    parser.add_argument("-n", "--remote-process-name", default="")
+
+    return parser
+
+
+def split_groups(argv):
+    groups = []
+    current = []
+
+    for arg in argv:
+        if arg == ":":
+            groups.append(current)
+            current = []
+        else:
+            current.append(arg)
+
+    groups.append(current)
+    return groups
+
+
+def print_help():
+    print(
+"""
+edmMpiSplitConfig script splits a CMSSW configuration \
+into local and one or multiple remote processes for MPI execution. 
+Selected modules (or sequences) are offloaded to a remote process while \
+the remaining modules stay in the local process.
+Data dependencies are \
+automatically analyzed and the required products are forwarded between processes.
+
+
+USAGE:
+    edmMpiSplitConfig config.py [GLOBAL OPTIONS] [PROCESS OPTIONS] [: PROCESS OPTIONS] ...
+
+DESCRIPTION:
+    Arguments before ':' apply to one remote process.
+    You can define multiple remote processes by separating groups with ':'.
+
+GLOBAL OPTIONS:
+Positional arguments (required):
+    config
+        Path to the input HLT Python configuration file.
+
+Optional arguments:
+    -l, --output-local
+        Path to the output configuration for the local process.
+        (default: local.py)
+   
+    -c, --reuse-cpp-names
+        False by default. If this script was run before, pass this 
+        argument to reuse the generated file with C++ product names
+    
+    -v, --verbose
+        Print debug outputs
+
+PROCESS OPTIONS (can be passed for different remote processes):
+    -m, --remote-modules
+        Modules to be offloaded to the remote process.
+        Sequences can also be passed as a parameter, in which case
+        all modules of that sequence will be offloaded
+        
+    -r, --output-remote
+        Path to the output configuration for the remote process.
+        (default: remote.py)
+
+    -d, --duplicate-modules
+        List of module labels that must run on both local and remote
+        processes. Products from these modules are not transferred
+        between processes.
+
+    -n, --remote-process-name
+        Name of the remote process (default: REMOTE)    
+    
+
+SINGLE REMOTE EXAMPLES:
+
+Example 1 (offloading GPU part of ECAL and HCAL):
+
+    edmMpiSplitConfig hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \\
+        hltHcalDigisSoA hltHbheRecoSoA hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \\
+        --duplicate-modules hltHcalDigis \\
+        --output-local local.py \\
+        --output-remote remote.py
+
+Example 2 (offloading GPU part of ECAL, HCAL and pixels):
+
+    edmMpiSplitConfig hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \\
+        hltHcalDigisSoA hltHbheRecoSoA hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \\
+        hltSiPixelClustersSoA hltSiPixelRecHitsSoA hltPixelTracksSoA hltPixelVerticesSoA \\
+        --duplicate-modules hltHcalDigis hltOnlineBeamSpot hltOnlineBeamSpotDevice \\
+        --output-local local_pixels.py \\
+        --output-remote remote_pixels.py
+
+MULTI-REMOTE EXAMPLES:
+
+    Separate remote groups using ':'.
+    
+    Example (offloading GPU part of ECAL to one process and HCAL to another):
+    
+    edmMpiSplitConfig hlt.py -l local.py \\
+        -m hltEcalDigisSoA hltEcalUncalibRecHitSoA -r remote_ecal.py -n ECAL : \\
+        -m hltHcalDigisSoA hltHbheRecoSoA hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \\
+        -d hltHcalDigis -r remote_hcal.py -n HCAL
+
+Notes:
+
+• To split a configuration it must be processed with 0 events.
+    This will cause creating output files and directories (by default in '.cppnamedir' directory).
+• If the splitter was run before, --reuse-cpp-names avoids rerunning cmsRun for products' characteristics.
+    Passing this option will make the script run much faster, given that needed information already exists.
+• For some modules it might be better to run on both processes
+    instead of sending their products. Use --duplicate-modules option to specify them.
+• Only dependencies expressed via InputTag are analyzed.
+• Execution order inside dependency groups is preserved.
+"""
+    )
+    
+
+def parse_mpi_style_args(argv):
+    if not argv or any(arg in ("-h", "--help") for arg in argv):
+        print_help()
+        sys.exit(0)
+
+    global_parser = build_global_parser()
+    process_parser = build_process_parser()
+
+    # parse global args from full argv
+    global_args, _ = global_parser.parse_known_args(argv)
+
+    # split independently
+    groups = split_groups(argv)
+    configs = []
+
+    # if no ":" - single process
+    if len(groups) == 1:
+        proc_args, _ = process_parser.parse_known_args(argv)
+
+        cfg = argparse.Namespace()
+
+        # merge
+        cfg.config = global_args.config
+        cfg.output_local = global_args.output_local
+        cfg.reuse_cpp_names = global_args.reuse_cpp_names
+        cfg.verbose = global_args.verbose
+
+        cfg.remote_modules = proc_args.remote_modules or []
+        cfg.output_remote = proc_args.output_remote
+        cfg.duplicate_modules = proc_args.duplicate_modules or []
+        cfg.remote_process_name = proc_args.remote_process_name or ""
+
+        configs.append(cfg)
+        return configs
+
+    # multi-process
+    for i, g in enumerate(groups):
+        proc_args, _ = process_parser.parse_known_args(g)
+        cfg = argparse.Namespace()
+
+        # globals
+        cfg.config = global_args.config
+        cfg.output_local = global_args.output_local
+        cfg.reuse_cpp_names = global_args.reuse_cpp_names
+        cfg.verbose = global_args.verbose
+
+        # per-process overrides
+        cfg.remote_modules = proc_args.remote_modules or []
+        cfg.output_remote = proc_args.output_remote or pathlib.Path(f"remote{i}.py")
+        cfg.duplicate_modules = proc_args.duplicate_modules or []
+        cfg.remote_process_name = proc_args.remote_process_name or ""
+
+        configs.append(cfg)
+
+    return configs

--- a/HeterogeneousCore/MPICore/python/configuration_splitter/split_remote.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/split_remote.py
@@ -1,0 +1,209 @@
+"""
+This module implements the logic to separate one remote process from the local one
+"""
+
+import pathlib
+import os
+import sys
+
+from HeterogeneousCore.MPICore.configuration_splitter.cpp_name_getter import CPPNameGetter
+from HeterogeneousCore.MPICore.configuration_splitter.module_dependency_analyzer import ModuleDependencyAnalyzer, flatten_all_to_module_list
+from HeterogeneousCore.MPICore.configuration_splitter.editor_functions import *
+from HeterogeneousCore.MPICore.configuration_splitter.path_state_helpers import *
+from HeterogeneousCore.MPICore.configuration_splitter.multiple_remotes_option_parser import *
+
+def split_remote(local_process, args, cpp_names_of_the_products):
+    modules_to_offload = flatten_all_to_module_list(local_process, args.remote_modules)
+    modules_to_run_on_both = flatten_all_to_module_list(local_process, args.duplicate_modules)
+    
+    # list of all modules to run on remote
+    modules_to_offload.extend(m for m in modules_to_run_on_both if m not in modules_to_offload)
+
+    analyzer = ModuleDependencyAnalyzer(local_process)
+
+    groups = analyzer.dependency_groups(modules_to_offload)
+    grouped_deps = analyzer.grouped_external_dependencies(groups)
+    producer_to_groups = analyzer.producer_to_groups(grouped_deps)
+
+    if args.verbose:
+        print("Dependency groups: ", groups)
+        print("Grouped depencencies:", grouped_deps )
+        print("Local producers - dependant groups correspondance: ", producer_to_groups)
+
+    # get products whose data needs to be sent, excluding modules without local dependencies and modules which should run on both processes
+    modules_to_send, modules_without_local_deps = analyzer.modules_to_send_back_by_group(groups, modules_to_run_on_both)
+
+    if args.verbose:
+        print("Offloaded modues whose products need to be sent: ", modules_to_send)
+        print("Offloaded modules without local dependencies: ", modules_without_local_deps)
+
+    # --- start editing ---
+
+    controller_name = add_controller_to_local(local_process, args.remote_process_name)
+    remote_process = create_remote_process(local_process, modules_to_offload, args.remote_process_name, local_process.name_())
+
+    mpi_path_modules_local = [controller_name]
+    mpi_path_modules_remote = []
+
+    instance = 1
+
+    # how to add state captures to the splitter?
+
+    # 1) For the local sender - create path state capture per sender. 
+    # Insert this path state capture before the first module of each needed group.
+    # If multiple groups need these products, create individual path state captures
+    # and add separate senders on top
+    # 
+    # 2) For the remote receiver - add path state product to the list.
+    # Add the general activity filter at the beginning of the group path
+    # and, if needed, separate activity filters for each group
+    #
+    # 3) For the remote sender - add the state capture at the end of the groups path.
+    # Each sender module for this group depens on this state capture
+    #
+    # 4) For the local receiver - before deleting the offloaded module, insert filter for the activity it receives
+
+    # send the data needed by offloaded modules from local to remote
+    remote_filters_by_group = [[] for _ in range(len(groups))]
+    local_sender_by_group = [[] for _ in range(len(groups))]
+    for local_dependency, group_indices in producer_to_groups.items():
+        first_dependency_in_a_group = [groups[i][0] for i in group_indices]
+        capture_name = f"activityCaptureBefore{local_dependency.title()}"
+        insert_path_state_capture_before(local_process, first_modules_in_a_group=first_dependency_in_a_group, capture_name=capture_name)
+        sender = create_sender(
+                module_name=local_dependency,
+                products=cpp_names_of_the_products[local_dependency],
+                instance=instance,
+                sender_upstream=controller_name,
+                path_state_capture = capture_name
+            )
+        sender_name = f"mpiSender{args.remote_process_name.title()}{local_dependency.title()}"
+        setattr(local_process, sender_name, sender)
+
+        receiver = create_receiver(
+                products=cpp_names_of_the_products[local_dependency],
+                instance=instance,
+                receiver_upstream="source",
+                path_state_capture=True,
+            )
+        # create filter for the path state
+        filter_name = f"activityFilterAfter{local_dependency.title()}"
+        add_activity_filter(remote_process, local_dependency, filter_name)
+        for group_idx in group_indices:
+            remote_filters_by_group[group_idx].append(filter_name)
+            local_sender_by_group[group_idx].append(sender_name)
+        
+        setattr(remote_process, local_dependency, receiver)
+
+        instance += 1
+        mpi_path_modules_local.append(sender_name)
+        mpi_path_modules_remote.append(local_dependency)
+
+        # Handle the case when onle local product is needed by multiple remote groups
+        # For sending from local process - if data is needed by multiple paths, insert additional path state capture and additional sender per group
+        # On remote insert one more receiver for this capture and one more filter in the beginning of the deps group
+        # In this approach if there are 2 senders with intersecting groups, it will result in only one group activation sender-receiver pair per group
+        if len(group_indices) >= 2:
+            for group_idx in group_indices:
+                capture_name=f"activityCaptureBefore{args.remote_process_name.title()}Group{group_idx}"
+                insert_path_state_capture_before(local_process, first_modules_in_a_group=[groups[group_idx][0]], capture_name=capture_name)
+                sender = create_sender(
+                        module_name=local_dependency,
+                        products=[],
+                        instance=instance,
+                        sender_upstream=controller_name,
+                        path_state_capture = capture_name
+                    )
+                sender_name = f"mpiSender{args.remote_process_name.title()}Group{group_idx}Activity"
+                setattr(local_process, sender_name, sender)
+
+                receiver = create_receiver(
+                        products=[],
+                        instance=instance,
+                        receiver_upstream="source",
+                        path_state_capture=True,
+                    )
+                receiver_name = f"mpiReceiver{args.remote_process_name.title()}Group{group_idx}Activity"
+                setattr(remote_process, receiver_name, receiver)
+
+                # create filter for the path state
+                filter_name = f"activityFilterBefore{args.remote_process_name.title()}Group{group_idx}"
+                add_activity_filter(remote_process, receiver_name, filter_name)
+                remote_filters_by_group[group_idx].append(filter_name)
+                local_sender_by_group[group_idx].append(sender_name)
+
+                instance += 1
+                mpi_path_modules_local.append(sender_name)
+                mpi_path_modules_remote.append(receiver_name)
+    
+
+    per_group_remote_captures = [[] for _ in range(len(groups))]
+    
+    # send the results from remote to local
+    for group_idx, group in enumerate(modules_to_send):
+        if len(group)==0:
+            continue
+
+        remote_capture_name = f"activityCaptureAfter{args.remote_process_name.title()}Group{group_idx}"
+        setattr(remote_process, remote_capture_name, cms.EDProducer("PathStateCapture"))
+        per_group_remote_captures[group_idx].append(remote_capture_name)
+        
+        sender = create_group_sender(
+            group=group,
+            all_products=cpp_names_of_the_products,
+            instance=instance,
+            upstream_module=mpi_path_modules_remote[0],
+            path_state_capture=remote_capture_name,
+        )
+        sender_name = f"mpiSender{args.remote_process_name.title()}Group{group_idx}"
+        setattr(remote_process, sender_name, sender)
+        
+        if len(local_sender_by_group[group_idx]) != 0:
+            receiver_upstream = local_sender_by_group[group_idx][-1]
+        else:
+            receiver_upstream = controller_name
+        
+        receiver = create_group_receiver(
+            group=group,
+            all_products=cpp_names_of_the_products,
+            instance=instance,
+            receiver_upstream=receiver_upstream,
+            path_state_capture=True,
+        )
+        receiver_name = f"mpiReceiver{args.remote_process_name.title()}Group{group_idx}"
+        setattr(local_process, receiver_name, receiver)
+        
+        instance += 1
+        
+        # insert filter on local before the first module which was supposed to run (is it correct?)
+        filter_name = f"activityFilterAfter{args.remote_process_name.title()}Group{group_idx}"
+        add_activity_filter(local_process, receiver_name, filter_name)
+        insert_modules_before(local_process, getattr(local_process, group[0]), getattr(local_process, filter_name))
+        
+        mpi_path_modules_remote.append(sender_name)
+        mpi_path_modules_local.append(receiver_name)
+        
+        
+        for i, offloaded_module in enumerate(group):
+            delattr(local_process, offloaded_module)
+            module_alias = create_receiver_alias(receiver_name=receiver_name,
+                products=cpp_names_of_the_products[offloaded_module],
+                module_name=offloaded_module
+            )
+            setattr(local_process, offloaded_module, module_alias)
+
+    
+    # delete offloaded modules whose products are not needed on local from the local process:
+    for product in modules_without_local_deps:
+        delattr(local_process, product)        
+ 
+    # add all needed paths to the process and schedule them
+    make_new_path(local_process, f"Offload{args.remote_process_name.title()}", mpi_path_modules_local)
+    make_new_path(remote_process, "MPIPath", mpi_path_modules_remote)
+    for i, group in enumerate(groups):
+        make_new_path(remote_process, args.remote_process_name.title()+"RemoteOffloadedSequence"+str(i), remote_filters_by_group[i]+group+per_group_remote_captures[i])
+    
+    if args.verbose:
+        print(f"Successfully split out remote config with name {args.remote_process_name}!")
+        
+    return remote_process

--- a/HeterogeneousCore/MPICore/scripts/edmMpiSplitConfig
+++ b/HeterogeneousCore/MPICore/scripts/edmMpiSplitConfig
@@ -5,61 +5,16 @@ This script splits an HLT configuration into local and remote processes
 by offloading selected modules or sequences.
 
 This tool analyzes data dependencies between CMSSW modules and generates
-two derived configuration files:
-    - a *local* process config
-    - a *remote* process config
+the derived configuration files:
+    - one *local* process config
+    - one or multiple *remote* process configs
 
-Modules specified for offloading will be moved to the remote process.
+Modules specified for offloading will be moved to the remote processes.
+If multiple remote processes are needed, individual parameters should
+be separated by ":".
 Any required data products are automatically identified and forwarded
 between processes unless the producing module is explicitly marked as
 shared.
-
-Positional arguments:
-    config
-        Path to the input HLT Python configuration file.
-
-Required arguments:
-    --remote-modules
-        Modules to be offloaded to the remote process.
-        Sequences can also be passed as a parameter, in which case
-        all modules of that sequence will be offloaded
-
-Optional arguments:
-    -l, --output-local
-        Path to the output configuration for the local process.
-        (default: local.py)
-
-    -r, --output-remote
-        Path to the output configuration for the remote process.
-        (default: remote.py)
-
-    -d, --duplicate-modules
-        List of module labels that must run on both local and remote
-        processes. Products from these modules are not transferred
-        between processes.
-    
-    -c, --reuse-cpp-names
-        False by default. If this script was run before, pass this 
-        argument to reuse the generated file with C++ product names
-    
-    -v, --verbose
-        Print debug outputs
-
-Example 1 (offloading GPU part of ECAL and HCAL):
-    edmMpiSplitConfig hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \
-        hltHcalDigisSoA hltHbheRecoSoA hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \
-        --duplicate-modules hltHcalDigis \
-        --output-local local.py \
-        --output-remote remote.py
-
-Example 2 (offloading GPU part of ECAL, HCAL and pixels):
-    edmMpiSplitConfig hlt.py --remote-modules hltEcalDigisSoA hltEcalUncalibRecHitSoA \
-        hltHcalDigisSoA hltHbheRecoSoA hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \
-        hltSiPixelClustersSoA hltSiPixelRecHitsSoA hltPixelTracksSoA hltPixelVerticesSoA \
-        --duplicate-modules hltHcalDigis hltOnlineBeamSpot   hltOnlineBeamSpotDevice \
-        --output-local local_pixels.py \
-        --output-remote remote_pixels.py
-
 
 Notes:
     - Only data dependencies expressed via InputTag are considered.
@@ -82,317 +37,55 @@ from HeterogeneousCore.MPICore.configuration_splitter.cpp_name_getter import CPP
 from HeterogeneousCore.MPICore.configuration_splitter.module_dependency_analyzer import ModuleDependencyAnalyzer, flatten_all_to_module_list
 from HeterogeneousCore.MPICore.configuration_splitter.editor_functions import *
 from HeterogeneousCore.MPICore.configuration_splitter.path_state_helpers import *
+from HeterogeneousCore.MPICore.configuration_splitter.multiple_remotes_option_parser import *
+from HeterogeneousCore.MPICore.configuration_splitter.split_remote import *
 from FWCore.ParameterSet.processFromFile import processFromFile
 
 
 def main():
-    parser = argparse.ArgumentParser(
-    description=(
-        "Split a CMSSW configuration into local and remote processes for MPI execution.\n"
-        "Selected modules (or sequences) are offloaded to a remote process while "
-        "the remaining modules stay in the local process. Data dependencies are "
-        "automatically analyzed and the required products are forwarded between processes."
-    ),
-    epilog=(
-        "Examples:\n"
-        "\n"
-        "Offload ECAL and HCAL GPU reconstruction modules:\n"
-        "  edmMpiSplitConfig hlt.py --remote-modules \\\n"
-        "      hltEcalDigisSoA hltEcalUncalibRecHitSoA \\\n"
-        "      hltHcalDigisSoA hltHbheRecoSoA \\\n"
-        "      hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \\\n"
-        "      --duplicate-modules hltHcalDigis \\\n"
-        "      --output-local local.py --output-remote remote.py\n"
-        "\n"
-        "Offload ECAL, HCAL and Pixel GPU reconstruction:\n"
-        "  edmMpiSplitConfig hlt.py --remote-modules \\\n"
-        "      hltEcalDigisSoA hltEcalUncalibRecHitSoA \\\n"
-        "      hltHcalDigisSoA hltHbheRecoSoA \\\n"
-        "      hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA \\\n"
-        "      hltSiPixelClustersSoA hltSiPixelRecHitsSoA \\\n"
-        "      hltPixelTracksSoA hltPixelVerticesSoA \\\n"
-        "      --duplicate-modules hltHcalDigis hltOnlineBeamSpot hltOnlineBeamSpotDevice\n"
-        "\n"
-        "Notes:\n"
-        "  • To split a configurationm it must be processed with 0 events."
-        " This will cause creating output files and directories (by default in '.cppnamedir' directory).\n"
-        "  • If the splitter was run before, --reuse-cpp-names avoids rerunning cmsRun for products' characteristics."
-        " Passing this option will make the script run much faster, given that needed information already exists.\n"
-        "  • For some modules it might be better to run on both processes"
-        " instead of sending their products. Use --duplicate-modules option to specify them.\n"
-        "  • Only dependencies expressed via InputTag are analyzed.\n"
-        "  • Execution order inside dependency groups is preserved.\n"
-    ),
-    formatter_class=argparse.RawTextHelpFormatter,
-    )
-    parser.add_argument(
-        "config",
-        metavar="[--] config.py",
-        type=pathlib.Path,
-        help="python configuration file to be split; use '--' to separate the positional argument from multi-value options"
-    )
-    parser.add_argument(
-        "-m",
-        "--remote-modules",
-        nargs="+",
-        default=[],
-        help="Modules and/or sequences to offload",
-    )
-    parser.add_argument(
-        "-l",
-        "--output-local",
-        type=pathlib.Path,
-        default=pathlib.Path("local.py"),
-        help="Output config path for the local process",
-    )
-    parser.add_argument(
-        "-r",
-        "--output-remote",
-        type=pathlib.Path,
-        default=pathlib.Path("remote.py"),
-        help="Output config path for the remote process",
-    )
-    parser.add_argument(
-        "-d",
-        "--duplicate-modules",
-        nargs="+",
-        default=[],
-        help="Modules that must run on both local and remote processes",
-    )
-    parser.add_argument(
-        "-c",
-        "--reuse-cpp-names",
-        action="store_true",
-        help="Assume the file with C++ product names already exists; "
-            "do not run cmsRun to regenerate it",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Print execution logs of the splitter",
-    )
-
-    args = parser.parse_args()
-
-    local_process = processFromFile(str(args.config))
-
-    modules_to_offload = flatten_all_to_module_list(local_process, args.remote_modules)
-    modules_to_run_on_both = flatten_all_to_module_list(local_process, args.duplicate_modules)
+    configs = parse_mpi_style_args(sys.argv[1:])
     
-    modules_to_offload.extend(m for m in modules_to_run_on_both if m not in modules_to_offload)
+    if configs[0].verbose:
+        for i, cfg in enumerate(configs):
+            print(f"\n=== Process {i} ===")
+            print(cfg)
 
-    analyzer = ModuleDependencyAnalyzer(local_process)
-
-    groups = analyzer.dependency_groups(modules_to_offload)
-    grouped_deps = analyzer.grouped_external_dependencies(groups)
-    producer_to_groups = analyzer.producer_to_groups(grouped_deps)
-
-    if args.verbose:
-        print("Dependency groups: ", groups)
-        print("Grouped depencencies:", grouped_deps )
-        print("Local producers - dependant groups correspondance: ", producer_to_groups)
-
-
-    # get products whose data needs to be sent, excluding modules without local dependencies and modules which should run on both processes
-    modules_to_send, modules_without_local_deps = analyzer.modules_to_send_back_by_group(groups, modules_to_run_on_both)
-
-    if args.verbose:
-        print("Offloaded modues whose products need to be sent: ", modules_to_send)
-        print("Offloaded modules without local dependencies: ", modules_without_local_deps)
-
+    local_process = processFromFile(str(configs[0].config))
 
     # -- get c++ names --
 
-    if args.verbose:
-        if not args.reuse_cpp_names:
+    if configs[0].verbose:
+        if not configs[0].reuse_cpp_names:
             print("Launching cmsRun to get C++ names of all products in the process...")
         else:
-            print("Truing to get C++ product names from existing file...")
+            print("Trying to get C++ product names from existing file...")
 
-    cpp_names_getter = CPPNameGetter(local_process, reuse=args.reuse_cpp_names)
+    cpp_names_getter = CPPNameGetter(local_process, reuse=configs[0].reuse_cpp_names)
     cpp_names_of_the_products = cpp_names_getter.get_cpp_types_of_module_products()
 
-    if args.verbose:
+    if configs[0].verbose:
         print("Got C++ product names")
     
-
-    # --- start editing ---
-
-    add_controller_to_local(local_process)
-    remote_process = create_remote_process(local_process, modules_to_offload)
-
-    mpi_path_modules_local = ["mpiController"]
-    mpi_path_modules_remote = []
-
-    instance = 1
-
-    # how to add state captures to the splitter?
-
-    # 1) For the local sender - create path state capture per sender. 
-    # Insert this path state capture before the first module of each needed group.
-    # If multiple groups need these products, create individual path state captures
-    # and add separate senders on top
-    # 
-    # 2) For the remote receiver - add path state product to the list.
-    # Add the general activity filter at the beginning of the group path
-    # and, if needed, separate activity filters for each group
-    #
-    # 3) For the remote sender - add the state capture at the end of the groups path.
-    # Each sender module for this group depens on this state capture
-    #
-    # 4) For the local receiver - before deleting the offloaded module, insert filter for the activity it receives
-
-    # send the data needed by offloaded modules from local to remote
-    remote_filters_by_group = [[] for _ in range(len(groups))]
-    local_sender_by_group = [[] for _ in range(len(groups))]
-    for local_dependency, group_indices in producer_to_groups.items():
-        first_dependency_in_a_group = [groups[i][0] for i in group_indices]
-        capture_name = f"activityCaptureBefore{local_dependency.title()}"
-        insert_path_state_capture_before(local_process, first_modules_in_a_group=first_dependency_in_a_group, capture_name=capture_name)
-        sender = create_sender(
-                module_name=local_dependency,
-                products=cpp_names_of_the_products[local_dependency],
-                instance=instance,
-                sender_upstream="mpiController",
-                path_state_capture = capture_name
-            )
-        sender_name = f"mpiSender{local_dependency.title()}"
-        setattr(local_process, sender_name, sender)
-
-        receiver = create_receiver(
-                products=cpp_names_of_the_products[local_dependency],
-                instance=instance,
-                receiver_upstream="source",
-                path_state_capture=True,
-            )
-        # create filter for the path state
-        filter_name = f"activityFilterAfter{local_dependency.title()}"
-        add_activity_filter(remote_process, local_dependency, filter_name)
-        for group_idx in group_indices:
-            remote_filters_by_group[group_idx].append(filter_name)
-            local_sender_by_group[group_idx].append(sender_name)
-        
-        setattr(remote_process, local_dependency, receiver)
-
-        instance += 1
-        mpi_path_modules_local.append(sender_name)
-        mpi_path_modules_remote.append(local_dependency)
-
-        # Handle the case when onle local product is needed by multiple remote groups
-        # For sending from local process - if data is needed by multiple paths, insert additional path state capture and additional sender per group
-        # On remote insert one more receiver for this capture and one more filter in the beginning of the deps group
-        # In this approach if there are 2 senders with intersecting groups, it will result in only one group activation sender-receiver pair per group
-        if len(group_indices) >= 2:
-            for group_idx in group_indices:
-                capture_name=f"activityCaptureBeforeGroup{group_idx}"
-                insert_path_state_capture_before(local_process, first_modules_in_a_group=[groups[group_idx][0]], capture_name=capture_name)
-                sender = create_sender(
-                        module_name=local_dependency,
-                        products=[],
-                        instance=instance,
-                        sender_upstream="mpiController",
-                        path_state_capture = capture_name
-                    )
-                sender_name = f"mpiSenderGroup{group_idx}Activity"
-                setattr(local_process, sender_name, sender)
-
-                receiver = create_receiver(
-                        products=[],
-                        instance=instance,
-                        receiver_upstream="source",
-                        path_state_capture=True,
-                    )
-                receiver_name = f"mpiReceiverGroup{group_idx}Activity"
-                setattr(remote_process, receiver_name, receiver)
-
-                # create filter for the path state
-                filter_name = f"activityFilterBeforeGroup{group_idx}"
-                add_activity_filter(remote_process, receiver_name, filter_name)
-                remote_filters_by_group[group_idx].append(filter_name)
-                local_sender_by_group[group_idx].append(sender_name)
-
-                instance += 1
-                mpi_path_modules_local.append(sender_name)
-                mpi_path_modules_remote.append(receiver_name)
+    num_remotes = len(configs)
     
-
-    per_group_remote_captures = [[] for _ in range(len(groups))]
+    for i, process_args in enumerate(configs):
+        if process_args.remote_process_name is None or process_args.remote_process_name == "":
+            process_args.remote_process_name = f"REMOTE{i}"
+        if process_args.output_remote is None:
+            if num_remotes == 1:
+                process_args.output_remote = pathlib.Path("remote.py")
+            else:
+                process_args.output_remote = pathlib.Path(
+                    f"remote_{process_args.remote_process_name}.py"
+                )
+        
+        remote_process = split_remote(local_process, process_args, cpp_names_of_the_products)
+        process_args.output_remote.parent.mkdir(parents=True, exist_ok=True)
+        process_args.output_remote.write_text(remote_process.dumpPython())
     
-    # send the results from remote to local
-    for group_idx, group in enumerate(modules_to_send):
-        if len(group)==0:
-            continue
-
-        remote_capture_name = f"activityCaptureAfterGroup{group_idx}"
-        setattr(remote_process, remote_capture_name, cms.EDProducer("PathStateCapture"))
-        per_group_remote_captures[group_idx].append(remote_capture_name)
-        
-        sender = create_group_sender(
-            group=group,
-            all_products=cpp_names_of_the_products,
-            instance=instance,
-            upstream_module=mpi_path_modules_remote[0],
-            path_state_capture=remote_capture_name,
-        )
-        sender_name = f"mpiSenderGroup{group_idx}"
-        setattr(remote_process, sender_name, sender)
-        
-        if len(local_sender_by_group[group_idx]) != 0:
-            receiver_upstream = local_sender_by_group[group_idx][-1]
-        else:
-            receiver_upstream = "mpiController"
-        
-        receiver = create_group_receiver(
-            group=group,
-            all_products=cpp_names_of_the_products,
-            instance=instance,
-            receiver_upstream=receiver_upstream,
-            path_state_capture=True,
-        )
-        receiver_name = f"mpiReceiverGroup{group_idx}"
-        setattr(local_process, receiver_name, receiver)
-        
-        instance += 1
-        
-        # insert filter on local before the first module which was supposed to run (is it correct?)
-        filter_name = f"activityFilterAfterGroup{group_idx}"
-        add_activity_filter(local_process, receiver_name, filter_name)
-        insert_modules_before(local_process, getattr(local_process, group[0]), getattr(local_process, filter_name))
-        
-        mpi_path_modules_remote.append(sender_name)
-        mpi_path_modules_local.append(receiver_name)
-        
-        
-        for i, offloaded_module in enumerate(group):
-            delattr(local_process, offloaded_module)
-            module_alias = create_receiver_alias(receiver_name=receiver_name,
-                products=cpp_names_of_the_products[offloaded_module],
-                module_name=offloaded_module
-            )
-            setattr(local_process, offloaded_module, module_alias)
-
+    configs[0].output_local.parent.mkdir(parents=True, exist_ok=True)
+    configs[0].output_local.write_text(local_process.dumpPython())
     
-    # delete offloaded modules whose products are not needed on local from the local process:
-    for product in modules_without_local_deps:
-        delattr(local_process, product)        
- 
-    # add all needed paths to the processed and schedule them
-
-    make_new_path(local_process, "Offload", mpi_path_modules_local)
-    make_new_path(remote_process, "MPIPath", mpi_path_modules_remote)
-    for i, group in enumerate(groups):
-        make_new_path(remote_process, "RemoteOffloadedSequence"+str(i), remote_filters_by_group[i]+group+per_group_remote_captures[i])
-
-    # dump the 2 processes into files
-
-    args.output_local.parent.mkdir(parents=True, exist_ok=True)
-    args.output_remote.parent.mkdir(parents=True, exist_ok=True)
-
-    args.output_local.write_text(local_process.dumpPython())
-    args.output_remote.write_text(remote_process.dumpPython())
-    print("Success!")
-
 
 if __name__ == "__main__":
     main()

--- a/HeterogeneousCore/MPICore/test/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/test/BuildFile.xml
@@ -44,7 +44,12 @@
 
 <test
   name="testMPIAutosplitter"
-  command="testAutomaticSplitter.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/scripts/edmMpiSplitConfig ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/configutration_for_automatic_splitter.py"
+  command="testAutomaticSplitter.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/configutration_for_automatic_splitter.py"
+/>
+
+<test
+  name="testMPIAutosplitter"
+  command="testAutomaticSplitterMultiProcess.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/configutration_for_automatic_splitter.py"
 />
 
 <test

--- a/HeterogeneousCore/MPICore/test/controller_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_cfg.py
@@ -21,7 +21,8 @@ process.maxEvents.input = 100
 from HeterogeneousCore.MPICore.modules import *
 
 process.mpiController = MPIController(
-    mode = 'CommWorld'
+    mode = 'CommWorld',
+    followerProcessName = 'Follower'
 )
 
 process.ids = cms.EDProducer("edmtest::EventIDProducer")

--- a/HeterogeneousCore/MPICore/test/controller_complex_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_complex_cfg.py
@@ -20,7 +20,8 @@ process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 from HeterogeneousCore.MPICore.modules import *
 
 process.mpiController = MPIController(
-    mode = 'CommWorld'
+    mode = 'CommWorld',
+    followerProcessName = 'MPIFollower'
 )
 
 # Phase-1 FED RAW data collection pseudo object

--- a/HeterogeneousCore/MPICore/test/controller_filters_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_filters_cfg.py
@@ -24,7 +24,8 @@ process.maxEvents.input = 30
 from HeterogeneousCore.MPICore.modules import MPIController, MPISender, MPIReceiver
 
 process.mpiController = MPIController(
-    mode = 'CommWorld'
+    mode = 'CommWorld',
+    followerProcessName = 'MPIFollower'
 )
 
 # Produce EventID, that will be sent to the Follower

--- a/HeterogeneousCore/MPICore/test/controller_multi_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_multi_cfg.py
@@ -30,7 +30,7 @@ process.initialcheck = cms.EDAnalyzer("edmtest::EventIDValidator",
 
 process.mpiController1 = MPIController(
     mode = 'CommWorld',
-    followers = [ 1 ]
+    followerProcessName = 'Follower1'
 )
 
 process.sender1 = MPISender(
@@ -72,7 +72,7 @@ process.path1 = cms.Path(
 
 process.mpiController2 = MPIController(
     mode = 'CommWorld',
-    followers = [ 2 ]
+    followerProcessName = 'Follower2'
 )
 
 process.sender2 = MPISender(

--- a/HeterogeneousCore/MPICore/test/controller_multi_rr_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_multi_rr_cfg.py
@@ -30,7 +30,7 @@ process.initialcheck = cms.EDAnalyzer("edmtest::EventIDValidator",
 
 process.mpiController1 = MPIController(
     mode = 'CommWorld',
-    followers = [ 1, 2 ]
+    followerProcessName = 'Follower1'
 )
 
 process.sender1 = MPISender(
@@ -72,7 +72,7 @@ process.path1 = cms.Path(
 
 process.mpiController2 = MPIController(
     mode = 'CommWorld',
-    followers = [ 3, 4 ]
+    followerProcessName = 'Follower2'
 )
 
 process.sender2 = MPISender(

--- a/HeterogeneousCore/MPICore/test/controller_rr_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_rr_cfg.py
@@ -22,7 +22,7 @@ from HeterogeneousCore.MPICore.modules import *
 
 process.mpiController = MPIController(
     mode = 'CommWorld',
-    followers = [ 1, 2 ]
+    followerProcessName = 'Follower'
 )
 
 process.ids = cms.EDProducer("edmtest::EventIDProducer")

--- a/HeterogeneousCore/MPICore/test/controller_soa_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_soa_cfg.py
@@ -24,7 +24,8 @@ process.load("HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi")
 from HeterogeneousCore.MPICore.modules import *
 
 process.mpiController = MPIController(
-    mode = 'CommWorld'
+    mode = 'CommWorld',
+    followerProcessName = 'MPIFollower'
 )
 
 process.producePortableObjects = cms.EDProducer("TestAlpakaProducer@alpaka",

--- a/HeterogeneousCore/MPICore/test/controller_too_many_streams_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_too_many_streams_cfg.py
@@ -34,7 +34,8 @@ process.maxEvents.input = 10
 from HeterogeneousCore.MPICore.modules import *
 
 process.mpiController = MPIController(
-    mode = 'CommWorld'
+    mode = 'CommWorld',
+    followerProcessName = 'MPIFollower'
 )
 
 process.ids = cms.EDProducer("edmtest::EventIDProducer")

--- a/HeterogeneousCore/MPICore/test/follower_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_cfg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("MPIFollower")
+process = cms.Process("Follower")
 
 process.options.numberOfThreads = 8
 process.options.numberOfStreams = 8
@@ -14,7 +14,7 @@ from HeterogeneousCore.MPICore.modules import *
 
 process.source = MPISource(
     mode = 'CommWorld',
-    controller = 0
+    controllerProcessName = 'MPIController'
 )
 
 process.maxEvents.input = -1

--- a/HeterogeneousCore/MPICore/test/follower_complex_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_complex_cfg.py
@@ -10,7 +10,10 @@ process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from HeterogeneousCore.MPICore.modules import *
 
-process.source = MPISource()
+process.source = MPISource(
+    mode = 'CommWorld',
+    controllerProcessName = 'MPIController'
+)
 
 process.maxEvents.input = -1
 

--- a/HeterogeneousCore/MPICore/test/follower_filters_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_filters_cfg.py
@@ -12,7 +12,10 @@ process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from HeterogeneousCore.MPICore.modules import MPISource, MPIReceiver, MPISender
 
-process.source = MPISource()
+process.source = MPISource(
+    mode = 'CommWorld',
+    controllerProcessName = 'MPIController'
+)
 
 process.maxEvents.input = -1
 

--- a/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("MPIFollower")
+process = cms.Process("Follower1")
 
 process.options.numberOfThreads = 8
 process.options.numberOfStreams = 8
@@ -14,7 +14,7 @@ from HeterogeneousCore.MPICore.modules import *
 
 process.source = MPISource(
     mode = 'CommWorld',
-    controller = 0
+    controllerProcessName = 'MPIController'
 )
 
 process.maxEvents.input = -1

--- a/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("MPIFollower")
+process = cms.Process("Follower2")
 
 process.options.numberOfThreads = 8
 process.options.numberOfStreams = 8
@@ -14,7 +14,7 @@ from HeterogeneousCore.MPICore.modules import *
 
 process.source = MPISource(
     mode = 'CommWorld',
-    controller = 0
+    controllerProcessName = 'MPIController'
 )
 
 process.maxEvents.input = -1

--- a/HeterogeneousCore/MPICore/test/follower_soa_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_soa_cfg.py
@@ -10,7 +10,9 @@ process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from HeterogeneousCore.MPICore.modules import *
 
-process.source = MPISource()
+process.source = MPISource(mode = 'CommWorld',
+    controllerProcessName = 'MPIController'
+)
 
 process.maxEvents.input = -1
 

--- a/HeterogeneousCore/MPICore/test/follower_too_many_streams_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_too_many_streams_cfg.py
@@ -14,7 +14,7 @@ from HeterogeneousCore.MPICore.modules import *
 
 process.source = MPISource(
     mode = 'CommWorld',
-    controller = 0
+    controllerProcessName = 'MPIController'
 )
 
 process.maxEvents.input = -1

--- a/HeterogeneousCore/MPICore/test/testAutomaticSplitter.sh
+++ b/HeterogeneousCore/MPICore/test/testAutomaticSplitter.sh
@@ -2,13 +2,12 @@
 
 # Shell script for testing the automattic config splitter for MPI in CMSSW
 
-SPLITTER=$(realpath "$1")
-WHOLE_CONFIG=$(realpath "$2")
+WHOLE_CONFIG=$(realpath "$1")
 
 LOCAL_PATH="./autosplit_result/local_test_config.py"
 REMOTE_PATH="./autosplit_result/remote_test_config.py"
 
-python3 "$SPLITTER" "$WHOLE_CONFIG" \
+edmMpiSplitConfig "$WHOLE_CONFIG" \
   --remote-modules triggerEventProducer testReadTriggerResults rawDataBufferProducer testReadFEDRawDataCollection \
   -l "$LOCAL_PATH" -r "$REMOTE_PATH"
 

--- a/HeterogeneousCore/MPICore/test/testAutomaticSplitterMultiProcess.sh
+++ b/HeterogeneousCore/MPICore/test/testAutomaticSplitterMultiProcess.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+# Shell script for testing the automattic config splitter for MPI in CMSSW
+
+WHOLE_CONFIG=$(realpath "$1")
+
+LOCAL_PATH="./autosplit_result/local_test_config.py"
+REMOTE_PATH_1="./autosplit_result/remote_test_config_1.py"
+REMOTE_PATH_2="./autosplit_result/remote_test_config_2.py"
+
+edmMpiSplitConfig "$WHOLE_CONFIG" -l "$LOCAL_PATH"\
+  --remote-modules triggerEventProducer testReadTriggerResults -r "$REMOTE_PATH_1" :\
+  --remote-modules rawDataBufferProducer testReadFEDRawDataCollection -r "$REMOTE_PATH_2"
+
+
+"$CMSSW_BASE"/src/HeterogeneousCore/MPICore/test/testMPICommWorld.sh "$LOCAL_PATH" "$REMOTE_PATH_1" "$REMOTE_PATH_2" 

--- a/HeterogeneousCore/MPIServices/interface/MPIService.h
+++ b/HeterogeneousCore/MPIServices/interface/MPIService.h
@@ -1,6 +1,10 @@
 #ifndef HeterogeneousCore_MPIServices_interface_MPIService_h
 #define HeterogeneousCore_MPIServices_interface_MPIService_h
 
+#include <mutex>
+#include <vector>
+#include <string>
+
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 class MPIService {
@@ -10,6 +14,13 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   static void required();
+  std::vector<int> getRanksByProcessName(std::string const& processName);
+
+private:
+  std::once_flag init_flag_;
+  std::vector<uint64_t> all_process_hashes_;
+
+  void exchangeProcessHashes_();
 };
 
 #endif  // HeterogeneousCore_MPIServices_interface_MPIService_h

--- a/HeterogeneousCore/MPIServices/src/MPIService.cc
+++ b/HeterogeneousCore/MPIServices/src/MPIService.cc
@@ -1,10 +1,12 @@
 // -*- C++ -*-
 #include <cstdlib>
 #include <exception>
+#include <mutex>
 #include <string>
 
 #include <mpi.h>
 
+#include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -110,4 +112,29 @@ Please add it to the configuration, for example via
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 )";
   }
+}
+
+// Ensure that processes exchange their hashes only once
+void MPIService::exchangeProcessHashes_() {
+  std::call_once(init_flag_, [&]() {
+    int world_size;
+    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+    all_process_hashes_.resize(world_size);
+    edm::Service<edm::service::TriggerNamesService> tns;
+    std::string const& processName = tns->getProcessName();
+    uint64_t this_process_hash = std::hash<std::string>{}(processName);
+    MPI_Allgather(&this_process_hash, 1, MPI_UINT64_T, all_process_hashes_.data(), 1, MPI_UINT64_T, MPI_COMM_WORLD);
+  });
+}
+
+std::vector<int> MPIService::getRanksByProcessName(std::string const& processName) {
+  this->exchangeProcessHashes_();
+  std::vector<int> process_indices;
+  uint64_t other_process_hash = std::hash<std::string>{}(processName);
+  for (size_t i = 0; i < all_process_hashes_.size(); i++) {
+    if (all_process_hashes_[i] == other_process_hash) {
+      process_indices.push_back(i);
+    }
+  }
+  return process_indices;
 }


### PR DESCRIPTION
#### PR description:

This pull request corresponds to ngt issue [#18](https://github.com/cms-ngt-hlt/ngt32/issues/18)

It changes the splitter to allow creating multiple-remote setups, where parameters for different processes are separated with ":"

It also changes the logic by which the **`MPIController`** and **`MPISource`** discover each other: instead of specifying ranks of the follower process, **`MPIController`** can set `remoteProcess` parameter with remote process name, and it's rank will be discovered at runtime. **`MPISource`** has to specify the controller process name via `controllerProcessName` parameter, and **`MPIController`** must specify name of matching process in `followerProcessName` parameter.

Integration tests were modified to account for the configuration changes.

#### PR validation:

Tried using new splitter with the command:

```bash
edmMpiSplitConfig hlt.py -l local.py -m hltEcalDigisSoA hltEcalUncalibRecHitSoA -r remote_ecal.py -n ECAL :  \
-m hltHcalDigisSoA hltHbheRecoSoA hltParticleFlowRecHitHBHESoA hltParticleFlowClusterHBHESoA -d hltHcalDigis -r remote_hcal.py -n HCAL
```

Also integration test to split multiple remotes was added in MPICore package.
