### PR TITLE
Add missing dependence on ROOT to CondFormats/MLObjects

### DIFF
--- a/CondFormats/MLObjects/BuildFile.xml
+++ b/CondFormats/MLObjects/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="PhysicsTools/ONNXRuntime"/>
 <use name="CondFormats/Serialization"/>
 <use name="boost_serialization"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
#### PR description:

The package `CondFormats/MLObjects` declares dictionaries and thus needs to depend on ROOT. Discovered in https://github.com/cms-sw/cmsdist/pull/10475#issuecomment-4207890912

Resolves https://github.com/cms-sw/framework-team/issues/2147

#### PR validation:

None