### PR TITLE
[online DQM] robust clientTag handling for NGT and improved ScoutingMuon 2D histogram formatting

### DIFF
--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -34,8 +34,14 @@ else:
 
 process.load("DQM.Integration.config.environment_cfi")
 
-process.dqmEnv.subSystemFolder = 'NGT' if unitTest else options.clientTag
-process.dqmSaver.tag = 'NGT' if unitTest else options.clientTag
+tag = 'NGT'
+if not unitTest:
+    if hasattr(options, 'clientTag') and options.clientTag:
+        tag = options.clientTag
+
+process.dqmEnv.subSystemFolder = tag
+process.dqmSaver.tag = tag
+
 process.dqmSaver.runNumber = options.runNumber
 # process.dqmSaverPB.tag = 'NGT'
 # process.dqmSaverPB.runNumber = options.runNumber

--- a/HLTriggerOffline/Scouting/plugins/ScoutingMuonPropertiesAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingMuonPropertiesAnalyzer.cc
@@ -732,12 +732,14 @@ void ScoutingMuonPropertiesAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
 
   // Helper lambda for 2D occupancy histograms
   auto bookOccupancy = [&](const std::string& name, const std::string& title) {
-    return ibooker.book2I(name, title, nEtaBins, etaMin, etaMax, nPhiBins, phiMin, phiMax);
+    auto* me = ibooker.book2I(name, title, nEtaBins, etaMin, etaMax, nPhiBins, phiMin, phiMax);
+    me->setOption("colz");
+    return me;
   };
 
-  h2_MuonVtx_eta_phi = bookOccupancy("eta_vs_phi_MuonVtx", "Track occupancy (MuonVtx);#eta;#phi");
+  h2_MuonVtx_eta_phi = bookOccupancy("eta_vs_phi_MuonVtx", "Track occupancy (MuonVtx);#eta;#phi [rad]");
 
-  h2_MuonNoVtx_eta_phi = bookOccupancy("eta_vs_phi_MuonNoVtx", "Track occupancy (MuonNoVtx);#eta;#phi");
+  h2_MuonNoVtx_eta_phi = bookOccupancy("eta_vs_phi_MuonNoVtx", "Track occupancy (MuonNoVtx);#eta;#phi [rad]");
 
   // Helper lambda for 2D profile histograms
   auto bookProfile2D = [&](const std::string& name, const std::string& title, double ymin, double ymax) {
@@ -747,30 +749,42 @@ void ScoutingMuonPropertiesAnalyzer::bookHistograms(DQMStore::IBooker& ibooker,
   };
 
   // Muons with vertex
-  p2_MuonVtx_nValidPixelHits_eta_phi = bookProfile2D(
-      "MuonVtx_nValidPixelHits_vs_eta_phi_prof", "nValidPixelHits vs #eta-#phi;<nValidPixelHits>;#eta;#phi", 0., 10.);
+  p2_MuonVtx_nValidPixelHits_eta_phi =
+      bookProfile2D("MuonVtx_nValidPixelHits_vs_eta_phi_prof",
+                    "nValidPixelHits vs #eta-#phi;#eta;#phi [rad];#LTnValidPixelHits#GT",
+                    0.,
+                    10.);
 
   p2_MuonVtx_nTrackerLayersWithMeasurement_eta_phi =
       bookProfile2D("MuonVtx_nTrackerLayersWithMeasurement_vs_eta_phi_prof",
-                    "nTrackerLayersWithMeasurement vs #eta-#phi;<nTrackerLayersWithMeasurement>;#eta;#phi",
+                    "nTrackerLayersWithMeasurement vs #eta-#phi;#eta;#phi [rad];#LTnTrackerLayersWithMeasurement#GT",
                     0.,
                     20.);
 
-  p2_MuonVtx_nValidStripHits_eta_phi = bookProfile2D(
-      "MuonVtx_nValidStripHits_vs_eta_phi_prof", "nValidStripHits vs #eta-#phi;<nValidStripHits>;#eta;#phi", 0., 30.);
+  p2_MuonVtx_nValidStripHits_eta_phi =
+      bookProfile2D("MuonVtx_nValidStripHits_vs_eta_phi_prof",
+                    "nValidStripHits vs #eta-#phi;#eta;#phi [rad];#LTnValidStripHits#GT",
+                    0.,
+                    30.);
 
   // Muons without vertex
-  p2_MuonNoVtx_nValidPixelHits_eta_phi = bookProfile2D(
-      "MuonNoVtx_nValidPixelHits_vs_eta_phi_prof", "nValidPixelHits vs #eta-#phi;<nValidPixelHits>;#eta;#phi", 0., 10.);
+  p2_MuonNoVtx_nValidPixelHits_eta_phi =
+      bookProfile2D("MuonNoVtx_nValidPixelHits_vs_eta_phi_prof",
+                    "nValidPixelHits vs #eta-#phi;#eta;#phi [rad];#LTnValidPixelHits#GT",
+                    0.,
+                    10.);
 
   p2_MuonNoVtx_nTrackerLayersWithMeasurement_eta_phi =
       bookProfile2D("MuonNoVtx_nTrackerLayersWithMeasurement_vs_eta_phi_prof",
-                    "nTrackerLayersWithMeasurement vs #eta-#phi;<nTrackerLayersWithMeasurement>;#eta;#phi",
+                    "nTrackerLayersWithMeasurement vs #eta-#phi;#eta;#phi [rad];#LTnTrackerLayersWithMeasurement#GT",
                     0.,
                     20.);
 
-  p2_MuonNoVtx_nValidStripHits_eta_phi = bookProfile2D(
-      "MuonNoVtx_nValidStripHits_vs_eta_phi_prof", "nValidStripHits vs #eta-#phi;<nValidStripHits>;#eta;#phi", 0., 30.);
+  p2_MuonNoVtx_nValidStripHits_eta_phi =
+      bookProfile2D("MuonNoVtx_nValidStripHits_vs_eta_phi_prof",
+                    "nValidStripHits vs #eta-#phi;#eta;#phi [rad];#LTnValidStripHits#GT",
+                    0.,
+                    30.);
 
   triggersMapped_ = false;
 }

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -208,8 +208,8 @@ ScoutingTrackMonitor::ScoutingTrackMonitor(const edm::ParameterSet& iConfig)
 void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const&) {
   ibooker.setCurrentFolder(topFolderName_);
 
-  h_dxy = ibooker.book1D("dxy", "d_{xy};d_{xy} [#mum];Tracks", 100, -0.15 * cmToUm, 0.15 * cmToUm);
-  h_dz = ibooker.book1D("dz", "d_{z};d_{z} [#mum];Tracks", 100, -0.35 * cmToUm, 0.35 * cmToUm);
+  h_dxy = ibooker.book1DD("dxy", "d_{xy};d_{xy} [#mum];Tracks", 100, -0.15 * cmToUm, 0.15 * cmToUm);
+  h_dz = ibooker.book1DD("dz", "d_{z};d_{z} [#mum];Tracks", 100, -0.35 * cmToUm, 0.35 * cmToUm);
 
   h_vtx_idx = ibooker.book1DD("vertexIndex", "tracks Vertex Index;Vertex index;Tracks", 17, -1.5, 15.5);
 
@@ -474,19 +474,19 @@ void ScoutingTrackMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
 
   // 1D variables
 
-  IP_ = iBooker.book1D(fmt::format("d{}_pt{}", varname_, pTcut_),
-                       fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_),
-                       VarBin,
-                       VarMin,
-                       VarMax);
+  IP_ = iBooker.book1DD(fmt::format("d{}_pt{}", varname_, pTcut_),
+                        fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_),
+                        VarBin,
+                        VarMin,
+                        VarMax);
 
-  IPErr_ = iBooker.book1D(fmt::format("d{}Err_pt{}", varname_, pTcut_),
-                          fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_),
-                          100,
-                          0.,
-                          (varname_.find("xy") != std::string::npos) ? 2000. : 10000.);
+  IPErr_ = iBooker.book1DD(fmt::format("d{}Err_pt{}", varname_, pTcut_),
+                           fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_),
+                           100,
+                           0.,
+                           (varname_.find("xy") != std::string::npos) ? 2000. : 10000.);
 
-  IPPull_ = iBooker.book1D(
+  IPPull_ = iBooker.book1DD(
       fmt::format("d{}Pull_pt{}", varname_, pTcut_),
       fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}}/#sigma_{{d_{{{}}}}}", pTcut_, varname_, varname_),
       100,


### PR DESCRIPTION
#### PR description:

This PR builds on top of https://github.com/cms-sw/cmssw/pull/50715 and https://github.com/cms-sw/cmssw/pull/50643
- 30b3d4b6a8cd5a17bedaac75eb61ace86b587f26 fixes axes labels and `colz` options in the 2D heatmaps in `ScoutingMuonPropertiesAnalyzer`
- 365740085fa9c10b2aa9374921861cbef99f126a provides a default to the dqmFileSaver tag in the NGT client, given the default of `options.clientTag` is an empty string

#### PR validation:

```
scram b runtests_TestDQMOnlineClient-ngt_dqm_sourceclient
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will be backported to CMSSW_16_1_X and CMSSW_16_0_X.
