### PR TITLE
Implement a `GenericClonerDevice.cc` as a test for the device TrivialSerialisation mechanism

### DIFF
--- a/HeterogeneousCore/TrivialSerialisation/interface/alpaka/Serialiser.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/alpaka/Serialiser.h
@@ -21,6 +21,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
   public:
     using WrapperType = edm::Wrapper<detail::DeviceProductType<T>>;
 
+    std::type_info const& productTypeID() const override { return typeid(detail::DeviceProductType<T>); }
+
     std::unique_ptr<WriterBase> writer() override { return std::make_unique<Writer<T>>(); }
 
     std::unique_ptr<const ReaderBase> reader(edm::WrapperBase const& wrapper, EDMetadata& metadata) override {

--- a/HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserBase.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserBase.h
@@ -2,6 +2,7 @@
 #define HeterogeneousCore_TrivialSerialisation_interface_alpaka_SerialiserBase_h
 
 #include <memory>
+#include <typeinfo>
 
 #include "DataFormats/Common/interface/WrapperBase.h"
 #include "DataFormats/AlpakaCommon/interface/alpaka/EDMetadata.h"
@@ -16,6 +17,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
   public:
     virtual std::unique_ptr<WriterBase> writer() = 0;
     virtual std::unique_ptr<const ReaderBase> reader(const edm::WrapperBase& wrapper, EDMetadata& metadata) = 0;
+
+    // Return the type_info of the product type (DeviceProduct<T> for async
+    // backends, T for serial_sync)
+    virtual std::type_info const& productTypeID() const = 0;
 
     virtual ~SerialiserBase() = default;
   };

--- a/HeterogeneousCore/TrivialSerialisation/plugins/BuildFile.xml
+++ b/HeterogeneousCore/TrivialSerialisation/plugins/BuildFile.xml
@@ -8,3 +8,17 @@
   <use name="HeterogeneousCore/TrivialSerialisation"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<library file="alpaka/*.cc" name="HeterogeneousCoreTrivialSerialisationPluginsPortable">
+  <use name="alpaka"/>
+  <use name="DataFormats/AlpakaCommon"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+  <use name="HeterogeneousCore/AlpakaCore"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousCore/TrivialSerialisation"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/HeterogeneousCore/TrivialSerialisation/plugins/alpaka/GenericClonerDevice.cc
+++ b/HeterogeneousCore/TrivialSerialisation/plugins/alpaka/GenericClonerDevice.cc
@@ -1,0 +1,169 @@
+/*
+ * This Alpaka EDProducer will clone all the device event products declared in
+ * its configuration, using the plugin-based NGT trivial serialisation.
+ *
+ * This module works only with device products that have a device serialiser
+ * registered in SerialiserFactoryDevice.
+ *
+ * Products are configured as a VPSet with type, label, and instance.
+ * The type must be the human-readable type alias used to register the device
+ * serialiser (e.g. "portabletest::TestDeviceCollection").
+ */
+
+// C++ include files
+#include <cassert>
+#include <memory>
+#include <string>
+#include <vector>
+
+// CMSSW include files
+#include "DataFormats/AlpakaCommon/interface/alpaka/EDMetadata.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/WrapperBaseHandle.h"
+#include "FWCore/Framework/interface/WrapperBaseOrphanHandle.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadataSentry.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/ReaderBase.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserBase.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h"
+#include "HeterogeneousCore/TrivialSerialisation/interface/alpaka/WriterBase.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
+
+  class GenericClonerDevice : public ProducerBase<edm::stream::EDProducer> {
+  public:
+    explicit GenericClonerDevice(edm::ParameterSet const& config);
+    ~GenericClonerDevice() override = default;
+
+    void produce(edm::Event& event, edm::EventSetup const&) final;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    struct Entry {
+      std::string typeName;  // human-readable type name, coming from the config, for serialiser lookup.
+      edm::TypeID typeID;    // product type as registered in the framework
+      edm::EDGetToken getToken;
+      edm::EDPutToken putToken;
+    };
+
+    std::vector<Entry> eventProducts_;
+    bool verbose_;
+  };
+
+  GenericClonerDevice::GenericClonerDevice(edm::ParameterSet const& config)
+      : ProducerBase<edm::stream::EDProducer>(config), verbose_(config.getUntrackedParameter<bool>("verbose")) {
+    auto const& products = config.getParameter<std::vector<edm::ParameterSet>>("eventProducts");
+    eventProducts_.reserve(products.size());
+
+    for (auto const& product : products) {
+      auto const& type = product.getParameter<std::string>("type");
+      auto const& label = product.getParameter<std::string>("label");
+      auto const& instance = product.getParameter<std::string>("instance");
+
+      // Get a device serialiser from the human-readable type that we got from
+      // the python config.
+      std::unique_ptr<ngt::SerialiserBase> serialiser{ngt::SerialiserFactoryDevice::get()->tryToCreate(type)};
+      if (!serialiser) {
+        throw edm::Exception(edm::errors::Configuration)
+            << "No device serialiser found for type '" << type
+            << "'. Only device products with a registered device serialiser are supported by GenericClonerDevice.";
+      }
+
+      Entry entry;
+      entry.typeName = type;
+
+      // Get the edm::TypeID from the serialiser. For asynchronous backends, this is the product type
+      // wrapped in edm::DeviceProduct; for serial_sync, this is the product type directly.
+      entry.typeID = edm::TypeID{serialiser->productTypeID()};
+
+      entry.getToken = this->consumes(edm::TypeToGet{entry.typeID, edm::PRODUCT_TYPE}, edm::InputTag{label, instance});
+      entry.putToken = this->producesCollector().produces(entry.typeID, instance);
+
+      if (verbose_) {
+        edm::LogInfo("GenericClonerDevice") << "will clone device product of type '" << type << "', label '" << label
+                                            << "', instance '" << instance << "'";
+      }
+
+      eventProducts_.emplace_back(std::move(entry));
+    }
+  }
+
+  void GenericClonerDevice::produce(edm::Event& event, edm::EventSetup const& /*unused*/) {
+    // The EDMetadata needs to be handled manually, as would normally be done in
+    // SynchronizingEDProducer.h
+    detail::EDMetadataSentry sentry(event.streamID(), this->synchronize());
+
+    for (size_t i = 0; i < eventProducts_.size(); ++i) {
+      auto const& entry = eventProducts_[i];
+
+      // Get the product from the Event, as a WrapperBase pointer.
+      edm::Handle<edm::WrapperBase> handle(entry.typeID.typeInfo());
+      event.getByToken(entry.getToken, handle);
+      edm::WrapperBase const* wrapper = handle.product();
+
+      // Get a device serialiser and initialise the corresponding Reader and Writer.
+      std::unique_ptr<ngt::SerialiserBase> serialiser{ngt::SerialiserFactoryDevice::get()->tryToCreate(entry.typeName)};
+      auto reader = serialiser->reader(*wrapper, *sentry.metadata());
+      auto writer = serialiser->writer();
+
+      // Initialise the clone with the queue and the parameters from the source.
+      writer->initialize(sentry.metadata()->queue(), reader->parameters());
+
+      // Copy the source regions to the target.
+      auto targets = writer->regions();
+      auto sources = reader->regions();
+
+      assert(sources.size() == targets.size());
+      for (size_t j = 0; j < sources.size(); ++j) {
+        assert(sources[j].data() != nullptr);
+        assert(targets[j].data() != nullptr);
+        assert(targets[j].size_bytes() == sources[j].size_bytes());
+        alpaka::memcpy(sentry.metadata()->queue(),
+                       cms::alpakatools::make_device_view(sentry.metadata()->queue(), targets[j]),
+                       cms::alpakatools::make_device_view(sentry.metadata()->queue(), sources[j]));
+      }
+
+      // Finalize the clone after the copy, if the type requires it.
+      writer->finalize();
+
+      // Move the clone into the Event.
+      event.put(entry.putToken, writer->get(sentry.metadata()));
+    }
+
+    this->putBackend(event);
+    sentry.finish(true);
+  }
+
+  void GenericClonerDevice::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    descriptions.setComment(
+        "This Alpaka EDProducer will clone all the device event products declared by its configuration, "
+        "using the device TrivialSerialisation mechanism.");
+
+    edm::ParameterSetDescription product;
+    product.add<std::string>("type")->setComment(
+        "Type name of the device product to be cloned, using the human-readable type alias "
+        "(e.g. \"portabletest::TestDeviceCollection\").");
+    product.add<std::string>("label")->setComment("Module label of the producer.");
+    product.add<std::string>("instance", "")->setComment("Product instance name.");
+
+    edm::ParameterSetDescription desc;
+    desc.addVPSet("eventProducts", product, {})->setComment("Device products to be cloned.");
+    desc.addUntracked<bool>("verbose", false)->setComment("Print the type names of the products that will be cloned.");
+
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt
+
+DEFINE_FWK_ALPAKA_MODULE(ngt::GenericClonerDevice);

--- a/HeterogeneousCore/TrivialSerialisation/test/BuildFile.xml
+++ b/HeterogeneousCore/TrivialSerialisation/test/BuildFile.xml
@@ -8,6 +8,7 @@
 
 <test name="TestHeterogeneousCoreTrivialSerialisationGenericCloner" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/TrivialSerialisation/test/testGenericCloner_cfg.py"/>
 <test name="TestHeterogeneousCoreTrivialSerialisationGenericClonerHost" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/TrivialSerialisation/test/testGenericClonerHost_cfg.py"/>
+<test name="TestHeterogeneousCoreTrivialSerialisationGenericClonerDevice" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/TrivialSerialisation/test/testGenericClonerDevice_cfg.py"/>
 
 <bin name="TestHeterogeneousCoreTrivialSerialisationPortable" file="alpaka/test_catch2_*.cc,alpaka/test_catch2_*.dev.cc">
   <use name="alpaka"/>

--- a/HeterogeneousCore/TrivialSerialisation/test/testGenericClonerDevice_cfg.py
+++ b/HeterogeneousCore/TrivialSerialisation/test/testGenericClonerDevice_cfg.py
@@ -1,0 +1,72 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.INFO.limit = 10000000
+
+process.options.numberOfThreads = 1
+process.options.numberOfStreams = 1
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 10
+
+# Produce, clone and validate a portable object, a portable collection, and some portable multicollections
+process.load("Configuration.StandardSequences.Accelerators_cff")
+process.load("HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi")
+
+process.producePortableObjects = cms.EDProducer("TestAlpakaProducer@alpaka",
+    size = cms.int32(42),
+    size2 = cms.int32(33),
+    size3 = cms.int32(61),
+    alpaka = cms.untracked.PSet(
+        backend = cms.untracked.string("")
+    )
+)
+
+process.clonePortableObjects = cms.EDProducer("ngt::GenericClonerDevice@alpaka",
+    eventProducts = cms.VPSet(
+        cms.PSet(
+            type = cms.string("portabletest::TestDeviceObject"),
+            label = cms.string("producePortableObjects"),
+            instance = cms.string("")
+        ),
+        cms.PSet(
+            type = cms.string("portabletest::TestDeviceCollection"),
+            label = cms.string("producePortableObjects"),
+            instance = cms.string("")
+        ),
+        cms.PSet(
+            type = cms.string("portabletest::TestDeviceCollection2"),
+            label = cms.string("producePortableObjects"),
+            instance = cms.string("")
+        ),
+        cms.PSet(
+            type = cms.string("portabletest::TestDeviceCollection3"),
+            label = cms.string("producePortableObjects"),
+            instance = cms.string("")
+        ),
+    ),
+    verbose = cms.untracked.bool(True),
+    alpaka = cms.untracked.PSet(
+        backend = cms.untracked.string("")
+    )
+)
+
+process.validatePortableCollections = cms.EDAnalyzer("TestAlpakaAnalyzer",
+    source = cms.InputTag("clonePortableObjects")
+)
+
+process.validatePortableObject = cms.EDAnalyzer("TestAlpakaObjectAnalyzer",
+    source = cms.InputTag("clonePortableObjects")
+)
+
+
+# TODO: Automatic Device <-> Host conversions are currently not supported when
+# the types are not known at compile-time.
+process.pathSoA = cms.Path(
+    process.producePortableObjects +
+    process.clonePortableObjects
+    # process.validatePortableCollections +
+    # process.validatePortableObject
+)


### PR DESCRIPTION
#### PR description:


- Adds a test to the device TrivialSerialisation mechanism introduced in #50597. The test consists of:
    - A `GenericClonerDevice.cc` module, which gets from the event a generic device collection and clones its contents into a new device collection of the same type. Similar to what the existing `GenericCloner.cc` does, but with device products.
    - A configuration for this module, `testGenericClonerDevice_cfg.py`, ran as a unit test.

- Adds a short method to the device serialiser interface, to retrieve the type information of each serialiser's concrete product type. This type information (convertible to `edm::TypeID`) is required by the `GenericClonerDevice` to
    - call the non-templated `edm::EDGetToken consumes(...)` to initialize an `edm::EDGetToken`, and 
    - construct an `edm::Handle<edm::WrapperBase>` to hold the product after getting it from the event.

This functionality will be required as well by the device MPI Sender and Receiver modules introduced in #50503.


#### PR validation:

The `GenericClonerDevice.cc` as introduced in this PR produces products on device that _cannot_ be automatically converted to host by the framework when they are needed by downstream host modules. Therefore, the `TestAlpakaAnalyzer` and `TestAlpakaObjectAnalyzer` cannot be used to validate the collections produced by this test.

The fix for this issue is introduced by #50750, which includes this PR. If possible, the two PRs should be tested together. Alternatively, this PR could be closed, and only #50750 could be merged.
