### PR TITLE
[16_0_X] Remove extra modules in MDPF HLT customization

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -60,7 +60,6 @@ def customizeHLTfor50303(process):
         process.hltParticleFlowRecHitHBHESoA +
         process.hltParticleFlowRecHitHBHE +
         process.hltParticleFlowClusterHBHESoA +
-        process.hltParticleFlowClusterHBHE +
         process.hltPFMultiDepthClusterSoA +
         process.hltParticleFlowClusterHCAL  # This now refers to LegacyMultiDepth producer
     )
@@ -83,7 +82,6 @@ def customizeHLTfor50303(process):
         process.hltParticleFlowRecHitHBHESoASerialSync +
         process.hltParticleFlowRecHitHBHESerialSync +
         process.hltParticleFlowClusterHBHESoASerialSync +
-        process.hltParticleFlowClusterHBHESerialSync +
         process.hltPFMultiDepthClusterSoASerialSync +
         process.hltParticleFlowClusterHCALSerialSync  # This now refers to LegacyMultiDepth producer
     )
@@ -106,7 +104,15 @@ def customizeHLTfor50303(process):
     process = replaceItemsInSequence(process, itemsList, process.HLTPFHcalClustering)
     process = replaceItemsInSequence(process, serialItemsList, process.HLTPFHcalClusteringSerialSync)
 
+    # Completely remove the old HBHE cluster module definitions from the process
+    if hasattr(process, 'hltParticleFlowClusterHBHE'):
+        del process.hltParticleFlowClusterHBHE
+
+    if hasattr(process, 'hltParticleFlowClusterHBHESerialSync'):
+        del process.hltParticleFlowClusterHBHESerialSync
+
     return process
+
 
 def replace_all_pixel_seed_inputtags(process):
     import FWCore.ParameterSet.Config as cms


### PR DESCRIPTION
#### PR description:

This PR updates a HLT customization function to remove modules which should no longer run when running Alpaka based PF multi-depth clustering. The affected modules are instances of the SoA to Legacy format converter `LegacyPFClusterProducer`.

#### PR validation:

PR was validated by applying the customization to a current menu generated with `hltGetConfiguration`. The generated config ran successfully, and inspection in interactive python shows that the modules are removed from the menu as intended.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of #50723 meant for 16.0.X

@mmusich 
