### PR TITLE
LST: add LSTGeometry package and associated ESProducer

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltLSTGeometry_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltLSTGeometry_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+hltLSTGeometry = cms.ESProducer('LSTGeometryESProducer',
+    ptCut = cms.double(0.8),
+)

--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -94,6 +94,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/trackdnn_source_cfi"
 
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPPixelCPEFastParams_cfi")
 
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltLSTGeometry_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi")
 

--- a/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
@@ -99,6 +99,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/trackdnn_source_cfi"
 
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPPixelCPEFastParams_cfi")
 
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltLSTGeometry_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi")
 

--- a/HLTrigger/Configuration/python/HLT_NGTScouting_cff.py
+++ b/HLTrigger/Configuration/python/HLT_NGTScouting_cff.py
@@ -93,6 +93,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFTrajectoryFi
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFTrajectorySmootherForL2Muon_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/trackdnn_source_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPPixelCPEFastParams_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltLSTGeometry_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPMkFit_cfi")

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -399,10 +399,11 @@ trackingPhase2PU140.toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_
 
 _HighPtTripletStepTask_LST = HighPtTripletStepTask.copy()
 from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import siPhase2RecHits
+from RecoTracker.LSTGeometry.lstGeometryESProducer_cfi import lstGeometryESProducer
 from RecoTracker.LST.lstInputProducer_cfi import lstInputProducer
 from RecoTracker.LST.lstProducerTask_cff import *
 
-_HighPtTripletStepTask_LST.add(siPhase2RecHits, lstInputProducer, lstProducerTask)
+_HighPtTripletStepTask_LST.add(siPhase2RecHits, lstGeometryESProducer, lstInputProducer, lstProducerTask)
 (trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_LST)
 
 from Configuration.ProcessModifiers.alpakaValidationLST_cff import alpakaValidationLST

--- a/RecoTracker/LST/plugins/alpaka/LSTModulesDevESProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTModulesDevESProducer.cc
@@ -1,5 +1,7 @@
 // LST includes
 #include "RecoTracker/LSTCore/interface/alpaka/LST.h"
+#include "RecoTracker/LSTGeometry/interface/Common.h"
+#include "RecoTracker/LSTGeometry/interface/Geometry.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -14,22 +16,27 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class LSTModulesDevESProducer : public ESProducer {
   private:
-    std::string ptCutLabel_;
+    double ptCut_;
+    edm::ESGetToken<lstgeometry::Geometry, TrackerRecoGeometryRecord> lstGeoToken_;
 
   public:
     LSTModulesDevESProducer(edm::ParameterSet const& iConfig)
-        : ESProducer(iConfig), ptCutLabel_(iConfig.getParameter<std::string>("ptCutLabel")) {
-      setWhatProduced(this, ptCutLabel_);
+        : ESProducer(iConfig), ptCut_(iConfig.getParameter<double>("ptCut")) {
+      std::string ptCutStr = lstgeometry::floatToStr(ptCut_, 1);
+
+      auto cc = setWhatProduced(this, ptCutStr);
+      lstGeoToken_ = cc.consumes<lstgeometry::Geometry>(edm::ESInputTag("", ptCutStr));
     }
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
-      desc.add<std::string>("ptCutLabel", "0.8");
+      desc.add<double>("ptCut", 0.8);
       descriptions.addWithDefaultLabel(desc);
     }
 
     std::unique_ptr<lst::LSTESData<DevHost>> produce(TrackerRecoGeometryRecord const& iRecord) {
-      return lst::loadAndFillESHost(ptCutLabel_);
+      const auto& lstg = iRecord.get(lstGeoToken_);
+      return lst::fillESDataHost(lstg);
     }
   };
 

--- a/RecoTracker/LST/plugins/alpaka/LSTModulesDevESProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTModulesDevESProducer.cc
@@ -22,7 +22,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   public:
     LSTModulesDevESProducer(edm::ParameterSet const& iConfig)
         : ESProducer(iConfig), ptCut_(iConfig.getParameter<double>("ptCut")) {
-      std::string ptCutStr = lstgeometry::floatToStr(ptCut_, 1);
+      std::string ptCutStr = lst::floatToStr(ptCut_, 1);
 
       auto cc = setWhatProduced(this, ptCutStr);
       lstGeoToken_ = cc.consumes<lstgeometry::Geometry>(edm::ESInputTag("", ptCutStr));

--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -28,7 +28,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         : EDProducer(config),
           verbose_(config.getParameter<bool>("verbose")),
           ptCut_(config.getParameter<double>("ptCut")),
-          ptCutStr_(lstgeometry::floatToStr(ptCut_, 1)),
+          ptCutStr_(lst::floatToStr(ptCut_, 1)),
           clustSizeCut_(static_cast<uint16_t>(config.getParameter<uint32_t>("clustSizeCut"))),
           nopLSDupClean_(config.getParameter<bool>("nopLSDupClean")),
           tcpLSTriplets_(config.getParameter<bool>("tcpLSTriplets")),

--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -1,6 +1,7 @@
 #include <alpaka/alpaka.hpp>
 
 #include "RecoTracker/LSTCore/interface/alpaka/LST.h"
+#include "RecoTracker/LSTGeometry/interface/Common.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -25,14 +26,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   public:
     LSTProducer(edm::ParameterSet const& config)
         : EDProducer(config),
-          lstInputToken_{consumes(config.getParameter<edm::InputTag>("lstInput"))},
-          lstESToken_{esConsumes(edm::ESInputTag("", config.getParameter<std::string>("ptCutLabel")))},
           verbose_(config.getParameter<bool>("verbose")),
           ptCut_(config.getParameter<double>("ptCut")),
+          ptCutStr_(lstgeometry::floatToStr(ptCut_, 1)),
           clustSizeCut_(static_cast<uint16_t>(config.getParameter<uint32_t>("clustSizeCut"))),
           nopLSDupClean_(config.getParameter<bool>("nopLSDupClean")),
           tcpLSTriplets_(config.getParameter<bool>("tcpLSTriplets")),
           reduceMemByFullPrecompute_(config.getParameter<bool>("reduceMemByFullPrecompute")),
+          lstInputToken_{consumes(config.getParameter<edm::InputTag>("lstInput"))},
+          lstESToken_{esConsumes(edm::ESInputTag("", ptCutStr_))},
           lstOutputToken_{produces()} {}
 
     void produce(edm::StreamID sid, device::Event& iEvent, const device::EventSetup& iSetup) const override {
@@ -43,7 +45,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       lst.run(iEvent.queue(),
               verbose_,
-              static_cast<float>(ptCut_),
+              ptCut_,
               clustSizeCut_,
               &lstESDeviceData,
               &lstInputDC,
@@ -62,7 +64,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       desc.add<bool>("verbose", false);
       desc.add<double>("ptCut", 0.8);
       desc.add<uint32_t>("clustSizeCut", 16);
-      desc.add<std::string>("ptCutLabel", "0.8");
       desc.add<bool>("nopLSDupClean", false);
       desc.add<bool>("tcpLSTriplets", false);
       desc.add<bool>("reduceMemByFullPrecompute", false)
@@ -74,14 +75,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
   private:
-    const device::EDGetToken<lst::LSTInputDeviceCollection> lstInputToken_;
-    const device::ESGetToken<lst::LSTESData<Device>, TrackerRecoGeometryRecord> lstESToken_;
     const bool verbose_;
     const double ptCut_;
+    const std::string ptCutStr_;
     const uint16_t clustSizeCut_;
     const bool nopLSDupClean_;
     const bool tcpLSTriplets_;
     const bool reduceMemByFullPrecompute_;
+    const device::EDGetToken<lst::LSTInputDeviceCollection> lstInputToken_;
+    const device::ESGetToken<lst::LSTESData<Device>, TrackerRecoGeometryRecord> lstESToken_;
     const device::EDPutToken<lst::TrackCandidatesBaseDeviceCollection> lstOutputToken_;
   };
 

--- a/RecoTracker/LST/python/lstProducerTask_cff.py
+++ b/RecoTracker/LST/python/lstProducerTask_cff.py
@@ -4,4 +4,8 @@ from RecoTracker.LST.lstProducer_cfi import lstProducer
 
 from RecoTracker.LST.lstModulesDevESProducer_cfi import lstModulesDevESProducer
 
-lstProducerTask = cms.Task(lstModulesDevESProducer, lstProducer)
+from RecoTracker.LST.lstInputProducer_cfi import lstInputProducer
+
+from RecoTracker.LSTGeometry.lstGeometryESProducer_cfi import lstGeometryESProducer
+
+lstProducerTask = cms.Task(lstGeometryESProducer, lstModulesDevESProducer, lstInputProducer, lstProducer)

--- a/RecoTracker/LSTCore/BuildFile.xml
+++ b/RecoTracker/LSTCore/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="DataFormats/SoATemplate"/>
 <use name="DataFormats/TrackerRecHit2D"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
+<use name="RecoTracker/LSTGeometry"/>
 <flags ALPAKA_BACKENDS="1"/>
 <export>
   <lib name="1"/>

--- a/RecoTracker/LSTCore/interface/Common.h
+++ b/RecoTracker/LSTCore/interface/Common.h
@@ -4,6 +4,8 @@
 #include "DataFormats/Common/interface/StdArray.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
+#include "RecoTracker/LSTGeometry/interface/Common.h"
+
 #if defined(FP16_Base)
 #if defined ALPAKA_ACC_GPU_CUDA_ENABLED
 #include <cuda_fp16.h>
@@ -41,6 +43,9 @@ namespace lst {
 
   constexpr uint16_t kTCEmptyLowerModule = 0xFFFF;     // Sentinel for empty lowerModule index
   constexpr unsigned int kTCEmptyHitIdx = 0xFFFFFFFF;  // Sentinel for empty hit slots
+
+  constexpr float kB = lstgeometry::kB;
+  constexpr float kC = lstgeometry::kC;
 
 // Half precision wrapper functions.
 #if defined(FP16_Base)

--- a/RecoTracker/LSTCore/interface/EndcapGeometry.h
+++ b/RecoTracker/LSTCore/interface/EndcapGeometry.h
@@ -1,6 +1,9 @@
 #ifndef RecoTracker_LSTCore_interface_EndcapGeometry_h
 #define RecoTracker_LSTCore_interface_EndcapGeometry_h
 
+#include "RecoTracker/LSTGeometry/interface/Sensor.h"
+#include "RecoTracker/LSTGeometry/interface/Slope.h"
+
 #include <map>
 #include <string>
 #include <vector>
@@ -18,9 +21,11 @@ namespace lst {
     unsigned int nEndCapMap;
 
     EndcapGeometry() = default;
-    EndcapGeometry(std::string const& filename);
+    EndcapGeometry(std::string const&);
+    EndcapGeometry(lstgeometry::Slopes const&, lstgeometry::Sensors const& sensors);
 
     void load(std::string const&);
+    void load(lstgeometry::Slopes const&, lstgeometry::Sensors const& sensors);
     void fillGeoMapArraysExplicit();
     float getdxdy_slope(unsigned int detid) const;
   };

--- a/RecoTracker/LSTCore/interface/LSTESData.h
+++ b/RecoTracker/LSTCore/interface/LSTESData.h
@@ -5,6 +5,7 @@
 #include "RecoTracker/LSTCore/interface/EndcapGeometryDevHostCollection.h"
 #include "RecoTracker/LSTCore/interface/ModulesHostCollection.h"
 #include "RecoTracker/LSTCore/interface/PixelMap.h"
+#include "RecoTracker/LSTGeometry/interface/Geometry.h"
 
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
 
@@ -40,7 +41,8 @@ namespace lst {
           pixelMapping(pixelMappingIn) {}
   };
 
-  std::unique_ptr<LSTESData<alpaka_common::DevHost>> loadAndFillESHost(std::string& ptCutLabel);
+  std::unique_ptr<LSTESData<alpaka_common::DevHost>> loadAndFillESDataHost(std::string& ptCutLabel);
+  std::unique_ptr<LSTESData<alpaka_common::DevHost>> fillESDataHost(lstgeometry::Geometry const& lstg);
 
 }  // namespace lst
 

--- a/RecoTracker/LSTCore/interface/ModuleConnectionMap.h
+++ b/RecoTracker/LSTCore/interface/ModuleConnectionMap.h
@@ -12,10 +12,12 @@ namespace lst {
     std::map<unsigned int, std::vector<unsigned int>> moduleConnections_;
 
   public:
-    ModuleConnectionMap();
-    ModuleConnectionMap(std::string const& filename);
+    ModuleConnectionMap() = default;
+    ModuleConnectionMap(std::string const&);
+    ModuleConnectionMap(std::map<unsigned int, std::vector<unsigned int>> const&);
 
     void load(std::string const&);
+    void load(std::map<unsigned int, std::vector<unsigned int>> const&);
     void add(std::string const&);
     void print();
 

--- a/RecoTracker/LSTCore/interface/TiltedGeometry.h
+++ b/RecoTracker/LSTCore/interface/TiltedGeometry.h
@@ -1,6 +1,8 @@
 #ifndef RecoTracker_LSTCore_interface_TiltedGeometry_h
 #define RecoTracker_LSTCore_interface_TiltedGeometry_h
 
+#include "RecoTracker/LSTGeometry/interface/Slope.h"
+
 #include <map>
 #include <string>
 #include <vector>
@@ -13,9 +15,11 @@ namespace lst {
 
   public:
     TiltedGeometry() = default;
-    TiltedGeometry(std::string const& filename);
+    TiltedGeometry(std::string const&);
+    TiltedGeometry(lstgeometry::Slopes const&);
 
     void load(std::string const&);
+    void load(lstgeometry::Slopes const&);
 
     float getDrDz(unsigned int detid) const;
     float getDxDy(unsigned int detid) const;

--- a/RecoTracker/LSTCore/interface/alpaka/Common.h
+++ b/RecoTracker/LSTCore/interface/alpaka/Common.h
@@ -32,8 +32,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       25.007152356, 37.2186993757, 52.3104270826, 68.6658656666, 85.9770373007, 108.301772384};
   HOST_DEVICE_CONSTANT float kMiniRminMeanEndcap[5] = {
       130.992832231, 154.813883559, 185.352604327, 221.635123002, 265.022076742};
-  HOST_DEVICE_CONSTANT float k2Rinv1GeVf = (2.99792458e-3 * 3.8) / 2;
-  HOST_DEVICE_CONSTANT float kR1GeVf = 1. / (2.99792458e-3 * 3.8);
+  HOST_DEVICE_CONSTANT float k2Rinv1GeVf = (kC * kB) / 2;
+  HOST_DEVICE_CONSTANT float kR1GeVf = 1. / (kC * kB);
   HOST_DEVICE_CONSTANT float kSinAlphaMax = 0.95;
   HOST_DEVICE_CONSTANT float kDeltaZLum = 15.0;
   HOST_DEVICE_CONSTANT float kPixelPSZpitch = 0.15;
@@ -44,8 +44,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   HOST_DEVICE_CONSTANT float kWidthPS = 0.01;
   HOST_DEVICE_CONSTANT float kPt_betaMax = 7.0;
   HOST_DEVICE_CONSTANT int kNTripletThreshold = 1000;
-  // To be updated with std::numeric_limits<float>::infinity() in the code and data files
-  HOST_DEVICE_CONSTANT float kVerticalModuleSlope = 123456789.0;
   HOST_DEVICE_CONSTANT int kLogicalOTLayers = 11;  // logical OT layers are 1..11
 
   HOST_DEVICE_CONSTANT float kMiniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};

--- a/RecoTracker/LSTCore/src/EndcapGeometry.cc
+++ b/RecoTracker/LSTCore/src/EndcapGeometry.cc
@@ -2,10 +2,15 @@
 
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 
 lst::EndcapGeometry::EndcapGeometry(std::string const& filename) { load(filename); }
+
+lst::EndcapGeometry::EndcapGeometry(lstgeometry::Slopes const& slopes, lstgeometry::Sensors const& sensors) {
+  load(slopes, sensors);
+}
 
 void lst::EndcapGeometry::load(std::string const& filename) {
   dxdy_slope_.clear();
@@ -26,7 +31,9 @@ void lst::EndcapGeometry::load(std::string const& filename) {
     ifile.read(reinterpret_cast<char*>(&centroid_phi), sizeof(centroid_phi));
 
     if (ifile) {
-      dxdy_slope_[detid] = dxdy_slope;
+      // TODO: This is needed for now in case old geometry files are used. Remove once deemed unnecessary.
+      constexpr float kLegacyVerticalSlope = 123456789.0f;
+      dxdy_slope_[detid] = (dxdy_slope == kLegacyVerticalSlope) ? std::numeric_limits<float>::infinity() : dxdy_slope;
       centroid_phis_[detid] = centroid_phi;
     } else {
       // End of file or read failed
@@ -34,6 +41,18 @@ void lst::EndcapGeometry::load(std::string const& filename) {
         throw std::runtime_error("Failed to read Endcap Geometry binary data.");
       }
     }
+  }
+
+  fillGeoMapArraysExplicit();
+}
+
+void lst::EndcapGeometry::load(lstgeometry::Slopes const& slopes, lstgeometry::Sensors const& sensors) {
+  dxdy_slope_.clear();
+  centroid_phis_.clear();
+
+  for (const auto& [detId, slope] : slopes) {
+    dxdy_slope_[detId] = slope.dxdy;
+    centroid_phis_[detId] = sensors.at(detId).centerPhi;
   }
 
   fillGeoMapArraysExplicit();

--- a/RecoTracker/LSTCore/src/LSTESData.cc
+++ b/RecoTracker/LSTCore/src/LSTESData.cc
@@ -144,7 +144,9 @@ std::unique_ptr<lst::LSTESData<alpaka_common::DevHost>> lst::fillESDataHost(lstg
 
   std::map<unsigned int, std::vector<unsigned int>> final_modulemap;
   for (auto const& [detId, connections] : lstg.module_map) {
-    final_modulemap[detId] = std::vector<unsigned int>(connections.begin(), connections.end());
+    if (connections.empty())
+      continue;
+    final_modulemap[detId] = connections;
   }
   moduleConnectionMap.load(final_modulemap);
 
@@ -153,17 +155,15 @@ std::unique_ptr<lst::LSTESData<alpaka_common::DevHost>> lst::fillESDataHost(lstg
 
     std::map<unsigned int, std::vector<unsigned int>> final_pixelmap;
     for (unsigned int isuperbin = 0; isuperbin < map.size(); isuperbin++) {
-      auto const& set = map.at(isuperbin);
-      final_pixelmap[isuperbin] = std::vector<unsigned int>(set.begin(), set.end());
+      auto const& vec = map.at(isuperbin);
+      if (vec.empty())
+        continue;
+      final_pixelmap[isuperbin] = vec;
     }
 
-    if (charge == 0) {
-      pLStoLayer[0][layer - 1 + (subdet == Endcap ? 2 : 0)] = lst::ModuleConnectionMap(final_pixelmap);
-    } else if (charge > 0) {
-      pLStoLayer[1][layer - 1 + (subdet == Endcap ? 2 : 0)] = lst::ModuleConnectionMap(final_pixelmap);
-    } else {
-      pLStoLayer[2][layer - 1 + (subdet == Endcap ? 2 : 0)] = lst::ModuleConnectionMap(final_pixelmap);
-    }
+    int charge_index = (charge == 0 ? 0 : (charge > 0 ? 1 : 2));
+    int layer_subdet_index = layer - 1 + (subdet == Endcap ? 2 : 0);
+    pLStoLayer[charge_index][layer_subdet_index] = lst::ModuleConnectionMap(final_pixelmap);
   }
 
   ModuleMetaData mmd;

--- a/RecoTracker/LSTCore/src/LSTESData.cc
+++ b/RecoTracker/LSTCore/src/LSTESData.cc
@@ -1,3 +1,5 @@
+#include <filesystem>
+
 #include "RecoTracker/LSTCore/interface/LSTESData.h"
 #include "RecoTracker/LSTCore/interface/EndcapGeometry.h"
 #include "RecoTracker/LSTCore/interface/ModuleConnectionMap.h"
@@ -5,8 +7,6 @@
 #include "RecoTracker/LSTCore/interface/PixelMap.h"
 
 #include "ModuleMethods.h"
-
-#include <filesystem>
 
 namespace {
   std::string geometryDataDir() {
@@ -79,7 +79,7 @@ namespace {
   }
 }  // namespace
 
-std::unique_ptr<lst::LSTESData<alpaka_common::DevHost>> lst::loadAndFillESHost(std::string& ptCutLabel) {
+std::unique_ptr<lst::LSTESData<alpaka_common::DevHost>> lst::loadAndFillESDataHost(std::string& ptCutLabel) {
   uint16_t nModules;
   uint16_t nLowerModules;
   unsigned int nPixels;
@@ -110,6 +110,86 @@ std::unique_ptr<lst::LSTESData<alpaka_common::DevHost>> lst::loadAndFillESHost(s
                                                  endcapGeometry,
                                                  tiltedGeometry,
                                                  moduleConnectionMap);
+  auto pixelMappingPtr = std::make_shared<PixelMap>(std::move(pixelMapping));
+  return std::make_unique<LSTESData<alpaka_common::DevHost>>(nModules,
+                                                             nLowerModules,
+                                                             nPixels,
+                                                             endcapGeometry.nEndCapMap,
+                                                             std::move(modulesBuffers),
+                                                             std::move(endcapGeometryDev),
+                                                             pixelMappingPtr);
+}
+
+std::unique_ptr<lst::LSTESData<alpaka_common::DevHost>> lst::fillESDataHost(lstgeometry::Geometry const& lstg) {
+  uint16_t nModules;
+  uint16_t nLowerModules;
+  unsigned int nPixels;
+  MapPLStoLayer pLStoLayer;
+  EndcapGeometry endcapGeometry;
+  TiltedGeometry tiltedGeometry;
+  PixelMap pixelMapping;
+  ModuleConnectionMap moduleConnectionMap;
+
+  endcapGeometry.load(lstg.endcap_slopes, lstg.sensors);
+  auto endcapGeometryDev =
+      std::make_shared<EndcapGeometryDevHostCollection>(cms::alpakatools::host(), endcapGeometry.nEndCapMap);
+  std::memcpy(endcapGeometryDev->view().geoMapDetId().data(),
+              endcapGeometry.geoMapDetId_buf.data(),
+              endcapGeometry.nEndCapMap * sizeof(unsigned int));
+  std::memcpy(endcapGeometryDev->view().geoMapPhi().data(),
+              endcapGeometry.geoMapPhi_buf.data(),
+              endcapGeometry.nEndCapMap * sizeof(float));
+
+  tiltedGeometry.load(lstg.barrel_slopes);
+
+  std::map<unsigned int, std::vector<unsigned int>> final_modulemap;
+  for (auto const& [detId, connections] : lstg.module_map) {
+    final_modulemap[detId] = std::vector<unsigned int>(connections.begin(), connections.end());
+  }
+  moduleConnectionMap.load(final_modulemap);
+
+  for (auto& [layersubdetcharge, map] : lstg.pixel_map) {
+    auto& [layer, subdet, charge] = layersubdetcharge;
+
+    std::map<unsigned int, std::vector<unsigned int>> final_pixelmap;
+    for (unsigned int isuperbin = 0; isuperbin < map.size(); isuperbin++) {
+      auto const& set = map.at(isuperbin);
+      final_pixelmap[isuperbin] = std::vector<unsigned int>(set.begin(), set.end());
+    }
+
+    if (charge == 0) {
+      pLStoLayer[0][layer - 1 + (subdet == Endcap ? 2 : 0)] = lst::ModuleConnectionMap(final_pixelmap);
+    } else if (charge > 0) {
+      pLStoLayer[1][layer - 1 + (subdet == Endcap ? 2 : 0)] = lst::ModuleConnectionMap(final_pixelmap);
+    } else {
+      pLStoLayer[2][layer - 1 + (subdet == Endcap ? 2 : 0)] = lst::ModuleConnectionMap(final_pixelmap);
+    }
+  }
+
+  ModuleMetaData mmd;
+  unsigned int counter = 0;
+  for (auto const& [detId, sensor] : lstg.sensors) {
+    mmd.detIdToIndex[detId] = counter;
+    mmd.module_x[detId] = sensor.centerX;
+    mmd.module_y[detId] = sensor.centerY;
+    mmd.module_z[detId] = sensor.centerZ;
+    mmd.module_type[detId] = static_cast<unsigned int>(sensor.moduleType);
+    counter++;
+  }
+  mmd.detIdToIndex[kPixelModuleId] = counter;  //pixel module is the last module in the module list
+  counter++;
+  nModules = counter;
+
+  auto modulesBuffers = constructModuleCollection(pLStoLayer,
+                                                  mmd,
+                                                  nModules,
+                                                  nLowerModules,
+                                                  nPixels,
+                                                  pixelMapping,
+                                                  endcapGeometry,
+                                                  tiltedGeometry,
+                                                  moduleConnectionMap);
+
   auto pixelMappingPtr = std::make_shared<PixelMap>(std::move(pixelMapping));
   return std::make_unique<LSTESData<alpaka_common::DevHost>>(nModules,
                                                              nLowerModules,

--- a/RecoTracker/LSTCore/src/ModuleConnectionMap.cc
+++ b/RecoTracker/LSTCore/src/ModuleConnectionMap.cc
@@ -5,9 +5,11 @@
 #include <sstream>
 #include <algorithm>
 
-lst::ModuleConnectionMap::ModuleConnectionMap() {}
-
 lst::ModuleConnectionMap::ModuleConnectionMap(std::string const& filename) { load(filename); }
+
+lst::ModuleConnectionMap::ModuleConnectionMap(std::map<unsigned int, std::vector<unsigned int>> const& map) {
+  load(map);
+}
 
 void lst::ModuleConnectionMap::load(std::string const& filename) {
   moduleConnections_.clear();
@@ -51,6 +53,10 @@ void lst::ModuleConnectionMap::load(std::string const& filename) {
       }
     }
   }
+}
+
+void lst::ModuleConnectionMap::load(std::map<unsigned int, std::vector<unsigned int>> const& map) {
+  moduleConnections_ = map;
 }
 
 void lst::ModuleConnectionMap::add(std::string const& filename) {

--- a/RecoTracker/LSTCore/src/ModuleMethods.h
+++ b/RecoTracker/LSTCore/src/ModuleMethods.h
@@ -16,6 +16,9 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 
 namespace lst {
+  // TODO: At some point it might be good to move some of these things to LSTGeometry
+  // or replace the functions with values computed from standard geometry/topology methods
+
   struct ModuleMetaData {
     std::map<unsigned int, uint16_t> detIdToIndex;
     std::map<unsigned int, float> module_x;
@@ -138,6 +141,15 @@ namespace lst {
       uint16_t index = it->second;
       auto& connectedModules = moduleConnectionMap.getConnectedModuleDetIds(detId);
       nConnectedModules[index] = connectedModules.size();
+      if (nConnectedModules[index] > max_connected_modules) {
+#ifdef WARNINGS
+        printf("Warning: module %u has %u connections, exceeding max_connected_modules=%u. Truncating.\n",
+               detId,
+               nConnectedModules[index],
+               max_connected_modules);
+#endif
+        nConnectedModules[index] = max_connected_modules;
+      }
       for (uint16_t i = 0; i < nConnectedModules[index]; i++) {
         moduleMap[index][i] = mmd.detIdToIndex.at(connectedModules[i]);
       }
@@ -213,24 +225,21 @@ namespace lst {
       }
     }
 
-    mmd.detIdToIndex[1] = counter;  //pixel module is the last module in the module list
+    mmd.detIdToIndex[kPixelModuleId] = counter;  //pixel module is the last module in the module list
     counter++;
     nModules = counter;
   }
 
-  inline std::shared_ptr<ModulesHostCollection> loadModulesFromFile(MapPLStoLayer const& pLStoLayer,
-                                                                    const char* moduleMetaDataFilePath,
-                                                                    uint16_t& nModules,
-                                                                    uint16_t& nLowerModules,
-                                                                    unsigned int& nPixels,
-                                                                    PixelMap& pixelMapping,
-                                                                    const EndcapGeometry& endcapGeometry,
-                                                                    const TiltedGeometry& tiltedGeometry,
-                                                                    const ModuleConnectionMap& moduleConnectionMap) {
-    ModuleMetaData mmd;
-
-    loadCentroidsFromFile(moduleMetaDataFilePath, mmd, nModules);
-
+  inline std::shared_ptr<ModulesHostCollection> constructModuleCollection(
+      MapPLStoLayer const& pLStoLayer,
+      ModuleMetaData& mmd,
+      uint16_t& nModules,
+      uint16_t& nLowerModules,
+      unsigned int& nPixels,
+      PixelMap& pixelMapping,
+      const EndcapGeometry& endcapGeometry,
+      const TiltedGeometry& tiltedGeometry,
+      const ModuleConnectionMap& moduleConnectionMap) {
     // TODO: this whole section could use some refactoring
     auto [totalSizes,
           connectedModuleDetIds,
@@ -382,7 +391,7 @@ namespace lst {
     *host_nLowerModules = nLowerModules;
 
     // Fill pixel part
-    pixelMapping.pixelModuleIndex = mmd.detIdToIndex.at(1);
+    pixelMapping.pixelModuleIndex = mmd.detIdToIndex.at(kPixelModuleId);
 
     auto modulesPixel_view = modulesHC->view().modulesPixel();
     auto connectedPixels =
@@ -402,5 +411,29 @@ namespace lst {
 
     return modulesHC;
   }
+
+  inline std::shared_ptr<ModulesHostCollection> loadModulesFromFile(MapPLStoLayer const& pLStoLayer,
+                                                                    const char* moduleMetaDataFilePath,
+                                                                    uint16_t& nModules,
+                                                                    uint16_t& nLowerModules,
+                                                                    unsigned int& nPixels,
+                                                                    PixelMap& pixelMapping,
+                                                                    const EndcapGeometry& endcapGeometry,
+                                                                    const TiltedGeometry& tiltedGeometry,
+                                                                    const ModuleConnectionMap& moduleConnectionMap) {
+    ModuleMetaData mmd;
+
+    loadCentroidsFromFile(moduleMetaDataFilePath, mmd, nModules);
+    return constructModuleCollection(pLStoLayer,
+                                     mmd,
+                                     nModules,
+                                     nLowerModules,
+                                     nPixels,
+                                     pixelMapping,
+                                     endcapGeometry,
+                                     tiltedGeometry,
+                                     moduleConnectionMap);
+  }
+
 }  // namespace lst
 #endif

--- a/RecoTracker/LSTCore/src/TiltedGeometry.cc
+++ b/RecoTracker/LSTCore/src/TiltedGeometry.cc
@@ -2,10 +2,13 @@
 
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 
 lst::TiltedGeometry::TiltedGeometry(std::string const& filename) { load(filename); }
+
+lst::TiltedGeometry::TiltedGeometry(lstgeometry::Slopes const& slopes) { load(slopes); }
 
 void lst::TiltedGeometry::load(std::string const& filename) {
   drdzs_.clear();
@@ -26,14 +29,26 @@ void lst::TiltedGeometry::load(std::string const& filename) {
     ifile.read(reinterpret_cast<char*>(&dxdy), sizeof(dxdy));
 
     if (ifile) {
-      drdzs_[detid] = drdz;
-      dxdys_[detid] = dxdy;
+      // TODO: This is needed for now in case old geometry files are used. Remove once deemed unnecessary.
+      constexpr float kLegacyVerticalSlope = 123456789.0f;
+      drdzs_[detid] = (drdz == kLegacyVerticalSlope) ? std::numeric_limits<float>::infinity() : drdz;
+      dxdys_[detid] = (dxdy == kLegacyVerticalSlope) ? std::numeric_limits<float>::infinity() : dxdy;
     } else {
       // End of file or read failed
       if (!ifile.eof()) {
         throw std::runtime_error("Failed to read Tilted Geometry binary data.");
       }
     }
+  }
+}
+
+void lst::TiltedGeometry::load(lstgeometry::Slopes const& slopes) {
+  drdzs_.clear();
+  dxdys_.clear();
+
+  for (const auto& [detId, slope] : slopes) {
+    drdzs_[detId] = slope.drdz;
+    dxdys_[detId] = slope.dxdy;
   }
 }
 

--- a/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
+++ b/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
@@ -307,7 +307,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     float drprime_x, drprime_y;  // drprime * {sin,cos}(atan(slope))
     // Algebraic: sin(atan(slope)) = |slope|/sqrt(1+slope^2), cos(atan(slope)) = 1/sqrt(1+slope^2)
     const float slope = mod.slope;
-    if (slope != kVerticalModuleSlope && edm::isFinite(slope)) {
+    if (edm::isFinite(slope)) {
       const float inv_hypot_slope = 1.f / alpaka::math::sqrt(acc, 1.f + slope * slope);
       drprime_x = drprime * ((xp > 0.f) - (xp < 0.f)) * alpaka::math::abs(acc, slope) * inv_hypot_slope;
       drprime_y = drprime * ((yp > 0.f) - (yp < 0.f)) * inv_hypot_slope;
@@ -321,7 +321,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
     // Compute the new strip hit position (handle slope = infinity and slope = 0 cases)
     float xn, yn;
-    if (slope == kVerticalModuleSlope || edm::isNotFinite(slope)) {
+    if (edm::isNotFinite(slope)) {
       xn = xa;
       yn = yo;
     } else if (slope == 0) {

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -667,9 +667,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       // Computing sigmas is a very tricky affair
       // if the module is tilted or endcap, we need to use the slopes properly!
 
-      absArctanSlope = ((slopes[i] != kVerticalModuleSlope && edm::isFinite(slopes[i]))
-                            ? alpaka::math::abs(acc, alpaka::math::atan(acc, slopes[i]))
-                            : kPi / 2.f);
+      absArctanSlope =
+          (edm::isFinite(slopes[i]) ? alpaka::math::abs(acc, alpaka::math::atan(acc, slopes[i])) : kPi / 2.f);
 
       if (xs[i] > 0 and ys[i] > 0) {
         angleM = kPi / 2.f - absArctanSlope;
@@ -751,9 +750,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     float chiSquared = 0.f;
     float absArctanSlope, angleM, xPrime, yPrime, sigma2;
     for (size_t i = 0; i < nPoints; i++) {
-      absArctanSlope = ((slopes[i] != kVerticalModuleSlope && edm::isFinite(slopes[i]))
-                            ? alpaka::math::abs(acc, alpaka::math::atan(acc, slopes[i]))
-                            : kPi / 2.f);
+      absArctanSlope =
+          (edm::isFinite(slopes[i]) ? alpaka::math::abs(acc, alpaka::math::atan(acc, slopes[i])) : kPi / 2.f);
       if (xs[i] > 0 and ys[i] > 0) {
         angleM = kPi / 2.f - absArctanSlope;
       } else if (xs[i] < 0 and ys[i] > 0) {

--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -376,7 +376,7 @@ void run_lst() {
   full_timer.Start();
   // Determine which maps to use based on given pt cut for standalone.
   std::string ptCutString = (ana.ptCut >= 0.8) ? "0.8" : "0.6";
-  auto hostESData = lst::loadAndFillESHost(ptCutString);
+  auto hostESData = lst::loadAndFillESDataHost(ptCutString);
   auto deviceESData =
       cms::alpakatools::CopyToDevice<lst::LSTESData<alpaka_common::DevHost>>::copyAsync(queues[0], *hostESData.get());
   float timeForMapLoading = full_timer.RealTime() * 1000;

--- a/RecoTracker/LSTCore/standalone/code/core/lst_math.h
+++ b/RecoTracker/LSTCore/standalone/code/core/lst_math.h
@@ -4,7 +4,12 @@
 #include <vector>
 #include <cmath>
 
+#include "RecoTracker/LSTGeometry/interface/Helix.h"
+
 namespace lst_math {
+
+  using Helix = lstgeometry::Helix;
+
   inline float Phi_mpi_pi(float x) {
     if (std::isnan(x)) {
       std::cout << "MathUtil::Phi_mpi_pi() function called with NaN" << std::endl;
@@ -32,85 +37,6 @@ namespace lst_math {
   };
 
   inline float ptEstimateFromRadius(float radius) { return 2.99792458e-3 * 3.8 * radius; };
-
-  class Helix {
-  public:
-    std::vector<float> center_;
-    float radius_;
-    float phi_;
-    float lam_;
-    float charge_;
-
-    Helix(std::vector<float> c, float r, float p, float l, float q) {
-      center_ = c;
-      radius_ = r;
-      phi_ = Phi_mpi_pi(p);
-      lam_ = l;
-      charge_ = q;
-    }
-
-    Helix(float pt, float eta, float phi, float vx, float vy, float vz, float charge) {
-      // Radius based on pt
-      radius_ = pt / (2.99792458e-3 * 3.8);
-      phi_ = phi;
-      charge_ = charge;
-
-      // reference point vector which for sim track is the vertex point
-      float ref_vec_x = vx;
-      float ref_vec_y = vy;
-      float ref_vec_z = vz;
-
-      // The reference to center vector
-      float inward_radial_vec_x = charge_ * radius_ * sin(phi_);
-      float inward_radial_vec_y = charge_ * radius_ * -cos(phi_);
-      float inward_radial_vec_z = 0;
-
-      // Center point
-      float center_vec_x = ref_vec_x + inward_radial_vec_x;
-      float center_vec_y = ref_vec_y + inward_radial_vec_y;
-      float center_vec_z = ref_vec_z + inward_radial_vec_z;
-      center_.push_back(center_vec_x);
-      center_.push_back(center_vec_y);
-      center_.push_back(center_vec_z);
-
-      // Lambda
-      lam_ = copysign(M_PI / 2. - 2. * atan(exp(-std::abs(eta))), eta);
-    }
-
-    const std::vector<float> center() { return center_; }
-    const float radius() { return radius_; }
-    const float phi() { return phi_; }
-    const float lam() { return lam_; }
-    const float charge() { return charge_; }
-
-    std::tuple<float, float, float, float> get_helix_point(float t) {
-      float x = center()[0] - charge() * radius() * sin(phi() - (charge()) * t);
-      float y = center()[1] + charge() * radius() * cos(phi() - (charge()) * t);
-      float z = center()[2] + radius() * tan(lam()) * t;
-      float r = sqrt(x * x + y * y);
-      return std::make_tuple(x, y, z, r);
-    }
-
-    float infer_t(const std::vector<float> point) {
-      // Solve for t based on z position
-      float t = (point[2] - center()[2]) / (radius() * tan(lam()));
-      return t;
-    }
-
-    float compare_radius(const std::vector<float> point) {
-      float t = infer_t(point);
-      auto [x, y, z, r] = get_helix_point(t);
-      float point_r = sqrt(point[0] * point[0] + point[1] * point[1]);
-      return (point_r - r);
-    }
-
-    float compare_xy(const std::vector<float> point) {
-      float t = infer_t(point);
-      auto [x, y, z, r] = get_helix_point(t);
-      float xy_dist = sqrt(pow(point[0] - x, 2) + pow(point[1] - y, 2));
-      return xy_dist;
-    }
-  };
 
   class Hit {
   public:

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
@@ -658,20 +658,20 @@ float drfracSimHitConsistentWithHelix(lst_math::Helix& helix,
                                       std::vector<float> const& trk_simhit_y,
                                       std::vector<float> const& trk_simhit_z) {
   // Sim hit vector
-  std::vector<float> point = {trk_simhit_x[isimhitidx], trk_simhit_y[isimhitidx], trk_simhit_z[isimhitidx]};
+  std::array<float, 3> point = {trk_simhit_x[isimhitidx], trk_simhit_y[isimhitidx], trk_simhit_z[isimhitidx]};
 
   // Inferring parameter t of helix parametric function via z position
-  float t = helix.infer_t(point);
+  float t = helix.inferT(point);
 
   // If the best fit is more than pi parameter away then it's a returning hit and should be ignored
   if (not(t <= M_PI))
     return 999;
 
   // Expected hit position with given z
-  auto [x, y, z, r] = helix.get_helix_point(t);
+  auto [x, y, z, r] = helix.point(t);
 
   // ( expected_r - simhit_r ) / expected_r
-  float drfrac = std::abs(helix.compare_radius(point)) / r;
+  float drfrac = std::abs(helix.compareRadius(point)) / r;
 
   return drfrac;
 }
@@ -711,10 +711,10 @@ float distxySimHitConsistentWithHelix(lst_math::Helix& helix,
                                       std::vector<float> const& trk_simhit_y,
                                       std::vector<float> const& trk_simhit_z) {
   // Sim hit vector
-  std::vector<float> point = {trk_simhit_x[isimhitidx], trk_simhit_y[isimhitidx], trk_simhit_z[isimhitidx]};
+  std::array<float, 3> point = {trk_simhit_x[isimhitidx], trk_simhit_y[isimhitidx], trk_simhit_z[isimhitidx]};
 
   // Inferring parameter t of helix parametric function via z position
-  float t = helix.infer_t(point);
+  float t = helix.inferT(point);
 
   // If the best fit is more than pi parameter away then it's a returning hit and should be ignored
   if (not(t <= M_PI))
@@ -724,7 +724,7 @@ float distxySimHitConsistentWithHelix(lst_math::Helix& helix,
   //auto [x, y, z, r] = helix.get_helix_point(t);
 
   // ( expected_r - simhit_r ) / expected_r
-  float distxy = helix.compare_xy(point);
+  float distxy = helix.compareXY(point);
 
   return distxy;
 }

--- a/RecoTracker/LSTGeometry/BuildFile.xml
+++ b/RecoTracker/LSTGeometry/BuildFile.xml
@@ -1,0 +1,8 @@
+<use name="boost_header"/>
+<use name="eigen"/>
+<use name="DataFormats/Common"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
+<use name="Geometry/CommonTopologies"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/RecoTracker/LSTGeometry/BuildFile.xml
+++ b/RecoTracker/LSTGeometry/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="boost_header"/>
 <use name="eigen"/>
 <use name="DataFormats/Common"/>
 <use name="Geometry/TrackerGeometryBuilder"/>

--- a/RecoTracker/LSTGeometry/interface/Common.h
+++ b/RecoTracker/LSTGeometry/interface/Common.h
@@ -32,13 +32,14 @@ namespace lstgeometry {
   float roundAngle(float angle, float tol = 1e-3);
   float roundCoordinate(float coord, float tol = 1e-3);
   std::pair<float, float> getEtaPhi(float x, float y, float z, float refphi = 0);
+}  // namespace lstgeometry
 
+namespace lst {
   inline std::string floatToStr(float num, unsigned int precision = 1) {
     std::ostringstream outSS;
     outSS << std::setprecision(precision) << num;
     return outSS.str();
   }
-
-}  // namespace lstgeometry
+}  // namespace lst
 
 #endif

--- a/RecoTracker/LSTGeometry/interface/Common.h
+++ b/RecoTracker/LSTGeometry/interface/Common.h
@@ -1,0 +1,44 @@
+#ifndef RecoTracker_LSTGeometry_interface_Common_h
+#define RecoTracker_LSTGeometry_interface_Common_h
+
+#include <array>
+#include <cmath>
+#include <iomanip>
+#include <limits>
+#include <numbers>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace lstgeometry {
+
+  constexpr float kB = 3.8;
+  constexpr float kC = 0.00299792458;
+
+  constexpr unsigned int kBarrelLayers = 6;
+  constexpr unsigned int kEndcapLayers = 5;
+
+  // For pixel maps
+  constexpr unsigned int kNEta = 25;
+  constexpr unsigned int kNPhi = 72;
+  constexpr unsigned int kNZ = 25;
+  constexpr std::array<float, 2> kPtBounds = {{2.0, 10'000.0}};
+
+  // This is defined as a constant in case the legacy value (123456789) needs to be used
+  constexpr float kDefaultSlope = std::numeric_limits<float>::infinity();
+
+  float degToRad(float degrees);
+  float phi_mpi_pi(float phi);
+  float roundAngle(float angle, float tol = 1e-3);
+  float roundCoordinate(float coord, float tol = 1e-3);
+  std::pair<float, float> getEtaPhi(float x, float y, float z, float refphi = 0);
+
+  inline std::string floatToStr(float num, unsigned int precision = 1) {
+    std::ostringstream outSS;
+    outSS << std::setprecision(precision) << num;
+    return outSS.str();
+  }
+
+}  // namespace lstgeometry
+
+#endif

--- a/RecoTracker/LSTGeometry/interface/Geometry.h
+++ b/RecoTracker/LSTGeometry/interface/Geometry.h
@@ -1,0 +1,29 @@
+#ifndef RecoTracker_LSTGeometry_interface_Geometry_h
+#define RecoTracker_LSTGeometry_interface_Geometry_h
+
+#include <array>
+#include <optional>
+
+#include "RecoTracker/LSTGeometry/interface/ModuleMap.h"
+#include "RecoTracker/LSTGeometry/interface/PixelMap.h"
+#include "RecoTracker/LSTGeometry/interface/Sensor.h"
+#include "RecoTracker/LSTGeometry/interface/Slope.h"
+
+namespace lstgeometry {
+
+  struct Geometry {
+    Sensors sensors;
+    Slopes barrel_slopes;
+    Slopes endcap_slopes;
+    PixelMap pixel_map;
+    ModuleMap module_map;
+
+    Geometry(Sensors sensors,
+             std::array<float, kBarrelLayers> const &average_r_barrel,
+             std::array<float, kEndcapLayers> const &average_z_endcap,
+             float ptCut);
+  };
+
+}  // namespace lstgeometry
+
+#endif

--- a/RecoTracker/LSTGeometry/interface/Helix.h
+++ b/RecoTracker/LSTGeometry/interface/Helix.h
@@ -1,0 +1,143 @@
+#ifndef RecoTracker_LSTGeometry_interface_Helix_h
+#define RecoTracker_LSTGeometry_interface_Helix_h
+
+// This header contains implementations so that the standalone part of LSTCore can use it without having to link some extra library.
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+#include "RecoTracker/LSTGeometry/interface/Common.h"
+
+namespace lstgeometry {
+
+  struct Helix {
+    std::array<float, 3> center;
+    float radius;
+    float phi;
+    float lambda;
+    int charge;
+
+    Helix(std::array<float, 3> center, float radius, float phi, float lambda, int charge)
+        : center(center), radius(radius), phi(phi_mpi_pi(phi)), lambda(lambda), charge(charge) {}
+
+    // Clarification : phi was derived assuming a negatively charged particle would start
+    // at the first quadrant. However the way signs are set up in the get_track_point function
+    // implies the particle actually starts out in the fourth quadrant, and phi is measured from
+    // the y axis as opposed to x axis in the expression provided in this function. Hence I tucked
+    // in an extra pi/2 to account for these effects
+    Helix(float pt, float vx, float vy, float vz, float mx, float my, float mz, int charge) : charge(charge) {
+      radius = pt / (kC * kB);
+
+      float t = 2. * std::asin(std::sqrt((vx - mx) * (vx - mx) + (vy - my) * (vy - my)) / (2. * radius));
+      phi = std::numbers::pi_v<float> / 2. + std::atan((vy - my) / (vx - mx)) +
+            ((vy - my) / (vx - mx) < 0) * (std::numbers::pi_v<float>)+charge * t / 2. +
+            (my - vy < 0) * (std::numbers::pi_v<float> / 2.) - (my - vy > 0) * (std::numbers::pi_v<float> / 2.);
+
+      center[0] = vx + charge * radius * std::sin(phi);
+      center[1] = vy - charge * radius * std::cos(phi);
+      center[2] = vz;
+      lambda = std::atan((mz - vz) / (radius * t));
+    }
+
+    Helix(float pt, float eta, float phi, float vx, float vy, float vz, float charge) : phi(phi), charge(charge) {
+      // Radius based on pt
+      radius = pt / (kC * kB);
+
+      // reference point vector which for sim track is the vertex point
+      float ref_vec_x = vx;
+      float ref_vec_y = vy;
+      float ref_vec_z = vz;
+
+      // The reference to center vector
+      float inward_radial_vec_x = charge * radius * std::sin(phi);
+      float inward_radial_vec_y = charge * radius * -std::cos(phi);
+      float inward_radial_vec_z = 0;
+
+      // Center point
+      center[0] = ref_vec_x + inward_radial_vec_x;
+      center[1] = ref_vec_y + inward_radial_vec_y;
+      center[2] = ref_vec_z + inward_radial_vec_z;
+
+      // Lambda
+      lambda = std::atan(std::sinh(eta));
+    }
+
+    std::array<float, 4> point(float t) const {
+      float x = center[0] - charge * radius * std::sin(phi - charge * t);
+      float y = center[1] + charge * radius * std::cos(phi - charge * t);
+      float z = center[2] + radius * std::tan(lambda) * t;
+      float r = std::sqrt(x * x + y * y);
+      return {x, y, z, r};
+    }
+
+    float inferT(std::array<float, 3> const& point) const {
+      return (point[2] - center[2]) / (radius * std::tan(lambda));
+    }
+
+    std::tuple<float, float, float, float> pointFromRadius(float target_r) const {
+      float cx = center[0], cy = center[1];
+      float center_r = std::sqrt(cx * cx + cy * cy);
+
+      float sin_val = (cx * cx + cy * cy + radius * radius - target_r * target_r) / (2.f * charge * radius * center_r);
+      sin_val = std::clamp(sin_val, -1.f, 1.f);
+
+      float offset = std::atan2(-cy, cx);
+      float alpha = std::asin(sin_val);
+
+      // Two solutions: theta = alpha - offset  or  pi - alpha - offset
+      // theta = phi - charge*t  =>  t = charge*(phi - theta)
+      auto to_t = [this](float theta) {
+        float t = charge * (phi - theta);
+        const float two_pi = 2.f * std::numbers::pi_v<float>;
+        t = std::fmod(t, two_pi);
+        if (t < 0.f)
+          t += two_pi;
+        return t;
+      };
+
+      float t1 = to_t(alpha - offset);
+      float t2 = to_t(std::numbers::pi_v<float> - alpha - offset);
+
+      // Prefer the smallest t in [0, pi], matching the original search range
+      bool t1_ok = t1 <= std::numbers::pi_v<float>;
+      bool t2_ok = t2 <= std::numbers::pi_v<float>;
+      float t = (t1_ok && t2_ok) ? std::min(t1, t2) : t1_ok ? t1 : t2_ok ? t2 : std::min(t1, t2);
+
+      float x = center[0] - charge * radius * std::sin(phi - charge * t);
+      float y = center[1] + charge * radius * std::cos(phi - charge * t);
+      float z = center[2] + radius * std::tan(lambda) * t;
+      float r = std::sqrt(x * x + y * y);
+
+      return std::make_tuple(x, y, z, r);
+    }
+
+    std::tuple<float, float, float, float> pointFromZ(float target_z) const {
+      float t = (target_z - center[2]) / (radius * std::tan(lambda));
+
+      float x = center[0] - charge * radius * std::sin(phi - charge * t);
+      float y = center[1] + charge * radius * std::cos(phi - charge * t);
+      float z = center[2] + radius * std::tan(lambda) * t;
+      float r = std::sqrt(x * x + y * y);
+
+      return std::make_tuple(x, y, z, r);
+    }
+
+    float compareRadius(std::array<float, 3> const& pt) const {
+      float t = inferT(pt);
+      auto [x, y, z, r] = point(t);
+      float point_r = std::sqrt(pt[0] * pt[0] + pt[1] * pt[1]);
+      return (point_r - r);
+    }
+
+    float compareXY(std::array<float, 3> const& pt) const {
+      float t = inferT(pt);
+      auto [x, y, z, r] = point(t);
+      float xy_dist = std::sqrt(std::pow(pt[0] - x, 2) + std::pow(pt[1] - y, 2));
+      return xy_dist;
+    }
+  };
+
+}  // namespace lstgeometry
+
+#endif

--- a/RecoTracker/LSTGeometry/interface/IO.h
+++ b/RecoTracker/LSTGeometry/interface/IO.h
@@ -3,8 +3,8 @@
 
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 
+#include "RecoTracker/LSTGeometry/interface/ModuleMap.h"
 #include "RecoTracker/LSTGeometry/interface/PixelMap.h"
 #include "RecoTracker/LSTGeometry/interface/Sensor.h"
 #include "RecoTracker/LSTGeometry/interface/Slope.h"
@@ -13,9 +13,7 @@ namespace lstgeometry {
 
   void writeSensorCentroids(Sensors const& sensors, std::string const& base_filename, bool binary = true);
   void writeSlopes(Slopes const& slopes, Sensors const& sensors, std::string const& base_filename, bool binary = true);
-  void writeModuleConnections(std::unordered_map<unsigned int, std::unordered_set<unsigned int>> const& connections,
-                              std::string const& base_filename,
-                              bool binary = true);
+  void writeModuleConnections(ModuleMap const& connections, std::string const& base_filename, bool binary = true);
   void writePixelMaps(PixelMap const& maps, std::string const& base_filename, bool binary = true);
 
 }  // namespace lstgeometry

--- a/RecoTracker/LSTGeometry/interface/IO.h
+++ b/RecoTracker/LSTGeometry/interface/IO.h
@@ -1,0 +1,23 @@
+#ifndef RecoTracker_LSTGeometry_interface_IO_h
+#define RecoTracker_LSTGeometry_interface_IO_h
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "RecoTracker/LSTGeometry/interface/PixelMap.h"
+#include "RecoTracker/LSTGeometry/interface/Sensor.h"
+#include "RecoTracker/LSTGeometry/interface/Slope.h"
+
+namespace lstgeometry {
+
+  void writeSensorCentroids(Sensors const& sensors, std::string const& base_filename, bool binary = true);
+  void writeSlopes(Slopes const& slopes, Sensors const& sensors, std::string const& base_filename, bool binary = true);
+  void writeModuleConnections(std::unordered_map<unsigned int, std::unordered_set<unsigned int>> const& connections,
+                              std::string const& base_filename,
+                              bool binary = true);
+  void writePixelMaps(PixelMap const& maps, std::string const& base_filename, bool binary = true);
+
+}  // namespace lstgeometry
+
+#endif

--- a/RecoTracker/LSTGeometry/interface/ModuleMap.h
+++ b/RecoTracker/LSTGeometry/interface/ModuleMap.h
@@ -1,7 +1,7 @@
 #ifndef RecoTracker_LSTGeometry_interface_ModuleMapMethods_h
 #define RecoTracker_LSTGeometry_interface_ModuleMapMethods_h
 
-#include <unordered_set>
+#include <vector>
 #include <unordered_map>
 
 #include "RecoTracker/LSTGeometry/interface/Sensor.h"
@@ -9,7 +9,7 @@
 
 namespace lstgeometry {
 
-  using ModuleMap = std::unordered_map<unsigned int, std::unordered_set<unsigned int>>;
+  using ModuleMap = std::unordered_map<unsigned int, std::vector<unsigned int>>;
 
   ModuleMap buildModuleMap(Sensors const& sensors,
                            BinnedDetIds const& binned_detids,

--- a/RecoTracker/LSTGeometry/interface/ModuleMap.h
+++ b/RecoTracker/LSTGeometry/interface/ModuleMap.h
@@ -1,0 +1,22 @@
+#ifndef RecoTracker_LSTGeometry_interface_ModuleMapMethods_h
+#define RecoTracker_LSTGeometry_interface_ModuleMapMethods_h
+
+#include <unordered_set>
+#include <unordered_map>
+
+#include "RecoTracker/LSTGeometry/interface/Sensor.h"
+#include "RecoTracker/LSTGeometry/interface/SensorBinning.h"
+
+namespace lstgeometry {
+
+  using ModuleMap = std::unordered_map<unsigned int, std::unordered_set<unsigned int>>;
+
+  ModuleMap buildModuleMap(Sensors const& sensors,
+                           BinnedDetIds const& binned_detids,
+                           std::array<float, kBarrelLayers> const& average_r_barrel,
+                           std::array<float, kEndcapLayers> const& average_z_endcap,
+                           float pt_cut);
+
+}  // namespace lstgeometry
+
+#endif

--- a/RecoTracker/LSTGeometry/interface/ModuleMap.h
+++ b/RecoTracker/LSTGeometry/interface/ModuleMap.h
@@ -1,8 +1,9 @@
-#ifndef RecoTracker_LSTGeometry_interface_ModuleMapMethods_h
-#define RecoTracker_LSTGeometry_interface_ModuleMapMethods_h
+#ifndef RecoTracker_LSTGeometry_interface_ModuleMap_h
+#define RecoTracker_LSTGeometry_interface_ModuleMap_h
 
-#include <vector>
+#include <array>
 #include <unordered_map>
+#include <vector>
 
 #include "RecoTracker/LSTGeometry/interface/Sensor.h"
 #include "RecoTracker/LSTGeometry/interface/SensorBinning.h"
@@ -13,8 +14,8 @@ namespace lstgeometry {
 
   ModuleMap buildModuleMap(Sensors const& sensors,
                            BinnedDetIds const& binned_detids,
-                           std::array<float, kBarrelLayers> const& average_r_barrel,
-                           std::array<float, kEndcapLayers> const& average_z_endcap,
+                           std::array<float, kBarrelLayers> const& averageRBarrel,
+                           std::array<float, kEndcapLayers> const& averageZEndcap,
                            float pt_cut);
 
 }  // namespace lstgeometry

--- a/RecoTracker/LSTGeometry/interface/PixelMap.h
+++ b/RecoTracker/LSTGeometry/interface/PixelMap.h
@@ -11,9 +11,8 @@
 namespace lstgeometry {
 
   using LayerSubdetChargeKey = std::tuple<unsigned int, unsigned int, int>;
-  using LayerSubdetChargeMap = std::unordered_map<LayerSubdetChargeKey,
-                                                  std::vector<std::vector<unsigned int>>,
-                                                  boost::hash<LayerSubdetChargeKey>>;
+  using LayerSubdetChargeMap =
+      std::unordered_map<LayerSubdetChargeKey, std::vector<std::vector<unsigned int>>, boost::hash<LayerSubdetChargeKey>>;
   using PixelMap = LayerSubdetChargeMap;
 
   PixelMap buildPixelMap(Sensors const& sensors, float pt_cut);

--- a/RecoTracker/LSTGeometry/interface/PixelMap.h
+++ b/RecoTracker/LSTGeometry/interface/PixelMap.h
@@ -1,0 +1,24 @@
+#ifndef RecoTracker_LSTGeometry_interface_PixelMap_h
+#define RecoTracker_LSTGeometry_interface_PixelMap_h
+
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <boost/functional/hash.hpp>
+
+#include "RecoTracker/LSTGeometry/interface/Sensor.h"
+#include "RecoTracker/LSTGeometry/interface/SensorBinning.h"
+
+namespace lstgeometry {
+
+  using LayerSubdetChargeKey = std::tuple<unsigned int, unsigned int, int>;
+  using LayerSubdetChargeMap = std::unordered_map<LayerSubdetChargeKey,
+                                                  std::vector<std::unordered_set<unsigned int>>,
+                                                  boost::hash<LayerSubdetChargeKey>>;
+  using PixelMap = LayerSubdetChargeMap;
+
+  PixelMap buildPixelMap(Sensors const& sensors, float pt_cut);
+
+}  // namespace lstgeometry
+
+#endif

--- a/RecoTracker/LSTGeometry/interface/PixelMap.h
+++ b/RecoTracker/LSTGeometry/interface/PixelMap.h
@@ -3,7 +3,6 @@
 
 #include <tuple>
 #include <unordered_map>
-#include <unordered_set>
 #include <boost/functional/hash.hpp>
 
 #include "RecoTracker/LSTGeometry/interface/Sensor.h"
@@ -13,7 +12,7 @@ namespace lstgeometry {
 
   using LayerSubdetChargeKey = std::tuple<unsigned int, unsigned int, int>;
   using LayerSubdetChargeMap = std::unordered_map<LayerSubdetChargeKey,
-                                                  std::vector<std::unordered_set<unsigned int>>,
+                                                  std::vector<std::vector<unsigned int>>,
                                                   boost::hash<LayerSubdetChargeKey>>;
   using PixelMap = LayerSubdetChargeMap;
 

--- a/RecoTracker/LSTGeometry/interface/PixelMap.h
+++ b/RecoTracker/LSTGeometry/interface/PixelMap.h
@@ -1,9 +1,10 @@
 #ifndef RecoTracker_LSTGeometry_interface_PixelMap_h
 #define RecoTracker_LSTGeometry_interface_PixelMap_h
 
+#include <functional>
 #include <tuple>
 #include <unordered_map>
-#include <boost/functional/hash.hpp>
+#include <vector>
 
 #include "RecoTracker/LSTGeometry/interface/Sensor.h"
 #include "RecoTracker/LSTGeometry/interface/SensorBinning.h"
@@ -11,8 +12,17 @@
 namespace lstgeometry {
 
   using LayerSubdetChargeKey = std::tuple<unsigned int, unsigned int, int>;
+  struct LayerSubdetChargeHash {
+    std::size_t operator()(LayerSubdetChargeKey const& key) const {
+      auto [layer, subdet, charge] = key;
+      std::size_t seed = std::hash<unsigned int>{}(layer);
+      seed ^= std::hash<unsigned int>{}(subdet) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+      seed ^= std::hash<int>{}(charge) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+      return seed;
+    }
+  };
   using LayerSubdetChargeMap =
-      std::unordered_map<LayerSubdetChargeKey, std::vector<std::vector<unsigned int>>, boost::hash<LayerSubdetChargeKey>>;
+      std::unordered_map<LayerSubdetChargeKey, std::vector<std::vector<unsigned int>>, LayerSubdetChargeHash>;
   using PixelMap = LayerSubdetChargeMap;
 
   PixelMap buildPixelMap(Sensors const& sensors, float pt_cut);

--- a/RecoTracker/LSTGeometry/interface/Sensor.h
+++ b/RecoTracker/LSTGeometry/interface/Sensor.h
@@ -1,0 +1,102 @@
+#ifndef RecoTracker_LSTGeometry_interface_Sensor_h
+#define RecoTracker_LSTGeometry_interface_Sensor_h
+
+// Some parts of this file are guarded by the LST_STANDALONE flag to avoid depending on Eigen for standalone LST
+
+#include <memory>
+#include <unordered_map>
+
+#ifndef LST_STANDALONE
+#include <Eigen/Dense>
+#endif
+
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/CommonTopologies/interface/GeomDetEnumerators.h"
+#include "DataFormats/SiStripDetId/interface/SiStripEnums.h"
+#include "DataFormats/GeometrySurface/interface/Surface.h"
+
+#include "RecoTracker/LSTGeometry/interface/Common.h"
+
+namespace lstgeometry {
+
+#ifndef LST_STANDALONE
+  using MatrixF3x3 = Eigen::Matrix<float, 3, 3, Eigen::RowMajor>;
+  using MatrixF4x2 = Eigen::Matrix<float, 4, 2, Eigen::RowMajor>;
+  using MatrixF4x3 = Eigen::Matrix<float, 4, 3, Eigen::RowMajor>;
+  using MatrixF8x3 = Eigen::Matrix<float, 8, 3, Eigen::RowMajor>;
+  using MatrixFNx2 = Eigen::Matrix<float, Eigen::Dynamic, 2, Eigen::RowMajor>;
+  using MatrixFNx3 = Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor>;
+  using RowVectorF2 = Eigen::Matrix<float, 1, 2>;
+  using ColVectorF3 = Eigen::Matrix<float, 3, 1>;
+  using RowVectorF3 = Eigen::Matrix<float, 1, 3>;
+#endif
+
+  using ModuleType = TrackerGeometry::ModuleType;
+  using SubDetector = GeomDetEnumerators::SubDetector;
+  using Location = GeomDetEnumerators::Location;
+
+  enum SubDet { InnerPixel = 0, Barrel = 5, Endcap = 4 };
+  enum Side { NegZ = 1, PosZ = 2, Center = 3 };
+
+  struct SensorExtraData {
+    // Module-level properties
+    SubDetector subdet;
+    Location location;
+    Side side;
+    unsigned int moduleId;
+    unsigned int layer;
+    unsigned int ring;
+    bool inverted;
+    // Sensor-level properties
+    float centerRho;
+    float centerPhi;
+    bool lower;
+    bool strip;
+#ifndef LST_STANDALONE  // Extra data is not used in standalone, so it doesn't matter that there is a struct mismatch
+    MatrixF4x3 corners;
+#endif
+    // Redundant, but convenient to avoid repeated computations
+    float centerEta;
+    float centerTheta;
+    float minR;
+    float maxR;
+    float minZ;
+    float maxZ;
+    float minPhi;
+    float maxPhi;
+  };
+
+  struct Sensor {
+    // Info that is always needed
+    ModuleType moduleType;
+    float centerPhi;
+    float centerX;
+    float centerY;
+    float centerZ;
+    // Info that can be dropped after map construction
+    std::unique_ptr<SensorExtraData> extra;
+
+    Sensor() = default;
+    Sensor(const Sensor&) = delete;
+    Sensor& operator=(const Sensor&) = delete;
+    Sensor(Sensor&&) = default;
+    Sensor& operator=(Sensor&&) = default;
+    Sensor(unsigned int detId,
+           ModuleType moduleType,
+           SubDetector subdet,
+           Location location,
+           Side side,
+           unsigned int moduleId,
+           unsigned int layer,
+           unsigned int ring,
+           float centerRho,
+           float centerZ,
+           float centerPhi,
+           Surface const& surface);
+  };
+
+  using Sensors = std::unordered_map<unsigned int, Sensor>;
+
+}  // namespace lstgeometry
+
+#endif

--- a/RecoTracker/LSTGeometry/interface/Sensor.h
+++ b/RecoTracker/LSTGeometry/interface/Sensor.h
@@ -43,20 +43,15 @@ namespace lstgeometry {
     SubDetector subdet;
     Location location;
     Side side;
-    unsigned int moduleId;
     unsigned int layer;
     unsigned int ring;
-    bool inverted;
     // Sensor-level properties
-    float centerRho;
-    float centerPhi;
     bool lower;
     bool strip;
 #ifndef LST_STANDALONE  // Extra data is not used in standalone, so it doesn't matter that there is a struct mismatch
     MatrixF4x3 corners;
 #endif
     // Redundant, but convenient to avoid repeated computations
-    float centerEta;
     float centerTheta;
     float minR;
     float maxR;

--- a/RecoTracker/LSTGeometry/interface/SensorBinning.h
+++ b/RecoTracker/LSTGeometry/interface/SensorBinning.h
@@ -1,0 +1,38 @@
+#ifndef RecoTracker_LSTGeometry_interface_SensorBinning_h
+#define RecoTracker_LSTGeometry_interface_SensorBinning_h
+
+#include <algorithm>
+#include <functional>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+#include <boost/functional/hash.hpp>
+
+#include "RecoTracker/LSTGeometry/interface/Common.h"
+#include "RecoTracker/LSTGeometry/interface/Sensor.h"
+
+namespace lstgeometry {
+
+  using LocationLayerThetaBinPhiBinKey = std::tuple<Location, unsigned int, unsigned int, unsigned int>;
+
+  using BinnedDetIds = std::unordered_map<LocationLayerThetaBinPhiBinKey,
+                                          std::vector<unsigned int>,
+                                          boost::hash<LocationLayerThetaBinPhiBinKey>>;
+
+  // We split modules into overlapping theta-phi bins so that it's easier to construct module maps
+  static constexpr unsigned int kNThetaBins = 4;
+  static constexpr float kThetaBinRad = std::numbers::pi_v<float> / kNThetaBins;
+  static constexpr unsigned int kNPhiBins = 6;
+  static constexpr float kPhiBinWidth = 2 * std::numbers::pi_v<float> / kNPhiBins;
+
+  bool isInThetaPhiBin(float theta, float phi, unsigned int theta_bin, unsigned int phi_bin);
+  std::pair<unsigned int, unsigned int> getThetaPhiBins(float theta, float phi);
+  std::pair<float, float> getCompatibleEtaRange(Sensor const& sensor, float zmin_bound, float zmax_bound);
+  std::pair<std::pair<float, float>, std::pair<float, float>> getCompatiblePhiRange(Sensor const& sensor,
+                                                                                    float ptmin,
+                                                                                    float ptmax);
+  BinnedDetIds binDetIds(Sensors const& sensors);
+
+}  // namespace lstgeometry
+
+#endif

--- a/RecoTracker/LSTGeometry/interface/SensorBinning.h
+++ b/RecoTracker/LSTGeometry/interface/SensorBinning.h
@@ -2,30 +2,40 @@
 #define RecoTracker_LSTGeometry_interface_SensorBinning_h
 
 #include <algorithm>
-#include <functional>
-#include <tuple>
-#include <unordered_map>
+#include <array>
 #include <vector>
-#include <boost/functional/hash.hpp>
 
 #include "RecoTracker/LSTGeometry/interface/Common.h"
 #include "RecoTracker/LSTGeometry/interface/Sensor.h"
 
 namespace lstgeometry {
 
-  using LocationLayerThetaBinPhiBinKey = std::tuple<Location, unsigned int, unsigned int, unsigned int>;
-
-  using BinnedDetIds = std::unordered_map<LocationLayerThetaBinPhiBinKey,
-                                          std::vector<unsigned int>,
-                                          boost::hash<LocationLayerThetaBinPhiBinKey>>;
-
   // We split modules into overlapping theta-phi bins so that it's easier to construct module maps
-  static constexpr unsigned int kNThetaBins = 4;
-  static constexpr float kThetaBinRad = std::numbers::pi_v<float> / kNThetaBins;
-  static constexpr unsigned int kNPhiBins = 6;
-  static constexpr float kPhiBinWidth = 2 * std::numbers::pi_v<float> / kNPhiBins;
+  inline constexpr unsigned int kNThetaBins = 4;
+  inline constexpr float kThetaBinRad = std::numbers::pi_v<float> / kNThetaBins;
+  inline constexpr unsigned int kNPhiBins = 6;
+  inline constexpr float kPhiBinWidth = 2 * std::numbers::pi_v<float> / kNPhiBins;
 
-  bool isInThetaPhiBin(float theta, float phi, unsigned int theta_bin, unsigned int phi_bin);
+  using BinnedDetIds =
+      std::array<std::array<std::array<std::array<std::vector<unsigned int>, kNPhiBins>, kNThetaBins>, kBarrelLayers + 1>,
+                 2>;
+
+  inline unsigned int locationIndex(Location location) { return location == Location::barrel ? 0 : 1; }
+
+  inline std::vector<unsigned int>& binnedDetIdsAt(
+      BinnedDetIds& binned_detids, Location location, unsigned int layer, unsigned int thetaBin, unsigned int phiBin) {
+    return binned_detids[locationIndex(location)][layer][thetaBin][phiBin];
+  }
+
+  inline std::vector<unsigned int> const& binnedDetIdsAt(BinnedDetIds const& binned_detids,
+                                                         Location location,
+                                                         unsigned int layer,
+                                                         unsigned int thetaBin,
+                                                         unsigned int phiBin) {
+    return binned_detids[locationIndex(location)][layer][thetaBin][phiBin];
+  }
+
+  bool isInThetaPhiBin(float theta, float phi, unsigned int thetaBin, unsigned int phiBin);
   std::pair<unsigned int, unsigned int> getThetaPhiBins(float theta, float phi);
   std::pair<float, float> getCompatibleEtaRange(Sensor const& sensor, float zmin_bound, float zmax_bound);
   std::pair<std::pair<float, float>, std::pair<float, float>> getCompatiblePhiRange(Sensor const& sensor,

--- a/RecoTracker/LSTGeometry/interface/Slope.h
+++ b/RecoTracker/LSTGeometry/interface/Slope.h
@@ -1,0 +1,24 @@
+#ifndef RecoTracker_LSTGeometry_interface_Slope_h
+#define RecoTracker_LSTGeometry_interface_Slope_h
+
+#include <unordered_map>
+
+#include "RecoTracker/LSTGeometry/interface/Sensor.h"
+
+namespace lstgeometry {
+
+  struct Slope {
+    float drdz;
+    float dxdy;
+
+    Slope() = default;
+    Slope(float dx, float dy, float dz);
+  };
+
+  using Slopes = std::unordered_map<unsigned int, Slope>;
+
+  std::tuple<Slopes, Slopes> computeSlopes(Sensors const& sensors);
+
+}  // namespace lstgeometry
+
+#endif

--- a/RecoTracker/LSTGeometry/interface/Slope.h
+++ b/RecoTracker/LSTGeometry/interface/Slope.h
@@ -1,6 +1,7 @@
 #ifndef RecoTracker_LSTGeometry_interface_Slope_h
 #define RecoTracker_LSTGeometry_interface_Slope_h
 
+#include <tuple>
 #include <unordered_map>
 
 #include "RecoTracker/LSTGeometry/interface/Sensor.h"

--- a/RecoTracker/LSTGeometry/plugins/BuildFile.xml
+++ b/RecoTracker/LSTGeometry/plugins/BuildFile.xml
@@ -1,0 +1,14 @@
+<library file="*.cc" name="RecoTrackerLSTCorePlugins">
+  <use name="DataFormats/Common"/>
+  <use name="DataFormats/TrackReco"/>
+  <use name="DataFormats/TrackerCommon"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="Geometry/CommonTopologies"/>
+  <use name="Geometry/Records"/>
+  <use name="Geometry/TrackerGeometryBuilder"/>
+  <use name="RecoTracker/LSTCore"/>
+  <use name="RecoTracker/LSTGeometry"/>
+  <use name="RecoTracker/Record"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/RecoTracker/LSTGeometry/plugins/LSTGeometryESProducer.cc
+++ b/RecoTracker/LSTGeometry/plugins/LSTGeometryESProducer.cc
@@ -1,0 +1,121 @@
+#include <array>
+#include <cmath>
+#include <unordered_map>
+#include <vector>
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+#include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
+#include "Geometry/CommonTopologies/interface/GeomDetEnumerators.h"
+
+#include "RecoTracker/LSTGeometry/interface/Geometry.h"
+#include "RecoTracker/LSTGeometry/interface/Sensor.h"
+
+class LSTGeometryESProducer : public edm::ESProducer {
+public:
+  LSTGeometryESProducer(const edm::ParameterSet &iConfig);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+  std::unique_ptr<lstgeometry::Geometry> produce(const TrackerRecoGeometryRecord &iRecord);
+
+private:
+  double ptCut_;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
+
+  const TrackerGeometry *trackerGeom_ = nullptr;
+  const TrackerTopology *trackerTopo_ = nullptr;
+};
+
+LSTGeometryESProducer::LSTGeometryESProducer(const edm::ParameterSet &iConfig)
+    : ptCut_(iConfig.getParameter<double>("ptCut")) {
+  std::string ptCutStr = lstgeometry::floatToStr(ptCut_, 1);
+
+  auto cc = setWhatProduced(this, ptCutStr);
+  geomToken_ = cc.consumes();
+  ttopoToken_ = cc.consumes();
+}
+
+void LSTGeometryESProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("ptCut", 0.8);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+std::unique_ptr<lstgeometry::Geometry> LSTGeometryESProducer::produce(const TrackerRecoGeometryRecord &iRecord) {
+  trackerGeom_ = &iRecord.get(geomToken_);
+  trackerTopo_ = &iRecord.get(ttopoToken_);
+
+  lstgeometry::Sensors sensors;
+
+  std::array<float, lstgeometry::kBarrelLayers> avg_r_barrel{};
+  std::array<float, lstgeometry::kEndcapLayers> avg_z_endcap{};
+  std::array<unsigned int, lstgeometry::kBarrelLayers> avg_r_barrel_counter{};
+  std::array<unsigned int, lstgeometry::kEndcapLayers> avg_z_endcap_counter{};
+
+  for (auto &det : trackerGeom_->dets()) {
+    const DetId detId = det->geographicalId();
+    const auto moduleType = trackerGeom_->getDetectorType(detId);
+
+    // TODO: Is there a more straightforward way to only loop through these?
+    if (moduleType != TrackerGeometry::ModuleType::Ph2PSP && moduleType != TrackerGeometry::ModuleType::Ph2PSS &&
+        moduleType != TrackerGeometry::ModuleType::Ph2SS) {
+      continue;
+    }
+
+    const unsigned int detid = detId();
+
+    const auto &surface = det->surface();
+    const auto &position = surface.position();
+
+    const float rho_cm = position.perp();
+    const float z_cm = lstgeometry::roundCoordinate(position.z());
+    const float phi_rad = lstgeometry::roundAngle(position.phi());
+
+    const auto subdet = trackerGeom_->geomDetSubDetector(detId.subdetId());
+    const auto location =
+        GeomDetEnumerators::isBarrel(subdet) ? lstgeometry::Location::barrel : lstgeometry::Location::endcap;
+    const auto side = static_cast<lstgeometry::Side>(
+        location == lstgeometry::Location::barrel ? static_cast<unsigned int>(trackerTopo_->barrelTiltTypeP2(detId))
+                                                  : trackerTopo_->side(detId));
+    const unsigned int moduleId = trackerTopo_->module(detId);
+    const unsigned int layer = trackerTopo_->layer(detId);
+    const unsigned int ring = trackerTopo_->endcapRingP2(detId);
+
+    if (det->isLeaf()) {
+      // Leafs are the sensors
+      sensors[detid] = lstgeometry::Sensor(
+          detid, moduleType, subdet, location, side, moduleId, layer, ring, rho_cm, z_cm, phi_rad, surface);
+
+      continue;
+    }
+
+    if (location == lstgeometry::Location::barrel) {
+      avg_r_barrel[layer - 1] += rho_cm;
+      avg_r_barrel_counter[layer - 1] += 1;
+    } else {
+      avg_z_endcap[layer - 1] += std::fabs(z_cm);
+      avg_z_endcap_counter[layer - 1] += 1;
+    }
+  }
+
+  for (size_t i = 0; i < avg_r_barrel.size(); ++i) {
+    avg_r_barrel[i] /= avg_r_barrel_counter[i];
+  }
+  for (size_t i = 0; i < avg_z_endcap.size(); ++i) {
+    avg_z_endcap[i] /= avg_z_endcap_counter[i];
+  }
+
+  auto lstGeometry = std::make_unique<lstgeometry::Geometry>(std::move(sensors), avg_r_barrel, avg_z_endcap, ptCut_);
+
+  return lstGeometry;
+}
+
+DEFINE_FWK_EVENTSETUP_MODULE(LSTGeometryESProducer);

--- a/RecoTracker/LSTGeometry/plugins/LSTGeometryESProducer.cc
+++ b/RecoTracker/LSTGeometry/plugins/LSTGeometryESProducer.cc
@@ -36,7 +36,7 @@ private:
 
 LSTGeometryESProducer::LSTGeometryESProducer(const edm::ParameterSet &iConfig)
     : ptCut_(iConfig.getParameter<double>("ptCut")) {
-  std::string ptCutStr = lstgeometry::floatToStr(ptCut_, 1);
+  std::string ptCutStr = lst::floatToStr(ptCut_, 1);
 
   auto cc = setWhatProduced(this, ptCutStr);
   geomToken_ = cc.consumes();
@@ -89,6 +89,11 @@ std::unique_ptr<lstgeometry::Geometry> LSTGeometryESProducer::produce(const Trac
     const unsigned int layer = trackerTopo_->layer(detId);
     const unsigned int ring = trackerTopo_->endcapRingP2(detId);
 
+    if (layer == 0 || (location == lstgeometry::Location::barrel && layer > lstgeometry::kBarrelLayers) ||
+        (location == lstgeometry::Location::endcap && layer > lstgeometry::kEndcapLayers)) {
+      continue;
+    }
+
     if (det->isLeaf()) {
       // Leafs are the sensors
       sensors[detid] = lstgeometry::Sensor(
@@ -107,10 +112,12 @@ std::unique_ptr<lstgeometry::Geometry> LSTGeometryESProducer::produce(const Trac
   }
 
   for (size_t i = 0; i < avg_r_barrel.size(); ++i) {
-    avg_r_barrel[i] /= avg_r_barrel_counter[i];
+    if (avg_r_barrel_counter[i] > 0)
+      avg_r_barrel[i] /= avg_r_barrel_counter[i];
   }
   for (size_t i = 0; i < avg_z_endcap.size(); ++i) {
-    avg_z_endcap[i] /= avg_z_endcap_counter[i];
+    if (avg_z_endcap_counter[i] > 0)
+      avg_z_endcap[i] /= avg_z_endcap_counter[i];
   }
 
   auto lstGeometry = std::make_unique<lstgeometry::Geometry>(std::move(sensors), avg_r_barrel, avg_z_endcap, ptCut_);

--- a/RecoTracker/LSTGeometry/plugins/LSTGeometryESProducer.cc
+++ b/RecoTracker/LSTGeometry/plugins/LSTGeometryESProducer.cc
@@ -3,8 +3,10 @@
 #include <unordered_map>
 #include <vector>
 
-#include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
@@ -30,8 +32,8 @@ private:
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
 
-  const TrackerGeometry *trackerGeom_ = nullptr;
-  const TrackerTopology *trackerTopo_ = nullptr;
+  TrackerGeometry const *trackerGeom_ = nullptr;
+  TrackerTopology const *trackerTopo_ = nullptr;
 };
 
 LSTGeometryESProducer::LSTGeometryESProducer(const edm::ParameterSet &iConfig)
@@ -54,6 +56,7 @@ std::unique_ptr<lstgeometry::Geometry> LSTGeometryESProducer::produce(const Trac
   trackerTopo_ = &iRecord.get(ttopoToken_);
 
   lstgeometry::Sensors sensors;
+  sensors.reserve(trackerGeom_->dets().size());
 
   std::array<float, lstgeometry::kBarrelLayers> avg_r_barrel{};
   std::array<float, lstgeometry::kEndcapLayers> avg_z_endcap{};
@@ -77,17 +80,11 @@ std::unique_ptr<lstgeometry::Geometry> LSTGeometryESProducer::produce(const Trac
 
     const float rho_cm = position.perp();
     const float z_cm = lstgeometry::roundCoordinate(position.z());
-    const float phi_rad = lstgeometry::roundAngle(position.phi());
 
     const auto subdet = trackerGeom_->geomDetSubDetector(detId.subdetId());
     const auto location =
         GeomDetEnumerators::isBarrel(subdet) ? lstgeometry::Location::barrel : lstgeometry::Location::endcap;
-    const auto side = static_cast<lstgeometry::Side>(
-        location == lstgeometry::Location::barrel ? static_cast<unsigned int>(trackerTopo_->barrelTiltTypeP2(detId))
-                                                  : trackerTopo_->side(detId));
-    const unsigned int moduleId = trackerTopo_->module(detId);
     const unsigned int layer = trackerTopo_->layer(detId);
-    const unsigned int ring = trackerTopo_->endcapRingP2(detId);
 
     if (layer == 0 || (location == lstgeometry::Location::barrel && layer > lstgeometry::kBarrelLayers) ||
         (location == lstgeometry::Location::endcap && layer > lstgeometry::kEndcapLayers)) {
@@ -96,8 +93,14 @@ std::unique_ptr<lstgeometry::Geometry> LSTGeometryESProducer::produce(const Trac
 
     if (det->isLeaf()) {
       // Leafs are the sensors
-      sensors[detid] = lstgeometry::Sensor(
-          detid, moduleType, subdet, location, side, moduleId, layer, ring, rho_cm, z_cm, phi_rad, surface);
+      const float phi_rad = lstgeometry::roundAngle(position.phi());
+      const auto side = static_cast<lstgeometry::Side>(
+          location == lstgeometry::Location::barrel ? static_cast<unsigned int>(trackerTopo_->barrelTiltTypeP2(detId))
+                                                    : trackerTopo_->side(detId));
+      const unsigned int moduleId = trackerTopo_->module(detId);
+      const unsigned int ring = location == lstgeometry::Location::endcap ? trackerTopo_->endcapRingP2(detId) : 0;
+      sensors.try_emplace(
+          detid, detid, moduleType, subdet, location, side, moduleId, layer, ring, rho_cm, z_cm, phi_rad, surface);
 
       continue;
     }

--- a/RecoTracker/LSTGeometry/src/Common.cc
+++ b/RecoTracker/LSTGeometry/src/Common.cc
@@ -1,0 +1,42 @@
+#include "RecoTracker/LSTGeometry/interface/Common.h"
+
+namespace lstgeometry {
+
+  float degToRad(float degrees) { return degrees * (std::numbers::pi_v<float> / 180); }
+
+  float phi_mpi_pi(float phi) {
+    while (phi >= std::numbers::pi_v<float>)
+      phi -= 2 * std::numbers::pi_v<float>;
+    while (phi < -std::numbers::pi_v<float>)
+      phi += 2 * std::numbers::pi_v<float>;
+    return phi;
+  }
+
+  float roundAngle(float angle, float tol) {
+    const float pi = std::numbers::pi_v<float>;
+    if (std::fabs(angle) < tol) {
+      return 0.0;
+    } else if (std::fabs(angle - pi / 2) < tol) {
+      return pi / 2;
+    } else if (std::fabs(angle + pi / 2) < tol) {
+      return -pi / 2;
+    } else if (std::fabs(angle - pi) < tol || std::fabs(angle + pi) < tol) {
+      return -pi;
+    }
+    return angle;
+  }
+
+  float roundCoordinate(float coord, float tol) {
+    if (std::fabs(coord) < tol) {
+      return 0.0;
+    }
+    return coord;
+  }
+
+  std::pair<float, float> getEtaPhi(float x, float y, float z, float refphi) {
+    float phi = phi_mpi_pi(std::atan2(y, x) - refphi);
+    float eta = std::asinh(z / std::sqrt(x * x + y * y));
+    return std::make_pair(eta, phi);
+  }
+
+}  // namespace lstgeometry

--- a/RecoTracker/LSTGeometry/src/Geometry.cc
+++ b/RecoTracker/LSTGeometry/src/Geometry.cc
@@ -1,0 +1,30 @@
+#include "RecoTracker/LSTGeometry/interface/Geometry.h"
+#include "RecoTracker/LSTGeometry/interface/SensorBinning.h"
+#include "RecoTracker/LSTGeometry/interface/Slope.h"
+
+using namespace lstgeometry;
+
+Geometry::Geometry(Sensors sensors,
+                   std::array<float, kBarrelLayers> const &average_r_barrel,
+                   std::array<float, kEndcapLayers> const &average_z_endcap,
+                   float pt_cut) {
+  auto slopes = computeSlopes(sensors);
+  barrel_slopes = std::move(std::get<0>(slopes));
+  endcap_slopes = std::move(std::get<1>(slopes));
+
+  auto binned_detids = binDetIds(sensors);
+
+  pixel_map = buildPixelMap(sensors, pt_cut);
+
+  module_map = buildModuleMap(sensors, binned_detids, average_r_barrel, average_z_endcap, pt_cut);
+
+  // Drop all the extra data that is no longer needed
+  for (auto &[detId, sensor] : sensors) {
+    sensor.extra.reset();
+  }
+
+  this->sensors = std::move(sensors);
+}
+
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(lstgeometry::Geometry);

--- a/RecoTracker/LSTGeometry/src/Geometry.cc
+++ b/RecoTracker/LSTGeometry/src/Geometry.cc
@@ -2,29 +2,31 @@
 #include "RecoTracker/LSTGeometry/interface/SensorBinning.h"
 #include "RecoTracker/LSTGeometry/interface/Slope.h"
 
-using namespace lstgeometry;
+namespace lstgeometry {
 
-Geometry::Geometry(Sensors sensors,
-                   std::array<float, kBarrelLayers> const &average_r_barrel,
-                   std::array<float, kEndcapLayers> const &average_z_endcap,
-                   float pt_cut) {
-  auto slopes = computeSlopes(sensors);
-  barrel_slopes = std::move(std::get<0>(slopes));
-  endcap_slopes = std::move(std::get<1>(slopes));
+  Geometry::Geometry(Sensors sensors,
+                     std::array<float, kBarrelLayers> const &average_r_barrel,
+                     std::array<float, kEndcapLayers> const &average_z_endcap,
+                     float pt_cut) {
+    auto slopes = computeSlopes(sensors);
+    barrel_slopes = std::move(std::get<0>(slopes));
+    endcap_slopes = std::move(std::get<1>(slopes));
 
-  auto binned_detids = binDetIds(sensors);
+    auto binned_detids = binDetIds(sensors);
 
-  pixel_map = buildPixelMap(sensors, pt_cut);
+    pixel_map = buildPixelMap(sensors, pt_cut);
 
-  module_map = buildModuleMap(sensors, binned_detids, average_r_barrel, average_z_endcap, pt_cut);
+    module_map = buildModuleMap(sensors, binned_detids, average_r_barrel, average_z_endcap, pt_cut);
 
-  // Drop all the extra data that is no longer needed
-  for (auto &[detId, sensor] : sensors) {
-    sensor.extra.reset();
+    // Drop all the extra data that is no longer needed
+    for (auto &[detId, sensor] : sensors) {
+      sensor.extra.reset();
+    }
+
+    this->sensors = std::move(sensors);
   }
 
-  this->sensors = std::move(sensors);
-}
+}  // namespace lstgeometry
 
 #include "FWCore/Utilities/interface/typelookup.h"
 TYPELOOKUP_DATA_REG(lstgeometry::Geometry);

--- a/RecoTracker/LSTGeometry/src/IO.cc
+++ b/RecoTracker/LSTGeometry/src/IO.cc
@@ -71,9 +71,7 @@ namespace lstgeometry {
     }
   }
 
-  void writeModuleConnections(std::unordered_map<unsigned int, std::unordered_set<unsigned int>> const& connections,
-                              std::string const& base_filename,
-                              bool binary) {
+  void writeModuleConnections(ModuleMap const& connections, std::string const& base_filename, bool binary) {
     std::filesystem::path filepath(base_filename);
     std::filesystem::create_directories(filepath.parent_path());
 
@@ -81,18 +79,18 @@ namespace lstgeometry {
     std::ofstream file(filename, binary ? std::ios::binary : std::ios::out);
 
     if (binary) {
-      for (auto const& [detid, set] : connections) {
+      for (auto const& [detid, list] : connections) {
         file.write(reinterpret_cast<const char*>(&detid), sizeof(detid));
-        unsigned int length = set.size();
+        unsigned int length = list.size();
         file.write(reinterpret_cast<const char*>(&length), sizeof(length));
-        for (unsigned int i : set) {
+        for (unsigned int i : list) {
           file.write(reinterpret_cast<const char*>(&i), sizeof(i));
         }
       }
     } else {
-      for (auto const& [detid, set] : connections) {
-        file << detid << "," << set.size();
-        for (unsigned int i : set) {
+      for (auto const& [detid, list] : connections) {
+        file << detid << "," << list.size();
+        for (unsigned int i : list) {
           file << "," << i;
         }
         file << std::endl;
@@ -104,41 +102,30 @@ namespace lstgeometry {
     std::filesystem::path filepath(base_filename);
     std::filesystem::create_directories(filepath.parent_path());
 
-    if (binary) {
-      for (auto const& [layersubdetcharge, map] : maps) {
-        auto const& [layer, subdet, charge] = layersubdetcharge;
+    for (auto const& [layersubdetcharge, vec_of_vecs] : maps) {
+      auto const& [layer, subdet, charge] = layersubdetcharge;
 
-        std::string charge_str = charge > 0 ? "_pos" : (charge < 0 ? "_neg" : "");
-        std::string filename = std::format("{}{}_layer{}_subdet{}.bin", base_filename, charge_str, layer, subdet);
+      std::string charge_str = charge > 0 ? "_pos" : (charge < 0 ? "_neg" : "");
+      std::string filename =
+          std::format("{}{}_layer{}_subdet{}.{}", base_filename, charge_str, layer, subdet, binary ? "bin" : "txt");
 
-        std::ofstream file(filename, std::ios::binary);
+      std::ofstream file(filename, binary ? std::ios::binary : std::ios::out);
 
-        for (unsigned int isuperbin = 0; isuperbin < map.size(); isuperbin++) {
-          auto const& set = map.at(isuperbin);
+      for (unsigned int isuperbin = 0; isuperbin < vec_of_vecs.size(); isuperbin++) {
+        auto const& vec = vec_of_vecs.at(isuperbin);
+        if (vec.empty())
+          continue;
 
+        unsigned int length = vec.size();
+        if (binary) {
           file.write(reinterpret_cast<const char*>(&isuperbin), sizeof(isuperbin));
-          unsigned int length = set.size();
           file.write(reinterpret_cast<const char*>(&length), sizeof(length));
-          for (unsigned int i : set) {
+          for (unsigned int i : vec) {
             file.write(reinterpret_cast<const char*>(&i), sizeof(i));
           }
-        }
-      }
-    } else {
-      for (auto const& [layersubdetcharge, map] : maps) {
-        auto const& [layer, subdet, charge] = layersubdetcharge;
-
-        std::string charge_str = charge > 0 ? "_pos" : (charge < 0 ? "_neg" : "");
-        std::string filename = std::format("{}{}_layer{}_subdet{}.txt", base_filename, charge_str, layer, subdet);
-
-        std::ofstream file(filename);
-
-        for (unsigned int isuperbin = 0; isuperbin < map.size(); isuperbin++) {
-          auto const& set = map.at(isuperbin);
-
-          unsigned int length = set.size();
+        } else {
           file << isuperbin << "," << length;
-          for (unsigned int i : set) {
+          for (unsigned int i : vec) {
             file << "," << i;
           }
           file << std::endl;

--- a/RecoTracker/LSTGeometry/src/IO.cc
+++ b/RecoTracker/LSTGeometry/src/IO.cc
@@ -1,0 +1,150 @@
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <format>
+#include <filesystem>
+
+#include "RecoTracker/LSTGeometry/interface/IO.h"
+
+namespace lstgeometry {
+
+  void writeSensorCentroids(Sensors const& sensors, std::string const& base_filename, bool binary) {
+    std::filesystem::path filepath(base_filename);
+    std::filesystem::create_directories(filepath.parent_path());
+
+    std::string filename = base_filename + (binary ? ".bin" : ".txt");
+    std::ofstream file(filename, binary ? std::ios::binary : std::ios::out);
+
+    if (binary) {
+      for (auto const& [detid, sensor] : sensors) {
+        float x = sensor.centerX;
+        float y = sensor.centerY;
+        float z = sensor.centerZ;
+        unsigned int moduleType = static_cast<unsigned int>(sensor.moduleType);
+        file.write(reinterpret_cast<const char*>(&detid), sizeof(detid));
+        file.write(reinterpret_cast<const char*>(&x), sizeof(x));
+        file.write(reinterpret_cast<const char*>(&y), sizeof(y));
+        file.write(reinterpret_cast<const char*>(&z), sizeof(z));
+        file.write(reinterpret_cast<const char*>(&moduleType), sizeof(moduleType));
+      }
+    } else {
+      for (auto const& [detid, sensor] : sensors) {
+        file << detid << "," << sensor.centerX << "," << sensor.centerY << "," << sensor.centerZ << ","
+             << static_cast<unsigned int>(sensor.moduleType) << std::endl;
+      }
+    }
+  }
+
+  void writeSlopes(Slopes const& slopes, Sensors const& sensors, std::string const& base_filename, bool binary) {
+    std::filesystem::path filepath(base_filename);
+    std::filesystem::create_directories(filepath.parent_path());
+
+    std::string filename = base_filename + (binary ? ".bin" : ".txt");
+    std::ofstream file(filename, binary ? std::ios::binary : std::ios::out);
+
+    if (binary) {
+      for (auto const& [detid, slope] : slopes) {
+        float drdz_slope = slope.drdz;
+        float dxdy_slope = slope.dxdy;
+        float phi = sensors.at(detid).centerPhi;
+        file.write(reinterpret_cast<const char*>(&detid), sizeof(detid));
+        if (drdz_slope != kDefaultSlope) {
+          file.write(reinterpret_cast<const char*>(&drdz_slope), sizeof(drdz_slope));
+          file.write(reinterpret_cast<const char*>(&dxdy_slope), sizeof(dxdy_slope));
+        } else {
+          file.write(reinterpret_cast<const char*>(&dxdy_slope), sizeof(dxdy_slope));
+          file.write(reinterpret_cast<const char*>(&phi), sizeof(phi));
+        }
+      }
+    } else {
+      for (auto const& [detid, slope] : slopes) {
+        float drdz_slope = slope.drdz;
+        float dxdy_slope = slope.dxdy;
+        float phi = sensors.at(detid).centerPhi;
+        file << detid << ",";
+        if (drdz_slope != kDefaultSlope) {
+          file << drdz_slope << "," << dxdy_slope << std::endl;
+        } else {
+          file << dxdy_slope << "," << phi << std::endl;
+        }
+      }
+    }
+  }
+
+  void writeModuleConnections(std::unordered_map<unsigned int, std::unordered_set<unsigned int>> const& connections,
+                              std::string const& base_filename,
+                              bool binary) {
+    std::filesystem::path filepath(base_filename);
+    std::filesystem::create_directories(filepath.parent_path());
+
+    std::string filename = base_filename + (binary ? ".bin" : ".txt");
+    std::ofstream file(filename, binary ? std::ios::binary : std::ios::out);
+
+    if (binary) {
+      for (auto const& [detid, set] : connections) {
+        file.write(reinterpret_cast<const char*>(&detid), sizeof(detid));
+        unsigned int length = set.size();
+        file.write(reinterpret_cast<const char*>(&length), sizeof(length));
+        for (unsigned int i : set) {
+          file.write(reinterpret_cast<const char*>(&i), sizeof(i));
+        }
+      }
+    } else {
+      for (auto const& [detid, set] : connections) {
+        file << detid << "," << set.size();
+        for (unsigned int i : set) {
+          file << "," << i;
+        }
+        file << std::endl;
+      }
+    }
+  }
+
+  void writePixelMaps(PixelMap const& maps, std::string const& base_filename, bool binary) {
+    std::filesystem::path filepath(base_filename);
+    std::filesystem::create_directories(filepath.parent_path());
+
+    if (binary) {
+      for (auto const& [layersubdetcharge, map] : maps) {
+        auto const& [layer, subdet, charge] = layersubdetcharge;
+
+        std::string charge_str = charge > 0 ? "_pos" : (charge < 0 ? "_neg" : "");
+        std::string filename = std::format("{}{}_layer{}_subdet{}.bin", base_filename, charge_str, layer, subdet);
+
+        std::ofstream file(filename, std::ios::binary);
+
+        for (unsigned int isuperbin = 0; isuperbin < map.size(); isuperbin++) {
+          auto const& set = map.at(isuperbin);
+
+          file.write(reinterpret_cast<const char*>(&isuperbin), sizeof(isuperbin));
+          unsigned int length = set.size();
+          file.write(reinterpret_cast<const char*>(&length), sizeof(length));
+          for (unsigned int i : set) {
+            file.write(reinterpret_cast<const char*>(&i), sizeof(i));
+          }
+        }
+      }
+    } else {
+      for (auto const& [layersubdetcharge, map] : maps) {
+        auto const& [layer, subdet, charge] = layersubdetcharge;
+
+        std::string charge_str = charge > 0 ? "_pos" : (charge < 0 ? "_neg" : "");
+        std::string filename = std::format("{}{}_layer{}_subdet{}.txt", base_filename, charge_str, layer, subdet);
+
+        std::ofstream file(filename);
+
+        for (unsigned int isuperbin = 0; isuperbin < map.size(); isuperbin++) {
+          auto const& set = map.at(isuperbin);
+
+          unsigned int length = set.size();
+          file << isuperbin << "," << length;
+          for (unsigned int i : set) {
+            file << "," << i;
+          }
+          file << std::endl;
+        }
+      }
+    }
+  }
+
+}  // namespace lstgeometry

--- a/RecoTracker/LSTGeometry/src/IO.cc
+++ b/RecoTracker/LSTGeometry/src/IO.cc
@@ -1,8 +1,8 @@
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <format>
 #include <filesystem>
+#include <format>
+#include <fstream>
+#include <iostream>
+#include <sstream>
 
 #include "RecoTracker/LSTGeometry/interface/IO.h"
 

--- a/RecoTracker/LSTGeometry/src/ModuleMap.cc
+++ b/RecoTracker/LSTGeometry/src/ModuleMap.cc
@@ -128,7 +128,7 @@ namespace lstgeometry {
     // We construct the reference polygon as a vector of polygons because the boost::geometry::difference
     // function can return multiple polygons if the difference results in disjoint pieces
     if (ref_location == Location::barrel) {
-      std::unordered_set<unsigned int> barrel_endcap_connected_tar_detids;
+      std::vector<unsigned int> barrel_endcap_connected_tar_detids;
 
       for (float zshift : {0, 10, -10}) {
         std::vector<Polygon> ref_polygon;
@@ -178,7 +178,7 @@ namespace lstgeometry {
           }
 
           if (intersects)
-            barrel_endcap_connected_tar_detids.insert(tar_detid);
+            barrel_endcap_connected_tar_detids.push_back(tar_detid);
         }
       }
       list_of_detids_etaphi_layer_tar.insert(list_of_detids_etaphi_layer_tar.end(),
@@ -301,7 +301,7 @@ namespace lstgeometry {
     // We construct the reference polygon as a vector of polygons because the boost::geometry::difference
     // function can return multiple polygons if the difference results in disjoint pieces
     if (ref_location == Location::barrel) {
-      std::unordered_set<unsigned int> barrel_endcap_connected_tar_detids;
+      std::vector<unsigned int> barrel_endcap_connected_tar_detids;
 
       int zshift = 0;
 
@@ -350,7 +350,7 @@ namespace lstgeometry {
           }
 
           if (intersects)
-            barrel_endcap_connected_tar_detids.insert(tar_detid);
+            barrel_endcap_connected_tar_detids.push_back(tar_detid);
         }
       }
 
@@ -369,8 +369,13 @@ namespace lstgeometry {
     for (auto* connections : connections_list) {
       for (auto const& [detid, list] : *connections) {
         auto& target = merged[detid];
-        target.insert(list.begin(), list.end());
+        target.insert(target.end(), list.begin(), list.end());
       }
+    }
+
+    for (auto& [detid, list] : merged) {
+      std::sort(list.begin(), list.end());
+      list.erase(std::unique(list.begin(), list.end()), list.end());
     }
 
     return merged;

--- a/RecoTracker/LSTGeometry/src/ModuleMap.cc
+++ b/RecoTracker/LSTGeometry/src/ModuleMap.cc
@@ -1,0 +1,401 @@
+#include <iterator>
+#include <vector>
+#include <tuple>
+#include <initializer_list>
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/polygon.hpp>
+
+#include "RecoTracker/LSTGeometry/interface/Helix.h"
+#include "RecoTracker/LSTGeometry/interface/ModuleMap.h"
+
+namespace lstgeometry {
+
+  using Point = boost::geometry::model::d2::point_xy<float>;
+  using Polygon = boost::geometry::model::polygon<Point>;
+
+  Polygon getEtaPhiPolygon(MatrixF4x3 const& corners, float refphi, float zshift = 0) {
+    MatrixF4x2 mod_boundaries_etaphi;
+    for (int i = 0; i < 4; ++i) {
+      auto ref_etaphi = getEtaPhi(corners(i, 1), corners(i, 2), corners(i, 0) + zshift, refphi);
+      mod_boundaries_etaphi(i, 0) = ref_etaphi.first;
+      mod_boundaries_etaphi(i, 1) = ref_etaphi.second;
+    }
+
+    Polygon poly;
+    // <= because we need to close the polygon with the first point
+    for (int i = 0; i <= 4; ++i) {
+      boost::geometry::append(poly, Point(mod_boundaries_etaphi(i % 4, 0), mod_boundaries_etaphi(i % 4, 1)));
+    }
+    boost::geometry::correct(poly);
+    return poly;
+  }
+
+  bool moduleOverlapsInEtaPhi(MatrixF4x3 const& ref_mod_boundaries,
+                              MatrixF4x3 const& tar_mod_boundaries,
+                              float refphi = 0,
+                              float zshift = 0,
+                              float ref_center_phi = std::numeric_limits<float>::max(),
+                              float tar_center_phi = std::numeric_limits<float>::max()) {
+    if (ref_center_phi < -std::numbers::pi_v<float> || ref_center_phi > std::numbers::pi_v<float>) {
+      RowVectorF3 ref_center = ref_mod_boundaries.colwise().sum();
+      ref_center /= 4.;
+      ref_center_phi = std::atan2(ref_center(2), ref_center(1));
+    }
+    if (tar_center_phi < -std::numbers::pi_v<float> || tar_center_phi > std::numbers::pi_v<float>) {
+      RowVectorF3 tar_center = tar_mod_boundaries.colwise().sum();
+      tar_center /= 4.;
+      tar_center_phi = std::atan2(tar_center(2), tar_center(1));
+    }
+
+    if (std::fabs(phi_mpi_pi(ref_center_phi - tar_center_phi)) > std::numbers::pi_v<float> / 2.)
+      return false;
+
+    MatrixF4x2 ref_mod_boundaries_etaphi;
+    MatrixF4x2 tar_mod_boundaries_etaphi;
+
+    for (int i = 0; i < 4; ++i) {
+      auto ref_etaphi =
+          getEtaPhi(ref_mod_boundaries(i, 1), ref_mod_boundaries(i, 2), ref_mod_boundaries(i, 0) + zshift, refphi);
+      auto tar_etaphi =
+          getEtaPhi(tar_mod_boundaries(i, 1), tar_mod_boundaries(i, 2), tar_mod_boundaries(i, 0) + zshift, refphi);
+      ref_mod_boundaries_etaphi(i, 0) = ref_etaphi.first;
+      ref_mod_boundaries_etaphi(i, 1) = ref_etaphi.second;
+      tar_mod_boundaries_etaphi(i, 0) = tar_etaphi.first;
+      tar_mod_boundaries_etaphi(i, 1) = tar_etaphi.second;
+    }
+
+    // Quick cut
+    RowVectorF2 diff = ref_mod_boundaries_etaphi.row(0) - tar_mod_boundaries_etaphi.row(0);
+    if (std::fabs(diff(0)) > 0.5)
+      return false;
+    if (std::fabs(phi_mpi_pi(diff(1))) > 1.)
+      return false;
+
+    Polygon ref_poly, tar_poly;
+
+    // <= 4 because we need to close the polygon with the first point
+    for (int i = 0; i <= 4; ++i) {
+      boost::geometry::append(ref_poly,
+                              Point(ref_mod_boundaries_etaphi(i % 4, 0), ref_mod_boundaries_etaphi(i % 4, 1)));
+      boost::geometry::append(tar_poly,
+                              Point(tar_mod_boundaries_etaphi(i % 4, 0), tar_mod_boundaries_etaphi(i % 4, 1)));
+    }
+    boost::geometry::correct(ref_poly);
+    boost::geometry::correct(tar_poly);
+
+    return boost::geometry::intersects(ref_poly, tar_poly);
+  }
+
+  std::vector<unsigned int> getStraightLineConnections(unsigned int ref_detid,
+                                                       Sensors const& sensors,
+                                                       BinnedDetIds const& binned_detids) {
+    auto const& ref_sensor = sensors.at(ref_detid);
+
+    float refphi = std::atan2(ref_sensor.centerY, ref_sensor.centerX);
+    unsigned short ref_layer = ref_sensor.extra->layer;
+    auto ref_location = ref_sensor.extra->location;
+
+    auto thetaphibins = getThetaPhiBins(ref_sensor.extra->centerTheta, ref_sensor.centerPhi);
+
+    auto const& tar_detids_to_be_considered =
+        binned_detids.at(std::make_tuple(ref_location, ref_layer + 1, thetaphibins.first, thetaphibins.second));
+
+    std::vector<unsigned int> list_of_detids_etaphi_layer_tar;
+    for (unsigned int tar_detid : tar_detids_to_be_considered) {
+      auto const& tar_sensor = sensors.at(tar_detid);
+      if (moduleOverlapsInEtaPhi(ref_sensor.extra->corners,
+                                 tar_sensor.extra->corners,
+                                 refphi,
+                                 0,
+                                 ref_sensor.centerPhi,
+                                 tar_sensor.centerPhi) ||
+          moduleOverlapsInEtaPhi(ref_sensor.extra->corners,
+                                 tar_sensor.extra->corners,
+                                 refphi,
+                                 10,
+                                 ref_sensor.centerPhi,
+                                 tar_sensor.centerPhi) ||
+          moduleOverlapsInEtaPhi(ref_sensor.extra->corners,
+                                 tar_sensor.extra->corners,
+                                 refphi,
+                                 -10,
+                                 ref_sensor.centerPhi,
+                                 tar_sensor.centerPhi))
+        list_of_detids_etaphi_layer_tar.push_back(tar_detid);
+    }
+
+    // Consider barrel to endcap connections if the intersection area is > 0
+    // We construct the reference polygon as a vector of polygons because the boost::geometry::difference
+    // function can return multiple polygons if the difference results in disjoint pieces
+    if (ref_location == Location::barrel) {
+      std::unordered_set<unsigned int> barrel_endcap_connected_tar_detids;
+
+      for (float zshift : {0, 10, -10}) {
+        std::vector<Polygon> ref_polygon;
+        ref_polygon.push_back(getEtaPhiPolygon(ref_sensor.extra->corners, refphi, zshift));
+
+        // Check whether there is still significant non-zero area
+        for (unsigned int tar_detid : list_of_detids_etaphi_layer_tar) {
+          if (ref_polygon.empty())
+            break;
+          Polygon tar_polygon = getEtaPhiPolygon(sensors.at(tar_detid).extra->corners, refphi, zshift);
+
+          std::vector<Polygon> difference;
+          for (auto const& ref_polygon_piece : ref_polygon) {
+            std::vector<Polygon> tmp_difference;
+            boost::geometry::difference(ref_polygon_piece, tar_polygon, tmp_difference);
+            difference.insert(difference.end(), tmp_difference.begin(), tmp_difference.end());
+          }
+
+          ref_polygon = std::move(difference);
+        }
+
+        float area = 0.;
+        for (auto const& ref_polygon_piece : ref_polygon)
+          area += boost::geometry::area(ref_polygon_piece);
+
+        if (area <= 1e-6)
+          continue;
+
+        auto const& new_tar_detids_to_be_considered =
+            binned_detids.at(std::make_tuple(Location::endcap, 1, thetaphibins.first, thetaphibins.second));
+
+        for (unsigned int tar_detid : new_tar_detids_to_be_considered) {
+          auto const& sensor_target = sensors.at(tar_detid);
+          float tarphi = std::atan2(sensor_target.centerY, sensor_target.centerX);
+
+          if (std::fabs(phi_mpi_pi(tarphi - refphi)) > std::numbers::pi_v<float> / 2.)
+            continue;
+
+          Polygon tar_polygon = getEtaPhiPolygon(sensor_target.extra->corners, refphi, zshift);
+
+          bool intersects = false;
+          for (auto const& ref_polygon_piece : ref_polygon) {
+            if (boost::geometry::intersects(ref_polygon_piece, tar_polygon)) {
+              intersects = true;
+              break;
+            }
+          }
+
+          if (intersects)
+            barrel_endcap_connected_tar_detids.insert(tar_detid);
+        }
+      }
+      list_of_detids_etaphi_layer_tar.insert(list_of_detids_etaphi_layer_tar.end(),
+                                             barrel_endcap_connected_tar_detids.begin(),
+                                             barrel_endcap_connected_tar_detids.end());
+    }
+
+    return list_of_detids_etaphi_layer_tar;
+  }
+
+  MatrixF4x3 boundsAfterCurved(unsigned int ref_detid,
+                               Sensors const& sensors,
+                               std::array<float, kBarrelLayers> const& average_r_barrel,
+                               std::array<float, kEndcapLayers> const& average_z_endcap,
+                               float ptCut,
+                               bool doR = true) {
+    auto const& ref_sensor = sensors.at(ref_detid);
+    auto const& bounds = ref_sensor.extra->corners;
+    int charge = 1;
+    float z_r = ref_sensor.centerZ /
+                std::sqrt(ref_sensor.centerX * ref_sensor.centerX + ref_sensor.centerY * ref_sensor.centerY);
+    float refphi = std::atan2(ref_sensor.centerY, ref_sensor.centerX);
+    unsigned short ref_layer = ref_sensor.extra->layer;
+    auto ref_location = ref_sensor.extra->location;
+    MatrixF4x3 next_layer_bound_points;
+
+    for (int i = 0; i < bounds.rows(); i++) {
+      auto helix_p10 = Helix(ptCut, 0, 0, 10, bounds(i, 1), bounds(i, 2), bounds(i, 0), -charge);
+      auto helix_m10 = Helix(ptCut, 0, 0, -10, bounds(i, 1), bounds(i, 2), bounds(i, 0), -charge);
+      auto helix_p10_pos = Helix(ptCut, 0, 0, 10, bounds(i, 1), bounds(i, 2), bounds(i, 0), charge);
+      auto helix_m10_pos = Helix(ptCut, 0, 0, -10, bounds(i, 1), bounds(i, 2), bounds(i, 0), charge);
+      float bound_z_r = bounds(i, 0) / std::sqrt(bounds(i, 1) * bounds(i, 1) + bounds(i, 2) * bounds(i, 2));
+      float bound_phi = std::atan2(bounds(i, 2), bounds(i, 1));
+      float phi_diff = phi_mpi_pi(bound_phi - refphi);
+
+      std::tuple<float, float, float, float> next_point;
+      if (ref_location == Location::barrel) {
+        if (doR) {
+          float tar_layer_radius = average_r_barrel[ref_layer];
+          if (bound_z_r < z_r) {
+            auto const& h = phi_diff > 0 ? helix_p10 : helix_p10_pos;
+            next_point = h.pointFromRadius(tar_layer_radius);
+          } else {
+            auto const& h = phi_diff > 0 ? helix_m10 : helix_m10_pos;
+            next_point = h.pointFromRadius(tar_layer_radius);
+          }
+        } else {
+          float tar_layer_z = average_z_endcap[0];
+          if (bound_z_r < z_r) {
+            if (phi_diff > 0) {
+              next_point = helix_p10.pointFromZ(std::copysign(tar_layer_z, helix_p10.lambda));
+            } else {
+              next_point = helix_p10_pos.pointFromZ(std::copysign(tar_layer_z, helix_p10_pos.lambda));
+            }
+          } else {
+            if (phi_diff > 0) {
+              next_point = helix_m10.pointFromZ(std::copysign(tar_layer_z, helix_m10.lambda));
+            } else {
+              next_point = helix_m10_pos.pointFromZ(std::copysign(tar_layer_z, helix_m10_pos.lambda));
+            }
+          }
+        }
+      } else {
+        float tar_layer_z = average_z_endcap[ref_layer];
+        if (bound_z_r < z_r) {
+          if (phi_diff > 0) {
+            next_point = helix_p10.pointFromZ(std::copysign(tar_layer_z, helix_p10.lambda));
+          } else {
+            next_point = helix_p10_pos.pointFromZ(std::copysign(tar_layer_z, helix_p10_pos.lambda));
+          }
+        } else {
+          if (phi_diff > 0) {
+            next_point = helix_m10.pointFromZ(std::copysign(tar_layer_z, helix_m10.lambda));
+          } else {
+            next_point = helix_m10_pos.pointFromZ(std::copysign(tar_layer_z, helix_m10_pos.lambda));
+          }
+        }
+      }
+      next_layer_bound_points(i, 0) = std::get<2>(next_point);
+      next_layer_bound_points(i, 1) = std::get<0>(next_point);
+      next_layer_bound_points(i, 2) = std::get<1>(next_point);
+    }
+
+    return next_layer_bound_points;
+  }
+
+  std::vector<unsigned int> getCurvedLineConnections(unsigned int ref_detid,
+                                                     Sensors const& sensors,
+                                                     BinnedDetIds const& binned_detids,
+                                                     std::array<float, kBarrelLayers> const& average_r_barrel,
+                                                     std::array<float, kEndcapLayers> const& average_z_endcap,
+                                                     float ptCut) {
+    auto const& ref_sensor = sensors.at(ref_detid);
+
+    float refphi = std::atan2(ref_sensor.centerY, ref_sensor.centerX);
+
+    unsigned short ref_layer = ref_sensor.extra->layer;
+    auto ref_location = ref_sensor.extra->location;
+
+    auto thetaphibins = getThetaPhiBins(ref_sensor.extra->centerTheta, ref_sensor.centerPhi);
+
+    auto const& tar_detids_to_be_considered =
+        binned_detids.at({ref_location, ref_layer + 1, thetaphibins.first, thetaphibins.second});
+
+    auto next_layer_bound_points = boundsAfterCurved(ref_detid, sensors, average_r_barrel, average_z_endcap, ptCut);
+
+    std::vector<unsigned int> list_of_detids_etaphi_layer_tar;
+    for (unsigned int tar_detid : tar_detids_to_be_considered) {
+      auto const& tar_sensor = sensors.at(tar_detid);
+      if (moduleOverlapsInEtaPhi(next_layer_bound_points,
+                                 tar_sensor.extra->corners,
+                                 refphi,
+                                 0,
+                                 std::numeric_limits<float>::max(),
+                                 tar_sensor.centerPhi))
+        list_of_detids_etaphi_layer_tar.push_back(tar_detid);
+    }
+
+    // Consider barrel to endcap connections if the intersection area is > 0
+    // We construct the reference polygon as a vector of polygons because the boost::geometry::difference
+    // function can return multiple polygons if the difference results in disjoint pieces
+    if (ref_location == Location::barrel) {
+      std::unordered_set<unsigned int> barrel_endcap_connected_tar_detids;
+
+      int zshift = 0;
+
+      std::vector<Polygon> ref_polygon;
+      ref_polygon.push_back(getEtaPhiPolygon(next_layer_bound_points, refphi, zshift));
+
+      // Check whether there is still significant non-zero area
+      for (unsigned int tar_detid : list_of_detids_etaphi_layer_tar) {
+        if (ref_polygon.empty())
+          break;
+        Polygon tar_polygon = getEtaPhiPolygon(sensors.at(tar_detid).extra->corners, refphi, zshift);
+
+        std::vector<Polygon> difference;
+        for (auto const& ref_polygon_piece : ref_polygon) {
+          std::vector<Polygon> tmp_difference;
+          boost::geometry::difference(ref_polygon_piece, tar_polygon, tmp_difference);
+          difference.insert(difference.end(), tmp_difference.begin(), tmp_difference.end());
+        }
+
+        ref_polygon = std::move(difference);
+      }
+
+      float area = 0.;
+      for (auto const& ref_polygon_piece : ref_polygon)
+        area += boost::geometry::area(ref_polygon_piece);
+
+      if (area > 1e-6) {
+        auto const& new_tar_detids_to_be_considered =
+            binned_detids.at({Location::endcap, 1, thetaphibins.first, thetaphibins.second});
+
+        for (unsigned int tar_detid : new_tar_detids_to_be_considered) {
+          auto const& sensor_target = sensors.at(tar_detid);
+          float tarphi = std::atan2(sensor_target.centerY, sensor_target.centerX);
+
+          if (std::fabs(phi_mpi_pi(tarphi - refphi)) > std::numbers::pi_v<float> / 2.)
+            continue;
+
+          Polygon tar_polygon = getEtaPhiPolygon(sensor_target.extra->corners, refphi, zshift);
+
+          bool intersects = false;
+          for (auto const& ref_polygon_piece : ref_polygon) {
+            if (boost::geometry::intersects(ref_polygon_piece, tar_polygon)) {
+              intersects = true;
+              break;
+            }
+          }
+
+          if (intersects)
+            barrel_endcap_connected_tar_detids.insert(tar_detid);
+        }
+      }
+
+      list_of_detids_etaphi_layer_tar.insert(list_of_detids_etaphi_layer_tar.end(),
+                                             barrel_endcap_connected_tar_detids.begin(),
+                                             barrel_endcap_connected_tar_detids.end());
+    }
+
+    return list_of_detids_etaphi_layer_tar;
+  }
+
+  ModuleMap mergeLineConnections(
+      std::initializer_list<const std::unordered_map<unsigned int, std::vector<unsigned int>>*> connections_list) {
+    ModuleMap merged;
+
+    for (auto* connections : connections_list) {
+      for (auto const& [detid, list] : *connections) {
+        auto& target = merged[detid];
+        target.insert(list.begin(), list.end());
+      }
+    }
+
+    return merged;
+  }
+
+  ModuleMap buildModuleMap(Sensors const& sensors,
+                           BinnedDetIds const& binned_detids,
+                           std::array<float, kBarrelLayers> const& average_r_barrel,
+                           std::array<float, kEndcapLayers> const& average_z_endcap,
+                           float pt_cut) {
+    std::unordered_map<unsigned int, std::vector<unsigned int>> straight_line_connections;
+    std::unordered_map<unsigned int, std::vector<unsigned int>> curved_line_connections;
+
+    for (auto const& [ref_detid, s] : sensors) {
+      // exclude the outermost modules that do not have connections to other modules
+      if (!((s.extra->location == Location::barrel && s.extra->lower && s.extra->layer != 6) ||
+            (s.extra->location == Location::endcap && s.extra->lower && s.extra->layer != 5 &&
+             !(s.extra->ring == 15 && s.extra->layer == 1) && !(s.extra->ring == 15 && s.extra->layer == 2) &&
+             !(s.extra->ring == 12 && s.extra->layer == 3) && !(s.extra->ring == 12 && s.extra->layer == 4))))
+        continue;
+      straight_line_connections[ref_detid] = getStraightLineConnections(ref_detid, sensors, binned_detids);
+      curved_line_connections[ref_detid] =
+          getCurvedLineConnections(ref_detid, sensors, binned_detids, average_r_barrel, average_z_endcap, pt_cut);
+    }
+    return mergeLineConnections({&straight_line_connections, &curved_line_connections});
+  }
+
+}  // namespace lstgeometry

--- a/RecoTracker/LSTGeometry/src/ModuleMap.cc
+++ b/RecoTracker/LSTGeometry/src/ModuleMap.cc
@@ -154,7 +154,7 @@ namespace lstgeometry {
         for (auto const& ref_polygon_piece : ref_polygon)
           area += boost::geometry::area(ref_polygon_piece);
 
-        if (area <= 1e-6)
+        if (area <= 5e-3)
           continue;
 
         auto const& new_tar_detids_to_be_considered =
@@ -328,7 +328,7 @@ namespace lstgeometry {
       for (auto const& ref_polygon_piece : ref_polygon)
         area += boost::geometry::area(ref_polygon_piece);
 
-      if (area > 1e-6) {
+      if (area > 5e-3) {
         auto const& new_tar_detids_to_be_considered =
             binned_detids.at({Location::endcap, 1, thetaphibins.first, thetaphibins.second});
 

--- a/RecoTracker/LSTGeometry/src/ModuleMap.cc
+++ b/RecoTracker/LSTGeometry/src/ModuleMap.cc
@@ -1,184 +1,470 @@
-#include <iterator>
-#include <vector>
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
 #include <tuple>
-#include <initializer_list>
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/polygon.hpp>
+#include <vector>
 
 #include "RecoTracker/LSTGeometry/interface/Helix.h"
 #include "RecoTracker/LSTGeometry/interface/ModuleMap.h"
 
 namespace lstgeometry {
 
-  using Point = boost::geometry::model::d2::point_xy<float>;
-  using Polygon = boost::geometry::model::polygon<Point>;
+  struct EtaPhiBounds {
+    float minEta = std::numeric_limits<float>::max();
+    float maxEta = std::numeric_limits<float>::lowest();
+    float minPhi = std::numeric_limits<float>::max();
+    float maxPhi = std::numeric_limits<float>::lowest();
+  };
 
-  Polygon getEtaPhiPolygon(MatrixF4x3 const& corners, float refphi, float zshift = 0) {
-    MatrixF4x2 mod_boundaries_etaphi;
-    for (int i = 0; i < 4; ++i) {
-      auto ref_etaphi = getEtaPhi(corners(i, 1), corners(i, 2), corners(i, 0) + zshift, refphi);
-      mod_boundaries_etaphi(i, 0) = ref_etaphi.first;
-      mod_boundaries_etaphi(i, 1) = ref_etaphi.second;
-    }
+  struct CornerCoordinates {
+    // Columns are z, 1/r, phi for each module corner.
+    MatrixF4x3 values;
+    // Columns are eta at z shifts 0, +10, -10.
+    MatrixF4x3 shiftedEtas;
+    float centerPhi;
+  };
 
-    Polygon poly;
-    // <= because we need to close the polygon with the first point
-    for (int i = 0; i <= 4; ++i) {
-      boost::geometry::append(poly, Point(mod_boundaries_etaphi(i % 4, 0), mod_boundaries_etaphi(i % 4, 1)));
-    }
-    boost::geometry::correct(poly);
-    return poly;
+  struct EtaPhiQuad {
+    MatrixF4x2 corners;
+    EtaPhiBounds bounds;
+  };
+
+  struct EtaPhiPoint {
+    float eta;
+    float phi;
+  };
+
+  struct RelativePhiData {
+    std::array<float, 4> corners;
+    float minPhi;
+    float maxPhi;
+  };
+
+  using CornerCoordinatesMap = std::unordered_map<unsigned int, CornerCoordinates>;
+
+  struct ModuleCandidate {
+    unsigned int detid;
+    CornerCoordinates const* corners;
+  };
+
+  struct MatchedCandidate {
+    ModuleCandidate const* candidate;
+    RelativePhiData relativePhis;
+  };
+
+  using BinnedCandidates = std::array<
+      std::array<std::array<std::array<std::vector<ModuleCandidate>, kNPhiBins>, kNThetaBins>, kBarrelLayers + 1>,
+      2>;
+
+  std::vector<ModuleCandidate>& candidatesAt(
+      BinnedCandidates& candidates, Location location, unsigned int layer, unsigned int thetaBin, unsigned int phiBin) {
+    return candidates[locationIndex(location)][layer][thetaBin][phiBin];
   }
 
-  bool moduleOverlapsInEtaPhi(MatrixF4x3 const& ref_mod_boundaries,
-                              MatrixF4x3 const& tar_mod_boundaries,
-                              float refphi = 0,
-                              float zshift = 0,
-                              float ref_center_phi = std::numeric_limits<float>::max(),
-                              float tar_center_phi = std::numeric_limits<float>::max()) {
-    if (ref_center_phi < -std::numbers::pi_v<float> || ref_center_phi > std::numbers::pi_v<float>) {
-      RowVectorF3 ref_center = ref_mod_boundaries.colwise().sum();
-      ref_center /= 4.;
-      ref_center_phi = std::atan2(ref_center(2), ref_center(1));
+  std::vector<ModuleCandidate> const& candidatesAt(BinnedCandidates const& candidates,
+                                                   Location location,
+                                                   unsigned int layer,
+                                                   unsigned int thetaBin,
+                                                   unsigned int phiBin) {
+    return candidates[locationIndex(location)][layer][thetaBin][phiBin];
+  }
+
+  BinnedCandidates buildBinnedCandidates(BinnedDetIds const& binned_detids,
+                                         CornerCoordinatesMap const& corner_coordinates) {
+    BinnedCandidates candidates;
+    for (Location location : {Location::barrel, Location::endcap}) {
+      for (unsigned int layer = 1; layer <= kBarrelLayers; ++layer) {
+        for (unsigned int thetaBin = 0; thetaBin < kNThetaBins; ++thetaBin) {
+          for (unsigned int phiBin = 0; phiBin < kNPhiBins; ++phiBin) {
+            auto const& detids = binnedDetIdsAt(binned_detids, location, layer, thetaBin, phiBin);
+            auto& binCandidates = candidatesAt(candidates, location, layer, thetaBin, phiBin);
+            binCandidates.reserve(detids.size());
+            for (unsigned int detid : detids)
+              binCandidates.push_back({detid, &corner_coordinates.at(detid)});
+          }
+        }
+      }
     }
-    if (tar_center_phi < -std::numbers::pi_v<float> || tar_center_phi > std::numbers::pi_v<float>) {
-      RowVectorF3 tar_center = tar_mod_boundaries.colwise().sum();
-      tar_center /= 4.;
-      tar_center_phi = std::atan2(tar_center(2), tar_center(1));
+    return candidates;
+  }
+
+  float normalizePhi(float phi) {
+    constexpr float pi = std::numbers::pi_v<float>;
+    constexpr float twoPi = 2.f * pi;
+    if (phi >= pi)
+      phi -= twoPi;
+    else if (phi < -pi)
+      phi += twoPi;
+    return phi;
+  }
+
+  CornerCoordinates getCornerCoordinates(Sensor const& sensor) {
+    CornerCoordinates coordinates;
+    coordinates.centerPhi = sensor.centerPhi;
+    auto const& corners = sensor.extra->corners;
+    for (int i = 0; i < 4; ++i) {
+      float x = corners(i, 1);
+      float y = corners(i, 2);
+      coordinates.values(i, 0) = corners(i, 0);
+      coordinates.values(i, 1) = 1.f / std::sqrt(x * x + y * y);
+      coordinates.values(i, 2) = std::atan2(y, x);
+      coordinates.shiftedEtas(i, 0) = std::asinh(coordinates.values(i, 0) * coordinates.values(i, 1));
+      coordinates.shiftedEtas(i, 1) = std::asinh((coordinates.values(i, 0) + 10.f) * coordinates.values(i, 1));
+      coordinates.shiftedEtas(i, 2) = std::asinh((coordinates.values(i, 0) - 10.f) * coordinates.values(i, 1));
+    }
+    return coordinates;
+  }
+
+  bool etaPhiBoundsOverlap(EtaPhiBounds const& lhs, EtaPhiBounds const& rhs) {
+    return lhs.minEta <= rhs.maxEta && lhs.maxEta >= rhs.minEta && lhs.minPhi <= rhs.maxPhi && lhs.maxPhi >= rhs.minPhi;
+  }
+
+  bool etaPhiBoundsContain(EtaPhiBounds const& bounds, EtaPhiPoint const& point) {
+    return point.eta >= bounds.minEta && point.eta <= bounds.maxEta && point.phi >= bounds.minPhi &&
+           point.phi <= bounds.maxPhi;
+  }
+
+  float cross2D(MatrixF4x2 const& points, int a, int b, int c) {
+    float abEta = points(b, 0) - points(a, 0);
+    float abPhi = points(b, 1) - points(a, 1);
+    float acEta = points(c, 0) - points(a, 0);
+    float acPhi = points(c, 1) - points(a, 1);
+    return abEta * acPhi - abPhi * acEta;
+  }
+
+  float cross2D(MatrixF4x2 const& segment, int a, int b, MatrixF4x2 const& points, int c) {
+    float abEta = segment(b, 0) - segment(a, 0);
+    float abPhi = segment(b, 1) - segment(a, 1);
+    float acEta = points(c, 0) - segment(a, 0);
+    float acPhi = points(c, 1) - segment(a, 1);
+    return abEta * acPhi - abPhi * acEta;
+  }
+
+  bool pointOnSegment(MatrixF4x2 const& segment, int a, int b, MatrixF4x2 const& points, int c) {
+    constexpr float eps = 1e-6;
+    if (std::fabs(cross2D(segment, a, b, points, c)) > eps)
+      return false;
+    return points(c, 0) >= std::min(segment(a, 0), segment(b, 0)) - eps &&
+           points(c, 0) <= std::max(segment(a, 0), segment(b, 0)) + eps &&
+           points(c, 1) >= std::min(segment(a, 1), segment(b, 1)) - eps &&
+           points(c, 1) <= std::max(segment(a, 1), segment(b, 1)) + eps;
+  }
+
+  bool segmentsIntersect(MatrixF4x2 const& lhs, int lhsA, int lhsB, MatrixF4x2 const& rhs, int rhsA, int rhsB) {
+    constexpr float eps = 1e-6;
+    float lhsCrossA = cross2D(lhs, lhsA, lhsB, rhs, rhsA);
+    float lhsCrossB = cross2D(lhs, lhsA, lhsB, rhs, rhsB);
+    float rhsCrossA = cross2D(rhs, rhsA, rhsB, lhs, lhsA);
+    float rhsCrossB = cross2D(rhs, rhsA, rhsB, lhs, lhsB);
+
+    if (std::fabs(lhsCrossA) <= eps && pointOnSegment(lhs, lhsA, lhsB, rhs, rhsA))
+      return true;
+    if (std::fabs(lhsCrossB) <= eps && pointOnSegment(lhs, lhsA, lhsB, rhs, rhsB))
+      return true;
+    if (std::fabs(rhsCrossA) <= eps && pointOnSegment(rhs, rhsA, rhsB, lhs, lhsA))
+      return true;
+    if (std::fabs(rhsCrossB) <= eps && pointOnSegment(rhs, rhsA, rhsB, lhs, lhsB))
+      return true;
+
+    return (lhsCrossA > eps) != (lhsCrossB > eps) && (rhsCrossA > eps) != (rhsCrossB > eps);
+  }
+
+  bool pointInPolygon(MatrixF4x2 const& polygon, MatrixF4x2 const& points, int point) {
+    bool inside = false;
+    float pointEta = points(point, 0);
+    float pointPhi = points(point, 1);
+
+    for (int i = 0, j = 3; i < 4; j = i++) {
+      if (pointOnSegment(polygon, j, i, points, point))
+        return true;
+
+      bool crossesPhi = (polygon(i, 1) > pointPhi) != (polygon(j, 1) > pointPhi);
+      if (!crossesPhi)
+        continue;
+
+      float etaAtPointPhi =
+          (polygon(j, 0) - polygon(i, 0)) * (pointPhi - polygon(i, 1)) / (polygon(j, 1) - polygon(i, 1)) +
+          polygon(i, 0);
+      if (pointEta < etaAtPointPhi)
+        inside = !inside;
     }
 
-    if (std::fabs(phi_mpi_pi(ref_center_phi - tar_center_phi)) > std::numbers::pi_v<float> / 2.)
+    return inside;
+  }
+
+  bool pointInQuad(EtaPhiQuad const& quad, EtaPhiPoint const& point) {
+    if (!etaPhiBoundsContain(quad.bounds, point))
       return false;
 
-    MatrixF4x2 ref_mod_boundaries_etaphi;
-    MatrixF4x2 tar_mod_boundaries_etaphi;
+    bool inside = false;
+    for (int i = 0, j = 3; i < 4; j = i++) {
+      EtaPhiPoint start{quad.corners(j, 0), quad.corners(j, 1)};
+      EtaPhiPoint end{quad.corners(i, 0), quad.corners(i, 1)};
+      float cross = (end.eta - start.eta) * (point.phi - start.phi) - (end.phi - start.phi) * (point.eta - start.eta);
+      constexpr float eps = 1e-6;
+      if (std::fabs(cross) <= eps && point.eta >= std::min(start.eta, end.eta) - eps &&
+          point.eta <= std::max(start.eta, end.eta) + eps && point.phi >= std::min(start.phi, end.phi) - eps &&
+          point.phi <= std::max(start.phi, end.phi) + eps) {
+        return true;
+      }
 
-    for (int i = 0; i < 4; ++i) {
-      auto ref_etaphi =
-          getEtaPhi(ref_mod_boundaries(i, 1), ref_mod_boundaries(i, 2), ref_mod_boundaries(i, 0) + zshift, refphi);
-      auto tar_etaphi =
-          getEtaPhi(tar_mod_boundaries(i, 1), tar_mod_boundaries(i, 2), tar_mod_boundaries(i, 0) + zshift, refphi);
-      ref_mod_boundaries_etaphi(i, 0) = ref_etaphi.first;
-      ref_mod_boundaries_etaphi(i, 1) = ref_etaphi.second;
-      tar_mod_boundaries_etaphi(i, 0) = tar_etaphi.first;
-      tar_mod_boundaries_etaphi(i, 1) = tar_etaphi.second;
+      bool crossesPhi = (end.phi > point.phi) != (start.phi > point.phi);
+      if (!crossesPhi)
+        continue;
+
+      float etaAtPointPhi = (start.eta - end.eta) * (point.phi - end.phi) / (start.phi - end.phi) + end.eta;
+      if (point.eta < etaAtPointPhi)
+        inside = !inside;
     }
+
+    return inside;
+  }
+
+  bool quadIntersects(MatrixF4x2 const& lhs, MatrixF4x2 const& rhs) {
+    for (int lhsEdge = 0; lhsEdge < 4; ++lhsEdge) {
+      int lhsNext = (lhsEdge + 1) % 4;
+      for (int rhsEdge = 0; rhsEdge < 4; ++rhsEdge) {
+        int rhsNext = (rhsEdge + 1) % 4;
+        if (segmentsIntersect(lhs, lhsEdge, lhsNext, rhs, rhsEdge, rhsNext))
+          return true;
+      }
+    }
+
+    return pointInPolygon(lhs, rhs, 0) || pointInPolygon(rhs, lhs, 0);
+  }
+
+  EtaPhiQuad getEtaPhiQuad(MatrixF4x3 const& corners, float refphi, float zshift = 0) {
+    EtaPhiQuad data;
+    for (int i = 0; i < 4; ++i) {
+      float x = corners(i, 1);
+      float y = corners(i, 2);
+      data.corners(i, 0) = std::asinh((corners(i, 0) + zshift) / std::sqrt(x * x + y * y));
+      data.corners(i, 1) = normalizePhi(std::atan2(y, x) - refphi);
+      data.bounds.minEta = std::min(data.bounds.minEta, data.corners(i, 0));
+      data.bounds.maxEta = std::max(data.bounds.maxEta, data.corners(i, 0));
+      data.bounds.minPhi = std::min(data.bounds.minPhi, data.corners(i, 1));
+      data.bounds.maxPhi = std::max(data.bounds.maxPhi, data.corners(i, 1));
+    }
+    return data;
+  }
+
+  EtaPhiQuad getEtaPhiQuad(CornerCoordinates const& corners, float refphi, int etaColumn) {
+    EtaPhiQuad data;
+    for (int i = 0; i < 4; ++i) {
+      data.corners(i, 0) = corners.shiftedEtas(i, etaColumn);
+      data.corners(i, 1) = normalizePhi(corners.values(i, 2) - refphi);
+      data.bounds.minEta = std::min(data.bounds.minEta, data.corners(i, 0));
+      data.bounds.maxEta = std::max(data.bounds.maxEta, data.corners(i, 0));
+      data.bounds.minPhi = std::min(data.bounds.minPhi, data.corners(i, 1));
+      data.bounds.maxPhi = std::max(data.bounds.maxPhi, data.corners(i, 1));
+    }
+    return data;
+  }
+
+  RelativePhiData getRelativePhiData(CornerCoordinates const& corners, float refphi) {
+    RelativePhiData data;
+    data.corners[0] = normalizePhi(corners.values(0, 2) - refphi);
+    data.minPhi = data.maxPhi = data.corners[0];
+    for (int i = 1; i < 4; ++i) {
+      data.corners[i] = normalizePhi(corners.values(i, 2) - refphi);
+      data.minPhi = std::min(data.minPhi, data.corners[i]);
+      data.maxPhi = std::max(data.maxPhi, data.corners[i]);
+    }
+    return data;
+  }
+
+  EtaPhiQuad getEtaPhiQuad(CornerCoordinates const& corners, RelativePhiData const& relativePhis, int etaColumn) {
+    EtaPhiQuad data;
+    data.bounds.minPhi = relativePhis.minPhi;
+    data.bounds.maxPhi = relativePhis.maxPhi;
+    for (int i = 0; i < 4; ++i) {
+      data.corners(i, 0) = corners.shiftedEtas(i, etaColumn);
+      data.corners(i, 1) = relativePhis.corners[i];
+      data.bounds.minEta = std::min(data.bounds.minEta, data.corners(i, 0));
+      data.bounds.maxEta = std::max(data.bounds.maxEta, data.corners(i, 0));
+    }
+    return data;
+  }
+
+  float getCenterPhi(MatrixF4x3 const& corners) {
+    RowVectorF3 center = corners.colwise().sum();
+    center /= 4.;
+    return std::atan2(center(2), center(1));
+  }
+
+  bool moduleOverlapsInEtaPhi(EtaPhiQuad const& ref_mod_boundaries_etaphi,
+                              CornerCoordinates const& tar_mod_boundaries,
+                              RelativePhiData const& relativePhis,
+                              int etaColumn) {
+    MatrixF4x2 tar_mod_boundaries_etaphi;
+    EtaPhiBounds tar_bounds;
+    tar_mod_boundaries_etaphi(0, 0) = tar_mod_boundaries.shiftedEtas(0, etaColumn);
+    tar_mod_boundaries_etaphi(0, 1) = relativePhis.corners[0];
+    tar_bounds.minEta = tar_bounds.maxEta = tar_mod_boundaries_etaphi(0, 0);
+    tar_bounds.minPhi = relativePhis.minPhi;
+    tar_bounds.maxPhi = relativePhis.maxPhi;
 
     // Quick cut
-    RowVectorF2 diff = ref_mod_boundaries_etaphi.row(0) - tar_mod_boundaries_etaphi.row(0);
-    if (std::fabs(diff(0)) > 0.5)
+    if (std::fabs(ref_mod_boundaries_etaphi.corners(0, 0) - tar_mod_boundaries_etaphi(0, 0)) > 0.5)
       return false;
-    if (std::fabs(phi_mpi_pi(diff(1))) > 1.)
+    if (std::fabs(normalizePhi(ref_mod_boundaries_etaphi.corners(0, 1) - tar_mod_boundaries_etaphi(0, 1))) > 1.)
       return false;
 
-    Polygon ref_poly, tar_poly;
-
-    // <= 4 because we need to close the polygon with the first point
-    for (int i = 0; i <= 4; ++i) {
-      boost::geometry::append(ref_poly,
-                              Point(ref_mod_boundaries_etaphi(i % 4, 0), ref_mod_boundaries_etaphi(i % 4, 1)));
-      boost::geometry::append(tar_poly,
-                              Point(tar_mod_boundaries_etaphi(i % 4, 0), tar_mod_boundaries_etaphi(i % 4, 1)));
+    for (int i = 1; i < 4; ++i) {
+      tar_mod_boundaries_etaphi(i, 0) = tar_mod_boundaries.shiftedEtas(i, etaColumn);
+      tar_mod_boundaries_etaphi(i, 1) = relativePhis.corners[i];
+      tar_bounds.minEta = std::min(tar_bounds.minEta, tar_mod_boundaries_etaphi(i, 0));
+      tar_bounds.maxEta = std::max(tar_bounds.maxEta, tar_mod_boundaries_etaphi(i, 0));
     }
-    boost::geometry::correct(ref_poly);
-    boost::geometry::correct(tar_poly);
 
-    return boost::geometry::intersects(ref_poly, tar_poly);
+    if (!etaPhiBoundsOverlap(ref_mod_boundaries_etaphi.bounds, tar_bounds))
+      return false;
+
+    return quadIntersects(ref_mod_boundaries_etaphi.corners, tar_mod_boundaries_etaphi);
   }
 
-  std::vector<unsigned int> getStraightLineConnections(unsigned int ref_detid,
-                                                       Sensors const& sensors,
-                                                       BinnedDetIds const& binned_detids) {
-    auto const& ref_sensor = sensors.at(ref_detid);
+  float quadArea(EtaPhiQuad const& quad) {
+    float area = 0.;
+    for (int i = 0; i < 4; ++i) {
+      int next = (i + 1) % 4;
+      area += quad.corners(i, 0) * quad.corners(next, 1) - quad.corners(next, 0) * quad.corners(i, 1);
+    }
+    return 0.5f * std::fabs(area);
+  }
 
-    float refphi = std::atan2(ref_sensor.centerY, ref_sensor.centerX);
+  bool pointCovered(EtaPhiPoint const& point, std::vector<EtaPhiQuad> const& covering_quads) {
+    for (auto const& quad : covering_quads) {
+      if (pointInQuad(quad, point))
+        return true;
+    }
+    return false;
+  }
+
+  float approximateUncoveredArea(EtaPhiQuad const& ref_quad,
+                                 std::vector<EtaPhiQuad> const& covering_quads,
+                                 std::vector<EtaPhiPoint>& uncovered_points) {
+    constexpr int kGrid = 8;
+    unsigned int nInside = 0;
+    unsigned int nUncovered = 0;
+    uncovered_points.clear();
+    uncovered_points.reserve(kGrid * kGrid);
+
+    for (int etaBin = 0; etaBin < kGrid; ++etaBin) {
+      float eta = ref_quad.bounds.minEta +
+                  (etaBin + 0.5f) * (ref_quad.bounds.maxEta - ref_quad.bounds.minEta) / static_cast<float>(kGrid);
+      for (int phiBin = 0; phiBin < kGrid; ++phiBin) {
+        float phi = ref_quad.bounds.minPhi +
+                    (phiBin + 0.5f) * (ref_quad.bounds.maxPhi - ref_quad.bounds.minPhi) / static_cast<float>(kGrid);
+        EtaPhiPoint point{eta, phi};
+        if (!pointInQuad(ref_quad, point))
+          continue;
+
+        ++nInside;
+        if (!pointCovered(point, covering_quads)) {
+          ++nUncovered;
+          uncovered_points.push_back(point);
+        }
+      }
+    }
+
+    if (nInside == 0)
+      return 0.;
+    return quadArea(ref_quad) * static_cast<float>(nUncovered) / static_cast<float>(nInside);
+  }
+
+  bool targetIntersectsApproxUncovered(EtaPhiQuad const& ref_quad,
+                                       std::vector<EtaPhiQuad> const& covering_quads,
+                                       std::vector<EtaPhiPoint> const& uncovered_points,
+                                       EtaPhiQuad const& target_quad) {
+    if (!etaPhiBoundsOverlap(ref_quad.bounds, target_quad.bounds))
+      return false;
+
+    for (auto const& point : uncovered_points) {
+      if (pointInQuad(target_quad, point))
+        return true;
+    }
+
+    for (int i = 0; i < 4; ++i) {
+      EtaPhiPoint target_corner{target_quad.corners(i, 0), target_quad.corners(i, 1)};
+      if (pointInQuad(ref_quad, target_corner) && !pointCovered(target_corner, covering_quads))
+        return true;
+    }
+
+    return false;
+  }
+
+  std::vector<unsigned int> getStraightLineConnections(Sensor const& ref_sensor,
+                                                       CornerCoordinates const& ref_corners,
+                                                       BinnedCandidates const& binned_candidates) {
+    float refphi = ref_sensor.centerPhi;
     unsigned short ref_layer = ref_sensor.extra->layer;
     auto ref_location = ref_sensor.extra->location;
 
     auto thetaphibins = getThetaPhiBins(ref_sensor.extra->centerTheta, ref_sensor.centerPhi);
 
     auto const& tar_detids_to_be_considered =
-        binned_detids.at(std::make_tuple(ref_location, ref_layer + 1, thetaphibins.first, thetaphibins.second));
+        candidatesAt(binned_candidates, ref_location, ref_layer + 1, thetaphibins.first, thetaphibins.second);
+
+    constexpr std::array<int, 3> etaColumns = {0, 1, 2};
+    std::array<EtaPhiQuad, 3> ref_quads = {getEtaPhiQuad(ref_corners, refphi, etaColumns[0]),
+                                           getEtaPhiQuad(ref_corners, refphi, etaColumns[1]),
+                                           getEtaPhiQuad(ref_corners, refphi, etaColumns[2])};
 
     std::vector<unsigned int> list_of_detids_etaphi_layer_tar;
-    for (unsigned int tar_detid : tar_detids_to_be_considered) {
-      auto const& tar_sensor = sensors.at(tar_detid);
-      if (moduleOverlapsInEtaPhi(ref_sensor.extra->corners,
-                                 tar_sensor.extra->corners,
-                                 refphi,
-                                 0,
-                                 ref_sensor.centerPhi,
-                                 tar_sensor.centerPhi) ||
-          moduleOverlapsInEtaPhi(ref_sensor.extra->corners,
-                                 tar_sensor.extra->corners,
-                                 refphi,
-                                 10,
-                                 ref_sensor.centerPhi,
-                                 tar_sensor.centerPhi) ||
-          moduleOverlapsInEtaPhi(ref_sensor.extra->corners,
-                                 tar_sensor.extra->corners,
-                                 refphi,
-                                 -10,
-                                 ref_sensor.centerPhi,
-                                 tar_sensor.centerPhi))
-        list_of_detids_etaphi_layer_tar.push_back(tar_detid);
+    list_of_detids_etaphi_layer_tar.reserve(tar_detids_to_be_considered.size());
+    std::vector<MatchedCandidate> list_of_candidates_etaphi_layer_tar;
+    list_of_candidates_etaphi_layer_tar.reserve(tar_detids_to_be_considered.size());
+    for (auto const& candidate : tar_detids_to_be_considered) {
+      auto const& tar_corners = *candidate.corners;
+      if (std::fabs(normalizePhi(ref_sensor.centerPhi - tar_corners.centerPhi)) > std::numbers::pi_v<float> / 2.)
+        continue;
+      RelativePhiData relativePhis = getRelativePhiData(tar_corners, refphi);
+      for (unsigned int i = 0; i < etaColumns.size(); ++i) {
+        if (moduleOverlapsInEtaPhi(ref_quads[i], tar_corners, relativePhis, etaColumns[i])) {
+          list_of_detids_etaphi_layer_tar.push_back(candidate.detid);
+          list_of_candidates_etaphi_layer_tar.push_back({&candidate, relativePhis});
+          break;
+        }
+      }
     }
 
-    // Consider barrel to endcap connections if the intersection area is > 0
-    // We construct the reference polygon as a vector of polygons because the boost::geometry::difference
-    // function can return multiple polygons if the difference results in disjoint pieces
+    // Consider barrel to endcap connections if the approximated uncovered area is > 0
+    // after accounting for target modules in the next barrel layer.
     if (ref_location == Location::barrel) {
       std::vector<unsigned int> barrel_endcap_connected_tar_detids;
+      std::vector<EtaPhiQuad> covering_quads;
+      std::vector<EtaPhiPoint> uncovered_points;
+      covering_quads.reserve(list_of_candidates_etaphi_layer_tar.size());
+      uncovered_points.reserve(64);
 
-      for (float zshift : {0, 10, -10}) {
-        std::vector<Polygon> ref_polygon;
-        ref_polygon.push_back(getEtaPhiPolygon(ref_sensor.extra->corners, refphi, zshift));
-
+      for (unsigned int i = 0; i < etaColumns.size(); ++i) {
         // Check whether there is still significant non-zero area
-        for (unsigned int tar_detid : list_of_detids_etaphi_layer_tar) {
-          if (ref_polygon.empty())
-            break;
-          Polygon tar_polygon = getEtaPhiPolygon(sensors.at(tar_detid).extra->corners, refphi, zshift);
-
-          std::vector<Polygon> difference;
-          for (auto const& ref_polygon_piece : ref_polygon) {
-            std::vector<Polygon> tmp_difference;
-            boost::geometry::difference(ref_polygon_piece, tar_polygon, tmp_difference);
-            difference.insert(difference.end(), tmp_difference.begin(), tmp_difference.end());
-          }
-
-          ref_polygon = std::move(difference);
+        covering_quads.clear();
+        for (auto const& candidate : list_of_candidates_etaphi_layer_tar) {
+          EtaPhiQuad tar_quad = getEtaPhiQuad(*candidate.candidate->corners, candidate.relativePhis, etaColumns[i]);
+          if (etaPhiBoundsOverlap(ref_quads[i].bounds, tar_quad.bounds))
+            covering_quads.push_back(std::move(tar_quad));
         }
-
-        float area = 0.;
-        for (auto const& ref_polygon_piece : ref_polygon)
-          area += boost::geometry::area(ref_polygon_piece);
+        float area = approximateUncoveredArea(ref_quads[i], covering_quads, uncovered_points);
 
         if (area <= 5e-3)
           continue;
 
         auto const& new_tar_detids_to_be_considered =
-            binned_detids.at(std::make_tuple(Location::endcap, 1, thetaphibins.first, thetaphibins.second));
+            candidatesAt(binned_candidates, Location::endcap, 1, thetaphibins.first, thetaphibins.second);
 
-        for (unsigned int tar_detid : new_tar_detids_to_be_considered) {
-          auto const& sensor_target = sensors.at(tar_detid);
-          float tarphi = std::atan2(sensor_target.centerY, sensor_target.centerX);
+        for (auto const& candidate : new_tar_detids_to_be_considered) {
+          auto const& tar_corners = *candidate.corners;
+          float tarphi = tar_corners.centerPhi;
 
-          if (std::fabs(phi_mpi_pi(tarphi - refphi)) > std::numbers::pi_v<float> / 2.)
+          if (std::fabs(normalizePhi(tarphi - refphi)) > std::numbers::pi_v<float> / 2.)
             continue;
 
-          Polygon tar_polygon = getEtaPhiPolygon(sensor_target.extra->corners, refphi, zshift);
-
-          bool intersects = false;
-          for (auto const& ref_polygon_piece : ref_polygon) {
-            if (boost::geometry::intersects(ref_polygon_piece, tar_polygon)) {
-              intersects = true;
-              break;
-            }
-          }
-
-          if (intersects)
-            barrel_endcap_connected_tar_detids.push_back(tar_detid);
+          RelativePhiData relativePhis = getRelativePhiData(tar_corners, refphi);
+          EtaPhiQuad target_quad = getEtaPhiQuad(tar_corners, relativePhis, etaColumns[i]);
+          if (targetIntersectsApproxUncovered(ref_quads[i], covering_quads, uncovered_points, target_quad))
+            barrel_endcap_connected_tar_detids.push_back(candidate.detid);
         }
       }
       list_of_detids_etaphi_layer_tar.insert(list_of_detids_etaphi_layer_tar.end(),
@@ -189,73 +475,34 @@ namespace lstgeometry {
     return list_of_detids_etaphi_layer_tar;
   }
 
-  MatrixF4x3 boundsAfterCurved(unsigned int ref_detid,
-                               Sensors const& sensors,
+  MatrixF4x3 boundsAfterCurved(Sensor const& ref_sensor,
                                std::array<float, kBarrelLayers> const& average_r_barrel,
                                std::array<float, kEndcapLayers> const& average_z_endcap,
-                               float ptCut,
-                               bool doR = true) {
-    auto const& ref_sensor = sensors.at(ref_detid);
+                               float ptCut) {
     auto const& bounds = ref_sensor.extra->corners;
     int charge = 1;
     float z_r = ref_sensor.centerZ /
                 std::sqrt(ref_sensor.centerX * ref_sensor.centerX + ref_sensor.centerY * ref_sensor.centerY);
-    float refphi = std::atan2(ref_sensor.centerY, ref_sensor.centerX);
+    float refphi = ref_sensor.centerPhi;
     unsigned short ref_layer = ref_sensor.extra->layer;
     auto ref_location = ref_sensor.extra->location;
     MatrixF4x3 next_layer_bound_points;
 
     for (int i = 0; i < bounds.rows(); i++) {
-      auto helix_p10 = Helix(ptCut, 0, 0, 10, bounds(i, 1), bounds(i, 2), bounds(i, 0), -charge);
-      auto helix_m10 = Helix(ptCut, 0, 0, -10, bounds(i, 1), bounds(i, 2), bounds(i, 0), -charge);
-      auto helix_p10_pos = Helix(ptCut, 0, 0, 10, bounds(i, 1), bounds(i, 2), bounds(i, 0), charge);
-      auto helix_m10_pos = Helix(ptCut, 0, 0, -10, bounds(i, 1), bounds(i, 2), bounds(i, 0), charge);
       float bound_z_r = bounds(i, 0) / std::sqrt(bounds(i, 1) * bounds(i, 1) + bounds(i, 2) * bounds(i, 2));
       float bound_phi = std::atan2(bounds(i, 2), bounds(i, 1));
-      float phi_diff = phi_mpi_pi(bound_phi - refphi);
+      float phi_diff = normalizePhi(bound_phi - refphi);
+      int helixCharge = phi_diff > 0 ? -charge : charge;
+      float vertexZ = bound_z_r < z_r ? 10.f : -10.f;
+      Helix helix(ptCut, 0, 0, vertexZ, bounds(i, 1), bounds(i, 2), bounds(i, 0), helixCharge);
 
       std::tuple<float, float, float, float> next_point;
       if (ref_location == Location::barrel) {
-        if (doR) {
-          float tar_layer_radius = average_r_barrel[ref_layer];
-          if (bound_z_r < z_r) {
-            auto const& h = phi_diff > 0 ? helix_p10 : helix_p10_pos;
-            next_point = h.pointFromRadius(tar_layer_radius);
-          } else {
-            auto const& h = phi_diff > 0 ? helix_m10 : helix_m10_pos;
-            next_point = h.pointFromRadius(tar_layer_radius);
-          }
-        } else {
-          float tar_layer_z = average_z_endcap[0];
-          if (bound_z_r < z_r) {
-            if (phi_diff > 0) {
-              next_point = helix_p10.pointFromZ(std::copysign(tar_layer_z, helix_p10.lambda));
-            } else {
-              next_point = helix_p10_pos.pointFromZ(std::copysign(tar_layer_z, helix_p10_pos.lambda));
-            }
-          } else {
-            if (phi_diff > 0) {
-              next_point = helix_m10.pointFromZ(std::copysign(tar_layer_z, helix_m10.lambda));
-            } else {
-              next_point = helix_m10_pos.pointFromZ(std::copysign(tar_layer_z, helix_m10_pos.lambda));
-            }
-          }
-        }
+        float tar_layer_radius = average_r_barrel[ref_layer];
+        next_point = helix.pointFromRadius(tar_layer_radius);
       } else {
         float tar_layer_z = average_z_endcap[ref_layer];
-        if (bound_z_r < z_r) {
-          if (phi_diff > 0) {
-            next_point = helix_p10.pointFromZ(std::copysign(tar_layer_z, helix_p10.lambda));
-          } else {
-            next_point = helix_p10_pos.pointFromZ(std::copysign(tar_layer_z, helix_p10_pos.lambda));
-          }
-        } else {
-          if (phi_diff > 0) {
-            next_point = helix_m10.pointFromZ(std::copysign(tar_layer_z, helix_m10.lambda));
-          } else {
-            next_point = helix_m10_pos.pointFromZ(std::copysign(tar_layer_z, helix_m10_pos.lambda));
-          }
-        }
+        next_point = helix.pointFromZ(std::copysign(tar_layer_z, helix.lambda));
       }
       next_layer_bound_points(i, 0) = std::get<2>(next_point);
       next_layer_bound_points(i, 1) = std::get<0>(next_point);
@@ -265,15 +512,12 @@ namespace lstgeometry {
     return next_layer_bound_points;
   }
 
-  std::vector<unsigned int> getCurvedLineConnections(unsigned int ref_detid,
-                                                     Sensors const& sensors,
-                                                     BinnedDetIds const& binned_detids,
+  std::vector<unsigned int> getCurvedLineConnections(Sensor const& ref_sensor,
+                                                     BinnedCandidates const& binned_candidates,
                                                      std::array<float, kBarrelLayers> const& average_r_barrel,
                                                      std::array<float, kEndcapLayers> const& average_z_endcap,
                                                      float ptCut) {
-    auto const& ref_sensor = sensors.at(ref_detid);
-
-    float refphi = std::atan2(ref_sensor.centerY, ref_sensor.centerX);
+    float refphi = ref_sensor.centerPhi;
 
     unsigned short ref_layer = ref_sensor.extra->layer;
     auto ref_location = ref_sensor.extra->location;
@@ -281,76 +525,58 @@ namespace lstgeometry {
     auto thetaphibins = getThetaPhiBins(ref_sensor.extra->centerTheta, ref_sensor.centerPhi);
 
     auto const& tar_detids_to_be_considered =
-        binned_detids.at({ref_location, ref_layer + 1, thetaphibins.first, thetaphibins.second});
+        candidatesAt(binned_candidates, ref_location, ref_layer + 1, thetaphibins.first, thetaphibins.second);
 
-    auto next_layer_bound_points = boundsAfterCurved(ref_detid, sensors, average_r_barrel, average_z_endcap, ptCut);
+    auto next_layer_bound_points = boundsAfterCurved(ref_sensor, average_r_barrel, average_z_endcap, ptCut);
+    EtaPhiQuad next_layer_quad = getEtaPhiQuad(next_layer_bound_points, refphi);
+    float next_layer_center_phi = getCenterPhi(next_layer_bound_points);
 
     std::vector<unsigned int> list_of_detids_etaphi_layer_tar;
-    for (unsigned int tar_detid : tar_detids_to_be_considered) {
-      auto const& tar_sensor = sensors.at(tar_detid);
-      if (moduleOverlapsInEtaPhi(next_layer_bound_points,
-                                 tar_sensor.extra->corners,
-                                 refphi,
-                                 0,
-                                 std::numeric_limits<float>::max(),
-                                 tar_sensor.centerPhi))
-        list_of_detids_etaphi_layer_tar.push_back(tar_detid);
+    list_of_detids_etaphi_layer_tar.reserve(tar_detids_to_be_considered.size());
+    std::vector<MatchedCandidate> list_of_candidates_etaphi_layer_tar;
+    list_of_candidates_etaphi_layer_tar.reserve(tar_detids_to_be_considered.size());
+    for (auto const& candidate : tar_detids_to_be_considered) {
+      auto const& tar_corners = *candidate.corners;
+      if (std::fabs(normalizePhi(next_layer_center_phi - tar_corners.centerPhi)) > std::numbers::pi_v<float> / 2.)
+        continue;
+      RelativePhiData relativePhis = getRelativePhiData(tar_corners, refphi);
+      if (moduleOverlapsInEtaPhi(next_layer_quad, tar_corners, relativePhis, 0)) {
+        list_of_detids_etaphi_layer_tar.push_back(candidate.detid);
+        list_of_candidates_etaphi_layer_tar.push_back({&candidate, relativePhis});
+      }
     }
 
-    // Consider barrel to endcap connections if the intersection area is > 0
-    // We construct the reference polygon as a vector of polygons because the boost::geometry::difference
-    // function can return multiple polygons if the difference results in disjoint pieces
+    // Consider barrel to endcap connections if the approximated uncovered area is > 0
+    // after accounting for target modules in the next barrel layer.
     if (ref_location == Location::barrel) {
       std::vector<unsigned int> barrel_endcap_connected_tar_detids;
 
-      int zshift = 0;
-
-      std::vector<Polygon> ref_polygon;
-      ref_polygon.push_back(getEtaPhiPolygon(next_layer_bound_points, refphi, zshift));
-
       // Check whether there is still significant non-zero area
-      for (unsigned int tar_detid : list_of_detids_etaphi_layer_tar) {
-        if (ref_polygon.empty())
-          break;
-        Polygon tar_polygon = getEtaPhiPolygon(sensors.at(tar_detid).extra->corners, refphi, zshift);
-
-        std::vector<Polygon> difference;
-        for (auto const& ref_polygon_piece : ref_polygon) {
-          std::vector<Polygon> tmp_difference;
-          boost::geometry::difference(ref_polygon_piece, tar_polygon, tmp_difference);
-          difference.insert(difference.end(), tmp_difference.begin(), tmp_difference.end());
-        }
-
-        ref_polygon = std::move(difference);
+      std::vector<EtaPhiQuad> covering_quads;
+      covering_quads.reserve(list_of_detids_etaphi_layer_tar.size());
+      for (auto const& candidate : list_of_candidates_etaphi_layer_tar) {
+        EtaPhiQuad tar_quad = getEtaPhiQuad(*candidate.candidate->corners, candidate.relativePhis, 0);
+        if (etaPhiBoundsOverlap(next_layer_quad.bounds, tar_quad.bounds))
+          covering_quads.push_back(std::move(tar_quad));
       }
-
-      float area = 0.;
-      for (auto const& ref_polygon_piece : ref_polygon)
-        area += boost::geometry::area(ref_polygon_piece);
+      std::vector<EtaPhiPoint> uncovered_points;
+      float area = approximateUncoveredArea(next_layer_quad, covering_quads, uncovered_points);
 
       if (area > 5e-3) {
         auto const& new_tar_detids_to_be_considered =
-            binned_detids.at({Location::endcap, 1, thetaphibins.first, thetaphibins.second});
+            candidatesAt(binned_candidates, Location::endcap, 1, thetaphibins.first, thetaphibins.second);
 
-        for (unsigned int tar_detid : new_tar_detids_to_be_considered) {
-          auto const& sensor_target = sensors.at(tar_detid);
-          float tarphi = std::atan2(sensor_target.centerY, sensor_target.centerX);
+        for (auto const& candidate : new_tar_detids_to_be_considered) {
+          auto const& tar_corners = *candidate.corners;
+          float tarphi = tar_corners.centerPhi;
 
-          if (std::fabs(phi_mpi_pi(tarphi - refphi)) > std::numbers::pi_v<float> / 2.)
+          if (std::fabs(normalizePhi(tarphi - refphi)) > std::numbers::pi_v<float> / 2.)
             continue;
 
-          Polygon tar_polygon = getEtaPhiPolygon(sensor_target.extra->corners, refphi, zshift);
-
-          bool intersects = false;
-          for (auto const& ref_polygon_piece : ref_polygon) {
-            if (boost::geometry::intersects(ref_polygon_piece, tar_polygon)) {
-              intersects = true;
-              break;
-            }
-          }
-
-          if (intersects)
-            barrel_endcap_connected_tar_detids.push_back(tar_detid);
+          RelativePhiData relativePhis = getRelativePhiData(tar_corners, refphi);
+          EtaPhiQuad target_quad = getEtaPhiQuad(tar_corners, relativePhis, 0);
+          if (targetIntersectsApproxUncovered(next_layer_quad, covering_quads, uncovered_points, target_quad))
+            barrel_endcap_connected_tar_detids.push_back(candidate.detid);
         }
       }
 
@@ -362,32 +588,22 @@ namespace lstgeometry {
     return list_of_detids_etaphi_layer_tar;
   }
 
-  ModuleMap mergeLineConnections(
-      std::initializer_list<const std::unordered_map<unsigned int, std::vector<unsigned int>>*> connections_list) {
-    ModuleMap merged;
-
-    for (auto* connections : connections_list) {
-      for (auto const& [detid, list] : *connections) {
-        auto& target = merged[detid];
-        target.insert(target.end(), list.begin(), list.end());
-      }
-    }
-
-    for (auto& [detid, list] : merged) {
-      std::sort(list.begin(), list.end());
-      list.erase(std::unique(list.begin(), list.end()), list.end());
-    }
-
-    return merged;
-  }
-
   ModuleMap buildModuleMap(Sensors const& sensors,
                            BinnedDetIds const& binned_detids,
                            std::array<float, kBarrelLayers> const& average_r_barrel,
                            std::array<float, kEndcapLayers> const& average_z_endcap,
                            float pt_cut) {
-    std::unordered_map<unsigned int, std::vector<unsigned int>> straight_line_connections;
-    std::unordered_map<unsigned int, std::vector<unsigned int>> curved_line_connections;
+    ModuleMap moduleMap;
+    moduleMap.reserve(sensors.size());
+
+    CornerCoordinatesMap corner_coordinates;
+    corner_coordinates.reserve(sensors.size());
+    for (auto const& [detid, sensor] : sensors) {
+      if (!sensor.extra->lower)
+        continue;
+      corner_coordinates.emplace(detid, getCornerCoordinates(sensor));
+    }
+    BinnedCandidates binned_candidates = buildBinnedCandidates(binned_detids, corner_coordinates);
 
     for (auto const& [ref_detid, s] : sensors) {
       // exclude the outermost modules that do not have connections to other modules
@@ -396,11 +612,19 @@ namespace lstgeometry {
              !(s.extra->ring == 15 && s.extra->layer == 1) && !(s.extra->ring == 15 && s.extra->layer == 2) &&
              !(s.extra->ring == 12 && s.extra->layer == 3) && !(s.extra->ring == 12 && s.extra->layer == 4))))
         continue;
-      straight_line_connections[ref_detid] = getStraightLineConnections(ref_detid, sensors, binned_detids);
-      curved_line_connections[ref_detid] =
-          getCurvedLineConnections(ref_detid, sensors, binned_detids, average_r_barrel, average_z_endcap, pt_cut);
+      auto const& ref_corners = corner_coordinates.at(ref_detid);
+      auto straight_line_connections = getStraightLineConnections(s, ref_corners, binned_candidates);
+      auto curved_line_connections =
+          getCurvedLineConnections(s, binned_candidates, average_r_barrel, average_z_endcap, pt_cut);
+      auto& connections = moduleMap[ref_detid];
+      connections.reserve(straight_line_connections.size() + curved_line_connections.size());
+      connections.insert(connections.end(), straight_line_connections.begin(), straight_line_connections.end());
+      connections.insert(connections.end(), curved_line_connections.begin(), curved_line_connections.end());
+      std::sort(connections.begin(), connections.end());
+      connections.erase(std::unique(connections.begin(), connections.end()), connections.end());
     }
-    return mergeLineConnections({&straight_line_connections, &curved_line_connections});
+
+    return moduleMap;
   }
 
 }  // namespace lstgeometry

--- a/RecoTracker/LSTGeometry/src/PixelMap.cc
+++ b/RecoTracker/LSTGeometry/src/PixelMap.cc
@@ -1,3 +1,6 @@
+#include <algorithm>
+#include <iterator>
+
 #include "RecoTracker/LSTGeometry/interface/Common.h"
 #include "RecoTracker/LSTGeometry/interface/PixelMap.h"
 
@@ -81,41 +84,50 @@ namespace lstgeometry {
             if (iphimin_pos <= iphimax_pos) {
               for (unsigned int iphi = iphimin_pos; iphi < iphimax_pos; iphi++) {
                 unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
-                maps[{layer, subdet, 1}][isuperbin].insert(detId);
-                maps[{layer, subdet, 0}][isuperbin].insert(detId);
+                maps[{layer, subdet, 1}][isuperbin].push_back(detId);
+                maps[{layer, subdet, 0}][isuperbin].push_back(detId);
               }
             } else {
               for (unsigned int iphi = 0; iphi < iphimax_pos; iphi++) {
                 unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
-                maps[{layer, subdet, 1}][isuperbin].insert(detId);
-                maps[{layer, subdet, 0}][isuperbin].insert(detId);
+                maps[{layer, subdet, 1}][isuperbin].push_back(detId);
+                maps[{layer, subdet, 0}][isuperbin].push_back(detId);
               }
               for (unsigned int iphi = iphimin_pos; iphi < kNPhi; iphi++) {
                 unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
-                maps[{layer, subdet, 1}][isuperbin].insert(detId);
-                maps[{layer, subdet, 0}][isuperbin].insert(detId);
+                maps[{layer, subdet, 1}][isuperbin].push_back(detId);
+                maps[{layer, subdet, 0}][isuperbin].push_back(detId);
               }
             }
             if (iphimin_neg <= iphimax_neg) {
               for (unsigned int iphi = iphimin_neg; iphi < iphimax_neg; iphi++) {
                 unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
-                maps[{layer, subdet, -1}][isuperbin].insert(detId);
-                maps[{layer, subdet, 0}][isuperbin].insert(detId);
+                maps[{layer, subdet, -1}][isuperbin].push_back(detId);
+                maps[{layer, subdet, 0}][isuperbin].push_back(detId);
               }
             } else {
               for (unsigned int iphi = 0; iphi < iphimax_neg; iphi++) {
                 unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
-                maps[{layer, subdet, -1}][isuperbin].insert(detId);
-                maps[{layer, subdet, 0}][isuperbin].insert(detId);
+                maps[{layer, subdet, -1}][isuperbin].push_back(detId);
+                maps[{layer, subdet, 0}][isuperbin].push_back(detId);
               }
               for (unsigned int iphi = iphimin_neg; iphi < kNPhi; iphi++) {
                 unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
-                maps[{layer, subdet, -1}][isuperbin].insert(detId);
-                maps[{layer, subdet, 0}][isuperbin].insert(detId);
+                maps[{layer, subdet, -1}][isuperbin].push_back(detId);
+                maps[{layer, subdet, 0}][isuperbin].push_back(detId);
               }
             }
           }
         }
+      }
+    }
+
+    for (auto& [key, vec_of_vecs] : maps) {
+      for (auto& vec : vec_of_vecs) {
+        if (vec.empty())
+          continue;
+        std::sort(vec.begin(), vec.end());
+        vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
       }
     }
 

--- a/RecoTracker/LSTGeometry/src/PixelMap.cc
+++ b/RecoTracker/LSTGeometry/src/PixelMap.cc
@@ -1,0 +1,125 @@
+#include "RecoTracker/LSTGeometry/interface/Common.h"
+#include "RecoTracker/LSTGeometry/interface/PixelMap.h"
+
+namespace lstgeometry {
+
+  PixelMap buildPixelMap(Sensors const& sensors, float pt_cut) {
+    // Charge 0 is the union of charge 1 and charge -1
+    PixelMap maps;
+
+    std::size_t nSuperbin = kPtBounds.size() * kNPhi * kNEta * kNZ;
+
+    // Initialize empty lists for the pixel map
+    for (unsigned int layer : {1, 2}) {
+      for (unsigned int subdet : {SubDet::Barrel, SubDet::Endcap}) {
+        for (int charge : {-1, 0, 1}) {
+          maps.try_emplace({layer, subdet, charge}, nSuperbin);
+        }
+      }
+    }
+
+    // Loop over the detids and for each detid compute which superbins it is connected to
+    for (auto const& [detId, sensor] : sensors) {
+      // Phase-2 enum differs from the legacy one used here
+      unsigned int subdet = sensor.extra->subdet == SubDetector::P2OTB ? SubDet::Barrel : SubDet::Endcap;
+      auto layer = sensor.extra->layer;
+      if (layer > 2)
+        continue;
+      auto location = sensor.extra->location;
+
+      // Skip if the module is not PS module and is not lower sensor
+      if (sensor.moduleType == ModuleType::Ph2SS || !sensor.extra->lower)
+        continue;
+
+      // For this module, now compute which super bins they belong to
+      // To compute which super bins it belongs to, one needs to provide at least pt and z window to compute compatible eta and phi range
+      // So we have a loop in pt and Z
+      for (unsigned int ipt = 0; ipt < kPtBounds.size(); ipt++) {
+        for (unsigned int iz = 0; iz < kNZ; iz++) {
+          // The zmin, zmax of consideration
+          float zmin = -30 + iz * (60. / kNZ);
+          float zmax = -30 + (iz + 1) * (60. / kNZ);
+
+          zmin -= 0.05;
+          zmax += 0.05;
+
+          // The ptmin, ptmax of consideration
+          float pt_lo = ipt == 0 ? pt_cut : kPtBounds[ipt - 1];
+          float pt_hi = kPtBounds[ipt];
+
+          auto [etamin, etamax] = getCompatibleEtaRange(sensor, zmin, zmax);
+
+          etamin -= 0.05;
+          etamax += 0.05;
+
+          if (layer == 2 && location == Location::endcap) {
+            if (etamax < 2.3)
+              continue;
+            if (etamin < 2.3)
+              etamin = 2.3;
+          }
+
+          // Compute the indices of the compatible eta range
+          unsigned int ietamin = static_cast<unsigned int>(std::max((etamin + 2.6f) / (5.2f / kNEta), 0.0f));
+          unsigned int ietamax =
+              static_cast<unsigned int>(std::min((etamax + 2.6f) / (5.2f / kNEta), static_cast<float>(kNEta - 1)));
+
+          auto phi_ranges = getCompatiblePhiRange(sensor, pt_lo, pt_hi);
+
+          unsigned int iphimin_pos = static_cast<unsigned int>((phi_ranges.first.first + std::numbers::pi_v<float>) /
+                                                               (2. * std::numbers::pi_v<float> / kNPhi));
+          unsigned int iphimax_pos = static_cast<unsigned int>((phi_ranges.first.second + std::numbers::pi_v<float>) /
+                                                               (2. * std::numbers::pi_v<float> / kNPhi));
+          unsigned int iphimin_neg = static_cast<unsigned int>((phi_ranges.second.first + std::numbers::pi_v<float>) /
+                                                               (2. * std::numbers::pi_v<float> / kNPhi));
+          unsigned int iphimax_neg = static_cast<unsigned int>((phi_ranges.second.second + std::numbers::pi_v<float>) /
+                                                               (2. * std::numbers::pi_v<float> / kNPhi));
+
+          // <= to cover some inefficiencies
+          for (unsigned int ieta = ietamin; ieta <= ietamax; ieta++) {
+            // if the range is crossing the -pi v. pi boundary special care is needed
+            if (iphimin_pos <= iphimax_pos) {
+              for (unsigned int iphi = iphimin_pos; iphi < iphimax_pos; iphi++) {
+                unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
+                maps[{layer, subdet, 1}][isuperbin].insert(detId);
+                maps[{layer, subdet, 0}][isuperbin].insert(detId);
+              }
+            } else {
+              for (unsigned int iphi = 0; iphi < iphimax_pos; iphi++) {
+                unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
+                maps[{layer, subdet, 1}][isuperbin].insert(detId);
+                maps[{layer, subdet, 0}][isuperbin].insert(detId);
+              }
+              for (unsigned int iphi = iphimin_pos; iphi < kNPhi; iphi++) {
+                unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
+                maps[{layer, subdet, 1}][isuperbin].insert(detId);
+                maps[{layer, subdet, 0}][isuperbin].insert(detId);
+              }
+            }
+            if (iphimin_neg <= iphimax_neg) {
+              for (unsigned int iphi = iphimin_neg; iphi < iphimax_neg; iphi++) {
+                unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
+                maps[{layer, subdet, -1}][isuperbin].insert(detId);
+                maps[{layer, subdet, 0}][isuperbin].insert(detId);
+              }
+            } else {
+              for (unsigned int iphi = 0; iphi < iphimax_neg; iphi++) {
+                unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
+                maps[{layer, subdet, -1}][isuperbin].insert(detId);
+                maps[{layer, subdet, 0}][isuperbin].insert(detId);
+              }
+              for (unsigned int iphi = iphimin_neg; iphi < kNPhi; iphi++) {
+                unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
+                maps[{layer, subdet, -1}][isuperbin].insert(detId);
+                maps[{layer, subdet, 0}][isuperbin].insert(detId);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return maps;
+  }
+
+}  // namespace lstgeometry

--- a/RecoTracker/LSTGeometry/src/PixelMap.cc
+++ b/RecoTracker/LSTGeometry/src/PixelMap.cc
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <iterator>
 
 #include "RecoTracker/LSTGeometry/interface/Common.h"
 #include "RecoTracker/LSTGeometry/interface/PixelMap.h"
@@ -9,8 +8,13 @@ namespace lstgeometry {
   PixelMap buildPixelMap(Sensors const& sensors, float pt_cut) {
     // Charge 0 is the union of charge 1 and charge -1
     PixelMap maps;
+    maps.reserve(12);
 
     std::size_t nSuperbin = kPtBounds.size() * kNPhi * kNEta * kNZ;
+    constexpr float zBinWidth = 60.f / kNZ;
+    constexpr float etaBinScale = kNEta / 5.2f;
+    constexpr float inversePhiBinWidth = kNPhi / (2.f * std::numbers::pi_v<float>);
+    constexpr float curvatureToPhi = kC * kB / 2.f;
 
     // Initialize empty lists for the pixel map
     for (unsigned int layer : {1, 2}) {
@@ -23,34 +27,63 @@ namespace lstgeometry {
 
     // Loop over the detids and for each detid compute which superbins it is connected to
     for (auto const& [detId, sensor] : sensors) {
-      // Phase-2 enum differs from the legacy one used here
-      unsigned int subdet = sensor.extra->subdet == SubDetector::P2OTB ? SubDet::Barrel : SubDet::Endcap;
       auto layer = sensor.extra->layer;
       if (layer > 2)
         continue;
-      auto location = sensor.extra->location;
 
       // Skip if the module is not PS module and is not lower sensor
       if (sensor.moduleType == ModuleType::Ph2SS || !sensor.extra->lower)
         continue;
 
+      // Phase-2 enum differs from the legacy one used here
+      unsigned int subdet = sensor.extra->subdet == SubDetector::P2OTB ? SubDet::Barrel : SubDet::Endcap;
+      auto location = sensor.extra->location;
+      float minR = sensor.extra->minR;
+      float maxR = sensor.extra->maxR;
+      float minZ = sensor.extra->minZ;
+      float maxZ = sensor.extra->maxZ;
+      float minPhi = sensor.extra->minPhi;
+      float maxPhi = sensor.extra->maxPhi;
+      float invMinR = 1.f / minR;
+      float invMaxR = 1.f / maxR;
+      float minEtaInvR = minZ > 0 ? invMaxR : invMinR;
+      float maxEtaInvR = maxZ > 0 ? invMinR : invMaxR;
+
+      auto& pos_map = maps.at({layer, subdet, 1});
+      auto& neg_map = maps.at({layer, subdet, -1});
+
       // For this module, now compute which super bins they belong to
       // To compute which super bins it belongs to, one needs to provide at least pt and z window to compute compatible eta and phi range
       // So we have a loop in pt and Z
       for (unsigned int ipt = 0; ipt < kPtBounds.size(); ipt++) {
+        // The ptmin, ptmax of consideration
+        float pt_lo = ipt == 0 ? pt_cut : kPtBounds[ipt - 1];
+        float pt_hi = kPtBounds[ipt];
+
+        float invPtLo = 1.f / pt_lo;
+        float invPtHi = 1.f / pt_hi;
+        float pos_q_phi_lo_bound = phi_mpi_pi(curvatureToPhi * minR * invPtHi + minPhi);
+        float pos_q_phi_hi_bound = phi_mpi_pi(curvatureToPhi * maxR * invPtLo + maxPhi);
+        float neg_q_phi_lo_bound = phi_mpi_pi(-curvatureToPhi * maxR * invPtLo + minPhi);
+        float neg_q_phi_hi_bound = phi_mpi_pi(-curvatureToPhi * minR * invPtHi + maxPhi);
+
+        unsigned int iphimin_pos =
+            static_cast<unsigned int>((pos_q_phi_lo_bound + std::numbers::pi_v<float>)*inversePhiBinWidth);
+        unsigned int iphimax_pos =
+            static_cast<unsigned int>((pos_q_phi_hi_bound + std::numbers::pi_v<float>)*inversePhiBinWidth);
+        unsigned int iphimin_neg =
+            static_cast<unsigned int>((neg_q_phi_lo_bound + std::numbers::pi_v<float>)*inversePhiBinWidth);
+        unsigned int iphimax_neg =
+            static_cast<unsigned int>((neg_q_phi_hi_bound + std::numbers::pi_v<float>)*inversePhiBinWidth);
+
         for (unsigned int iz = 0; iz < kNZ; iz++) {
           // The zmin, zmax of consideration
-          float zmin = -30 + iz * (60. / kNZ);
-          float zmax = -30 + (iz + 1) * (60. / kNZ);
-
-          zmin -= 0.05;
-          zmax += 0.05;
-
-          // The ptmin, ptmax of consideration
-          float pt_lo = ipt == 0 ? pt_cut : kPtBounds[ipt - 1];
-          float pt_hi = kPtBounds[ipt];
-
-          auto [etamin, etamax] = getCompatibleEtaRange(sensor, zmin, zmax);
+          float zmin = -30.f + iz * zBinWidth - 0.05f;
+          float zmax = -30.f + (iz + 1) * zBinWidth + 0.05f;
+          float etamin = std::asinh((minZ - zmin) * minEtaInvR);
+          float etamax = std::asinh((maxZ - zmax) * maxEtaInvR);
+          if (etamax < etamin)
+            std::swap(etamax, etamin);
 
           etamin -= 0.05;
           etamax += 0.05;
@@ -63,61 +96,58 @@ namespace lstgeometry {
           }
 
           // Compute the indices of the compatible eta range
-          unsigned int ietamin = static_cast<unsigned int>(std::max((etamin + 2.6f) / (5.2f / kNEta), 0.0f));
+          unsigned int ietamin = static_cast<unsigned int>(std::max((etamin + 2.6f) * etaBinScale, 0.0f));
           unsigned int ietamax =
-              static_cast<unsigned int>(std::min((etamax + 2.6f) / (5.2f / kNEta), static_cast<float>(kNEta - 1)));
-
-          auto phi_ranges = getCompatiblePhiRange(sensor, pt_lo, pt_hi);
-
-          unsigned int iphimin_pos = static_cast<unsigned int>((phi_ranges.first.first + std::numbers::pi_v<float>) /
-                                                               (2. * std::numbers::pi_v<float> / kNPhi));
-          unsigned int iphimax_pos = static_cast<unsigned int>((phi_ranges.first.second + std::numbers::pi_v<float>) /
-                                                               (2. * std::numbers::pi_v<float> / kNPhi));
-          unsigned int iphimin_neg = static_cast<unsigned int>((phi_ranges.second.first + std::numbers::pi_v<float>) /
-                                                               (2. * std::numbers::pi_v<float> / kNPhi));
-          unsigned int iphimax_neg = static_cast<unsigned int>((phi_ranges.second.second + std::numbers::pi_v<float>) /
-                                                               (2. * std::numbers::pi_v<float> / kNPhi));
+              static_cast<unsigned int>(std::min((etamax + 2.6f) * etaBinScale, static_cast<float>(kNEta - 1)));
 
           // <= to cover some inefficiencies
           for (unsigned int ieta = ietamin; ieta <= ietamax; ieta++) {
+            unsigned int superbinEtaBase = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + iz;
             // if the range is crossing the -pi v. pi boundary special care is needed
             if (iphimin_pos <= iphimax_pos) {
               for (unsigned int iphi = iphimin_pos; iphi < iphimax_pos; iphi++) {
-                unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
-                maps[{layer, subdet, 1}][isuperbin].push_back(detId);
-                maps[{layer, subdet, 0}][isuperbin].push_back(detId);
+                unsigned int isuperbin = superbinEtaBase + iphi * kNZ;
+                pos_map[isuperbin].push_back(detId);
               }
             } else {
               for (unsigned int iphi = 0; iphi < iphimax_pos; iphi++) {
-                unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
-                maps[{layer, subdet, 1}][isuperbin].push_back(detId);
-                maps[{layer, subdet, 0}][isuperbin].push_back(detId);
+                unsigned int isuperbin = superbinEtaBase + iphi * kNZ;
+                pos_map[isuperbin].push_back(detId);
               }
               for (unsigned int iphi = iphimin_pos; iphi < kNPhi; iphi++) {
-                unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
-                maps[{layer, subdet, 1}][isuperbin].push_back(detId);
-                maps[{layer, subdet, 0}][isuperbin].push_back(detId);
+                unsigned int isuperbin = superbinEtaBase + iphi * kNZ;
+                pos_map[isuperbin].push_back(detId);
               }
             }
             if (iphimin_neg <= iphimax_neg) {
               for (unsigned int iphi = iphimin_neg; iphi < iphimax_neg; iphi++) {
-                unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
-                maps[{layer, subdet, -1}][isuperbin].push_back(detId);
-                maps[{layer, subdet, 0}][isuperbin].push_back(detId);
+                unsigned int isuperbin = superbinEtaBase + iphi * kNZ;
+                neg_map[isuperbin].push_back(detId);
               }
             } else {
               for (unsigned int iphi = 0; iphi < iphimax_neg; iphi++) {
-                unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
-                maps[{layer, subdet, -1}][isuperbin].push_back(detId);
-                maps[{layer, subdet, 0}][isuperbin].push_back(detId);
+                unsigned int isuperbin = superbinEtaBase + iphi * kNZ;
+                neg_map[isuperbin].push_back(detId);
               }
               for (unsigned int iphi = iphimin_neg; iphi < kNPhi; iphi++) {
-                unsigned int isuperbin = (ipt * kNPhi * kNEta * kNZ) + (ieta * kNPhi * kNZ) + (iphi * kNZ) + iz;
-                maps[{layer, subdet, -1}][isuperbin].push_back(detId);
-                maps[{layer, subdet, 0}][isuperbin].push_back(detId);
+                unsigned int isuperbin = superbinEtaBase + iphi * kNZ;
+                neg_map[isuperbin].push_back(detId);
               }
             }
           }
+        }
+      }
+    }
+
+    for (unsigned int layer : {1, 2}) {
+      for (unsigned int subdet : {SubDet::Barrel, SubDet::Endcap}) {
+        auto const& pos_map = maps.at({layer, subdet, 1});
+        auto const& neg_map = maps.at({layer, subdet, -1});
+        auto& zero_map = maps.at({layer, subdet, 0});
+        for (std::size_t isuperbin = 0; isuperbin < nSuperbin; ++isuperbin) {
+          zero_map[isuperbin].reserve(pos_map[isuperbin].size() + neg_map[isuperbin].size());
+          zero_map[isuperbin].insert(zero_map[isuperbin].end(), pos_map[isuperbin].begin(), pos_map[isuperbin].end());
+          zero_map[isuperbin].insert(zero_map[isuperbin].end(), neg_map[isuperbin].begin(), neg_map[isuperbin].end());
         }
       }
     }
@@ -130,7 +160,6 @@ namespace lstgeometry {
         vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
       }
     }
-
     return maps;
   }
 

--- a/RecoTracker/LSTGeometry/src/Sensor.cc
+++ b/RecoTracker/LSTGeometry/src/Sensor.cc
@@ -1,0 +1,135 @@
+#include <cmath>
+
+#include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
+
+#include "RecoTracker/LSTGeometry/interface/Sensor.h"
+
+using namespace lstgeometry;
+
+// Not sure if there is functionality for this already in CMSSW
+bool isInverted(unsigned int moduleId, Location location, Side side, unsigned int layer) {
+  bool moduleIdIsEven = moduleId % 2 == 0;
+  if (location == Location::endcap) {
+    if (side == Side::NegZ) {
+      return !moduleIdIsEven;
+    } else if (side == Side::PosZ) {
+      return moduleIdIsEven;
+    }
+  } else if (location == Location::barrel) {
+    if (side == Side::Center) {
+      if (layer <= 3) {
+        return !moduleIdIsEven;
+      } else if (layer >= 4) {
+        return moduleIdIsEven;
+      }
+    } else if (side == Side::NegZ || side == Side::PosZ) {
+      if (layer <= 2) {
+        return !moduleIdIsEven;
+      } else if (layer == 3) {
+        return moduleIdIsEven;
+      }
+    }
+  }
+  return false;
+}
+
+// This differs from TrackerTopology::isLower since it considers if the module is inverted
+bool isLower(unsigned int moduleId, Location location, Side side, unsigned int layer, unsigned int detId) {
+  return isInverted(moduleId, location, side, layer) ? !(detId & 1) : (detId & 1);
+}
+
+bool isStrip(ModuleType moduleType, bool isInverted, bool isLower) {
+  if (moduleType == ModuleType::Ph2SS)
+    return true;
+  if (isInverted)
+    return isLower;
+  return !isLower;
+}
+
+Sensor::Sensor(unsigned int detId,
+               ModuleType moduleType,
+               SubDetector subdet,
+               Location location,
+               Side side,
+               unsigned int moduleId,
+               unsigned int layer,
+               unsigned int ring,
+               float centerRho,
+               float centerZ,
+               float centerPhi,
+               Surface const &surface)
+    : moduleType(moduleType),
+      centerPhi(centerPhi),
+      centerX(centerRho * std::cos(centerPhi)),
+      centerY(centerRho * std::sin(centerPhi)),
+      centerZ(centerZ),
+      extra(std::make_unique<SensorExtraData>()) {
+  extra->subdet = subdet;
+  extra->location = location;
+  extra->side = side;
+  extra->moduleId = moduleId;
+  extra->layer = layer;
+  extra->ring = ring;
+  extra->inverted = isInverted(moduleId, location, side, layer);
+  extra->centerRho = centerRho;
+  extra->lower = isLower(moduleId, location, side, layer, detId);
+  extra->strip = isStrip(moduleType, extra->inverted, extra->lower);
+  extra->centerEta = std::asinh(centerZ / centerRho);
+  extra->centerTheta = 2.f * std::atan(std::exp(-extra->centerEta));
+
+  const Bounds &bounds = surface.bounds();
+  const RectangularPlaneBounds &plane_bounds = dynamic_cast<const RectangularPlaneBounds &>(bounds);
+  float wid = plane_bounds.width();
+  float len = plane_bounds.length();
+  auto c1 = GloballyPositioned<float>::LocalPoint(-wid / 2, -len / 2, 0);
+  auto c2 = GloballyPositioned<float>::LocalPoint(-wid / 2, len / 2, 0);
+  auto c3 = GloballyPositioned<float>::LocalPoint(wid / 2, len / 2, 0);
+  auto c4 = GloballyPositioned<float>::LocalPoint(wid / 2, -len / 2, 0);
+  auto c1g = surface.toGlobal(c1);
+  auto c2g = surface.toGlobal(c2);
+  auto c3g = surface.toGlobal(c3);
+  auto c4g = surface.toGlobal(c4);
+  // store corners with z, x, y ordering
+  extra->corners << c1g.z(), c1g.x(), c1g.y(), c2g.z(), c2g.x(), c2g.y(), c3g.z(), c3g.x(), c3g.y(), c4g.z(), c4g.x(),
+      c4g.y();
+
+  // Precompute min/max R, Z, Phi for convenience
+  extra->minR = std::numeric_limits<float>::max();
+  extra->maxR = std::numeric_limits<float>::lowest();
+  extra->minZ = std::numeric_limits<float>::max();
+  extra->maxZ = std::numeric_limits<float>::lowest();
+  extra->minPhi = std::numeric_limits<float>::max();
+  float minPosPhi = std::numeric_limits<float>::max();
+  extra->maxPhi = std::numeric_limits<float>::lowest();
+  float maxNegPhi = std::numeric_limits<float>::lowest();
+  unsigned int nPos = 0;
+  unsigned int nOverPi2 = 0;
+  for (int i = 0; i < extra->corners.rows(); i++) {
+    float x = extra->corners(i, 1);
+    float y = extra->corners(i, 2);
+    float r = std::sqrt(x * x + y * y);
+    float z = extra->corners(i, 0);
+    float phi = phi_mpi_pi(std::numbers::pi_v<float> + std::atan2(-extra->corners(i, 2), -extra->corners(i, 1)));
+
+    extra->minR = std::min(extra->minR, r);
+    extra->maxR = std::max(extra->maxR, r);
+    extra->minZ = std::min(extra->minZ, z);
+    extra->maxZ = std::max(extra->maxZ, z);
+    extra->minPhi = std::min(extra->minPhi, phi);
+    extra->maxPhi = std::max(extra->maxPhi, phi);
+
+    if (phi > 0) {
+      minPosPhi = std::min(minPosPhi, phi);
+      nPos++;
+    } else {
+      maxNegPhi = std::max(maxNegPhi, phi);
+    }
+    if (std::fabs(phi) > std::numbers::pi_v<float> / 2.) {
+      nOverPi2++;
+    }
+  }
+  if (nOverPi2 == 4 && nPos != 4 && nPos != 0) {
+    extra->minPhi = minPosPhi;
+    extra->maxPhi = maxNegPhi;
+  }
+}

--- a/RecoTracker/LSTGeometry/src/Sensor.cc
+++ b/RecoTracker/LSTGeometry/src/Sensor.cc
@@ -75,12 +75,19 @@ Sensor::Sensor(unsigned int detId,
   extra->lower = isLower(moduleId, location, side, layer, detId);
   extra->strip = isStrip(moduleType, extra->inverted, extra->lower);
   extra->centerEta = std::asinh(centerZ / centerRho);
-  extra->centerTheta = 2.f * std::atan(std::exp(-extra->centerEta));
+  extra->centerTheta = std::numbers::pi_v<float> / 2. - std::atan(centerZ / centerRho);
 
   const Bounds &bounds = surface.bounds();
-  const RectangularPlaneBounds &plane_bounds = dynamic_cast<const RectangularPlaneBounds &>(bounds);
-  float wid = plane_bounds.width();
-  float len = plane_bounds.length();
+  const RectangularPlaneBounds *rectangular_bounds = dynamic_cast<const RectangularPlaneBounds *>(&bounds);
+
+  float wid, len;
+  if (rectangular_bounds) {
+    wid = rectangular_bounds->width();
+    len = rectangular_bounds->length();
+  } else {
+    throw std::runtime_error("Sensor::Sensor: Surface bounds are not rectangular");
+  }
+
   auto c1 = GloballyPositioned<float>::LocalPoint(-wid / 2, -len / 2, 0);
   auto c2 = GloballyPositioned<float>::LocalPoint(-wid / 2, len / 2, 0);
   auto c3 = GloballyPositioned<float>::LocalPoint(wid / 2, len / 2, 0);

--- a/RecoTracker/LSTGeometry/src/Sensor.cc
+++ b/RecoTracker/LSTGeometry/src/Sensor.cc
@@ -1,142 +1,145 @@
 #include <cmath>
+#include <limits>
+#include <stdexcept>
 
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
 
 #include "RecoTracker/LSTGeometry/interface/Sensor.h"
 
-using namespace lstgeometry;
+namespace lstgeometry {
 
-// Not sure if there is functionality for this already in CMSSW
-bool isInverted(unsigned int moduleId, Location location, Side side, unsigned int layer) {
-  bool moduleIdIsEven = moduleId % 2 == 0;
-  if (location == Location::endcap) {
-    if (side == Side::NegZ) {
-      return !moduleIdIsEven;
-    } else if (side == Side::PosZ) {
-      return moduleIdIsEven;
-    }
-  } else if (location == Location::barrel) {
-    if (side == Side::Center) {
-      if (layer <= 3) {
-        return !moduleIdIsEven;
-      } else if (layer >= 4) {
-        return moduleIdIsEven;
+  namespace {
+
+    // Not sure if there is functionality for this already in CMSSW
+    bool isInverted(unsigned int moduleId, Location location, Side side, unsigned int layer) {
+      const bool moduleIdIsEven = moduleId % 2 == 0;
+      if (location == Location::endcap) {
+        if (side == Side::NegZ) {
+          return !moduleIdIsEven;
+        } else if (side == Side::PosZ) {
+          return moduleIdIsEven;
+        }
+      } else if (location == Location::barrel) {
+        if (side == Side::Center) {
+          if (layer <= 3) {
+            return !moduleIdIsEven;
+          } else if (layer >= 4) {
+            return moduleIdIsEven;
+          }
+        } else if (side == Side::NegZ || side == Side::PosZ) {
+          if (layer <= 2) {
+            return !moduleIdIsEven;
+          } else if (layer == 3) {
+            return moduleIdIsEven;
+          }
+        }
       }
-    } else if (side == Side::NegZ || side == Side::PosZ) {
-      if (layer <= 2) {
-        return !moduleIdIsEven;
-      } else if (layer == 3) {
-        return moduleIdIsEven;
-      }
+      return false;
     }
-  }
-  return false;
-}
 
-// This differs from TrackerTopology::isLower since it considers if the module is inverted
-bool isLower(unsigned int moduleId, Location location, Side side, unsigned int layer, unsigned int detId) {
-  return isInverted(moduleId, location, side, layer) ? !(detId & 1) : (detId & 1);
-}
+    // This differs from TrackerTopology::isLower since it considers if the module is inverted
+    bool isLower(bool inverted, unsigned int detId) { return inverted ? !(detId & 1) : (detId & 1); }
 
-bool isStrip(ModuleType moduleType, bool isInverted, bool isLower) {
-  if (moduleType == ModuleType::Ph2SS)
-    return true;
-  if (isInverted)
-    return isLower;
-  return !isLower;
-}
+    bool isStrip(ModuleType moduleType, bool inverted, bool lower) {
+      if (moduleType == ModuleType::Ph2SS)
+        return true;
+      if (inverted)
+        return lower;
+      return !lower;
+    }
+  }  // namespace
 
-Sensor::Sensor(unsigned int detId,
-               ModuleType moduleType,
-               SubDetector subdet,
-               Location location,
-               Side side,
-               unsigned int moduleId,
-               unsigned int layer,
-               unsigned int ring,
-               float centerRho,
-               float centerZ,
-               float centerPhi,
-               Surface const &surface)
-    : moduleType(moduleType),
-      centerPhi(centerPhi),
-      centerX(centerRho * std::cos(centerPhi)),
-      centerY(centerRho * std::sin(centerPhi)),
-      centerZ(centerZ),
-      extra(std::make_unique<SensorExtraData>()) {
-  extra->subdet = subdet;
-  extra->location = location;
-  extra->side = side;
-  extra->moduleId = moduleId;
-  extra->layer = layer;
-  extra->ring = ring;
-  extra->inverted = isInverted(moduleId, location, side, layer);
-  extra->centerRho = centerRho;
-  extra->lower = isLower(moduleId, location, side, layer, detId);
-  extra->strip = isStrip(moduleType, extra->inverted, extra->lower);
-  extra->centerEta = std::asinh(centerZ / centerRho);
-  extra->centerTheta = std::numbers::pi_v<float> / 2. - std::atan(centerZ / centerRho);
+  Sensor::Sensor(unsigned int detId,
+                 ModuleType moduleType,
+                 SubDetector subdet,
+                 Location location,
+                 Side side,
+                 unsigned int moduleId,
+                 unsigned int layer,
+                 unsigned int ring,
+                 float centerRho,
+                 float centerZ,
+                 float centerPhi,
+                 Surface const& surface)
+      : moduleType(moduleType),
+        centerPhi(centerPhi),
+        centerX(centerRho * std::cos(centerPhi)),
+        centerY(centerRho * std::sin(centerPhi)),
+        centerZ(centerZ),
+        extra(std::make_unique<SensorExtraData>()) {
+    extra->subdet = subdet;
+    extra->location = location;
+    extra->side = side;
+    extra->layer = layer;
+    extra->ring = ring;
+    bool inverted = isInverted(moduleId, location, side, layer);
+    extra->lower = isLower(inverted, detId);
+    extra->strip = isStrip(moduleType, inverted, extra->lower);
+    extra->centerTheta = std::numbers::pi_v<float> / 2. - std::atan(centerZ / centerRho);
 
-  const Bounds &bounds = surface.bounds();
-  const RectangularPlaneBounds *rectangular_bounds = dynamic_cast<const RectangularPlaneBounds *>(&bounds);
+    Bounds const& bounds = surface.bounds();
+    auto const* rectangular_bounds = dynamic_cast<RectangularPlaneBounds const*>(&bounds);
 
-  float wid, len;
-  if (rectangular_bounds) {
-    wid = rectangular_bounds->width();
-    len = rectangular_bounds->length();
-  } else {
-    throw std::runtime_error("Sensor::Sensor: Surface bounds are not rectangular");
-  }
-
-  auto c1 = GloballyPositioned<float>::LocalPoint(-wid / 2, -len / 2, 0);
-  auto c2 = GloballyPositioned<float>::LocalPoint(-wid / 2, len / 2, 0);
-  auto c3 = GloballyPositioned<float>::LocalPoint(wid / 2, len / 2, 0);
-  auto c4 = GloballyPositioned<float>::LocalPoint(wid / 2, -len / 2, 0);
-  auto c1g = surface.toGlobal(c1);
-  auto c2g = surface.toGlobal(c2);
-  auto c3g = surface.toGlobal(c3);
-  auto c4g = surface.toGlobal(c4);
-  // store corners with z, x, y ordering
-  extra->corners << c1g.z(), c1g.x(), c1g.y(), c2g.z(), c2g.x(), c2g.y(), c3g.z(), c3g.x(), c3g.y(), c4g.z(), c4g.x(),
-      c4g.y();
-
-  // Precompute min/max R, Z, Phi for convenience
-  extra->minR = std::numeric_limits<float>::max();
-  extra->maxR = std::numeric_limits<float>::lowest();
-  extra->minZ = std::numeric_limits<float>::max();
-  extra->maxZ = std::numeric_limits<float>::lowest();
-  extra->minPhi = std::numeric_limits<float>::max();
-  float minPosPhi = std::numeric_limits<float>::max();
-  extra->maxPhi = std::numeric_limits<float>::lowest();
-  float maxNegPhi = std::numeric_limits<float>::lowest();
-  unsigned int nPos = 0;
-  unsigned int nOverPi2 = 0;
-  for (int i = 0; i < extra->corners.rows(); i++) {
-    float x = extra->corners(i, 1);
-    float y = extra->corners(i, 2);
-    float r = std::sqrt(x * x + y * y);
-    float z = extra->corners(i, 0);
-    float phi = phi_mpi_pi(std::numbers::pi_v<float> + std::atan2(-extra->corners(i, 2), -extra->corners(i, 1)));
-
-    extra->minR = std::min(extra->minR, r);
-    extra->maxR = std::max(extra->maxR, r);
-    extra->minZ = std::min(extra->minZ, z);
-    extra->maxZ = std::max(extra->maxZ, z);
-    extra->minPhi = std::min(extra->minPhi, phi);
-    extra->maxPhi = std::max(extra->maxPhi, phi);
-
-    if (phi > 0) {
-      minPosPhi = std::min(minPosPhi, phi);
-      nPos++;
+    float wid, len;
+    if (rectangular_bounds) {
+      wid = rectangular_bounds->width();
+      len = rectangular_bounds->length();
     } else {
-      maxNegPhi = std::max(maxNegPhi, phi);
+      throw std::runtime_error("Sensor::Sensor: Surface bounds are not rectangular");
     }
-    if (std::fabs(phi) > std::numbers::pi_v<float> / 2.) {
-      nOverPi2++;
+
+    auto c1 = GloballyPositioned<float>::LocalPoint(-wid / 2, -len / 2, 0);
+    auto c2 = GloballyPositioned<float>::LocalPoint(-wid / 2, len / 2, 0);
+    auto c3 = GloballyPositioned<float>::LocalPoint(wid / 2, len / 2, 0);
+    auto c4 = GloballyPositioned<float>::LocalPoint(wid / 2, -len / 2, 0);
+    auto c1g = surface.toGlobal(c1);
+    auto c2g = surface.toGlobal(c2);
+    auto c3g = surface.toGlobal(c3);
+    auto c4g = surface.toGlobal(c4);
+    // store corners with z, x, y ordering
+    extra->corners << c1g.z(), c1g.x(), c1g.y(), c2g.z(), c2g.x(), c2g.y(), c3g.z(), c3g.x(), c3g.y(), c4g.z(), c4g.x(),
+        c4g.y();
+
+    // Precompute min/max R, Z, Phi for convenience
+    extra->minR = std::numeric_limits<float>::max();
+    extra->maxR = std::numeric_limits<float>::lowest();
+    extra->minZ = std::numeric_limits<float>::max();
+    extra->maxZ = std::numeric_limits<float>::lowest();
+    extra->minPhi = std::numeric_limits<float>::max();
+    float minPosPhi = std::numeric_limits<float>::max();
+    extra->maxPhi = std::numeric_limits<float>::lowest();
+    float maxNegPhi = std::numeric_limits<float>::lowest();
+    unsigned int nPos = 0;
+    unsigned int nOverPi2 = 0;
+    for (int i = 0; i < extra->corners.rows(); i++) {
+      const float x = extra->corners(i, 1);
+      const float y = extra->corners(i, 2);
+      const float r = std::sqrt(x * x + y * y);
+      const float z = extra->corners(i, 0);
+      const float phi =
+          phi_mpi_pi(std::numbers::pi_v<float> + std::atan2(-extra->corners(i, 2), -extra->corners(i, 1)));
+
+      extra->minR = std::min(extra->minR, r);
+      extra->maxR = std::max(extra->maxR, r);
+      extra->minZ = std::min(extra->minZ, z);
+      extra->maxZ = std::max(extra->maxZ, z);
+      extra->minPhi = std::min(extra->minPhi, phi);
+      extra->maxPhi = std::max(extra->maxPhi, phi);
+
+      if (phi > 0) {
+        minPosPhi = std::min(minPosPhi, phi);
+        nPos++;
+      } else {
+        maxNegPhi = std::max(maxNegPhi, phi);
+      }
+      if (std::fabs(phi) > std::numbers::pi_v<float> / 2.) {
+        nOverPi2++;
+      }
+    }
+    if (nOverPi2 == 4 && nPos != 4 && nPos != 0) {
+      extra->minPhi = minPosPhi;
+      extra->maxPhi = maxNegPhi;
     }
   }
-  if (nOverPi2 == 4 && nPos != 4 && nPos != 0) {
-    extra->minPhi = minPosPhi;
-    extra->maxPhi = maxNegPhi;
-  }
-}
+
+}  // namespace lstgeometry

--- a/RecoTracker/LSTGeometry/src/SensorBinning.cc
+++ b/RecoTracker/LSTGeometry/src/SensorBinning.cc
@@ -1,0 +1,101 @@
+#include "RecoTracker/LSTGeometry/interface/SensorBinning.h"
+
+namespace lstgeometry {
+
+  bool isInThetaPhiBin(float theta, float phi, unsigned int theta_bin, unsigned int phi_bin) {
+    if (theta_bin == 0) {
+      if (theta > 3. * kThetaBinRad / 2.)
+        return false;
+    } else if (theta_bin == kNThetaBins - 1) {
+      if (theta < (2 * (kNThetaBins - 1) - 1) * kThetaBinRad / 2.)
+        return false;
+    } else if (theta < (2 * theta_bin - 1) * kThetaBinRad / 2. ||
+               theta > (2 * (theta_bin + 1) + 1) * kThetaBinRad / 2.) {
+      return false;
+    }
+
+    float pi = std::numbers::pi_v<float>;
+    if (phi_bin == 0) {
+      if (phi > -pi + kPhiBinWidth && phi < pi - kPhiBinWidth)
+        return false;
+    } else {
+      if (phi < -pi + (phi_bin - 1) * kPhiBinWidth || phi > -pi + (phi_bin + 1) * kPhiBinWidth)
+        return false;
+    }
+
+    return true;
+  }
+
+  std::pair<unsigned int, unsigned int> getThetaPhiBins(float theta, float phi) {
+    unsigned int theta_bin = std::clamp(static_cast<unsigned int>(theta / kThetaBinRad), 0u, kNThetaBins - 1);
+
+    float pi = std::numbers::pi_v<float>;
+    unsigned int phi_bin =
+        std::clamp(static_cast<unsigned int>((phi + pi + kPhiBinWidth / 2.) / kPhiBinWidth), 0u, kNPhiBins - 1);
+    if (phi >= pi - kPhiBinWidth / 2)
+      phi_bin = 0;  // The 0 bin wraps around
+
+    return std::make_pair(theta_bin, phi_bin);
+  }
+
+  std::pair<float, float> getCompatibleEtaRange(Sensor const& sensor, float zmin_bound, float zmax_bound) {
+    float minr = sensor.extra->minR;
+    float maxr = sensor.extra->maxR;
+    float minz = sensor.extra->minZ;
+    float maxz = sensor.extra->maxZ;
+    float mineta = -std::log(std::tan(std::atan2(minz > 0 ? maxr : minr, minz - zmin_bound) / 2.));
+    float maxeta = -std::log(std::tan(std::atan2(maxz > 0 ? minr : maxr, maxz - zmax_bound) / 2.));
+
+    if (maxeta < mineta)
+      std::swap(maxeta, mineta);
+    return std::make_pair(mineta, maxeta);
+  }
+
+  std::pair<std::pair<float, float>, std::pair<float, float>> getCompatiblePhiRange(Sensor const& sensor,
+                                                                                    float ptmin,
+                                                                                    float ptmax) {
+    float minr = sensor.extra->minR;
+    float maxr = sensor.extra->maxR;
+    float minphi = sensor.extra->minPhi;
+    float maxphi = sensor.extra->maxPhi;
+    float A = kC * kB / 2.;
+    float pos_q_phi_lo_bound = phi_mpi_pi(A * minr / ptmax + minphi);
+    float pos_q_phi_hi_bound = phi_mpi_pi(A * maxr / ptmin + maxphi);
+    float neg_q_phi_lo_bound = phi_mpi_pi(-A * maxr / ptmin + minphi);
+    float neg_q_phi_hi_bound = phi_mpi_pi(-A * minr / ptmax + maxphi);
+    return std::make_pair(std::make_pair(pos_q_phi_lo_bound, pos_q_phi_hi_bound),
+                          std::make_pair(neg_q_phi_lo_bound, neg_q_phi_hi_bound));
+  }
+
+  BinnedDetIds binDetIds(Sensors const& sensors) {
+    BinnedDetIds binned_detids;
+
+    // Initialize all vectors
+    for (unsigned int thetabin = 0; thetabin < kNThetaBins; thetabin++) {
+      for (unsigned int phibin = 0; phibin < kNPhiBins; phibin++) {
+        for (unsigned int layer = 1; layer <= kBarrelLayers; layer++) {
+          binned_detids[{Location::barrel, layer, thetabin, phibin}] = {};
+        }
+        for (unsigned int layer = 1; layer <= kEndcapLayers; layer++) {
+          binned_detids[{Location::endcap, layer, thetabin, phibin}] = {};
+        }
+      }
+    }
+
+    for (auto const& [detid, sensor] : sensors) {
+      if (!sensor.extra->lower)
+        continue;
+      // We need to loop over all bins instead of using getThetaPhiBins because of the overlapping bins
+      for (unsigned int thetabin = 0; thetabin < kNThetaBins; thetabin++) {
+        for (unsigned int phibin = 0; phibin < kNPhiBins; phibin++) {
+          if (isInThetaPhiBin(sensor.extra->centerTheta, sensor.centerPhi, thetabin, phibin)) {
+            binned_detids[{sensor.extra->location, sensor.extra->layer, thetabin, phibin}].push_back(detid);
+          }
+        }
+      }
+    }
+
+    return binned_detids;
+  }
+
+}  // namespace lstgeometry

--- a/RecoTracker/LSTGeometry/src/SensorBinning.cc
+++ b/RecoTracker/LSTGeometry/src/SensorBinning.cc
@@ -43,8 +43,8 @@ namespace lstgeometry {
     float maxr = sensor.extra->maxR;
     float minz = sensor.extra->minZ;
     float maxz = sensor.extra->maxZ;
-    float mineta = -std::log(std::tan(std::atan2(minz > 0 ? maxr : minr, minz - zmin_bound) / 2.));
-    float maxeta = -std::log(std::tan(std::atan2(maxz > 0 ? minr : maxr, maxz - zmax_bound) / 2.));
+    float mineta = std::asinh((minz - zmin_bound) / (minz > 0 ? maxr : minr));
+    float maxeta = std::asinh((maxz - zmax_bound) / (maxz > 0 ? minr : maxr));
 
     if (maxeta < mineta)
       std::swap(maxeta, mineta);
@@ -70,26 +70,22 @@ namespace lstgeometry {
   BinnedDetIds binDetIds(Sensors const& sensors) {
     BinnedDetIds binned_detids;
 
-    // Initialize all vectors
-    for (unsigned int thetabin = 0; thetabin < kNThetaBins; thetabin++) {
-      for (unsigned int phibin = 0; phibin < kNPhiBins; phibin++) {
-        for (unsigned int layer = 1; layer <= kBarrelLayers; layer++) {
-          binned_detids[{Location::barrel, layer, thetabin, phibin}] = {};
-        }
-        for (unsigned int layer = 1; layer <= kEndcapLayers; layer++) {
-          binned_detids[{Location::endcap, layer, thetabin, phibin}] = {};
-        }
-      }
-    }
-
     for (auto const& [detid, sensor] : sensors) {
       if (!sensor.extra->lower)
         continue;
-      // We need to loop over all bins instead of using getThetaPhiBins because of the overlapping bins
-      for (unsigned int thetabin = 0; thetabin < kNThetaBins; thetabin++) {
-        for (unsigned int phibin = 0; phibin < kNPhiBins; phibin++) {
+      // Only the central bin and its direct neighbors can be touched by the overlapping bin windows.
+      auto [centerThetaBin, centerPhiBin] = getThetaPhiBins(sensor.extra->centerTheta, sensor.centerPhi);
+      for (int thetaOffset = -1; thetaOffset <= 1; ++thetaOffset) {
+        int thetaBin = static_cast<int>(centerThetaBin) + thetaOffset;
+        if (thetaBin < 0 || thetaBin >= static_cast<int>(kNThetaBins))
+          continue;
+        for (int phiOffset = -1; phiOffset <= 1; ++phiOffset) {
+          unsigned int phibin = static_cast<unsigned int>(
+              (static_cast<int>(centerPhiBin) + static_cast<int>(kNPhiBins) + phiOffset) % static_cast<int>(kNPhiBins));
+          unsigned int thetabin = static_cast<unsigned int>(thetaBin);
           if (isInThetaPhiBin(sensor.extra->centerTheta, sensor.centerPhi, thetabin, phibin)) {
-            binned_detids[{sensor.extra->location, sensor.extra->layer, thetabin, phibin}].push_back(detid);
+            binnedDetIdsAt(binned_detids, sensor.extra->location, sensor.extra->layer, thetabin, phibin)
+                .push_back(detid);
           }
         }
       }

--- a/RecoTracker/LSTGeometry/src/Slope.cc
+++ b/RecoTracker/LSTGeometry/src/Slope.cc
@@ -1,0 +1,42 @@
+#include <tuple>
+#include <cmath>
+
+#include "RecoTracker/LSTGeometry/interface/Common.h"
+#include "RecoTracker/LSTGeometry/interface/Slope.h"
+
+namespace lstgeometry {
+
+  Slope::Slope(float dx, float dy, float dz) {
+    float dr = sqrt(dx * dx + dy * dy);
+    drdz = dz != 0 ? dr / dz : kDefaultSlope;
+    dxdy = dy != 0 ? -dx / dy : kDefaultSlope;
+  }
+
+  // Use each sensor's corners to calculate and categorize drdz and dxdy slopes.
+  std::tuple<Slopes, Slopes> computeSlopes(Sensors const& sensors) {
+    Slopes barrel_slopes;
+    Slopes endcap_slopes;
+
+    for (auto const& [detId, sensor] : sensors) {
+      float dx = roundCoordinate(sensor.extra->corners(1, 1) - sensor.extra->corners(0, 1));
+      float dy = roundCoordinate(sensor.extra->corners(1, 2) - sensor.extra->corners(0, 2));
+      float dz = roundCoordinate(sensor.extra->corners(1, 0) - sensor.extra->corners(0, 0));
+
+      Slope slope(dx, dy, dz);
+
+      auto location = sensor.extra->location;
+      bool is_tilted = sensor.extra->side != Side::Center;
+      bool is_strip = sensor.extra->strip;
+
+      if (!is_strip)
+        continue;
+
+      if (location == Location::barrel and is_tilted)
+        barrel_slopes[detId] = slope;
+      else if (location == Location::endcap)
+        endcap_slopes[detId] = slope;
+    }
+
+    return std::make_tuple(barrel_slopes, endcap_slopes);
+  }
+}  // namespace lstgeometry

--- a/RecoTracker/LSTGeometry/src/Slope.cc
+++ b/RecoTracker/LSTGeometry/src/Slope.cc
@@ -1,5 +1,5 @@
-#include <tuple>
 #include <cmath>
+#include <tuple>
 
 #include "RecoTracker/LSTGeometry/interface/Common.h"
 #include "RecoTracker/LSTGeometry/interface/Slope.h"
@@ -7,7 +7,7 @@
 namespace lstgeometry {
 
   Slope::Slope(float dx, float dy, float dz) {
-    float dr = sqrt(dx * dx + dy * dy);
+    const float dr = std::sqrt(dx * dx + dy * dy);
     drdz = dz != 0 ? dr / dz : kDefaultSlope;
     dxdy = dy != 0 ? -dx / dy : kDefaultSlope;
   }

--- a/RecoTracker/LSTGeometry/test/BuildFile.xml
+++ b/RecoTracker/LSTGeometry/test/BuildFile.xml
@@ -1,0 +1,7 @@
+<library file="DumpLSTGeometry.cc" name="RecoTrackerLSTCoreTest">
+  <flags EDM_PLUGIN="1"/>
+  <use name="FWCore/Framework"/>
+  <use name="RecoTracker/LSTGeometry"/>
+  <use name="RecoTracker/Record"/>
+</library>
+<test name="testDumpLSTGeometry" command="testDumpLSTGeometry.sh"/>

--- a/RecoTracker/LSTGeometry/test/BuildFile.xml
+++ b/RecoTracker/LSTGeometry/test/BuildFile.xml
@@ -1,6 +1,7 @@
 <library file="DumpLSTGeometry.cc" name="RecoTrackerLSTCoreTest">
   <flags EDM_PLUGIN="1"/>
   <use name="FWCore/Framework"/>
+  <use name="FWCore/MessageLogger"/>
   <use name="RecoTracker/LSTGeometry"/>
   <use name="RecoTracker/Record"/>
 </library>

--- a/RecoTracker/LSTGeometry/test/DumpLSTGeometry.cc
+++ b/RecoTracker/LSTGeometry/test/DumpLSTGeometry.cc
@@ -1,0 +1,49 @@
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+
+#include "RecoTracker/LSTGeometry/interface/Common.h"
+#include "RecoTracker/LSTGeometry/interface/Geometry.h"
+#include "RecoTracker/LSTGeometry/interface/IO.h"
+
+class DumpLSTGeometry : public edm::one::EDAnalyzer<> {
+public:
+  explicit DumpLSTGeometry(const edm::ParameterSet& config);
+
+private:
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
+
+  double ptCut_;
+  std::string ptCutStr_;
+  std::string outputDirectory_;
+  bool binaryOutput_;
+
+  edm::ESGetToken<lstgeometry::Geometry, TrackerRecoGeometryRecord> lstGeoToken_;
+};
+
+DumpLSTGeometry::DumpLSTGeometry(const edm::ParameterSet& config)
+    : ptCut_(config.getParameter<double>("ptCut")),
+      ptCutStr_(lstgeometry::floatToStr(ptCut_, 1)),
+      outputDirectory_(config.getUntrackedParameter<std::string>("outputDirectory", "data/")),
+      binaryOutput_(config.getUntrackedParameter<bool>("outputAsBinary", true)),
+      lstGeoToken_{esConsumes(edm::ESInputTag("", ptCutStr_))} {}
+
+void DumpLSTGeometry::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto const& lstg = iSetup.getData(lstGeoToken_);
+
+  lstgeometry::writeSensorCentroids(lstg.sensors, outputDirectory_ + "sensor_centroids", binaryOutput_);
+  lstgeometry::writeSlopes(
+      lstg.barrel_slopes, lstg.sensors, outputDirectory_ + "tilted_barrel_orientation", binaryOutput_);
+  lstgeometry::writeSlopes(lstg.endcap_slopes, lstg.sensors, outputDirectory_ + "endcap_orientation", binaryOutput_);
+  lstgeometry::writePixelMaps(lstg.pixel_map, outputDirectory_ + "pixelmap/pLS_map", binaryOutput_);
+  lstgeometry::writeModuleConnections(
+      lstg.module_map, outputDirectory_ + "module_connection_tracing_merged", binaryOutput_);
+
+  edm::LogInfo("DumpLSTGeometry") << "Geometry data was successfully dumped." << std::endl;
+}
+
+DEFINE_FWK_MODULE(DumpLSTGeometry);

--- a/RecoTracker/LSTGeometry/test/DumpLSTGeometry.cc
+++ b/RecoTracker/LSTGeometry/test/DumpLSTGeometry.cc
@@ -27,7 +27,7 @@ private:
 
 DumpLSTGeometry::DumpLSTGeometry(const edm::ParameterSet& config)
     : ptCut_(config.getParameter<double>("ptCut")),
-      ptCutStr_(lstgeometry::floatToStr(ptCut_, 1)),
+      ptCutStr_(lst::floatToStr(ptCut_, 1)),
       outputDirectory_(config.getUntrackedParameter<std::string>("outputDirectory", "data/")),
       binaryOutput_(config.getUntrackedParameter<bool>("outputAsBinary", true)),
       lstGeoToken_{esConsumes(edm::ESInputTag("", ptCutStr_))} {}

--- a/RecoTracker/LSTGeometry/test/DumpLSTGeometry.cc
+++ b/RecoTracker/LSTGeometry/test/DumpLSTGeometry.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 

--- a/RecoTracker/LSTGeometry/test/dumpLSTGeometry.py
+++ b/RecoTracker/LSTGeometry/test/dumpLSTGeometry.py
@@ -1,0 +1,70 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.AlCa.GlobalTag import GlobalTag
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+import FWCore.ParameterSet.VarParsing as VarParsing
+from RecoTracker.LSTGeometry.lstGeometryESProducer_cfi import lstGeometryESProducer as _lstGeom
+
+trackingLSTCommon = cms.Modifier()
+trackingLST = cms.ModifierChain(trackingLSTCommon)
+
+###################################################################
+# Set default phase-2 settings
+###################################################################
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
+# No era in Fireworks/Geom reco dumper
+process = cms.Process("DUMP", _PH2_ERA, trackingLST)
+
+# import of standard configurations
+process.load("Configuration.StandardSequences.Services_cff")
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load("Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.Reconstruction_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+
+process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG, "")
+
+process.MessageLogger.cerr.threshold = "INFO"
+process.MessageLogger.cerr.LSTGeometryESProducer = dict(limit=-1)
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 1
+
+options = VarParsing.VarParsing()
+options.register(
+    "outputDirectory",
+    "data/",
+    VarParsing.VarParsing.multiplicity.singleton,
+    VarParsing.VarParsing.varType.string,
+    "Output directory for LST geometry files",
+)
+options.register(
+    "ptCut",
+    0.8,
+    VarParsing.VarParsing.multiplicity.singleton,
+    VarParsing.VarParsing.varType.float,
+    "pT cut for LST module maps",
+)
+options.register(
+    "binaryOutput",
+    True,
+    VarParsing.VarParsing.multiplicity.singleton,
+    VarParsing.VarParsing.varType.bool,
+    "Dump LST geometry as binary files",
+)
+options.parseArguments()
+
+process.dump = cms.EDAnalyzer(
+    "DumpLSTGeometry",
+    outputDirectory = cms.untracked.string(options.outputDirectory),
+    ptCut = cms.double(options.ptCut),
+    outputAsBinary = cms.untracked.bool(options.binaryOutput),
+)
+
+process.lstGeometryESProducer = _lstGeom.clone(ptCut = cms.double(options.ptCut))
+process.dTask = cms.Task(process.lstGeometryESProducer)
+process.dSeq = cms.Sequence(process.dump,process.dTask)
+process.p = cms.Path(process.dSeq)
+
+print(f"Requesting LST geometry dump into directory: {options.outputDirectory}\n")

--- a/RecoTracker/LSTGeometry/test/dumpLSTGeometry.py
+++ b/RecoTracker/LSTGeometry/test/dumpLSTGeometry.py
@@ -1,7 +1,8 @@
+from argparse import ArgumentParser
+
 import FWCore.ParameterSet.Config as cms
 from Configuration.AlCa.GlobalTag import GlobalTag
 import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
-import FWCore.ParameterSet.VarParsing as VarParsing
 from RecoTracker.LSTGeometry.lstGeometryESProducer_cfi import lstGeometryESProducer as _lstGeom
 
 trackingLSTCommon = cms.Modifier()
@@ -31,33 +32,28 @@ process.MessageLogger.cerr.LSTGeometryESProducer = dict(limit=-1)
 process.source = cms.Source("EmptySource")
 process.maxEvents.input = 1
 
-options = VarParsing.VarParsing()
-options.register(
-    "outputDirectory",
-    "data/",
-    VarParsing.VarParsing.multiplicity.singleton,
-    VarParsing.VarParsing.varType.string,
-    "Output directory for LST geometry files",
+parser = ArgumentParser()
+parser.add_argument(
+    "--outputDirectory",
+    default="data/",
+    help="Output directory for LST geometry files"
 )
-options.register(
-    "ptCut",
-    0.8,
-    VarParsing.VarParsing.multiplicity.singleton,
-    VarParsing.VarParsing.varType.float,
-    "pT cut for LST module maps",
+parser.add_argument(
+    "--ptCut",
+    type=float,
+    default=0.8,
+    help="pT cut for LST module maps"
 )
-options.register(
-    "binaryOutput",
-    True,
-    VarParsing.VarParsing.multiplicity.singleton,
-    VarParsing.VarParsing.varType.bool,
-    "Dump LST geometry as binary files",
+parser.add_argument(
+    "--binaryOutput",
+    action="store_true",
+    help="Dump LST geometry as binary files"
 )
-options.parseArguments()
+options = parser.parse_args()
 
 process.dump = cms.EDAnalyzer(
     "DumpLSTGeometry",
-    outputDirectory = cms.untracked.string(options.outputDirectory),
+    outputDirectory = cms.untracked.string(options.outputDirectory + "/"),
     ptCut = cms.double(options.ptCut),
     outputAsBinary = cms.untracked.bool(options.binaryOutput),
 )

--- a/RecoTracker/LSTGeometry/test/dumpLSTGeometry.py
+++ b/RecoTracker/LSTGeometry/test/dumpLSTGeometry.py
@@ -58,9 +58,9 @@ process.dump = cms.EDAnalyzer(
     outputAsBinary = cms.untracked.bool(options.binaryOutput),
 )
 
-process.lstGeometryESProducer = _lstGeom.clone(ptCut = cms.double(options.ptCut))
+process.lstGeometryESProducer = _lstGeom.clone(ptCut=options.ptCut)
 process.dTask = cms.Task(process.lstGeometryESProducer)
-process.dSeq = cms.Sequence(process.dump,process.dTask)
+process.dSeq = cms.Sequence(process.dump, process.dTask)
 process.p = cms.Path(process.dSeq)
 
 print(f"Requesting LST geometry dump into directory: {options.outputDirectory}\n")

--- a/RecoTracker/LSTGeometry/test/testDumpLSTGeometry.sh
+++ b/RecoTracker/LSTGeometry/test/testDumpLSTGeometry.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+function die { echo $1: status $2; exit $2; }
+
+if [ "${SCRAM_TEST_NAME}" != "" ] ; then
+  mkdir ${SCRAM_TEST_NAME}
+  cd ${SCRAM_TEST_NAME}
+fi
+
+(cmsRun ${SCRAM_TEST_PATH}/dumpLSTGeometry.py outputDirectory="data/" ptCut=0.8 binaryOutput=true) || die "failed to run dumpLSTGeometry.py" $?

--- a/RecoTracker/LSTGeometry/test/testDumpLSTGeometry.sh
+++ b/RecoTracker/LSTGeometry/test/testDumpLSTGeometry.sh
@@ -7,4 +7,4 @@ if [ "${SCRAM_TEST_NAME}" != "" ] ; then
   cd ${SCRAM_TEST_NAME}
 fi
 
-(cmsRun ${SCRAM_TEST_PATH}/dumpLSTGeometry.py outputDirectory="data/" ptCut=0.8 binaryOutput=true) || die "failed to run dumpLSTGeometry.py" $?
+(cmsRun ${SCRAM_TEST_PATH}/dumpLSTGeometry.py --outputDirectory data --ptCut 0.8 --binaryOutput) || die "failed to run dumpLSTGeometry.py" $?

--- a/RecoTracker/LSTGeometry/test/testDumpLSTGeometry.sh
+++ b/RecoTracker/LSTGeometry/test/testDumpLSTGeometry.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 
-function die { echo $1: status $2; exit $2; }
+die() {
+  echo "$1: status $2"
+  exit "$2"
+}
 
 if [ "${SCRAM_TEST_NAME}" != "" ] ; then
-  mkdir ${SCRAM_TEST_NAME}
-  cd ${SCRAM_TEST_NAME}
+  mkdir "${SCRAM_TEST_NAME}"
+  cd "${SCRAM_TEST_NAME}" || die "failed to enter ${SCRAM_TEST_NAME}" $?
 fi
 
-(cmsRun ${SCRAM_TEST_PATH}/dumpLSTGeometry.py --outputDirectory data --ptCut 0.8 --binaryOutput) || die "failed to run dumpLSTGeometry.py" $?
+cmsRun "${SCRAM_TEST_PATH}/dumpLSTGeometry.py" --outputDirectory data --ptCut 0.8 --binaryOutput ||
+  die "failed to run dumpLSTGeometry.py" $?


### PR DESCRIPTION
This PR adds a new `RecoTracker/LSTGeometry` package containing the module map computation used by the LST algorithm. Currently, the maps are pre-computed by the code in https://github.com/SegmentLinking/LSTGeometry and they are stored in https://github.com/cms-data/RecoTracker-LSTCore. This PR allows for the on-the-fly computation of these maps via an ESProducer, ensuring that they stay consistent with the tracker geometry being used.

This is the last major task in #46746.

c.c. @slava77 
