### PR TITLE
Improve handling of missing/invalid inputs in `TrackingAssocValueMapsProducer`

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/TrackingAssocValueMapsProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/TrackingAssocValueMapsProducer.cc
@@ -120,6 +120,8 @@ TrackingAssocValueMapsProducer::TrackingAssocValueMapsProducer(const edm::Parame
 }
 
 void TrackingAssocValueMapsProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
+  const std::string metname = "PhysicsTools/NanoAOD/TrackingAssocValueMapsProducer";
+
   edm::Handle<edm::View<reco::Track>> tracksH;
   iEvent.getByToken(tracksToken_, tracksH);
 
@@ -145,19 +147,10 @@ void TrackingAssocValueMapsProducer::produce(edm::Event& iEvent, const edm::Even
 
   const size_t nTracks = tracksH->size();
 
-  if (nTracks == 0 || !inputsValid) {
-    // No tracks or invalid handles, put empty ValueMaps and return
-    iEvent.put(std::make_unique<edm::ValueMap<int>>(), "matched");
-    iEvent.put(std::make_unique<edm::ValueMap<int>>(), "duplicate");
-    iEvent.put(std::make_unique<edm::ValueMap<int>>(), "tpPdgId");
-    iEvent.put(std::make_unique<edm::ValueMap<int>>(), "tpCharge");
-    if (storeTPKinematics_) {
-      iEvent.put(std::make_unique<edm::ValueMap<float>>(), "tpPt");
-      iEvent.put(std::make_unique<edm::ValueMap<float>>(), "tpEta");
-      iEvent.put(std::make_unique<edm::ValueMap<float>>(), "tpPhi");
-    }
-    return;
-  }
+  LogDebug(metname) << "Retrieved " << nTracks << " tracks and " << tpH->size()
+                    << " tracking particles. Track handle valid: " << tracksH.isValid()
+                    << ", TP handle valid: " << tpH.isValid() << ", associator handle valid: "
+                    << (useMuonAssociators_ ? recoToSimH.isValid() && simToRecoH.isValid() : associatorH.isValid());
 
   std::vector<int> matched(nTracks, 0);
   std::vector<int> duplicate(nTracks, 0);
@@ -169,6 +162,21 @@ void TrackingAssocValueMapsProducer::produce(edm::Event& iEvent, const edm::Even
     tpPt.assign(nTracks, -1.f);
     tpEta.assign(nTracks, -10.f);
     tpPhi.assign(nTracks, -10.f);
+  }
+
+  if (nTracks == 0 || !inputsValid) {
+    LogDebug(metname) << "No tracks or invalid inputs, producing empty ValueMaps.";
+    // No tracks or invalid handles, put ValueMaps with default values and return
+    fillAndPut<int>(iEvent, tracksH, std::make_unique<edm::ValueMap<int>>(), matched, "matched");
+    fillAndPut<int>(iEvent, tracksH, std::make_unique<edm::ValueMap<int>>(), duplicate, "duplicate");
+    fillAndPut<int>(iEvent, tracksH, std::make_unique<edm::ValueMap<int>>(), tpPdgId, "tpPdgId");
+    fillAndPut<int>(iEvent, tracksH, std::make_unique<edm::ValueMap<int>>(), tpCharge, "tpCharge");
+    if (storeTPKinematics_) {
+      fillAndPut<float>(iEvent, tracksH, std::make_unique<edm::ValueMap<float>>(), tpPt, "tpPt");
+      fillAndPut<float>(iEvent, tracksH, std::make_unique<edm::ValueMap<float>>(), tpEta, "tpEta");
+      fillAndPut<float>(iEvent, tracksH, std::make_unique<edm::ValueMap<float>>(), tpPhi, "tpPhi");
+    }
+    return;
   }
 
   edm::RefToBaseVector<reco::Track> trackRefs;


### PR DESCRIPTION
#### PR description:
This PR fixes the incorrect handling of missing/invalid inputs in [`TrackingAssocValueMapsProducer`](https://github.com/cms-sw/cmssw/blob/dac08ff912f8c285ff5c1fea605d29d6a1abb697/PhysicsTools/NanoAOD/plugins/TrackingAssocValueMapsProducer.cc). 
@elenavernazza (thank you!) found out that when running the [`NanoPixelTables`](https://github.com/cms-sw/cmssw/blob/dac08ff912f8c285ff5c1fea605d29d6a1abb697/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py#L79-L84) sequence without the Validation step, the job would crash with 
```
----- Begin Fatal Exception 15-Apr-2026 15:01:50 CEST-----------------------
An exception of category 'InvalidReference' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 3 stream: 0
   [1] Running path 'nanoAOD_step'
   [2] Calling method for module SimpleTriggerTrackFlatTableProducer/'hltPixelTrackTable'
Exception Message:
ValueMap: no associated value for given product and index
----- End Fatal Exception -------------------------------------------------
```
This happens because the `associator` required by `TrackingAssocValueMapsProducer` is only produced on the fly in the validation sequence. However, the module should simply return empty `valueMaps` in these cases, which it now correctly does.

#### PR validation:

Before this PR, running 
```bash
cmsDriver.py TTbar_14TeV_TuneCP5_cfi  \
-s GEN,SIM -n 10 \
--conditions auto:phase2_realistic_T35 \
--beamspot DBrealisticHLLHC \
--datatier GEN-SIM \
--eventcontent FEVTDEBUG \
--geometry ExtendedRun4D110 \
--era Phase2C17I13M9 \
--relval 9000,100 \
--fileout file:step1.root

cmsDriver.py step2 \
-s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:@relvalRun4,NANO:@Phase2HLTVal \
-n 10 \
--conditions auto:phase2_realistic_T35 \
--datatier GEN-SIM-DIGI-RAW,NANOAODSIM \
--eventcontent FEVTDEBUGHLT,NANOAODSIM \
--geometry ExtendedRun4D110 \
--era Phase2C17I13M9 \
--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
--filein  file:step1.root \
--fileout file:step2.root
```

would fail, while the workflow now runs and produces the expected "empty" `valueMaps` (filled with default values).