### PR TITLE
Fix clang build errors due to #define accidentally removed

### DIFF
--- a/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc
@@ -7,6 +7,11 @@
  *   - SimCluster "merged" : takes "boundary" SimClusters and merges them according to some algorithm (to merge SimClusters that are not separable at reconstruction level)
  *  and RefVectors to map back to CaloParticle (and map "boundary" to "merged")
  */
+
+// Switch to true to compile debug printouts and dump the graph to graphviz format
+// should be defined before including DecayGraph.h
+#define DEBUG false
+
 #include <iterator>
 #include <algorithm>
 #include <memory>


### PR DESCRIPTION
#### PR description:
In https://github.com/cms-sw/cmssw/pull/50578 I accidentaly removed a `#define DEBUG false`, which causes build errors in clang (reported [here](https://github.com/cms-sw/cmssw/pull/50578#discussion_r3068189240)). 
This PR adds it back.

FYI @smuzaffar 



