### PR TITLE
CMSSW_17_0_X - Unpacking support for CSC Run3-b OTMB LCT ME11-GEM data format changes

### DIFF
--- a/DQM/CSCMonitorModule/data/emuDQMBooking.xml
+++ b/DQM/CSCMonitorModule/data/emuDQMBooking.xml
@@ -1297,6 +1297,27 @@
                 <Name>Event_Display_XY</Name>
 	</Histogram>
 
+	<Histogram>
+                <Prefix>EMU</Prefix>
+                <SetNdivisionsX>36</SetNdivisionsX>
+                <SetNdivisionsY>8</SetNdivisionsY>
+                <SetOption>textcolz</SetOption>
+                <SetOptStat>e</SetOptStat>
+		<SetYLabels>1='z- LCT1/GEMLy1'|2='z- LCT1/GEMLy0'|3='z- LCT0/GEMLy1'|4='z- LCT0/GEMLy0'|5='z+ LCT0/GEMLy0'|6='z+ LCT0/GEMLy1'|7='z+ LCT1/GEMLy0'|8='z+ LCT1/GEMLy1'|</SetYLabels>
+                <Title>ME11s Correlated LCTs GEM Layers</Title>
+                <Type>h2</Type>
+                <XBins>36</XBins>
+                <XMax>37</XMax>
+                <XMin>1</XMin>
+                <XTitle>ME11 chambers</XTitle>
+                <YBins>8</YBins>
+                <YMax>8</YMax>
+                <YMin>0</YMin>
+                <YTitle>LCT# / GEM Layer</YTitle>
+                <Name>ME11_Corr_LCT_Run3b_GEM_Layers</Name>
+        </Histogram>
+
+
         <!-- DDU Histograms -->
 
 	<Histogram>
@@ -3910,6 +3931,45 @@
                 <XTitle>Run3 5-bit CLCT Pattern ID</XTitle>
                 <YTitle>Number of events</YTitle>
                 <Name>Corr_LCT_Run3_PatternID</Name>
+        </Histogram>
+
+	<Histogram>
+		<Folder>TMB</Folder>
+		<Prefix>CSC</Prefix>
+		<SetLabelSizeX>0.025</SetLabelSizeX>
+		<SetMinimum>0</SetMinimum>
+		<SetNdivisionsX>64</SetNdivisionsX>
+                <SetOption>texthist</SetOption>
+		<SetOptStat>e</SetOptStat>
+		<Title>Run3b 6-bits LCT%d CLCT slope/bend distribution</Title>
+		<Type>h1</Type>
+		<XBins>64</XBins>
+		<XMax>64</XMax>
+		<XMin>0</XMin>
+                <XTitle>Run3b 6-bits LCT%d CLCT slope/bend</XTitle>
+                <YTitle>Number of events</YTitle>
+		<Name from="0" to="1">Corr_LCT%d_Run3b_Slope</Name>
+        </Histogram>
+
+
+        <Histogram>
+		<Folder>TMB</Folder>
+                <Prefix>CSC</Prefix>
+		<SetNdivisionsX>2</SetNdivisionsX>
+                <SetNdivisionsY>2</SetNdivisionsY>
+                <SetOption>textcolz</SetOption>
+		<SetOptStat>e</SetOptStat>
+		<Title>Correlated LCTs GEM Layers</Title>
+		<Type>h2</Type>
+		<XBins>2</XBins>
+		<XMax>2</XMax>
+		<XMin>0</XMin>
+		<XTitle>GEM Layer</XTitle>
+		<YBins>2</YBins>
+		<YMax>2</YMax>
+		<YMin>0</YMin>
+                <YTitle>LCT #</YTitle>
+		<Name>Corr_LCT_Run3b_GEM_Layers</Name>
         </Histogram>
 
         <Histogram>

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
@@ -871,12 +871,18 @@ namespace cscdqm {
           bool isRun3_df = false;
           bool isGEM_df = false;
           bool isTMB_hybrid_df = false;
+          bool isOTMB_ME11_Run3b = false;
           if (tmbHeader->FirmwareVersion() == 2020) {
-            // revision code major part: 0x0 - Run3 df, 0x1 - is legacy Run2 df
+            // revision code major part: 0x0 - Run3 df, 0x1 - is legacy Run2 df, 0x2 - Run3b df
             if (((tmbHeader->FirmwareRevision() >> 5) & 0xF) == 0x0)
               isRun3_df = true;
-            if (((tmbHeader->FirmwareRevision() >> 9) & 0xF) == 0x3)
+            if (((tmbHeader->FirmwareRevision() >> 9) & 0xF) == 0x3) {
               isGEM_df = true;
+              if (((tmbHeader->FirmwareRevision() >> 5) & 0xF) == 0x2) {
+                isRun3_df = true;
+                isOTMB_ME11_Run3b = true;
+              }
+            }
             if (((tmbHeader->FirmwareRevision() >> 9) & 0xF) == 0x4)
               isTMB_hybrid_df = true;
             /** Summary plot for chambers with detected (O)TMB Run3 data format */
@@ -1069,7 +1075,7 @@ namespace cscdqm {
                 mo->Fill(tmbHeader->clctHMT(), tmbHeader->alctHMT());
               }
 
-              if (getCSCHisto(h::CSC_CORR_LCT_RUN3_PATTERN_ID, crateID, dmbID, mo)) {
+              if (getCSCHisto(h::CSC_CORR_LCT_RUN3_PATTERN_ID, crateID, dmbID, mo) && !isOTMB_ME11_Run3b) {
                 mo->Fill(tmbHeader->run3_CLCT_patternID());
               }
             }
@@ -1166,7 +1172,7 @@ namespace cscdqm {
             }
 
             if (lct == 0) {
-              if (corr_lctsDatasTmp[lct].isRun3() || isTMB_hybrid_df) {
+              if (corr_lctsDatasTmp[lct].isRun3() || isTMB_hybrid_df || isOTMB_ME11_Run3b) {
                 /// Summary occupancy plot for combined HMT bits sent to MPC
                 if (getEMUHisto(h::EMU_CSC_LCT_HMT_REPORTING, mo)) {
                   if (corr_lctsDatasTmp[lct].getHMT() > 0)
@@ -1217,7 +1223,7 @@ namespace cscdqm {
 
           if (!corr_lctsDatas.empty()) {
             if (corr_lctsDatasTmp[0].isRun3()) {
-              if (getCSCHisto(h::CSC_CORR_LCT0_VS_LCT1_RUN3_PATTERN, crateID, dmbID, mo)) {
+              if (getCSCHisto(h::CSC_CORR_LCT0_VS_LCT1_RUN3_PATTERN, crateID, dmbID, mo) && !isOTMB_ME11_Run3b) {
                 int lct1_pattern = corr_lctsDatasTmp[1].getRun3Pattern();
                 if (!corr_lctsDatasTmp[1].isValid())
                   lct1_pattern = -1;
@@ -1228,7 +1234,7 @@ namespace cscdqm {
 
           for (uint32_t lct = 0; lct < corr_lctsDatas.size(); lct++) {
             /*
-                  LOG_DEBUG << "CorrelatedLCT Digis dump: "
+                  LOG_INFO << "CorrelatedLCT Digis dump: "
                             << "CorrLCT" << lct << " isRun3:" << corr_lctsDatasTmp[lct].isRun3()
                             << ", isValid: " << corr_lctsDatasTmp[lct].isValid()
                             << ", getStrip: " << corr_lctsDatasTmp[lct].getStrip()
@@ -1236,7 +1242,7 @@ namespace cscdqm {
                             << ", getQuality: " << corr_lctsDatasTmp[lct].getQuality()
                             << ", getFractionalStrip: " <<  corr_lctsDatasTmp[lct].getFractionalStrip()
                             << ", getQuartStrip: " << corr_lctsDatasTmp[lct].getQuartStripBit()
-                            << ", getEightStrip: " << corr_lctsDatasTmp[lct].getEightStripBit()
+                            << ", getEightStrip: " << corr_lctsDatasTmp[lct].getEighthStripBit()
                             << ",\n getSlope: " << corr_lctsDatasTmp[lct].getSlope() << std::dec
                             << ", getBend: " << corr_lctsDatasTmp[lct].getBend()
                             << ", getBX: " << corr_lctsDatasTmp[lct].getBX()
@@ -1245,7 +1251,7 @@ namespace cscdqm {
                             // << ", getRun3PatternID: " << std::dec << corr_lctsDatasTmp[lct].getRun3PatternID()
                             << ", getHMT: " << corr_lctsDatasTmp[lct].getHMT()
 			    << std::dec;
-*/
+			*/
             if (getCSCHisto(h::CSC_CORR_LCTXX_HITS_DISTRIBUTION, crateID, dmbID, lct, mo)) {
               mo->Fill(corr_lctsDatas[lct].getStrip(), corr_lctsDatas[lct].getKeyWG());
             }
@@ -1258,22 +1264,48 @@ namespace cscdqm {
               mo->Fill(corr_lctsDatas[lct].getStrip(2));
             }
 
-            if (corr_lctsDatas[lct].isRun3()) {
-              if (getCSCHisto(h::CSC_CORR_LCTXX_KEY_QUARTSTRIP, crateID, dmbID, lct, mo)) {
-                mo->Fill(corr_lctsDatas[lct].getStrip(4));
-              }
+            if (corr_lctsDatas[lct].isRun3() || isOTMB_ME11_Run3b) {
+              if (!isTMB_hybrid_df) {
+                if (getCSCHisto(h::CSC_CORR_LCTXX_KEY_QUARTSTRIP, crateID, dmbID, lct, mo)) {
+                  mo->Fill(corr_lctsDatas[lct].getStrip(4));
+                }
 
-              if (getCSCHisto(h::CSC_CORR_LCTXX_KEY_EIGHTSTRIP, crateID, dmbID, lct, mo)) {
-                mo->Fill(corr_lctsDatas[lct].getStrip(8));
-              }
+                if (getCSCHisto(h::CSC_CORR_LCTXX_KEY_EIGHTSTRIP, crateID, dmbID, lct, mo)) {
+                  mo->Fill(corr_lctsDatas[lct].getStrip(8));
+                }
 
-              if (getCSCHisto(h::CSC_CORR_LCTXX_RUN3_TO_RUN2_PATTERN, crateID, dmbID, lct, mo)) {
-                int bend = corr_lctsDatas[lct].getSlope() + ((corr_lctsDatas[lct].getBend() & 0x1) << 4);
-                mo->Fill(bend, corr_lctsDatas[lct].getPattern());
-              }
+                if (getCSCHisto(h::CSC_CORR_LCTXX_RUN3_TO_RUN2_PATTERN, crateID, dmbID, lct, mo)) {
+                  int bend = corr_lctsDatas[lct].getSlope() + ((corr_lctsDatas[lct].getBend() & 0x1) << 4);
+                  mo->Fill(bend, corr_lctsDatas[lct].getPattern());
+                }
 
-              if (getCSCHisto(h::CSC_CORR_LCTXX_BEND_VS_SLOPE, crateID, dmbID, lct, mo)) {
-                mo->Fill(corr_lctsDatas[lct].getSlope(), corr_lctsDatas[lct].getBend());
+                if (getCSCHisto(h::CSC_CORR_LCTXX_BEND_VS_SLOPE, crateID, dmbID, lct, mo)) {
+                  mo->Fill(corr_lctsDatas[lct].getSlope(), corr_lctsDatas[lct].getBend());
+                }
+
+                /// Fill Run3-b ME11-GEM LCT format histograms
+                if (isOTMB_ME11_Run3b) {
+                  if (getCSCHisto(h::CSC_CORR_LCTXX_RUN3B_SLOPE, crateID, dmbID, lct, mo)) {
+                    mo->Fill(corr_lctsDatasTmp[lct].getSlopeEx());
+                  }
+                  /// Check CSC-GEM match only ME11 quality
+                  if ((corr_lctsDatasTmp[lct].getQuality() == 5) || (corr_lctsDatasTmp[lct].getQuality() == 7)) {
+                    if (getCSCHisto(h::CSC_CORR_LCT_RUN3B_GEM_LAYERS, crateID, dmbID, mo)) {
+                      mo->Fill(corr_lctsDatasTmp[lct].getGemLayerUsedForSlopeComputation(), lct);
+                    }
+                    /// Fill summary histogram
+                    if (getEMUHisto(h::EMU_ME11_CORR_LCT_RUN3B_GEM_LAYERS, mo)) {
+                      if (cid.endcap() == 1) {  // z+
+                        mo->Fill(cscPosition,
+                                 4 + (lct * 2 + corr_lctsDatasTmp[lct].getGemLayerUsedForSlopeComputation()));
+                      }
+                      if (cid.endcap() == 2) {  // z-
+                        mo->Fill(cscPosition,
+                                 3 - (lct * 2 + corr_lctsDatasTmp[lct].getGemLayerUsedForSlopeComputation()));
+                      }
+                    }
+                  }
+                }
               }
 
               if (getCSCHisto(h::CSC_CORR_LCTXX_KEY_STRIP_TYPE, crateID, dmbID, lct, mo)) {
@@ -1309,7 +1341,7 @@ namespace cscdqm {
               }
 
               if (!alctsDatas.empty() && getCSCHisto(h::CSC_RUN3_HMT_COINCIDENCE_MATCH, crateID, dmbID, mo) &&
-                  corr_lctsDatasTmp[0].isRun3() && (corr_lctsDatasTmp[0].getHMT() > 0) &&
+                  (corr_lctsDatasTmp[0].isRun3() || isOTMB_ME11_Run3b) && (corr_lctsDatasTmp[0].getHMT() > 0) &&
                   (corr_lctsDatasTmp[0].getHMT() <= 0xF) && alctsDatas[0].isValid()) {
                 mo->Fill(1);  // Run3 HMT+ALCT match
               }

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_HistoNames.icc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_HistoNames.icc
@@ -487,7 +487,10 @@ namespace h {
   HIST_ID(EMU_CSC_ANODE_HMT_ALCT_REPORTING)                     \
   HIST_ID(EMU_CSC_TMB_RUN3_DATA_FORMAT)                         \
   HIST_ID(EMU_CSC_TMB_RUN3_CCLUT_MODE)                          \
-  HIST_ID(EMU_CSC_RUN3_ALCT_FORMAT)
+  HIST_ID(EMU_CSC_RUN3_ALCT_FORMAT)                             \
+  HIST_ID(CSC_CORR_LCTXX_RUN3B_SLOPE)                           \
+  HIST_ID(CSC_CORR_LCT_RUN3B_GEM_LAYERS)                        \
+  HIST_ID(EMU_ME11_CORR_LCT_RUN3B_GEM_LAYERS)
 
 #define HIST_NAME_TABLE                                         \
   HIST_NAME("Actual_DMB_CFEB_DAV_Frequency")                    \
@@ -946,7 +949,10 @@ namespace h {
   HIST_NAME("CSC_Anode_HMT_ALCT_Reporting")                     \
   HIST_NAME("CSC_TMB_Run3_Data_Format")                         \
   HIST_NAME("CSC_TMB_Run3_CCLUT_Mode")                          \
-  HIST_NAME("CSC_ALCT_Run3_Format")
+  HIST_NAME("CSC_ALCT_Run3_Format")                             \
+  HIST_NAME("Corr_LCT%d_Run3b_Slope")                           \
+  HIST_NAME("Corr_LCT_Run3b_GEM_Layers")                        \
+  HIST_NAME("ME11_Corr_LCT_Run3b_GEM_Layers")
 
 #define HIST_ID(a) a,
   enum HistoId { HIST_ID_TABLE };

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
@@ -27,6 +27,7 @@ struct CSCTMBHeader2020_TMB;
 struct CSCTMBHeader2020_CCLUT;
 struct CSCTMBHeader2020_GEM;
 struct CSCTMBHeader2020_Run2;
+struct CSCTMBHeader2020_GEM_Run3b;
 
 class CSCTMBHeader {
 public:
@@ -64,6 +65,7 @@ public:
   CSCTMBHeader2020_CCLUT tmbHeader2020_CCLUT() const;
   CSCTMBHeader2020_GEM tmbHeader2020_GEM() const;
   CSCTMBHeader2020_Run2 tmbHeader2020_Run2() const;
+  CSCTMBHeader2020_GEM tmbHeader2020_GEM_Run3b() const;
 
   uint16_t NTBins() const { return theHeaderFormat->NTBins(); }
   uint16_t NCFEBs() const { return theHeaderFormat->NCFEBs(); }

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_GEM_Run3b.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_GEM_Run3b.h
@@ -1,0 +1,172 @@
+#ifndef EventFilter_CSCRawToDigi_CSCTMBHeader2020_GEM_Run3b_h
+#define EventFilter_CSCRawToDigi_CSCTMBHeader2020_GEM_Run3b_h
+#include "EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+
+struct CSCTMBHeader2020_GEM_Run3b : public CSCVTMBHeaderFormat {
+  enum { NWORDS = 43 };
+  CSCTMBHeader2020_GEM_Run3b();
+  CSCTMBHeader2020_GEM_Run3b(const unsigned short* buf);
+  void setEventInformation(const CSCDMBHeader& dmbHeader) override;
+
+  uint16_t BXNCount() const override { return bits.bxnCount; }
+  uint16_t ALCTMatchTime() const override { return bits.matchWin; }
+  void setALCTMatchTime(uint16_t alctmatchtime) override { bits.matchWin = alctmatchtime & 0xF; }
+  uint16_t CLCTOnly() const override { return bits.clctOnly; }
+  uint16_t ALCTOnly() const override { return bits.alctOnly; }
+  uint16_t TMBMatch() const override { return bits.tmbMatch; }
+  uint16_t Bxn0Diff() const override { return 0; }
+  uint16_t Bxn1Diff() const override { return 0; }
+  uint16_t L1ANumber() const override { return bits.l1aNumber; }
+  uint16_t NTBins() const override { return bits.nTBins; }
+  uint16_t NCFEBs() const override { return bits.nCFEBs; }
+  void setNCFEBs(uint16_t ncfebs) override { bits.nCFEBs = ncfebs & 0x7F; }
+  uint16_t firmwareRevision() const override { return bits.firmRevCode; }
+  uint16_t syncError() const override { return bits.syncError; }
+  uint16_t syncErrorCLCT() const override { return bits.clct_sync_err; }
+  uint16_t syncErrorMPC0() const override { return 0; }
+  uint16_t syncErrorMPC1() const override { return 0; }
+  uint16_t L1AMatchTime() const override { return bits.pop_l1a_match_win; }
+
+  // == Run 3 CSC-GEM Trigger Format
+  uint16_t clct0_ComparatorCode() const override { return bits.clct0_comparator_code; }
+  uint16_t clct1_ComparatorCode() const override { return bits.clct1_comparator_code; }
+  uint16_t clct0_xky() const override { return bits.clct0_xky; }
+  uint16_t clct1_xky() const override { return bits.clct1_xky; }
+  uint16_t hmt_nhits() const override {
+    return ((bits.hmt_nhits_bit0 & 0x1) + ((bits.hmt_nhits_bit1 & 0x1) << 1) +
+            ((bits.hmt_nhits_bits_high & 0x1F) << 2));
+  }
+  uint16_t hmt_ALCTMatchTime() const override { return bits.hmt_match_win; }
+  uint16_t alctHMT() const override { return bits.anode_hmt; }
+  uint16_t clctHMT() const override { return bits.cathode_hmt; }
+  uint16_t gem_enabled_fibers() const override { return (bits.gem_enabled_fibers_ & 0xF); }
+  uint16_t gem_fifo_tbins() const override { return bits.fifo_tbins_gem_; }
+  uint16_t gem_fifo_pretrig() const override { return bits.fifo_pretrig_gem_; }
+  uint16_t gem_zero_suppress() const override { return bits.gem_zero_suppression_; }
+  uint16_t gem_sync_dataword() const override {
+    return ((bits.lct0_nogem) + (bits.lct0_with_gemA << 1) + (bits.lct0_with_gemB << 2) + (bits.lct0_with_copad << 3) +
+            (bits.lct1_nogem << 4) + (bits.lct1_with_gemA << 5) + (bits.lct1_with_gemB << 6) +
+            (bits.lct1_with_copad << 7) + (bits.gemA_vpf << 8) + (bits.gemB_vpf << 9) + (bits.gemA_over_flow << 10) +
+            (bits.gemB_over_flow << 11) + (bits.gemA_sync << 12) + (bits.gemB_sync << 13) + (bits.gems_sync << 14));
+  }
+  uint16_t gem_timing_dataword() const override {
+    return ((bits.num_copad & 0xF) + ((bits.gem_delay & 0xF) << 4) + ((bits.gem_clct_win & 0xF) << 8) +
+            ((bits.alct_gem_win & 0x7) << 12));
+  }
+  uint16_t run3_CLCT_patternID()
+      const override {  // Run3-b MPC-LCT format for ME11s with GEMs does not use Run3 CLCT pattern IDs
+    return 0;
+  }
+  // ==
+
+  ///returns CLCT digis
+  std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer) override;
+  ///returns CorrelatedLCT digis
+  std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const override;
+  ///returns lct HMT Shower digi
+  CSCShowerDigi showerDigi(uint32_t idlayer) const override;
+  ///returns anode HMT Shower digi
+  CSCShowerDigi anodeShowerDigi(uint32_t idlayer) const override;
+  ///returns cathode HMT Shower digi
+  CSCShowerDigi cathodeShowerDigi(uint32_t idlayer) const override;
+
+  /// in 16-bit words.  Add olne because we include beginning(b0c) and
+  /// end (e0c) flags
+  unsigned short int sizeInWords() const override { return NWORDS; }
+
+  unsigned short int NHeaderFrames() const override { return bits.nHeaderFrames; }
+  /// returns the first data word
+  unsigned short* data() override { return (unsigned short*)(&bits); }
+  bool check() const override { return bits.e0bline == 0x6e0b; }
+
+  /// for data packing
+  void addCLCT0(const CSCCLCTDigi& digi) override;
+  void addCLCT1(const CSCCLCTDigi& digi) override;
+  void addALCT0(const CSCALCTDigi& digi) override;
+  void addALCT1(const CSCALCTDigi& digi) override;
+  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) override;
+  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) override;
+  void addShower(const CSCShowerDigi& digi) override;
+  void addAnodeShower(const CSCShowerDigi& digi) override;
+  void addCathodeShower(const CSCShowerDigi& digi) override;
+
+  void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
+
+  void print(std::ostream& os) const override;
+
+  struct {
+    // 0
+    unsigned b0cline : 16;
+    unsigned bxnCount : 12, dduCode1 : 3, flag1 : 1;
+    unsigned l1aNumber : 12, dduCode2 : 3, flag2 : 1;
+    unsigned readoutCounter : 12, dduCode3 : 3, flag3 : 1;
+    // 4
+    unsigned boardID : 5, cscID : 4, runID : 4, stackOvf : 1, syncError : 1, flag4 : 1;
+    unsigned nHeaderFrames : 6, fifoMode : 3, r_type : 2, l1atype : 2, hasBuf : 1, bufFull : 1, flag5 : 1;
+    unsigned bd_status : 15, flag6 : 1;
+    unsigned firmRevCode : 15, flag7 : 1;
+    // 8
+    unsigned bxnPreTrigger : 12, tmb_clct0_discard : 1, tmb_clct1_discard : 1, clock_lock_lost : 1, flag8 : 1;
+    unsigned preTrigCounter : 15, flag9 : 1;
+    unsigned clct0_comparator_code : 12, clct0_xky : 2, hmt_nhits_bit0 : 1, flag10 : 1;  // 12-bits comp code fw version
+    unsigned clctCounterLow : 15, flag11 : 1;
+    // 12
+    unsigned lct0_nogem : 1, lct0_with_gemA : 1, lct0_with_gemB : 1, lct0_with_copad : 1, lct1_nogem : 1,
+        lct1_with_gemA : 1, lct1_with_gemB : 1, lct1_with_copad : 1, gemA_vpf : 1, gemB_vpf : 1, gemA_over_flow : 1,
+        gemB_over_flow : 1, gemA_sync : 1, gemB_sync : 1, gems_sync : 1, flag12 : 1;
+    unsigned trigCounter : 15, flag13 : 1;
+    unsigned clct1_comparator_code : 12, clct1_xky : 2, hmt_nhits_bit1 : 1, flag14 : 1;  // 12-bits comp code fw version
+    unsigned alctCounterLow : 15, flag15 : 1;
+    // 16
+    unsigned num_copad : 4, gem_delay : 4, gem_clct_win : 4, alct_gem_win : 3, flag16 : 1;
+    unsigned uptimeCounterLow : 15, flag17 : 1;
+    unsigned uptimeCounterHigh : 15, flag18 : 1;
+    unsigned nCFEBs : 3, nTBins : 5, fifoPretrig : 5, scopeExists : 1, vmeExists : 1, flag19 : 1;
+    // 20
+    unsigned hitThresh : 3, pidThresh : 4, nphThresh : 3, pid_thresh_postdrift : 4, staggerCSC : 1, flag20 : 1;
+    unsigned triadPersist : 4, dmbThresh : 3, alct_delay : 4, clct_width : 4, flag21 : 1;
+    unsigned trigSourceVect : 9, clct0_slope : 4, clct0_LR_bend : 1, clct1_LR_bend : 1, flag22 : 1;
+    unsigned activeCFEBs : 5, readCFEBs : 5, pop_l1a_match_win : 4, aff_source : 1, flag23 : 1;
+    // 24
+    unsigned tmbMatch : 1, alctOnly : 1, clctOnly : 1, matchWin : 4, noALCT : 1, oneALCT : 1, oneCLCT : 1, twoALCT : 1,
+        twoCLCT : 1, dupeALCT : 1, dupeCLCT : 1, lctRankErr : 1, flag24 : 1;
+    unsigned clct0_valid : 1, clct0_quality : 3, clct0_shape : 4, clct0_key_low : 7, flag25 : 1;
+    unsigned clct1_valid : 1, clct1_quality : 3, clct1_shape : 4, clct1_key_low : 7, flag26 : 1;
+    unsigned clct0_key_high : 1, clct1_key_high : 1, clct_bxn : 2, clct_sync_err : 1, clct0Invalid : 1,
+        clct1Invalid : 1, clct1Busy : 1, parity_err_cfeb_ram : 5, parity_err_rpc : 1, parity_err_summary : 1,
+        flag27 : 1;
+    // 28
+    unsigned alct0Valid : 1, alct0Quality : 2, alct0Amu : 1, alct0Key : 7, clct1_slope : 4, flag28 : 1;
+    unsigned alct1Valid : 1, alct1Quality : 2, alct1Amu : 1, alct1Key : 7, drift_delay : 2, bcb_read_enable : 1,
+        hs_layer_trig : 1, flag29 : 1;
+    unsigned hmt_nhits_bits_high : 5, alct_ecc_err : 2, cfeb_badbits_found : 5, cfeb_badbits_blocked : 1, alctCfg : 1,
+        bx0_match : 1, flag30 : 1;
+    unsigned MPC_Muon0_alct_key_wire : 7, MPC_Muon0_clct_bend_run3b_extra : 2, MPC_Muon1_clct_bend_run3b_extra : 2,
+        MPC_Muon0_lct_quality : 3, MPC_Muon0_clct_QuarterStrip : 1, flag31 : 1;
+    // 32
+    unsigned MPC_Muon0_clct_key_halfstrip : 8, MPC_Muon0_clct_LR : 1, MPC_Muon0_clct_EighthStrip : 1,
+        MPC_Muon_alct_bxn : 1, MPC_Muon0_clct_bx0 : 1, MPC_Muon0_clct_bend_low : 3, flag32 : 1;
+    unsigned MPC_Muon1_alct_key_wire : 7, MPC_Muon0_GEM_layer : 1, MPC_Muon_HMT_high : 2, MPC_Muon1_GEM_layer : 1,
+        MPC_Muon1_lct_quality : 3, MPC_Muon1_clct_QuarterStrip : 1, flag33 : 1;
+    unsigned MPC_Muon1_clct_key_halfstrip : 8, MPC_Muon1_clct_LR : 1, MPC_Muon1_clct_EighthStrip : 1,
+        MPC_Muon_HMT_bit0 : 1, MPC_Muon1_clct_bx0 : 1, MPC_Muon1_clct_bend_low : 3, flag34 : 1;
+    unsigned MPC_Muon0_lct_vpf : 1, MPC_Muon0_clct_bend_high : 1, MPC_Muon1_lct_vpf : 1, MPC_Muon1_clct_bend_high : 1,
+        MPCDelay : 4, MPCAccept : 2, CFEBsEnabled : 5, flag35 : 1;
+    // 36
+    unsigned gem_enabled_fibers_ : 4, gem_zero_suppression_ : 1, fifo_tbins_gem_ : 5, fifo_pretrig_gem_ : 5, flag36 : 1;
+    unsigned r_wr_buf_adr : 11, r_wr_buf_ready : 1, wr_buf_ready : 1, buf_q_full : 1, buf_q_empty : 1, flag37 : 1;
+    unsigned r_buf_fence_dist : 11, buf_q_ovf_err : 1, buf_q_udf_err : 1, buf_q_adr_err : 1, buf_stalled : 1,
+        flag38 : 1;
+    unsigned buf_fence_cnt : 12, reverse_hs_csc : 1, reverse_hs_me1a : 1, reverse_hs_me1b : 1, flag39 : 1;
+    // 40
+    unsigned activeCFEBs_2 : 2, readCFEBs_2 : 2, cfeb_badbits_found_2 : 2, parity_err_cfeb_ram_2 : 2,
+        CFEBsEnabled_2 : 2, buf_fence_cnt_is_peak : 1, gem_csc_bend_enable : 1, trig_source_vec : 2, tmb_trig_pulse : 1,
+        flag40 : 1;
+    unsigned run3_trig_df : 1, gem_enable : 1, hmt_match_win : 4, tmb_alct_only_ro : 1, tmb_clct_only_ro : 1,
+        tmb_match_ro : 1, tmb_trig_keep : 1, tmb_non_trig_keep : 1, cathode_hmt : 2, anode_hmt : 2, flag41 : 1;
+    unsigned e0bline : 16;
+  } bits;
+};
+
+#endif

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
@@ -9,6 +9,7 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_CCLUT.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_GEM.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_Run2.h"
+#include "EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_GEM_Run3b.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -32,6 +33,7 @@ CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision)
       bool isTMB_Run2_fw = false;
       bool isTMB_hybrid_fw = false;  /// Copper TMB hybrid fw Run2 CLCT + Run3 LCT/MPC + anode-only HMT (March 2022)
       bool isRun2_df = false;
+      bool isGEM_Run3b_fw = false;                          /// 2026 ME11 with GEMs OTMB Run3-v MPC-LCT format changes
       unsigned df_version = (firmwareRevision >> 9) & 0xF;  // 4-bits Data Format version
       unsigned major_ver = (firmwareRevision >> 5) & 0xF;   // 4-bits major version part
       // unsigned minor_ver = firmwareRevision & 0x1F;         // 5-bits minor version part
@@ -41,6 +43,8 @@ CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision)
           break;
         case 0x3:
           isGEM_fw = true;
+          if (major_ver == 2)
+            isGEM_Run3b_fw = true;
           break;
         case 0x2:
           isCCLUT_HMT_fw = true;
@@ -65,7 +69,11 @@ CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision)
         if (isRun2_df) {
           theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_Run2(firmwareRevision));
         } else {
-          theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM());
+          if (isGEM_Run3b_fw) {
+            theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM_Run3b());
+          } else {
+            theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM());
+          }
         }
       } else if (isCCLUT_HMT_fw) {
         if (isRun2_df) {
@@ -96,12 +104,20 @@ CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision)
       /* Revisions > 0x6000 - OTMB firmwares, < 0x42D5 - new TMB revisions in 2016 */
       if ((firmwareRevision >= 0x6000) || (firmwareRevision < 0x42D5)) {
         bool isGEMfirmware = false;
+        bool isGEM_Run3b_fw = false;
         /* There are OTMB2013 firmware versions exist, which reports firmwareRevision code = 0x0 */
         if ((firmwareRevision < 0x4000) && (firmwareRevision > 0x0)) { /* New (O)TMB firmware revision format */
-          if (((firmwareRevision >> 9) & 0x3) == 0x3)
+          if (((firmwareRevision >> 9) & 0x3) == 0x3) {
             isGEMfirmware = true;
+            if (((firmwareRevision >> 5) & 0xF) == 0x2)
+              isGEM_Run3b_fw = true;
+          }
           if (isGEMfirmware) {
-            theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM());
+            if (isGEM_Run3b_fw) {
+              theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM_Run3b());
+            } else {
+              theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM());
+            }
           } else {
             theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013());
           }
@@ -143,6 +159,7 @@ CSCTMBHeader::CSCTMBHeader(const unsigned short *buf) : theHeaderFormat() {
         bool isTMB_Run2_fw = false;
         bool isTMB_hybrid_fw = false;  /// Copper TMB hybrid fw Run2 CLCT + Run3 LCT/MPC + anode-only HMT (March 2022)
         bool isRun2_df = false;
+        bool isGEM_Run3b_fw = false;  /// 2026 ME11+GE11 Run3-b MPC-LCT format OTMB fw
         unsigned firmwareRevision = theHeaderFormat->firmwareRevision();
         /* There are OTMB2013 firmware versions exist, which reports firmwareRevision code = 0x0 */
         if ((firmwareRevision < 0x4000) && (firmwareRevision > 0x0)) { /* New (O)TMB firmware revision format */
@@ -156,6 +173,8 @@ CSCTMBHeader::CSCTMBHeader(const unsigned short *buf) : theHeaderFormat() {
               break;
             case 0x3:
               isGEM_fw = true;
+              if (major_ver == 2)
+                isGEM_Run3b_fw = true;
               break;
             case 0x2:
               isCCLUT_HMT_fw = true;
@@ -180,6 +199,8 @@ CSCTMBHeader::CSCTMBHeader(const unsigned short *buf) : theHeaderFormat() {
           if (isGEM_fw) {
             if (isRun2_df) {
               theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_Run2(buf));
+            } else if (isGEM_Run3b_fw) {
+              theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM_Run3b(buf));
             } else {
               theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM(buf));
             }
@@ -364,6 +385,8 @@ void CSCTMBHeader::selfTest(int firmwareVersion, int firmwareRevision) {
         bool isTMB_Run2_fw = false;
         bool isTMB_hybrid_fw = false;
         bool isRun2_df = false;
+        // bool isGEM_Run3b_fw = false;
+
         unsigned df_version = (firmwareRevision >> 9) & 0xF;  // 4-bits Data Format version
         unsigned major_ver = (firmwareRevision >> 5) & 0xF;   // 4-bits major version part
         // unsigned minor_ver = firmwareRevision & 0x1F;         // 5-bits minor version part
@@ -373,6 +396,7 @@ void CSCTMBHeader::selfTest(int firmwareVersion, int firmwareRevision) {
             break;
           case 0x3:
             isGEM_fw = true;
+            // if (major_ver == 2) isGEM_Run3b_fw = true;
             break;
           case 0x2:
             isCCLUT_HMT_fw = true;

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader2020_GEM_Run3b.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader2020_GEM_Run3b.cc
@@ -1,0 +1,420 @@
+#include "EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_GEM_Run3b.h"
+#include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+const std::vector<std::pair<unsigned, unsigned> >
+    run3_pattern_lookup_tbl = {{0, 0}, {0, 1}, {0, 2}, {0, 3}, {0, 4},  /// Valid LCT0, invalid LCT1 combination. Check LCT1 vpf
+                               {0, 0}, {0, 1}, {0, 2}, {0, 3}, {0, 4}, {1, 0}, {1, 1}, {1, 2}, {1, 3},
+                               {1, 4}, {2, 0}, {2, 1}, {2, 2}, {2, 3}, {2, 4}, {3, 0}, {3, 1}, {3, 2},
+                               {3, 3}, {3, 4}, {4, 0}, {4, 1}, {4, 2}, {4, 3}, {4, 4}};  /// pattern IDs 30,31 are reserved
+
+const unsigned run2_pattern_lookup_tbl[2][16] = {{10, 10, 10, 8, 8, 8, 6, 6, 6, 4, 4, 4, 2, 2, 2, 2},
+                                                 {10, 10, 10, 9, 9, 9, 7, 7, 7, 5, 5, 5, 3, 3, 3, 3}};
+
+CSCTMBHeader2020_GEM_Run3b::CSCTMBHeader2020_GEM_Run3b() {
+  bzero(data(), sizeInWords() * 2);
+  bits.nHeaderFrames = 42;
+  bits.e0bline = 0x6E0B;
+  bits.b0cline = 0xDB0C;
+  bits.firmRevCode = 0x601;
+  bits.nTBins = 12;
+  bits.nCFEBs = 7;
+  /// Set default GEM-OTMB readout configuration
+  /// 12 time bins, all 4 GEM fibers enabled
+  bits.fifo_tbins_gem_ = 12;
+  bits.gem_enabled_fibers_ = 0xf;
+}
+
+CSCTMBHeader2020_GEM_Run3b::CSCTMBHeader2020_GEM_Run3b(const unsigned short* buf) {
+  memcpy(data(), buf, sizeInWords() * 2);
+}
+
+void CSCTMBHeader2020_GEM_Run3b::setEventInformation(const CSCDMBHeader& dmbHeader) {
+  bits.cscID = dmbHeader.dmbID();
+  bits.l1aNumber = dmbHeader.l1a();
+  bits.bxnCount = dmbHeader.bxn();
+}
+
+///returns CLCT digis
+std::vector<CSCCLCTDigi> CSCTMBHeader2020_GEM_Run3b::CLCTDigis(uint32_t idlayer) {
+  std::vector<CSCCLCTDigi> result;
+  unsigned halfstrip = bits.clct0_key_low + (bits.clct0_key_high << 7);
+  unsigned strip = halfstrip % 32;
+  // CLCT0 1/4 strip bit
+  bool quartstrip = (bits.clct0_xky >> 1) & 0x1;
+  // CLCT1 1/8 strip bit
+  bool eighthstrip = bits.clct0_xky & 0x1;
+  unsigned cfeb = halfstrip / 32;
+
+  /// CLCT0 LR bend and slope are from dedicated header fields
+  unsigned run3_pattern = bits.clct0_shape & 0x7;  // 3-bit Run3 CLCT PatternID
+  unsigned bend = bits.clct0_LR_bend;
+  unsigned slope = bits.clct0_slope;
+  unsigned run2_pattern = run2_pattern_lookup_tbl[bend][slope];
+
+  CSCCLCTDigi digi0(bits.clct0_valid,
+                    bits.clct0_quality,
+                    run2_pattern,
+                    1,
+                    bend,
+                    strip,
+                    cfeb,
+                    bits.clct_bxn,
+                    1,
+                    bits.bxnPreTrigger,
+                    bits.clct0_comparator_code,
+                    CSCCLCTDigi::Version::Run3,
+                    quartstrip,
+                    eighthstrip,
+                    run3_pattern,
+                    slope);
+
+  halfstrip = bits.clct1_key_low + (bits.clct1_key_high << 7);
+  strip = halfstrip % 32;
+  // CLCT0 1/4 strip bit
+  quartstrip = (bits.clct1_xky >> 1) & 0x1;
+  // CLCT1 1/8 strip bit
+  eighthstrip = bits.clct1_xky & 0x1;
+  cfeb = halfstrip / 32;
+
+  // CLCT LR bend and slope are from dedicated header fields
+  run3_pattern = bits.clct1_shape & 0x7;  // 3-bit Run3 CLCT PatternID
+  bend = bits.clct1_LR_bend;
+  slope = bits.clct1_slope;
+  run2_pattern = run2_pattern_lookup_tbl[bend][slope];
+
+  CSCCLCTDigi digi1(bits.clct1_valid,
+                    bits.clct1_quality,
+                    run2_pattern,
+                    1,
+                    bend,
+                    strip,
+                    cfeb,
+                    bits.clct_bxn,
+                    2,
+                    bits.bxnPreTrigger,
+                    bits.clct1_comparator_code,
+                    CSCCLCTDigi::Version::Run3,
+                    quartstrip,
+                    eighthstrip,
+                    run3_pattern,
+                    slope);
+
+  result.push_back(digi0);
+  result.push_back(digi1);
+  return result;
+}
+
+///returns CorrelatedLCT digis
+std::vector<CSCCorrelatedLCTDigi> CSCTMBHeader2020_GEM_Run3b::CorrelatedLCTDigis(uint32_t idlayer) const {
+  std::vector<CSCCorrelatedLCTDigi> result;
+  /// for the zeroth MPC word:
+  unsigned strip = bits.MPC_Muon0_clct_key_halfstrip;  //this goes from 0-223
+  unsigned slope = (bits.MPC_Muon0_clct_bend_low & 0x7) | (bits.MPC_Muon0_clct_bend_high << 3);
+  unsigned hmt =
+      bits.MPC_Muon_HMT_bit0 | ((bits.MPC_Muon_HMT_high & 0x3) << 1);  // HighMultiplicityTrigger for (Run3-b 3-bits)
+  // unsigned clct_pattern_id = bits.MPC_Muon_clct_pattern_low | (bits.MPC_Muon_clct_pattern_bit5 << 4); // Run3-b CLCT pattern is gone
+
+  unsigned run2_pattern = run2_pattern_lookup_tbl[bits.MPC_Muon0_clct_LR][slope];
+  unsigned run3_pattern = 0;                                                   // Run3-b CLCT pattern is gone
+  unsigned run3b_slope = (slope << 2) | bits.MPC_Muon0_clct_bend_run3b_extra;  // Run3b 6-bits slope
+  // unsigned run3b_slope = slope;
+
+  CSCCorrelatedLCTDigi digi(1,
+                            bits.MPC_Muon0_lct_vpf,
+                            bits.MPC_Muon0_lct_quality,
+                            bits.MPC_Muon0_alct_key_wire,
+                            strip,
+                            run2_pattern,
+                            bits.MPC_Muon0_clct_LR,
+                            bits.MPC_Muon_alct_bxn,
+                            0,
+                            bits.MPC_Muon0_clct_bx0,
+                            0,
+                            0,
+                            CSCCorrelatedLCTDigi::Version::Run3HR,
+                            bits.MPC_Muon0_clct_QuarterStrip,
+                            bits.MPC_Muon0_clct_EighthStrip,
+                            run3_pattern,
+                            run3b_slope);
+  digi.setHMT(hmt);
+  digi.setGemLayerUsedForSlopeComputation(bits.MPC_Muon0_GEM_layer);  // Run3-b ME11 with GE11 GEM layer information
+  // digi.setRun3bSlopeExtraBits(bits.MPC_Muon0_clct_bend_run3b_extra); // Run3-b extra bits for more precise slope/bend
+  result.push_back(digi);
+  /// for the first MPC word:
+  strip = bits.MPC_Muon1_clct_key_halfstrip;  //this goes from 0-223
+  slope = (bits.MPC_Muon1_clct_bend_low & 0x7) | (bits.MPC_Muon1_clct_bend_high << 3);
+  run2_pattern = run2_pattern_lookup_tbl[bits.MPC_Muon1_clct_LR][slope];
+  run3_pattern = 0;                                                   // Run3-b CLCT pattern is gone
+  run3b_slope = (slope << 2) | bits.MPC_Muon1_clct_bend_run3b_extra;  // Run3b 6-bits slope
+  // run3b_slope = slope;
+
+  digi = CSCCorrelatedLCTDigi(2,
+                              bits.MPC_Muon1_lct_vpf,
+                              bits.MPC_Muon1_lct_quality,
+                              bits.MPC_Muon1_alct_key_wire,
+                              strip,
+                              run2_pattern,
+                              bits.MPC_Muon1_clct_LR,
+                              bits.MPC_Muon_alct_bxn,
+                              0,
+                              bits.MPC_Muon1_clct_bx0,
+                              0,
+                              0,
+                              CSCCorrelatedLCTDigi::Version::Run3HR,
+                              bits.MPC_Muon1_clct_QuarterStrip,
+                              bits.MPC_Muon1_clct_EighthStrip,
+                              run3_pattern,
+                              run3b_slope);
+  digi.setHMT(hmt);
+  digi.setGemLayerUsedForSlopeComputation(bits.MPC_Muon1_GEM_layer);  // Run3-b ME11 with GE11 GEM layer information
+  // digi.setRun3bSlopeExtraBits(bits.MPC_Muon1_clct_bend_run3b_extra); // Run3-b extra bits for more precise slope/bend
+  result.push_back(digi);
+  return result;
+}
+
+CSCShowerDigi CSCTMBHeader2020_GEM_Run3b::showerDigi(uint32_t idlayer) const {
+  unsigned hmt_bits = bits.MPC_Muon_HMT_bit0 | (bits.MPC_Muon_HMT_high << 1);  // HighMultiplicityTrigger bits
+  uint16_t cscid = bits.cscID;  // ??? What is 4-bits CSC Id in CSshowerDigi
+  //L1A_TMB_WINDOW is not included in below formula
+  //correct version:  CSCConstants::LCT_CENTRAL_BX - bits.pop_l1a_match_win + L1A_TMB_WINDOW/2;
+  // same for anode HMT and cathode HMT. offline analysis would take care of this
+  uint16_t bx = CSCConstants::LCT_CENTRAL_BX - bits.pop_l1a_match_win;
+  //LCTshower with showerType = 3.  comparatorNHits from hmt_nhits() and wireNHits is not available
+  CSCShowerDigi result(hmt_bits & 0x3,
+                       (hmt_bits >> 2) & 0x3,
+                       cscid,
+                       bx,
+                       CSCShowerDigi::ShowerType::kLCTShower,
+                       0,
+                       hmt_nhits());  // 2-bits intime, 2-bits out of time
+  return result;
+}
+
+CSCShowerDigi CSCTMBHeader2020_GEM_Run3b::anodeShowerDigi(uint32_t idlayer) const {
+  uint16_t cscid = bits.cscID;
+  uint16_t bx = CSCConstants::LCT_CENTRAL_BX - bits.pop_l1a_match_win;
+  //ALCT shower with showerType = 1. wireNHits is not available from unpack data
+  CSCShowerDigi result(
+      bits.anode_hmt & 0x3, 0, cscid, bx, CSCShowerDigi::ShowerType::kALCTShower, 0, 0);  // 2-bits intime, no out of time
+  return result;
+}
+
+CSCShowerDigi CSCTMBHeader2020_GEM_Run3b::cathodeShowerDigi(uint32_t idlayer) const {
+  uint16_t cscid = bits.cscID;
+  uint16_t bx = CSCConstants::LCT_CENTRAL_BX - bits.pop_l1a_match_win - bits.hmt_match_win + 3;
+  //CLCT shower with showerType = 2. comparatorNHits from hmt_nhits()
+  CSCShowerDigi result(bits.cathode_hmt & 0x3,
+                       0,
+                       cscid,
+                       bx,
+                       CSCShowerDigi::ShowerType::kCLCTShower,
+                       0,
+                       hmt_nhits());  // 2-bits intime, no out of time
+  return result;
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addALCT0(const CSCALCTDigi& digi) {
+  throw cms::Exception("In CSC TMBHeaderFormat 2007, ALCTs belong in  ALCT header");
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addALCT1(const CSCALCTDigi& digi) {
+  throw cms::Exception("In CSC TMBHeaderFormat 2007, ALCTs belong in  ALCT header");
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addCLCT0(const CSCCLCTDigi& digi) {
+  unsigned halfStrip = digi.getKeyStrip();
+  unsigned pattern = digi.getRun3Pattern();
+  bits.clct0_valid = digi.isValid();
+  bits.clct0_quality = digi.getQuality();
+  bits.clct0_shape = pattern;
+  // first 7 bits of halfstrip
+  bits.clct0_key_low = halfStrip & (0x7F);
+  // most-significant (8th) bit
+  bits.clct0_key_high = (halfStrip >> 7) & (0x1);
+  bits.clct_bxn = digi.getBX();
+  bits.bxnPreTrigger = digi.getFullBX();
+  bits.clct0_comparator_code = digi.getCompCode();
+  bits.clct0_xky = (digi.getEighthStripBit() & 0x1) + ((digi.getQuartStripBit() & 0x1) << 1);
+  bits.clct0_LR_bend = digi.getBend();
+  bits.clct0_slope = digi.getSlope();
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addCLCT1(const CSCCLCTDigi& digi) {
+  unsigned halfStrip = digi.getKeyStrip();
+  unsigned pattern = digi.getRun3Pattern();
+  bits.clct1_valid = digi.isValid();
+  bits.clct1_quality = digi.getQuality();
+  bits.clct1_shape = pattern;
+  // first 7 bits of halfstrip
+  bits.clct1_key_low = halfStrip & (0x7F);
+  // most-significant (8th) bit
+  bits.clct1_key_high = (halfStrip >> 7) & (0x1);
+  // There is just one BX field common for CLCT0 and CLCT1 (since both
+  // are latched at the same BX); set it in addCLCT0().
+  bits.bxnPreTrigger = digi.getFullBX();
+  bits.clct1_comparator_code = digi.getCompCode();
+  bits.clct1_xky = (digi.getEighthStripBit() & 0x1) + ((digi.getQuartStripBit() & 0x1) << 1);
+  bits.clct1_LR_bend = digi.getBend();
+  bits.clct1_slope = digi.getSlope();
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) {
+  bits.MPC_Muon0_lct_vpf = digi.isValid();
+  bits.MPC_Muon0_alct_key_wire = digi.getKeyWG();
+  bits.MPC_Muon0_clct_key_halfstrip = digi.getStrip(2) & 0xFF;
+  bits.MPC_Muon0_clct_QuarterStrip = digi.getQuartStripBit() & 0x1;
+  bits.MPC_Muon0_clct_EighthStrip = digi.getEighthStripBit() & 0x1;
+  bits.MPC_Muon0_lct_quality = digi.getQuality() & 0x7;
+
+  // Run3-b 6-bits slope/bend
+  bits.MPC_Muon0_clct_bend_low = (digi.getSlopeEx() >> 2) & 0x7;
+  bits.MPC_Muon0_clct_bend_high = (digi.getSlopeEx() >> 5) & 0x1;
+  bits.MPC_Muon0_clct_bend_run3b_extra = digi.getSlopeEx() & 0x3;
+  bits.MPC_Muon0_clct_LR = digi.getBend() & 0x1;
+  bits.MPC_Muon_HMT_bit0 = digi.getHMT() & 0x1;
+  bits.MPC_Muon_HMT_high = (digi.getHMT() >> 1) & 0x3;                   // Run3-b MPC-LCT HMT is 3-bits
+  bits.MPC_Muon0_GEM_layer = digi.getGemLayerUsedForSlopeComputation();  // Run3-b ME11 with GE11 GEM layer information
+  bits.MPC_Muon_alct_bxn = digi.getBX();
+  bits.MPC_Muon0_clct_bx0 = digi.getBX0();
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) {
+  bits.MPC_Muon1_lct_vpf = digi.isValid();
+  bits.MPC_Muon1_alct_key_wire = digi.getKeyWG();
+  bits.MPC_Muon1_clct_key_halfstrip = digi.getStrip(2) & 0xFF;
+  bits.MPC_Muon1_clct_QuarterStrip = digi.getQuartStripBit() & 0x1;
+  bits.MPC_Muon1_clct_EighthStrip = digi.getEighthStripBit() & 0x1;
+  bits.MPC_Muon1_lct_quality = digi.getQuality() & 0x7;
+
+  // Run3-b 6-bits slope/bend
+  bits.MPC_Muon1_clct_bend_low = (digi.getSlopeEx() >> 2) & 0x7;
+  bits.MPC_Muon1_clct_bend_high = (digi.getSlopeEx() >> 5) & 0x1;
+  bits.MPC_Muon1_clct_bend_run3b_extra = digi.getSlopeEx() & 0x3;
+  bits.MPC_Muon1_clct_LR = digi.getBend() & 0x1;
+  bits.MPC_Muon_HMT_bit0 = digi.getHMT() & 0x1;
+  bits.MPC_Muon_HMT_high = (digi.getHMT() >> 1) & 0x3;                   // Run3-b MPC-LCT HMT is 3-bits
+  bits.MPC_Muon1_GEM_layer = digi.getGemLayerUsedForSlopeComputation();  // Run3-b ME11 with GE11 GEM layer information
+  bits.MPC_Muon_alct_bxn = digi.getBX();
+  bits.MPC_Muon1_clct_bx0 = digi.getBX0();
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addShower(const CSCShowerDigi& digi) {
+  uint16_t hmt_bits = (digi.bitsInTime() & 0x3) + ((digi.bitsOutOfTime() & 0x3) << 2);
+  //not valid LCT shower, then in-time bits must be 0
+  if (not digi.isValid())
+    hmt_bits = ((digi.bitsOutOfTime() & 0x3) << 2);
+  bits.MPC_Muon_HMT_bit0 = hmt_bits & 0x1;
+  bits.MPC_Muon_HMT_high = (hmt_bits >> 1) & 0x3;
+  //to keep pop_l1a_match_win
+  if (digi.isValid())
+    bits.pop_l1a_match_win = CSCConstants::LCT_CENTRAL_BX - digi.getBX();
+  else
+    bits.pop_l1a_match_win = 3;  //default value
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addAnodeShower(const CSCShowerDigi& digi) {
+  uint16_t hmt_bits = digi.bitsInTime() & 0x3;
+  if (not digi.isValid())
+    hmt_bits = 0;
+  bits.anode_hmt = hmt_bits;
+  if (not(bits.MPC_Muon_HMT_bit0 or bits.MPC_Muon_HMT_high) and digi.isValid())
+    bits.pop_l1a_match_win = CSCConstants::LCT_CENTRAL_BX - digi.getBX();
+  else if (not(digi.isValid()))
+    bits.pop_l1a_match_win = 3;  //default value
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addCathodeShower(const CSCShowerDigi& digi) {
+  uint16_t hmt_bits = digi.bitsInTime() & 0x3;
+  if (not digi.isValid())
+    hmt_bits = 0;
+  bits.cathode_hmt = hmt_bits;
+  bits.hmt_nhits_bit0 = digi.getComparatorNHits() & 0x1;
+  bits.hmt_nhits_bit1 = (digi.getComparatorNHits() >> 1) & 0x1;
+  bits.hmt_nhits_bits_high = (digi.getComparatorNHits() >> 2) & 0x1F;
+  if (bits.MPC_Muon_HMT_bit0 or bits.MPC_Muon_HMT_high or bits.anode_hmt) {
+    //pop_l1a_match_win is assigned
+    bits.hmt_match_win = CSCConstants::LCT_CENTRAL_BX - bits.pop_l1a_match_win + 3 - digi.getBX();
+  } else if (digi.isValid()) {
+    bits.pop_l1a_match_win = 3;  //default value
+    bits.hmt_match_win = CSCConstants::LCT_CENTRAL_BX - digi.getBX();
+  } else {
+    bits.pop_l1a_match_win = 3;  //default value
+    bits.hmt_match_win = 0;      //no HMT case
+  }
+}
+
+void CSCTMBHeader2020_GEM_Run3b::print(std::ostream& os) const {
+  os << "...............(O)TMB2020 ME11 GEM/CCLUT/HMT Header.................."
+     << "\n";
+  os << std::hex << "BOC LINE " << bits.b0cline << " EOB " << bits.e0bline << "\n";
+  os << std::hex << "FW revision: 0x" << bits.firmRevCode << "\n";
+  os << std::dec << "fifoMode = " << bits.fifoMode << ", nTBins = " << bits.nTBins << "\n";
+  os << "boardID = " << bits.boardID << ", cscID = " << bits.cscID << "\n";
+  os << "l1aNumber = " << bits.l1aNumber << ", bxnCount = " << bits.bxnCount << "\n";
+  os << "trigSourceVect = " << bits.trigSourceVect << ", run3_trig_df = " << bits.run3_trig_df
+     << ", gem_enable = " << bits.gem_enable << ", gem_csc_bend_enable = " << bits.gem_csc_bend_enable
+     << ", activeCFEBs = 0x" << std::hex << (bits.activeCFEBs | (bits.activeCFEBs_2 << 5)) << ", readCFEBs = 0x"
+     << std::hex << (bits.readCFEBs | (bits.readCFEBs_2 << 5)) << std::dec << "\n";
+  os << "bxnPreTrigger = " << bits.bxnPreTrigger << "\n";
+  os << "ALCT location in CLCT window " << bits.matchWin << " L1A location in TMB window " << bits.pop_l1a_match_win
+     << " ALCT in cathde HMT window " << bits.hmt_match_win << "\n";
+  os << "tmbMatch = " << bits.tmbMatch << " alctOnly = " << bits.alctOnly << " clctOnly = " << bits.clctOnly << "\n";
+
+  os << "readoutCounter: " << std::dec << bits.readoutCounter << ", buf_q_ovf: " << bits.stackOvf
+     << ", sync_err: " << bits.syncError << ", has_buf: " << bits.hasBuf << ", buf_stalled: " << bits.bufFull << "\n";
+  os << "r_wr_buf_adr: 0x" << std::hex << bits.r_wr_buf_adr << ", r_wr_buf_ready: " << bits.r_wr_buf_ready
+     << ", wr_buf_ready: " << bits.wr_buf_ready << ", buf_q_full: " << bits.buf_q_full
+     << ", buf_q_empty: " << bits.buf_q_empty << ",\nr_buf_fence_dist: 0x" << bits.r_buf_fence_dist
+     << ", buf_q_ovf_err: " << bits.buf_q_ovf_err << ", buf_q_udf_err: " << bits.buf_q_udf_err
+     << ", buf_q_adr_err: " << bits.buf_q_adr_err << ", buf_stalled: " << bits.buf_stalled << ",\nbuf_fence_cnt: 0x"
+     << bits.buf_fence_cnt << ", reverse_hs_csc: " << bits.reverse_hs_csc
+     << ", reverse_hs_me1a: " << bits.reverse_hs_me1a << ", reverse_hs_me1b: " << bits.reverse_hs_me1b << std::dec
+     << "\n";
+  os << "CLCT Words:\n"
+     << " bits.clct0_valid = " << bits.clct0_valid << " bits.clct0_shape = " << bits.clct0_shape
+     << " bits.clct0_quality = " << bits.clct0_quality
+     << " halfstrip = " << (bits.clct0_key_low + (bits.clct0_key_high << 7)) << "\n";
+  os << " bits.clct0_xky = " << bits.clct0_xky << " bits.clct0_comparator_code = " << bits.clct0_comparator_code
+     << " bits.clct0_LR_bend = " << bits.clct0_LR_bend << " bits.clct0_slope = " << bits.clct0_slope << "\n";
+
+  os << " bits.clct1_valid = " << bits.clct1_valid << " bits.clct1_shape = " << bits.clct1_shape
+     << " bits.clct1_quality = " << bits.clct1_quality
+     << " halfstrip = " << (bits.clct1_key_low + (bits.clct1_key_high << 7)) << "\n";
+  os << " bits.clct1_xky = " << bits.clct1_xky << " bits.clct1_comparator_code = " << bits.clct1_comparator_code
+     << " bits.clct1_LR_bend = " << bits.clct1_LR_bend << " bits.clct1_slope = " << bits.clct1_slope << "\n";
+
+  os << "MPC Words:\n"
+     << " LCT0 valid = " << bits.MPC_Muon0_lct_vpf << " key WG = " << bits.MPC_Muon0_alct_key_wire
+     << " key halfstrip = " << bits.MPC_Muon0_clct_key_halfstrip
+     << " 1/4strip flag = " << bits.MPC_Muon0_clct_QuarterStrip
+     << " 1/8strip flag = " << bits.MPC_Muon0_clct_EighthStrip << "\n"
+     << " quality = " << bits.MPC_Muon0_lct_quality << " 6bits slope/bend = "
+     << ((bits.MPC_Muon0_clct_bend_run3b_extra & 0x3) | ((bits.MPC_Muon0_clct_bend_low & 0x7) << 2) |
+         (bits.MPC_Muon0_clct_bend_high << 5))
+     << " (extra bend bits = " << bits.MPC_Muon0_clct_bend_run3b_extra << ")"
+     << " L/R bend = " << bits.MPC_Muon0_clct_LR << " LCT0_GEM layer = " << bits.MPC_Muon0_GEM_layer << "\n";
+
+  os << " LCT1 valid = " << bits.MPC_Muon1_lct_vpf << " key WG = " << bits.MPC_Muon1_alct_key_wire
+     << " key halfstrip = " << bits.MPC_Muon1_clct_key_halfstrip
+     << " 1/4strip flag = " << bits.MPC_Muon1_clct_QuarterStrip
+     << " 1/8strip flag = " << bits.MPC_Muon1_clct_EighthStrip << "\n"
+     << " quality = " << bits.MPC_Muon1_lct_quality << " 6bits slope/bend = "
+     << ((bits.MPC_Muon1_clct_bend_run3b_extra & 0x3) | ((bits.MPC_Muon1_clct_bend_low & 0x7) << 2) |
+         (bits.MPC_Muon1_clct_bend_high << 5))
+     << " (extra bend bits = " << bits.MPC_Muon1_clct_bend_run3b_extra << ")"
+     << " L/R bend = " << bits.MPC_Muon1_clct_LR << " LCT1_GEM layer = " << bits.MPC_Muon1_GEM_layer << "\n";
+
+  os << " HMT = " << (bits.MPC_Muon_HMT_bit0 | (bits.MPC_Muon_HMT_high << 1)) << ", alctHMT = " << bits.anode_hmt
+     << ", clctHMT = " << bits.cathode_hmt << " cathode nhits " << hmt_nhits() << "\n";
+
+  // os << "..................CLCT....................." << "\n";
+  os << "GEM Data:\n"
+     << " gem_enabled_fibers = 0x" << std::hex << gem_enabled_fibers() << std::dec
+     << " gem_fifo_tbins = " << gem_fifo_tbins() << " gem_fifo_pretrig = " << gem_fifo_pretrig()
+     << " gem_zero_suppress = " << gem_zero_suppress() << " gem_csc_bend_enable = " << bits.gem_csc_bend_enable
+     << " gem_sync_dataword = 0x" << std::hex << gem_sync_dataword() << " gem_timing_dataword = 0x" << std::hex
+     << gem_timing_dataword() << std::dec << "\n";
+  os << " gem num_copad: " << bits.num_copad << ", gem_delay: " << bits.gem_delay
+     << ", gem_clct_win: " << bits.gem_clct_win << ", alct_gem_win: " << bits.alct_gem_win << "\n";
+}


### PR DESCRIPTION
CMSSW_17_X - Unpacking support for CSC Run3b OTMB LCT ME11 GEM data format changes

#### PR description:

The CSC unpacking support for CSC Run3b OTMB LCT ME11 GEM data format changes
PR relies on PR #50633 (Support for a 6-bit slope in the CSC OTMB emulator)
Based on  currently implemented  by CSC ME11 OTMB firmware developers data format changes 
https://indico.cern.ch/event/1670542/contributions/7023502/attachments/3252692/5805202/OTMB_firmware_2026-03-18-1.pdf
PR adds the handling of currently implemented logic in ME11 OTMB firmware (fw is planned for further testing deployment before the end of the Run3)
Supporting expert-level CSC DQM plots are added as well.

#### PR validation:
Standard CMSSW validation checks.

Also was initially validated with two special global cosmic runs data taken on March  6, 2026 https://cmsonline.cern.ch/cms-elog/1325340 (6 CSC ME11 + 3 z+ GEM chambers in total)
Expected data format changes in the output were confirmed with added expert-level CSC DQM plots (sample ones ME11 chambers plots are below) 

Correlated LCT CLCT 6-bits higher resolution slopes
<img width="1177" height="309" alt="run3b_6bits_slope_hr" src="https://github.com/user-attachments/assets/76e83586-3d38-4576-88fa-892575b18ffe" />

Single chamber CSC Correlated LCT and GEM layers matching info
(Please note that firmware developer found and fixed fw bug, after those test runs were taken)
<img width="1123" height="740" alt="run3b_gem_layers" src="https://github.com/user-attachments/assets/e74b8416-bebd-4bcd-a6dc-c8653abdbdec" />

Summary plot for CSC Correlated LCT and GEM layers matching info
<img width="1499" height="852" alt="run3b_gem_layers_summary" src="https://github.com/user-attachments/assets/551eb33c-71b6-4359-91eb-5d271f423576" />

#### PR backport

Could you please advise what backports would be needed for this PR and PR  #50633 for the deployment with the production system (if possible, by the end of April-May 2026) to support further studies by CSC-GEM trigger group?