### PR TITLE
[EGM][HLT] Update `hltEgammaHLTExtra` `L1Seeded` collection for Phase2

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/python/hltEgammaHLTExtra_cfi.py
+++ b/RecoEgamma/EgammaHLTProducers/python/hltEgammaHLTExtra_cfi.py
@@ -47,3 +47,15 @@ hltEgammaHLTExtra = cms.EDProducer("EgammaHLTExtraProducer",
                                    
 )
 
+# Phase2 modification
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+
+def _phase2Fix(module):
+    for pset in module.egCands:
+        if pset.label.value() == '':
+            pset.pixelSeeds = cms.InputTag("hltEgammaElectronPixelSeedsL1Seeded")
+            pset.ecalCands  = cms.InputTag("hltEgammaCandidatesL1Seeded")
+            pset.gsfTracks  = cms.InputTag("hltEgammaGsfTracksL1Seeded")
+            pset.label      = cms.string('L1Seeded')
+
+phase2_common.toModify(hltEgammaHLTExtra, _phase2Fix)


### PR DESCRIPTION
#### PR description:

The PR updates the EGM module `hltEgammaHLTExtra` , which is the core for all the  EGM trigger developments:

The module is run privately only, and produces the following 2 output collections for Phase2: 

`vector<trigger::EgammaObject>  "hltEgammaHLTExtra"   "L1Seeded"  "HLTX" `
`vector<trigger::EgammaObject>  "hltEgammaHLTExtra"   "Unseeded"  "HLTX"`

out of which the former is currently turning out empty. The PR fixes this by updating the input collections in `CMSSW` via `phase2_common` modifier, so that the change does not have to be made manually every time by the developers (given that Phase 2 is going to be the default soon).

No physics change is expected from the PR.

#### PR validation:

- Module not run in any central workflow, but output/change tested locally before and after the PR using [a basic FWLite script](https://ssaumya.web.cern.ch/ssaumya/EGM/check_collection_FWLite.py):

Reference:
```
===== Event 0 =====
L1Seeded size: 0
Unseeded size: 4
Unseeded objects:
  pt=2195.70, eta=-0.015, phi=2.967
  pt=23.20, eta=0.010, phi=2.907
  pt=22.79, eta=1.436, phi=-0.155
  pt=21.37, eta=1.299, phi=-0.045
```
Target
```
===== Event 0 =====
L1Seeded size: 4
Unseeded size: 4
Unseeded objects:
  pt=2195.70, eta=-0.015, phi=2.967
  pt=23.20, eta=0.010, phi=2.907
  pt=22.79, eta=1.436, phi=-0.155
  pt=21.37, eta=1.299, phi=-0.045
L1Seeded objects:
  pt=2198.15, eta=-0.015, phi=2.967
  pt=23.27, eta=0.010, phi=2.907
  pt=22.95, eta=1.436, phi=-0.155
  pt=20.31, eta=1.295, phi=-0.061
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport; no backport needed 
