### PR TITLE
Validation plots for TICL Particle ID used as input to superclustering

### DIFF
--- a/Validation/Configuration/python/hgcalSimValid_cff.py
+++ b/Validation/Configuration/python/hgcalSimValid_cff.py
@@ -35,6 +35,8 @@ hgcalTiclPFValidation = cms.Sequence(ticlPFValidation)
 from Validation.HGCalValidation.ticlTrackstersEdgesValidation_cfi import ticlTrackstersEdgesValidation
 hgcalTiclTrackstersEdgesValidationSequence = cms.Sequence(ticlTrackstersEdgesValidation)
 
+from Validation.HGCalValidation.ticlSuperclusterValidation_cff import *
+
 hgcalValidatorSequence = cms.Sequence(hgcalValidator)
 hgcalPFJetValidation = _hgcalPFJetValidation.clone(BenchmarkLabel = 'PFJetValidation/HGCAlCompWithGenJet',
     VariablePtBins=[10., 30., 80., 120., 250., 600.],
@@ -69,6 +71,7 @@ hgcalValidation = cms.Sequence(hgcalSimHitValidationEE
                                + hgcalHitValidationSequence
                                + hgcalValidatorSequence
                                + hgcalTiclPFValidation
+                               + ticlSuperclusterValidation
                                #Currently commented out until trackster edges are saved
 #                               + hgcalTiclTrackstersEdgesValidationSequence
                                + hgcalPFJetValidation)

--- a/Validation/HGCalValidation/plugins/TracksterAssociationMaskProducer.cc
+++ b/Validation/HGCalValidation/plugins/TracksterAssociationMaskProducer.cc
@@ -1,0 +1,164 @@
+/**
+ * Selects a subset of tracksters based on their association score to simulation, to compute efficiencies and fake rates.
+ * Builds vector<bool> as a mask associated to a trackster collection, for "signal" (reco2Sim < threshold) and "fake" (reco2Sim > threshold)
+ * Author : Theo Cuisset (LLR)
+ */
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/HGCalReco/interface/Trackster.h"
+#include "SimDataFormats/Associations/interface/TICLAssociationMap.h"
+
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+
+#include "DataFormats/HGCalReco/interface/Common.h"
+
+#include <CLHEP/Units/SystemOfUnits.h>
+
+#include <numeric>
+#include <vector>
+#include <algorithm>
+
+// using namespace ticl;
+using std::vector;
+using ticl::AssociationMap;
+using ticl::Trackster;
+using ticl::TracksterCollection;
+
+using TracksterToTracksterMap =
+    ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, vector<ticl::Trackster>, vector<ticl::Trackster>>;
+
+class TracksterAssociationMaskProducer : public edm::stream::EDProducer<> {
+public:
+  explicit TracksterAssociationMaskProducer(const edm::ParameterSet&);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
+  const edm::EDGetTokenT<TracksterCollection> tracksters_token_;
+
+  const edm::EDGetTokenT<TracksterToTracksterMap> simToRecoAssociator_;
+  const edm::EDGetTokenT<TracksterToTracksterMap> recoToSimAssociator_;
+
+  const edm::EDPutTokenT<vector<int>> mask_output_token_, mask_fake_output_token_;
+
+  float recoToSimScoreCut_;
+  float recoToSimScoreCut_forFakes_;
+  vector<Trackster::ParticleType> particleTypes_signal_;
+};
+
+DEFINE_FWK_MODULE(TracksterAssociationMaskProducer);
+
+TracksterAssociationMaskProducer::TracksterAssociationMaskProducer(const edm::ParameterSet& ps)
+    : tracksters_token_(consumes<TracksterCollection>(ps.getParameter<edm::InputTag>("tracksters"))),
+      simToRecoAssociator_(consumes<TracksterToTracksterMap>(ps.getParameter<edm::InputTag>("associatorSimToReco"))),
+      recoToSimAssociator_(consumes<TracksterToTracksterMap>(ps.getParameter<edm::InputTag>("associatorRecoToSim"))),
+      mask_output_token_(produces<vector<int>>()),
+      mask_fake_output_token_(produces<vector<int>>("fakes")),
+      recoToSimScoreCut_(ps.getParameter<double>("recoToSimScoreCut")),
+      recoToSimScoreCut_forFakes_(ps.getParameter<double>("recoToSimScoreCut_forFakes")),
+      particleTypes_signal_() {
+  vector<int> v = ps.getParameter<vector<int>>("particleTypesSignal");
+  particleTypes_signal_.reserve(v.size());
+  for (auto x : v)
+    particleTypes_signal_.push_back(static_cast<Trackster::ParticleType>(x));
+}
+
+void TracksterAssociationMaskProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("tracksters")->setComment("Input tag for tracksters");
+
+  desc.add<edm::InputTag>("associatorRecoToSim")->setComment("Input tag for the RecoToSim associator");
+  desc.add<edm::InputTag>("associatorSimToReco")->setComment("Input tag for the SimToReco associator");
+
+  desc.add<double>("recoToSimScoreCut")
+      ->setComment("Cut on reco2Sim score to consider a trackster 'signal' (if reco2Sim < cut)");
+  desc.add<double>("recoToSimScoreCut_forFakes")
+      ->setComment(
+          "Cut on reco2Sim score to consider a trackster as 'non-signal' (if reco2Sim > cut). Should be greater than "
+          "recoToSimScoreCut to make sense");
+  desc.add<vector<int>>("particleTypesSignal")
+      ->setComment("ticl::Trackster::ParticleType list to filter on SimTrackster (ie electron is 1, photon 0)");
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void TracksterAssociationMaskProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  TracksterCollection const& tracksters = evt.get(tracksters_token_);
+  TracksterToTracksterMap const& simToRecoMap = evt.get(simToRecoAssociator_);
+  TracksterToTracksterMap const& recoToSimMap = evt.get(recoToSimAssociator_);
+
+  vector<int> mask_res(tracksters.size(), 1);
+  for (size_t i_sim = 0; i_sim < simToRecoMap.size(); ++i_sim) {  // Looping over sim
+    Trackster const& simTs = *simToRecoMap.getRefFirst(i_sim);
+    const double id_probability_value =
+        std::transform_reduce(particleTypes_signal_.begin(),
+                              particleTypes_signal_.end(),
+                              0.,
+                              std::plus<>{},
+                              [&simTs](Trackster::ParticleType partType) { return simTs.id_probability(partType); });
+    if (id_probability_value < 1.)
+      continue;
+
+    auto best_reco_trackster_it = std::ranges::max_element(
+        simToRecoMap[i_sim],
+        [](TracksterToTracksterMap::AssociationElementType const& a,
+           TracksterToTracksterMap::AssociationElementType const& b) { return a.sharedEnergy() < b.sharedEnergy(); });
+
+    if (best_reco_trackster_it == simToRecoMap[i_sim].end()) {
+      continue;  // SimTrackster having no association to reco
+    }
+
+    // We check the reco-sim score for the same pair
+    auto recoToSimAssoc = std::ranges::find_if(
+        recoToSimMap[best_reco_trackster_it->index()],
+        [i_sim](const TracksterToTracksterMap::AssociationElementType& e) { return e.index() == i_sim; });
+    assert(recoToSimAssoc != recoToSimMap[best_reco_trackster_it->index()].end());
+    if (recoToSimAssoc->score() > recoToSimScoreCut_)
+      mask_res[best_reco_trackster_it->index()] = 2;  // 2 means failing (evaluates to false)
+    else
+      mask_res[best_reco_trackster_it->index()] = 0;  // passes all selections
+  }
+
+  evt.emplace(mask_output_token_, std::move(mask_res));
+
+  // Building the "fake" mask, ie tracksters that are not matched to any signal
+  // essentially an "inverted" mask_res, but with potentially different cuts (to avoid in-between area of "partially-gen-matched" tracksters)
+  vector<int> mask_fake_res(tracksters.size(), 1);
+
+  for (size_t i_reco = 0; i_reco < recoToSimMap.size(); ++i_reco) {  // Looping over reco
+    bool isPotentiallySignalMatched = false;
+    // Listing all simTracksters matched to reco, looking if there is one well-matched to a speciifc PID
+    for (auto assoc : recoToSimMap[i_reco]) {
+      if (assoc.score() > recoToSimScoreCut_forFakes_)
+        continue;  // ignore bad association scores
+
+      Trackster const& simTs = *recoToSimMap.getRefSecond(assoc.index());
+      const double id_probability_value =
+          std::transform_reduce(particleTypes_signal_.begin(),
+                                particleTypes_signal_.end(),
+                                0.,
+                                std::plus<>{},
+                                [&simTs](Trackster::ParticleType partType) { return simTs.id_probability(partType); });
+      if (id_probability_value > 0.) {
+        // We have a trackster with good reco2sim score with a simTrackster that has a PID from signal
+        // do not include that trackster as a fake
+        isPotentiallySignalMatched = true;
+        break;
+      }
+    }
+    if (isPotentiallySignalMatched)
+      continue;
+
+    mask_fake_res[i_reco] = 0;  // This is a potential fake
+  }
+
+  evt.emplace(mask_fake_output_token_, std::move(mask_fake_res));
+}

--- a/Validation/HGCalValidation/plugins/TracksterPIDValidator.cc
+++ b/Validation/HGCalValidation/plugins/TracksterPIDValidator.cc
@@ -1,0 +1,243 @@
+/**
+DQM plots for trackster PID, based on simulation truth
+Takes as input a trackster collection and a mask to build the baseline (efficiency denominator)
+ Computes the efficiency as EFF=#(baseline & passing PID cut) / #(baseline)
+Another mask is used to define a "fake" baseline region (populated by unmatched tracksters),
+ the fake rate is then defined as FR=#(fake baseline & passing signal PID cut)/#(fake baseline)
+
+Author: Théo Cuisset (LLR)
+*/
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/HGCalReco/interface/Trackster.h"
+
+using namespace ticl;
+
+struct Histograms_TracksterPIDValidation {
+  dqm::reco::MonitorElement* pt_eta_pid_;  // 3D histo pt-abs(eta)-PID value
+
+  dqm::reco::MonitorElement* pt_eta_reco2SimSelected_;  // 2D pt-eta after selection on reco2Sim score but before PID cut
+  dqm::reco::MonitorElement* pt_eta_noReco2SimSelection_;  // 2D pt-eta before selection on reco2Sim score (->denominator)
+  dqm::reco::MonitorElement* pt_eta_pidNum_;               // 2D pt-eta after PID cut
+
+  dqm::reco::MonitorElement* pt_eta_pid_fakes_;     // 3D histo pt-abs(eta)-PID value in fakes region
+  dqm::reco::MonitorElement* pt_eta_fakes_;         // 2D pt-eta fakes selection before PID cut
+  dqm::reco::MonitorElement* pt_eta_fakes_pid_Num;  // 2D pt-eta fakes selection after PID cut
+};
+
+class TICLTracksterPIDValidation : public DQMGlobalEDAnalyzer<Histograms_TracksterPIDValidation> {
+public:
+  explicit TICLTracksterPIDValidation(const edm::ParameterSet&);
+  ~TICLTracksterPIDValidation() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void bookHistograms(DQMStore::IBooker&,
+                      edm::Run const&,
+                      edm::EventSetup const&,
+                      Histograms_TracksterPIDValidation&) const override;
+
+  void dqmAnalyze(edm::Event const&, edm::EventSetup const&, Histograms_TracksterPIDValidation const&) const override;
+
+  const std::string folder_;
+  edm::EDGetTokenT<ticl::TracksterCollection> tracksters_token_;
+  edm::EDGetTokenT<std::vector<int>> tracksters_mask_token_;
+  edm::EDGetTokenT<std::vector<int>> tracksters_mask_fakes_token_;
+
+  const bool doFakes_;
+
+  const double pidCut_;
+
+  const std::vector<ticl::Trackster::ParticleType> pidsToConsider_;
+  const std::vector<double> pidBins_;
+};
+
+TICLTracksterPIDValidation::TICLTracksterPIDValidation(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")),
+      tracksters_token_(consumes<ticl::TracksterCollection>(iConfig.getParameter<edm::InputTag>("tracksters"))),
+      doFakes_(iConfig.exists("tracksterMaskFakes")),
+      pidCut_(iConfig.getParameter<double>("pidCut")),
+      pidsToConsider_({ticl::Trackster::ParticleType::electron, ticl::Trackster::ParticleType::photon}),
+      pidBins_(iConfig.getParameter<std::vector<double>>("pidBins")) {
+  if (iConfig.exists("tracksterMask"))
+    tracksters_mask_token_ = consumes<std::vector<int>>(iConfig.getParameter<edm::InputTag>("tracksterMask"));
+  if (iConfig.exists("tracksterMaskFakes"))
+    tracksters_mask_fakes_token_ =
+        consumes<std::vector<int>>(iConfig.getParameter<edm::InputTag>("tracksterMaskFakes"));
+  else
+    edm::LogInfo("PIDValidation") << "Not using any mask for fakes, will not run validation for fakes";
+}
+
+void TICLTracksterPIDValidation::dqmAnalyze(edm::Event const& iEvent,
+                                            edm::EventSetup const& iSetup,
+                                            Histograms_TracksterPIDValidation const& histos) const {
+  ticl::TracksterCollection const& tracksters = iEvent.get(tracksters_token_);
+  std::vector<int> const& tracksterMask = tracksters_mask_token_.isUninitialized()
+                                              ? std::vector<int>(tracksters.size(), 1)
+                                              : iEvent.get(tracksters_mask_token_);
+  if (tracksters_mask_token_.isUninitialized())
+    edm::LogWarning("PIDValidation") << "Not using any mask";
+
+  assert(tracksterMask.size() == tracksters.size());
+
+  auto doFill = [](dqm::reco::MonitorElement* h, Trackster const& ts) {
+    h->Fill(ts.raw_pt(), std::abs(ts.barycenter().eta()));
+  };
+
+  // Signal
+  for (std::size_t i = 0; i < tracksters.size(); i++) {
+    if (tracksterMask[i] == 1)
+      continue;  // Trackster is not the best-matched one to CaloParticle
+    ticl::Trackster const& ts = tracksters[i];
+
+    doFill(histos.pt_eta_noReco2SimSelection_, ts);
+
+    if (tracksterMask[i] != 0)
+      continue;  // Trackster is not the best-matched one to CaloParticle
+
+    doFill(histos.pt_eta_reco2SimSelected_, ts);
+
+    const double pidValue = std::transform_reduce(
+        pidsToConsider_.begin(), pidsToConsider_.end(), 0., std::plus<>{}, [&ts](Trackster::ParticleType partType) {
+          return ts.id_probability(partType);
+        });
+
+    histos.pt_eta_pid_->Fill(ts.raw_pt(), std::abs(ts.barycenter().eta()), pidValue);
+
+    if (pidValue > pidCut_)
+      doFill(histos.pt_eta_pidNum_, ts);
+  }
+
+  // Fakes
+  if (!doFakes_) {
+    return;
+  }
+
+  std::vector<int> const& tracksterMaskFakes = iEvent.get(tracksters_mask_fakes_token_);
+  assert(tracksterMaskFakes.size() == tracksters.size());
+
+  for (std::size_t i = 0; i < tracksters.size(); i++) {
+    if (tracksterMaskFakes[i] != 0)
+      continue;  // Trackster is not in the fakes mask (too signal like for example)
+    ticl::Trackster const& ts = tracksters[i];
+
+    doFill(histos.pt_eta_fakes_, ts);
+
+    const double pidValue = std::transform_reduce(
+        pidsToConsider_.begin(), pidsToConsider_.end(), 0., std::plus<>{}, [&ts](Trackster::ParticleType partType) {
+          return ts.id_probability(partType);
+        });
+    histos.pt_eta_pid_fakes_->Fill(ts.raw_pt(), std::abs(ts.barycenter().eta()), pidValue);
+
+    if (pidValue > pidCut_)
+      doFill(histos.pt_eta_fakes_pid_Num, ts);
+  }
+}
+
+void TICLTracksterPIDValidation::bookHistograms(DQMStore::IBooker& ibook,
+                                                edm::Run const& run,
+                                                edm::EventSetup const& iSetup,
+                                                Histograms_TracksterPIDValidation& histos) const {
+  ibook.setCurrentFolder(folder_);
+  // ROOT histograms have bin edges in double, but CMSSW DQM wants float. But for PID we need double edges, so make two arrays
+  constexpr std::array<double, 20> ptBins = {0., 0.5, 1.,  1.5, 2.,  2.5, 3.,  4.,  5.,  6.,
+                                             7., 8.,  10., 12., 15., 20., 30., 40., 50., 100.};
+  std::array<float, ptBins.size()> ptBinsF;
+  std::copy(ptBins.begin(), ptBins.end(), ptBinsF.begin());  // convert to float
+
+  //    constexpr std::array etaBins = {1.5, 1.6, 1.7, 1.8, 1.9, 2., 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3., 3.1};
+  constexpr std::array<double, 9> etaBins = {1.6, 1.8, 2.1, 2.3, 2.5, 2.7, 2.8, 2.9, 3.};
+  std::array<float, etaBins.size()> etaBinsF;
+  std::copy(etaBins.begin(), etaBins.end(), etaBinsF.begin());  // convert to float
+
+  auto make3D = [&](const char* name, const char* title) -> TH3F* {
+    return new TH3F(name,
+                    title,
+                    ptBins.size() - 1,
+                    ptBins.data(),  // pt
+                    etaBins.size() - 1,
+                    etaBins.data(),  //abs(eta)
+                    pidBins_.size() - 1,
+                    pidBins_.data()  //PID
+    );
+  };
+  histos.pt_eta_pid_ = ibook.book3D("pt_eta_pid", make3D("pt_eta_pid", "Pt-abs(eta)-PID value for trackster (signal)"));
+  histos.pt_eta_pid_fakes_ =
+      ibook.book3D("pt_eta_pid_fakes", make3D("pt_eta_pid_fakes", "Pt-abs(eta)-PID value for trackster (fakes)"));
+
+  histos.pt_eta_noReco2SimSelection_ =
+      ibook.book2D("pt_eta_noReco2SimSelection",
+                   "Pt-abs(eta) for the trackster best-associated (shared energy) to sim",
+                   ptBinsF.size() - 1,
+                   ptBinsF.data(),  // pt
+                   etaBinsF.size() - 1,
+                   etaBinsF.data()  //abs(eta)
+      );
+  histos.pt_eta_reco2SimSelected_ = ibook.book2D(
+      "pt_eta_reco2SimSelected",
+      "Pt-abs(eta) for the trackster best-associated (shared energy) to sim (additionally passing reco2sim cut)",
+      ptBinsF.size() - 1,
+      ptBinsF.data(),  // pt
+      etaBinsF.size() - 1,
+      etaBinsF.data()  //abs(eta)
+  );
+
+  histos.pt_eta_pidNum_ = ibook.book2D("pt_eta_pidNum",
+                                       "Pt-abs(eta) for trackster after PID cut",
+                                       ptBinsF.size() - 1,
+                                       ptBinsF.data(),  // pt
+                                       etaBinsF.size() - 1,
+                                       etaBinsF.data()  //abs(eta)
+  );
+
+  // fakes
+  if (doFakes_) {
+    histos.pt_eta_fakes_ = ibook.book2D("pt_eta_fakes",
+                                        "Pt-abs(eta) for the 'fake' tracksters before PID selection",
+                                        ptBinsF.size() - 1,
+                                        ptBinsF.data(),  // pt
+                                        etaBinsF.size() - 1,
+                                        etaBinsF.data()  //abs(eta)
+    );
+    histos.pt_eta_fakes_pid_Num =
+        ibook.book2D("pt_eta_fakes_pid_Num",
+                     "Pt-abs(eta) for the 'fake' tracksters after (signal) PID selection (numerator for fake rate)",
+                     ptBinsF.size() - 1,
+                     ptBinsF.data(),  // pt
+                     etaBinsF.size() - 1,
+                     etaBinsF.data()  //abs(eta)
+        );
+  }
+}
+
+void TICLTracksterPIDValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("folder", "HGCAL/TICLTracksterPIDValidation/");  // Please keep the trailing '/'
+  desc.add<edm::InputTag>("tracksters", edm::InputTag("ticlTrackstersCLUE3DHigh"));
+  desc.addOptional<edm::InputTag>("tracksterMask");
+  desc.addOptional<edm::InputTag>("tracksterMaskFakes");
+  desc.add<double>("pidCut", 0.5)->setComment("Cut on the PID score to apply while making PID efficiency plots");
+
+  // The default was generated with a logit :  [1/(1+math.exp(-x)) for x in np.linspace(-10, 10, 99)]
+  // clang-format off
+  desc.add<std::vector<double>>("pidBins",
+                                {0., 
+                                  2.0611536181902037e-09, 3.100083662879109e-09, 4.662689198418738e-09, 7.012930265158089e-09, 1.054781666819802e-08, 1.58644720624746e-08, 2.3861001860734702e-08, 3.588820385960723e-08, 5.3977748963680536e-08, 8.118537690037458e-08, 1.2210708039159532e-07, 1.836554727399914e-07, 2.762274842111852e-07, 4.1546063580332945e-07, 6.248745604778494e-07, 9.398439742943763e-07, 1.413574198167425e-06, 2.1260885755925174e-06, 3.197745837255419e-06, 4.8095705106148075e-06, 7.233829979130707e-06, 1.0880021845800016e-05, 1.6364036499311468e-05, 2.4612170282493442e-05, 3.70175419513405e-05, 5.5675295113294124e-05, 8.373622806675614e-05, 0.00012593838443361062, 0.00018940594382518605, 0.00028484932661867926, 0.00042836689448632893, 0.000644147300607427, 0.000968517024997084, 0.0014559898567672233, 0.0021882795075905265, 0.0032876613859340125, 0.0049366352189008315, 0.007406529685701493, 0.011098377611465102, 0.016599683415824223, 0.02475963197867262, 0.03678076158088027, 0.0543132661326406, 0.07951320168980043, 0.11498363458710696, 0.16346724250610595, 0.22714729517594293, 0.30654399138843746, 0.39935261733925703, 0.5, 0.6006473826607429, 0.6934560086115625, 0.7728527048240571, 0.8365327574938946, 0.8850163654128934, 0.9204867983101995, 0.9456867338673594, 0.9632192384191197, 0.9752403680213275, 0.9834003165841759, 0.9889016223885349, 0.9925934703142986, 0.9950633647810992, 0.9967123386140659, 0.9978117204924094, 0.9985440101432327, 0.9990314829750029, 0.9993558526993926, 0.9995716331055137, 0.9997151506733813, 0.9998105940561749, 0.9998740616155662, 0.9999162637719331, 0.9999443247048868, 0.9999629824580487, 0.9999753878297175, 0.9999836359635007, 0.9999891199781543, 0.9999927661700209, 0.9999951904294894, 0.9999968022541628, 0.9999978739114245, 0.9999985864258019, 0.9999990601560258, 0.9999993751254396, 0.9999995845393642, 0.9999997237725157, 0.9999998163445274, 0.9999998778929196, 0.999999918814623, 0.9999999460222511, 0.9999999641117963, 0.999999976138998, 0.9999999841355278, 0.9999999894521833, 0.9999999929870698, 0.9999999953373109, 0.9999999968999163, 0.9999999979388463,
+                                  1. + std::numeric_limits<double>::epsilon()})  // clang-format on
+      ->setComment(
+          "Bins of the PID score histograms. For ROC curves, it is best to generate them as logits : "
+          "[0.]+[1/(1+math.exp(-x)) for x in np.linspace(-10, 10, 99)]+[1.+epsilon]");
+  descriptions.add("ticlTracksterPIDValidation", desc);
+}
+
+DEFINE_FWK_MODULE(TICLTracksterPIDValidation);

--- a/Validation/HGCalValidation/plugins/TracksterSuperclusteringValidCandidateMaskProducer.cc
+++ b/Validation/HGCalValidation/plugins/TracksterSuperclusteringValidCandidateMaskProducer.cc
@@ -1,0 +1,142 @@
+/**
+ * Builds a vector<int> as a mask associated to a trackster collection, to identify tracksters that are best-matched to simulation
+ */
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/HGCalReco/interface/Trackster.h"
+#include "SimDataFormats/Associations/interface/TICLAssociationMap.h"
+
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+
+#include "DataFormats/HGCalReco/interface/Common.h"
+
+#include <CLHEP/Units/SystemOfUnits.h>
+
+#include <numeric>
+#include <vector>
+#include <algorithm>
+
+// using namespace ticl;
+using std::vector;
+using ticl::AssociationMap;
+using ticl::Trackster;
+using ticl::TracksterCollection;
+
+using TracksterToTracksterMap =
+    ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, vector<ticl::Trackster>, vector<ticl::Trackster>>;
+
+class TracksterSuperclusteringValidCandidateMaskProducer : public edm::stream::EDProducer<> {
+public:
+  explicit TracksterSuperclusteringValidCandidateMaskProducer(const edm::ParameterSet&);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
+  const edm::EDGetTokenT<TracksterCollection> tracksters_token_;
+
+  const edm::EDGetTokenT<TracksterToTracksterMap> simToRecoAssociator_;
+  const edm::EDGetTokenT<TracksterToTracksterMap> recoToSimAssociator_;
+
+  const edm::EDPutTokenT<vector<int>> mask_output_token_;
+
+  float recoToSimScoreCut_;
+  bool ignoreSuperclusterSeed_;
+  vector<Trackster::ParticleType> particleTypes_signal_;
+};
+
+DEFINE_FWK_MODULE(TracksterSuperclusteringValidCandidateMaskProducer);
+
+TracksterSuperclusteringValidCandidateMaskProducer::TracksterSuperclusteringValidCandidateMaskProducer(
+    const edm::ParameterSet& ps)
+    : tracksters_token_(consumes<TracksterCollection>(ps.getParameter<edm::InputTag>("tracksters"))),
+      simToRecoAssociator_(consumes<TracksterToTracksterMap>(ps.getParameter<edm::InputTag>("associatorSimToReco"))),
+      recoToSimAssociator_(consumes<TracksterToTracksterMap>(ps.getParameter<edm::InputTag>("associatorRecoToSim"))),
+      mask_output_token_(produces<vector<int>>()),
+      recoToSimScoreCut_(ps.getParameter<double>("recoToSimScoreCut")),
+      ignoreSuperclusterSeed_(ps.getParameter<bool>("ignoreSuperclusterSeed")),
+      particleTypes_signal_() {
+  vector<int> v = ps.getParameter<vector<int>>("particleTypesSignal");
+  particleTypes_signal_.reserve(v.size());
+  for (auto x : v)
+    particleTypes_signal_.push_back(static_cast<Trackster::ParticleType>(x));
+}
+
+void TracksterSuperclusteringValidCandidateMaskProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("tracksters")->setComment("Input tag for tracksters");
+
+  desc.add<edm::InputTag>("associatorRecoToSim")->setComment("Input tag for the SimToReco associator");
+  desc.add<edm::InputTag>("associatorSimToReco")->setComment("Input tag for the RecoToSim associator");
+
+  desc.add<double>("recoToSimScoreCut")
+      ->setComment("Cut on reco2Sim score to consider a trackster 'signal' (if reco2Sim < cut)");
+  desc.add<vector<int>>("particleTypesSignal")
+      ->setComment("ticl::Trackster::ParticleType list to filter on SimTrackster (ie electron is 1, photon 0)");
+  desc.add<bool>("ignoreSuperclusterSeed", true)
+      ->setComment(
+          "Do not include the 'seed' trackster of the supercluster (the one with largest shared energy with sim "
+          "object) in the output mask");
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void TracksterSuperclusteringValidCandidateMaskProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  TracksterCollection const& tracksters = evt.get(tracksters_token_);
+  TracksterToTracksterMap const& simToRecoMap = evt.get(simToRecoAssociator_);
+  TracksterToTracksterMap const& recoToSimMap = evt.get(recoToSimAssociator_);
+
+  vector<int> mask_res(tracksters.size(), 1);
+
+  for (size_t i_sim = 0; i_sim < simToRecoMap.size(); ++i_sim) {  // Looping over sim
+    Trackster const& simTs = *simToRecoMap.getRefFirst(i_sim);
+
+    // Ignore sim objects that are not of gen pdgId of interest
+    const double id_probability_value =
+        std::transform_reduce(particleTypes_signal_.begin(),
+                              particleTypes_signal_.end(),
+                              0.,
+                              std::plus<>{},
+                              [&simTs](Trackster::ParticleType partType) { return simTs.id_probability(partType); });
+    if (id_probability_value < 1.)
+      continue;
+
+    // Finding the supercluster seed, as the trackster with the largest shared energy with the SimTrackster
+    auto best_reco_trackster_it = std::ranges::max_element(
+        simToRecoMap[i_sim],
+        [](TracksterToTracksterMap::AssociationElementType const& a,
+           TracksterToTracksterMap::AssociationElementType const& b) { return a.sharedEnergy() < b.sharedEnergy(); });
+
+    // Loop over all reco tracksters having some energy shared with the sim object
+    for (auto simToRecoAssoc : simToRecoMap[i_sim]) {
+      if (ignoreSuperclusterSeed_ && simToRecoAssoc.index() == best_reco_trackster_it->index()) {
+        mask_res[simToRecoAssoc.index()] = 3;  // mark as failing but with special value
+        continue;
+      }
+
+      if (simToRecoAssoc.score() == 1.)
+        continue;  // cut on simToReco as early exit (if sim->reco score is 1, no need to find reco->sim score which will also be 1)
+
+      // retrieve reco->sim score
+      auto recoToSimAssoc = std::ranges::find_if(
+          recoToSimMap[simToRecoAssoc.index()],
+          [i_sim](const TracksterToTracksterMap::AssociationElementType& e) { return e.index() == i_sim; });
+
+      assert(recoToSimAssoc != recoToSimMap[simToRecoAssoc.index()].end());
+
+      if (recoToSimAssoc->score() > recoToSimScoreCut_)
+        mask_res[simToRecoAssoc.index()] = 2;  // 2 means failing (evaluates to false)
+      else
+        mask_res[simToRecoAssoc.index()] = 0;  // passes all selections
+    }
+  }
+
+  evt.emplace(mask_output_token_, std::move(mask_res));
+}

--- a/Validation/HGCalValidation/python/HGCalPostProcessor_cff.py
+++ b/Validation/HGCalValidation/python/HGCalPostProcessor_cff.py
@@ -4,6 +4,7 @@ from Validation.HGCalValidation.HGCalSimHitsClient_cff import *
 from Validation.HGCalValidation.HGCalDigiClient_cff    import *
 from Validation.HGCalValidation.HGCalRecHitsClient_cff import *
 from Validation.HGCalValidation.PostProcessorHGCAL_cfi import postProcessorHGCALlayerclusters,postProcessorHGCALsimclusters,postProcessorHGCALTracksters,postProcessorHGCALCandidates
+from Validation.HGCalValidation.ticlSuperclusterValidation_cff import *
 
 hgcalPostProcessor = cms.Sequence(hgcalSimHitClientEE
     + hgcalSimHitClientHEF
@@ -19,5 +20,6 @@ hgcalValidatorPostProcessor = cms.Sequence(
     postProcessorHGCALlayerclusters+
     postProcessorHGCALsimclusters+
     postProcessorHGCALTracksters+
-    postProcessorHGCALCandidates)
+    postProcessorHGCALCandidates+
+    postProcessorTiclSupercluster)
 

--- a/Validation/HGCalValidation/python/ticlSuperclusterValidation_cff.py
+++ b/Validation/HGCalValidation/python/ticlSuperclusterValidation_cff.py
@@ -1,0 +1,101 @@
+# Validation for the superclustering sequence in TICL
+# monitors efficiency of the PID cut and of supercluster building (in trackster dataformat)
+# to be used on samples containing prompt electrons (or photons)
+import FWCore.ParameterSet.Config as cms
+
+from Validation.HGCalValidation.tracksterAssociationMaskProducer_cfi import tracksterAssociationMaskProducer as _tracksterAssociationMaskProducer
+from Validation.HGCalValidation.tracksterSuperclusteringValidCandidateMaskProducer_cfi import tracksterSuperclusteringValidCandidateMaskProducer as _tracksterSuperclusteringValidCandidateMaskProducer
+
+
+sourceTracksterIteration = "ticlTrackstersCLUE3DHigh" # trackster collection used as input to superclustering (CLUE3D tracksters)
+superclusterTracksterIteration = "ticlTracksterLinksSuperclusteringDNN" # trackster collection output by superclustering (superclusters in trackster dataformat)
+simTrackstersCollection = "ticlSimTrackstersfromCPs" # simtrackster collection used for genmatching (CaloParticle)
+sim2recoscore = 0.3 # cut on sim2reco score to consider a supercluster genmatched
+
+
+################ Validation of PID cut for superclustering
+
+## Building masks to select tracksters for efficiency and fake rate "baseline"
+# finding the reco trackster that is the "seed" cluster for each electron caloparticle
+ticlValidSuperclusteringSeedMask = _tracksterAssociationMaskProducer.clone(
+    tracksters=cms.InputTag(sourceTracksterIteration),
+    associatorRecoToSim=cms.InputTag(f"allTrackstersToSimTrackstersAssociationsByLCs:{sourceTracksterIteration}To{simTrackstersCollection}"),
+    associatorSimToReco=cms.InputTag(f"allTrackstersToSimTrackstersAssociationsByLCs:{simTrackstersCollection}To{sourceTracksterIteration}"),
+    recoToSimScoreCut=cms.double(0.1), # for the seed cluster of an electron, we want a tight cut (will remove low energy electron clusters that are heavily pileup contaminated)
+    recoToSimScoreCut_forFakes=cms.double(0.8), # we don't want to study fake rates of PID in tracksters that have some electron/photon in it
+    particleTypesSignal=cms.vint32(0, 1) # ele+photon (SimTrackster ParticleType enum, photon=0, ele=1, muon=2, pi0=3, h+-=4, h0=5)
+)
+
+# finding all reco tracksters that are a "brem"/"superclustering candidate" cluster of an electron
+tracksterSuperclusteringValidCandidateMaskProducer = _tracksterSuperclusteringValidCandidateMaskProducer.clone(
+    tracksters=cms.InputTag(sourceTracksterIteration),
+    associatorRecoToSim=cms.InputTag(f"allTrackstersToSimTrackstersAssociationsByLCs:{sourceTracksterIteration}To{simTrackstersCollection}"),
+    associatorSimToReco=cms.InputTag(f"allTrackstersToSimTrackstersAssociationsByLCs:{simTrackstersCollection}To{sourceTracksterIteration}"),
+    recoToSimScoreCut=cms.double(0.15), # for the candidate brem clusters of an electron, we want a slightly looser cut
+    particleTypesSignal=cms.vint32(0, 1) # ele+photon (SimTrackster ParticleType enum, photon=0, ele=1, muon=2, pi0=3, h+-=4, h0=5)
+)
+
+## actual validation DQM
+from Validation.HGCalValidation.ticlTracksterPIDValidation_cfi import ticlTracksterPIDValidation as _ticlTracksterPIDValidation
+ticlValidSuperclusteringSeedPID = _ticlTracksterPIDValidation.clone(
+    tracksters = cms.InputTag(sourceTracksterIteration),
+    tracksterMask = cms.InputTag("ticlValidSuperclusteringSeedMask"),
+    tracksterMaskFakes = cms.InputTag("ticlValidSuperclusteringSeedMask", "fakes"),
+    folder = cms.string("HGCAL/TICLTracksterPIDValidation/superclusteringSeedTrackster/"),
+    pidCut = cms.double(0.5)
+)
+ticlValidSuperclusteringCandidatePID = _ticlTracksterPIDValidation.clone(
+    tracksters = cms.InputTag(sourceTracksterIteration),
+    tracksterMask = cms.InputTag("tracksterSuperclusteringValidCandidateMaskProducer"),
+    # for fakes the selection is the same as for seeds, only the PID cut is potentially different
+    tracksterMaskFakes = cms.InputTag("ticlValidSuperclusteringSeedMask", "fakes"),
+    folder = cms.string("HGCAL/TICLTracksterPIDValidation/superclusteringCandidateTrackster/"),
+    pidCut = cms.double(0.2),
+)
+
+ticlSuperclusterPIDValidation = cms.Sequence(
+    ticlValidSuperclusteringSeedMask + tracksterSuperclusteringValidCandidateMaskProducer +
+    ticlValidSuperclusteringSeedPID + ticlValidSuperclusteringCandidatePID
+)
+
+
+
+#### post-processing : computing efficiencies of PID cut as ratios of histogram
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+postProcessorTICLPIDValid = DQMEDHarvester('DQMGenericClient',
+    subDirs = cms.untracked.vstring("HGCAL/TICLTracksterPIDValidation/superclusteringSeedTrackster", "HGCAL/TICLTracksterPIDValidation/superclusteringCandidateTrackster"),
+    efficiencySets = cms.untracked.VPSet(
+        cms.untracked.PSet( # validating the efficiency of the gen-matching selections on electron caloparticles
+            name=cms.untracked.string("pt_eta_reco2SimSelection_eff"),
+            title=cms.untracked.string("Efficiency of reco2Sim cut as a function of pt and abs(eta) on superclusteringSeedTrackster"),
+            numerator=cms.untracked.string("pt_eta_reco2SimSelected"),
+            denominator=cms.untracked.string("pt_eta_noReco2SimSelection")
+        ),
+
+        cms.untracked.PSet(
+            name=cms.untracked.string("pt_eta_PID_eff"),
+            title=cms.untracked.string("Efficiency of PID cut as a function of pt and abs(eta) on superclusteringSeedTrackster"),
+            numerator=cms.untracked.string("pt_eta_pidNum"),
+            denominator=cms.untracked.string("pt_eta_reco2SimSelected")
+        ),
+        cms.untracked.PSet(
+            name=cms.untracked.string("pt_eta_PID_fakeRate"),
+            title=cms.untracked.string("Fake rate of PID cut as a function of pt and abs(eta) on superclusteringSeedTrackster (computed on tracksters failing sim-matching to electron)"),
+            numerator=cms.untracked.string("pt_eta_fakes_pid_Num"),
+            denominator=cms.untracked.string("pt_eta_fakes")
+        ),
+
+        
+    ),
+    efficiency = cms.vstring(),
+    resolution = cms.vstring(),
+    verbose = cms.untracked.uint32(4))
+
+
+########################### Sequences
+ticlSuperclusterValidation = cms.Sequence(
+    ticlSuperclusterPIDValidation
+)
+postProcessorTiclSupercluster = cms.Sequence(
+    postProcessorTICLPIDValid
+)

--- a/Validation/HGCalValidation/scripts/makeTiclSuperclusteringPIDValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeTiclSuperclusteringPIDValidationPlots.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import mplhep as mpl
+mpl.style.use(mpl.style.CMS)
+import uproot, hist
+import matplotlib.pyplot as plt
+import numpy as np
+import argparse
+
+def make_eff_fake(h_eff, h_fake):
+    eff, fakes = [], []
+    for pidCut in h_eff.axes[0].edges:
+        eff.append(h_eff[hist.loc(pidCut)::hist.sum] / h_eff[hist.sum] if h_eff[hist.sum]>0 else 0.)
+        fakes.append(h_fake[hist.loc(pidCut)::hist.sum] / h_fake[hist.sum] if h_fake[hist.sum] else 0.)
+    return h_eff.axes[0].edges, eff, fakes
+
+prefix = "DQMData/Run 1/HGCAL/Run summary/TICLTracksterPIDValidation/"
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+                    prog='makeTiclSuperclusteringPIDValidationPlots',
+                    description='Takes multidimensional histograms from DQM output and makes ROC curves for PID used for superclustering')
+    parser.add_argument('filename', nargs="+", help="DQM files to do the plots") 
+    args = parser.parse_args()
+
+    # ROC curve for seed
+    plt.figure(figsize=(7, 7))
+    for file in args.filename:
+        with uproot.open(file) as f:
+            pid, eff, fake = make_eff_fake(f[prefix+"superclusteringSeedTrackster/pt_eta_pid"].to_hist()[hist.sum, hist.loc(1.6):hist.loc(2.9):hist.sum, :], f[prefix+"superclusteringSeedTrackster/pt_eta_pid_fakes"].to_hist()[hist.sum, hist.loc(1.6):hist.loc(2.9):hist.sum, :])
+        plt.plot(eff, fake, "o-",  markersize=4, label=file)
+
+    plt.xlabel("Signal efficiency")
+    plt.ylabel("Background efficiency")
+    plt.xlim(0.8, 1.)
+    plt.ylim(1e-8, 2)
+    plt.yscale("log")
+    plt.legend(fontsize=15)
+    plt.text(0.04, 0.96, "Seed electron trackster", transform=plt.gca().transAxes, va="top", ha="left", fontsize=20)
+    plt.savefig("superclusteringSeedTrackster_ROC.png", bbox_inches="tight")
+    plt.savefig("superclusteringSeedTrackster_ROC.pdf", bbox_inches="tight")
+
+    # ROC curve for candidate
+    plt.figure(figsize=(7, 7))
+    for file in args.filename:
+        with uproot.open(file) as f:
+            pid, eff, fake = make_eff_fake(f[prefix+"superclusteringCandidateTrackster/pt_eta_pid"].to_hist()[hist.sum, hist.loc(1.6):hist.loc(2.9):hist.sum, :], f[prefix+"superclusteringCandidateTrackster/pt_eta_pid_fakes"].to_hist()[hist.sum,  hist.loc(1.6):hist.loc(2.9):hist.sum, :])
+        plt.plot(eff, fake, "o-", markersize=4, label=file)
+
+    plt.xlabel("Signal efficiency")
+    plt.ylabel("Background efficiency")
+    plt.legend(fontsize=15)
+    plt.text(0.04, 0.96, "Trackster from electron 'brem'", transform=plt.gca().transAxes, va="top", ha="left", fontsize=20)
+    plt.savefig("superclusteringCandidateTrackster_ROC.png", bbox_inches="tight")
+    plt.savefig("superclusteringCandidateTrackster_ROC.pdf", bbox_inches="tight")
+


### PR DESCRIPTION
#### PR description:
Add DQM validation plots to monitor the performance of the TICL Particle ID (PID) that is used as input to the superclustering. The PID filters electromagnetic from hadronic/pileup tracksters.

Two producers create masks of input tracksters (vector<bool>) that dertermine the collection subset to be used for efficiency/fake measurements. Then [TracksterPIDValidator.cc](https://github.com/cms-sw/cmssw/compare/master...tcuisset:cmssw:pidValidationForSupercluster-pr#diff-b104d07c23e9d94cddecd022185222798cc45a1c1170a2e709f18c5e5aab5f46) computes : 
 - efficiencies for gen-matched tracksters (separately for "seed" ie leading cluster and "candidate" ie brem)
 - fake rate, computed on non-gen-matched tracksters

Also included is a short python script to make ROC curves.

[Presentation at TICL meeting](https://indico.cern.ch/event/1639403/sessions/645092/attachments/3246438/5792243/PID%20-%20TICL%20March26.pdf)

#### PR validation:
Validated on electron samples (see linked slides).