### PR TITLE
Add typedef of ProductDependencies to dictionary generation

### DIFF
--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -73,6 +73,8 @@
  <class name="edm::BranchChildren" ClassVersion="10">
   <version ClassVersion="10" checksum="137742168"/>
  </class>
+ <!--ProductDependencies is a typedef of BranchChildren  -->
+ <typedef name="edm::ProductDependencies"/>
  <class name="edm::ProductProvenance" ClassVersion="12">
   <version ClassVersion="12" checksum="737844716"/>
   <version ClassVersion="11" checksum="3594205707"/>


### PR DESCRIPTION

#### PR description:

In ROOT 6.39 the RNTuple tests fail without the typedef.

#### PR validation:

Code compiled and tested using experimental build of newest ROOT. See https://github.com/cms-sw/cmsdist/pull/10475

resolves https://github.com/cms-sw/framework-team/issues/2143