### PR TITLE
Disabled ROCs for Online DQM Pixel Summary 2026 [BP 16_1_X]

### DIFF
--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -272,7 +272,7 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
   //Fill the dead ROC summary
   std::vector<trendPlots> trendOrder = {layer1, layer2, layer3, layer4, ring1, ring2};
   std::vector<int> nRocsPerTrend = {1536, 3584, 5632, 8192, 4224, 6528};
-  std::vector<int> nDisabledRocs = {16, 152, 272, 320, 368, 256};
+  std::vector<int> nDisabledRocs = {76, 168, 288, 320, 408, 256};
   for (unsigned int i = 0; i < trendOrder.size(); i++) {
     int xBin = i < 4 ? 1 : 2;
     int yBin = i % 4 + 1;


### PR DESCRIPTION
Yearly update of number of Disabled ROCs for Online DQM Pixel Summary: 6 values taken from [TWiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/PixelKnownProblems#2026) (updated by Pixel Ops team).

#### About backport
This PR is intended for 2026 data taking. Backport to 16_1_X of PR #50698