### PR TITLE
[EVO] PFCandidate no longer inherits from CompositeCandidate

### DIFF
--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
@@ -14,7 +14,7 @@
 
 #include "DataFormats/Math/interface/Point3D.h"
 
-#include "DataFormats/Candidate/interface/CompositeCandidate.h"
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockFwd.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
@@ -39,7 +39,7 @@ namespace reco {
      \date   February 2007
   */
 
-    class PFCandidate : public CompositeCandidate {
+    class PFCandidate : public LeafCandidate {
     public:
       /// particle types
       enum ParticleType {

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -65,7 +65,7 @@ PFCandidate::PFCandidate(const PFCandidatePtr& sourcePtr) : PFCandidate(*sourceP
 }
 
 PFCandidate::PFCandidate(Charge charge, const LorentzVector& p4, ParticleType partId)
-    : CompositeCandidate(charge, p4),
+    : LeafCandidate(charge, p4),
       elementsInBlocks_(nullptr),
       ecalERatio_(1.),
       hcalERatio_(1.),
@@ -123,7 +123,7 @@ PFCandidate::PFCandidate(Charge charge, const LorentzVector& p4, ParticleType pa
 }
 
 PFCandidate::PFCandidate(PFCandidate const& iOther)
-    : CompositeCandidate(iOther),
+    : LeafCandidate(static_cast<LeafCandidate const&>(iOther)),
       elementsInBlocks_(nullptr),
       blocksStorage_(iOther.blocksStorage_),
       elementsStorage_(iOther.elementsStorage_),
@@ -168,7 +168,7 @@ PFCandidate::PFCandidate(PFCandidate const& iOther)
 }
 
 PFCandidate& PFCandidate::operator=(PFCandidate const& iOther) {
-  CompositeCandidate::operator=(iOther);
+  LeafCandidate::operator=(iOther);
   auto tmp = iOther.elementsInBlocks_.load(std::memory_order_acquire);
   if (nullptr != tmp) {
     delete elementsInBlocks_.exchange(new ElementsInBlocks{*tmp}, std::memory_order_acq_rel);

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -1,7 +1,7 @@
 <lcgdict>
 
    <class name="reco::io_v1::PFCandidate" ClassVersion="3">
-    <version ClassVersion="3" checksum="3624191462"/>
+    <version ClassVersion="3" checksum="2023344531"/>
      <field name="elementsInBlocks_" transient="true"/>
      <field name="getter_" transient="true"/>
      <field name="refsCollectionCache_" transient="true"/>
@@ -48,7 +48,7 @@
   <class name="edm::Wrapper<edm::PtrVector<reco::io_v1::PFCandidate> >"/>
 
   <class name="reco::IsolatedPFCandidate"  ClassVersion="3">
-   <version ClassVersion="3" checksum="1014378071"/>
+   <version ClassVersion="3" checksum="2477942852"/>
   </class>
   <class name="std::vector<reco::IsolatedPFCandidate>"/>
   <class name="edm::Wrapper<std::vector<reco::IsolatedPFCandidate> >"/>
@@ -58,7 +58,7 @@
   <class name="reco::IsolatedPFCandidatePtr"/>
 
   <class name="reco::PileUpPFCandidate"  ClassVersion="3">
-   <version ClassVersion="3" checksum="4065313068"/>
+   <version ClassVersion="3" checksum="3974747921"/>
   </class>
   <class name="std::vector<reco::PileUpPFCandidate>"/>
   <class name="edm::Wrapper<std::vector<reco::PileUpPFCandidate> >"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -132,7 +132,7 @@
    <version ClassVersion="3" checksum="3450971292"/>
   </class>
   <class name="pat::PFParticle"  ClassVersion="3">
-   <version ClassVersion="3" checksum="213995894"/>
+   <version ClassVersion="3" checksum="2508658165"/>
   </class>
   <class name="pat::GenericParticle"  ClassVersion="3">
    <version ClassVersion="3" checksum="3105008866"/>


### PR DESCRIPTION
#### PR description:

This simplification is intended to make it easier for ROOT to store this class.

The original attempt in the main line was done here https://github.com/cms-sw/cmssw/pull/38999.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2142