### PR TITLE
[16_0_X] Protection for DetSetVector::inserv exception in sistrip::SiStripClustersToLegacy

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClustersToLegacy.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClustersToLegacy.cc
@@ -57,18 +57,19 @@ namespace sistrip {
 
       // Educated guess for the total number of detector IDs,
       // based on Run: 386593 Event: 536278171 with 13883 detectors.
-      // const uint32_t nModulesWithClustersGuess = 15000;
+      const uint32_t nModulesWithClustersGuess = 15000;
       // The number of clusters from x->nClusterCandidates() is an upper limit,
       // the flag trueCluster then mask the real clusters.
       // From Run: 386593 Event: 536278171 there are nClusterCandidates=112735 with
       // 99863 real clusters (so 112735-99863 = 12872 clusters are masked out )
       const uint32_t clusterCandidatesNb = clusters_onHost->nClusterCandidates();
       const uint32_t goodClustersNb = clusters_onHost->candidateAcceptedPrefix(nClusterCandidates - 1);
-      // output->reserve(nModulesWithClustersGuess, goodClustersNb);
+      output->reserve(nModulesWithClustersGuess, goodClustersNb);
 
       uint32_t clusterN = 0;
       for (uint32_t i = 0; i < clusterCandidatesNb && (clusterN < goodClustersNb);) {
         const auto detid = detIdArr[i];
+
         out_t::FastFiller record(*output, detid);
 
         while (i < clusterCandidatesNb && detIdArr[i] == detid) {
@@ -90,9 +91,6 @@ namespace sistrip {
         }
       }
 
-      if (edm::isDebugEnabled()) {
-        dumpClusters(output.get());
-      }
       iEvent.put(siStripClustersSetVecPutToken_, std::move(output));
     }
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToCluster.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToCluster.cc
@@ -202,22 +202,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::sistrip {
         if (!(buffROMode >= READOUT_MODE_ZERO_SUPPRESSED_LITE10 &&
               buffROMode <= READOUT_MODE_ZERO_SUPPRESSED_LITE8_BOTBOT_CMOVERRIDE &&
               buffROMode != READOUT_MODE_PROC_RAW)) {
-          if (edm::isDebugEnabled()) {
-            std::ostringstream ss;
-            ss << "Unsupported buffer ROmode=" << buffROMode << " fedID= " << fedId;
-            edm::LogWarning("fillFedIdFedChBuffer") << ss.str();
-          }
+          LogDebug("fillFedIdFedChBuffer") << "Unsupported buffer ROmode=" << buffROMode << " fedID= " << fedId;
           continue;  // conn loop
         }
 
         // check channel
         const uint8_t fedCh = conn->fedCh();
         if (!buffer->channelGood(fedCh, doAPVEmulatorCheck_)) {
-          if (edm::isDebugEnabled()) {
-            std::ostringstream ss;
-            ss << "Problem unpacking channel " << (int)fedCh << " on FED " << fedId;
-            edm::LogWarning("fillFedIdFedChBuffer") << ss.str();
-          }
+          LogDebug("fillFedIdFedChBuffer") << "Problem unpacking channel " << (int)fedCh << " on FED " << fedId;
           continue;  // conn loop
         }
 
@@ -227,11 +219,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::sistrip {
 
         auto diff = channel.data() - raw[fedId]->data();
         if (diff < 0 || diff > std::numeric_limits<uint32_t>::max()) {
-          if (edm::isDebugEnabled()) {
-            std::ostringstream ss;
-            ss << "Large diff " << diff << " for fedId " << fedId << " fedCh " << fedCh;
-            edm::LogWarning("fillFedIdFedChBuffer") << ss.str();
-          }
+          LogDebug("fillFedIdFedChBuffer") << "Large diff " << diff << " for fedId " << fedId << " fedCh " << fedCh;
           continue;
         }
         const uint32_t fedChOfs_wrt_rawFedId = static_cast<const uint32_t>(diff);
@@ -264,27 +252,21 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::sistrip {
     // Check on FEDRawData pointer
     const auto st_buffer = sistrip::preconstructCheckFEDBuffer(rawData);
     if UNLIKELY (sistrip::FEDBufferStatusCode::SUCCESS != st_buffer) {
-      if (edm::isDebugEnabled()) {
-        edm::LogWarning(sistrip::mlRawToCluster_)
-            << "[ClustersFromRawProducer::" << __func__ << "]" << st_buffer << " for FED ID " << fedId;
-      }
+      LogDebug(sistrip::mlRawToCluster_) << "[ClustersFromRawProducer::" << __func__ << "]" << st_buffer
+                                         << " for FED ID " << fedId;
       return buffer;
     }
     buffer = std::make_unique<sistrip::FEDBuffer>(rawData);
     const auto st_chan = buffer->findChannels();
     if UNLIKELY (sistrip::FEDBufferStatusCode::SUCCESS != st_chan) {
-      if (edm::isDebugEnabled()) {
-        edm::LogWarning(sistrip::mlRawToCluster_)
-            << "Exception caught when creating FEDBuffer object for FED " << fedId << ": " << st_chan;
-      }
+      LogDebug(sistrip::mlRawToCluster_) << "Exception caught when creating FEDBuffer object for FED " << fedId << ": "
+                                         << st_chan;
       buffer.reset();
       return buffer;
     }
     if UNLIKELY (!buffer->doChecks(false)) {
-      if (edm::isDebugEnabled()) {
-        edm::LogWarning(sistrip::mlRawToCluster_)
-            << "Exception caught when creating FEDBuffer object for FED " << fedId << ": FED Buffer check fails";
-      }
+      LogDebug(sistrip::mlRawToCluster_) << "Exception caught when creating FEDBuffer object for FED " << fedId
+                                         << ": FED Buffer check fails";
       buffer.reset();
       return buffer;
     }

--- a/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToClusterAlgo.dev.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToClusterAlgo.dev.cc
@@ -345,7 +345,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::sistrip {
                                                                             mode,
                                                                             packetCode);
         if (retCode != fedchannelunpacker::StatusCode::SUCCESS) {
-          printf("[%i] [fedID %hu] [fedCH %hhu] - Returned %i \n", chan, fedId, fedCh, (int)retCode);
+          // The strips belonging to this fedCh do not count for the clustering
+          // All the invalid strips are mapped to the channel zero, which gets masked out during NC seeding
+          // because these invalid strips have identical properties (stripId and chan=0)
+          // printf("[%i] [fedID %hu] [fedCH %hhu] - Returned %i \n", chan, fedId, fedCh, (int)retCode);
+
+          // This occurs very rarely - so no real gain in masking out invalidstrips and continuing in the seeding step
+          // for (uint32_t i = absoluteOffset; i < absoluteOffset + fedChan.length(); ++i) {
+          //   stripDigis.channel(i) = chan;
+          //   stripDigis.stripId(i) = invalidStrip;
+          //   // printf("[%i] [fedID %hu] [fedCH %hhu] [status %i] [%i] \n", chan, fedId, fedCh, (int)retCode, i);
+          // }
         }
       }  // data != nullptr && len > 0
     }
@@ -366,9 +376,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::sistrip {
         clusterDataObj.prefixSeedStripsNCMask(i) = 0;
 
         const auto ch = stripDigi.channel(i);
+        const auto stripID = stripDigi.stripId(i);
+
         const auto fedId = mapping.fedID(ch);
         const auto fedCh = mapping.fedCh(ch);
-        const auto stripID = stripDigi.stripId(i);
 
         const uint32_t idx = stripIndex(fedId, fedCh, stripID);
         const uint16_t noise_tmp = calibs->noise[idx];
@@ -746,6 +757,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::sistrip {
       return nStrips;
     }
     digis_d_ = std::make_unique<SiStripDigiDevice>(queue, nStrips);
+    digis_d_->zeroInitialise(queue);
 
     // Run the unpacking kernel
     uint32_t divider = 256u;


### PR DESCRIPTION
Backport of [cmssw/pull/50690](https://github.com/cms-sw/cmssw/pull/50690)

#### PR description:
> The PR addresses the crash reported in [cmssw/issues/50587](https://github.com/cms-sw/cmssw/issues/50587).
> For more detail see [cmssw/pull/50690](https://github.com/cms-sw/cmssw/pull/50690).

#### PR validation:
> Tested on the [reproducer](https://github.com/cms-sw/cmssw/issues/50587#issue-4169541880) on run 402512 with no crashes.
> Timing checked on the timing server with run 402360 and by running tracking only
> - baseline [554.1 ± 0.8 evt/s](https://timing-gui-tsg-steam.app.cern.ch/display/pgrutta/CMSSW_16_0_4_ReducedIterativeTracking_baseline.20260409_001146)
> - with the proposed fix [557.6 ± 0.5 evt/s](https://timing-gui-tsg-steam.app.cern.ch/display/pgrutta/CMSSW_16_0_4_ReducedIterativeTracking_target_v2.20260409_001133)
> showing no degradation in performance

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Verbatim backport of [cmssw/pull/50690](https://github.com/cms-sw/cmssw/pull/50690) for fixing HLT issue reported in [cmssw/issues/50587](https://github.com/cms-sw/cmssw/issues/50587) for the 2026 data-taking release.
