### PR TITLE
Schedule MPI communication in runAsync to avoid deadlocks

### DIFF
--- a/HeterogeneousCore/MPICore/plugins/MPIController.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIController.cc
@@ -185,7 +185,9 @@ MPIController::~MPIController() {
   // Disconnect the per-stream communicators.
   for (auto& stream : streams_) {
     // TODO move this to end stream
-    stream->reset();
+    if (stream) {
+      stream->reset();
+    }
   }
 
   // Close the intercommunicator.

--- a/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
@@ -64,6 +64,8 @@ public:
 
       products_.emplace_back(std::move(entry));
     }
+
+    received_wrappers_.resize(products_.size());
   }
 
   void acquire(edm::Event const& event, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder holder) final {
@@ -75,17 +77,87 @@ public:
     edm::Service<edm::Async> as;
     as->runAsync(
         std::move(holder),
-        [this, token]() { token.channel()->receiveMetadata(instance_, received_meta_); },
+        [this, token]() {
+          token.channel()->receiveMetadata(instance_, received_meta_);
+#ifdef EDM_ML_DEBUG
+          // dump the summary of metadata
+          received_meta_->debugPrintMetadataSummary();
+#endif
+
+          // if filter was false before the sender, receive nothing
+          if (received_meta_->productCount() == -1) {
+            return;
+          }
+
+          std::unique_ptr<TBufferFile> serialized_buffer;
+          if (received_meta_->hasSerialized()) {
+            serialized_buffer =
+                token.channel()->receiveSerializedBuffer(instance_, received_meta_->serializedBufferSize());
+#ifdef EDM_ML_DEBUG
+            {
+              edm::LogSystem msg("MPIReceiver");
+              msg << "Received serialised product:\n";
+              for (int i = 0; i < received_meta_->serializedBufferSize(); ++i) {
+                msg << "0x" << std::hex << std::setw(2) << std::setfill('0')
+                    << (unsigned int)(unsigned char)serialized_buffer->Buffer()[i] << (i % 16 == 15 ? '\n' : ' ');
+              }
+            }
+#endif
+          }
+
+          for (size_t i = 0; i < products_.size(); ++i) {
+            auto product_meta = received_meta_->getNext();
+            if (product_meta.kind == ProductMetadata::Kind::Missing) {
+              continue;
+            }
+
+            auto const& entry = products_[i];
+
+            if (product_meta.kind == ProductMetadata::Kind::Serialized) {
+              std::unique_ptr<edm::WrapperBase> wrapper(
+                  reinterpret_cast<edm::WrapperBase*>(entry.wrappedType.getClass()->New()));
+              assert(static_cast<int32_t>(serialized_buffer->Length() + product_meta.sizeMeta) <=
+                         received_meta_->serializedBufferSize() &&
+                     "serialized data buffer is shorter than expected");
+              entry.wrappedType.getClass()->Streamer(wrapper.get(), *serialized_buffer);
+              received_wrappers_[i] = std::move(wrapper);
+            }
+
+            else if (product_meta.kind == ProductMetadata::Kind::TrivialCopy) {
+              if (not enableTrivialSerialisation_) {
+                edm::LogError("MPIReceiver")
+                    << "Received a trivially-serialised product, but enableTrivialSerialisation is set to false in "
+                       "this MPIReceiver. Please check that the MPISender and MPIReceiver have consistent settings.";
+                MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+              }
+              std::unique_ptr<ngt::SerialiserBase> serialiser =
+                  ngt::SerialiserFactory::get()->tryToCreate(entry.type.typeInfo().name());
+              if (not serialiser) {
+                throw cms::Exception("SerializerError")
+                    << "Receiver could not retrieve its serializer when it was expected";
+              }
+              auto writer = serialiser->writer();
+              ngt::AnyBuffer buffer = writer->uninitialized_parameters();  // constructs buffer with typeid
+              assert(buffer.size_bytes() == product_meta.sizeMeta);
+              std::memcpy(buffer.data(), product_meta.trivialCopyOffset, product_meta.sizeMeta);
+              writer->initialize(buffer);
+              token.channel()->receiveInitializedTrivialCopy(instance_, *writer);
+              writer->finalize();
+              received_wrappers_[i] = writer->get();
+            }
+          }
+
+          if (received_meta_->hasSerialized()) {
+            assert(serialized_buffer->Length() == received_meta_->serializedBufferSize() &&
+                   "serialized data buffer is not equal to the expected length");
+          }
+        },
         []() { return "Calling MPIReceiver::acquire()"; });
   }
 
   void produce(edm::Event& event, edm::EventSetup const&) final {
     // read the MPIToken used to establish the communication channel
     MPIToken token = event.get(upstream_);
-#ifdef EDM_ML_DEBUG
-    // dump the summary of metadata
-    received_meta_->debugPrintMetadataSummary();
-#endif
 
     // if filter was false before the sender, receive nothing
     if (received_meta_->productCount() == -1) {
@@ -96,66 +168,12 @@ public:
       event.emplace(pathStateToken_);
     }
 
-    std::unique_ptr<TBufferFile> serialized_buffer;
-    if (received_meta_->hasSerialized()) {
-      serialized_buffer = token.channel()->receiveSerializedBuffer(instance_, received_meta_->serializedBufferSize());
-#ifdef EDM_ML_DEBUG
-      {
-        edm::LogSystem msg("MPISender");
-        msg << "Received serialised product:\n";
-        for (int i = 0; i < received_meta_->serializedBufferSize(); ++i) {
-          msg << "0x" << std::hex << std::setw(2) << std::setfill('0')
-              << (unsigned int)(unsigned char)serialized_buffer->Buffer()[i] << (i % 16 == 15 ? '\n' : ' ');
-        }
+    for (size_t i = 0; i < products_.size(); ++i) {
+      if (received_wrappers_[i]) {
+        event.put(products_[i].token, std::move(received_wrappers_[i]));
+      } else {
+        edm::LogWarning("MPIReceiver") << "Product " << products_[i].type.name() << " was not received.";
       }
-#endif
-    }
-
-    for (auto const& entry : products_) {
-      auto product_meta = received_meta_->getNext();
-      if (product_meta.kind == ProductMetadata::Kind::Missing) {
-        edm::LogWarning("MPIReceiver") << "Product " << entry.type.name() << " was not received.";
-        continue;  // Skip products that weren't sent
-      }
-
-      else if (product_meta.kind == ProductMetadata::Kind::Serialized) {
-        std::unique_ptr<edm::WrapperBase> wrapper(
-            reinterpret_cast<edm::WrapperBase*>(entry.wrappedType.getClass()->New()));
-        assert(static_cast<int32_t>(serialized_buffer->Length() + product_meta.sizeMeta) <=
-                   received_meta_->serializedBufferSize() &&
-               "serialized data buffer is shorter than expected");
-        entry.wrappedType.getClass()->Streamer(wrapper.get(), *serialized_buffer);
-        // put the data into the Event
-        event.put(entry.token, std::move(wrapper));
-      }
-
-      else if (product_meta.kind == ProductMetadata::Kind::TrivialCopy) {
-        if (not enableTrivialSerialisation_) {
-          edm::LogError("MPIReceiver")
-              << "Received a trivially-serialised product, but enableTrivialSerialisation is set to false in this "
-                 "MPIReceiver. Please check that the MPISender and MPIReceiver have consistent settings.";
-          MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
-        }
-        std::unique_ptr<ngt::SerialiserBase> serialiser =
-            ngt::SerialiserFactory::get()->tryToCreate(entry.type.typeInfo().name());
-        if (not serialiser) {
-          throw cms::Exception("SerializerError") << "Receiver could not retrieve its serializer when it was expected";
-        }
-        auto writer = serialiser->writer();
-        ngt::AnyBuffer buffer = writer->uninitialized_parameters();  // constructs buffer with typeid
-        assert(buffer.size_bytes() == product_meta.sizeMeta);
-        std::memcpy(buffer.data(), product_meta.trivialCopyOffset, product_meta.sizeMeta);
-        writer->initialize(buffer);
-        token.channel()->receiveInitializedTrivialCopy(instance_, *writer);
-        writer->finalize();
-        // put the data into the Event
-        event.put(entry.token, writer->get());
-      }
-    }
-
-    if (received_meta_->hasSerialized()) {
-      assert(serialized_buffer->Length() == received_meta_->serializedBufferSize() &&
-             "serialized data buffer is not equal to the expected length");
     }
 
     // write a shallow copy of the channel to the output, so other modules can consume it
@@ -207,6 +225,7 @@ private:
   bool activity_;                           // indicator whether the PathStateToken will be received by the module
   edm::EDPutTokenT<edm::PathStateToken> pathStateToken_;
   std::shared_ptr<ProductMetadataBuilder> received_meta_;
+  std::vector<std::unique_ptr<edm::WrapperBase>> received_wrappers_;
   bool enableTrivialSerialisation_ = true;
 };
 

--- a/HeterogeneousCore/MPICore/plugins/MPISender.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISender.cc
@@ -112,6 +112,13 @@ public:
     const MPIToken& token = event.get(upstream_);
     // pass the number of products to estimate the right size for the metadata buffer
     auto meta = std::make_shared<ProductMetadataBuilder>(products_.size());
+
+    // We use std::shared_ptr, instead of std::unique_ptr, so that readers can
+    // be captured by move by runAsync's lamnda. This is ultimately because this
+    // lambda is used to construct an std::function, which requires its callable
+    // to be copy-constructible.
+    std::vector<std::shared_ptr<const ngt::ReaderBase>> readers;
+    readers.reserve(products_.size());
     size_t index = 0;
     buffer_->Reset();
     has_serialized_ = false;
@@ -145,6 +152,7 @@ public:
             auto reader = serialiser->reader(*wrapper);
             ngt::AnyBuffer buffer = reader->parameters();
             meta->addTrivialCopy(buffer.data(), buffer.size_bytes());
+            readers.push_back(std::move(reader));
           } else {
             LogDebug("MPISender") << "No serializer for type \"" << entry.type.name() << "\" ("
                                   << entry.type.typeInfo().name() << "), using ROOT serialization";
@@ -169,50 +177,32 @@ public:
     edm::Service<edm::Async> as;
     as->runAsync(
         std::move(holder),
-        [this, token, meta = std::move(meta)]() { token.channel()->sendMetadata(instance_, meta); },
+        [this, token, meta = std::move(meta), readers = std::move(readers)]() {
+          token.channel()->sendMetadata(instance_, meta);
+          if (has_serialized_) {
+#ifdef EDM_ML_DEBUG
+            {
+              edm::LogSystem msg("MPISender");
+              msg << "Sending serialised product:\n";
+              for (int i = 0; i < buffer_->Length(); ++i) {
+                msg << "0x" << std::hex << std::setw(2) << std::setfill('0')
+                    << (unsigned int)(unsigned char)buffer_->Buffer()[i] << (i % 16 == 15 ? '\n' : ' ');
+              }
+            }
+#endif
+            token.channel()->sendBuffer(buffer_->Buffer(), buffer_->Length(), instance_, EDM_MPI_SendSerializedProduct);
+          }
+          for (auto const& reader : readers) {
+            token.channel()->sendTrivialCopyProduct(instance_, *reader);
+          }
+        },
         []() { return "Calling MPISender::acquire()"; });
   }
 
   void produce(edm::Event& event, edm::EventSetup const&) final {
-    MPIToken token = event.get(upstream_);
-
-    if (!is_active_) {
-      event.emplace(token_, token);
-      return;
-    }
-
-    if (has_serialized_) {
-#ifdef EDM_ML_DEBUG
-      {
-        edm::LogSystem msg("MPISender");
-        msg << "Sending serialised product:\n";
-        for (int i = 0; i < buffer_->Length(); ++i) {
-          msg << "0x" << std::hex << std::setw(2) << std::setfill('0')
-              << (unsigned int)(unsigned char)buffer_->Buffer()[i] << (i % 16 == 15 ? '\n' : ' ');
-        }
-      }
-#endif
-      token.channel()->sendBuffer(buffer_->Buffer(), buffer_->Length(), instance_, EDM_MPI_SendSerializedProduct);
-    }
-
-    for (auto const& entry : products_) {
-      edm::Handle<edm::WrapperBase> handle(entry.type.typeInfo());
-      event.getByToken(entry.token, handle);
-      edm::WrapperBase const* wrapper = handle.product();
-      // we don't send missing products
-      if (handle.isValid()) {
-        std::unique_ptr<ngt::SerialiserBase> serialiser;
-        if (enableTrivialSerialisation_) {
-          serialiser = ngt::SerialiserFactory::get()->tryToCreate(entry.type.typeInfo().name());
-        }
-        if (serialiser) {
-          auto reader = serialiser->reader(*wrapper);
-          token.channel()->sendTrivialCopyProduct(instance_, *reader);
-        }
-      }
-    }
     // write a shallow copy of the channel to the output, so other modules can consume it
     // to indicate that they should run after this
+    MPIToken token = event.get(upstream_);
     event.emplace(token_, token);
   }
 

--- a/HeterogeneousCore/MPICore/test/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/test/BuildFile.xml
@@ -46,3 +46,8 @@
   name="testMPIAutosplitter"
   command="testAutomaticSplitter.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/scripts/edmMpiSplitConfig ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/configutration_for_automatic_splitter.py"
 />
+
+<test
+  name="testMPITooManyStreams"
+  command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_too_many_streams_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_too_many_streams_cfg.py"
+/>

--- a/HeterogeneousCore/MPICore/test/controller_too_many_streams_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_too_many_streams_cfg.py
@@ -1,0 +1,71 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MPIController")
+
+
+# This test tests two different scenarios that can lead to errors.
+
+# 1. It tests that streams that remain uninitialized are handled correctly by
+# the MPI modules. This situation is reproduced by setting numberOfStreams
+# higher than the number of events.
+
+# 2. Due to the non-deterministic task scheduling in CMSSW, non-matching MPI
+# modules might be scheduled in the local and remote process. This is ok, unless
+# these modules contain blocking MPI calls. In this case, if they utilize all
+# available working threads, the execution will deadlock. The probability of
+# this to happen is close to 100% when numberOfStreams >> numberOfThreads
+
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 40
+# MPIController supports a single concurrent LuminosityBlock
+process.options.numberOfConcurrentLuminosityBlocks = 1
+process.options.numberOfConcurrentRuns = 1
+process.options.wantSummary = False
+
+process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+
+from eventlist_cff import eventlist
+process.source = cms.Source("EmptySourceFromEventIDs",
+    events = cms.untracked(eventlist)
+)
+
+process.maxEvents.input = 10
+
+from HeterogeneousCore.MPICore.modules import *
+
+process.mpiController = MPIController(
+    mode = 'CommWorld'
+)
+
+process.ids = cms.EDProducer("edmtest::EventIDProducer")
+
+process.initialcheck = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag('ids')
+)
+
+process.sender = MPISender(
+    upstream = "mpiController",
+    instance = 42,
+    products = [ "edmEventID_ids__*" ]
+)
+
+process.othersender = MPISender(
+    upstream = "mpiController",
+    instance = 19,
+    products = [ "edmEventID_ids__*" ]
+)
+
+process.receiver = MPIReceiver(
+    upstream = "othersender",   # guarantees that this module will only run after "othersender" has run
+    instance = 99,
+    products = [ dict(
+        type = "edm::EventID",
+        label = ""
+    )]
+)
+
+process.finalcheck = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag('receiver')
+)
+
+process.path = cms.Path(process.mpiController + process.ids + process.initialcheck + process.sender + process.othersender + process.receiver + process.finalcheck)

--- a/HeterogeneousCore/MPICore/test/follower_too_many_streams_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_too_many_streams_cfg.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MPIFollower")
+
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 40
+process.options.numberOfConcurrentLuminosityBlocks = 2
+process.options.numberOfConcurrentRuns = 2
+process.options.wantSummary = False
+
+process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+
+from HeterogeneousCore.MPICore.modules import *
+
+process.source = MPISource(
+    mode = 'CommWorld',
+    controller = 0
+)
+
+process.maxEvents.input = -1
+
+# very verbose
+#from HeterogeneousCore.MPICore.mpiReporter_cfi import mpiReporter as mpiReporter_
+#process.reporter = mpiReporter_.clone()
+
+process.receiver = MPIReceiver(
+    upstream = "source",
+    instance = 42,
+    products = [ dict(
+        type = "edm::EventID",
+        label = ""
+    )]
+)
+
+process.otherreceiver = MPIReceiver(
+    upstream = "source",
+    instance = 19,
+    products = [ dict(
+        type = "edm::EventID",
+        label = ""
+    )]
+)
+
+process.sender = MPISender(
+    upstream = "otherreceiver", # guarantees that this module will only run after otherreceiver has run
+    instance = 99,
+    products = [ "edmEventID_otherreceiver__*" ]
+)
+
+process.analyzer = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag("receiver")
+)
+
+process.path = cms.Path(process.receiver + process.analyzer + process.otherreceiver + process.sender)


### PR DESCRIPTION
#### PR description:

Schedule all MPI communication in an async thread to avoid deadlocks.

These deadlocks can happen when, after the `acquire()` of MPI modules has completed in the local and remote processes, the framework in the local process schedules the `produce()` of a MPI module that do not match the `produce()` of the MPI module that was scheduled in the remote process.

As an example, in a run where two threads are available to both local and remote processes, Sender A and B could be scheduled locally while Receiver C and D are scheduled in the remote process. Sender's A and B will not complete until receivers A and B run, which will never happen since the two worker threads in the remote process are stuck on Receiver C and D (which are waiting for Sender C and D, etc.)

The likelihood for this deadlock to happen is higher the higher the streams/threads ratio is.

We overcome this situation in this PR by scheduling all the blocking MPI calls of the `MPISender` and `MPIReceiver` modules in an async thread, via `runAsync()`.

The approach comes with a performance penalty of 3%, which will be addressed in the future.

#### PR validation:

Tests pass, even when they are launched with a small number of threads and a large number of streams.

#### Backport:

This PR will be backported to `16_1_X` and `16_0_X`.