### PR TITLE
[DBG_X] attempts to fix compilation errors 

### DIFF
--- a/SimGeneral/MixingModule/interface/DecayGraph.h
+++ b/SimGeneral/MixingModule/interface/DecayGraph.h
@@ -4,6 +4,10 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimDataFormats/Track/interface/SimTrack.h"
 
+#ifndef DEBUG
+#define DEBUG 0
+#endif
+
 #if DEBUG
 // boost optional (used by boost graph) results in some false positives with
 // // -Wmaybe-uninitialized


### PR DESCRIPTION
#### PR description:

Add DEBUG macro definition to DecayGraph.h to fix CLANG Warnings and compilation errors in DEBUG IBs.