### PR TITLE
Update PbPb EW skim

### DIFF
--- a/Configuration/Skimming/python/PbPb_EWSkim_cff.py
+++ b/Configuration/Skimming/python/PbPb_EWSkim_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 # primary vertex filter
 primaryVertexFilterForPbPbEWSkim = cms.EDFilter("VertexSelector",
-    src = cms.InputTag("offlinePrimaryVertices"),
+    src = cms.InputTag("offlineSlimmedPrimaryVertices"),
     cut = cms.string("!isFake && abs(z) <= 25 && position.Rho <= 2"), 
     filter = cms.bool(True),
 )
@@ -27,15 +27,31 @@ oneLeptonForPbPbEWSkim = cms.EDFilter("PATLeptonCountFilter",
     maxNumber = cms.uint32(1000000),
 )
 
+# photon filter
+goodPhotonsForPbPbEWSkim = cms.EDFilter("PATPhotonSelector",
+    src = cms.InputTag("slimmedPhotons"),
+    cut = cms.string("et >= 25.0")
+)
+onePhotonForPbPbEWSkim = cms.EDFilter("PATCandViewCountFilter",
+    src = cms.InputTag("goodPhotonsForPbPbEWSkim"),
+    minNumber = cms.uint32(1),
+    maxNumber = cms.uint32(1000000),
+)
+
 # skim sequence
-EWSkimSequence = cms.Sequence(
+EWSkimLeptonSequence = cms.Sequence(
     primaryVertexFilterForPbPbEWSkim *
     goodMuonsForPbPbEWSkim *
     goodElectronsForPbPbEWSkim *
     oneLeptonForPbPbEWSkim
 )
+EWSkimPhotonSequence = cms.Sequence(
+    primaryVertexFilterForPbPbEWSkim *
+    goodPhotonsForPbPbEWSkim *
+    onePhotonForPbPbEWSkim
+)
 
 # skim content
 from Configuration.EventContent.EventContent_cff import MINIAODEventContent
 EWSkimContent = MINIAODEventContent.clone()
-EWSkimContent.outputCommands.append("drop *_*_*_SKIM")
+EWSkimContent.outputCommands += ["drop *_*_*_SKIM", "drop *_dedxEstimator_*_*"]

--- a/Configuration/Skimming/python/Skims_PbPb_cff.py
+++ b/Configuration/Skimming/python/Skims_PbPb_cff.py
@@ -92,11 +92,12 @@ SKIMStreamUPCMonopole = cms.FilteredStream(
 #####################
 
 from Configuration.Skimming.PbPb_EWSkim_cff import *
-EWSkimPathPbPb = cms.Path( EWSkimSequence )
+EWSkimLeptonPathPbPb = cms.Path( EWSkimLeptonSequence )
+EWSkimPhotonPathPbPb = cms.Path( EWSkimPhotonSequence )
 SKIMStreamPbPbEW = cms.FilteredStream(
     responsible = 'HI PAG',
     name = 'PbPbEW',
-    paths = (EWSkimPathPbPb),
+    paths = (EWSkimLeptonPathPbPb,EWSkimPhotonPathPbPb),
     content = EWSkimContent.outputCommands,
     selectEvents = cms.untracked.PSet(),
     dataTier = cms.untracked.string('MINIAOD')


### PR DESCRIPTION
#### PR description:

This PR updates the PbPb EW skim of the HIPhysicsRawPrime datasets for the 2026 PbPb data taking. It extends the skim to also include photons of ET > 25 GeV, removes the dEdx collection and fixes the PV collection.

Checks performed on 2025 PbPb MiniAOD data show just an increase of 18% in size compared to the previous EW skim while the total size of the skim remains 63 times smaller than the HIPhysicsRawPrime MiniAOD size.

@mandrenguyen @flodamas

#### PR validation:

Tested with relvals 141.202,142.202,143.202,144.202

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 16_1_X for 2026 PbPb data taking