### PR TITLE
[16.0.X] `DQM/Integration`: Make HLT PB and NGT client tag configurable via command line options

### DIFF
--- a/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
@@ -24,9 +24,9 @@ else:
 #### DQM Environment
 #----------------------------
 process.load("DQM.Integration.config.environment_cfi")
-process.dqmEnv.subSystemFolder = 'HLTpb'
+process.dqmEnv.subSystemFolder = 'HLTpb' if unitTest else options.clientTag
 process.dqmEnv.eventInfoFolder = 'EventInfo'
-process.dqmSaver.tag = 'HLTpb'
+process.dqmSaver.tag = 'HLTpb' if unitTest else options.clientTag
 #process.dqmSaver.path = './HLT'
 process.dqmSaver.runNumber = options.runNumber
 # process.dqmSaverPB.tag = 'HLTpb'

--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -34,8 +34,14 @@ else:
 
 process.load("DQM.Integration.config.environment_cfi")
 
-process.dqmEnv.subSystemFolder = 'NGT' if unitTest else options.clientTag
-process.dqmSaver.tag = 'NGT' if unitTest else options.clientTag
+tag = 'NGT'
+if not unitTest:
+    if hasattr(options, 'clientTag') and options.clientTag:
+        tag = options.clientTag
+
+process.dqmEnv.subSystemFolder = tag
+process.dqmSaver.tag = tag
+
 process.dqmSaver.runNumber = options.runNumber
 # process.dqmSaverPB.tag = 'NGT'
 # process.dqmSaverPB.runNumber = options.runNumber

--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -34,8 +34,8 @@ else:
 
 process.load("DQM.Integration.config.environment_cfi")
 
-process.dqmEnv.subSystemFolder = 'NGT'
-process.dqmSaver.tag = 'NGT'
+process.dqmEnv.subSystemFolder = 'NGT' if unitTest else options.clientTag
+process.dqmSaver.tag = 'NGT' if unitTest else options.clientTag
 process.dqmSaver.runNumber = options.runNumber
 # process.dqmSaverPB.tag = 'NGT'
 # process.dqmSaverPB.runNumber = options.runNumber

--- a/DQM/Integration/python/config/inputsource_cfi.py
+++ b/DQM/Integration/python/config/inputsource_cfi.py
@@ -77,7 +77,11 @@ options.register('outputBaseDir',
                  VarParsing.VarParsing.varType.string,
                  "Directory where the visualization output files will appear.")
 
-
+options.register('clientTag',
+                 '',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Name of the tag to be used in the DQMFileSaverOnline")
 
 options.parseArguments()
 

--- a/DQM/Integration/python/config/pbsource_cfi.py
+++ b/DQM/Integration/python/config/pbsource_cfi.py
@@ -70,6 +70,18 @@ options.register('outputBaseDir',
                  VarParsing.VarParsing.varType.string,
                  "Directory where the visualization output files will appear.")
 
+# Parameter to specify which stream label to take
+options.register('streamLabel',
+                 'streamDQMHistograms',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Stream label for input data.")
+
+options.register('clientTag',
+                 'HLTpb',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Name of the tag to be used in the DQMFileSaverOnline")
 
 options.parseArguments()
 
@@ -94,7 +106,7 @@ if options.scanOnce:
 source = cms.Source("DQMProtobufReader",
     runNumber = cms.untracked.uint32(options.runNumber),
     runInputDir = cms.untracked.string(options.runInputDir),
-    streamLabel = cms.untracked.string('streamDQMHistograms'),
+    streamLabel = cms.untracked.string(options.streamLabel),
     scanOnce = cms.untracked.bool(options.scanOnce),
     datafnPosition = cms.untracked.uint32(options.datafnPosition),
     delayMillis = cms.untracked.uint32(500),


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50643

#### PR description:

From the original PR description:

> This PR makes the HLTPB and NGT DQM clients lconfiguration more flexible by allowing the DQM subsystem folder, saver tag (and for the HLTPB client the protobuf stream label) to be configured via command line options instead of being hardcoded.
> 
> The following changes were made:
> 
> Added new `VarParsing` options:
> - `clientTag`: used to set `dqmEnv.subSystemFolder` and `dqmSaver.tag`
> - `streamLabel`: used to configure the input stream label for `DQMProtobufReader`
> 
> Updated:
> 
> - `hlt_dqm_clientPB-live_cfg.py` to use `options.clientTag` instead of the hardcoded `'HLTpb'` 
> - `pbsource_cfi.py` to use `options.streamLabel` instead of the hardcoded `'streamDQMHistograms'`
> - `ngt_dqm_sourceclient-live_cfg.py` to use the  `options.clientTag` instead of the hardcoded `'NGT'` 
> - `inputsource_cfi.py` to allow to configure `options.clientTag`
> 
> These changes allow running the same configuration for different clients and streams without modifying the Python configuration files.

#### PR validation:

See https://github.com/cms-sw/cmssw/pull/50643#issuecomment-4269818945

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of  https://github.com/cms-sw/cmssw/pull/50643 to CMSSW_16_0_X for 2026 data-taking operations.