### PR TITLE
[16.0.X] add impact parameters monitoring to the `ShortenedTrackResolution` and  `ShortenedTrackValidation`

### DIFF
--- a/Alignment/OfflineValidation/plugins/ShortenedTrackValidation.cc
+++ b/Alignment/OfflineValidation/plugins/ShortenedTrackValidation.cc
@@ -345,6 +345,8 @@ private:
   std::vector<TH1F *> histsPtDiffAll_;
   std::vector<TH1F *> histsEtaDiffAll_;
   std::vector<TH1F *> histsPhiDiffAll_;
+  std::vector<TH1F *> histsdxyDiffAll_;
+  std::vector<TH1F *> histsdzDiffAll_;
   std::vector<TH2F *> histsPtRatioVsDeltaRAll_;
   std::vector<TH1F *> histsDeltaPtOverPtAll_;
   std::vector<TH1F *> histsPtAll_;
@@ -381,6 +383,8 @@ ShortenedTrackValidation::ShortenedTrackValidation(const edm::ParameterSet &ps)
   histsPtDiffAll_.clear();
   histsEtaDiffAll_.clear();
   histsPhiDiffAll_.clear();
+  histsdxyDiffAll_.clear();
+  histsdzDiffAll_.clear();
   histsPtRatioVsDeltaRAll_.clear();
   histsDeltaPtOverPtAll_.clear();
   histsPtAll_.clear();
@@ -464,6 +468,16 @@ void ShortenedTrackValidation::beginJob() {
     title = fmt::sprintf("Short Track #phi - Full Track #phi - %s layers;#phi^{short} - #phi^{full};n. tracks", label);
     histsPhiDiffAll_.push_back(book1DRes(name, title, 100, -0.001, 0.001));
 
+    name = fmt::sprintf("trackdxyDiff_%s", label);
+    title = fmt::sprintf(
+        "Short Track d_{xy} - Full Track d_{xy} - %s layers;d_{xy}^{short} - d_{xy}^{full} [cm];n. tracks", label);
+    histsdxyDiffAll_.push_back(book1DRes(name, title, 100, -0.1, 0.1));
+
+    name = fmt::sprintf("trackdzDiff_%s", label);
+    title = fmt::sprintf("Short Track d_{z} - Full Track d_{z} - %s layers;d_{z}^{short} - d_{z}^{full} [cm];n. tracks",
+                         label);
+    histsdzDiffAll_.push_back(book1DRes(name, title, 100, -0.1, 0.1));
+
     name = fmt::sprintf("trackPtRatioVsDeltaR_%s", label);
     title = fmt::sprintf(
         "Short Track p_{T} / Full Track p_{T} - %s layers vs #DeltaR;#DeltaR(short,full);p_{T}^{short}/p_{T}^{full};n. "
@@ -517,6 +531,8 @@ void ShortenedTrackValidation::analyze(edm::Event const &iEvent, edm::EventSetup
     beamSpot = reco::BeamSpot();
   }
 
+  math::XYZPoint BS(beamSpot.x0(), beamSpot.y0(), beamSpot.z0());
+
   reco::Vertex pvtx;
   edm::Handle<reco::VertexCollection> vertexHandle = iEvent.getHandle(vertexToken_);
   if (vertexHandle.isValid()) {
@@ -559,6 +575,8 @@ void ShortenedTrackValidation::analyze(edm::Event const &iEvent, edm::EventSetup
             histsDeltaPtOverPtAll_[i]->Fill((track_rereco.pt() - track.pt()) / track.pt());
             histsEtaDiffAll_[i]->Fill(track_rereco.eta() - track.eta());
             histsPhiDiffAll_[i]->Fill(track_rereco.phi() - track.phi());
+            histsdxyDiffAll_[i]->Fill(track_rereco.dxy(BS) - track.dxy(BS));
+            histsdzDiffAll_[i]->Fill(track_rereco.dz(BS) - track.dz(BS));
             histsPtRatioVsDeltaRAll_[i]->Fill(deltaR, track_rereco.pt() / track.pt());
             histsPtAll_[i]->Fill(track_rereco.pt());
             histsNhitsAll_[i]->Fill(track_rereco.numberOfValidHits());

--- a/DQM/TrackingMonitorSource/plugins/ShortenedTrackResolution.cc
+++ b/DQM/TrackingMonitorSource/plugins/ShortenedTrackResolution.cc
@@ -2,6 +2,7 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -38,16 +39,25 @@ private:
   const std::vector<edm::InputTag> tracksRerecoTag_;
   const edm::EDGetTokenT<std::vector<reco::Track>> tracksToken_;
   const std::vector<edm::EDGetTokenT<std::vector<reco::Track>>> tracksRerecoToken_;
+  const edm::InputTag beamSpotTag_;
+  const edm::EDGetTokenT<reco::BeamSpot> beamspotToken_;
 
+  // resolutions
   std::vector<MonitorElement *> histsPtRatioAll_;
   std::vector<MonitorElement *> histsPtDiffAll_;
   std::vector<MonitorElement *> histsEtaDiffAll_;
   std::vector<MonitorElement *> histsPhiDiffAll_;
+  std::vector<MonitorElement *> histsdxyDiffAll_;
+  std::vector<MonitorElement *> histsdzDiffAll_;
   std::vector<MonitorElement *> histsPtRatioVsDeltaRAll_;
   std::vector<MonitorElement *> histsDeltaPtOverPtAll_;
+
+  // properties
   std::vector<MonitorElement *> histsPtAll_;
   std::vector<MonitorElement *> histsNhitsAll_;
   std::vector<MonitorElement *> histsDeltaRAll_;
+  std::vector<MonitorElement *> histsdxyAll_;
+  std::vector<MonitorElement *> histsdzAll_;
 };
 
 // -----------------------------
@@ -65,27 +75,23 @@ ShortenedTrackResolution::ShortenedTrackResolution(const edm::ParameterSet &ps)
       tracksRerecoTag_(ps.getUntrackedParameter<std::vector<edm::InputTag>>("tracksRerecoInputTag")),
       tracksToken_(consumes<std::vector<reco::Track>>(tracksTag_)),
       tracksRerecoToken_(edm::vector_transform(
-          tracksRerecoTag_, [this](edm::InputTag const &tag) { return consumes<std::vector<reco::Track>>(tag); })) {
-  histsPtRatioAll_.clear();
-  histsPtDiffAll_.clear();
-  histsEtaDiffAll_.clear();
-  histsPhiDiffAll_.clear();
-  histsPtRatioVsDeltaRAll_.clear();
-  histsDeltaPtOverPtAll_.clear();
-  histsPtAll_.clear();
-  histsNhitsAll_.clear();
-  histsDeltaRAll_.clear();
-
+          tracksRerecoTag_, [this](edm::InputTag const &tag) { return consumes<std::vector<reco::Track>>(tag); })),
+      beamSpotTag_(ps.getUntrackedParameter<edm::InputTag>("BeamSpotTag", edm::InputTag("offlineBeamSpot"))),
+      beamspotToken_(consumes<reco::BeamSpot>(beamSpotTag_)) {
   const size_t n = hitsRemain_.size();
   histsPtRatioAll_.reserve(n);
   histsPtDiffAll_.reserve(n);
   histsEtaDiffAll_.reserve(n);
   histsPhiDiffAll_.reserve(n);
+  histsdxyDiffAll_.reserve(n);
+  histsdzDiffAll_.reserve(n);
   histsPtRatioVsDeltaRAll_.reserve(n);
   histsDeltaPtOverPtAll_.reserve(n);
   histsPtAll_.reserve(n);
   histsNhitsAll_.reserve(n);
   histsDeltaRAll_.reserve(n);
+  histsdxyAll_.reserve(n);
+  histsdzAll_.reserve(n);
 }
 
 //__________________________________________________________________________________
@@ -131,6 +137,16 @@ void ShortenedTrackResolution::bookHistograms(DQMStore::IBooker &iBook,
     title = fmt::sprintf("Short Track #phi - Full Track #phi - %s layers;#phi^{short} - #phi^{full};n. tracks", label);
     histsPhiDiffAll_.push_back(book1D(name, title, 100, -0.001, 0.001));
 
+    name = fmt::sprintf("trackdxyDiff_%s", label);
+    title = fmt::sprintf(
+        "Short Track d_{xy} - Full Track d_{xy} - %s layers;d_{xy}^{short} - d_{xy}^{full} [cm];n. tracks", label);
+    histsdxyDiffAll_.push_back(book1D(name, title, 100, -0.1, 0.1));
+
+    name = fmt::sprintf("trackdzDiff_%s", label);
+    title = fmt::sprintf("Short Track d_{z} - Full Track d_{z} - %s layers;d_{z}^{short} - d_{z}^{full} [cm];n. tracks",
+                         label);
+    histsdzDiffAll_.push_back(book1D(name, title, 100, -0.1, 0.1));
+
     name = fmt::sprintf("trackPtRatioVsDeltaR_%s", label);
     title = fmt::sprintf(
         "Short Track p_{T} / Full Track p_{T} - %s layers vs "
@@ -160,6 +176,14 @@ void ShortenedTrackResolution::bookHistograms(DQMStore::IBooker &iBook,
     title = fmt::sprintf("Short Track n. hits - %s layers;n. hits per track;n. tracks", label);
     histsNhitsAll_.push_back(book1D(name, title, 20, -0.5, 19.5));
 
+    name = fmt::sprintf("trackDxy_%s", label);
+    title = fmt::sprintf("Short Track d_{xy} - %s layers;track d_{xy} [cm];n. tracks", label);
+    histsdxyAll_.push_back(book1D(name, title, 100, -0.025, 0.025));
+
+    name = fmt::sprintf("trackDz_%s", label);
+    title = fmt::sprintf("Short Track d_{z} - %s layers;track d_{z} [cm];n. tracks", label);
+    histsdzAll_.push_back(book1D(name, title, 80, -20, 20));
+
     name = fmt::sprintf("trackDeltaR_%s", label);
     title = fmt::sprintf("Short Track / Full Track #DeltaR - %s layers;#DeltaR(short,full);n. tracks", label);
     histsDeltaRAll_.push_back(book1D(name, title, 100, 0., 0.005));
@@ -174,6 +198,16 @@ void ShortenedTrackResolution::analyze(edm::Event const &iEvent, edm::EventSetup
     edm::LogError("ShortenedTrackResolution") << "Missing input track collection " << tracksTag_.encode() << std::endl;
     return;
   }
+
+  reco::BeamSpot beamSpot;
+  edm::Handle<reco::BeamSpot> beamSpotHandle = iEvent.getHandle(beamspotToken_);
+  if (beamSpotHandle.isValid()) {
+    beamSpot = *beamSpotHandle;
+  } else {
+    beamSpot = reco::BeamSpot();
+  }
+
+  math::XYZPoint BS(beamSpot.x0(), beamSpot.y0(), beamSpot.z0());
 
   for (const auto &track : *tracks) {
     const reco::HitPattern &hp = track.hitPattern();
@@ -196,13 +230,20 @@ void ShortenedTrackResolution::analyze(edm::Event const &iEvent, edm::EventSetup
         if (deltaR < maxDr_) {
           if (track_rereco.pt() >= minTracksPt_ && track_rereco.pt() <= maxTracksPt_ &&
               std::abs(track_rereco.eta()) >= minTracksEta_ && std::abs(track_rereco.eta()) <= maxTracksEta_) {
+            // resolutions
             histsPtRatioAll_[i]->Fill(1.0 * track_rereco.pt() / track.pt());
             histsPtDiffAll_[i]->Fill(track_rereco.pt() - track.pt());
             histsDeltaPtOverPtAll_[i]->Fill((track_rereco.pt() - track.pt()) / track.pt());
             histsEtaDiffAll_[i]->Fill(track_rereco.eta() - track.eta());
             histsPhiDiffAll_[i]->Fill(track_rereco.phi() - track.phi());
+            histsdxyDiffAll_[i]->Fill(track_rereco.dxy(BS) - track.dxy(BS));
+            histsdzDiffAll_[i]->Fill(track_rereco.dz(BS) - track.dz(BS));
             histsPtRatioVsDeltaRAll_[i]->Fill(deltaR, track_rereco.pt() / track.pt());
+
+            // properties
             histsPtAll_[i]->Fill(track_rereco.pt());
+            histsdxyAll_[i]->Fill(track.dxy(BS));
+            histsdzAll_[i]->Fill(track.dz(BS));
             histsNhitsAll_[i]->Fill(track_rereco.numberOfValidHits());
             histsDeltaRAll_[i]->Fill(deltaR);
           }


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50638

#### PR description:

From the original PR:

>  TItle says it all, adds monitoring of the impact parameters for the shortened tracks workflow, both in offline DQM and in the standalone tracker alignment monitoring tool.

#### PR validation:


Run successfully:

```
runTheMatrix.py --what upgrade -l 18450.0 -t 4 -j 8 --nEvents 500 --ibeos -i all
```

and found in the output DQM file the appropriate set of new histograms.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

 backport of https://github.com/cms-sw/cmssw/pull/50638 for the 2026 data-taking release.