### PR TITLE
[backport 15_1_X] Add Angantyr heavy-ion path to Pythia8 hadronizer with LS-safe init

### DIFF
--- a/Configuration/Generator/python/Pythia8Angantyr_pO_9p6TeV_MinimumBias_cfi.py
+++ b/Configuration/Generator/python/Pythia8Angantyr_pO_9p6TeV_MinimumBias_cfi.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    AngantyrInitialState = cms.PSet(),
+    comEnergy = cms.double(9600.),
+    PythiaParameters = cms.PSet(
+        processParameters = cms.vstring(
+            # Op collisions (oxygen in the positive Z direction in CMS)
+            'Beams:idA = 1000080160',
+            'Beams:idB = 2212',
+            'Beams:frameType = 2',
+            'Beams:eA = 3400',
+            'Beams:eB = 6800',
+            
+            # HI Angatyr setup (https://www.pythia.org/latest-manual/htmldoc/examples/main422.html)
+            'SoftQCD:inelastic = on',
+            'HeavyIon:SigFitErr = 0.02,0.02,0.1,0.05,0.05,0.0,0.1,0.0',
+            'HeavyIon:SigFitNGen = 20',
+            'HeavyIon:SigFitDefPar = 2.15,17.24,0.33',
+            
+            # Harmonic Oscillator Shell model (Oxygen geometry)
+            'Angantyr:NucleusModelA = 3',
+            
+            #Forward tune (https://arxiv.org/pdf/2309.08604)
+            'BeamRemnants:dampPopcorn=0',
+            'BeamRemnants:hardRemnantBaryon=on',
+            'BeamRemnants:aRemnantBaryon=0.36',
+            'BeamRemnants:bRemnantBaryon=1.69',
+            'BeamRemnants:primordialKTsoft=0.58',
+            'BeamRemnants:primordialKThard=1.8',
+            'BeamRemnants:halfScaleForKT=10',
+            'BeamRemnants:halfMassForKT=1',
+            'BeamRemnants:primordialKTremnant=0.58',
+        ),
+        parameterSets = cms.vstring('processParameters')
+    )
+)

--- a/Configuration/Generator/python/Pythia8Angantyr_pO_9p6TeV_MinimumBias_skipRefit_cfi.py
+++ b/Configuration/Generator/python/Pythia8Angantyr_pO_9p6TeV_MinimumBias_skipRefit_cfi.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    AngantyrInitialState = cms.PSet(
+        # Skip Pythia8::init() on LS re-entry (reuses the first-LS Angantyr
+        # SigFit result in memory). Default is False (refit every LS).
+        skipRefit = cms.untracked.bool(True),
+    ),
+    comEnergy = cms.double(9600.),
+    PythiaParameters = cms.PSet(
+        processParameters = cms.vstring(
+            # Op collisions (oxygen in the positive Z direction in CMS)
+            'Beams:idA = 1000080160',
+            'Beams:idB = 2212',
+            'Beams:frameType = 2',
+            'Beams:eA = 3400',
+            'Beams:eB = 6800',
+            
+            # HI Angatyr setup (https://www.pythia.org/latest-manual/htmldoc/examples/main422.html)
+            'SoftQCD:inelastic = on',
+            'HeavyIon:SigFitErr = 0.02,0.02,0.1,0.05,0.05,0.0,0.1,0.0',
+            'HeavyIon:SigFitNGen = 20',
+            'HeavyIon:SigFitDefPar = 2.15,17.24,0.33',
+            
+            # Harmonic Oscillator Shell model (Oxygen geometry)
+            'Angantyr:NucleusModelA = 3',
+            
+            #Forward tune (https://arxiv.org/pdf/2309.08604)
+            'BeamRemnants:dampPopcorn=0',
+            'BeamRemnants:hardRemnantBaryon=on',
+            'BeamRemnants:aRemnantBaryon=0.36',
+            'BeamRemnants:bRemnantBaryon=1.69',
+            'BeamRemnants:primordialKTsoft=0.58',
+            'BeamRemnants:primordialKThard=1.8',
+            'BeamRemnants:halfScaleForKT=10',
+            'BeamRemnants:halfMassForKT=1',
+            'BeamRemnants:primordialKTremnant=0.58',
+        ),
+        parameterSets = cms.vstring('processParameters')
+    )
+)

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -150,8 +150,8 @@ private:
   std::string LHEInputFileName;
   std::shared_ptr<LHAupLesHouches> lhaUP;
 
-  enum { PP, PPbar, ElectronPositron, HeavyIons };
-  int fInitialState;  // pp, ppbar, e-e+ or HI
+  enum { PP, PPbar, ElectronPositron, HeavyIons, Angantyr };
+  int fInitialState;  // pp, ppbar, e-e+, HI or Angantyr
 
   double fBeam1PZ;
   double fBeam2PZ;
@@ -159,6 +159,17 @@ private:
   //PDFPtr for the photonFlux
   //Following main70.cc example in PYTHIA8 v3.10
   edm::ParameterSet photonFluxParams;
+
+  //Angantyr heavy-ion parameters
+  edm::ParameterSet angantyrParams;
+
+  // If true, skip the expensive Pythia8::init() call on every LS after the
+  // first one for the Angantyr path. Saves the SigFit scan cost at the cost
+  // of not picking up per-LS setting changes. Only honored when
+  // fInitialState == Angantyr. Default off (refit every LS, matches legacy).
+  bool skipAngantyrRefit_ = false;
+  // Latched true after fMasterGen->init() succeeds; guards the skip above.
+  bool masterGenInitialized_ = false;
 
   //helper class to allow multiple user hooks simultaneously
   std::shared_ptr<UserHooksVector> fUserHooksVector;
@@ -264,10 +275,23 @@ Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params)
     } else {
       // probably need to throw on attempt to override ?
     }
+  } else if (params.exists("AngantyrInitialState")) {
+    if (fInitialState == PP) {
+      fInitialState = Angantyr;
+      angantyrParams = params.getParameter<edm::ParameterSet>("AngantyrInitialState");
+      skipAngantyrRefit_ = angantyrParams.getUntrackedParameter<bool>("skipRefit", false);
+      edm::LogInfo("GeneratorInterface|Pythia8Interface")
+          << "Pythia8 will be initialized for ANGANTYR HEAVY ION collisions. "
+          << "This is a user-request change from the DEFAULT PROTON-PROTON initial state."
+          << (skipAngantyrRefit_ ? " skipRefit=true: fMasterGen->init() will only run on the first LS." : "");
+    } else {
+      // probably need to throw on attempt to override ?
+    }
   } else if (params.exists("ElectronProtonInitialState") || params.exists("PositronProtonInitialState")) {
     // throw on unknown initial state !
     throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
-        << " UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron \n";
+        << " UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron, HeavyIons, "
+           "Angantyr \n";
   }
 
   // avoid filling weights twice (from v8.30x)
@@ -408,6 +432,14 @@ Pythia8Hadronizer::~Pythia8Hadronizer() {}
 bool Pythia8Hadronizer::initializeForInternalPartons() {
   bool status = false, status1 = false;
 
+  // If the user opted into Angantyr skipRefit, after the very first successful
+  // fMasterGen->init() we skip only that expensive call (which re-runs the
+  // Angantyr SigFit scan) on subsequent LS transitions. The rest of this
+  // method — including fDecayer setup, which Py8InterfaceBase::readSettings
+  // recreates every LS — still runs so residualDecay() and EvtGen remain
+  // correctly initialized.
+  const bool skipMasterInit = (fInitialState == Angantyr && skipAngantyrRefit_ && masterGenInitialized_);
+
   if (lheFile_.empty()) {
     if (fInitialState == PP)  // default
     {
@@ -421,10 +453,23 @@ bool Pythia8Hadronizer::initializeForInternalPartons() {
       fMasterGen->settings.mode("Beams:idB", -11);
     } else if (fInitialState == HeavyIons) {
       // let user to set up the beam particles
+    } else if (fInitialState == Angantyr) {
+      // Initialize Angantyr model for heavy-ion collisions
+      fMasterGen->settings.mode("HeavyIon:mode", 2);
+      // Set beam particles from process parameters if provided
+      if (!angantyrParams.empty()) {
+        if (angantyrParams.exists("beamA")) {
+          fMasterGen->settings.mode("Beams:idA", angantyrParams.getParameter<int>("beamA"));
+        }
+        if (angantyrParams.exists("beamB")) {
+          fMasterGen->settings.mode("Beams:idB", angantyrParams.getParameter<int>("beamB"));
+        }
+      }
     } else {
       // throw on unknown initial state !
       throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
-          << " UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron, HeavyIons \n";
+          << " UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron, HeavyIons, "
+             "Angantyr \n";
     }
     fMasterGen->settings.parm("Beams:eCM", comEnergy);
   } else {
@@ -568,8 +613,16 @@ bool Pythia8Hadronizer::initializeForInternalPartons() {
     }
   }
 
-  edm::LogInfo("Pythia8Interface") << "Initializing MasterGen";
-  status = fMasterGen->init();
+  if (skipMasterInit) {
+    edm::LogInfo("Pythia8Interface")
+        << "Skipping fMasterGen->init() (Angantyr, skipRefit=true); reusing previously fitted state.";
+    status = true;
+  } else {
+    edm::LogInfo("Pythia8Interface") << "Initializing MasterGen";
+    status = fMasterGen->init();
+    if (status)
+      masterGenInitialized_ = true;
+  }
 
   //clean up temp file
   if (!slhafile_.empty()) {

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8HepMC3Hadronizer.cc
@@ -150,8 +150,8 @@ private:
   std::string LHEInputFileName;
   std::shared_ptr<LHAupLesHouches> lhaUP;
 
-  enum { PP, PPbar, ElectronPositron };
-  int fInitialState;  // pp, ppbar, or e-e+
+  enum { PP, PPbar, ElectronPositron, Angantyr };
+  int fInitialState;  // pp, ppbar, e-e+ or Angantyr
 
   double fBeam1PZ;
   double fBeam2PZ;
@@ -159,6 +159,17 @@ private:
   //PDFPtr for the photonFlux
   //Following main70.cc example in PYTHIA8 v3.10
   edm::ParameterSet photonFluxParams;
+
+  //Angantyr heavy-ion parameters
+  edm::ParameterSet angantyrParams;
+
+  // If true, skip the expensive Pythia8::init() call on every LS after the
+  // first one for the Angantyr path. Saves the SigFit scan cost at the cost
+  // of not picking up per-LS setting changes. Only honored when
+  // fInitialState == Angantyr. Default off (refit every LS, matches legacy).
+  bool skipAngantyrRefit_ = false;
+  // Latched true after fMasterGen->init() succeeds; guards the skip above.
+  bool masterGenInitialized_ = false;
 
   //helper class to allow multiple user hooks simultaneously
   std::shared_ptr<UserHooksVector> fUserHooksVector;
@@ -255,10 +266,23 @@ Pythia8HepMC3Hadronizer::Pythia8HepMC3Hadronizer(const edm::ParameterSet &params
     } else {
       // probably need to throw on attempt to override ?
     }
+  } else if (params.exists("AngantyrInitialState")) {
+    if (fInitialState == PP) {
+      fInitialState = Angantyr;
+      angantyrParams = params.getParameter<edm::ParameterSet>("AngantyrInitialState");
+      skipAngantyrRefit_ = angantyrParams.getUntrackedParameter<bool>("skipRefit", false);
+      edm::LogInfo("GeneratorInterface|Pythia8Interface")
+          << "Pythia8 will be initialized for ANGANTYR HEAVY ION collisions. "
+          << "This is a user-request change from the DEFAULT PROTON-PROTON initial state."
+          << (skipAngantyrRefit_ ? " skipRefit=true: fMasterGen->init() will only run on the first LS." : "");
+    } else {
+      // probably need to throw on attempt to override ?
+    }
   } else if (params.exists("ElectronProtonInitialState") || params.exists("PositronProtonInitialState")) {
     // throw on unknown initial state !
     throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
-        << " UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron \n";
+        << " UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron, "
+           "Angantyr \n";
   }
 
   // avoid filling weights twice (from v8.30x)
@@ -397,6 +421,14 @@ Pythia8HepMC3Hadronizer::Pythia8HepMC3Hadronizer(const edm::ParameterSet &params
 bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
   bool status = false, status1 = false;
 
+  // If the user opted into Angantyr skipRefit, after the very first successful
+  // fMasterGen->init() we skip only that expensive call (which re-runs the
+  // Angantyr SigFit scan) on subsequent LS transitions. The rest of this
+  // method — including fDecayer setup, which Py8HMC3InterfaceBase recreates
+  // every LS — still runs so residualDecay() and EvtGen remain correctly
+  // initialized.
+  const bool skipMasterInit = (fInitialState == Angantyr && skipAngantyrRefit_ && masterGenInitialized_);
+
   if (lheFile_.empty()) {
     if (fInitialState == PP)  // default
     {
@@ -408,10 +440,23 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
     } else if (fInitialState == ElectronPositron) {
       fMasterGen->settings.mode("Beams:idA", 11);
       fMasterGen->settings.mode("Beams:idB", -11);
+    } else if (fInitialState == Angantyr) {
+      // Initialize Angantyr model for heavy-ion collisions
+      fMasterGen->settings.mode("HeavyIon:mode", 2);
+      // Set beam particles from process parameters if provided
+      if (!angantyrParams.empty()) {
+        if (angantyrParams.exists("beamA")) {
+          fMasterGen->settings.mode("Beams:idA", angantyrParams.getParameter<int>("beamA"));
+        }
+        if (angantyrParams.exists("beamB")) {
+          fMasterGen->settings.mode("Beams:idB", angantyrParams.getParameter<int>("beamB"));
+        }
+      }
     } else {
       // throw on unknown initial state !
       throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
-          << " UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron \n";
+          << " UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron, "
+             "Angantyr \n";
     }
     fMasterGen->settings.parm("Beams:eCM", comEnergy);
   } else {
@@ -555,8 +600,16 @@ bool Pythia8HepMC3Hadronizer::initializeForInternalPartons() {
     }
   }
 
-  edm::LogInfo("Pythia8Interface") << "Initializing MasterGen";
-  status = fMasterGen->init();
+  if (skipMasterInit) {
+    edm::LogInfo("Pythia8Interface")
+        << "Skipping fMasterGen->init() (Angantyr, skipRefit=true); reusing previously fitted state.";
+    status = true;
+  } else {
+    edm::LogInfo("Pythia8Interface") << "Initializing MasterGen";
+    status = fMasterGen->init();
+    if (status)
+      masterGenInitialized_ = true;
+  }
 
   //clean up temp file
   if (!slhafile_.empty()) {

--- a/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_HIN_pO_Angantyr.sh
+++ b/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_HIN_pO_Angantyr.sh
@@ -1,0 +1,81 @@
+#!/bin/bash -e
+# Smoke test for the Angantyr (HeavyIon:mode=2) code path in the Pythia8
+# hadronizers, running through Pythia8ConcurrentGeneratorFilter.
+#
+# Drives two example fragments from Configuration/Generator:
+#   - Pythia8Angantyr_pO_9p6TeV_MinimumBias_cfi.py
+#                       : AngantyrInitialState = cms.PSet()   (refit every LS)
+#   - Pythia8Angantyr_pO_9p6TeV_MinimumBias_skipRefit_cfi.py
+#                       : AngantyrInitialState = cms.PSet(
+#                             skipRefit = cms.untracked.bool(True) )
+#
+# Each fragment runs 200 events with numberEventsInLuminosityBlock=100 so the
+# job crosses an LS 1 -> LS 2 boundary, first single-threaded and then with
+# four concurrent streams.
+#
+# Expected (as of Pythia8 8.311 / 8.316):
+#   * skipRefit=true  : runs clean, 200 events, exit 0.
+#   * refit (default) : crashes at event 101 with
+#                       vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)
+#                       from inside Pythia8. This is a known upstream bug
+#                       exposed by successive Pythia::init() calls on an
+#                       Angantyr-configured master generator. The refit cases
+#                       are marked with `|| true` and only reported; they do
+#                       not fail the test.
+#
+# The test fails (non-zero exit) if either skipRefit run does not finish cleanly.
+
+declare -i FAILED=0
+
+run_skiprefit() {
+  local nthreads=$1
+  local tag="HIN_pO_Angantyr_skipRefit_${nthreads}th"
+  echo "================  ${tag}  ================"
+  cmsDriver.py Configuration/Generator/python/Pythia8Angantyr_pO_9p6TeV_MinimumBias_skipRefit_cfi.py \
+    --python_filename "${tag}_cfg.py" \
+    --eventcontent RAWSIM --datatier GEN \
+    --fileout "file:${tag}.root" \
+    --conditions auto:phase1_2025_realistic \
+    --beamspot Realistic25ns13TeVEarly2017Collision \
+    --customise_commands "process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(100)" \
+    --step GEN --geometry DB:Extended --era Run3_2025_UPC_OXY \
+    --mc -n 200 --nThreads "${nthreads}" --nConcurrentLumis 1 --no_exec
+  if cmsRun "${tag}_cfg.py"; then
+    echo "PASS: ${tag}"
+  else
+    echo "FAIL: ${tag}"
+    FAILED+=1
+  fi
+}
+
+run_refit_expect_crash() {
+  local nthreads=$1
+  local tag="HIN_pO_Angantyr_refit_${nthreads}th"
+  echo "================  ${tag} (known Pythia8 bug; non-fatal to this test)  ================"
+  cmsDriver.py Configuration/Generator/python/Pythia8Angantyr_pO_9p6TeV_MinimumBias_cfi.py \
+    --python_filename "${tag}_cfg.py" \
+    --eventcontent RAWSIM --datatier GEN \
+    --fileout "file:${tag}.root" \
+    --conditions auto:phase1_2025_realistic \
+    --beamspot Realistic25ns13TeVEarly2017Collision \
+    --customise_commands "process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(100)" \
+    --step GEN --geometry DB:Extended --era Run3_2025_UPC_OXY \
+    --mc -n 200 --nThreads "${nthreads}" --nConcurrentLumis 1 --no_exec
+  if cmsRun "${tag}_cfg.py"; then
+    echo "UNEXPECTED PASS: ${tag} — Pythia8 Angantyr re-init bug may be fixed upstream; " \
+         "consider dropping the skipRefit workaround."
+  else
+    echo "EXPECTED FAIL: ${tag} — Pythia8 Angantyr re-init crash reproduced."
+  fi
+}
+
+run_skiprefit 1
+run_skiprefit 4
+run_refit_expect_crash 1 || true
+run_refit_expect_crash 4 || true
+
+if (( FAILED > 0 )); then
+  echo "Summary: ${FAILED} skipRefit run(s) failed."
+  exit 1
+fi
+echo "Summary: all skipRefit runs passed."


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50756 

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

This PR backports only Pythia8Hadronizer (to keep divergence minimal...! there was no HepMC3 variants for heavy ion initiate state for the first place here) to support the Pythia8 Angantyr heavy-ion model via a new AngantyrInitialState PSet. Due to an issue of the Angantyr generator: in a program if the `Pythia::init()` is called twice, then it fails, which however is the case at switching lumisection, more details can be found at https://gitlab.cern.ch/cms-gen/mccm/-/issues/850 and https://its.cern.ch/jira/browse/CMSCOMPPR-61973 etc. 

The fix implemented is thus: When AngantyrInitialState is set, fInitialState is flipped from the default PP to Angantyr and HeavyIon:mode=2 is enabled on the master generator. Beam particles can optionally be provided via beamA/beamB inside the PSet; otherwise processParameters supplies them. Note that `skipRefit` implemented here **has to be turned on**.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

Two example fragments for a proton-Oxygen minimum-bias run (`Configuration/GenProduction/python/pO-example-fragment{,-skiprefit}.py`) are supplied  and a shell smoke test under GeneratorInterface/Pythia8Interface/test that exercises refit and skipRefit paths serial and 4-thread concurrent at a 200-event / LS-size-100 run.

Due to the lack of HIN dedicated validation workflows I haven't check the others.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:


@stahlleiton 

