### PR TITLE
[16.1.X] HLT Scouting DQM: add monitoring of scouting track properties and other optimizations

### DIFF
--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -299,6 +299,8 @@ private:
   dqm::reco::MonitorElement* trkdz_ele_hist;
   dqm::reco::MonitorElement* trkd0BS_ele_hist;
   dqm::reco::MonitorElement* trkdzBS_ele_hist;
+  dqm::reco::MonitorElement* trkd0Vtx_ele_hist;
+  dqm::reco::MonitorElement* trkdzVtx_ele_hist;
   dqm::reco::MonitorElement* trkpt_ele_hist;
   dqm::reco::MonitorElement* trketa_ele_hist;
   dqm::reco::MonitorElement* trkphi_els_hist;
@@ -746,6 +748,23 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
         beamspot.x0(), beamspot.y0(), beamspot.z0(), 0., 0., 0., 0., 0., true, 0., 0., 0., 0);
   }
 
+  // lambda to find closest vertex
+  auto findClosestVtx = [&](float dz0) -> const Run3ScoutingVertex* {
+    const Run3ScoutingVertex* bestVtx = nullptr;
+    float bestDist = std::numeric_limits<float>::max();
+
+    for (const auto& vtx : *primaryVerticesH) {
+      float dist = std::abs(dz0 - vtx.z());
+
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestVtx = &vtx;
+      }
+    }
+
+    return bestVtx;
+  };
+
   // fill all the electron histograms
   for (std::size_t iEl = 0; iEl < electronsH->size(); ++iEl) {
     // Ref needed to index into the ValueMaps
@@ -802,16 +821,30 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
     float pz = pt * std::sinh(eta);
     float pt2 = pt * pt;
 
-    float vx = beamspotVertex->x();
-    float vy = beamspotVertex->y();
-    float vz = beamspotVertex->z();
+    float bsx = beamspotVertex->x();
+    float bsy = beamspotVertex->y();
+    float bsz = beamspotVertex->z();
 
     // dxy and dz w.r.t. vertex
-    float dxy_vtx = vmD0[elRef] + (-vx * py + vy * px) / pt;
-    float dz_vtx = vmDz[elRef] - vz + (vx * px + vy * py) * pz / pt2;
+    float dxy_bs = vmD0[elRef] + (-bsx * py + bsy * px) / pt;
+    float dz_bs = vmDz[elRef] - bsz + (bsx * px + bsy * py) * pz / pt2;
 
-    trkd0BS_ele_hist->Fill(dxy_vtx);
-    trkdzBS_ele_hist->Fill(dz_vtx);
+    trkd0BS_ele_hist->Fill(dxy_bs);
+    trkdzBS_ele_hist->Fill(dz_bs);
+
+    const auto* vtx = findClosestVtx(vmDz[elRef]);
+    if (vtx) {
+      float vx = vtx->x();
+      float vy = vtx->y();
+      float vz = vtx->z();
+
+      // dxy and dz w.r.t. vertex
+      float dxy_vtx = vmD0[elRef] + (-vx * py + vy * px) / pt;
+      float dz_vtx = vmDz[elRef] - vz + (vx * px + vy * py) * pz / pt2;
+
+      trkd0Vtx_ele_hist->Fill(dxy_vtx);
+      trkdzVtx_ele_hist->Fill(dz_vtx);
+    }
 
     trkpt_ele_hist->Fill(vmPt[elRef]);
     trketa_ele_hist->Fill(vmEta[elRef]);
@@ -1365,10 +1398,10 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   trkBestIdx_ele_hist = ibook.book1DD("trkBestIdx", "Best-track index;index;Electrons", 20, 0, 20);
   trkd0_ele_hist = ibook.book1DD("trkd0", "Best-track d_{0};d_{0} [cm];Electrons", 100, -0.5, 0.5);
   trkdz_ele_hist = ibook.book1DD("trkdz", "Best-track d_{z};d_{z} [cm];Electrons", 100, -25, 25);
-
   trkd0BS_ele_hist = ibook.book1DD("trkd0BS", "Best-track d_{0}(BS);d_{0}(BS) [cm];Electrons", 100, -0.5, 0.5);
   trkdzBS_ele_hist = ibook.book1DD("trkdzBS", "Best-track d_{z}(BS);d_{z}(BS) [cm];Electrons", 100, -25, 25);
-
+  trkd0Vtx_ele_hist = ibook.book1DD("trkd0Vtx", "Best-track d_{0}(PV);d_{0}(PV) [cm];Electrons", 100, -0.5, 0.5);
+  trkdzVtx_ele_hist = ibook.book1DD("trkdzVtx", "Best-track d_{z}(PV);d_{z}(PV) [cm];Electrons", 100, -25, 25);
   trkpt_ele_hist = ibook.book1DD("trkpt", "Best-track p_{T};p_{T} [GeV];Electrons", 100, 0, 200);
   trketa_ele_hist = ibook.book1DD("trketa", "Best-track #eta;#eta;Electrons", 60, -3, 3);
   trkphi_els_hist = ibook.book1DD("trkphi", "Best-track #phi;#phi [rad];Electrons", 64, -3.2, 3.2);

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -1194,9 +1194,9 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   pfMetPt_hist = ibook.book1D("pfMetPt", "pf MET p_{T};p_{T} [GeV];Entries", 100, 0.0, 250.0);
 
   if (!onlyScouting_) {
-    PVvsPU_hist =
-        ibook.bookProfile("PVvsPU", "Number of primary vertices vs pile up; pile up; <N_{PV}>", 70, 0, 70, 0, 65);
-    rhovsPU_hist = ibook.bookProfile("rhovsPU", "#rho vs pile up; pile up; <#rho>", 70, 0, 70, 0, 45);
+    PVvsPU_hist = ibook.bookProfile(
+        "PVvsPU", "Number of primary vertices vs pile up; pile up; #LTN_{PV}#GT", 70, 0., 70., 0., 70., "");
+    rhovsPU_hist = ibook.bookProfile("rhovsPU", "#rho vs pile up; pile up; #LT#rho#GT", 70, 0., 70., 0., 45., "");
   }
 
   ibook.setCurrentFolder(topfoldername_ + "/PFcand");

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -1307,7 +1307,8 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   ibook.setCurrentFolder(topfoldername_ + "/Electron");
   pt_ele_hist = ibook.book1DD("pt_ele", "Electron p_{T}; p_{T} (GeV); Entries", 100, 0.0, 100.0);
   eta_ele_hist = ibook.book1DD("eta_ele", "Electron #eta; #eta; Entries", 100, -2.7, 2.7);
-  phi_ele_hist = ibook.book1DD("phi_ele", "Electron #phi; #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
+  phi_ele_hist =
+      ibook.book1DD("phi_ele", "Electron #phi; #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
   rawEnergy_ele_hist = ibook.book1DD("rawEnergy_ele", "Raw Energy Electron; Energy (GeV); Entries", 100, 0.0, 250.0);
   preshowerEnergy_ele_hist =
       ibook.book1DD("preshowerEnergy_ele", "Preshower Energy Electron; Energy (GeV); Entries", 100, 0.0, 10.0);
@@ -1363,7 +1364,8 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
 
     pt_mu_hist[i] = ibook.book1DD("pt_mu" + sfx, "Muon p_{T} (" + lbl + "); p_{T} (GeV); Entries", 100, 0.0, 200.0);
     eta_mu_hist[i] = ibook.book1DD("eta_mu" + sfx, "Muon #eta (" + lbl + "); #eta; Entries", 100, -2.7, 2.7);
-    phi_mu_hist[i] = ibook.book1DD("phi_mu" + sfx, "Muon #phi (" + lbl + "); #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
+    phi_mu_hist[i] = ibook.book1DD(
+        "phi_mu" + sfx, "Muon #phi (" + lbl + "); #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
     type_mu_hist[i] = ibook.book1DD("type_mu" + sfx, "Muon Type (" + lbl + "); Type; Entries", 10, 0, 10);
     charge_mu_hist[i] = ibook.book1DD("charge_mu" + sfx, "Muon Charge (" + lbl + "); Charge; Entries", 3, -1, 2);
     normalizedChi2_mu_hist[i] =
@@ -1437,8 +1439,11 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
         ibook.book1DD("trk_lambda_mu" + sfx, "Muon Lambda (" + lbl + "); #lambda; Entries", 100, -2, 2);
     trk_pt_mu_hist[i] =
         ibook.book1DD("trk_pt_mu" + sfx, "Muon Tracker p_{T} (" + lbl + "); p_{T} (GeV); Entries", 100, 0.0, 200.0);
-    trk_phi_mu_hist[i] =
-        ibook.book1DD("trk_phi_mu" + sfx, "Muon Tracker #phi (" + lbl + "); #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
+    trk_phi_mu_hist[i] = ibook.book1DD("trk_phi_mu" + sfx,
+                                       "Muon Tracker #phi (" + lbl + "); #phi (rad); Entries",
+                                       100,
+                                       -std::numbers::pi,
+                                       std::numbers::pi);
     trk_eta_mu_hist[i] =
         ibook.book1DD("trk_eta_mu" + sfx, "Muon Tracker #eta (" + lbl + "); #eta; Entries", 100, -3.0, 3.0);
     trk_dxyError_mu_hist[i] = ibook.book1DD(
@@ -1589,7 +1594,8 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   ibook.setCurrentFolder(topfoldername_ + "/Tracking");
   tk_pt_tk_hist = ibook.book1DD("tk_pt_tk", "Track p_{T}; p_{T} (GeV); Entries", 100, 0.0, 30.0);
   tk_eta_tk_hist = ibook.book1DD("tk_eta_tk", "Track #eta; #eta; Entries", 100, -2.7, 2.7);
-  tk_phi_tk_hist = ibook.book1DD("tk_phi_tk", "Track #phi; #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
+  tk_phi_tk_hist =
+      ibook.book1DD("tk_phi_tk", "Track #phi; #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
   tk_chi2_tk_hist = ibook.book1DD("tk_chi2_tk", "Track #chi^{2}; #chi^{2}; Entries", 100, 0.0, 50.0);
   tk_ndof_tk_hist = ibook.book1DD("tk_ndof_tk", "Track Ndof; Ndof; Entries", 100, 0, 10);
   tk_charge_tk_hist = ibook.book1DD("tk_charge_tk", "Track Charge; Charge; Entries", 3, -1, 2);

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -21,6 +21,7 @@ It is based on the preexisting work of the scouting group and can be found at gi
 #include <cmath>
 #include <memory>
 #include <vector>
+#include <numbers>
 #include <TLorentzVector.h>
 
 // user include files
@@ -1134,7 +1135,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   nPFCands_hist = ibook.book1D("nPFCands", "Number of PF Candidates;N_{pfcand};Entries", 1001, 0, 1000);
 
   rho_hist = ibook.book1D("rho", "#rho; #rho; Entries", 100, 0.0, 60.0);
-  pfMetPhi_hist = ibook.book1D("pfMetPhi", "pf MET #phi; #phi ;Entries", 100, -3.14, 3.14);
+  pfMetPhi_hist = ibook.book1D("pfMetPhi", "pf MET #phi; #phi ;Entries", 100, -std::numbers::pi, std::numbers::pi);
   pfMetPt_hist = ibook.book1D("pfMetPt", "pf MET p_{T};p_{T} [GeV];Entries", 100, 0.0, 250.0);
 
   if (!onlyScouting_) {
@@ -1281,7 +1282,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   ibook.setCurrentFolder(topfoldername_ + "/Photon");
   pt_pho_hist = ibook.book1DD("pt_pho", "Photon p_{T}; p_{T} (GeV); Entries", 100, 0.0, 100.0);
   eta_pho_hist = ibook.book1DD("eta_pho", "photon #eta; #eta; Entries", 100, -2.7, 2.7);
-  phi_pho_hist = ibook.book1DD("phi_pho", "Photon #phi; #phi (rad); Entries", 100, -3.14, 3.14);
+  phi_pho_hist = ibook.book1DD("phi_pho", "Photon #phi; #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
   rawEnergy_pho_hist = ibook.book1DD("rawEnergy_pho", "Raw Energy Photon; Energy (GeV); Entries", 100, 0.0, 250.0);
   preshowerEnergy_pho_hist =
       ibook.book1DD("preshowerEnergy_pho", "Preshower Energy Photon; Energy (GeV); Entries", 100, 0.0, 8.0);
@@ -1306,7 +1307,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   ibook.setCurrentFolder(topfoldername_ + "/Electron");
   pt_ele_hist = ibook.book1DD("pt_ele", "Electron p_{T}; p_{T} (GeV); Entries", 100, 0.0, 100.0);
   eta_ele_hist = ibook.book1DD("eta_ele", "Electron #eta; #eta; Entries", 100, -2.7, 2.7);
-  phi_ele_hist = ibook.book1DD("phi_ele", "Electron #phi; #phi (rad); Entries", 100, -3.14, 3.14);
+  phi_ele_hist = ibook.book1DD("phi_ele", "Electron #phi; #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
   rawEnergy_ele_hist = ibook.book1DD("rawEnergy_ele", "Raw Energy Electron; Energy (GeV); Entries", 100, 0.0, 250.0);
   preshowerEnergy_ele_hist =
       ibook.book1DD("preshowerEnergy_ele", "Preshower Energy Electron; Energy (GeV); Entries", 100, 0.0, 10.0);
@@ -1362,7 +1363,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
 
     pt_mu_hist[i] = ibook.book1DD("pt_mu" + sfx, "Muon p_{T} (" + lbl + "); p_{T} (GeV); Entries", 100, 0.0, 200.0);
     eta_mu_hist[i] = ibook.book1DD("eta_mu" + sfx, "Muon #eta (" + lbl + "); #eta; Entries", 100, -2.7, 2.7);
-    phi_mu_hist[i] = ibook.book1DD("phi_mu" + sfx, "Muon #phi (" + lbl + "); #phi (rad); Entries", 100, -3.14, 3.14);
+    phi_mu_hist[i] = ibook.book1DD("phi_mu" + sfx, "Muon #phi (" + lbl + "); #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
     type_mu_hist[i] = ibook.book1DD("type_mu" + sfx, "Muon Type (" + lbl + "); Type; Entries", 10, 0, 10);
     charge_mu_hist[i] = ibook.book1DD("charge_mu" + sfx, "Muon Charge (" + lbl + "); Charge; Entries", 3, -1, 2);
     normalizedChi2_mu_hist[i] =
@@ -1437,9 +1438,9 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
     trk_pt_mu_hist[i] =
         ibook.book1DD("trk_pt_mu" + sfx, "Muon Tracker p_{T} (" + lbl + "); p_{T} (GeV); Entries", 100, 0.0, 200.0);
     trk_phi_mu_hist[i] =
-        ibook.book1DD("trk_phi_mu" + sfx, "Muon Tracker #phi (" + lbl + "); #phi (rad); Entries", 100, -3.14, 3.14);
+        ibook.book1DD("trk_phi_mu" + sfx, "Muon Tracker #phi (" + lbl + "); #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
     trk_eta_mu_hist[i] =
-        ibook.book1DD("trk_eta_mu" + sfx, "Muon Tracker #eta (" + lbl + "); #eta; Entries", 100, -2.7, 2.7);
+        ibook.book1DD("trk_eta_mu" + sfx, "Muon Tracker #eta (" + lbl + "); #eta; Entries", 100, -3.0, 3.0);
     trk_dxyError_mu_hist[i] = ibook.book1DD(
         "trk_dxyError_mu" + sfx, "Muon d_{xy} Error (" + lbl + "); d_{xy} Error (cm); Entries", 100, 0.0, 0.05);
     trk_dzError_mu_hist[i] = ibook.book1DD(
@@ -1502,7 +1503,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   ibook.setCurrentFolder(topfoldername_ + "/PFJet");
   pt_pfj_hist = ibook.book1DD("pt_pfj", "PF Jet p_{T}; p_{T} (GeV); Entries", 100, 0.0, 150.0);
   eta_pfj_hist = ibook.book1DD("eta_pfj", "PF Jet #eta; #eta; Entries", 100, -5.0, 5.0);
-  phi_pfj_hist = ibook.book1DD("phi_pfj", "PF Jet #phi; #phi (rad); Entries", 100, -3.14, 3.14);
+  phi_pfj_hist = ibook.book1DD("phi_pfj", "PF Jet #phi; #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
   m_pfj_hist = ibook.book1DD("m_pfj", "PF Jet Mass; Mass (GeV); Entries", 100, 0.0, 40.0);
   jetArea_pfj_hist = ibook.book1DD("jetArea_pfj", "PF Jet Area; Area; Entries", 100, 0.0, 0.8);
   chargedHadronEnergy_pfj_hist =
@@ -1588,7 +1589,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   ibook.setCurrentFolder(topfoldername_ + "/Tracking");
   tk_pt_tk_hist = ibook.book1DD("tk_pt_tk", "Track p_{T}; p_{T} (GeV); Entries", 100, 0.0, 30.0);
   tk_eta_tk_hist = ibook.book1DD("tk_eta_tk", "Track #eta; #eta; Entries", 100, -2.7, 2.7);
-  tk_phi_tk_hist = ibook.book1DD("tk_phi_tk", "Track #phi; #phi (rad); Entries", 100, -3.14, 3.14);
+  tk_phi_tk_hist = ibook.book1DD("tk_phi_tk", "Track #phi; #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
   tk_chi2_tk_hist = ibook.book1DD("tk_chi2_tk", "Track #chi^{2}; #chi^{2}; Entries", 100, 0.0, 50.0);
   tk_ndof_tk_hist = ibook.book1DD("tk_ndof_tk", "Track Ndof; Ndof; Entries", 100, 0, 10);
   tk_charge_tk_hist = ibook.book1DD("tk_charge_tk", "Track Charge; Charge; Entries", 3, -1, 2);
@@ -1616,8 +1617,8 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   tk_PV_dz_hist = ibook.book1DD("tk_PV_dz", "Track d_{z} w.r.t. PV; Track d_{z} w.r.t. PV; Entries", 100, -0.35, 0.35);
   tk_PV_dxy_hist =
       ibook.book1DD("tk_PV_dxy", "Track d_{xy} w.r.t. PV; Track d_{xy} w.r.t. PV; Entries", 100, -0.15, 0.15);
-  tk_BS_dxy_hist = ibook.book1D("tk_BS_dxy", "Track d_{xy} w.r.t. BeamSpot;dxy_{BS} (cm);Entries", 100, -0.5, 0.5);
-  tk_BS_dz_hist = ibook.book1D("tk_BS_dz", "Track d_{z} w.r.t. BeamSpot;dz_{BS} (cm);Entries", 100, -20.0, 20.0);
+  tk_BS_dxy_hist = ibook.book1DD("tk_BS_dxy", "Track d_{xy} w.r.t. BeamSpot;dxy_{BS} (cm);Entries", 100, -0.5, 0.5);
+  tk_BS_dz_hist = ibook.book1DD("tk_BS_dz", "Track d_{z} w.r.t. BeamSpot;dz_{BS} (cm);Entries", 100, -20.0, 20.0);
 
   // book the calo rechits histograms
   const std::array<std::string, 2> caloLabels = {{"Accepted", "Rejected"}};

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -811,37 +811,35 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
     trkd0_ele_hist->Fill(vmD0[elRef]);
     trkdz_ele_hist->Fill(vmDz[elRef]);
 
-    // computations to get IP w.r.t. Beamspot
-    float pt = vmPt[elRef];
-    float phi = vmPhi[elRef];
-    float eta = vmEta[elRef];
+    // computations to get IP w.r.t. a point
+    const float pt = vmPt[elRef];
+    const float phi = vmPhi[elRef];
+    const float eta = vmEta[elRef];
 
-    float px = pt * std::cos(phi);
-    float py = pt * std::sin(phi);
-    float pz = pt * std::sinh(eta);
-    float pt2 = pt * pt;
+    const float px = pt * std::cos(phi);
+    const float py = pt * std::sin(phi);
+    const float pz = pt * std::sinh(eta);
+    const float pt2 = pt * pt;
 
-    float bsx = beamspotVertex->x();
-    float bsy = beamspotVertex->y();
-    float bsz = beamspotVertex->z();
+    const float dxy0 = vmD0[elRef];
+    const float dz0 = vmDz[elRef];
 
-    // dxy and dz w.r.t. vertex
-    float dxy_bs = vmD0[elRef] + (-bsx * py + bsy * px) / pt;
-    float dz_bs = vmDz[elRef] - bsz + (bsx * px + bsy * py) * pz / pt2;
+    // lambda to compute IP wrt any (x,y,z)
+    auto computeIP = [&](float x, float y, float z) {
+      float dxy = dxy0 + (-x * py + y * px) / pt;
+      float dz = dz0 - z + (x * px + y * py) * pz / pt2;
+      return std::pair<float, float>{dxy, dz};
+    };
+
+    // compute w.r.t. beamspot
+    auto [dxy_bs, dz_bs] = computeIP(beamspotVertex->x(), beamspotVertex->y(), beamspotVertex->z());
 
     trkd0BS_ele_hist->Fill(dxy_bs);
     trkdzBS_ele_hist->Fill(dz_bs);
 
     const auto* vtx = findClosestVtx(vmDz[elRef]);
     if (vtx) {
-      float vx = vtx->x();
-      float vy = vtx->y();
-      float vz = vtx->z();
-
-      // dxy and dz w.r.t. vertex
-      float dxy_vtx = vmD0[elRef] + (-vx * py + vy * px) / pt;
-      float dz_vtx = vmDz[elRef] - vz + (vx * px + vy * py) * pz / pt2;
-
+      auto [dxy_vtx, dz_vtx] = computeIP(vtx->x(), vtx->y(), vtx->z());
       trkd0Vtx_ele_hist->Fill(dxy_vtx);
       trkdzVtx_ele_hist->Fill(dz_vtx);
     }

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -1140,8 +1140,8 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
 
   if (!onlyScouting_) {
     PVvsPU_hist =
-        ibook.bookProfile("PVvsPU", "Number of primary vertices vs pile up; pile up; <N_{PV}>", 20, 20, 70, 0, 65);
-    rhovsPU_hist = ibook.bookProfile("rhovsPU", "#rho vs pile up; pile up; <#rho>", 20, 20, 70, 0, 45);
+        ibook.bookProfile("PVvsPU", "Number of primary vertices vs pile up; pile up; <N_{PV}>", 70, 0, 70, 0, 65);
+    rhovsPU_hist = ibook.bookProfile("rhovsPU", "#rho vs pile up; pile up; <#rho>", 70, 0, 70, 0, 45);
   }
 
   ibook.setCurrentFolder(topfoldername_ + "/PFcand");
@@ -1338,20 +1338,20 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   nTracks_ele_hist = ibook.book1D("nTracksPerElectron", "Number of tracks per electron;N_{trk};Electrons", 20, 0, 20);
 
   // --- Best-track variables (from ValueMaps) ---
-  trkBestIdx_ele_hist = ibook.book1D("trkBestIdx", "Best-track index;index;Electrons", 20, 0, 20);
-  trkd0_ele_hist = ibook.book1D("trkd0", "Best-track d_{0};d_{0} [cm];Electrons", 100, -0.5, 0.5);
-  trkdz_ele_hist = ibook.book1D("trkdz", "Best-track d_{z};d_{z} [cm];Electrons", 100, -25, 25);
-  trkpt_ele_hist = ibook.book1D("trkpt", "Best-track p_{T};p_{T} [GeV];Electrons", 100, 0, 200);
-  trketa_ele_hist = ibook.book1D("trketa", "Best-track #eta;#eta;Electrons", 60, -3, 3);
-  trkphi_els_hist = ibook.book1D("trkphi", "Best-track #phi;#phi [rad];Electrons", 64, -3.2, 3.2);
-  trkpMode_ele_hist = ibook.book1D("trkpMode", "Best-track p (mode);p_{mode} [GeV];Electrons", 100, 0, 200);
-  trketaMode_ele_hist = ibook.book1D("trketaMode", "Best-track #eta (mode);#eta_{mode};Electrons", 60, -3, 3);
-  trkphiMode_ele_hist = ibook.book1D("trkphiMode", "Best-track #phi (mode);#phi_{mode} [rad];Electrons", 64, -3.2, 3.2);
-  trkqoverpModeError_ele_hist = ibook.book1D(
+  trkBestIdx_ele_hist = ibook.book1DD("trkBestIdx", "Best-track index;index;Electrons", 20, 0, 20);
+  trkd0_ele_hist = ibook.book1DD("trkd0", "Best-track d_{0};d_{0} [cm];Electrons", 100, -0.5, 0.5);
+  trkdz_ele_hist = ibook.book1DD("trkdz", "Best-track d_{z};d_{z} [cm];Electrons", 100, -25, 25);
+  trkpt_ele_hist = ibook.book1DD("trkpt", "Best-track p_{T};p_{T} [GeV];Electrons", 100, 0, 200);
+  trketa_ele_hist = ibook.book1DD("trketa", "Best-track #eta;#eta;Electrons", 60, -3, 3);
+  trkphi_els_hist = ibook.book1DD("trkphi", "Best-track #phi;#phi [rad];Electrons", 64, -3.2, 3.2);
+  trkpMode_ele_hist = ibook.book1DD("trkpMode", "Best-track p (mode);p_{mode} [GeV];Electrons", 100, 0, 200);
+  trketaMode_ele_hist = ibook.book1DD("trketaMode", "Best-track #eta (mode);#eta_{mode};Electrons", 60, -3, 3);
+  trkphiMode_ele_hist = ibook.book1DD("trkphiMode", "Best-track #phi (mode);#phi_{mode} [rad];Electrons", 64, -3.2, 3.2);
+  trkqoverpModeError_ele_hist = ibook.book1DD(
       "trkqoverpModeError", "Best-track #sigma(q/p) (mode);#sigma(q/p)_{mode} [GeV^{-1}];Electrons", 100, 0, 0.01);
   trkchi2overndf_ele_hist =
-      ibook.book1D("trkchi2overndf", "Best-track #chi^{2}/ndof;#chi^{2}/ndof;Electrons", 100, 0, 10);
-  trkcharge_ele_hist = ibook.book1D("trkcharge", "Best-track charge;charge;Electrons", 3, -1.5, 1.5);
+      ibook.book1DD("trkchi2overndf", "Best-track #chi^{2}/ndof;#chi^{2}/ndof;Electrons", 100, 0, 10);
+  trkcharge_ele_hist = ibook.book1DD("trkcharge", "Best-track charge;charge;Electrons", 3, -1.5, 1.5);
 
   // book the muon histograms (noVtx and Vtx collections)
   const std::array<std::string, 2> muonLabels = {{"muonsNoVtx", "muonsVtx"}};
@@ -1597,7 +1597,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   tk_phi_tk_hist =
       ibook.book1DD("tk_phi_tk", "Track #phi; #phi (rad); Entries", 100, -std::numbers::pi, std::numbers::pi);
   tk_chi2_tk_hist = ibook.book1DD("tk_chi2_tk", "Track #chi^{2}; #chi^{2}; Entries", 100, 0.0, 50.0);
-  tk_ndof_tk_hist = ibook.book1DD("tk_ndof_tk", "Track Ndof; Ndof; Entries", 100, 0, 10);
+  tk_ndof_tk_hist = ibook.book1DD("tk_ndof_tk", "Track Ndof; Ndof; Entries", 30, 0, 30);
   tk_charge_tk_hist = ibook.book1DD("tk_charge_tk", "Track Charge; Charge; Entries", 3, -1, 2);
   tk_dxy_tk_hist = ibook.book1DD("tk_dxy_tk", "Track d_{xy}; d_{xy} (cm); Entries", 100, -0.5, 0.5);
   tk_dz_tk_hist = ibook.book1DD("tk_dz_tk", "Track d_{z}; d_{z} (cm); Entries", 100, -20.0, 20.0);
@@ -1618,7 +1618,7 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   tk_vx_tk_hist = ibook.book1DD("tk_vx_tk", "Tracker Vertex X; x (cm); Entries", 100, -0.5, 0.5);
   tk_vy_tk_hist = ibook.book1DD("tk_vy_tk", "Tracker Vertex Y; y (cm); Entries", 100, -0.5, 0.5);
   tk_vz_tk_hist = ibook.book1DD("tk_vz_tk", "Tracker Vertex Z; z (cm); Entries", 100, -20.0, 20.0);
-  tk_chi2_ndof_tk_hist = ibook.book1DD("tk_chi2_ndof_tk", "Reduced #chi^{2}; #chi^{2}/NDOF; Entries", 100, 0, 50);
+  tk_chi2_ndof_tk_hist = ibook.book1DD("tk_chi2_ndof_tk", "Reduced #chi^{2}; #chi^{2}/NDOF; Entries", 100, 0, 10);
   tk_chi2_prob_hist = ibook.book1DD("tk_chi2_prob_hist", "p(#chi^{2}, NDOF); p(#chi^{2}, NDOF); Entries", 100, 0, 1);
   tk_PV_dz_hist = ibook.book1DD("tk_PV_dz", "Track d_{z} w.r.t. PV; Track d_{z} w.r.t. PV; Entries", 100, -0.35, 0.35);
   tk_PV_dxy_hist =

--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -297,6 +297,8 @@ private:
   dqm::reco::MonitorElement* trkBestIdx_ele_hist;
   dqm::reco::MonitorElement* trkd0_ele_hist;
   dqm::reco::MonitorElement* trkdz_ele_hist;
+  dqm::reco::MonitorElement* trkd0BS_ele_hist;
+  dqm::reco::MonitorElement* trkdzBS_ele_hist;
   dqm::reco::MonitorElement* trkpt_ele_hist;
   dqm::reco::MonitorElement* trketa_ele_hist;
   dqm::reco::MonitorElement* trkphi_els_hist;
@@ -735,6 +737,15 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
   const auto& vmChi2 = iEvent.get(vmTrkchi2overndfToken_);
   const auto& vmCharge = iEvent.get(vmTrkchargeToken_);
 
+  // determine the beamspot position (if it exists in the event)
+  std::unique_ptr<Run3ScoutingVertex> beamspotVertex{nullptr};
+  edm::Handle<reco::BeamSpot> beamSpotH;
+  if (getValidHandle(iEvent, beamSpotToken_, beamSpotH, "beamSpot")) {
+    const auto& beamspot = *beamSpotH;
+    beamspotVertex = std::make_unique<Run3ScoutingVertex>(
+        beamspot.x0(), beamspot.y0(), beamspot.z0(), 0., 0., 0., 0., 0., true, 0., 0., 0., 0);
+  }
+
   // fill all the electron histograms
   for (std::size_t iEl = 0; iEl < electronsH->size(); ++iEl) {
     // Ref needed to index into the ValueMaps
@@ -780,6 +791,28 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
     // best-track value whenever bestIdx >= 0.
     trkd0_ele_hist->Fill(vmD0[elRef]);
     trkdz_ele_hist->Fill(vmDz[elRef]);
+
+    // computations to get IP w.r.t. Beamspot
+    float pt = vmPt[elRef];
+    float phi = vmPhi[elRef];
+    float eta = vmEta[elRef];
+
+    float px = pt * std::cos(phi);
+    float py = pt * std::sin(phi);
+    float pz = pt * std::sinh(eta);
+    float pt2 = pt * pt;
+
+    float vx = beamspotVertex->x();
+    float vy = beamspotVertex->y();
+    float vz = beamspotVertex->z();
+
+    // dxy and dz w.r.t. vertex
+    float dxy_vtx = vmD0[elRef] + (-vx * py + vy * px) / pt;
+    float dz_vtx = vmDz[elRef] - vz + (vx * px + vy * py) * pz / pt2;
+
+    trkd0BS_ele_hist->Fill(dxy_vtx);
+    trkdzBS_ele_hist->Fill(dz_vtx);
+
     trkpt_ele_hist->Fill(vmPt[elRef]);
     trketa_ele_hist->Fill(vmEta[elRef]);
     trkphi_els_hist->Fill(vmPhi[elRef]);
@@ -928,15 +961,6 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
   // displaced vertex histograms with MuonNoVtx (index1: NoVtx)
   for (const auto& vtx : *verticesNoVtxH)
     fillVtxHistograms(vtx, 1);
-
-  // determine the beamspot position (if it exists in the event)
-  std::unique_ptr<Run3ScoutingVertex> beamspotVertex{nullptr};
-  edm::Handle<reco::BeamSpot> beamSpotH;
-  if (getValidHandle(iEvent, beamSpotToken_, beamSpotH, "beamSpot")) {
-    const auto& beamspot = *beamSpotH;
-    beamspotVertex = std::make_unique<Run3ScoutingVertex>(
-        beamspot.x0(), beamspot.y0(), beamspot.z0(), 0., 0., 0., 0., 0., true, 0., 0., 0., 0);
-  }
 
   // fill tracks histograms
   for (const auto& tk : *tracksH) {
@@ -1341,12 +1365,17 @@ void ScoutingCollectionMonitor::bookHistograms(DQMStore::IBooker& ibook,
   trkBestIdx_ele_hist = ibook.book1DD("trkBestIdx", "Best-track index;index;Electrons", 20, 0, 20);
   trkd0_ele_hist = ibook.book1DD("trkd0", "Best-track d_{0};d_{0} [cm];Electrons", 100, -0.5, 0.5);
   trkdz_ele_hist = ibook.book1DD("trkdz", "Best-track d_{z};d_{z} [cm];Electrons", 100, -25, 25);
+
+  trkd0BS_ele_hist = ibook.book1DD("trkd0BS", "Best-track d_{0}(BS);d_{0}(BS) [cm];Electrons", 100, -0.5, 0.5);
+  trkdzBS_ele_hist = ibook.book1DD("trkdzBS", "Best-track d_{z}(BS);d_{z}(BS) [cm];Electrons", 100, -25, 25);
+
   trkpt_ele_hist = ibook.book1DD("trkpt", "Best-track p_{T};p_{T} [GeV];Electrons", 100, 0, 200);
   trketa_ele_hist = ibook.book1DD("trketa", "Best-track #eta;#eta;Electrons", 60, -3, 3);
   trkphi_els_hist = ibook.book1DD("trkphi", "Best-track #phi;#phi [rad];Electrons", 64, -3.2, 3.2);
   trkpMode_ele_hist = ibook.book1DD("trkpMode", "Best-track p (mode);p_{mode} [GeV];Electrons", 100, 0, 200);
   trketaMode_ele_hist = ibook.book1DD("trketaMode", "Best-track #eta (mode);#eta_{mode};Electrons", 60, -3, 3);
-  trkphiMode_ele_hist = ibook.book1DD("trkphiMode", "Best-track #phi (mode);#phi_{mode} [rad];Electrons", 64, -3.2, 3.2);
+  trkphiMode_ele_hist =
+      ibook.book1DD("trkphiMode", "Best-track #phi (mode);#phi_{mode} [rad];Electrons", 64, -3.2, 3.2);
   trkqoverpModeError_ele_hist = ibook.book1DD(
       "trkqoverpModeError", "Best-track #sigma(q/p) (mode);#sigma(q/p)_{mode} [GeV^{-1}];Electrons", 100, 0, 0.01);
   trkchi2overndf_ele_hist =

--- a/DQM/HLTEvF/python/ScoutingTrackingMonitor_cff.py
+++ b/DQM/HLTEvF/python/ScoutingTrackingMonitor_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+## See DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+from HLTriggerOffline.Scouting.ScoutingTrackMonitor_cfi import *
+
+ScoutingTrackMonitorOnline = ScoutingTrackMonitor.clone(
+    topFolderName = 'HLT/ScoutingOnline/Tracks'
+)
+
+ScoutingTracksMonitoring = cms.Sequence(ScoutingTrackMonitorOnline)

--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -101,7 +101,7 @@ process.dqmHLTFiltersDQMonitor.lightMonitor = True
 
 process.p = cms.Path(process.dqmcommon *
                      process.hltOnlineBeamSpot *
-                     process.ScoutingTracksMonitoring *
+                     process.ScoutingTrackMonitorOnline *
                      process.run3ScoutingElectronBestTrack *
                      process.scoutingCollectionMonitor *
                      process.ScoutingRecHitsMonitoring *

--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -54,6 +54,9 @@ from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProduce
 process.hltOnlineBeamSpot = _onlineBeamSpotProducer.clone()
 
 ### for pp collisions
+process.load("DQM.HLTEvF.ScoutingTrackingMonitor_cff")
+process.ScoutingTrackMonitorOnline.topFolderName = 'NGT/ScoutingOnline/Tracks'
+
 process.load("DQM.HLTEvF.ScoutingCollectionMonitor_cfi")
 process.scoutingCollectionMonitor.topfoldername = "NGT/ScoutingOnline/ScoutingCollections"
 process.scoutingCollectionMonitor.onlyScouting = False
@@ -98,6 +101,7 @@ process.dqmHLTFiltersDQMonitor.lightMonitor = True
 
 process.p = cms.Path(process.dqmcommon *
                      process.hltOnlineBeamSpot *
+                     process.ScoutingTracksMonitoring *
                      process.run3ScoutingElectronBestTrack *
                      process.scoutingCollectionMonitor *
                      process.ScoutingRecHitsMonitoring *

--- a/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scouting_dqm_sourceclient-live_cfg.py
@@ -53,6 +53,7 @@ process.scoutingCollectionMonitor.rho = ["hltScoutingPFPacker", "rho"]
 process.dqmcommon = cms.Sequence(process.dqmEnv
                                * process.dqmSaver)#*process.dqmSaverPB)
 
+process.load("DQM.HLTEvF.ScoutingTrackingMonitor_cff")
 process.load("DQM.HLTEvF.ScoutingMuonMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingJetMonitoring_cff")
 process.load("DQM.HLTEvF.ScoutingElectronMonitoring_cff")
@@ -66,6 +67,7 @@ process.run3ScoutingElectronBestTrack =  _Run3ScoutingElectronBestTrackProducer.
 
 process.p = cms.Path(process.dqmcommon *
                      process.hltOnlineBeamSpot *
+                     process.ScoutingTracksMonitoring *
                      process.run3ScoutingElectronBestTrack *
                      process.scoutingCollectionMonitor *
                      process.ScoutingMuonMonitoring *

--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -7,6 +7,9 @@ currently running EGM and MUO monitoring modules.
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester                                
 
+### Tracks
+from HLTriggerOffline.Scouting.ScoutingTrackMonitor_cfi import *
+
 ### Muons monitoring
 from HLTriggerOffline.Scouting.ScoutingMuonTriggerAnalyzer_cfi import *
 from HLTriggerOffline.Scouting.ScoutingMuonTagProbeAnalyzer_cfi import *
@@ -34,6 +37,8 @@ from HLTriggerOffline.Scouting.HLTScoutingDileptonMonitor_cfi import *
 ### Pi0 Monitoring
 from HLTriggerOffline.Scouting.HLTScoutingPi0Monitor_cfi import *
 
+hltScoutingTrackMonitor = cms.Sequence(ScoutingTrackMonitor)
+
 hltScoutingMuonDqmOffline = cms.Sequence(scoutingMonitoringTagProbeMuonNoVtx *
                                          scoutingMonitoringTagProbeMuonVtx *
                                          scoutingMonitoringTriggerMuon_DoubleMu *
@@ -50,7 +55,8 @@ hltScoutingCollectionMonitor = cms.Sequence(scoutingCollectionMonitor)
 hltScoutingDileptonMonitor = cms.Sequence(ScoutingDileptonMonitor)
 hltScoutingPi0Monitor = cms.Sequence(ScoutingPi0Monitor)
 
-hltScoutingDqmOffline = cms.Sequence(hltScoutingMuonDqmOffline +
+hltScoutingDqmOffline = cms.Sequence(hltScoutingTrackMonitor +
+                                     hltScoutingMuonDqmOffline +
                                      hltScoutingEGammaDqmOffline +
                                      hltScoutingJetDqmOffline +
                                      run3ScoutingElectronBestTrack +

--- a/HLTriggerOffline/Scouting/plugins/ScoutingMuonPropertiesAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingMuonPropertiesAnalyzer.cc
@@ -199,6 +199,19 @@ private:
   MonitorElement* h_SVVtx_mass_Z_;
   MonitorElement* h_SVVtx_mass_JPsi_;
   MonitorElement* h_SVVtx_nMuon_;
+
+  // Occupancy maps
+  MonitorElement* h2_MuonVtx_eta_phi;
+  MonitorElement* h2_MuonNoVtx_eta_phi;
+
+  // 2D eta-phi profiles
+  MonitorElement* p2_MuonVtx_nValidPixelHits_eta_phi;
+  MonitorElement* p2_MuonVtx_nTrackerLayersWithMeasurement_eta_phi;
+  MonitorElement* p2_MuonVtx_nValidStripHits_eta_phi;
+
+  MonitorElement* p2_MuonNoVtx_nValidPixelHits_eta_phi;
+  MonitorElement* p2_MuonNoVtx_nTrackerLayersWithMeasurement_eta_phi;
+  MonitorElement* p2_MuonNoVtx_nValidStripHits_eta_phi;
 };
 
 ScoutingMuonPropertiesAnalyzer::ScoutingMuonPropertiesAnalyzer(const edm::ParameterSet& iConfig)
@@ -708,6 +721,57 @@ void ScoutingMuonPropertiesAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
   h_SVVtx_nMuon_->setAxisTitle("Number of Muons", 1);
   h_SVVtx_nMuon_->setAxisTitle("Vertices", 2);
 
+  // Common eta-phi binning
+  constexpr int nEtaBins = 50;
+  constexpr double etaMin = -2.4;
+  constexpr double etaMax = 2.4;
+
+  constexpr int nPhiBins = 50;
+  constexpr double phiMin = -std::numbers::pi;
+  constexpr double phiMax = std::numbers::pi;
+
+  // Helper lambda for 2D occupancy histograms
+  auto bookOccupancy = [&](const std::string& name, const std::string& title) {
+    return ibooker.book2I(name, title, nEtaBins, etaMin, etaMax, nPhiBins, phiMin, phiMax);
+  };
+
+  h2_MuonVtx_eta_phi = bookOccupancy("eta_vs_phi_MuonVtx", "Track occupancy (MuonVtx);#eta;#phi");
+
+  h2_MuonNoVtx_eta_phi = bookOccupancy("eta_vs_phi_MuonNoVtx", "Track occupancy (MuonNoVtx);#eta;#phi");
+
+  // Helper lambda for 2D profile histograms
+  auto bookProfile2D = [&](const std::string& name, const std::string& title, double ymin, double ymax) {
+    auto* me = ibooker.bookProfile2D(name, title, nEtaBins, etaMin, etaMax, nPhiBins, phiMin, phiMax, ymin, ymax, "");
+    me->setOption("colz");
+    return me;
+  };
+
+  // Muons with vertex
+  p2_MuonVtx_nValidPixelHits_eta_phi = bookProfile2D(
+      "MuonVtx_nValidPixelHits_vs_eta_phi_prof", "nValidPixelHits vs #eta-#phi;<nValidPixelHits>;#eta;#phi", 0., 10.);
+
+  p2_MuonVtx_nTrackerLayersWithMeasurement_eta_phi =
+      bookProfile2D("MuonVtx_nTrackerLayersWithMeasurement_vs_eta_phi_prof",
+                    "nTrackerLayersWithMeasurement vs #eta-#phi;<nTrackerLayersWithMeasurement>;#eta;#phi",
+                    0.,
+                    20.);
+
+  p2_MuonVtx_nValidStripHits_eta_phi = bookProfile2D(
+      "MuonVtx_nValidStripHits_vs_eta_phi_prof", "nValidStripHits vs #eta-#phi;<nValidStripHits>;#eta;#phi", 0., 30.);
+
+  // Muons without vertex
+  p2_MuonNoVtx_nValidPixelHits_eta_phi = bookProfile2D(
+      "MuonNoVtx_nValidPixelHits_vs_eta_phi_prof", "nValidPixelHits vs #eta-#phi;<nValidPixelHits>;#eta;#phi", 0., 10.);
+
+  p2_MuonNoVtx_nTrackerLayersWithMeasurement_eta_phi =
+      bookProfile2D("MuonNoVtx_nTrackerLayersWithMeasurement_vs_eta_phi_prof",
+                    "nTrackerLayersWithMeasurement vs #eta-#phi;<nTrackerLayersWithMeasurement>;#eta;#phi",
+                    0.,
+                    20.);
+
+  p2_MuonNoVtx_nValidStripHits_eta_phi = bookProfile2D(
+      "MuonNoVtx_nValidStripHits_vs_eta_phi_prof", "nValidStripHits vs #eta-#phi;<nValidStripHits>;#eta;#phi", 0., 30.);
+
   triggersMapped_ = false;
 }
 
@@ -822,6 +886,22 @@ void ScoutingMuonPropertiesAnalyzer::analyze(const edm::Event& iEvent, const edm
         h_ScoutingMuonNoVtx_trkvz_->Fill(mu.trk_vz());
       }
 
+      const double eta = mu.eta();
+      const double phi = mu.phi();
+
+      // Extract hit information
+      const double nValidPixelHits = mu.nValidPixelHits();
+      const double nTrackerLayersWithMeasurement = mu.nTrackerLayersWithMeasurement();
+      const double nValidStripHits = mu.nValidStripHits();
+
+      // Occupancy
+      h2_MuonNoVtx_eta_phi->Fill(eta, phi);
+
+      // Profiles
+      p2_MuonNoVtx_nValidPixelHits_eta_phi->Fill(eta, phi, nValidPixelHits);
+      p2_MuonNoVtx_nTrackerLayersWithMeasurement_eta_phi->Fill(eta, phi, nTrackerLayersWithMeasurement);
+      p2_MuonNoVtx_nValidStripHits_eta_phi->Fill(eta, phi, nValidStripHits);
+
       h_ScoutingMuonNoVtx_m_->Fill(mu.m());
       h_ScoutingMuonNoVtx_vtxIndx_->Fill(mu.vtxIndx().size());
       muonNoVtx_vtxIndx.push_back(mu.vtxIndx());
@@ -890,6 +970,22 @@ void ScoutingMuonPropertiesAnalyzer::analyze(const edm::Event& iEvent, const edm
         h_ScoutingMuonVtx_trkvy_->Fill(mu.trk_vy());
         h_ScoutingMuonVtx_trkvz_->Fill(mu.trk_vz());
       }
+
+      const double eta = mu.eta();
+      const double phi = mu.phi();
+
+      // Extract hit information
+      const double nValidPixelHits = mu.nValidPixelHits();
+      const double nTrackerLayersWithMeasurement = mu.nTrackerLayersWithMeasurement();
+      const double nValidStripHits = mu.nValidStripHits();
+
+      // Occupancy
+      h2_MuonVtx_eta_phi->Fill(eta, phi);
+
+      // Profiles
+      p2_MuonVtx_nValidPixelHits_eta_phi->Fill(eta, phi, nValidPixelHits);
+      p2_MuonVtx_nTrackerLayersWithMeasurement_eta_phi->Fill(eta, phi, nTrackerLayersWithMeasurement);
+      p2_MuonVtx_nValidStripHits_eta_phi->Fill(eta, phi, nValidStripHits);
 
       h_ScoutingMuonVtx_m_->Fill(mu.m());
       h_ScoutingMuonVtx_vtxIndx_->Fill(mu.vtxIndx().size());

--- a/HLTriggerOffline/Scouting/plugins/ScoutingMuonPropertiesAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingMuonPropertiesAnalyzer.cc
@@ -732,12 +732,14 @@ void ScoutingMuonPropertiesAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
 
   // Helper lambda for 2D occupancy histograms
   auto bookOccupancy = [&](const std::string& name, const std::string& title) {
-    return ibooker.book2I(name, title, nEtaBins, etaMin, etaMax, nPhiBins, phiMin, phiMax);
+    auto* me = ibooker.book2I(name, title, nEtaBins, etaMin, etaMax, nPhiBins, phiMin, phiMax);
+    me->setOption("colz");
+    return me;
   };
 
-  h2_MuonVtx_eta_phi = bookOccupancy("eta_vs_phi_MuonVtx", "Track occupancy (MuonVtx);#eta;#phi");
+  h2_MuonVtx_eta_phi = bookOccupancy("eta_vs_phi_MuonVtx", "Track occupancy (MuonVtx);#eta;#phi [rad]");
 
-  h2_MuonNoVtx_eta_phi = bookOccupancy("eta_vs_phi_MuonNoVtx", "Track occupancy (MuonNoVtx);#eta;#phi");
+  h2_MuonNoVtx_eta_phi = bookOccupancy("eta_vs_phi_MuonNoVtx", "Track occupancy (MuonNoVtx);#eta;#phi [rad]");
 
   // Helper lambda for 2D profile histograms
   auto bookProfile2D = [&](const std::string& name, const std::string& title, double ymin, double ymax) {
@@ -747,30 +749,42 @@ void ScoutingMuonPropertiesAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
   };
 
   // Muons with vertex
-  p2_MuonVtx_nValidPixelHits_eta_phi = bookProfile2D(
-      "MuonVtx_nValidPixelHits_vs_eta_phi_prof", "nValidPixelHits vs #eta-#phi;<nValidPixelHits>;#eta;#phi", 0., 10.);
+  p2_MuonVtx_nValidPixelHits_eta_phi =
+      bookProfile2D("MuonVtx_nValidPixelHits_vs_eta_phi_prof",
+                    "nValidPixelHits vs #eta-#phi;#eta;#phi [rad];#LTnValidPixelHits#GT",
+                    0.,
+                    10.);
 
   p2_MuonVtx_nTrackerLayersWithMeasurement_eta_phi =
       bookProfile2D("MuonVtx_nTrackerLayersWithMeasurement_vs_eta_phi_prof",
-                    "nTrackerLayersWithMeasurement vs #eta-#phi;<nTrackerLayersWithMeasurement>;#eta;#phi",
+                    "nTrackerLayersWithMeasurement vs #eta-#phi;#eta;#phi [rad];#LTnTrackerLayersWithMeasurement#GT",
                     0.,
                     20.);
 
-  p2_MuonVtx_nValidStripHits_eta_phi = bookProfile2D(
-      "MuonVtx_nValidStripHits_vs_eta_phi_prof", "nValidStripHits vs #eta-#phi;<nValidStripHits>;#eta;#phi", 0., 30.);
+  p2_MuonVtx_nValidStripHits_eta_phi =
+      bookProfile2D("MuonVtx_nValidStripHits_vs_eta_phi_prof",
+                    "nValidStripHits vs #eta-#phi;#eta;#phi [rad];#LTnValidStripHits#GT",
+                    0.,
+                    30.);
 
   // Muons without vertex
-  p2_MuonNoVtx_nValidPixelHits_eta_phi = bookProfile2D(
-      "MuonNoVtx_nValidPixelHits_vs_eta_phi_prof", "nValidPixelHits vs #eta-#phi;<nValidPixelHits>;#eta;#phi", 0., 10.);
+  p2_MuonNoVtx_nValidPixelHits_eta_phi =
+      bookProfile2D("MuonNoVtx_nValidPixelHits_vs_eta_phi_prof",
+                    "nValidPixelHits vs #eta-#phi;#eta;#phi [rad];#LTnValidPixelHits#GT",
+                    0.,
+                    10.);
 
   p2_MuonNoVtx_nTrackerLayersWithMeasurement_eta_phi =
       bookProfile2D("MuonNoVtx_nTrackerLayersWithMeasurement_vs_eta_phi_prof",
-                    "nTrackerLayersWithMeasurement vs #eta-#phi;<nTrackerLayersWithMeasurement>;#eta;#phi",
+                    "nTrackerLayersWithMeasurement vs #eta-#phi;#eta;#phi [rad];#LTnTrackerLayersWithMeasurement#GT",
                     0.,
                     20.);
 
-  p2_MuonNoVtx_nValidStripHits_eta_phi = bookProfile2D(
-      "MuonNoVtx_nValidStripHits_vs_eta_phi_prof", "nValidStripHits vs #eta-#phi;<nValidStripHits>;#eta;#phi", 0., 30.);
+  p2_MuonNoVtx_nValidStripHits_eta_phi =
+      bookProfile2D("MuonNoVtx_nValidStripHits_vs_eta_phi_prof",
+                    "nValidStripHits vs #eta-#phi;#eta;#phi [rad];#LTnValidStripHits#GT",
+                    0.,
+                    30.);
 
   triggersMapped_ = false;
 }

--- a/HLTriggerOffline/Scouting/plugins/ScoutingMuonPropertiesAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingMuonPropertiesAnalyzer.cc
@@ -170,8 +170,8 @@ private:
   MonitorElement* h_SVNoVtx_chi2_;
   MonitorElement* h_SVNoVtx_ndof_;
   MonitorElement* h_SVNoVtx_isvalidvtx_;
-  MonitorElement* h_SVNoVtx_dxy_;
-  MonitorElement* h_SVNoVtx_dxySig_;
+  MonitorElement* h_SVNoVtx_dlenXY_;
+  MonitorElement* h_SVNoVtx_dlenXYSig_;
   MonitorElement* h_SVNoVtx_dlen_;
   MonitorElement* h_SVNoVtx_dlenSig_;
   MonitorElement* h_SVNoVtx_mass_;
@@ -191,8 +191,8 @@ private:
   MonitorElement* h_SVVtx_chi2_;
   MonitorElement* h_SVVtx_ndof_;
   MonitorElement* h_SVVtx_isvalidvtx_;
-  MonitorElement* h_SVVtx_dxy_;
-  MonitorElement* h_SVVtx_dxySig_;
+  MonitorElement* h_SVVtx_dlenXY_;
+  MonitorElement* h_SVVtx_dlenXYSig_;
   MonitorElement* h_SVVtx_dlen_;
   MonitorElement* h_SVVtx_dlenSig_;
   MonitorElement* h_SVVtx_mass_;
@@ -642,19 +642,19 @@ void ScoutingMuonPropertiesAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
 
   // SVNoVtx
 
-  h_SVNoVtx_dxy_ = ibooker.book1D("SVNoVtx_dxy", "SVNoVtx dxy", 100, 0, 0.5);
-  h_SVNoVtx_dxy_->setAxisTitle("dxy [cm]", 1);
-  h_SVNoVtx_dxy_->setAxisTitle("Vertices", 2);
+  h_SVNoVtx_dlenXY_ = ibooker.book1D("SVNoVtx_dlenXY", "SVNoVtx dlen_{xy}", 100, 0, 20.);
+  h_SVNoVtx_dlenXY_->setAxisTitle("Transverse Decay Length [cm]", 1);
+  h_SVNoVtx_dlenXY_->setAxisTitle("Vertices", 2);
 
-  h_SVNoVtx_dxySig_ = ibooker.book1D("SVNoVtx_dxySig", "SVNoVtx dxy significance", 100, 0, 10);
-  h_SVNoVtx_dxySig_->setAxisTitle("dxy Significance", 1);
-  h_SVNoVtx_dxySig_->setAxisTitle("Vertices", 2);
+  h_SVNoVtx_dlenXYSig_ = ibooker.book1D("SVNoVtx_dlenXYSig", "SVNoVtx dlen_{xy} significance", 100, 0, 10);
+  h_SVNoVtx_dlenXYSig_->setAxisTitle("Transvertse Decay Length Significance", 1);
+  h_SVNoVtx_dlenXYSig_->setAxisTitle("Vertices", 2);
 
-  h_SVNoVtx_dlen_ = ibooker.book1D("SVNoVtx_dlen", "SVNoVtx dlen", 100, 0, 20);
+  h_SVNoVtx_dlen_ = ibooker.book1D("SVNoVtx_dlen", "SVNoVtx dlen", 250, 0, 125);
   h_SVNoVtx_dlen_->setAxisTitle("Decay Length [cm]", 1);
   h_SVNoVtx_dlen_->setAxisTitle("Vertices", 2);
 
-  h_SVNoVtx_dlenSig_ = ibooker.book1D("SVNoVtx_dlenSig", "SVNoVtx dlen significance", 100, 0, 50);
+  h_SVNoVtx_dlenSig_ = ibooker.book1D("SVNoVtx_dlenSig", "SVNoVtx dlen significance", 100, 0, 10);
   h_SVNoVtx_dlenSig_->setAxisTitle("Decay Length Significance", 1);
   h_SVNoVtx_dlenSig_->setAxisTitle("Vertices", 2);
 
@@ -662,27 +662,27 @@ void ScoutingMuonPropertiesAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
   h_SVNoVtx_mass_->setAxisTitle("Mass [GeV]", 1);
   h_SVNoVtx_mass_->setAxisTitle("Vertices", 2);
 
-  h_SVNoVtx_mass_JPsi_ = ibooker.book1D("SVNoVtx_mass_JPsi", "SVNoVtx mass J/Psi", 50, 0, 10);
+  h_SVNoVtx_mass_JPsi_ = ibooker.book1D("SVNoVtx_mass_JPsi", "SVNoVtx mass J/Psi", 100, 0., 10.);
   h_SVNoVtx_mass_JPsi_->setAxisTitle("Mass [GeV]", 1);
   h_SVNoVtx_mass_JPsi_->setAxisTitle("Vertices", 2);
 
-  h_SVNoVtx_mass_Z_ = ibooker.book1D("SVNoVtx_mass_Z", "SVNoVtx mass Z", 50, 80, 100);
+  h_SVNoVtx_mass_Z_ = ibooker.book1D("SVNoVtx_mass_Z", "SVNoVtx mass Z", 100, 80, 100);
   h_SVNoVtx_mass_Z_->setAxisTitle("Mass [GeV]", 1);
   h_SVNoVtx_mass_Z_->setAxisTitle("Vertices", 2);
 
-  h_SVNoVtx_nMuon_ = ibooker.book1D("SVNoVtx_nMuon", "SVNoVtx nMuon", 10, 0, 10);
+  h_SVNoVtx_nMuon_ = ibooker.book1D("SVNoVtx_nMuon", "SVNoVtx nMuon", 10, -0.5, 9.5);
   h_SVNoVtx_nMuon_->setAxisTitle("Number of Muons", 1);
   h_SVNoVtx_nMuon_->setAxisTitle("Vertices", 2);
 
   // SVVtx
 
-  h_SVVtx_dxy_ = ibooker.book1D("SVVtx_dxy", "SVVtx dxy", 100, 0, 0.5);
-  h_SVVtx_dxy_->setAxisTitle("dxy [cm]", 1);
-  h_SVVtx_dxy_->setAxisTitle("Vertices", 2);
+  h_SVVtx_dlenXY_ = ibooker.book1D("SVVtx_dlenXY", "SVVtx dlen_{xy}", 100, 0, 0.5);
+  h_SVVtx_dlenXY_->setAxisTitle("Transverse Decay Length [cm]", 1);
+  h_SVVtx_dlenXY_->setAxisTitle("Vertices", 2);
 
-  h_SVVtx_dxySig_ = ibooker.book1D("SVVtx_dxySig", "SVVtx dxy significance", 100, 0, 10);
-  h_SVVtx_dxySig_->setAxisTitle("dxy Significance", 1);
-  h_SVVtx_dxySig_->setAxisTitle("Vertices", 2);
+  h_SVVtx_dlenXYSig_ = ibooker.book1D("SVVtx_dlenXYSig", "SVVtx dlen_{xy} significance", 100, 0, 10);
+  h_SVVtx_dlenXYSig_->setAxisTitle("Transverse Decay Length Significance", 1);
+  h_SVVtx_dlenXYSig_->setAxisTitle("Vertices", 2);
 
   h_SVVtx_dlen_ = ibooker.book1D("SVVtx_dlen", "SVVtx dlen", 100, 0, 20);
   h_SVVtx_dlen_->setAxisTitle("Decay Length [cm]", 1);
@@ -696,15 +696,15 @@ void ScoutingMuonPropertiesAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
   h_SVVtx_mass_->setAxisTitle("Mass [GeV]", 1);
   h_SVVtx_mass_->setAxisTitle("Vertices", 2);
 
-  h_SVVtx_mass_JPsi_ = ibooker.book1D("SVVtx_mass_JPsi", "SVVtx mass J/Psi", 50, 0, 10);
+  h_SVVtx_mass_JPsi_ = ibooker.book1D("SVVtx_mass_JPsi", "SVVtx mass J/Psi", 100, 0., 10.);
   h_SVVtx_mass_JPsi_->setAxisTitle("Mass [GeV]", 1);
   h_SVVtx_mass_JPsi_->setAxisTitle("Vertices", 2);
 
-  h_SVVtx_mass_Z_ = ibooker.book1D("SVVtx_mass_Z", "SVVtx mass Z", 50, 80, 100);
+  h_SVVtx_mass_Z_ = ibooker.book1D("SVVtx_mass_Z", "SVVtx mass Z", 100, 80, 100);
   h_SVVtx_mass_Z_->setAxisTitle("Mass [GeV]", 1);
   h_SVVtx_mass_Z_->setAxisTitle("Vertices", 2);
 
-  h_SVVtx_nMuon_ = ibooker.book1D("SVVtx_nMuon", "SVVtx nMuon", 10, 0, 10);
+  h_SVVtx_nMuon_ = ibooker.book1D("SVVtx_nMuon", "SVVtx nMuon", 10, -0.5, 9.5);
   h_SVVtx_nMuon_->setAxisTitle("Number of Muons", 1);
   h_SVVtx_nMuon_->setAxisTitle("Vertices", 2);
 
@@ -956,8 +956,8 @@ void ScoutingMuonPropertiesAnalyzer::analyze(const edm::Event& iEvent, const edm
         reco::Vertex svCand(svPos, svErr, sv.chi2(), sv.ndof(), sv.tracksSize());
         Measurement1D dxy = vdistXY.distance(PV0, svCand);
         Measurement1D dlen = vdist.distance(PV0, svCand);
-        h_SVNoVtx_dxy_->Fill(dxy.value());
-        h_SVNoVtx_dxySig_->Fill(dxy.significance());
+        h_SVNoVtx_dlenXY_->Fill(dxy.value());
+        h_SVNoVtx_dlenXYSig_->Fill(dxy.significance());
         h_SVNoVtx_dlen_->Fill(dlen.value());
         h_SVNoVtx_dlenSig_->Fill(dlen.significance());
       }
@@ -1017,8 +1017,8 @@ void ScoutingMuonPropertiesAnalyzer::analyze(const edm::Event& iEvent, const edm
         reco::Vertex svCand(svPos, svErr, sv.chi2(), sv.ndof(), sv.tracksSize());
         Measurement1D dxy = vdistXY.distance(PV0, svCand);
         Measurement1D dlen = vdist.distance(PV0, svCand);
-        h_SVVtx_dxy_->Fill(dxy.value());
-        h_SVVtx_dxySig_->Fill(dxy.significance());
+        h_SVVtx_dlenXY_->Fill(dxy.value());
+        h_SVVtx_dlenXYSig_->Fill(dxy.significance());
         h_SVVtx_dlen_->Fill(dlen.value());
         h_SVVtx_dlenSig_->Fill(dlen.significance());
       }

--- a/HLTriggerOffline/Scouting/plugins/ScoutingMuonPropertiesAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingMuonPropertiesAnalyzer.cc
@@ -660,7 +660,7 @@ void ScoutingMuonPropertiesAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
   h_SVNoVtx_dlenXY_->setAxisTitle("Vertices", 2);
 
   h_SVNoVtx_dlenXYSig_ = ibooker.book1D("SVNoVtx_dlenXYSig", "SVNoVtx dlen_{xy} significance", 100, 0, 10);
-  h_SVNoVtx_dlenXYSig_->setAxisTitle("Transvertse Decay Length Significance", 1);
+  h_SVNoVtx_dlenXYSig_->setAxisTitle("Transverse Decay Length Significance", 1);
   h_SVNoVtx_dlenXYSig_->setAxisTitle("Vertices", 2);
 
   h_SVNoVtx_dlen_ = ibooker.book1D("SVNoVtx_dlen", "SVNoVtx dlen", 250, 0, 125);

--- a/HLTriggerOffline/Scouting/plugins/ScoutingPi0Analyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingPi0Analyzer.cc
@@ -111,110 +111,110 @@ void ScoutingPi0Analyzer::fillDescriptions(edm::ConfigurationDescriptions& descr
 
 void ScoutingPi0Analyzer::bookHistSet(DQMStore::IBooker& ibook, Pi0Histograms& h, const std::string& suffix) {
   // Input Kinematics
-  h.h_input_pt = ibook.book1D(("h_input_pt_" + suffix).c_str(),
-                              ("Input Photon p_{T} (" + suffix + ");#gamma p_{T} [GeV];Photons").c_str(),
-                              50,
-                              0,
-                              20);
-  h.h_input_eta = ibook.book1D(("h_input_eta_" + suffix).c_str(),
-                               ("Input Photon #eta (" + suffix + ");#gamma #eta;Photons").c_str(),
-                               60,
-                               -3.0,
-                               3.0);
-  h.h_input_phi = ibook.book1D(("h_input_phi_" + suffix).c_str(),
-                               ("Input Photon #phi (" + suffix + ");#gamma #phi [rad];Photons").c_str(),
-                               64,
-                               -3.2,
-                               3.2);
+  h.h_input_pt = ibook.book1DD(("h_input_pt_" + suffix).c_str(),
+                               ("Input Photon p_{T} (" + suffix + ");#gamma p_{T} [GeV];Photons").c_str(),
+                               50,
+                               0,
+                               20);
+  h.h_input_eta = ibook.book1DD(("h_input_eta_" + suffix).c_str(),
+                                ("Input Photon #eta (" + suffix + ");#gamma #eta;Photons").c_str(),
+                                60,
+                                -3.0,
+                                3.0);
+  h.h_input_phi = ibook.book1DD(("h_input_phi_" + suffix).c_str(),
+                                ("Input Photon #phi (" + suffix + ");#gamma #phi [rad];Photons").c_str(),
+                                64,
+                                -3.2,
+                                3.2);
 
   // Selected Kinematics
-  h.h_sel_pt = ibook.book1D(("h_sel_pt_" + suffix).c_str(),
-                            ("Selected Photon p_{T} (" + suffix + ");#gamma p_{T} [GeV];Photons").c_str(),
-                            50,
-                            0,
-                            20);
-  h.h_sel_eta = ibook.book1D(("h_sel_eta_" + suffix).c_str(),
-                             ("Selected Photon #eta (" + suffix + ");#gamma #eta;Photons").c_str(),
-                             60,
-                             -3.0,
-                             3.0);
-  h.h_sel_phi = ibook.book1D(("h_sel_phi_" + suffix).c_str(),
-                             ("Selected Photon #phi (" + suffix + ");#gamma #phi [rad];Photons").c_str(),
-                             64,
-                             -3.2,
-                             3.2);
+  h.h_sel_pt = ibook.book1DD(("h_sel_pt_" + suffix).c_str(),
+                             ("Selected Photon p_{T} (" + suffix + ");#gamma p_{T} [GeV];Photons").c_str(),
+                             50,
+                             0,
+                             20);
+  h.h_sel_eta = ibook.book1DD(("h_sel_eta_" + suffix).c_str(),
+                              ("Selected Photon #eta (" + suffix + ");#gamma #eta;Photons").c_str(),
+                              60,
+                              -3.0,
+                              3.0);
+  h.h_sel_phi = ibook.book1DD(("h_sel_phi_" + suffix).c_str(),
+                              ("Selected Photon #phi (" + suffix + ");#gamma #phi [rad];Photons").c_str(),
+                              64,
+                              -3.2,
+                              3.2);
 
   // Cut Variables: Isolation
-  h.h_iso_maxPtRatio = ibook.book1D(("h_iso_maxPtRatio_" + suffix).c_str(),
-                                    ("Max Hadron p_{T} / Photon p_{T} in Cone (" + suffix + ");Ratio;Photons").c_str(),
-                                    50,
-                                    0,
-                                    2.0);
-  h.h_iso_minDr = ibook.book1D(("h_iso_minDr_" + suffix).c_str(),
-                               ("Min #Delta R #gamma to Hadron (" + suffix + ");#Delta R(#gamma,had);Photons").c_str(),
-                               50,
-                               0,
-                               0.5);
+  h.h_iso_maxPtRatio = ibook.book1DD(("h_iso_maxPtRatio_" + suffix).c_str(),
+                                     ("Max Hadron p_{T} / Photon p_{T} in Cone (" + suffix + ");Ratio;Photons").c_str(),
+                                     50,
+                                     0,
+                                     2.0);
+  h.h_iso_minDr = ibook.book1DD(("h_iso_minDr_" + suffix).c_str(),
+                                ("Min #Delta R #gamma to Hadron (" + suffix + ");#Delta R(#gamma,had);Photons").c_str(),
+                                50,
+                                0,
+                                0.5);
 
   // Cut Variables: Pairs
-  h.h_pair_pt = ibook.book1D(("h_pair_pt_" + suffix).c_str(),
-                             ("Diphoton p_{T} (" + suffix + ");#gamma#gamma p_{T} [GeV];Photon Pairs").c_str(),
-                             50,
-                             0,
-                             50);
-  h.h_pair_asym = ibook.book1D(("h_pair_asym_" + suffix).c_str(),
-                               ("Diphoton Energy Asymmetry (" + suffix +
-                                ");|E_{#gamma 1}-E_{#gamma 2}|/(E_{#gamma 1}+E_{#gamma 2});Photon Pairs")
-                                   .c_str(),
-                               50,
-                               0,
-                               1.0);
-  h.h_pair_dr = ibook.book1D(("h_pair_dr_" + suffix).c_str(),
-                             ("Diphoton #Delta R (" + suffix + ");#Delta R(#gamma,#gamma);Photon Pairs").c_str(),
-                             50,
-                             0,
-                             1.0);
+  h.h_pair_pt = ibook.book1DD(("h_pair_pt_" + suffix).c_str(),
+                              ("Diphoton p_{T} (" + suffix + ");#gamma#gamma p_{T} [GeV];Photon Pairs").c_str(),
+                              50,
+                              0,
+                              50);
+  h.h_pair_asym = ibook.book1DD(("h_pair_asym_" + suffix).c_str(),
+                                ("Diphoton Energy Asymmetry (" + suffix +
+                                 ");|E_{#gamma 1}-E_{#gamma 2}|/(E_{#gamma 1}+E_{#gamma 2});Photon Pairs")
+                                    .c_str(),
+                                50,
+                                0,
+                                1.0);
+  h.h_pair_dr = ibook.book1DD(("h_pair_dr_" + suffix).c_str(),
+                              ("Diphoton #Delta R (" + suffix + ");#Delta R(#gamma,#gamma);Photon Pairs").c_str(),
+                              50,
+                              0,
+                              1.0);
 
   // Selected final di-photons plots
   h.h_selpair_mass =
-      ibook.book1D(("h_mass_" + suffix).c_str(),
-                   ("Diphoton Invariant Mass (" + suffix + ");M_{#gamma#gamma} [GeV];Photon Pairs").c_str(),
-                   100,
-                   0,
-                   1.0);
+      ibook.book1DD(("h_mass_" + suffix).c_str(),
+                    ("Diphoton Invariant Mass (" + suffix + ");M_{#gamma#gamma} [GeV];Photon Pairs").c_str(),
+                    100,
+                    0,
+                    1.0);
 
   h.h_selpair_pt =
-      ibook.book1D(("h_selpair_pt_" + suffix).c_str(),
-                   ("Selected Diphoton p_{T} (" + suffix + ");#gamma#gamma p_{T} [GeV];Photon Pairs").c_str(),
-                   50,
-                   0,
-                   50);
+      ibook.book1DD(("h_selpair_pt_" + suffix).c_str(),
+                    ("Selected Diphoton p_{T} (" + suffix + ");#gamma#gamma p_{T} [GeV];Photon Pairs").c_str(),
+                    50,
+                    0,
+                    50);
 
   // Selected final photons kinematics
   h.h_selpair_leadPt =
-      ibook.book1D(("h_selpair_leadPt_" + suffix).c_str(),
-                   ("Leading Photon p_{T} (" + suffix + ");leading #gamma p_{T} [GeV];Photon Pairs").c_str(),
-                   50,
-                   0,
-                   50);
-  h.h_selpair_leadEta = ibook.book1D(("h_selpair_leadEta_" + suffix).c_str(),
-                                     ("Leading Photon #eta (" + suffix + ");leading #gamma #eta;Photons").c_str(),
-                                     60,
-                                     -3.0,
-                                     3.0);
+      ibook.book1DD(("h_selpair_leadPt_" + suffix).c_str(),
+                    ("Leading Photon p_{T} (" + suffix + ");leading #gamma p_{T} [GeV];Photon Pairs").c_str(),
+                    50,
+                    0,
+                    50);
+  h.h_selpair_leadEta = ibook.book1DD(("h_selpair_leadEta_" + suffix).c_str(),
+                                      ("Leading Photon #eta (" + suffix + ");leading #gamma #eta;Photons").c_str(),
+                                      60,
+                                      -3.0,
+                                      3.0);
 
   h.h_selpair_subleadPt =
-      ibook.book1D(("h_selpair_subleadPt_" + suffix).c_str(),
-                   ("Subleading Photon p_{T} (" + suffix + ");subleading #gamma p_{T} [GeV];Photons").c_str(),
-                   50,
-                   0,
-                   50);
+      ibook.book1DD(("h_selpair_subleadPt_" + suffix).c_str(),
+                    ("Subleading Photon p_{T} (" + suffix + ");subleading #gamma p_{T} [GeV];Photons").c_str(),
+                    50,
+                    0,
+                    50);
   h.h_selpair_subleadEta =
-      ibook.book1D(("h_selpair_subleadEta_" + suffix).c_str(),
-                   ("Subleading Photon #eta (" + suffix + ");subleading #gamma #eta;Photons").c_str(),
-                   60,
-                   -3.0,
-                   3.0);
+      ibook.book1DD(("h_selpair_subleadEta_" + suffix).c_str(),
+                    ("Subleading Photon #eta (" + suffix + ");subleading #gamma #eta;Photons").c_str(),
+                    60,
+                    -3.0,
+                    3.0);
 }
 
 void ScoutingPi0Analyzer::bookHistograms(DQMStore::IBooker& ibook, edm::Run const&, edm::EventSetup const&) {
@@ -222,7 +222,7 @@ void ScoutingPi0Analyzer::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
 
   // Scouting Histogram
   h_mass_scouting =
-      ibook.book1D("h_mass_scouting", "Diphoton Mass (Scouting);Invariant Mass [GeV];Entries", 100, 0.0, maxMass_);
+      ibook.book1DD("h_mass_scouting", "Diphoton Mass (Scouting);Invariant Mass [GeV];Entries", 100, 0.0, maxMass_);
 
   bookHistSet(ibook, h_scouting, "Scouting");
 }

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -1,0 +1,178 @@
+// system includes
+#include <cmath>
+#include <vector>
+#include <numbers>
+
+// user includes
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingTrack.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingVertex.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+class ScoutingTrackMonitor : public DQMEDAnalyzer {
+public:
+  explicit ScoutingTrackMonitor(const edm::ParameterSet&);
+  ~ScoutingTrackMonitor() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+
+private:
+  // tokens
+  const edm::EDGetTokenT<std::vector<Run3ScoutingTrack>> tracksToken_;
+  const edm::EDGetTokenT<std::vector<Run3ScoutingVertex>> verticesToken_;
+
+  const std::string topFolderName_;  // top folder name where to book histograms
+
+  // histograms
+  MonitorElement* h_dxy;
+  MonitorElement* h_dz;
+  MonitorElement* p_dxy_eta;
+  MonitorElement* p_dxy_phi;
+  MonitorElement* p_dz_eta;
+  MonitorElement* p_dz_phi;
+
+  // helpers
+  reco::Track makeRecoTrack(const Run3ScoutingTrack& sTrack) const;
+  reco::Vertex makeRecoVertex(const Run3ScoutingVertex& sVertex) const;
+};
+
+// constructor
+ScoutingTrackMonitor::ScoutingTrackMonitor(const edm::ParameterSet& iConfig)
+    : tracksToken_{consumes<std::vector<Run3ScoutingTrack>>(iConfig.getParameter<edm::InputTag>("tracks"))},
+      verticesToken_{consumes<std::vector<Run3ScoutingVertex>>(iConfig.getParameter<edm::InputTag>("vertices"))},
+      topFolderName_{iConfig.getParameter<std::string>("topFolderName")} {}
+
+// histogram booking
+void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) {
+  ibooker.setCurrentFolder(topFolderName_);
+
+  h_dxy = ibooker.book1D("dxy", "dxy;dxy [cm];Entries", 100, -0.5, 0.5);
+  h_dz = ibooker.book1D("dz", "dz;dz [cm];Entries", 100, -1.0, 1.0);
+
+  p_dxy_eta = ibooker.bookProfile("dxy_vs_eta", "dxy vs eta;eta;<dxy>", 50, -3.0, 3.0, -0.5, 0.5, "");
+  p_dxy_phi =
+      ibooker.bookProfile("dxy_vs_phi", "dxy vs phi;phi;<dxy>", 50, -std::numbers::pi, std::numbers::pi, -0.5, 0.5, "");
+  p_dz_eta = ibooker.bookProfile("dz_vs_eta", "dz vs eta;eta;<dz>", 50, -3.0, 3.0, -1.0, 1.0, "");
+  p_dz_phi =
+      ibooker.bookProfile("dz_vs_phi", "dz vs phi;phi;<dz>", 50, -std::numbers::pi, std::numbers::pi, -1.0, 1.0, "");
+}
+
+// main event loop
+void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
+  auto const& tracks = iEvent.get(tracksToken_);
+  auto const& vertices = iEvent.get(verticesToken_);
+
+  if (vertices.empty())
+    return;
+
+  for (const auto& trk : tracks) {
+    // --- build reco track ---
+    reco::Track recoTrk = makeRecoTrack(trk);
+
+    float bestDist = 1e9;
+    const Run3ScoutingVertex* closestVtx = nullptr;
+
+    // --- find closest vertex in z ---
+    for (const auto& vtx : vertices) {
+      float dz = std::abs(trk.tk_vz() - vtx.z());
+      if (dz < bestDist) {
+        bestDist = dz;
+        closestVtx = &vtx;
+      }
+    }
+
+    if (!closestVtx)
+      continue;
+
+    // --- build reco vertex ---
+    reco::Vertex recoVtx = makeRecoVertex(*closestVtx);
+
+    // --- impact parameters (standard CMSSW definitions) ---
+    float dxy = recoTrk.dxy(recoVtx.position());
+    float dz = recoTrk.dz(recoVtx.position());
+
+    if (recoTrk.pt() < 3.)
+      continue;
+
+    // --- fill histograms ---
+    h_dxy->Fill(dxy);
+    h_dz->Fill(dz);
+
+    p_dxy_eta->Fill(recoTrk.eta(), dxy);
+    p_dxy_phi->Fill(recoTrk.phi(), dxy);
+
+    p_dz_eta->Fill(recoTrk.eta(), dz);
+    p_dz_phi->Fill(recoTrk.phi(), dz);
+  }
+}
+
+// helper: build reco::Track
+reco::Track ScoutingTrackMonitor::makeRecoTrack(const Run3ScoutingTrack& sTrack) const {
+  reco::Track::Point v(sTrack.tk_vx(), sTrack.tk_vy(), sTrack.tk_vz());
+  reco::Track::Vector p(math::RhoEtaPhiVector(sTrack.tk_pt(), sTrack.tk_eta(), sTrack.tk_phi()));
+
+  reco::TrackBase::CovarianceMatrix cov;
+  cov(0, 0) = std::pow(sTrack.tk_qoverp_Error(), 2);
+  cov(0, 1) = sTrack.tk_qoverp_lambda_cov();
+  cov(0, 2) = sTrack.tk_qoverp_phi_cov();
+  cov(0, 3) = sTrack.tk_qoverp_dxy_cov();
+  cov(0, 4) = sTrack.tk_qoverp_dsz_cov();
+
+  cov(1, 1) = std::pow(sTrack.tk_lambda_Error(), 2);
+  cov(1, 2) = sTrack.tk_lambda_phi_cov();
+  cov(1, 3) = sTrack.tk_lambda_dxy_cov();
+  cov(1, 4) = sTrack.tk_lambda_dsz_cov();
+
+  cov(2, 2) = std::pow(sTrack.tk_phi_Error(), 2);
+  cov(2, 3) = sTrack.tk_phi_dxy_cov();
+  cov(2, 4) = sTrack.tk_phi_dsz_cov();
+
+  cov(3, 3) = std::pow(sTrack.tk_dxy_Error(), 2);
+  cov(3, 4) = sTrack.tk_dxy_dsz_cov();
+
+  cov(4, 4) = std::pow(sTrack.tk_dsz_Error(), 2);
+
+  return reco::Track(sTrack.tk_chi2(), sTrack.tk_ndof(), v, p, sTrack.tk_charge(), cov);
+}
+
+// helper: build reco::Vertex
+reco::Vertex ScoutingTrackMonitor::makeRecoVertex(const Run3ScoutingVertex& sVertex) const {
+  reco::Vertex::Error err;
+
+  err(0, 0) = std::pow(sVertex.xError(), 2);
+  err(1, 1) = std::pow(sVertex.yError(), 2);
+  err(2, 2) = std::pow(sVertex.zError(), 2);
+
+  err(0, 1) = sVertex.xyCov();
+  err(0, 2) = sVertex.xzCov();
+  err(1, 2) = sVertex.yzCov();
+
+  return reco::Vertex(reco::Vertex::Point(sVertex.x(), sVertex.y(), sVertex.z()),
+                      err,
+                      sVertex.chi2(),
+                      sVertex.ndof(),
+                      sVertex.tracksSize());
+}
+
+void ScoutingTrackMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("tracks", edm::InputTag("hltScoutingTrackPacker"));
+  desc.add<edm::InputTag>("vertices", edm::InputTag("hltScoutingPrimaryVertexPacker", "primaryVtx"));
+  desc.add<std::string>("topFolderName", "HLT/ScoutingOffline/Tracks");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(ScoutingTrackMonitor);

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -45,6 +45,8 @@ private:
   // helpers
   reco::Track makeRecoTrack(const Run3ScoutingTrack& sTrack) const;
   reco::Vertex makeRecoVertex(const Run3ScoutingVertex& sVertex) const;
+  std::pair<unsigned int, const Run3ScoutingVertex*> findClosestScoutingVertex(
+      const reco::Track* track, const std::vector<Run3ScoutingVertex>& vertices);
 };
 
 // constructor
@@ -80,20 +82,23 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     // --- build reco track ---
     reco::Track recoTrk = makeRecoTrack(trk);
 
-    float bestDist = 1e9;
-    const Run3ScoutingVertex* closestVtx = nullptr;
-
-    // --- find closest vertex in z ---
-    for (const auto& vtx : vertices) {
-      float dz = std::abs(trk.tk_vz() - vtx.z());
-      if (dz < bestDist) {
-        bestDist = dz;
-        closestVtx = &vtx;
-      }
-    }
-
+    auto [vtxIndex, closestVtx] = findClosestScoutingVertex(&recoTrk, vertices);
     if (!closestVtx)
       continue;
+
+    // // --- find closest vertex in z ---
+    // float bestDist = 1e9;
+    // const Run3ScoutingVertex* closestVtx = nullptr;
+    // for (const auto& vtx : vertices) {
+    //   float dz = std::abs(trk.tk_vz() - vtx.z());
+    //   if (dz < bestDist) {
+    //     bestDist = dz;
+    //     closestVtx = &vtx;
+    //   }
+    // }
+
+    // if (!closestVtx)
+    //   continue;
 
     // --- build reco vertex ---
     reco::Vertex recoVtx = makeRecoVertex(*closestVtx);
@@ -163,6 +168,31 @@ reco::Vertex ScoutingTrackMonitor::makeRecoVertex(const Run3ScoutingVertex& sVer
                       sVertex.chi2(),
                       sVertex.ndof(),
                       sVertex.tracksSize());
+}
+
+std::pair<unsigned int, const Run3ScoutingVertex*> ScoutingTrackMonitor::findClosestScoutingVertex(
+    const reco::Track* track, const std::vector<Run3ScoutingVertex>& vertices) {
+  double minDistance = std::numeric_limits<double>::max();
+  const Run3ScoutingVertex* closestVertex = nullptr;
+
+  unsigned int index{0}, theIndex{999};
+
+  for (const auto& vertex : vertices) {
+    math::XYZPoint vertexPosition(vertex.x(), vertex.y(), vertex.z());
+
+    const auto& trackMomentum = track->momentum();
+    const auto& vertexToPoint = vertexPosition - track->referencePoint();
+
+    double distance = vertexToPoint.Cross(trackMomentum).R() / trackMomentum.R();
+
+    if (distance < minDistance) {
+      minDistance = distance;
+      closestVertex = &vertex;
+      theIndex = index;
+    }
+    index++;
+  }
+  return std::make_pair(theIndex, closestVertex);
 }
 
 void ScoutingTrackMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -52,6 +52,8 @@ private:
   MonitorElement* p2_nTrackerLayersWithMeasurement_eta_phi;
   MonitorElement* p2_nValidStripHits_eta_phi;
 
+  static constexpr int cmToUm = 10000;
+
   // helpers
   reco::Track makeRecoTrack(const Run3ScoutingTrack& sTrack) const;
   reco::Vertex makeRecoVertex(const Run3ScoutingVertex& sVertex) const;
@@ -69,62 +71,64 @@ ScoutingTrackMonitor::ScoutingTrackMonitor(const edm::ParameterSet& iConfig)
 void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) {
   ibooker.setCurrentFolder(topFolderName_);
 
-  h_dxy = ibooker.book1D("dxy", "dxy;dxy [cm];Entries", 100, -0.5, 0.5);
-  h_dz = ibooker.book1D("dz", "dz;dz [cm];Entries", 100, -1.0, 1.0);
+  h_dxy = ibooker.book1D("dxy", "d_{xy};d_{xy} [#mum];Tracks", 100, -0.01 * cmToUm, 0.01 * cmToUm);
+  h_dz = ibooker.book1D("dz", "d_{z};d_{z} [#mum];Tracks", 100, -0.05 * cmToUm, 0.05 * cmToUm);
 
-  h_vtx_idx = ibooker.book1DD("vertexIndex", "tracks Vertex Index;Vertex index;Entries", 17, -1.5, 15.5);
+  h_vtx_idx = ibooker.book1DD("vertexIndex", "tracks Vertex Index;Vertex index;Tracks", 17, -1.5, 15.5);
 
-  p_dxy_eta = ibooker.bookProfile("dxy_vs_eta", "dxy vs eta;eta;<dxy>", 50, -3.0, 3.0, -0.5, 0.5, "");
-  p_dxy_phi =
-      ibooker.bookProfile("dxy_vs_phi", "dxy vs phi;phi;<dxy>", 50, -std::numbers::pi, std::numbers::pi, -0.5, 0.5, "");
-  p_dz_eta = ibooker.bookProfile("dz_vs_eta", "dz vs eta;eta;<dz>", 50, -3.0, 3.0, -1.0, 1.0, "");
-  p_dz_phi =
-      ibooker.bookProfile("dz_vs_phi", "dz vs phi;phi;<dz>", 50, -std::numbers::pi, std::numbers::pi, -1.0, 1.0, "");
+  p_dxy_eta = ibooker.bookProfile(
+      "dxy_vs_eta", "d_{xy} vs #eta;#eta;#LTd_{xy}#GT [#mum]", 50, -3.0, 3.0, -0.01 * cmToUm, 0.01 * cmToUm, "");
+  p_dxy_phi = ibooker.bookProfile("dxy_vs_phi",
+                                  "d_{xy} vs #phi;#phi [rad];#LTd_{xy}#GT [#mum]",
+                                  50,
+                                  -std::numbers::pi,
+                                  std::numbers::pi,
+                                  -0.01 * cmToUm,
+                                  0.01 * cmToUm,
+                                  "");
+  p_dz_eta = ibooker.bookProfile(
+      "dz_vs_eta", "d_{z} vs #eta;#eta;#LTd_{z}#GT [#mum]", 50, -3.0, 3.0, -0.05 * cmToUm, 0.05 * cmToUm, "");
+  p_dz_phi = ibooker.bookProfile("dz_vs_phi",
+                                 "d_{z} vs #phi;#phi [rad];#LTd_{z}#GT [#mum]",
+                                 50,
+                                 -std::numbers::pi,
+                                 std::numbers::pi,
+                                 -0.05 * cmToUm,
+                                 0.05 * cmToUm,
+                                 "");
 
   // 2D eta-phi occupancy histograms
-  h2_eta_phi =
-      ibooker.book2I("eta_vs_phi", "Track occupancy;#eta;#phi", 50, -3.0, 3.0, 50, -std::numbers::pi, std::numbers::pi);
+  h2_eta_phi = ibooker.book2I(
+      "eta_vs_phi", "Track occupancy;#eta;#phi [rad]", 50, -3.0, 3.0, 50, -std::numbers::pi, std::numbers::pi);
 
   // 2D eta-phi profiles
   p2_dxy_eta_phi = ibooker.bookProfile2D("dxy_vs_eta_phi",
-                                         "dxy vs #eta-#phi;<dxy>;#eta;#phi",
+                                         "d_{xy} vs #eta-#phi;#eta;#phi [rad];#LTd_{xy}#GT [#mum]",
                                          50,
                                          -3.0,
                                          3.0,
                                          50,
                                          -std::numbers::pi,
                                          std::numbers::pi,
-                                         -0.5,
-                                         0.5,
+                                         -0.01 * cmToUm,
+                                         0.01 * cmToUm,
                                          "");
 
   p2_dz_eta_phi = ibooker.bookProfile2D("dz_vs_eta_phi",
-                                        "dz vs #eta-#phi;<dz>;#eta;#phi",
+                                        "d_{z} vs #eta-#phi;#eta;#phi [rad];#LTd_{z}#GT [#mum]",
                                         50,
                                         -3.0,
                                         3.0,
                                         50,
                                         -std::numbers::pi,
                                         std::numbers::pi,
-                                        -1.0,
-                                        1.0,
+                                        -0.05 * cmToUm,
+                                        0.05 * cmToUm,
                                         "");
 
-  p2_nValidPixelHits_eta_phi = ibooker.bookProfile2D("nValidPixelHits_vs_eta_phi_prof",
-                                                     "nValidPixelHits vs #eta-#phi;<nValidPixelHits>;#eta;#phi",
-                                                     50,
-                                                     -3.0,
-                                                     3.0,
-                                                     50,
-                                                     -std::numbers::pi,
-                                                     std::numbers::pi,
-                                                     0.,
-                                                     10.,
-                                                     "");
-
-  p2_nTrackerLayersWithMeasurement_eta_phi =
-      ibooker.bookProfile2D("nTrackerLayersWithMeasurement_vs_eta_phi_prof",
-                            "nTrackerLayersWithMeasurement vs #eta-#phi;<nTrackerLayersWithMeasurement>;#eta;#phi",
+  p2_nValidPixelHits_eta_phi =
+      ibooker.bookProfile2D("nValidPixelHits_vs_eta_phi_prof",
+                            "nValidPixelHits vs #eta-#phi;#eta;#phi [rad];#LTnValidPixelHits#GT",
                             50,
                             -3.0,
                             3.0,
@@ -132,20 +136,34 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
                             -std::numbers::pi,
                             std::numbers::pi,
                             0.,
-                            20.,
+                            10.,
                             "");
 
-  p2_nValidStripHits_eta_phi = ibooker.bookProfile2D("nValidStripHits_vs_eta_phi_prof",
-                                                     "nValidStripHits vs #eta-#phi;<nValidStripHits>;#eta;#phi",
-                                                     50,
-                                                     -3.0,
-                                                     3.0,
-                                                     50,
-                                                     -std::numbers::pi,
-                                                     std::numbers::pi,
-                                                     0.,
-                                                     30.,
-                                                     "");
+  p2_nTrackerLayersWithMeasurement_eta_phi = ibooker.bookProfile2D(
+      "nTrackerLayersWithMeasurement_vs_eta_phi_prof",
+      "nTrackerLayersWithMeasurement vs #eta-#phi;#eta;#phi [rad];#LTnTrackerLayersWithMeasurement#GT",
+      50,
+      -3.0,
+      3.0,
+      50,
+      -std::numbers::pi,
+      std::numbers::pi,
+      0.,
+      20.,
+      "");
+
+  p2_nValidStripHits_eta_phi =
+      ibooker.bookProfile2D("nValidStripHits_vs_eta_phi_prof",
+                            "nValidStripHits vs #eta-#phi;#eta;#phi [rad];#LTnValidStripHits#GT",
+                            50,
+                            -3.0,
+                            3.0,
+                            50,
+                            -std::numbers::pi,
+                            std::numbers::pi,
+                            0.,
+                            30.,
+                            "");
 }
 
 // main event loop
@@ -186,18 +204,18 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
       continue;
 
     // --- fill histograms ---
-    h_dxy->Fill(dxy);
-    h_dz->Fill(dz);
+    h_dxy->Fill(dxy * cmToUm);
+    h_dz->Fill(dz * cmToUm);
 
-    p_dxy_eta->Fill(recoTrk.eta(), dxy);
-    p_dxy_phi->Fill(recoTrk.phi(), dxy);
+    p_dxy_eta->Fill(recoTrk.eta(), dxy * cmToUm);
+    p_dxy_phi->Fill(recoTrk.phi(), dxy * cmToUm);
 
-    p_dz_eta->Fill(recoTrk.eta(), dz);
-    p_dz_phi->Fill(recoTrk.phi(), dz);
+    p_dz_eta->Fill(recoTrk.eta(), dz * cmToUm);
+    p_dz_phi->Fill(recoTrk.phi(), dz * cmToUm);
 
     // --- fill 2D eta-phi profiles ---
-    p2_dxy_eta_phi->Fill(eta, phi, dxy);
-    p2_dz_eta_phi->Fill(eta, phi, dz);
+    p2_dxy_eta_phi->Fill(eta, phi, dxy * cmToUm);
+    p2_dz_eta_phi->Fill(eta, phi, dz * cmToUm);
   }
 }
 

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -3,6 +3,7 @@
 #include <vector>
 #include <numbers>
 #include <fmt/format.h>
+#include <boost/range/adaptor/indexed.hpp>
 
 // user includes
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
@@ -150,11 +151,26 @@ private:
   IPMonitoring dz_pt1;
   IPMonitoring dz_pt10;
 
+  // profiles
+  std::vector<MonitorElement*> vTrackProfiles_;
+
   // helpers
   reco::Track makeRecoTrack(const Run3ScoutingTrack& sTrack) const;
   reco::Vertex makeRecoVertex(const Run3ScoutingVertex& sVertex) const;
   std::pair<unsigned int, const Run3ScoutingVertex*> findClosestScoutingVertex(
       const reco::Track* track, const std::vector<Run3ScoutingVertex>& vertices);
+
+  template <class OBJECT_TYPE>
+  int index(const std::vector<OBJECT_TYPE*>& vec, const TString& name) {
+    for (const auto& iter : vec | boost::adaptors::indexed(0)) {
+      if (iter.value() && iter.value()->getName() == name) {
+        return iter.index();
+      }
+    }
+    edm::LogError("ScoutingTrackMonitor") << "@SUB=ScoutingTrackMonitor::index"
+                                          << " could not find " << name;
+    return -1;
+  }
 };
 
 // constructor
@@ -267,6 +283,129 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
                             30.,
                             "");
   p2_nValidStripHits_eta_phi->setOption("colz");
+
+  // intialize the profiles
+  double xBins[19] = {0., 0.15, 0.5, 1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5, 5., 7., 10., 15., 25., 40., 100., 200.};
+  vTrackProfiles_.push_back(ibooker.bookProfile("p_d0_vs_phi",
+                                                "Transverse Impact Parameter vs. #phi;#phi_{Track};#LT d_{0} #GT [cm]",
+                                                100,
+                                                -std::numbers::pi,
+                                                std::numbers::pi,
+                                                -0.15 * cmToUm,
+                                                0.15 * cmToUm,
+                                                ""));
+  vTrackProfiles_.push_back(
+      ibooker.bookProfile("p_dz_vs_phi",
+                          "Longitudinal Impact Parameter vs. #phi;#phi_{Track};#LT d_{z} #GT [cm]",
+                          100,
+                          -std::numbers::pi,
+                          std::numbers::pi,
+                          -0.35 * cmToUm,
+                          0.35 * cmToUm,
+                          ""));
+  vTrackProfiles_.push_back(ibooker.bookProfile("p_d0_vs_eta",
+                                                "Transverse Impact Parameter vs. #eta;#eta_{Track};#LT d_{0} #GT [cm]",
+                                                100,
+                                                -3.,
+                                                3.,
+                                                -0.15 * cmToUm,
+                                                0.15 * cmToUm,
+                                                ""));
+  vTrackProfiles_.push_back(
+      ibooker.bookProfile("p_dz_vs_eta",
+                          "Longitudinal Impact Parameter vs. #eta;#eta_{Track};#LT d_{z} #GT [cm]",
+                          100,
+                          -3.,
+                          3.,
+                          -0.35 * cmToUm,
+                          0.35 * cmToUm,
+                          ""));
+  vTrackProfiles_.push_back(ibooker.bookProfile("p_chi2_vs_phi",
+                                                "#chi^{2} vs. #phi;#phi_{Track};#LT #chi^{2} #GT",
+                                                100,
+                                                -std::numbers::pi,
+                                                std::numbers::pi,
+                                                0,
+                                                100,
+                                                ""));
+  vTrackProfiles_.push_back(
+      ibooker.bookProfile("p_chi2Prob_vs_phi",
+                          "#chi^{2} probablility vs. #phi;#phi_{Track};#LT #chi^{2} probability#GT",
+                          100,
+                          -std::numbers::pi,
+                          std::numbers::pi,
+                          0.,
+                          1.,
+                          ""));
+  vTrackProfiles_.push_back(
+      ibooker.bookProfile("p_chi2Prob_vs_d0",
+                          "#chi^{2} probablility vs. |d_{0}|;|d_{0}|[cm];#LT #chi^{2} probability#GT",
+                          100,
+                          0,
+                          80,
+                          0.,
+                          1.,
+                          ""));
+  vTrackProfiles_.push_back(ibooker.bookProfile("p_chi2Prob_vs_dz",
+                                                "#chi^{2} probablility vs. dz;d_{z} [cm];#LT #chi^{2} probability#GT",
+                                                100,
+                                                -30,
+                                                30,
+                                                0.,
+                                                1.,
+                                                ""));
+  vTrackProfiles_.push_back(ibooker.bookProfile("p_normchi2_vs_phi",
+                                                "#chi^{2}/ndof vs. #phi;#phi_{Track};#LT #chi^{2}/ndof #GT",
+                                                100,
+                                                -std::numbers::pi,
+                                                std::numbers::pi,
+                                                0.,
+                                                5.,
+                                                ""));
+  vTrackProfiles_.push_back(ibooker.bookProfile(
+      "p_chi2_vs_eta", "#chi^{2} vs. #eta;#eta_{Track};#LT #chi^{2} #GT", 100, -3., 3., 0., 100., ""));
+  vTrackProfiles_.push_back(ibooker.bookProfile("p_normchi2_vs_pt",
+                                                "norm #chi^{2} vs. p_{T}_{Track}; p_{T}_{Track};#LT #chi^{2}/ndof #GT",
+                                                18,
+                                                xBins,
+                                                0.,
+                                                5.,
+                                                ""));
+  vTrackProfiles_.push_back(ibooker.bookProfile(
+      "p_normchi2_vs_p", "#chi^{2}/ndof vs. p_{Track};p_{Track};#LT #chi^{2}/ndof #GT", 18, xBins, 0., 5., ""));
+  vTrackProfiles_.push_back(
+      ibooker.bookProfile("p_chi2Prob_vs_eta",
+                          "#chi^{2} probability vs. #eta;#eta_{Track};#LT #chi^{2} probability #GT",
+                          100,
+                          -3.,
+                          3.,
+                          0.,
+                          1.,
+                          ""));
+  vTrackProfiles_.push_back(ibooker.bookProfile(
+      "p_normchi2_vs_eta", "#chi^{2}/ndof vs. #eta;#eta_{Track};#LT #chi^{2}/ndof #GT", 100, -3., 3., 0., 5, ""));
+  vTrackProfiles_.push_back(ibooker.bookProfile(
+      "p_kappa_vs_phi", "#kappa vs. #phi;#phi_{Track};#kappa", 100, -std::numbers::pi, std::numbers::pi, -5., 5., ""));
+  vTrackProfiles_.push_back(
+      ibooker.bookProfile("p_kappa_vs_eta", "#kappa vs. #eta;#eta_{Track};#kappa", 100, -3., 3., -5., 5., ""));
+  vTrackProfiles_.push_back(
+      ibooker.bookProfile("p_ptResolution_vs_phi",
+                          "#delta_{p_{T}}/p_{T}^{track};#phi^{track};#delta_{p_{T}}/p_{T}^{track}",
+                          100,
+                          -std::numbers::pi,
+                          std::numbers::pi,
+                          0.,
+                          1.,
+                          ""));
+  vTrackProfiles_.push_back(
+      ibooker.bookProfile("p_ptResolution_vs_eta",
+                          "#delta_{p_{T}}/p_{T}^{track};#eta^{track};#delta_{p_{T}}/p_{T}^{track}",
+                          100,
+                          -3.,
+                          3.,
+                          0.,
+                          1.,
+                          ""));
 
   // initialize and book the monitors;
   dxy_pt1.varname_ = "xy";
@@ -516,6 +655,52 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     p2_dxy_eta_phi->Fill(eta, phi, dxy);
     p2_dz_eta_phi->Fill(eta, phi, dz);
 
+    // Fill track profiles
+    double chi2Prob = TMath::Prob(recoTrk.chi2(), recoTrk.ndof());
+    double normchi2 = recoTrk.normalizedChi2();
+    double kappa = trk.tk_qoverp();
+
+    //GlobalPoint gPoint(recoTrk.vx(), recoTrk.vy(), recoTrk.vz());
+    //double theLocalMagFieldInInverseGeV = magneticField_->inInverseGeV(gPoint).z();
+    //double kappa = -recoTrk.charge() * theLocalMagFieldInInverseGeV / recoTrk.pt();
+
+    static const int d0phiindex = this->index(vTrackProfiles_, "p_d0_vs_phi");
+    vTrackProfiles_[d0phiindex]->Fill(recoTrk.phi(), recoTrk.d0());
+    static const int dzphiindex = this->index(vTrackProfiles_, "p_dz_vs_phi");
+    vTrackProfiles_[dzphiindex]->Fill(recoTrk.phi(), recoTrk.dz());
+    static const int d0etaindex = this->index(vTrackProfiles_, "p_d0_vs_eta");
+    vTrackProfiles_[d0etaindex]->Fill(recoTrk.eta(), recoTrk.d0());
+    static const int dzetaindex = this->index(vTrackProfiles_, "p_dz_vs_eta");
+    vTrackProfiles_[dzetaindex]->Fill(recoTrk.eta(), recoTrk.dz());
+    static const int chiProbphiindex = this->index(vTrackProfiles_, "p_chi2Prob_vs_phi");
+    vTrackProfiles_[chiProbphiindex]->Fill(recoTrk.phi(), chi2Prob);
+    static const int chiProbabsd0index = this->index(vTrackProfiles_, "p_chi2Prob_vs_d0");
+    vTrackProfiles_[chiProbabsd0index]->Fill(fabs(recoTrk.d0()), chi2Prob);
+    static const int chiProbabsdzindex = this->index(vTrackProfiles_, "p_chi2Prob_vs_dz");
+    vTrackProfiles_[chiProbabsdzindex]->Fill(recoTrk.dz(), chi2Prob);
+    static const int chiphiindex = this->index(vTrackProfiles_, "p_chi2_vs_phi");
+    vTrackProfiles_[chiphiindex]->Fill(recoTrk.phi(), recoTrk.chi2());
+    static const int normchiphiindex = this->index(vTrackProfiles_, "p_normchi2_vs_phi");
+    vTrackProfiles_[normchiphiindex]->Fill(recoTrk.phi(), normchi2);
+    static const int chietaindex = this->index(vTrackProfiles_, "p_chi2_vs_eta");
+    vTrackProfiles_[chietaindex]->Fill(recoTrk.eta(), recoTrk.chi2());
+    static const int normchiptindex = this->index(vTrackProfiles_, "p_normchi2_vs_pt");
+    vTrackProfiles_[normchiptindex]->Fill(recoTrk.pt(), normchi2);
+    static const int normchipindex = this->index(vTrackProfiles_, "p_normchi2_vs_p");
+    vTrackProfiles_[normchipindex]->Fill(recoTrk.p(), normchi2);
+    static const int chiProbetaindex = this->index(vTrackProfiles_, "p_chi2Prob_vs_eta");
+    vTrackProfiles_[chiProbetaindex]->Fill(recoTrk.eta(), chi2Prob);
+    static const int normchietaindex = this->index(vTrackProfiles_, "p_normchi2_vs_eta");
+    vTrackProfiles_[normchietaindex]->Fill(recoTrk.eta(), normchi2);
+    static const int kappaphiindex = this->index(vTrackProfiles_, "p_kappa_vs_phi");
+    vTrackProfiles_[kappaphiindex]->Fill(recoTrk.phi(), kappa);
+    static const int kappaetaindex = this->index(vTrackProfiles_, "p_kappa_vs_eta");
+    vTrackProfiles_[kappaetaindex]->Fill(recoTrk.eta(), kappa);
+    static const int ptResphiindex = this->index(vTrackProfiles_, "p_ptResolution_vs_phi");
+    vTrackProfiles_[ptResphiindex]->Fill(recoTrk.phi(), recoTrk.ptError() / recoTrk.pt());
+    static const int ptResetaindex = this->index(vTrackProfiles_, "p_ptResolution_vs_eta");
+    vTrackProfiles_[ptResetaindex]->Fill(recoTrk.eta(), recoTrk.ptError() / recoTrk.pt());
+
     if (trk.tk_pt() < 1.)
       continue;
 
@@ -665,8 +850,8 @@ void ScoutingTrackMonitor::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<double>("DzMin", -2000.0);
   desc.add<double>("DzMax", 2000.0);
   desc.add<int>("PhiBin", 32);
-  desc.add<double>("PhiMin", -M_PI);
-  desc.add<double>("PhiMax", M_PI);
+  desc.add<double>("PhiMin", -std::numbers::pi);
+  desc.add<double>("PhiMax", std::numbers::pi);
   desc.add<int>("EtaBin", 26);
   desc.add<double>("EtaMin", 2.5);
   desc.add<double>("EtaMax", -2.5);

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -426,7 +426,15 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
                           0.,
                           1.,
                           ""));
-
+  vTrackProfiles_.push_back(
+      ibooker.bookProfile("p_ptResolution_vs_pt",
+                          "#delta_{p_{T}}/p_{T}^{track};p_{T}^{track};#delta_{p_{T}}/p_{T}^{track}",
+                          100,
+                          0.,
+                          100.,
+                          0.,
+                          1.,
+                          ""));
   // initialize and book the monitors;
   dxy_pt1.varname_ = "xy";
   dxy_pt1.pTcut_ = 1.f;
@@ -756,6 +764,8 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     vTrackProfiles_[ptResphiindex]->Fill(recoTrk.phi(), recoTrk.ptError() / recoTrk.pt());
     static const int ptResetaindex = this->index(vTrackProfiles_, "p_ptResolution_vs_eta");
     vTrackProfiles_[ptResetaindex]->Fill(recoTrk.eta(), recoTrk.ptError() / recoTrk.pt());
+    static const int ptResptindex = this->index(vTrackProfiles_, "p_ptResolution_vs_pt");
+    vTrackProfiles_[ptResptindex]->Fill(recoTrk.pt(), recoTrk.ptError() / recoTrk.pt());
 
     if (trk.tk_pt() < 1.)
       continue;

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -66,7 +66,6 @@ namespace sctTrackMonitor {
     const auto& name = h1->GetName();
     return ibook.book1D(name, h1.release());
   }
-
 }  // namespace sctTrackMonitor
 
 class ScoutingTrackMonitor : public DQMEDAnalyzer {
@@ -88,6 +87,18 @@ public:
   private:
     int PhiBin_, EtaBin_, PtBin_;
     double PhiMin_, PhiMax_, EtaMin_, EtaMax_, PtMin_, PtMax_;
+  };
+
+  struct ProfileConfig {
+    std::string name;   // Base name
+    std::string title;  // Human-readable title
+    double ymin;        // Minimum Y value
+    double ymax;        // Maximum Y value
+
+    // MonitorElements
+    MonitorElement* p2_eta_phi = nullptr;
+    MonitorElement* p_eta = nullptr;
+    MonitorElement* p_phi = nullptr;
   };
 
 protected:
@@ -128,19 +139,19 @@ private:
   MonitorElement* h_dxy;
   MonitorElement* h_dz;
   MonitorElement* h_vtx_idx;
-  MonitorElement* p_dxy_eta;
-  MonitorElement* p_dxy_phi;
-  MonitorElement* p_dz_eta;
-  MonitorElement* p_dz_phi;
-
   MonitorElement* h2_eta_phi;
 
-  // 2D eta-phi profiles
+  MonitorElement* p_dxy_eta;
+  MonitorElement* p_dxy_phi;
   MonitorElement* p2_dxy_eta_phi;
+
+  MonitorElement* p_dz_eta;
+  MonitorElement* p_dz_phi;
   MonitorElement* p2_dz_eta_phi;
-  MonitorElement* p2_nValidPixelHits_eta_phi;
-  MonitorElement* p2_nTrackerLayersWithMeasurement_eta_phi;
-  MonitorElement* p2_nValidStripHits_eta_phi;
+
+  // hit profiles configuration
+  std::vector<ProfileConfig> hitProfiles_;
+  std::vector<ProfileConfig> impactParameterProfiles_;
 
   static constexpr int cmToUm = 10000;
 
@@ -178,7 +189,14 @@ ScoutingTrackMonitor::ScoutingTrackMonitor(const edm::ParameterSet& iConfig)
     : conf_(iConfig),
       tracksToken_{consumes<std::vector<Run3ScoutingTrack>>(iConfig.getParameter<edm::InputTag>("tracks"))},
       verticesToken_{consumes<std::vector<Run3ScoutingVertex>>(iConfig.getParameter<edm::InputTag>("vertices"))},
-      topFolderName_{iConfig.getParameter<std::string>("topFolderName")} {}
+      topFolderName_{iConfig.getParameter<std::string>("topFolderName")} {
+  hitProfiles_ = {{"nValidPixelHits", "nValidPixelHits", 0., 10.},
+                  {"nTrackerLayersWithMeasurement", "nTrackerLayersWithMeasurement", 0., 20.},
+                  {"nValidStripHits", "nValidStripHits", 0., 30.}};
+
+  impactParameterProfiles_ = {{"dxy", "d_{xy}", -0.15 * cmToUm, 0.15 * cmToUm},
+                              {"dz", "d_{z}", -0.35 * cmToUm, 0.35 * cmToUm}};
+}
 
 // histogram booking
 void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) {
@@ -189,100 +207,96 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
 
   h_vtx_idx = ibooker.book1DD("vertexIndex", "tracks Vertex Index;Vertex index;Tracks", 17, -1.5, 15.5);
 
-  p_dxy_eta = ibooker.bookProfile(
-      "dxy_vs_eta", "d_{xy} vs #eta;#eta;#LTd_{xy}#GT [#mum]", 50, -3.0, 3.0, -0.01 * cmToUm, 0.01 * cmToUm, "");
-  p_dxy_phi = ibooker.bookProfile("dxy_vs_phi",
-                                  "d_{xy} vs #phi;#phi [rad];#LTd_{xy}#GT [#mum]",
-                                  50,
-                                  -std::numbers::pi,
-                                  std::numbers::pi,
-                                  -0.15 * cmToUm,
-                                  0.15 * cmToUm,
-                                  "");
-  p_dz_eta = ibooker.bookProfile(
-      "dz_vs_eta", "d_{z} vs #eta;#eta;#LTd_{z}#GT [#mum]", 50, -3.0, 3.0, -0.05 * cmToUm, 0.05 * cmToUm, "");
-  p_dz_phi = ibooker.bookProfile("dz_vs_phi",
-                                 "d_{z} vs #phi;#phi [rad];#LTd_{z}#GT [#mum]",
-                                 50,
-                                 -std::numbers::pi,
-                                 std::numbers::pi,
-                                 -0.35 * cmToUm,
-                                 0.35 * cmToUm,
-                                 "");
-
   // 2D eta-phi occupancy histograms
   h2_eta_phi = ibooker.book2I(
       "eta_vs_phi", "Track occupancy;#eta;#phi [rad]", 50, -3.0, 3.0, 50, -std::numbers::pi, std::numbers::pi);
   h2_eta_phi->setOption("colz");
 
-  // 2D eta-phi profiles
-  p2_dxy_eta_phi = ibooker.bookProfile2D("dxy_vs_eta_phi",
-                                         "d_{xy} vs #eta-#phi;#eta;#phi [rad];#LTd_{xy}#GT [#mum]",
-                                         50,
-                                         -3.0,
-                                         3.0,
-                                         50,
-                                         -std::numbers::pi,
-                                         std::numbers::pi,
-                                         -0.15 * cmToUm,
-                                         0.15 * cmToUm,
-                                         "");
-  p2_dxy_eta_phi->setOption("colz");
+  // Profiles
+  constexpr int nEtaBins = 50;
+  constexpr double etaMin = -3.0;
+  constexpr double etaMax = 3.0;
 
-  p2_dz_eta_phi = ibooker.bookProfile2D("dz_vs_eta_phi",
-                                        "d_{z} vs #eta-#phi;#eta;#phi [rad];#LTd_{z}#GT [#mum]",
-                                        50,
-                                        -3.0,
-                                        3.0,
-                                        50,
-                                        -std::numbers::pi,
-                                        std::numbers::pi,
-                                        -0.35 * cmToUm,
-                                        0.35 * cmToUm,
-                                        "");
-  p2_dz_eta_phi->setOption("colz");
+  constexpr int nPhiBins = 50;
+  constexpr double phiMin = -std::numbers::pi;
+  constexpr double phiMax = std::numbers::pi;
 
-  p2_nValidPixelHits_eta_phi =
-      ibooker.bookProfile2D("nValidPixelHits_vs_eta_phi_prof",
-                            "nValidPixelHits vs #eta-#phi;#eta;#phi [rad];#LTnValidPixelHits#GT",
-                            50,
-                            -3.0,
-                            3.0,
-                            50,
-                            -std::numbers::pi,
-                            std::numbers::pi,
-                            0.,
-                            10.,
-                            "");
-  p2_nValidPixelHits_eta_phi->setOption("colz");
+  // n. hits profiles
+  for (auto& cfg : hitProfiles_) {
+    const std::string& base = cfg.name;
+    const std::string& title = cfg.title;
 
-  p2_nTrackerLayersWithMeasurement_eta_phi = ibooker.bookProfile2D(
-      "nTrackerLayersWithMeasurement_vs_eta_phi_prof",
-      "nTrackerLayersWithMeasurement vs #eta-#phi;#eta;#phi [rad];#LTnTrackerLayersWithMeasurement#GT",
-      50,
-      -3.0,
-      3.0,
-      50,
-      -std::numbers::pi,
-      std::numbers::pi,
-      0.,
-      20.,
-      "");
-  p2_nTrackerLayersWithMeasurement_eta_phi->setOption("colz");
+    // 2D Profile: vs eta-phi
+    cfg.p2_eta_phi = ibooker.bookProfile2D(base + "_vs_eta_phi_prof",
+                                           title + " vs #eta-#phi;#eta;#phi [rad];#LT" + title + "#GT",
+                                           nEtaBins,
+                                           etaMin,
+                                           etaMax,
+                                           nPhiBins,
+                                           phiMin,
+                                           phiMax,
+                                           cfg.ymin,
+                                           cfg.ymax,
+                                           "");
+    cfg.p2_eta_phi->setOption("colz");
 
-  p2_nValidStripHits_eta_phi =
-      ibooker.bookProfile2D("nValidStripHits_vs_eta_phi_prof",
-                            "nValidStripHits vs #eta-#phi;#eta;#phi [rad];#LTnValidStripHits#GT",
-                            50,
-                            -3.0,
-                            3.0,
-                            50,
-                            -std::numbers::pi,
-                            std::numbers::pi,
-                            0.,
-                            30.,
-                            "");
-  p2_nValidStripHits_eta_phi->setOption("colz");
+    // 1D Profile: vs eta
+    cfg.p_eta = ibooker.bookProfile(base + "_vs_eta_prof",
+                                    title + " vs #eta;#eta;#LT" + title + "#GT",
+                                    nEtaBins,
+                                    etaMin,
+                                    etaMax,
+                                    cfg.ymin,
+                                    cfg.ymax,
+                                    "");
+
+    // 1D Profile: vs phi
+    cfg.p_phi = ibooker.bookProfile(base + "_vs_phi_prof",
+                                    title + " vs #phi;#phi [rad];#LT" + title + "#GT",
+                                    nPhiBins,
+                                    phiMin,
+                                    phiMax,
+                                    cfg.ymin,
+                                    cfg.ymax,
+                                    "");
+  }
+
+  // IP profiles
+  for (auto& cfg : impactParameterProfiles_) {
+    // Profile vs eta
+    cfg.p_eta = ibooker.bookProfile(cfg.name + "_vs_eta",
+                                    cfg.title + " vs #eta;#eta;#LT" + cfg.title + "#GT [#mum]",
+                                    nEtaBins,
+                                    etaMin,
+                                    etaMax,
+                                    cfg.ymin,
+                                    cfg.ymax,
+                                    "");
+
+    // Profile vs phi
+    cfg.p_phi = ibooker.bookProfile(cfg.name + "_vs_phi",
+                                    cfg.title + " vs #phi;#phi [rad];#LT" + cfg.title + "#GT [#mum]",
+                                    nPhiBins,
+                                    phiMin,
+                                    phiMax,
+                                    cfg.ymin,
+                                    cfg.ymax,
+                                    "");
+
+    // 2D profile vs eta-phi
+    cfg.p2_eta_phi = ibooker.bookProfile2D(cfg.name + "_vs_eta_phi",
+                                           cfg.title + " vs #eta-#phi;#eta;#phi [rad];#LT" + cfg.title + "#GT [#mum]",
+                                           nEtaBins,
+                                           etaMin,
+                                           etaMax,
+                                           nPhiBins,
+                                           phiMin,
+                                           phiMax,
+                                           cfg.ymin,
+                                           cfg.ymax,
+                                           "");
+    cfg.p2_eta_phi->setOption("colz");
+  }
 
   // intialize the profiles
   double xBins[19] = {0., 0.15, 0.5, 1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5, 5., 7., 10., 15., 25., 40., 100., 200.};
@@ -341,8 +355,8 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
       ibooker.bookProfile("p_chi2Prob_vs_d0",
                           "#chi^{2} probablility vs. |d_{0}|;|d_{0}|[cm];#LT #chi^{2} probability#GT",
                           100,
-                          0,
-                          80,
+                          0.,
+                          80.,
                           0.,
                           1.,
                           ""));
@@ -623,11 +637,23 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     const float phi = trk.tk_phi();
     const float pt = trk.tk_pt();
 
+    const int nValidPixelHits = trk.tk_nValidPixelHits();
+    const int nTrackerLayers = trk.tk_nTrackerLayersWithMeasurement();
+    const int nValidStripHits = trk.tk_nValidStripHits();
+
     // --- fill 2D eta-phi occupancy histograms ---
     h2_eta_phi->Fill(eta, phi);
-    p2_nValidPixelHits_eta_phi->Fill(eta, phi, trk.tk_nValidPixelHits());
-    p2_nTrackerLayersWithMeasurement_eta_phi->Fill(eta, phi, trk.tk_nTrackerLayersWithMeasurement());
-    p2_nValidStripHits_eta_phi->Fill(eta, phi, trk.tk_nValidStripHits());
+    const std::array<double, 3> values = {static_cast<double>(nValidPixelHits),
+                                          static_cast<double>(nTrackerLayers),
+                                          static_cast<double>(nValidStripHits)};
+
+    for (size_t i = 0; i < hitProfiles_.size(); ++i) {
+      const auto& cfg = hitProfiles_[i];
+      const double value = values[i];
+      cfg.p2_eta_phi->Fill(eta, phi, value);
+      cfg.p_eta->Fill(eta, value);
+      cfg.p_phi->Fill(phi, value);
+    }
 
     // --- build reco vertex ---
     reco::Vertex recoVtx = makeRecoVertex(*closestVtx);
@@ -645,15 +671,15 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     h_dxy->Fill(dxy);
     h_dz->Fill(dz);
 
-    p_dxy_eta->Fill(eta, dxy);
-    p_dxy_phi->Fill(phi, dxy);
+    const std::array<double, 2> ipvalues = {dxy, dz};
+    for (size_t i = 0; i < impactParameterProfiles_.size(); ++i) {
+      const auto& cfg = impactParameterProfiles_[i];
+      const double value = ipvalues[i];
 
-    p_dz_eta->Fill(eta, dz);
-    p_dz_phi->Fill(phi, dz);
-
-    // --- fill 2D eta-phi profiles ---
-    p2_dxy_eta_phi->Fill(eta, phi, dxy);
-    p2_dz_eta_phi->Fill(eta, phi, dz);
+      cfg.p_eta->Fill(eta, value);
+      cfg.p_phi->Fill(phi, value);
+      cfg.p2_eta_phi->Fill(eta, phi, value);
+    }
 
     // Fill track profiles
     double chi2Prob = TMath::Prob(recoTrk.chi2(), recoTrk.ndof());

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -28,6 +28,26 @@ protected:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
 private:
+  static inline std::pair<float, float> trk_vtx_offSet(const Run3ScoutingTrack& tk, const Run3ScoutingVertex& vtx) {
+    const auto pt = tk.tk_pt();
+    const auto phi = tk.tk_phi();
+    const auto eta = tk.tk_eta();
+
+    const auto px = pt * std::cos(phi);
+    const auto py = pt * std::sin(phi);
+    const auto pz = pt * std::sinh(eta);
+    const auto pt2 = pt * pt;
+
+    const auto dx = tk.tk_vx() - vtx.x();
+    const auto dy = tk.tk_vy() - vtx.y();
+    const auto dz = tk.tk_vz() - vtx.z();
+
+    const auto tk_dxyPV = (-dx * py + dy * px) / pt;
+    const auto tk_dzPV = dz - (dx * px + dy * py) * pz / pt2;
+
+    return {tk_dxyPV, tk_dzPV};
+  }
+
   // tokens
   const edm::EDGetTokenT<std::vector<Run3ScoutingTrack>> tracksToken_;
   const edm::EDGetTokenT<std::vector<Run3ScoutingVertex>> verticesToken_;
@@ -176,16 +196,30 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
 
   for (const auto& trk : tracks) {
     // --- build reco track ---
-    reco::Track recoTrk = makeRecoTrack(trk);
+    //reco::Track recoTrk = makeRecoTrack(trk);
+    //auto [vtxIndex, closestVtx] = findClosestScoutingVertex(&recoTrk, vertices);
+    //if (!closestVtx)
+    //  continue;
 
-    auto [vtxIndex, closestVtx] = findClosestScoutingVertex(&recoTrk, vertices);
-    if (!closestVtx)
-      continue;
+    // initialize the impact parameters to large values
+    std::pair<float, float> best_offset{9999.f, 99999.f};
+
+    // loop on all the vertices and find the closest one
+    unsigned int vtxIndex = 999;
+    unsigned int idx = 0;
+    for (const auto& vtx : vertices) {
+      const auto offset = trk_vtx_offSet(trk, vtx);
+      if (std::abs(offset.second) < std::abs(best_offset.second)) {
+        best_offset = offset;
+        vtxIndex = idx;  // save the index of the best vertex
+      }
+      idx++;
+    }
 
     h_vtx_idx->Fill(vtxIndex);
 
-    const float eta = recoTrk.eta();
-    const float phi = recoTrk.phi();
+    const float eta = trk.tk_eta();
+    const float phi = trk.tk_phi();
 
     // --- fill 2D eta-phi occupancy histograms ---
     h2_eta_phi->Fill(eta, phi);
@@ -194,24 +228,27 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     p2_nValidStripHits_eta_phi->Fill(eta, phi, trk.tk_nValidStripHits());
 
     // --- build reco vertex ---
-    reco::Vertex recoVtx = makeRecoVertex(*closestVtx);
+    //reco::Vertex recoVtx = makeRecoVertex(*closestVtx);
 
     // --- impact parameters (standard CMSSW definitions) ---
-    float dxy = recoTrk.dxy(recoVtx.position());
-    float dz = recoTrk.dz(recoVtx.position());
+    //float dxy = recoTrk.dxy(recoVtx.position());
+    //float dz = recoTrk.dz(recoVtx.position());
 
-    if (recoTrk.pt() < 3.)
+    float dxy = best_offset.first;
+    float dz = best_offset.second;
+
+    if (trk.tk_pt() < 3.)
       continue;
 
     // --- fill histograms ---
     h_dxy->Fill(dxy * cmToUm);
     h_dz->Fill(dz * cmToUm);
 
-    p_dxy_eta->Fill(recoTrk.eta(), dxy * cmToUm);
-    p_dxy_phi->Fill(recoTrk.phi(), dxy * cmToUm);
+    p_dxy_eta->Fill(eta, dxy * cmToUm);
+    p_dxy_phi->Fill(phi, dxy * cmToUm);
 
-    p_dz_eta->Fill(recoTrk.eta(), dz * cmToUm);
-    p_dz_phi->Fill(recoTrk.phi(), dz * cmToUm);
+    p_dz_eta->Fill(eta, dz * cmToUm);
+    p_dz_phi->Fill(phi, dz * cmToUm);
 
     // --- fill 2D eta-phi profiles ---
     p2_dxy_eta_phi->Fill(eta, phi, dxy * cmToUm);

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -919,8 +919,8 @@ void ScoutingTrackMonitor::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<double>("PhiMin", -std::numbers::pi);
   desc.add<double>("PhiMax", std::numbers::pi);
   desc.add<int>("EtaBin", 26);
-  desc.add<double>("EtaMin", 2.5);
-  desc.add<double>("EtaMax", -2.5);
+  desc.add<double>("EtaMin", -3.0);
+  desc.add<double>("EtaMax", 3.0);
   desc.add<int>("PtBin", 49);
   desc.add<double>("PtMin", 1.);
   desc.add<double>("PtMax", 50.);

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -120,6 +120,7 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
   // 2D eta-phi occupancy histograms
   h2_eta_phi = ibooker.book2I(
       "eta_vs_phi", "Track occupancy;#eta;#phi [rad]", 50, -3.0, 3.0, 50, -std::numbers::pi, std::numbers::pi);
+  h2_eta_phi->setOption("colz");
 
   // 2D eta-phi profiles
   p2_dxy_eta_phi = ibooker.bookProfile2D("dxy_vs_eta_phi",
@@ -133,6 +134,7 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
                                          -0.01 * cmToUm,
                                          0.01 * cmToUm,
                                          "");
+  p2_dxy_eta_phi->setOption("colz");
 
   p2_dz_eta_phi = ibooker.bookProfile2D("dz_vs_eta_phi",
                                         "d_{z} vs #eta-#phi;#eta;#phi [rad];#LTd_{z}#GT [#mum]",
@@ -145,6 +147,7 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
                                         -0.05 * cmToUm,
                                         0.05 * cmToUm,
                                         "");
+  p2_dz_eta_phi->setOption("colz");
 
   p2_nValidPixelHits_eta_phi =
       ibooker.bookProfile2D("nValidPixelHits_vs_eta_phi_prof",
@@ -158,6 +161,7 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
                             0.,
                             10.,
                             "");
+  p2_nValidPixelHits_eta_phi->setOption("colz");
 
   p2_nTrackerLayersWithMeasurement_eta_phi = ibooker.bookProfile2D(
       "nTrackerLayersWithMeasurement_vs_eta_phi_prof",
@@ -171,6 +175,7 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
       0.,
       20.,
       "");
+  p2_nTrackerLayersWithMeasurement_eta_phi->setOption("colz");
 
   p2_nValidStripHits_eta_phi =
       ibooker.bookProfile2D("nValidStripHits_vs_eta_phi_prof",
@@ -184,6 +189,7 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
                             0.,
                             30.,
                             "");
+  p2_nValidStripHits_eta_phi->setOption("colz");
 }
 
 // main event loop

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <vector>
 #include <numbers>
+#include <fmt/format.h>
 
 // user includes
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
@@ -17,11 +18,76 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
+namespace sctTrackMonitor {
+  // same logic used for the MTV:
+  // cf https://github.com/cms-sw/cmssw/blob/master/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+  typedef dqm::reco::DQMStore DQMStore;
+
+  inline void setBinLog(TAxis* axis) {
+    int bins = axis->GetNbins();
+    float from = axis->GetXmin();
+    float to = axis->GetXmax();
+    float width = (to - from) / bins;
+    std::vector<float> new_bins(bins + 1, 0);
+    for (int i = 0; i <= bins; i++) {
+      new_bins[i] = TMath::Power(10, from + i * width);
+    }
+    axis->Set(bins, new_bins.data());
+  }
+
+  inline void setBinLogX(TH1* h) {
+    TAxis* axis = h->GetXaxis();
+    setBinLog(axis);
+  }
+  inline void setBinLogY(TH1* h) {
+    TAxis* axis = h->GetYaxis();
+    setBinLog(axis);
+  }
+
+  template <typename... Args>
+  dqm::reco::MonitorElement* makeProfileIfLog(DQMStore::IBooker& ibook, bool logx, bool logy, Args&&... args) {
+    auto prof = std::make_unique<TProfile>(std::forward<Args>(args)...);
+    if (logx)
+      setBinLogX(prof.get());
+    if (logy)
+      setBinLogY(prof.get());
+    const auto& name = prof->GetName();
+    return ibook.bookProfile(name, prof.release());
+  }
+
+  template <typename... Args>
+  dqm::reco::MonitorElement* makeTH1IfLog(DQMStore::IBooker& ibook, bool logx, bool logy, Args&&... args) {
+    auto h1 = std::make_unique<TH1F>(std::forward<Args>(args)...);
+    if (logx)
+      setBinLogX(h1.get());
+    if (logy)
+      setBinLogY(h1.get());
+    const auto& name = h1->GetName();
+    return ibook.book1D(name, h1.release());
+  }
+
+}  // namespace sctTrackMonitor
+
 class ScoutingTrackMonitor : public DQMEDAnalyzer {
 public:
   explicit ScoutingTrackMonitor(const edm::ParameterSet&);
   ~ScoutingTrackMonitor() override = default;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  struct IPMonitoring {
+    std::string varname_;
+    float pTcut_;
+    dqm::reco::MonitorElement *IP_, *IPErr_, *IPPull_;
+    dqm::reco::MonitorElement *IPVsPhi_, *IPVsEta_, *IPVsPt_;
+    dqm::reco::MonitorElement *IPErrVsPhi_, *IPErrVsEta_, *IPErrVsPt_;
+    dqm::reco::MonitorElement *IPVsEtaVsPhi_, *IPErrVsEtaVsPhi_;
+
+    void bookIPMonitor(DQMStore::IBooker&, const edm::ParameterSet&);
+
+  private:
+    int PhiBin_, EtaBin_, PtBin_;
+    double PhiMin_, PhiMax_, EtaMin_, EtaMax_, PtMin_, PtMax_;
+  };
 
 protected:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
@@ -47,6 +113,9 @@ private:
 
     return {tk_dxyPV, tk_dzPV};
   }
+
+  // configuration
+  const edm::ParameterSet conf_;
 
   // tokens
   const edm::EDGetTokenT<std::vector<Run3ScoutingTrack>> tracksToken_;
@@ -74,6 +143,13 @@ private:
 
   static constexpr int cmToUm = 10000;
 
+  // IP monitoring structs
+  IPMonitoring dxy_pt1;
+  IPMonitoring dxy_pt10;
+
+  IPMonitoring dz_pt1;
+  IPMonitoring dz_pt10;
+
   // helpers
   reco::Track makeRecoTrack(const Run3ScoutingTrack& sTrack) const;
   reco::Vertex makeRecoVertex(const Run3ScoutingVertex& sVertex) const;
@@ -83,7 +159,8 @@ private:
 
 // constructor
 ScoutingTrackMonitor::ScoutingTrackMonitor(const edm::ParameterSet& iConfig)
-    : tracksToken_{consumes<std::vector<Run3ScoutingTrack>>(iConfig.getParameter<edm::InputTag>("tracks"))},
+    : conf_(iConfig),
+      tracksToken_{consumes<std::vector<Run3ScoutingTrack>>(iConfig.getParameter<edm::InputTag>("tracks"))},
       verticesToken_{consumes<std::vector<Run3ScoutingVertex>>(iConfig.getParameter<edm::InputTag>("vertices"))},
       topFolderName_{iConfig.getParameter<std::string>("topFolderName")} {}
 
@@ -190,6 +267,185 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
                             30.,
                             "");
   p2_nValidStripHits_eta_phi->setOption("colz");
+
+  // initialize and book the monitors;
+  dxy_pt1.varname_ = "xy";
+  dxy_pt1.pTcut_ = 1.f;
+  dxy_pt1.bookIPMonitor(ibooker, conf_);
+
+  dxy_pt10.varname_ = "xy";
+  dxy_pt10.pTcut_ = 10.f;
+  dxy_pt10.bookIPMonitor(ibooker, conf_);
+
+  dz_pt1.varname_ = "z";
+  dz_pt1.pTcut_ = 1.f;
+  dz_pt1.bookIPMonitor(ibooker, conf_);
+
+  dz_pt10.varname_ = "z";
+  dz_pt10.pTcut_ = 10.f;
+  dz_pt10.bookIPMonitor(ibooker, conf_);
+}
+
+void ScoutingTrackMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooker, const edm::ParameterSet& config) {
+  int VarBin = config.getParameter<int>(fmt::format("D{}Bin", varname_));
+  double VarMin = config.getParameter<double>(fmt::format("D{}Min", varname_));
+  double VarMax = config.getParameter<double>(fmt::format("D{}Max", varname_));
+
+  PhiBin_ = config.getParameter<int>("PhiBin");
+  PhiMin_ = config.getParameter<double>("PhiMin");
+  PhiMax_ = config.getParameter<double>("PhiMax");
+  int PhiBin2D = config.getParameter<int>("PhiBin2D");
+
+  EtaBin_ = config.getParameter<int>("EtaBin");
+  EtaMin_ = config.getParameter<double>("EtaMin");
+  EtaMax_ = config.getParameter<double>("EtaMax");
+  int EtaBin2D = config.getParameter<int>("EtaBin2D");
+
+  PtBin_ = config.getParameter<int>("PtBin");
+  PtMin_ = config.getParameter<double>("PtMin") * pTcut_;
+  PtMax_ = config.getParameter<double>("PtMax") * pTcut_;
+
+  // 1D variables
+
+  IP_ = iBooker.book1D(fmt::format("d{}_pt{}", varname_, pTcut_),
+                       fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_),
+                       VarBin,
+                       VarMin,
+                       VarMax);
+
+  IPErr_ = iBooker.book1D(fmt::format("d{}Err_pt{}", varname_, pTcut_),
+                          fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_),
+                          100,
+                          0.,
+                          (varname_.find("xy") != std::string::npos) ? 2000. : 10000.);
+
+  IPPull_ = iBooker.book1D(
+      fmt::format("d{}Pull_pt{}", varname_, pTcut_),
+      fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}}/#sigma_{{d_{{{}}}}}", pTcut_, varname_, varname_),
+      100,
+      -5.,
+      5.);
+
+  // IP profiles
+
+  IPVsPhi_ = iBooker.bookProfile(fmt::format("d{}VsPhi_pt{}", varname_, pTcut_),
+                                 fmt::format("PV tracks (p_{{T}} > {}) d_{{{}}} VS track #phi", pTcut_, varname_),
+                                 PhiBin_,
+                                 PhiMin_,
+                                 PhiMax_,
+                                 VarBin,
+                                 VarMin,
+                                 VarMax,
+                                 "");
+  IPVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 1);
+  IPVsPhi_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_), 2);
+
+  IPVsEta_ = iBooker.bookProfile(fmt::format("d{}VsEta_pt{}", varname_, pTcut_),
+                                 fmt::format("PV tracks (p_{{T}} > {}) d_{{{}}} VS track #eta", pTcut_, varname_),
+                                 EtaBin_,
+                                 EtaMin_,
+                                 EtaMax_,
+                                 VarBin,
+                                 VarMin,
+                                 VarMax,
+                                 "");
+  IPVsEta_->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
+  IPVsEta_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_), 2);
+
+  IPVsPt_ = sctTrackMonitor::makeProfileIfLog(
+      iBooker,
+      true,  /* x-axis */
+      false, /* y-axis */
+      fmt::format("d{}VsPt_pt{}", varname_, pTcut_).c_str(),
+      fmt::format("PV tracks (p_{{T}} > {}) d_{{{}}} VS track p_{{T}}", pTcut_, varname_).c_str(),
+      PtBin_,
+      log10(PtMin_),
+      log10(PtMax_),
+      VarMin,
+      VarMax,
+      "");
+  IPVsPt_->setAxisTitle("PV track (p_{T} > 1 GeV) p_{T} [GeV]", 1);
+  IPVsPt_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_), 2);
+
+  // IP error profiles
+
+  IPErrVsPhi_ =
+      iBooker.bookProfile(fmt::format("d{}ErrVsPhi_pt{}", varname_, pTcut_),
+                          fmt::format("PV tracks (p_{{T}} > {}) d_{{{}}} error VS track #phi", pTcut_, varname_),
+                          PhiBin_,
+                          PhiMin_,
+                          PhiMax_,
+                          VarBin,
+                          0.,
+                          (varname_.find("xy") != std::string::npos) ? 100. : 200.,
+                          "");
+  IPErrVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 1);
+  IPErrVsPhi_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_), 2);
+
+  IPErrVsEta_ =
+      iBooker.bookProfile(fmt::format("d{}ErrVsEta_pt{}", varname_, pTcut_),
+                          fmt::format("PV tracks (p_{{T}} > {}) d_{{{}}} error VS track #eta", pTcut_, varname_),
+                          EtaBin_,
+                          EtaMin_,
+                          EtaMax_,
+                          VarBin,
+                          0.,
+                          (varname_.find("xy") != std::string::npos) ? 100. : 200.,
+                          "");
+  IPErrVsEta_->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
+  IPErrVsEta_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_), 2);
+
+  IPErrVsPt_ = sctTrackMonitor::makeProfileIfLog(
+      iBooker,
+      true,  /* x-axis */
+      false, /* y-axis */
+      fmt::format("d{}ErrVsPt_pt{}", varname_, pTcut_).c_str(),
+      fmt::format("PV tracks (p_{{T}} > {}) d_{{{}}} error VS track p_{{T}}", pTcut_, varname_).c_str(),
+      PtBin_,
+      log10(PtMin_),
+      log10(PtMax_),
+      VarMin,
+      VarMax,
+      "");
+  IPErrVsPt_->setAxisTitle("PV track (p_{T} > 1 GeV) p_{T} [GeV]", 1);
+  IPErrVsPt_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_), 2);
+
+  // 2D profiles
+
+  IPVsEtaVsPhi_ = iBooker.bookProfile2D(
+      fmt::format("d{}VsEtaVsPhi_pt{}", varname_, pTcut_),
+      fmt::format("PV tracks (p_{{T}} > {}) d_{{{}}} VS track #eta VS track #phi", pTcut_, varname_),
+      EtaBin2D,
+      EtaMin_,
+      EtaMax_,
+      PhiBin2D,
+      PhiMin_,
+      PhiMax_,
+      VarBin,
+      VarMin,
+      VarMax,
+      "");
+  IPVsEtaVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
+  IPVsEtaVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 2);
+  IPVsEtaVsPhi_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_), 3);
+
+  IPErrVsEtaVsPhi_ = iBooker.bookProfile2D(
+      fmt::format("d{}ErrVsEtaVsPhi_pt{}", varname_, pTcut_),
+      fmt::format("PV tracks (p_{{T}} > {}) d_{{{}}} error VS track #eta VS track #phi", pTcut_, varname_),
+      EtaBin2D,
+      EtaMin_,
+      EtaMax_,
+      PhiBin2D,
+      PhiMin_,
+      PhiMax_,
+      VarBin,
+      0.,
+      (varname_.find("xy") != std::string::npos) ? 100. : 200.,
+      "");
+  IPErrVsEtaVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
+  IPErrVsEtaVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 2);
+  IPErrVsEtaVsPhi_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_),
+                                 3);
 }
 
 // main event loop
@@ -202,30 +458,31 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
 
   for (const auto& trk : tracks) {
     // --- build reco track ---
-    //reco::Track recoTrk = makeRecoTrack(trk);
-    //auto [vtxIndex, closestVtx] = findClosestScoutingVertex(&recoTrk, vertices);
-    //if (!closestVtx)
-    //  continue;
+    reco::Track recoTrk = makeRecoTrack(trk);
+    auto [vtxIndex, closestVtx] = findClosestScoutingVertex(&recoTrk, vertices);
+    if (!closestVtx)
+      continue;
 
-    // initialize the impact parameters to large values
-    std::pair<float, float> best_offset{9999.f, 99999.f};
+    // // initialize the impact parameters to large values
+    // std::pair<float, float> best_offset{9999.f, 99999.f};
 
-    // loop on all the vertices and find the closest one
-    unsigned int vtxIndex = 999;
-    unsigned int idx = 0;
-    for (const auto& vtx : vertices) {
-      const auto offset = trk_vtx_offSet(trk, vtx);
-      if (std::abs(offset.second) < std::abs(best_offset.second)) {
-        best_offset = offset;
-        vtxIndex = idx;  // save the index of the best vertex
-      }
-      idx++;
-    }
+    // // loop on all the vertices and find the closest one
+    // unsigned int vtxIndex = 999;
+    // unsigned int idx = 0;
+    // for (const auto& vtx : vertices) {
+    //   const auto offset = trk_vtx_offSet(trk, vtx);
+    //   if (std::abs(offset.second) < std::abs(best_offset.second)) {
+    //     best_offset = offset;
+    //     vtxIndex = idx;  // save the index of the best vertex
+    //   }
+    //   idx++;
+    // }
 
     h_vtx_idx->Fill(vtxIndex);
 
     const float eta = trk.tk_eta();
     const float phi = trk.tk_phi();
+    const float pt = trk.tk_pt();
 
     // --- fill 2D eta-phi occupancy histograms ---
     h2_eta_phi->Fill(eta, phi);
@@ -234,31 +491,92 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     p2_nValidStripHits_eta_phi->Fill(eta, phi, trk.tk_nValidStripHits());
 
     // --- build reco vertex ---
-    //reco::Vertex recoVtx = makeRecoVertex(*closestVtx);
+    reco::Vertex recoVtx = makeRecoVertex(*closestVtx);
 
     // --- impact parameters (standard CMSSW definitions) ---
-    //float dxy = recoTrk.dxy(recoVtx.position());
-    //float dz = recoTrk.dz(recoVtx.position());
+    float dxy = recoTrk.dxy(recoVtx.position()) * cmToUm;
+    float dz = recoTrk.dz(recoVtx.position()) * cmToUm;
+    float dxyErr = recoTrk.dxyError() * cmToUm;
+    float dzErr = recoTrk.dzError() * cmToUm;
 
-    float dxy = best_offset.first;
-    float dz = best_offset.second;
-
-    if (trk.tk_pt() < 3.)
-      continue;
+    //float dxy = best_offset.first;
+    //float dz = best_offset.second;
 
     // --- fill histograms ---
-    h_dxy->Fill(dxy * cmToUm);
-    h_dz->Fill(dz * cmToUm);
+    h_dxy->Fill(dxy);
+    h_dz->Fill(dz);
 
-    p_dxy_eta->Fill(eta, dxy * cmToUm);
-    p_dxy_phi->Fill(phi, dxy * cmToUm);
+    p_dxy_eta->Fill(eta, dxy);
+    p_dxy_phi->Fill(phi, dxy);
 
-    p_dz_eta->Fill(eta, dz * cmToUm);
-    p_dz_phi->Fill(phi, dz * cmToUm);
+    p_dz_eta->Fill(eta, dz);
+    p_dz_phi->Fill(phi, dz);
 
     // --- fill 2D eta-phi profiles ---
-    p2_dxy_eta_phi->Fill(eta, phi, dxy * cmToUm);
-    p2_dz_eta_phi->Fill(eta, phi, dz * cmToUm);
+    p2_dxy_eta_phi->Fill(eta, phi, dxy);
+    p2_dz_eta_phi->Fill(eta, phi, dz);
+
+    if (trk.tk_pt() < 1.)
+      continue;
+
+    dxy_pt1.IP_->Fill(dxy);
+    dxy_pt1.IPVsPhi_->Fill(phi, dxy);
+    dxy_pt1.IPVsEta_->Fill(eta, dxy);
+    dxy_pt1.IPVsPt_->Fill(pt, dxy);
+    dxy_pt1.IPVsEtaVsPhi_->Fill(eta, phi, dxy);
+
+    dxy_pt1.IPErr_->Fill(dxyErr);
+    dxy_pt1.IPPull_->Fill(dxy / dxyErr);
+    dxy_pt1.IPErrVsPhi_->Fill(phi, dxyErr);
+    dxy_pt1.IPErrVsEta_->Fill(eta, dxyErr);
+    dxy_pt1.IPErrVsPt_->Fill(pt, dxyErr);
+    dxy_pt1.IPErrVsEtaVsPhi_->Fill(eta, phi, dxyErr);
+
+    // dz pT>1
+
+    dz_pt1.IP_->Fill(dz);
+    dz_pt1.IPVsPhi_->Fill(phi, dz);
+    dz_pt1.IPVsEta_->Fill(eta, dz);
+    dz_pt1.IPVsPt_->Fill(pt, dz);
+    dz_pt1.IPVsEtaVsPhi_->Fill(eta, phi, dz);
+
+    dz_pt1.IPErr_->Fill(dzErr);
+    dz_pt1.IPPull_->Fill(dz / dzErr);
+    dz_pt1.IPErrVsPhi_->Fill(phi, dzErr);
+    dz_pt1.IPErrVsEta_->Fill(eta, dzErr);
+    dz_pt1.IPErrVsPt_->Fill(pt, dzErr);
+    dz_pt1.IPErrVsEtaVsPhi_->Fill(eta, phi, dzErr);
+
+    if (pt < 10.)
+      continue;
+
+    // dxy pT>10
+    dxy_pt10.IP_->Fill(dxy);
+    dxy_pt10.IPVsPhi_->Fill(phi, dxy);
+    dxy_pt10.IPVsEta_->Fill(eta, dxy);
+    dxy_pt10.IPVsPt_->Fill(pt, dxy);
+    dxy_pt10.IPVsEtaVsPhi_->Fill(eta, phi, dxy);
+
+    dxy_pt10.IPErr_->Fill(dxyErr);
+    dxy_pt10.IPPull_->Fill(dxy / dxyErr);
+    dxy_pt10.IPErrVsPhi_->Fill(phi, dxyErr);
+    dxy_pt10.IPErrVsEta_->Fill(eta, dxyErr);
+    dxy_pt10.IPErrVsPt_->Fill(pt, dxyErr);
+    dxy_pt10.IPErrVsEtaVsPhi_->Fill(eta, phi, dxyErr);
+
+    // dxz pT>10
+    dz_pt10.IP_->Fill(dz);
+    dz_pt10.IPVsPhi_->Fill(phi, dz);
+    dz_pt10.IPVsEta_->Fill(eta, dz);
+    dz_pt10.IPVsPt_->Fill(pt, dz);
+    dz_pt10.IPVsEtaVsPhi_->Fill(eta, phi, dz);
+
+    dz_pt10.IPErr_->Fill(dzErr);
+    dz_pt10.IPPull_->Fill(dz / dzErr);
+    dz_pt10.IPErrVsPhi_->Fill(phi, dzErr);
+    dz_pt10.IPErrVsEta_->Fill(eta, dzErr);
+    dz_pt10.IPErrVsPt_->Fill(pt, dzErr);
+    dz_pt10.IPErrVsEtaVsPhi_->Fill(eta, phi, dzErr);
   }
 }
 
@@ -340,6 +658,23 @@ void ScoutingTrackMonitor::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<edm::InputTag>("tracks", edm::InputTag("hltScoutingTrackPacker"));
   desc.add<edm::InputTag>("vertices", edm::InputTag("hltScoutingPrimaryVertexPacker", "primaryVtx"));
   desc.add<std::string>("topFolderName", "HLT/ScoutingOffline/Tracks");
+  desc.add<int>("DxyBin", 100);
+  desc.add<double>("DxyMin", -5000.0);
+  desc.add<double>("DxyMax", 5000.0);
+  desc.add<int>("DzBin", 100);
+  desc.add<double>("DzMin", -2000.0);
+  desc.add<double>("DzMax", 2000.0);
+  desc.add<int>("PhiBin", 32);
+  desc.add<double>("PhiMin", -M_PI);
+  desc.add<double>("PhiMax", M_PI);
+  desc.add<int>("EtaBin", 26);
+  desc.add<double>("EtaMin", 2.5);
+  desc.add<double>("EtaMax", -2.5);
+  desc.add<int>("PtBin", 49);
+  desc.add<double>("PtMin", 1.);
+  desc.add<double>("PtMax", 50.);
+  desc.add<int>("PhiBin2D", 12);
+  desc.add<int>("EtaBin2D", 8);
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -37,6 +37,7 @@ private:
   // histograms
   MonitorElement* h_dxy;
   MonitorElement* h_dz;
+  MonitorElement* h_vtx_idx;
   MonitorElement* p_dxy_eta;
   MonitorElement* p_dxy_phi;
   MonitorElement* p_dz_eta;
@@ -62,6 +63,8 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
   h_dxy = ibooker.book1D("dxy", "dxy;dxy [cm];Entries", 100, -0.5, 0.5);
   h_dz = ibooker.book1D("dz", "dz;dz [cm];Entries", 100, -1.0, 1.0);
 
+  h_vtx_idx = ibooker.book1DD("vertexIndex", "tracks Vertex Index;Vertex index;Entries", 17, -1.5, 15.5);
+
   p_dxy_eta = ibooker.bookProfile("dxy_vs_eta", "dxy vs eta;eta;<dxy>", 50, -3.0, 3.0, -0.5, 0.5, "");
   p_dxy_phi =
       ibooker.bookProfile("dxy_vs_phi", "dxy vs phi;phi;<dxy>", 50, -std::numbers::pi, std::numbers::pi, -0.5, 0.5, "");
@@ -85,6 +88,8 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     auto [vtxIndex, closestVtx] = findClosestScoutingVertex(&recoTrk, vertices);
     if (!closestVtx)
       continue;
+
+    h_vtx_idx->Fill(vtxIndex);
 
     // // --- find closest vertex in z ---
     // float bestDist = 1e9;

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -43,6 +43,15 @@ private:
   MonitorElement* p_dz_eta;
   MonitorElement* p_dz_phi;
 
+  MonitorElement* h2_eta_phi;
+
+  // 2D eta-phi profiles
+  MonitorElement* p2_dxy_eta_phi;
+  MonitorElement* p2_dz_eta_phi;
+  MonitorElement* p2_nValidPixelHits_eta_phi;
+  MonitorElement* p2_nTrackerLayersWithMeasurement_eta_phi;
+  MonitorElement* p2_nValidStripHits_eta_phi;
+
   // helpers
   reco::Track makeRecoTrack(const Run3ScoutingTrack& sTrack) const;
   reco::Vertex makeRecoVertex(const Run3ScoutingVertex& sVertex) const;
@@ -71,6 +80,72 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
   p_dz_eta = ibooker.bookProfile("dz_vs_eta", "dz vs eta;eta;<dz>", 50, -3.0, 3.0, -1.0, 1.0, "");
   p_dz_phi =
       ibooker.bookProfile("dz_vs_phi", "dz vs phi;phi;<dz>", 50, -std::numbers::pi, std::numbers::pi, -1.0, 1.0, "");
+
+  // 2D eta-phi occupancy histograms
+  h2_eta_phi =
+      ibooker.book2I("eta_vs_phi", "Track occupancy;#eta;#phi", 50, -3.0, 3.0, 50, -std::numbers::pi, std::numbers::pi);
+
+  // 2D eta-phi profiles
+  p2_dxy_eta_phi = ibooker.bookProfile2D("dxy_vs_eta_phi",
+                                         "dxy vs #eta-#phi;<dxy>;#eta;#phi",
+                                         50,
+                                         -3.0,
+                                         3.0,
+                                         50,
+                                         -std::numbers::pi,
+                                         std::numbers::pi,
+                                         -0.5,
+                                         0.5,
+                                         "");
+
+  p2_dz_eta_phi = ibooker.bookProfile2D("dz_vs_eta_phi",
+                                        "dz vs #eta-#phi;<dz>;#eta;#phi",
+                                        50,
+                                        -3.0,
+                                        3.0,
+                                        50,
+                                        -std::numbers::pi,
+                                        std::numbers::pi,
+                                        -1.0,
+                                        1.0,
+                                        "");
+
+  p2_nValidPixelHits_eta_phi = ibooker.bookProfile2D("nValidPixelHits_vs_eta_phi_prof",
+                                                     "nValidPixelHits vs #eta-#phi;<nValidPixelHits>;#eta;#phi",
+                                                     50,
+                                                     -3.0,
+                                                     3.0,
+                                                     50,
+                                                     -std::numbers::pi,
+                                                     std::numbers::pi,
+                                                     0.,
+                                                     10.,
+                                                     "");
+
+  p2_nTrackerLayersWithMeasurement_eta_phi =
+      ibooker.bookProfile2D("nTrackerLayersWithMeasurement_vs_eta_phi_prof",
+                            "nTrackerLayersWithMeasurement vs #eta-#phi;<nTrackerLayersWithMeasurement>;#eta;#phi",
+                            50,
+                            -3.0,
+                            3.0,
+                            50,
+                            -std::numbers::pi,
+                            std::numbers::pi,
+                            0.,
+                            20.,
+                            "");
+
+  p2_nValidStripHits_eta_phi = ibooker.bookProfile2D("nValidStripHits_vs_eta_phi_prof",
+                                                     "nValidStripHits vs #eta-#phi;<nValidStripHits>;#eta;#phi",
+                                                     50,
+                                                     -3.0,
+                                                     3.0,
+                                                     50,
+                                                     -std::numbers::pi,
+                                                     std::numbers::pi,
+                                                     0.,
+                                                     30.,
+                                                     "");
 }
 
 // main event loop
@@ -91,19 +166,14 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
 
     h_vtx_idx->Fill(vtxIndex);
 
-    // // --- find closest vertex in z ---
-    // float bestDist = 1e9;
-    // const Run3ScoutingVertex* closestVtx = nullptr;
-    // for (const auto& vtx : vertices) {
-    //   float dz = std::abs(trk.tk_vz() - vtx.z());
-    //   if (dz < bestDist) {
-    //     bestDist = dz;
-    //     closestVtx = &vtx;
-    //   }
-    // }
+    const float eta = recoTrk.eta();
+    const float phi = recoTrk.phi();
 
-    // if (!closestVtx)
-    //   continue;
+    // --- fill 2D eta-phi occupancy histograms ---
+    h2_eta_phi->Fill(eta, phi);
+    p2_nValidPixelHits_eta_phi->Fill(eta, phi, trk.tk_nValidPixelHits());
+    p2_nTrackerLayersWithMeasurement_eta_phi->Fill(eta, phi, trk.tk_nTrackerLayersWithMeasurement());
+    p2_nValidStripHits_eta_phi->Fill(eta, phi, trk.tk_nValidStripHits());
 
     // --- build reco vertex ---
     reco::Vertex recoVtx = makeRecoVertex(*closestVtx);
@@ -124,6 +194,10 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
 
     p_dz_eta->Fill(recoTrk.eta(), dz);
     p_dz_phi->Fill(recoTrk.phi(), dz);
+
+    // --- fill 2D eta-phi profiles ---
+    p2_dxy_eta_phi->Fill(eta, phi, dxy);
+    p2_dz_eta_phi->Fill(eta, phi, dz);
   }
 }
 

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -208,8 +208,8 @@ ScoutingTrackMonitor::ScoutingTrackMonitor(const edm::ParameterSet& iConfig)
 void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) {
   ibooker.setCurrentFolder(topFolderName_);
 
-  h_dxy = ibooker.book1D("dxy", "d_{xy};d_{xy} [#mum];Tracks", 100, -0.15 * cmToUm, 0.15 * cmToUm);
-  h_dz = ibooker.book1D("dz", "d_{z};d_{z} [#mum];Tracks", 100, -0.35 * cmToUm, 0.35 * cmToUm);
+  h_dxy = ibooker.book1DD("dxy", "d_{xy};d_{xy} [#mum];Tracks", 100, -0.15 * cmToUm, 0.15 * cmToUm);
+  h_dz = ibooker.book1DD("dz", "d_{z};d_{z} [#mum];Tracks", 100, -0.35 * cmToUm, 0.35 * cmToUm);
 
   h_vtx_idx = ibooker.book1DD("vertexIndex", "tracks Vertex Index;Vertex index;Tracks", 17, -1.5, 15.5);
 
@@ -474,19 +474,19 @@ void ScoutingTrackMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
 
   // 1D variables
 
-  IP_ = iBooker.book1D(fmt::format("d{}_pt{}", varname_, pTcut_),
-                       fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_),
-                       VarBin,
-                       VarMin,
-                       VarMax);
+  IP_ = iBooker.book1DD(fmt::format("d{}_pt{}", varname_, pTcut_),
+                        fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_),
+                        VarBin,
+                        VarMin,
+                        VarMax);
 
-  IPErr_ = iBooker.book1D(fmt::format("d{}Err_pt{}", varname_, pTcut_),
-                          fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_),
-                          100,
-                          0.,
-                          (varname_.find("xy") != std::string::npos) ? 2000. : 10000.);
+  IPErr_ = iBooker.book1DD(fmt::format("d{}Err_pt{}", varname_, pTcut_),
+                           fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_),
+                           100,
+                           0.,
+                           (varname_.find("xy") != std::string::npos) ? 2000. : 10000.);
 
-  IPPull_ = iBooker.book1D(
+  IPPull_ = iBooker.book1DD(
       fmt::format("d{}Pull_pt{}", varname_, pTcut_),
       fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}}/#sigma_{{d_{{{}}}}}", pTcut_, varname_, varname_),
       100,

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -171,6 +171,12 @@ private:
   std::pair<unsigned int, const Run3ScoutingVertex*> findClosestScoutingVertex(
       const reco::Track* track, const std::vector<Run3ScoutingVertex>& vertices);
 
+  template <typename T>
+  bool getValidHandle(const edm::Event& iEvent,
+                      const edm::EDGetTokenT<T>& token,
+                      edm::Handle<T>& handle,
+                      const std::string& label);
+
   template <class OBJECT_TYPE>
   int index(const std::vector<OBJECT_TYPE*>& vec, const TString& name) {
     for (const auto& iter : vec | boost::adaptors::indexed(0)) {
@@ -601,10 +607,32 @@ void ScoutingTrackMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
                                  3);
 }
 
+template <typename T>
+bool ScoutingTrackMonitor::getValidHandle(const edm::Event& iEvent,
+                                          const edm::EDGetTokenT<T>& token,
+                                          edm::Handle<T>& handle,
+                                          const std::string& label) {
+  iEvent.getByToken(token, handle);
+  if (!handle.isValid()) {
+    edm::LogWarning("ScoutingTrackMonitor") << "Invalid handle for " << label;
+    return false;
+  }
+  return true;
+}
+
 // main event loop
 void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
-  auto const& tracks = iEvent.get(tracksToken_);
-  auto const& vertices = iEvent.get(verticesToken_);
+  edm::Handle<std::vector<Run3ScoutingVertex>> primaryVerticesH;
+  edm::Handle<std::vector<Run3ScoutingTrack>> tracksH;
+
+  if (!getValidHandle(iEvent, verticesToken_, primaryVerticesH, "primary vertices") ||
+      !getValidHandle(iEvent, tracksToken_, tracksH, "tracks")) {
+    return;
+  }
+
+  // derefernce handles when it's safe to do so.
+  auto const& tracks = *tracksH;
+  auto const& vertices = *primaryVerticesH;
 
   if (vertices.empty())
     return;

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -91,8 +91,8 @@ ScoutingTrackMonitor::ScoutingTrackMonitor(const edm::ParameterSet& iConfig)
 void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) {
   ibooker.setCurrentFolder(topFolderName_);
 
-  h_dxy = ibooker.book1D("dxy", "d_{xy};d_{xy} [#mum];Tracks", 100, -0.01 * cmToUm, 0.01 * cmToUm);
-  h_dz = ibooker.book1D("dz", "d_{z};d_{z} [#mum];Tracks", 100, -0.05 * cmToUm, 0.05 * cmToUm);
+  h_dxy = ibooker.book1D("dxy", "d_{xy};d_{xy} [#mum];Tracks", 100, -0.15 * cmToUm, 0.15 * cmToUm);
+  h_dz = ibooker.book1D("dz", "d_{z};d_{z} [#mum];Tracks", 100, -0.35 * cmToUm, 0.35 * cmToUm);
 
   h_vtx_idx = ibooker.book1DD("vertexIndex", "tracks Vertex Index;Vertex index;Tracks", 17, -1.5, 15.5);
 
@@ -103,8 +103,8 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
                                   50,
                                   -std::numbers::pi,
                                   std::numbers::pi,
-                                  -0.01 * cmToUm,
-                                  0.01 * cmToUm,
+                                  -0.15 * cmToUm,
+                                  0.15 * cmToUm,
                                   "");
   p_dz_eta = ibooker.bookProfile(
       "dz_vs_eta", "d_{z} vs #eta;#eta;#LTd_{z}#GT [#mum]", 50, -3.0, 3.0, -0.05 * cmToUm, 0.05 * cmToUm, "");
@@ -113,8 +113,8 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
                                  50,
                                  -std::numbers::pi,
                                  std::numbers::pi,
-                                 -0.05 * cmToUm,
-                                 0.05 * cmToUm,
+                                 -0.35 * cmToUm,
+                                 0.35 * cmToUm,
                                  "");
 
   // 2D eta-phi occupancy histograms
@@ -131,8 +131,8 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
                                          50,
                                          -std::numbers::pi,
                                          std::numbers::pi,
-                                         -0.01 * cmToUm,
-                                         0.01 * cmToUm,
+                                         -0.15 * cmToUm,
+                                         0.15 * cmToUm,
                                          "");
   p2_dxy_eta_phi->setOption("colz");
 
@@ -144,8 +144,8 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
                                         50,
                                         -std::numbers::pi,
                                         std::numbers::pi,
-                                        -0.05 * cmToUm,
-                                        0.05 * cmToUm,
+                                        -0.35 * cmToUm,
+                                        0.35 * cmToUm,
                                         "");
   p2_dz_eta_phi->setOption("colz");
 

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -587,6 +587,7 @@ void ScoutingTrackMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
   IPVsEtaVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
   IPVsEtaVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 2);
   IPVsEtaVsPhi_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_), 3);
+  IPVsEtaVsPhi_->setOption("colz");
 
   IPErrVsEtaVsPhi_ = iBooker.bookProfile2D(
       fmt::format("d{}ErrVsEtaVsPhi_pt{}", varname_, pTcut_),
@@ -605,6 +606,7 @@ void ScoutingTrackMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
   IPErrVsEtaVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 2);
   IPErrVsEtaVsPhi_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_),
                                  3);
+  IPErrVsEtaVsPhi_->setOption("colz");
 }
 
 template <typename T>

--- a/HLTriggerOffline/Scouting/python/ScoutingTrackMonitor_cfi.py
+++ b/HLTriggerOffline/Scouting/python/ScoutingTrackMonitor_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
+ScoutingTrackMonitor =  DQMEDAnalyzer('ScoutingTrackMonitor',
+                                      tracks = cms.InputTag('hltScoutingTrackPacker'),
+                                      vertices = cms.InputTag('hltScoutingPrimaryVertexPacker', 'primaryVtx'),
+                                      topFolderName = cms.string('HLT/ScoutingOffline/Tracks')
+                                      )

--- a/HLTriggerOffline/Scouting/test/testHLTScoutingDQMAnalyzers.cc
+++ b/HLTriggerOffline/Scouting/test/testHLTScoutingDQMAnalyzers.cc
@@ -140,3 +140,9 @@ TEST_CASE("ScoutingMuonTriggerAnalyzer tests", "[ScoutingMuonTriggerAnalyzer]") 
   const std::string baseConfig = generateBaseConfig("scoutingMuonTriggerAnalyzer");
   runTestForAnalyzer(baseConfig, "ScoutingMuonTriggerAnalyzer");
 }
+
+//___________________________________________________________________________________________
+TEST_CASE("ScoutingTrackMonitor tests", "[ScoutingTrackMonitor]") {
+  const std::string baseConfig = generateBaseConfig("scoutingTrackMonitor");
+  runTestForAnalyzer(baseConfig, "ScoutingTrackMonitor");
+}


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50715

#### PR description:

From the original PR:

> This PR enhances the **Data Quality Monitoring (DQM)** for HLT scouting by introducing monitoring of additional scouting track properties. It consists of multiple commits that extend, refine, and clean up the relevant DQM modules to improve validation and performance studies of NGT demonstrator scouting workflow.
> 
> The main updates include:
> 
> - *Extended DQM monitoring for scouting tracks*
>   - Adds new histograms to monitor key track properties, including kinematic, quality, and hit-related variables.
>   - Improves the validation and physics usability of scouting data.
> 
> - *Improvement of existing HLT scouting DQM modules*
>   - `ScoutingCollectionMonitor`: add monitoring of electron impact parameters w.r.t. beamspot and PV, avoid capping of histrograms content due to booking in single precision;
>   - `ScoutingMuonPropertiesAnalyzer`: improve histogram naming and axes labeling conventions;
>   - `ScoutingPi0Analyzer`: improve histogram naming and axes labeling;
>   
> - *Refactoring and code cleanup*
>   - Improves code readability, modularity, and maintainability.
>   - Harmonizes naming conventions and removes redundancies.
> 
> - *Configuration updates*
>   - Updates the relevant Python configuration files to include the new monitoring elements.
>   - Ensures seamless integration into standard DQM sequences.

#### PR validation:

Both of these tests runs fine:

```
scram b runtests_TestDQMOnlineClient-ngt_dqm_sourceclient
scram b runtests_TestDQMOnlineClient-scouting_dqm_sourceclient
```

Additionally we have run the following script:

```bash
#!/bin/bash -ex

LOCALPATH='/eos/cms/store/group/tsg-phase2/user/jprendi/NERD25/MoreStats/EGammas/HLT/'
echo "Input source: |${LOCALPATH}|"
LOCALFILES=$(ls -1 ${LOCALPATH} | grep Scouting)
ALL_FILES=""
for f in ${LOCALFILES[@]}; do
    ALL_FILES+="file:${LOCALPATH}/${f},"
done

# Remove the last character
ALL_FILES="${ALL_FILES%?}"
echo "Discovered files: $ALL_FILES"

cmsDriver.py step2 -s DQM:hltScoutingCollectionMonitor \
             --conditions 160X_dataRun3_HLT_v1 \
             --datatier DQMIO \
             -n 100000 \
             --eventcontent DQMIO \
             --geometry DB:Extended \
             --era Run3_2025 \
             --filein file:$ALL_FILES \
             --fileout file:step2.root \
             --nThreads 24 \
             --python_filename dqm.py \
             --no_exec

cat <<@EOF >> dqm.py 
# import beamspot
from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer as _onlineBeamSpotProducer
process.hltOnlineBeamSpot = _onlineBeamSpotProducer.clone()
process.scoutingCollectionMonitor.onlineMetaDataDigis = "hltOnlineMetaDataDigis"
process.scoutingCollectionMonitor.onlyScouting = True

# best electron track producer
from PhysicsTools.Scouting.Run3ScoutingElectronBestTrackProducer_cfi import Run3ScoutingElectronBestTrackProducer as _Run3ScoutingElectronBestTrackProducer
process.run3ScoutingElectronBestTrack =  _Run3ScoutingElectronBestTrackProducer.clone()

process.dqmoffline_step = cms.EndPath(process.hltOnlineBeamSpot+process.run3ScoutingElectronBestTrack+process.hltScoutingCollectionMonitor+process.hltScoutingTrackMonitor)
@EOF

cmsRun dqm.py >& dqm.log

cmsDriver.py step3 -s HARVESTING:@standardDQM \
         --conditions 160X_dataRun3_HLT_v1 \
         --data \
         --geometry DB:Extended \
         --scenario pp \
         --filetype DQM \
         --era Run3_2025 \
         -n 10000 \
         --filein file:step2.root \
         --fileout file:step3.root \
         --no_exec

cmsRun step3_HARVESTING.py >& harvesting.log
```

and examined the output DQM file.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim intermediate backport of https://github.com/cms-sw/cmssw/pull/50715 to 16.1.X for 2026 data-taking operations.