### PR TITLE
Add NANOGENMinimal, i.e. NANOGEN as in "same GEN content of NANOAOD"

### DIFF
--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -115,6 +115,9 @@ autoNANO = {
     # NANOGEN (from MiniAOD)
     'GENFromMini': {'sequence': 'PhysicsTools/NanoAOD/nanogen_cff.nanogenSequence',
                     'customize': 'PhysicsTools/NanoAOD/nanogen_cff.customizeNanoGENFromMini'},
+    # NANOGEN as in same GEN content of regular NANOAODSIM
+    'GENMinimal': {'sequence': 'PhysicsTools/NanoAOD/nanogen_cff.nanogenSequence',
+            'customize': 'PhysicsTools/NanoAOD/nanogen_cff.customizeNanoGENMinimal'},
     # Tau embedding NanoAOD (includes Data as well as MC tables with an addition tau embedding table)
     'TauEmbedding': {'sequence': '@PHYS+PhysicsTools/NanoAOD/nano_cff.nanoSequenceFS+TauAnalysis/MCEmbeddingTools/Nano_cff.embeddingTable_seq',
                      'customize': '@PHYS'},

--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -125,6 +125,14 @@ def customizeNanoGEN(process):
     nanoGenCommonCustomize(process)
     return process
 
+def customizeNanoGENMinimal(process):
+    process.nanogenSequence.insert(0, process.finalGenParticles)
+    for output in ("NANOEDMAODSIMoutput", "NANOAODSIMoutput"):
+        if hasattr(process, output):
+            getattr(process, output).outputCommands.append("drop edmTriggerResults_*_*_*")
+
+    return process
+
 # Prune gen particles with tight conditions applied in usual NanoAOD
 def pruneGenParticlesNano(process):
     process.finalGenParticles.src = process.genParticleTable.src.getModuleLabel()


### PR DESCRIPTION
#### PR description:
This introduces a new customization to enable the production of NANOGEN with same GEN content of NANOAOD.
The current "NANOGEN" is not really a subset of NANOAOD.

#### PR validation:
cmsDriver.py nanotest  --fileout file:testNanoGenAR.root --filein file:0022c2b6-a0d2-4dca-ba57-39c296411fdf.root --mc --eventcontent NANOAODSIM --datatier NANOEDMAODSIM --conditions 133X_mcRun3_2024_realistic_v10 --beamspot Realistic25ns13TeV2016Collision --step NANO:@GENMinimal --era Run3_2024 -n 100


