### PR TITLE
Phase2 HLT nano workflows: miscelleaneous fixes for TICL-related modules.

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -67,7 +67,8 @@ The offsets currently in use are:
 * 0.756 HLT phase-2 timing menu trimmed tracking
 * 0.757: HLT phase-2 timing menu mkFitFit variant
 * 0.758 HLT phase-2 timing menu ticl_barrel variant
-* 0.759: HLT phase-2 timing menu, with NANO:@Phase2HLT
+* 0.759: HLT phase-2 menu, with NANO:@Phase2HLT
+* 0.7591: HLT phase-2 menu, with NANO:@Phase2HLTVal
 * 0.76: HLT phase-2 reduced menu, with DIGI step
 * 0.77: HLT phase-2 NGT Scouting menu
 * 0.771: HLT phase-2 NGT Scouting menu, Alpaka, TICL-v5, TICL-Barrel

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -70,12 +70,12 @@ numWFIB.extend([prefixDet+34.755])  # HLTTiming75e33, trackingLST
 numWFIB.extend([prefixDet+34.756])  # HLTTiming75e33, phase2_hlt_vertexTrimming
 numWFIB.extend([prefixDet+34.757])  # HLTTiming75e33, MkFitFit
 numWFIB.extend([prefixDet+34.758])  # HLTTiming75e33, ticl_barrel
-numWFIB.extend([prefixDet+34.759])  # HLTTiming75e33 + NANO
+numWFIB.extend([prefixDet+34.759])  # HLT75e33 + NANO
+numWFIB.extend([prefixDet+34.7591]) # HLT75e33 + NANO (including validation)
 numWFIB.extend([prefixDet+34.77])   # NGTScouting
 numWFIB.extend([prefixDet+34.771])  # NGTScouting + alpaka + TICL-v5 + TICL-Barrel
 numWFIB.extend([prefixDet+34.772])  # NGTScouting + NANO
 numWFIB.extend([prefixDet+34.773])  # NGTScouting + NANO (including validation)
-numWFIB.extend([prefixDet+34.774])  # HLTTiming75e33, + NANO (including validation)
 numWFIB.extend([prefixDet+34.775])  # NGTScouting + Phase2CAExtension&LSTT5 as GeneralTracks
 
 for numWF in numWFIB:

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -75,6 +75,7 @@ numWFIB.extend([prefixDet+34.77])   # NGTScouting
 numWFIB.extend([prefixDet+34.771])  # NGTScouting + alpaka + TICL-v5 + TICL-Barrel
 numWFIB.extend([prefixDet+34.772])  # NGTScouting + NANO
 numWFIB.extend([prefixDet+34.773])  # NGTScouting + NANO (including validation)
+numWFIB.extend([prefixDet+34.774])  # HLTTiming75e33, + NANO (including validation)
 numWFIB.extend([prefixDet+34.775])  # NGTScouting + Phase2CAExtension&LSTT5 as GeneralTracks
 
 for numWF in numWFIB:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2185,6 +2185,15 @@ upgradeWFs['HLTPhase2WithNano'].step2 = {
     '--eventcontent':'FEVTDEBUGHLT,NANOAODSIM'
 }
 
+upgradeWFs['HLTPhase2WithNanoValid'] = deepcopy(upgradeWFs['HLTPhase2WithNano'])
+upgradeWFs['HLTPhase2WithNanoValid'].suffix = '_HLTPhase2WithNanoValid'
+upgradeWFs['HLTPhase2WithNanoValid'].offset = 0.7591
+upgradeWFs['HLTPhase2WithNanoValid'].step2 = {
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33,VALIDATION:@hltValidation,NANO:@Phase2HLTVal',
+    '--datatier':'GEN-SIM-DIGI-RAW,NANOAODSIM',
+    '--eventcontent':'FEVTDEBUGHLT,NANOAODSIM'
+}
+
 upgradeWFs['NGTScoutingWithNano'] = deepcopy(upgradeWFs['HLTPhase2WithNano'])
 upgradeWFs['NGTScoutingWithNano'].suffix = '_NGTScoutingWithNano'
 upgradeWFs['NGTScoutingWithNano'].offset = 0.772
@@ -2204,16 +2213,6 @@ upgradeWFs['NGTScoutingWithNanoValid'].step2 = {
     '--procModifiers': 'ngtScouting',
     '--eventcontent':'FEVTDEBUGHLT,NANOAODSIM'
 }
-
-upgradeWFs['HLTPhase2WithNanoValid'] = deepcopy(upgradeWFs['HLTPhase2WithNano'])
-upgradeWFs['HLTPhase2WithNanoValid'].suffix = '_HLTPhase2WithNanoValid'
-upgradeWFs['HLTPhase2WithNanoValid'].offset = 0.774
-upgradeWFs['HLTPhase2WithNanoValid'].step2 = {
-    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33,NANO:@Phase2HLTVal',
-    '--datatier':'GEN-SIM-DIGI-RAW,NANOAODSIM',
-    '--eventcontent':'FEVTDEBUGHLT,NANOAODSIM'
-}
-
 
 class UpgradeWorkflow_HLTwDIGI75e33(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2205,6 +2205,16 @@ upgradeWFs['NGTScoutingWithNanoValid'].step2 = {
     '--eventcontent':'FEVTDEBUGHLT,NANOAODSIM'
 }
 
+upgradeWFs['HLTPhase2WithNanoValid'] = deepcopy(upgradeWFs['HLTPhase2WithNano'])
+upgradeWFs['HLTPhase2WithNanoValid'].suffix = '_HLTPhase2WithNanoValid'
+upgradeWFs['HLTPhase2WithNanoValid'].offset = 0.774
+upgradeWFs['HLTPhase2WithNanoValid'].step2 = {
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33,NANO:@Phase2HLTVal',
+    '--datatier':'GEN-SIM-DIGI-RAW,NANOAODSIM',
+    '--eventcontent':'FEVTDEBUGHLT,NANOAODSIM'
+}
+
+
 class UpgradeWorkflow_HLTwDIGI75e33(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'DigiTrigger' in step:

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -175,6 +175,7 @@ if __name__ == '__main__':
                      prefixDet+34.771,   # HLT phase-2 NGT Scouting menu, Alpaka, TICL-v5, TICL-Barrel
                      prefixDet+34.772,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
                      prefixDet+34.773,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScoutingVal
+                     prefixDet+34.774,   # HLT phase-2 timing menu, with NANO:@Phase2HLTVal
                      prefixDet+34.775],  # HLT phase-2 NGT Scouting menu, Phase2CAExtension&LSTT5 as GeneralTracks
     }
 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -170,12 +170,12 @@ if __name__ == '__main__':
                      prefixDet+34.756,   # HLT phase-2 timing menu trimmed tracking
                      prefixDet+34.757,   # HLT phase-2 timing menu mkFit fitting variant
                      prefixDet+34.758,   # HLT phase-2 timing menu ticl_barrel variant
-                     prefixDet+34.759,   # HLT phase-2 timing menu, with NANO:@Phase2HLT
+                     prefixDet+34.759,   # HLT phase-2 menu, with NANO:@Phase2HLT
+                     prefixDet+34.7591,  # HLT phase-2 menu, with NANO:@Phase2HLTVal
                      prefixDet+34.77,    # HLT phase-2 NGT Scouting menu
                      prefixDet+34.771,   # HLT phase-2 NGT Scouting menu, Alpaka, TICL-v5, TICL-Barrel
                      prefixDet+34.772,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
                      prefixDet+34.773,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScoutingVal
-                     prefixDet+34.774,   # HLT phase-2 timing menu, with NANO:@Phase2HLTVal
                      prefixDet+34.775],  # HLT phase-2 NGT Scouting menu, Phase2CAExtension&LSTT5 as GeneralTracks
     }
 

--- a/HLTrigger/NGTScouting/plugins/SimTracksterTableProducer.cc
+++ b/HLTrigger/NGTScouting/plugins/SimTracksterTableProducer.cc
@@ -41,12 +41,10 @@ public:
 private:
   void produce(edm::StreamID id, edm::Event& event, const edm::EventSetup& setup) const override {
     const auto simTrackstersHandle = event.getHandle(simTrackstersToken_);
-    const auto& simTracksters = *simTrackstersHandle;
     const auto caloParticlesHandle = event.getHandle(caloParticlesToken_);
-    const auto& caloParticles = *caloParticlesHandle;
     const auto simClustersHandle = event.getHandle(simClustersToken_);
-    const auto& simClusters = *simClustersHandle;
-    const auto cpToSCMap = event.get(caloParticleToSimClustersMap_token_);
+    const auto cpToSCMapHandle = event.getHandle(caloParticleToSimClustersMap_token_);
+
     const size_t nSimTracksters = simTrackstersHandle.isValid() ? simTrackstersHandle->size() : 0;
 
     static constexpr float default_value = std::numeric_limits<float>::quiet_NaN();
@@ -64,29 +62,36 @@ private:
     std::vector<float> genPt(nSimTracksters, default_value);
     std::vector<float> mass(nSimTracksters, default_value);
 
-    //utility lambda for filling vectors
-    auto fillVectors = [&](const auto& obj, size_t iSim, float time) {
-      const auto& simTrack = obj.g4Tracks()[0];
-      const auto caloPt = obj.pt();
-      const auto simHitSumEnergy = obj.simEnergy();
-      const auto caloMass = obj.mass();
+    if ((simTrackstersHandle.isValid() && caloParticlesHandle.isValid() && simClustersHandle.isValid() &&
+         cpToSCMapHandle.isValid()) ||
+        !(this->skipNonExistingSrc_)) {
+      const auto& simTracksters = *simTrackstersHandle;
+      const auto& caloParticles = *caloParticlesHandle;
+      const auto& simClusters = *simClustersHandle;
+      const auto& cpToSCMap = *cpToSCMapHandle;
 
-      boundaryX[iSim] = simTrack.getPositionAtBoundary().x();
-      boundaryY[iSim] = simTrack.getPositionAtBoundary().y();
-      boundaryZ[iSim] = simTrack.getPositionAtBoundary().z();
-      boundaryEta[iSim] = simTrack.getPositionAtBoundary().eta();
-      boundaryPhi[iSim] = simTrack.getPositionAtBoundary().phi();
-      boundaryPx[iSim] = simTrack.getMomentumAtBoundary().x();
-      boundaryPy[iSim] = simTrack.getMomentumAtBoundary().y();
-      boundaryPz[iSim] = simTrack.getMomentumAtBoundary().z();
+      //utility lambda for filling vectors
+      auto fillVectors = [&](const auto& obj, size_t iSim, float time) {
+        const auto& simTrack = obj.g4Tracks()[0];
+        const auto caloPt = obj.pt();
+        const auto simHitSumEnergy = obj.simEnergy();
+        const auto caloMass = obj.mass();
 
-      simTime[iSim] = time;
-      simEnergy[iSim] = simHitSumEnergy;
-      genPt[iSim] = caloPt;
-      mass[iSim] = caloMass;
-    };
+        boundaryX[iSim] = simTrack.getPositionAtBoundary().x();
+        boundaryY[iSim] = simTrack.getPositionAtBoundary().y();
+        boundaryZ[iSim] = simTrack.getPositionAtBoundary().z();
+        boundaryEta[iSim] = simTrack.getPositionAtBoundary().eta();
+        boundaryPhi[iSim] = simTrack.getPositionAtBoundary().phi();
+        boundaryPx[iSim] = simTrack.getMomentumAtBoundary().x();
+        boundaryPy[iSim] = simTrack.getMomentumAtBoundary().y();
+        boundaryPz[iSim] = simTrack.getMomentumAtBoundary().z();
 
-    if (simTrackstersHandle.isValid() || !(this->skipNonExistingSrc_)) {
+        simTime[iSim] = time;
+        simEnergy[iSim] = simHitSumEnergy;
+        genPt[iSim] = caloPt;
+        mass[iSim] = caloMass;
+      };
+
       for (size_t iSim = 0; iSim < simTracksters.size(); ++iSim) {
         const auto& simT = simTracksters[iSim];
         float time = default_value;
@@ -108,6 +113,7 @@ private:
         }
       }
     }
+
     auto simTrackstersTable =
         std::make_unique<nanoaod::FlatTable>(nSimTracksters, tableName_, /*singleton*/ false, /*extension*/ true);
     simTrackstersTable->addColumn<float>(

--- a/HLTrigger/NGTScouting/plugins/TICLCandidateExtraTableProducer.cc
+++ b/HLTrigger/NGTScouting/plugins/TICLCandidateExtraTableProducer.cc
@@ -34,6 +34,36 @@ public:
   void produce(edm::Event& iEvent, const edm::EventSetup&) override {
     const auto& prod = iEvent.getHandle(this->src_);
 
+    // Check if handle is valid
+    if (!prod.isValid() && this->skipNonExistingSrc_) {
+      // Still book and write empty FlatTables
+      auto out = std::make_unique<nanoaod::FlatTable>(0, this->name_, /*singleton*/ false, /*extension*/ false);
+
+      for (const auto& coltable : this->coltables_) {
+        std::vector<uint16_t> emptyCounts;
+        std::vector<uint16_t> emptyOffsets;
+
+        if (coltable.useCount) {
+          out->addColumn<uint16_t>("n" + coltable.name, emptyCounts, "Count for " + coltable.name);
+        }
+        if (coltable.useOffset) {
+          out->addColumn<uint16_t>("o" + coltable.name, emptyOffsets, "Offset for " + coltable.name);
+        }
+
+        auto outcoltable = std::make_unique<nanoaod::FlatTable>(0, coltable.name, false, false);
+        std::vector<uint32_t> emptyTracksterKeys;
+        outcoltable->addColumn<uint32_t>("tracksterIndex", emptyTracksterKeys, "Index of associated Trackster");
+        outcoltable->setDoc(coltable.doc);
+        iEvent.put(std::move(outcoltable), coltable.name + "Table");
+      }
+
+      if (out->nColumns() > 0) {
+        out->setDoc(this->doc_);
+        iEvent.put(std::move(out));
+      }
+      return;
+    }
+
     const auto& candidates = *prod;
     const size_t table_size = candidates.size();
 

--- a/HLTrigger/NGTScouting/python/hltTICLCandidates_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltTICLCandidates_cfi.py
@@ -99,6 +99,7 @@ hltTiclCandidateExtraTable = cms.EDProducer(
     "TICLCandidateExtraTableProducer",
     src = cms.InputTag("hltTiclTrackstersMerge"),
     name = cms.string("Candidate2Tracksters"),
+    skipNonExistingSrc = cms.bool(True),
     doc = cms.string("TICLCandidates extra table with linked Tracksters"),
     collectionVariables = cms.PSet(
         tracksters = cms.PSet(
@@ -115,6 +116,7 @@ hltSimTiclCandidateExtraTable = cms.EDProducer(
     "TICLCandidateExtraTableProducer",
     src = cms.InputTag("hltTiclSimTracksters"),
     name = cms.string("SimCandidate2Tracksters"),
+    skipNonExistingSrc = cms.bool(True),
     doc = cms.string("TICLCandidates extra table with linked Tracksters"),
     collectionVariables = cms.PSet(
         tracksters = cms.PSet(

--- a/HLTrigger/NGTScouting/python/hltTracksters_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltTracksters_cfi.py
@@ -83,6 +83,7 @@ for iterLabel in hltTiclIterLabels:
             src=cms.InputTag(
                 f"hltAllTrackstersToSimTrackstersAssociationsByHits:{iterLabelSim}To{iterLabel}"
             ),
+            skipNonExistingSrc=cms.bool(True),
             name=cms.string(f"Sim{CP_SC_label}2{iterLabel}ByHits"),
             doc=cms.string(
                 f"Association between SimTracksters and {iterLabel}, by hits."),
@@ -116,6 +117,7 @@ for iterLabel in hltTiclIterLabels:
             src=cms.InputTag(
                 f"hltAllTrackstersToSimTrackstersAssociationsByHits:{iterLabel}To{iterLabelSim}"
             ),
+            skipNonExistingSrc=cms.bool(True),
             name=cms.string(f"Reco{iterLabel}2Sim{CP_SC_label}ByHits"),
             doc=cms.string(
                 f"Association between {iterLabel} and SimTracksters, by hits."),
@@ -245,6 +247,7 @@ hltSimCl2CPOneToOneFlatTable = cms.EDProducer(
     src=cms.InputTag(
         "SimClusterToCaloParticleAssociation:simClusterToCaloParticleMap"),
     name=cms.string("SimCl2CPWithFraction"),
+    skipNonExistingSrc=cms.bool(True),
     doc=cms.string("Association between SimClusters and CaloParticles."),
     variables=cms.PSet(
         index=Var("index", "int", doc="Index of linked CaloParticle."),

--- a/HLTrigger/NGTScouting/python/hltTracksters_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltTracksters_cfi.py
@@ -4,8 +4,7 @@ from PhysicsTools.NanoAOD.nano_cff import nanoMetadata
 from Validation.HGCalValidation.HLT_TICLIterLabels_cff import hltTiclIterLabels
 
 hltUpgradeNanoTask = cms.Task(nanoMetadata)
-hltSimTrackstersLabels = [
-    'hltTiclSimTracksters', 'hltTiclSimTrackstersfromCPs']
+hltSimTrackstersLabels = ['hltTiclSimTracksters', 'hltTiclSimTrackstersfromCPs']
 # Tracksters
 hltTrackstersTable = []
 hltSimTrackstersTable = []
@@ -21,39 +20,24 @@ for iterLabel in hltTiclIterLabels:
         doc=cms.string(iterLabel),
         singleton=cms.bool(False),  # the number of entries is variable
         variables=cms.PSet(
-            raw_energy=Var("raw_energy", "float",
-                           doc="Raw Energy of the trackster [GeV]"),
-            raw_em_energy=Var("raw_em_energy", "float",
-                              doc="EM raw Energy of the trackster [GeV]"),
-            raw_pt=Var(
-                "raw_pt", "float", doc="Trackster raw pT, computed from trackster raw energy and direction [GeV]"),
+            raw_energy=Var("raw_energy", "float", doc="Raw Energy of the trackster [GeV]"),
+            raw_em_energy=Var("raw_em_energy", "float", doc="EM raw Energy of the trackster [GeV]"),
+            raw_pt=Var("raw_pt", "float", doc="Trackster raw pT, computed from trackster raw energy and direction [GeV]"),
             regressed_energy=Var("regressed_energy", "float",
                                  doc="Regressed Energy of the trackster, for the SimTrackster it corresponds to the GEN-energy"),
-            barycenter_x=Var("barycenter.x", "float",
-                             doc="Trackster barycenter x [cm]"),
-            barycenter_y=Var("barycenter.y", "float",
-                             doc="Trackster barycenter y [cm]"),
-            barycenter_z=Var("barycenter.z", "float",
-                             doc="Trackster barycenter z [cm]"),
-            barycenter_eta=Var("barycenter.eta", "float",
-                               doc="Trackster barycenter pseudorapidity"),
-            barycenter_phi=Var("barycenter.phi", "float",
-                               doc="Trackster barycenter phi"),
-            EV1=Var("eigenvalues()[0]", "float",
-                    doc="Trackster PCA eigenvalues 0"),
-            EV2=Var("eigenvalues()[1]", "float",
-                    doc="Trackster PCA eigenvalues 1"),
-            EV3=Var("eigenvalues()[2]", "float",
-                    doc="Trackster PCA eigenvalues 2"),
-            eVector0_x=Var(
-                "eigenvectors()[0].x", "float", doc="Trackster PCA principal axis, x component"),
-            eVector0_y=Var(
-                "eigenvectors()[0].z", "float", doc="Trackster PCA principal axis, y component"),
-            eVector0_z=Var(
-                "eigenvectors()[0].y", "float", doc="Trackster PCA principal axis, z component"),
+            barycenter_x=Var("barycenter.x", "float", doc="Trackster barycenter x [cm]"),
+            barycenter_y=Var("barycenter.y", "float", doc="Trackster barycenter y [cm]"),
+            barycenter_z=Var("barycenter.z", "float", doc="Trackster barycenter z [cm]"),
+            barycenter_eta=Var("barycenter.eta", "float", doc="Trackster barycenter pseudorapidity"),
+            barycenter_phi=Var("barycenter.phi", "float", doc="Trackster barycenter phi"),
+            EV1=Var("eigenvalues()[0]", "float", doc="Trackster PCA eigenvalues 0"),
+            EV2=Var("eigenvalues()[1]", "float", doc="Trackster PCA eigenvalues 1"),
+            EV3=Var("eigenvalues()[2]", "float", doc="Trackster PCA eigenvalues 2"),
+            eVector0_x=Var("eigenvectors()[0].x", "float", doc="Trackster PCA principal axis, x component"),
+            eVector0_y=Var("eigenvectors()[0].z", "float", doc="Trackster PCA principal axis, y component"),
+            eVector0_z=Var("eigenvectors()[0].y", "float", doc="Trackster PCA principal axis, z component"),
             time=Var("time", "float", doc="Trackster HGCAL time"),
-            timeError=Var("timeError", "float",
-                          doc="Trackster HGCAL time error")
+            timeError=Var("timeError", "float", doc="Trackster HGCAL time error")
         ),
         collectionVariables=cms.PSet(
             tracksterVertices=cms.PSet(
@@ -62,12 +46,9 @@ for iterLabel in hltTiclIterLabels:
                 useCount=cms.bool(True),
                 useOffset=cms.bool(True),
                 variables=cms.PSet(
-                    vertices=Var("vertices", "uint",
-                                 doc="Layer clusters indices."),
-                    vertex_mult=Var(
-                        "vertex_multiplicity",
-                        "float",
-                        doc="Fraction of Layer cluster energy used by the Trackster.",
+                    vertices=Var("vertices", "uint", doc="Layer clusters indices."),
+                    vertex_mult=Var("vertex_multiplicity", "float",
+                                    doc="Fraction of Layer cluster energy used by the Trackster.",
                     ),
                 ),
             )
@@ -80,29 +61,19 @@ for iterLabel in hltTiclIterLabels:
         CP_SC_label = "CP" if "CP" in iterLabelSim else "SC"
         trackstersAssociationOneToManyS2RTable = cms.EDProducer(
             "TracksterTracksterEnergyScoreFlatTableProducer",
-            src=cms.InputTag(
-                f"hltAllTrackstersToSimTrackstersAssociationsByHits:{iterLabelSim}To{iterLabel}"
-            ),
+            src=cms.InputTag(f"hltAllTrackstersToSimTrackstersAssociationsByHits:{iterLabelSim}To{iterLabel}"),
             skipNonExistingSrc=cms.bool(True),
             name=cms.string(f"Sim{CP_SC_label}2{iterLabel}ByHits"),
-            doc=cms.string(
-                f"Association between SimTracksters and {iterLabel}, by hits."),
+            doc=cms.string(f"Association between SimTracksters and {iterLabel}, by hits."),
             collectionVariables=cms.PSet(
                 links=cms.PSet(
-                    name=cms.string(
-                        f"Sim{CP_SC_label}2{iterLabel}ByHitsLinks"),
+                    name=cms.string(f"Sim{CP_SC_label}2{iterLabel}ByHitsLinks"),
                     doc=cms.string("Association links."),
                     useCount=cms.bool(True),
                     useOffset=cms.bool(True),
-                    variables=cms.PSet(
-                        index=Var("index", "uint",
-                                  doc="Index of the associated Trackster."),
-                        sharedEnergy=Var(
-                            "sharedEnergy",
-                            "float",
-                            doc="Shared energy with associated Trackster.",
-                        ),
-                        score=Var("score", "float", doc="Sim2Reco Association score."),
+                    variables=cms.PSet(index=Var("index", "uint", doc="Index of the associated Trackster."),
+                                       sharedEnergy=Var("sharedEnergy", "float", doc="Shared energy with associated Trackster."),
+                                       score=Var("score", "float", doc="Sim2Reco Association score."),
                     ),
                 )
             ),
@@ -112,30 +83,20 @@ for iterLabel in hltTiclIterLabels:
         hltTrackstersAssociationOneToManyTableProducers.append(
             globals()[labelAssociation])
 
-        trackstersAssociationOneToManyR2STable = cms.EDProducer(
-            "TracksterTracksterEnergyScoreFlatTableProducer",
-            src=cms.InputTag(
-                f"hltAllTrackstersToSimTrackstersAssociationsByHits:{iterLabel}To{iterLabelSim}"
-            ),
+        trackstersAssociationOneToManyR2STable = cms.EDProducer("TracksterTracksterEnergyScoreFlatTableProducer",
+            src=cms.InputTag(f"hltAllTrackstersToSimTrackstersAssociationsByHits:{iterLabel}To{iterLabelSim}"),
             skipNonExistingSrc=cms.bool(True),
             name=cms.string(f"Reco{iterLabel}2Sim{CP_SC_label}ByHits"),
-            doc=cms.string(
-                f"Association between {iterLabel} and SimTracksters, by hits."),
+            doc=cms.string(f"Association between {iterLabel} and SimTracksters, by hits."),
             collectionVariables=cms.PSet(
                 links=cms.PSet(
                     name=cms.string(f"Reco{iterLabel}2Sim{CP_SC_label}ByHitsLinks"),
                     doc=cms.string("Association links."),
                     useCount=cms.bool(True),
                     useOffset=cms.bool(False),
-                    variables=cms.PSet(
-                        index=Var("index", "uint",
-                                  doc="Index of the associated SimTrackster."),
-                        sharedEnergy=Var(
-                            "sharedEnergy",
-                            "float",
-                            doc="Shared energy with associated SimTrackster.",
-                        ),
-                        score=Var("score", "float", doc="Reco2Sim Association score."),
+                    variables=cms.PSet(index=Var("index", "uint",doc="Index of the associated SimTrackster."),
+                                       sharedEnergy=Var("sharedEnergy", "float", doc="Shared energy with associated SimTrackster."),
+                                       score=Var("score", "float", doc="Reco2Sim Association score."),
                     ),
                 )
             ),
@@ -145,18 +106,15 @@ for iterLabel in hltTiclIterLabels:
         hltTrackstersAssociationOneToManyTableProducers.append(
             globals()[labelAssociation])
 
-hltTrackstersTableSequence = cms.Sequence(
-    sum(tracksterTableProducers, cms.Sequence()))
-hltTiclAssociationsTableSequence = cms.Sequence(
-    sum(hltTrackstersAssociationOneToManyTableProducers, cms.Sequence()))
+hltTrackstersTableSequence = cms.Sequence(sum(tracksterTableProducers, cms.Sequence()))
+hltTiclAssociationsTableSequence = cms.Sequence(sum(hltTrackstersAssociationOneToManyTableProducers, cms.Sequence()))
 simTracksterTableProducers = []
 for iterLabel in hltSimTrackstersLabels:
     label = iterLabel
     objName = ""
     if ("CP" in iterLabel):
         label, objName = iterLabel.split("hltTiclSimTracksters")
-    hltSimTracksterTable = cms.EDProducer(
-        "TracksterCollectionTableProducer",
+    hltSimTracksterTable = cms.EDProducer("TracksterCollectionTableProducer",
         skipNonExistingSrc=cms.bool(True),
         src=cms.InputTag(f"hltTiclSimTracksters", objName),
         cut=cms.string(""),
@@ -164,39 +122,23 @@ for iterLabel in hltSimTrackstersLabels:
         doc=cms.string(f"{iterLabel}"),
         singleton=cms.bool(False),  # the number of entries is variable
         variables=cms.PSet(
-            raw_energy=Var("raw_energy", "float",
-                           doc="Raw Energy of the trackster [GeV]"),
-            raw_em_energy=Var("raw_em_energy", "float",
-                              doc="EM raw Energy of the trackster [GeV]"),
-            raw_pt=Var(
-                "raw_pt", "float", doc="Trackster raw pT, computed from trackster raw energy and direction [GeV]"),
-            regressed_energy=Var("regressed_energy", "float",
-                                 doc="Regressed Energy of the trackster, for the SimTrackster it corresponds to the GEN-energy"),
-            barycenter_x=Var("barycenter.x", "float",
-                             doc="Trackster barycenter x [cm]"),
-            barycenter_y=Var("barycenter.y", "float",
-                             doc="Trackster barycenter y [cm]"),
-            barycenter_z=Var("barycenter.z", "float",
-                             doc="Trackster barycenter z [cm]"),
-            barycenter_eta=Var("barycenter.eta", "float",
-                               doc="Trackster barycenter pseudorapidity"),
-            barycenter_phi=Var("barycenter.phi", "float",
-                               doc="Trackster barycenter phi"),
-            EV1=Var("eigenvalues()[0]", "float",
-                    doc="Trackster PCA eigenvalues 0"),
-            EV2=Var("eigenvalues()[1]", "float",
-                    doc="Trackster PCA eigenvalues 1"),
-            EV3=Var("eigenvalues()[2]", "float",
-                    doc="Trackster PCA eigenvalues 2"),
-            eVector0_x=Var(
-                "eigenvectors()[0].x", "float", doc="Trackster PCA principal axis, x component"),
-            eVector0_y=Var(
-                "eigenvectors()[0].z", "float", doc="Trackster PCA principal axis, y component"),
-            eVector0_z=Var(
-                "eigenvectors()[0].y", "float", doc="Trackster PCA principal axis, z component"),
+            raw_energy=Var("raw_energy", "float", doc="Raw Energy of the trackster [GeV]"),
+            raw_em_energy=Var("raw_em_energy", "float", doc="EM raw Energy of the trackster [GeV]"),
+            raw_pt=Var("raw_pt", "float", doc="Trackster raw pT, computed from trackster raw energy and direction [GeV]"),
+            regressed_energy=Var("regressed_energy", "float", doc="Regressed Energy of the trackster, for the SimTrackster it corresponds to the GEN-energy"),
+            barycenter_x=Var("barycenter.x", "float", doc="Trackster barycenter x [cm]"),
+            barycenter_y=Var("barycenter.y", "float", doc="Trackster barycenter y [cm]"),
+            barycenter_z=Var("barycenter.z", "float", doc="Trackster barycenter z [cm]"),
+            barycenter_eta=Var("barycenter.eta", "float", doc="Trackster barycenter pseudorapidity"),
+            barycenter_phi=Var("barycenter.phi", "float", doc="Trackster barycenter phi"),
+            EV1=Var("eigenvalues()[0]", "float", doc="Trackster PCA eigenvalues 0"),
+            EV2=Var("eigenvalues()[1]", "float", doc="Trackster PCA eigenvalues 1"),
+            EV3=Var("eigenvalues()[2]", "float", doc="Trackster PCA eigenvalues 2"),
+            eVector0_x=Var("eigenvectors()[0].x", "float", doc="Trackster PCA principal axis, x component"),
+            eVector0_y=Var("eigenvectors()[0].z", "float", doc="Trackster PCA principal axis, y component"),
+            eVector0_z=Var("eigenvectors()[0].y", "float", doc="Trackster PCA principal axis, z component"),
             time=Var("time", "float", doc="Trackster HGCAL time"),
-            timeError=Var("timeError", "float",
-                          doc="Trackster HGCAL time error")
+            timeError=Var("timeError", "float", doc="Trackster HGCAL time error")
         ),
         collectionVariables=cms.PSet(
             tracksterVertices=cms.PSet(
@@ -205,13 +147,8 @@ for iterLabel in hltSimTrackstersLabels:
                 useCount=cms.bool(True),
                 useOffset=cms.bool(True),
                 variables=cms.PSet(
-                    vertices=Var("vertices", "uint",
-                                 doc="Layer clusters indices."),
-                    vertex_mult=Var(
-                        "vertex_multiplicity",
-                        "float",
-                        doc="Fraction of Layer cluster energy used by the Trackster.",
-                    ),
+                    vertices=Var("vertices", "uint", doc="Layer clusters indices."),
+                    vertex_mult=Var("vertex_multiplicity", "float", doc="Fraction of Layer cluster energy used by the Trackster."),
                 ),
             )
         ),
@@ -221,18 +158,12 @@ for iterLabel in hltSimTrackstersLabels:
     simTracksterTableProducers.append(globals()[label])
 
     hltTiclSimTrackstersExtraTable = cms.EDProducer("SimTracksterTableProducer",
-                                                    tableName=cms.string(
-                                                        f"{iterLabel}"),
-                                                    skipNonExistingSrc=cms.bool(
-                                                        True),
-                                                    simTracksters=cms.InputTag(
-                                                        "hltTiclSimTracksters", objName),
-                                                    caloParticles=cms.InputTag(
-                                                        "mix", "MergedCaloTruth"),
-                                                    simClusters=cms.InputTag(
-                                                        "mix", "MergedCaloTruth"),
-                                                    caloParticleToSimClustersMap=cms.InputTag(
-                                                        "hltTiclSimTracksters"),
+                                                    tableName=cms.string(f"{iterLabel}"),
+                                                    skipNonExistingSrc=cms.bool(True),
+                                                    simTracksters=cms.InputTag("hltTiclSimTracksters", objName),
+                                                    caloParticles=cms.InputTag("mix", "MergedCaloTruth"),
+                                                    simClusters=cms.InputTag("mix", "MergedCaloTruth"),
+                                                    caloParticleToSimClustersMap=cms.InputTag("hltTiclSimTracksters"),
                                                     precision=cms.int32(7),
                                                     )
     labelExtra = f"{iterLabel}TableExtraProducer"
@@ -244,15 +175,13 @@ hltSimTracksterSequence = cms.Sequence(
 # Tracksters Associators
 hltSimCl2CPOneToOneFlatTable = cms.EDProducer(
     "SimClusterCaloParticleFractionFlatTableProducer",
-    src=cms.InputTag(
-        "SimClusterToCaloParticleAssociation:simClusterToCaloParticleMap"),
+    src=cms.InputTag("SimClusterToCaloParticleAssociation:simClusterToCaloParticleMap"),
     name=cms.string("SimCl2CPWithFraction"),
     skipNonExistingSrc=cms.bool(True),
     doc=cms.string("Association between SimClusters and CaloParticles."),
     variables=cms.PSet(
         index=Var("index", "int", doc="Index of linked CaloParticle."),
-        fraction=Var("fraction", "float",
-                     doc="Fraction of linked CaloParticle."),
+        fraction=Var("fraction", "float",doc="Fraction of linked CaloParticle."),
     ),
 )
 hltTiclAssociationsTableSequence += hltSimCl2CPOneToOneFlatTable

--- a/PhysicsTools/NanoAOD/interface/AssociationMapFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/AssociationMapFlatTableProducer.h
@@ -32,7 +32,12 @@ public:
   std::unique_ptr<nanoaod::FlatTable> fillTable(const edm::Event &iEvent, const edm::Handle<T> &prod) const override {
     // First unroll the Container inside the associator map.
 
-    auto table_size = prod->getMap().size();
+    // Determine the table size safely
+    size_t table_size = 0;
+    if (prod.isValid()) {
+      table_size = prod->getMap().size();
+    }
+
     auto out = std::make_unique<nanoaod::FlatTable>(table_size, this->name_, false);
 
     std::vector<const TProd *> selobjs;
@@ -104,21 +109,27 @@ public:
 
   void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override {
     // same as SimpleFlatTableProducer
-    edm::Handle<T> prod;
-    iEvent.getByToken(SimpleFlatTableProducerBase<T, T>::src_, prod);
+    edm::Handle<T> prod = iEvent.getHandle(SimpleFlatTableProducerBase<T, T>::src_);
 
     // First unroll the Container inside the associator map.
 
-    auto table_size = prod->getMap().size();
+    // Determine the table size safely
+    size_t table_size = 0;
+    if (prod.isValid()) {
+      table_size = prod->getMap().size();
+    }
+
     auto out = std::make_unique<nanoaod::FlatTable>(table_size, this->name_, false);
 
     // Now proceed with the variable-sized linked objects.
     unsigned int coltablesize = 0;
     std::vector<unsigned int> counts;
     counts.reserve(table_size);
-    for (auto const &links : prod->getMap()) {
-      counts.push_back(links.size());
-      coltablesize += counts.back();
+    if (prod.isValid() || !(this->skipNonExistingSrc_)) {
+      for (auto const &links : prod->getMap()) {
+        counts.push_back(links.size());
+        coltablesize += counts.back();
+      }
     }
 
     std::vector<const TProd *> selobjs;


### PR DESCRIPTION
#### PR description:

It was noticed by @elenavernazza that:
- we are not running any workflow in the `ph2_hlt` matrix to exercise the `@Phase2HLTVal` flavour
- when running workflow in which the `VALIDATION` step is not explicited in the `cmsDriver` the setup crashes on missing input on various TICL-related modules.

The goal for this PR is:
- to include a new workflow family `.0.7591` that exercises the `@Phase2HLTVal` nano flavour
- to implement in all the modules that didn't have a protection again missing input, such protection, profiting of the existing `skipNonExistingSrc` mechanism in the base classes

I profit of this PR to include commit https://github.com/cms-ngt-hlt/cmssw/commit/bcc2972e391caf4542414d8e94c4a25fd8d86f28 to improve the readability of `HLTrigger/NGTScouting/python/hltTracksters_cfi.py`

#### PR validation:

I've run successfully the following workflow:

```
runTheMatrix.py -l 34434.7591 -t 4 -j 8
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will not be backported.

Cc: @waredjeb 