### PR TITLE
[16.0.X] remove redundant zero initialization for PF clusters

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
@@ -170,7 +170,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       pfClusteringVars_.emplace(event.queue(), nRH);
       pfClusteringEdgeVars_.emplace(event.queue(), nRH * 8);
       pfClusters_.emplace(event.queue(), nRH);
-      pfClusters_->zeroInitialise(event.queue());
 
       *numRHF_ = 0;
       if (nRH == 0) {


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50709

#### PR description:

Title says it all. As requested at https://github.com/cms-sw/cmssw/pull/50670#discussion_r3042057771.
See also https://github.com/cms-sw/cmssw/pull/50671#discussion_r3074153341 

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Plain backport of https://github.com/cms-sw/cmssw/pull/50709 to 16.0.X possibly for 2026 data-taking operations.