### PR TITLE
[16_1_X] Add zero initialization of PF layer cluster SoA

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
@@ -170,10 +170,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       pfClusteringVars_.emplace(event.queue(), nRH);
       pfClusteringEdgeVars_.emplace(event.queue(), nRH * 8);
       pfClusters_.emplace(event.queue(), nRH);
+      pfClusters_->zeroInitialise(event.queue());
 
       *numRHF_ = 0;
-
-      if (nRH != 0) {
+      if (nRH == 0) {
+        pfClusters_->zeroInitialise(event.queue());
+      } else {
         PFClusterProducerKernel kernel(event.queue());
         kernel.seedTopoAndContract(event.queue(),
                                    params.const_view(),


### PR DESCRIPTION
#### PR description:
This PR addresses a downstream issue in PF clustering when Alpaka-based multi-depth clustering is enabled. In a rare case like https://github.com/cms-sw/cmssw/issues/44668 when HCAL is out, the layer cluster SoA must be initialized to prevent a crash in `RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterSoAProducer.cc`.

#### PR validation:

The PR was validated (in 16_0_X) by running an HLT menu using Alpaka-based multi-depth clustering on the data initially saved from the linked issue.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of #50670 meant for `16_1_X`
