### PR TITLE
Add dictionaries to avoid header parsing

### DIFF
--- a/DataFormats/BTauReco/src/classes_def.xml
+++ b/DataFormats/BTauReco/src/classes_def.xml
@@ -392,6 +392,7 @@
   <class name="edm::ValueMap<edm::Ptr<reco::BaseTagInfo> >" />
   <class name="edm::Wrapper<edm::ValueMap<edm::Ptr<reco::BaseTagInfo> > >" />
   <class name="std::vector<reco::BaseTagInfo *>" />
+  <class name="edm::ClonePolicy<reco::BaseTagInfo>"/>
   <class name="edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >" rntupleStreamerMode="true"/>
  <exclusion>
   <class name="edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >">

--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -28,6 +28,7 @@
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> >"/>
   <class name="edm::ClonePolicy<CSCSegment>"/> <!-- Root6 -->
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> > >"/>
+  <class name="edm::refhelper::FindUsingAdvance<edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> >,CSCSegment>"/>
   <class name="CSCSegmentRef"/>
 </selection>
 

--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -250,6 +250,7 @@
   <class name="edm::Wrapper<CTPPSLocalTrackLite>"/>
   <class name="edm::Wrapper<std::vector<CTPPSLocalTrackLite>>"/>
   <class name="edm::RefProd<std::vector<CTPPSLocalTrackLite> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<vector<CTPPSLocalTrackLite>,CTPPSLocalTrackLite>"/>
   <class name="edm::Ref<std::vector<CTPPSLocalTrackLite>,CTPPSLocalTrackLite,edm::refhelper::FindUsingAdvance<std::vector<CTPPSLocalTrackLite>,CTPPSLocalTrackLite> >"/>
   <class name="edm::RefVector<vector<CTPPSLocalTrackLite>,CTPPSLocalTrackLite,edm::refhelper::FindUsingAdvance<vector<CTPPSLocalTrackLite>,CTPPSLocalTrackLite> >"/>
 </lcgdict>

--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -156,6 +156,7 @@
   <class name="edm::helpers::KeyVal<reco::CandidateRefProd, reco::CandidateRefProd>" />
   <class name="edm::helpers::KeyVal<reco::CandidateBaseRefProd, reco::CandidateBaseRefProd>" />
   <class name="edm::helpers::KeyVal<reco::CandidateBaseRef, reco::CandidateBaseRef>" />
+  <class name="edm::ClonePolicy<reco::Candidate>"/>
   <class name="std::map<unsigned int,edm::helpers::KeyVal<reco::CandidateBaseRef, reco::CandidateBaseRef> >" />
   <class name="edm::AssociationMap<edm::OneToOne<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,unsigned int> >">
     <field name="transientMap_" transient="true" />

--- a/DataFormats/DTRecHit/src/classes_def.xml
+++ b/DataFormats/DTRecHit/src/classes_def.xml
@@ -60,6 +60,7 @@
   <class name="edm::ClonePolicy<DTRecSegment4D>" /> <!-- Root6 -->
   <class name="edm::RangeMap <DTChamberId, edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >,edm::ClonePolicy<DTRecSegment4D> >"/>
   <class name="edm::Wrapper<edm::RangeMap <DTChamberId, edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >,edm::ClonePolicy<DTRecSegment4D> > >"/>
+  <class name="edm::refhelper::FindUsingAdvance<edm::RangeMap<DTChamberId,edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >,edm::ClonePolicy<DTRecSegment4D> >,DTRecSegment4D>"/>
   <class name="DTRecSegment4DRef"/>
 </selection>
 <exclusion>

--- a/DataFormats/EcalRecHit/src/classes_def.xml
+++ b/DataFormats/EcalRecHit/src/classes_def.xml
@@ -24,6 +24,7 @@
   <class name="edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >"/>
   <class name="edm::StrictWeakOrdering<EcalRecHit>" /> <!-- Root6 -->
   <class name="edm::Wrapper<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> > >" />
+  <class name="edm::refhelper::FindUsingAdvance<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit>"/>
   <class name="edm::Ref<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit> >"/>
   <class name="edm::RefVector<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit> >"/>
   <class name="edm::RefProd<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> > >"/>

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -85,6 +85,7 @@
   <class name="edm::RefToBaseProd<reco::PhotonCore>" />
   <class name="edm::reftobase::BaseVectorHolder<reco::PhotonCore>" />
   <class name="edm::Wrapper<std::vector<reco::PhotonCore> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::PhotonCore>,reco::PhotonCore>"/>
   <class name="edm::Ref<std::vector<reco::PhotonCore>,reco::PhotonCore,edm::refhelper::FindUsingAdvance<std::vector<reco::PhotonCore>,reco::PhotonCore> >"/>
   <class name="edm::RefProd<std::vector<reco::PhotonCore> >"/>
   <class name="edm::RefVector<std::vector<reco::PhotonCore>,reco::PhotonCore,edm::refhelper::FindUsingAdvance<std::vector<reco::PhotonCore>,reco::PhotonCore> >"/>
@@ -145,6 +146,7 @@
   <class name="edm::RefToBaseProd<reco::GsfElectronCore>" />
   <class name="edm::reftobase::BaseVectorHolder<reco::GsfElectronCore>" />
   <class name="edm::Wrapper<std::vector<reco::GsfElectronCore> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::GsfElectronCore>,reco::GsfElectronCore>"/>
   <class name="edm::Ref<std::vector<reco::GsfElectronCore>,reco::GsfElectronCore,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfElectronCore>,reco::GsfElectronCore> >"/>
   <class name="edm::RefProd<std::vector<reco::GsfElectronCore> >"/>
   <class name="edm::RefVector<std::vector<reco::GsfElectronCore>,reco::GsfElectronCore,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfElectronCore>,reco::GsfElectronCore> >"/>
@@ -277,6 +279,7 @@
 
   <class name="std::vector<reco::Conversion>"/>
   <class name="edm::Wrapper<std::vector<reco::Conversion> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::Conversion>,reco::Conversion>"/>
   <class name="edm::Ref<std::vector<reco::Conversion>,reco::Conversion,edm::refhelper::FindUsingAdvance<std::vector<reco::Conversion>,reco::Conversion> >"/>
   <class name="edm::RefProd<std::vector<reco::Conversion> >"/>
   <class name="edm::RefVector<std::vector<reco::Conversion>,reco::Conversion,edm::refhelper::FindUsingAdvance<std::vector<reco::Conversion>,reco::Conversion> >"/>

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -30,6 +30,7 @@
   </class>
   <class name="std::vector<reco::SuperCluster>"/>
   <class name="edm::Wrapper<std::vector<reco::SuperCluster> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<vector<reco::SuperCluster>,reco::SuperCluster>"/>
   <class name="edm::Ref<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> >"/>
   <class name="edm::RefProd<std::vector<reco::SuperCluster> >"/>
   <class name="edm::RefVector<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> >"/>
@@ -105,6 +106,7 @@
   </class>
 
   <class name="std::vector<reco::ElectronSeed>"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed>"/>
   <class name="edm::Ref<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> >"/>
   <class name="edm::RefProd<std::vector<reco::ElectronSeed> >"/>
   <class name="edm::Wrapper<std::vector<reco::ElectronSeed> >"/>

--- a/DataFormats/GEMRecHit/src/classes_def.xml
+++ b/DataFormats/GEMRecHit/src/classes_def.xml
@@ -9,6 +9,7 @@
   <class name="std::vector<GEMRecHit*>" splitLevel="0"/>
   <class name="std::map<GEMDetId, std::pair<unsigned int, unsigned int> >" splitLevel="0"/>
   <class name="std::map<GEMDetId, std::pair<unsigned long, unsigned long> >" splitLevel="0"/>
+  <class name="edm::ClonePolicy<GEMRecHit>"/>
   <class name="edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >" splitLevel="0"  rntupleStreamerMode="true"/>
   <class name="edm::RangeMap<GEMDetId, edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >, edm::ClonePolicy<GEMRecHit> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<GEMDetId, edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >, edm::ClonePolicy<GEMRecHit> > >" splitLevel="0"/>
@@ -44,6 +45,7 @@
   </ioread>
   </class>
   <class name="std::vector<GEMSegment*>" splitLevel="0"/>
+  <class name="edm::ClonePolicy<GEMSegment>"/>
   <class name="edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >" splitLevel="0"  rntupleStreamerMode="true"/>
   <class name="edm::RangeMap<GEMDetId,edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >,edm::ClonePolicy<GEMSegment> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<GEMDetId,edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >,edm::ClonePolicy<GEMSegment> > >" splitLevel="0"/>
@@ -57,6 +59,7 @@
   <version ClassVersion="10" checksum="2562385753"/>
   </class>
   <class name="std::vector<ME0Segment*>" splitLevel="0"/>
+  <class name="edm::ClonePolicy<ME0Segment>"/>
   <class name="edm::OwnVector<ME0Segment,edm::ClonePolicy<ME0Segment> >" splitLevel="0"  rntupleStreamerMode="true" />
   <class name="edm::RangeMap<ME0DetId,edm::OwnVector<ME0Segment,edm::ClonePolicy<ME0Segment> >,edm::ClonePolicy<ME0Segment> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<ME0DetId,edm::OwnVector<ME0Segment,edm::ClonePolicy<ME0Segment> >,edm::ClonePolicy<ME0Segment> > >" splitLevel="0"/>

--- a/DataFormats/GEMRecHit/src/classes_def.xml
+++ b/DataFormats/GEMRecHit/src/classes_def.xml
@@ -47,6 +47,7 @@
   <class name="edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >" splitLevel="0"  rntupleStreamerMode="true"/>
   <class name="edm::RangeMap<GEMDetId,edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >,edm::ClonePolicy<GEMSegment> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<GEMDetId,edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >,edm::ClonePolicy<GEMSegment> > >" splitLevel="0"/>
+  <class name="edm::refhelper::FindUsingAdvance<edm::RangeMap<GEMDetId,edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >,edm::ClonePolicy<GEMSegment> >,GEMSegment>"/>
   <class name="GEMSegmentRef" splitLevel="0"/>
 
   <class name="ME0Segment" ClassVersion="13">
@@ -59,6 +60,7 @@
   <class name="edm::OwnVector<ME0Segment,edm::ClonePolicy<ME0Segment> >" splitLevel="0"  rntupleStreamerMode="true" />
   <class name="edm::RangeMap<ME0DetId,edm::OwnVector<ME0Segment,edm::ClonePolicy<ME0Segment> >,edm::ClonePolicy<ME0Segment> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<ME0DetId,edm::OwnVector<ME0Segment,edm::ClonePolicy<ME0Segment> >,edm::ClonePolicy<ME0Segment> > >" splitLevel="0"/>
+  <class name="edm::refhelper::FindUsingAdvance<edm::RangeMap<ME0DetId,edm::OwnVector<ME0Segment,edm::ClonePolicy<ME0Segment> >,edm::ClonePolicy<ME0Segment> >,ME0Segment>"/>
   <class name="ME0SegmentRef" splitLevel="0"/>
 
 </selection>

--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -21,6 +21,7 @@
   <class name="std::vector<reco::GsfTrackExtra>"/>
   <class name="edm::Wrapper<std::vector<reco::GsfTrackExtra> >" splitLevel="0"/>
   <class name="edm::RefProd<std::vector<reco::GsfTrackExtra> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<vector<reco::GsfTrackExtra>,reco::GsfTrackExtra>"/>
   <class name="edm::Ref<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
 
@@ -40,6 +41,7 @@
   <class name="std::vector<reco::GsfTrack>"/>
   <class name="edm::Wrapper<std::vector<reco::GsfTrack> >"/>
   <class name="edm::RefProd<std::vector<reco::GsfTrack> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<vector<reco::GsfTrack>,reco::GsfTrack>"/>
   <class name="edm::Ref<std::vector<reco::GsfTrack>,reco::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>,reco::GsfTrack> >"/>
   <class name="edm::RefVector<std::vector<reco::GsfTrack>,reco::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>,reco::GsfTrack> >"/>
 

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -89,6 +89,8 @@
 
    <class name="edm::Wrapper<HcalSourcePositionData>"/>
 
+   <class name="edm::refhelper::FindUsingAdvance<edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> >,HBHERecHit>"/>
+   
    <class name="edm::Ref<edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> >, HBHERecHit, edm::refhelper::FindUsingAdvance<edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> >, HBHERecHit> >"/>
    <class name="edm::Ref<edm::SortedCollection<HORecHit,edm::StrictWeakOrdering<HORecHit> >, HORecHit, edm::refhelper::FindUsingAdvance<edm::SortedCollection<HORecHit,edm::StrictWeakOrdering<HORecHit> >, HORecHit> >"/>
    <class name="edm::Ref<edm::SortedCollection<HFPreRecHit,edm::StrictWeakOrdering<HFPreRecHit> >, HFPreRecHit, edm::refhelper::FindUsingAdvance<edm::SortedCollection<HFPreRecHit,edm::StrictWeakOrdering<HFPreRecHit> >, HFPreRecHit> >"/>

--- a/DataFormats/HepMCCandidate/src/classes_def.xml
+++ b/DataFormats/HepMCCandidate/src/classes_def.xml
@@ -12,6 +12,7 @@
   <class name="edm::Wrapper<edm::Association<std::vector<reco::GenParticle> > >" />
 
 
+  <class name="edm::refhelper::FindUsingAdvance<vector<reco::GenParticle>,reco::GenParticle>"/>
   <class name="reco::GenParticleRef" />
   <class name="reco::GenParticleRefProd" />
   <class name="reco::GenParticleRefVector" />

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -20,6 +20,7 @@
   </class>
   <class name="std::vector<reco::CaloJet>"/>
   <class name="edm::RefProd<std::vector<reco::CaloJet> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<vector<reco::CaloJet>,reco::CaloJet>"/>
   <class name="edm::RefVector<std::vector<reco::CaloJet>,reco::CaloJet,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloJet>,reco::CaloJet> >"/>
   <class name="std::vector<edm::Ref<std::vector<reco::CaloJet>,reco::CaloJet,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloJet>,reco::CaloJet> > >"/>
   <class name="edm::Ref<std::vector<reco::CaloJet>,reco::CaloJet,edm::refhelper::FindUsingAdvance<std::vector<reco::CaloJet>,reco::CaloJet> >"/>
@@ -104,6 +105,7 @@
    <version ClassVersion="10" checksum="3126154868"/>
   </class>
   <class name="std::vector<reco::GenJet>"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::GenJet>,reco::GenJet>"/>
   <class name="edm::RefVector<std::vector<reco::GenJet>,reco::GenJet,edm::refhelper::FindUsingAdvance<std::vector<reco::GenJet>,reco::GenJet> >"/>
   <class name="edm::Ref<std::vector<reco::GenJet>,reco::GenJet,edm::refhelper::FindUsingAdvance<std::vector<reco::GenJet>,reco::GenJet> >"/>
   <class name="edm::RefProd<std::vector<reco::GenJet> >"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -531,6 +531,7 @@
   <class name="edm::Wrapper<std::vector<pat::PackedGenParticle> >"/>
 
   <!-- PAT Object References -->
+  <class name="edm::refhelper::FindUsingAdvance<vector<pat::PackedCandidate>,pat::PackedCandidate>"/>
   <class name="pat::ElectronRef" />
   <class name="pat::MuonRef" />
   <class name="pat::TauRef" />

--- a/DataFormats/PatCandidates/src/classes_def_user.xml
+++ b/DataFormats/PatCandidates/src/classes_def_user.xml
@@ -5,6 +5,7 @@
   <class name="pat::UserData"  ClassVersion="10">
    <version ClassVersion="10" checksum="85383148"/>
   </class>
+  <class name="edm::ClonePolicy<pat::UserData>"/>
   <class name="std::vector<pat::UserData *>" />
   <class name="pat::UserDataCollection"  rntupleStreamerMode="true"/>
   <!-- UserData: Standalone UserData in the event. Needed? -->

--- a/DataFormats/TauReco/src/classes_def_1.xml
+++ b/DataFormats/TauReco/src/classes_def_1.xml
@@ -26,6 +26,7 @@
   </class>
   <class name="std::vector<reco::PFTauTagInfo>"/>
   <class name="edm::Wrapper<std::vector<reco::PFTauTagInfo> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTagInfo>,reco::PFTauTagInfo>"/>
   <class name="edm::Ref<std::vector<reco::PFTauTagInfo>,reco::PFTauTagInfo,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTagInfo>,reco::PFTauTagInfo> >"/>
   <class name="edm::RefProd<std::vector<reco::PFTauTagInfo> >"/>
   <class name="edm::RefVector<std::vector<reco::PFTauTagInfo>,reco::PFTauTagInfo,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTagInfo>,reco::PFTauTagInfo> >"/>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -374,6 +374,7 @@ isolationTauChargedHadronCandidates_.reset();
   <class name="edm::AtomicPtrCache<std::vector<reco::RecoTauPiZero> >"/>
      <class name="std::vector<std::vector<reco::RecoTauPiZero> >"/>
   <class name="edm::Wrapper<std::vector<reco::RecoTauPiZero> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero>"/>
   <class name="edm::Ref<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero> >"/>
   <class name="edm::RefProd<std::vector<reco::RecoTauPiZero> >"/>
   <class name="edm::RefVector<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero> >"/>
@@ -391,6 +392,7 @@ isolationTauChargedHadronCandidates_.reset();
   <class name="edm::AtomicPtrCache<std::vector<reco::PFRecoTauChargedHadron> >"/>
      <class name="std::vector<std::vector<reco::PFRecoTauChargedHadron> >"/>
   <class name="edm::Wrapper<std::vector<reco::PFRecoTauChargedHadron> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron>"/>
   <class name="edm::Ref<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron> >"/>
   <class name="edm::RefProd<std::vector<reco::PFRecoTauChargedHadron> >"/>
   <class name="edm::RefVector<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron> >"/>

--- a/DataFormats/VertexReco/src/classes_def.xml
+++ b/DataFormats/VertexReco/src/classes_def.xml
@@ -5,6 +5,7 @@
   </class>
   <class name="std::vector<reco::Vertex>" />
   <class name="edm::Wrapper<std::vector<reco::Vertex> >" />
+  <class name="edm::refhelper::FindUsingAdvance<vector<reco::Vertex>,reco::Vertex>"/>
   <class name="edm::Ref<std::vector<reco::Vertex>, reco::Vertex, edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>, reco::Vertex> >" />
   <class name="edm::RefProd<std::vector<reco::Vertex> >" />
   <class name="edm::RefVector<std::vector<reco::Vertex>, reco::Vertex, edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>, reco::Vertex> >" />


### PR DESCRIPTION
#### PR description:

This PR adds dictionaries for types that were found to cause header parsing in ROOT master in https://github.com/cms-sw/cmssw/issues/50580#issuecomment-4171097559 (for TTree IO) and https://github.com/cms-sw/cmssw/issues/49949#issuecomment-4202068780 (for RNTuple IO)

Resolves https://github.com/cms-sw/framework-team/issues/2153

#### PR validation:

With these changes the `gInterpreter->Print("autoparsed")` (via https://github.com/cms-sw/cmssw/pull/50632) no longer listed types causing header parsing that we could easily do something about.
