### PR TITLE
Do not call MPI_Finalize on error

### DIFF
--- a/HeterogeneousCore/MPIServices/src/MPIService.cc
+++ b/HeterogeneousCore/MPIServices/src/MPIService.cc
@@ -1,5 +1,6 @@
 // -*- C++ -*-
 #include <cstdlib>
+#include <exception>
 #include <string>
 
 #include <mpi.h>
@@ -85,8 +86,11 @@ MPIService::MPIService(edm::ParameterSet const& config) {
 }
 
 MPIService::~MPIService() {
-  // terminate the MPI execution environment
-  MPI_Finalize();
+  // Finalize MPI execution environment if the program finished correctly
+  // Otherwise let it proceed naturally (this way original error will be printed)
+  if (std::uncaught_exceptions() == 0) {
+    MPI_Finalize();
+  }
 }
 
 void MPIService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {


### PR DESCRIPTION
#### PR description:

This PR prevents MPI_Filalize to be called if an exception was thrown previously. This avoids hanging behavior when MPI_Service destructor is called due to the previous error. If the program finishes normally, MPI_Filalize is still called to ensure correctness of the exit.

#### PR validation:

Checked that on error in MPIController the program crashes and the message is printed.
