### PR TITLE
[15_1_X] Backport: Bug Fix Tau Embedding HLT information#50765

### DIFF
--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -10,6 +10,10 @@ unpackedPatTrigger = cms.EDProducer("PATTriggerObjectStandAloneUnpacker",
     triggerResults              = cms.InputTag('TriggerResults::HLT'),
     unpackFilterLabels = cms.bool(True)
 )
+# Modify for the tau embedding methods merging step
+# Switch trigger source from HLT to SIMembeddingHLT of patTrigger
+from Configuration.ProcessModifiers.tau_embedding_merging_cff import tau_embedding_merging
+tau_embedding_merging.toModify(unpackedPatTrigger, triggerResults=cms.InputTag("TriggerResults::SIMembeddingHLT"))
 
 def mksel( selection, doc=None, bit=None):
     ddoc=""

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -134,6 +134,11 @@ def miniAOD_customizeCommon(process):
     from PhysicsTools.PatAlgos.tools.trigTools import switchOnTriggerStandAlone
     switchOnTriggerStandAlone( process, outputModule = '' )
     process.patTrigger.packTriggerPathNames = cms.bool(True)
+
+    # Modify for the tau embedding methods merging step
+    # Switch trigger source from HLT to SIMembeddingHLT of patTrigger
+    from Configuration.ProcessModifiers.tau_embedding_merging_cff import tau_embedding_merging
+    tau_embedding_merging.toModify(process.patTrigger, processName = cms.string("SIMembeddingHLT"))
     #
     # apply type I + other PFMEt corrections to pat::MET object
     # and estimate systematic uncertainties on MET

--- a/TauAnalysis/MCEmbeddingTools/python/Merging_USER_cff.py
+++ b/TauAnalysis/MCEmbeddingTools/python/Merging_USER_cff.py
@@ -32,9 +32,12 @@ from Configuration.ProcessModifiers.tau_embedding_merging_cff import tau_embeddi
 # This is needed because we now have a hybrid event which contains both simulation and reconstructed data.
 PhysicsTools.PatAlgos.tools.coreTools.removeMCMatching = lambda process, names, postfix, outputModules : miniAOD_customizeMC(process)
 
+# change the trigger source to SIMembeddingHLT for the PAT related trigger producers and unpackers, which are alsoneeded for the nanoAOD production.
 from PhysicsTools.PatAlgos.slimming.unpackedPatTrigger_cfi import unpackedPatTrigger
+from PhysicsTools.PatAlgos.slimming.slimmedPatTrigger_cfi import slimmedPatTrigger
 
 unpackedPatTrigger.triggerResults = cms.InputTag("TriggerResults::SIMembeddingHLT")
+slimmedPatTrigger.triggerResults = cms.InputTag("TriggerResults::SIMembeddingHLT")
 
 # In the following replace producers that produce collections which are used as input for particle flow producers
 # by their corresponding merger producers.

--- a/TauAnalysis/MCEmbeddingTools/python/Simulation_GEN_cfi.py
+++ b/TauAnalysis/MCEmbeddingTools/python/Simulation_GEN_cfi.py
@@ -91,6 +91,7 @@ generator = cms.EDFilter(
             "Init:showChangedSettings = off",
             "Init:showChangedParticleData = off",
             "ProcessLevel:all = off",
+            "PartonLevel:FSR = off", # disable final state radiation
         ),
         parameterSets=cms.vstring(
             "pythia8CommonSettings", "pythia8CUEP8M1Settings", "processParameters"
@@ -111,16 +112,6 @@ tau_embedding_mu_to_mu.toModify(
             "Final_States": cms.vstring("MuMu"),
         }
     },
-    # disable final state radiation for mu->mu embedding
-    PythiaParameters={
-        "processParameters": cms.vstring(
-            "JetMatching:merge = off",
-            "Init:showChangedSettings = off",
-            "Init:showChangedParticleData = off",
-            "ProcessLevel:all = off",
-            "PartonLevel:FSR = off",
-        )
-    },
 )
 # only one simulation needed, as the muons don't decay like taus and no wights need to be calculated.
 tau_embedding_mu_to_mu.toModify(generator, nAttempts=cms.uint32(1))
@@ -135,16 +126,6 @@ tau_embedding_mu_to_e.toModify(
             ),
             "Final_States": cms.vstring("ElEl"),
         }
-    },
-    # disable final state radiation for mu->e embedding
-    PythiaParameters={
-        "processParameters": cms.vstring(
-            "JetMatching:merge = off",
-            "Init:showChangedSettings = off",
-            "Init:showChangedParticleData = off",
-            "ProcessLevel:all = off",
-            "PartonLevel:FSR = off",
-        )
     },
 )
 # only one simulation needed, as the electrons don't decay like taus and no wights need to be calculated.


### PR DESCRIPTION
#### PR description:

This PR is a backport of #50764. It is needed for the production of tau embedding events in Run3.

> This PR fixes a bug in the [tau embedding method](https://twiki.cern.ch/twiki/bin/viewauth/CMS/TauEmbeddingSamplesUL)([`TauAnalysis/MCEmbeddingTools`](https://github.com/cms-sw/cmssw/tree/master/TauAnalysis/MCEmbeddingTools)) which delivered the wrong HLT Trigger information to the PAT collections and NanoAOD.
>
> Normally the patTrigger producer takes the trigger information from collections produced in the `HLT` step/process. For the tau embedding method, where we run the HLT step again on the simulated particles in our event, we want the patTrigger producer to take the trigger information from this (`SIMembeddingHLT`) step instead.
>
> I also added a small change in the simulation step of the tau embedding method, to disable the generation of final state radiation (FSR).
The kinematic information for the particles, which are going to be simulated, is taken from reconstructed measured muons. As we are not considering FSR in the reconstruction of those muons at the moment, we don't want to produce more FSR, which would falsify the energy and momentum of the simulated tau leptons even more.

Other Backports of #50764:
14_0_X: #50768
14_1_X: #49410
14_2_X: #50770
15_0_X: #50765
15_1_X: #50771
16_0_X: #50769
16_1_X: #50772