### PR TITLE
Update UPCMonopole skim

### DIFF
--- a/Configuration/Skimming/python/PbPb_UPC_Monopole_cff.py
+++ b/Configuration/Skimming/python/PbPb_UPC_Monopole_cff.py
@@ -1,18 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-# HLT UPC pixel thrust trigger
-import HLTrigger.HLTfilters.hltHighLevel_cfi
-hltUPCMonopole = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
-hltUPCMonopole.HLTPaths = ["HLT_HIUPC_MinPixelThrust0p8_MaxPixelCluster10000_v*"]
-hltUPCMonopole.throw = False
-hltUPCMonopole.andOr = True
-
-from HLTrigger.special.hltPixelActivityFilter_cfi import hltPixelActivityFilter as _hltPixelActivityFilter
-hltPixelActivityFilterMinClusters40 = _hltPixelActivityFilter.clone(inputTag = "siPixelClusters", minClusters = 40)
+from HLTrigger.special.hltPixelThrustFilter_cfi import hltPixelThrustFilter as _hltPixelThrustFilter
+hltUPCMonopole = _hltPixelThrustFilter.clone(inputTag = "siPixelClusters", maxNPixels = 10000, minNSaturatedPixels = 2, minThrust = 0.85)
 
 from Configuration.Skimming.PDWG_EXOMONOPOLE_cff import EXOMonopoleSkimContent
 upcMonopoleSkimContent = EXOMonopoleSkimContent.clone()
 upcMonopoleSkimContent.outputCommands.append('keep FEDRawDataCollection_rawDataRepacker_*_*')
 
 # UPC monopole skim sequence
-upcMonopoleSkimSequence = cms.Sequence(hltUPCMonopole * hltPixelActivityFilterMinClusters40)
+upcMonopoleSkimSequence = cms.Sequence(hltUPCMonopole)


### PR DESCRIPTION
#### PR description:

This PR updates the UPC monopole skim of the HIForward datasets for the 2026 PbPb data taking by using tighter selections.

Checks performed on 2025 PbPb RAW data show a reduction on the number of events by a factor of ~40 using the new settings compared to the previous ones and a size per event for the new skim of 50 times smaller than the HIForward MiniAOD size.

@mandrenguyen @flodamas 

#### PR validation:

Tested with relvals 141.201,142.201,143.201,144.201

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 16_1_X for 2026 PbPb data taking
