### PR TITLE
Improve `realloc()` handling in AllocMonitor proxies and in IntrusiveAllocProfiler

### DIFF
--- a/PerfTools/AllocMonitor/README.md
+++ b/PerfTools/AllocMonitor/README.md
@@ -165,7 +165,7 @@ These services register monitors when the service is created (after python parsi
 
 void someFunction() {
   {
-    edm::Service<IntrusiveMonitorBase> monitor;
+    edm::Service<edm::IntrusiveMonitorBase> monitor;
     auto guard = monitor->startMonitoring("Measurement description");
 
     // more code doing memory allocations
@@ -224,6 +224,8 @@ The Service has the following configuration parameters
 |-----------|---------|-------------|
 | `filePattern` | empty | If empty, print the repots with MessageLogger. If non-empty, specifies the pattern for output text files. Must contain at least one `%I` for a file counter, and `%M` for the measurement name. |
 | `statistics` | `False` | If `True`, print internal statistics to the log. |
+| `deallocationReport` | `True` | Allows to disable deallocation report (can speed up the profiling in presence of deep stack traces) |
+| `churnReport` | `True` | Allows to disable churn report (can speed up the profiling in presence of deep stack traces) |
 
 By default all reports are printed with MessageLogger. With `filePattern` the reports are written into files, with the file names being printed with MessageLogger at the time when each measurment ends. The `edmIntrusiveAllocProfilerFoldStacks.py` script can be used to "fold" the stack traces to a format understood e.g. flamegraph tools such as https://github.com/brendangregg/FlameGraph for one quantity at a time. An example
 ```sh

--- a/PerfTools/AllocMonitor/plugins/IntrusiveAllocProfiler.cc
+++ b/PerfTools/AllocMonitor/plugins/IntrusiveAllocProfiler.cc
@@ -529,11 +529,14 @@ namespace {
               auto deallocEntries = deallocTraceStrings | std::views::reverse;
 
               auto [it_alloc, it_dealloc] = std::ranges::mismatch(allocEntries, deallocEntries);
-              assert(it_alloc != allocEntries.end() and it_dealloc != deallocEntries.end());
-
-              // Because the comparisons were done with strings, the
-              // it_alloc and it_dealloc should point to different
-              // functions. Go one level up (toward outer frames) to find the common function
+              // If it_alloc and it_dealloc point to different
+              // functions, go one level up (toward outer frames) to
+              // find the common function.
+              //
+              // If it_alloc and it_dealloc point to the same function
+              // (can happen at least with realloc()), it_alloc would
+              // point to allocEntries.end(), and to get the lowest
+              // entry need to decrease the iterator as well.
               assert(it_alloc != allocEntries.begin());
               --it_alloc;
 

--- a/PerfTools/AllocMonitor/plugins/IntrusiveAllocProfiler.cc
+++ b/PerfTools/AllocMonitor/plugins/IntrusiveAllocProfiler.cc
@@ -245,14 +245,21 @@ namespace {
   class StackNodeData;
   using MonitorStackNode = cms::perftools::allocMon::MonitorStackNode<StackNodeData>;
 
+  struct ReportConfiguration {
+    bool printStatistics_ = false;
+    bool deallocationReport_ = true;
+    bool churnReport_ = true;
+  };
+
   class StackNodeData {
   public:
-    StackNodeData(std::stacktrace trace, unsigned int fileCount, std::string filePattern, bool printStatistics)
+    StackNodeData(std::stacktrace trace, unsigned int fileCount, std::string filePattern, ReportConfiguration config)
         : trace_(std::move(trace)),
           filePattern_(std::move(filePattern)),
-          statistics_(printStatistics ? static_cast<std::unique_ptr<StatisticsStrategy>>(
-                                            std::make_unique<CollectingStatisticsStrategy>())
-                                      : std::make_unique<NoOpStatisticsStrategy>()) {
+          statistics_(config.printStatistics_ ? static_cast<std::unique_ptr<StatisticsStrategy>>(
+                                                    std::make_unique<CollectingStatisticsStrategy>())
+                                              : std::make_unique<NoOpStatisticsStrategy>()),
+          config_(config) {
       // Skip first entries that are internals for AllocMonitor if they are in the trace
       // By experience these entries are not always part of the stack trace
       auto it = trace_.cbegin();
@@ -329,8 +336,12 @@ namespace {
       log.format(" Reported stack traces are based on\n{}", formatTrace(trace_, startFromEntry_, 0));
 
       printAllocations(log, measurementName);
-      printDeallocations(log, measurementName);
-      printChurn(log, measurementName);
+      if (config_.deallocationReport_) {
+        printDeallocations(log, measurementName);
+      }
+      if (config_.churnReport_) {
+        printChurn(log, measurementName);
+      }
 
       statistics_->printStatistics(log, uniqueAllocTraces_.size(), uniqueDeallocTraces_.size());
     }
@@ -699,6 +710,7 @@ namespace {
     std::size_t stackDepth_ = 0;
     std::string filePattern_;
     std::unique_ptr<StatisticsStrategy> statistics_;
+    ReportConfiguration config_;
 
     // Collection of stack traces
     long long presentActual_ = 0;
@@ -733,14 +745,14 @@ namespace {
 
   class MonitorAdaptor : public cms::perftools::AllocMonitorBase {
   public:
-    static void startOnThread(std::string_view name, std::string filePattern, bool printStatistics) {
+    static void startOnThread(std::string_view name, std::string filePattern, ReportConfiguration config) {
       threadActiveMonitoring() = false;
       auto trace = std::stacktrace::current();
       auto const fileCount = globalFileCounter().fetch_add(1);
       auto node = std::make_unique<MonitorStackNode>(
           name,
           std::move(currentMonitorStackNode()),
-          StackNodeData(std::move(trace), fileCount, std::move(filePattern), printStatistics));
+          StackNodeData(std::move(trace), fileCount, std::move(filePattern), config));
       {
         edm::LogSystem log("IntrusiveAllocProfiler");
         using namespace cms::perftools::allocMon;
@@ -794,7 +806,9 @@ class IntrusiveAllocProfiler : public edm::IntrusiveMonitorBase {
 public:
   IntrusiveAllocProfiler(edm::ParameterSet const& iPSet)
       : pattern_(iPSet.getUntrackedParameter<std::string>("filePattern")),
-        printStatistics_(iPSet.getUntrackedParameter<bool>("statistics")) {
+        config_{.printStatistics_ = iPSet.getUntrackedParameter<bool>("statistics"),
+                .deallocationReport_ = iPSet.getUntrackedParameter<bool>("deallocationReport"),
+                .churnReport_ = iPSet.getUntrackedParameter<bool>("churnReport")} {
     if (not pattern_.empty()) {
       if (not pattern_.contains("%I")) {
         throw edm::Exception(edm::errors::Configuration) << "filePattern did not contain '%I'";
@@ -808,9 +822,7 @@ public:
   };
   ~IntrusiveAllocProfiler() noexcept override = default;
 
-  void start(std::string_view name, bool nameIsString) final {
-    MonitorAdaptor::startOnThread(name, pattern_, printStatistics_);
-  }
+  void start(std::string_view name, bool nameIsString) final { MonitorAdaptor::startOnThread(name, pattern_, config_); }
   void stop(std::string_view name) noexcept final { MonitorAdaptor::stopOnThread(name); }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& iDesc) {
@@ -822,12 +834,20 @@ public:
             "'churnalloc'). If empty (default), results are printed with MessageLogger.");
     ps.addUntracked<bool>("statistics", false)
         ->setComment("Whether to print some timing statistics about the memory measurement itself. Default is false.");
+    ps.addUntracked<bool>("deallocationReport", true)
+        ->setComment(
+            "Whether to produce a report on deallocations. On deep stack traces this can take time, so turning it off "
+            "could speed up if the deallocation report is not needed");
+    ps.addUntracked<bool>("churnReport", true)
+        ->setComment(
+            "Whether to produce reports on memory churn. On deep stack traces this can take time, so turning it off "
+            "could speed up if the deallocation report is not needed");
     iDesc.addDefault(ps);
   }
 
 private:
   std::string pattern_;
-  bool printStatistics_ = false;
+  ReportConfiguration const config_;
 };
 
 typedef edm::serviceregistry::ParameterSetMaker<edm::IntrusiveMonitorBase, IntrusiveAllocProfiler>

--- a/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/test/test_intrusiveAllocMonitor.cc
@@ -12,7 +12,33 @@
 #include <format>
 #include <memory>
 #include <string_view>
+#include <tuple>
 #include <vector>
+
+[[gnu::noinline]] std::tuple<int*, int> testReallocInner(int* ptr, int oldsize) {
+  int size = oldsize + 10;
+  ptr = static_cast<int*>(realloc(ptr, size * sizeof(int)));
+  for (int i = oldsize; i < size; ++i) {
+    ptr[i] = i * 2;
+  }
+
+  oldsize = size;
+  size = oldsize + 20;
+  ptr = static_cast<int*>(realloc(ptr, size * sizeof(int)));
+  for (int i = oldsize; i < size; ++i) {
+    ptr[i] = i * 3 - 42;
+  }
+  return std::tuple(ptr, size);
+}
+
+[[gnu::noinline]] std::tuple<int*, int> testRealloc() {
+  int size = 10;
+  int* ptr = static_cast<int*>(malloc(size * sizeof(int)));
+  for (int i = 0; i < size; ++i) {
+    ptr[i] = i + 10;
+  }
+  return testReallocInner(ptr, size);
+}
 
 [[gnu::noinline]] std::vector<int> nestedChurn() {
   std::vector<int> vec;
@@ -171,6 +197,20 @@ process.add_(cms.Service('{}'))
     edm::LogPrint("Test").format("Sum {}", sum);
   }
   edm::LogPrint("Test").format("====================");
+
+  edm::LogPrint("Test").format("Test realloc");
+  {
+    int sum = 0;
+    {
+      auto guard = imb->startMonitoring("Realloc");
+      auto [rawPtr, size] = testRealloc();
+      for (int i = 0; i < size; ++i) {
+        sum += rawPtr[size];
+      }
+      free(rawPtr);
+    }
+    edm::LogPrint("Test").format("Sum {}", sum);
+  }
 
   return 0;
 }

--- a/PerfTools/AllocMonitor/test/verifyIntrusiveAllocMonitor.py
+++ b/PerfTools/AllocMonitor/test/verifyIntrusiveAllocMonitor.py
@@ -417,14 +417,52 @@ def verify_nested_churning(test_case):
         raise ValueError(f"nested churning: expected sum 149935000, got {test_case['sum']}")
 
 
+def verify_realloc(test_case):
+    """Verify conditions for 'realloc' test case."""
+    name = test_case['name']
+    if name != 'realloc':
+        raise ValueError(f"Expected 'realloc', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 1:
+        raise ValueError(f"realloc: expected 1 message, got {len(messages)}")
+
+    msg = messages[0]
+
+    # Check labels
+    expected_labels = ['Realloc']
+    if msg['labels'] != expected_labels:
+        raise ValueError(f"realloc: expected labels {expected_labels}, got {msg['labels']}")
+
+    # added is 0: all memory is freed within the scope
+    if msg['added'] != 0:
+        raise ValueError(f"realloc: added must be 0 (all memory freed), got {msg['added']}")
+
+    # nAlloc equals nDealloc (all allocations freed)
+    if msg['nAlloc'] != msg['nDealloc']:
+        raise ValueError(f"realloc: nAlloc ({msg['nAlloc']}) must equal nDealloc ({msg['nDealloc']})")
+
+    # nAlloc is at least 3 (malloc + 2 reallocs)
+    if msg['nAlloc'] < 3:
+        raise ValueError(f"realloc: nAlloc must be >= 3 (malloc + 2 reallocs), got {msg['nAlloc']}")
+
+    # requested, peak, and max_alloc are larger than 0
+    if msg['requested'] <= 0:
+        raise ValueError(f"realloc: requested must be > 0, got {msg['requested']}")
+    if msg['peak'] <= 0:
+        raise ValueError(f"realloc: peak must be > 0, got {msg['peak']}")
+    if msg['max_alloc'] <= 0:
+        raise ValueError(f"realloc: max alloc must be > 0, got {msg['max_alloc']}")
+
+
 def main():
     """Main function to parse and verify IntrusiveAllocMonitor output."""
     try:
         test_cases = read_test_cases()
 
-        # Check that we have exactly 6 test cases
-        if len(test_cases) != 6:
-            raise ValueError(f"Expected exactly 6 test cases, got {len(test_cases)}")
+        # Check that we have exactly 7 test cases
+        if len(test_cases) != 7:
+            raise ValueError(f"Expected exactly 7 test cases, got {len(test_cases)}")
 
         # Verify each test case
         verify_vector_fill(test_cases[0])
@@ -433,6 +471,7 @@ def main():
         verify_nested_allocation(test_cases[3])
         verify_nested_with_string_messages(test_cases[4])
         verify_nested_churning(test_cases[5])
+        verify_realloc(test_cases[6])
 
         # All checks passed, exit silently with code 0
         sys.exit(0)

--- a/PerfTools/AllocMonitor/test/verifyIntrusiveAllocProfiler.py
+++ b/PerfTools/AllocMonitor/test/verifyIntrusiveAllocProfiler.py
@@ -623,13 +623,63 @@ def verify_nested_churning(test_case):
         raise ValueError(f"nested churning: expected sum 149935000, got {test_case['sum']}")
 
 
+def verify_realloc(test_case):
+    """Verify the 'realloc' test case."""
+    name = test_case['name']
+    if name != 'realloc':
+        raise ValueError(f"Expected test 'realloc', got '{name}'")
+
+    messages = test_case['messages']
+    if len(messages) != 1:
+        raise ValueError(f"realloc: expected 1 message, got {len(messages)}")
+
+    msg = messages[0]
+    if msg['name'] != 'Realloc':
+        raise ValueError(f"realloc: expected message name 'Realloc', got '{msg['name']}'")
+
+    alloc_t = totals(msg['alloc'])
+    dealloc_t = totals(msg['dealloc'], 'dealloc')
+
+    # At least 3 allocations: malloc + 2 reallocs
+    if alloc_t['count'] < 3:
+        raise ValueError(f"realloc: alloc count must be >= 3 (malloc + 2 reallocs), got {alloc_t['count']}")
+
+    # All memory freed within the scope: added must be empty
+    if msg['added']:
+        raise ValueError("realloc: added section must be empty (all memory freed within scope)")
+
+    # All allocations were freed: dealloc count equals alloc count
+    if dealloc_t['count'] != alloc_t['count']:
+        raise ValueError(
+            f"realloc: dealloc count ({dealloc_t['count']}) must equal "
+            f"alloc count ({alloc_t['count']})"
+        )
+
+    # Churn section must be non-empty (all allocations are alloc+free within scope)
+    if not msg['churn']:
+        raise ValueError("realloc: churn section must be non-empty")
+
+    # churnalloc totals match churn totals
+    churn_t = totals(msg['churn'])
+    churnalloc_t = totals(msg['churnalloc'])
+    if churnalloc_t['count'] != churn_t['count']:
+        raise ValueError(f"realloc: churnalloc count ({churnalloc_t['count']}) must equal churn count ({churn_t['count']})")
+    if churnalloc_t['actual'] != churn_t['actual']:
+        raise ValueError(f"realloc: churnalloc actual ({churnalloc_t['actual']}) must equal churn actual ({churn_t['actual']})")
+
+    # At peak, two buffers are simultaneously live (old + new during the final realloc)
+    atMaxActual_t = totals(msg['atMaxActual'])
+    if atMaxActual_t['count'] != 2:
+        raise ValueError(f"realloc: atMaxActual count must be 2 (two buffers live during realloc peak), got {atMaxActual_t['count']}")
+
+
 def main():
     """Main: parse and verify IntrusiveAllocProfiler output from stdin."""
     try:
         test_cases = read_test_cases()
 
-        if len(test_cases) != 6:
-            raise ValueError(f"Expected exactly 6 test cases, got {len(test_cases)}")
+        if len(test_cases) != 7:
+            raise ValueError(f"Expected exactly 7 test cases, got {len(test_cases)}")
 
         verify_vector_fill(test_cases[0])
         verify_vector_fill_again(test_cases[1])
@@ -637,6 +687,7 @@ def main():
         verify_nested_allocation(test_cases[3])
         verify_nested_with_string_messages(test_cases[4])
         verify_nested_churning(test_cases[5])
+        verify_realloc(test_cases[6])
 
         sys.exit(0)
 

--- a/PerfTools/AllocMonitorPreload/src/memory_proxies.cc
+++ b/PerfTools/AllocMonitorPreload/src/memory_proxies.cc
@@ -230,8 +230,18 @@ void* realloc(void* ptr, size_t size) noexcept {
   }
   size_t used = malloc_usable_size(ret);
   if (used != oldsize) {
-    reg.deallocCalled(ptr, [](auto) {}, [oldsize](auto) { return oldsize; });
-    reg.allocCalled(size, [ret]() { return ret; }, [used](auto) { return used; });
+    if (ret == ptr) {
+      // If the allocation was extended (in which case the address ought to stay the same), signal dealloc+alloc in
+      // order to allow an assumption in the AllocMonitor implementations that each memory address looks like being
+      // "allocated" at most once at all times
+      reg.deallocCalled(ptr, [](auto) {}, [oldsize](auto) { return oldsize; });
+      reg.allocCalled(size, [ret]() { return ret; }, [used](auto) { return used; });
+    } else {
+      // If realloc() returns a new address it must have allocated the new address first in order to copy the contents
+      // from the old address. Signaling alloc+dealloc makes the peak memory tracking closer to reality.
+      reg.allocCalled(size, [ret]() { return ret; }, [used](auto) { return used; });
+      reg.deallocCalled(ptr, [](auto) {}, [oldsize](auto) { return oldsize; });
+    }
   }
   return ret;
 }


### PR DESCRIPTION
#### PR description:

While investigating https://github.com/cms-sw/cmssw/pull/50292#issuecomment-4158533647 I encountered `IntrusiveAllocProfiler` to die in assertion failure in case of `realloc()` (that was called by LLVM during ROOT's header parsing). The assertion assumed that an address gets allocated and deallocated by different functions, which is not the case with an address that gets allocated by a `realloc()` and deallocated by a subsequent `realloc()` in the same function. The assertion turned out to be unnecessary, so it is removed (and comments there extended).

While extending the tests of `IntrusiveAllocMonitor` I noticed (with the help of an AI agent) that the present way to model `realloc()` in the AllocMonitor memory proxies as dealloc+alloc does not reflect the reality when the `realloc()` allocates a new address. In that case the `realloc()` internally must allocate the new address, copy the contents, and deallocate the old address. This difference can have an impact in the tracking of peak memory usage, so this PR adds that case in the `realloc()` proxy.

This PR also adds configuration options to `IntrusiveAllocProfiler` to disable deallocation and churn reports (they are enabled by default). Disabling those can be useful in presence of deep stack traces (ROOT header parsing can go over 200 stack frames) when the user is not interested in those reports.

Resolves https://github.com/cms-sw/framework-team/issues/2148


#### PR validation:

Tests pass. The profiled job ran and produced a useful profile.