### PR TITLE
Backport hotfix for multiblock Alpaka multi-depth PF clusterizer 16 1 x

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterECLCC.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterECLCC.h
@@ -255,33 +255,25 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
       const int topH = pfClusteringCCLabels.topH();
 
       for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
-        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nClusters)) {
-          if (idx.local >= nClusters)
-            continue;
-
-          if (::cms::alpakatools::once_per_block(acc)) {
-            int i = alpaka::atomicAdd(acc, &pfClusteringCCLabels.posH() /*posH*/, -1, alpaka::hierarchy::Grids{});
-            v = (i > topH) ? pfClusteringCCLabels[i].workl() : -1;
-          }
+        if (::cms::alpakatools::once_per_block(acc)) {
+          int i = alpaka::atomicAdd(acc, &pfClusteringCCLabels.posH() /*posH*/, -1, alpaka::hierarchy::Grids{});
+          v = (i > topH) ? pfClusteringCCLabels[i].workl() : -1;
         }
 
         alpaka::syncBlockThreads(acc);
 
         while (v >= 0) {
           for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nClusters)) {
-            if (idx.local >= nClusters)
-              continue;
-
             const int begin_v = pfClusteringEdgeVars[v].mdpf_adjacencyIndex() + idx.local;
             const int end_v = pfClusteringEdgeVars[v + 1].mdpf_adjacencyIndex();
 
             hook(acc, pfClusteringCCLabels, pfClusteringEdgeVars, v, begin_v, end_v, blockDim_x);
-
-            if (::cms::alpakatools::once_per_block(acc)) {
-              int i = alpaka::atomicAdd(acc, &pfClusteringCCLabels.posH() /*posH*/, -1, alpaka::hierarchy::Blocks{});
-              v = (i > topH) ? pfClusteringCCLabels[i].workl() : -1;
-            }
           }
+          if (::cms::alpakatools::once_per_block(acc)) {
+            int i = alpaka::atomicAdd(acc, &pfClusteringCCLabels.posH() /*posH*/, -1, alpaka::hierarchy::Blocks{});
+            v = (i > topH) ? pfClusteringCCLabels[i].workl() : -1;
+          }
+
           alpaka::syncBlockThreads(acc);
         }
       }

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterECLCC.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterECLCC.h
@@ -256,7 +256,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
 
       for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
         if (::cms::alpakatools::once_per_block(acc)) {
-          int i = alpaka::atomicAdd(acc, &pfClusteringCCLabels.posH() /*posH*/, -1, alpaka::hierarchy::Grids{});
+          int i = alpaka::atomicAdd(acc, &pfClusteringCCLabels.posH() /*posH*/, -1, alpaka::hierarchy::Blocks{});
           v = (i > topH) ? pfClusteringCCLabels[i].workl() : -1;
         }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologueMultiBlock.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologueMultiBlock.h
@@ -253,7 +253,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
           const auto lane_idx = idx.local % w_extent;
-          if (lane_idx >= w_items)
+          if (idx.local >= w_items)
             continue;
           const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
 
@@ -305,7 +305,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         // Constract coarse-grained offset (offsets for each warp):
         for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
           const auto lane_idx = idx.local % w_extent;
-          if (lane_idx >= w_extent)
+          if (idx.local >= w_extent)
             continue;
 
           const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
@@ -347,7 +347,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             // Create the full warp mask (all lanes will vote):
             const auto lane_idx = idx.local % w_extent;
 
-            if (lane_idx >= nBlocks)
+            if (idx.local >= nBlocks)
               continue;
 
             const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologueMultiBlock.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologueMultiBlock.h
@@ -169,7 +169,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           warp_local_nlist[idx.local] = dst_vertex_idx == src_vertex_idx ? 0 : 1;
           block_local_nlist[idx.local] = 0;
 
-          if (idx.local < max_w_items) {
+          if (idx.local < w_extent) {
             subdomain_offsets[idx.local] = 0;
           }
         }
@@ -303,9 +303,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::syncBlockThreads(acc);
 
         // Constract coarse-grained offset (offsets for each warp):
-        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, w_extent)) {
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
           const auto lane_idx = idx.local % w_extent;
-          if (lane_idx >= w_items)
+          if (lane_idx >= w_extent)
             continue;
 
           const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);


### PR DESCRIPTION
PR description:

This PR provides a hotfix for the multi-block Alpaka multi-depth PF clusterizer.
The following changes were made:

-- fixed the index range handling in ECLCCPrologueComputeOffsetsKernel for the multi-block implementation
-- fixed initialization of the reduction buffer, which was incomplete in the previous version
-- applied minor cleanup to the ECLCC high-degree-vertex compute kernel

The issue could cause a crash in a rare event and was not detected by the standard validation tests.

This is a backport of https://github.com/cms-sw/cmssw/pull/50746 for 16.1.X