### PR TITLE
Adding `skipEvents` option to `cmsDriver`

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -37,6 +37,7 @@ defaultOptions.harvesting= 'AtRunEnd'
 defaultOptions.gflash = False
 defaultOptions.number = -1
 defaultOptions.number_out = None
+defaultOptions.skipEvents = -1
 defaultOptions.arguments = ""
 defaultOptions.name = "NO NAME GIVEN"
 defaultOptions.evt_type = ""
@@ -417,7 +418,7 @@ class ConfigBuilder(object):
         if self._options.number_out:
             self.process.maxEvents.output = self._options.number_out
         self.addedObjects.append(("","maxEvents"))
-
+        
     def addSource(self):
         """Here the source is built. Priority: file, generator"""
         self.addedObjects.append(("Input source","source"))
@@ -920,6 +921,8 @@ class ConfigBuilder(object):
             if not self._options.dropDescendant:
                 self.process.source.dropDescendantsOfDroppedBranches = cms.untracked.bool(False)
 
+        if self._options.skipEvents >= 0:
+            self.process.source.skipEvents = cms.untracked.uint32(self._options.skipEvents)
 
         return
 

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -78,6 +78,12 @@ parser.add_argument("-o", "--number_out",
                     type=int,
                     dest="number_out")
 
+parser.add_argument("--skipEvents",
+                    help="The number of events that will be skipped.",
+                    default=-1,
+                    type=int,
+                    dest="skipEvents")
+
 parser.add_argument("--mc",
                     help="Specify that simulation is to be processed (default = guess based on options)",
                     action="store_true",


### PR DESCRIPTION
#### PR description:

This PR proposes to add a `--skipEvents N` option to `cmsDriver` to insert automatically a  `skipEvents = cms.untracked.uint32(N)` in the process `source`. 

#### PR validation:

Running, e.g., 

```
cmsDriver.py SingleMuPt10_Eta2p85_cfi  -s GEN,SIM -n 10 --conditions auto:phase1_2026_realistic --beamspot DBrealistic --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry DB:Extended --era Run3_2026 --relval 9000,100 --fileout file:step1.root  \

cmsDriver.py step2  -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2026 --conditions auto:phase1_2026_realistic --datatier GEN-SIM-DIGI-RAW -n 10 --eventcontent FEVTDEBUGHLT --geometry DB:Extended --era Run3_2026 --filein  file:step1.root  --fileout file:step2.root --skipEvents 5
```

one gets

```
[...]
Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at 22-Apr-2026 12:51:39.388 CEST
Begin processing the 2nd record. Run 1, Event 2, LumiSection 1 on stream 0 at 22-Apr-2026 12:51:39.513 CEST
Begin processing the 3rd record. Run 1, Event 3, LumiSection 1 on stream 0 at 22-Apr-2026 12:51:39.589 CEST
Begin processing the 4th record. Run 1, Event 4, LumiSection 1 on stream 0 at 22-Apr-2026 12:51:39.662 CEST
Begin processing the 5th record. Run 1, Event 5, LumiSection 1 on stream 0 at 22-Apr-2026 12:51:39.698 CEST
Begin processing the 6th record. Run 1, Event 6, LumiSection 1 on stream 0 at 22-Apr-2026 12:51:39.761 CEST
Begin processing the 7th record. Run 1, Event 7, LumiSection 1 on stream 0 at 22-Apr-2026 12:51:39.826 CEST
Begin processing the 8th record. Run 1, Event 8, LumiSection 1 on stream 0 at 22-Apr-2026 12:51:39.865 CEST
Begin processing the 9th record. Run 1, Event 9, LumiSection 1 on stream 0 at 22-Apr-2026 12:51:39.930 CEST
Begin processing the 10th record. Run 1, Event 10, LumiSection 1 on stream 0 at 22-Apr-2026 12:51:39.962 CEST

 *-------  PYTHIA Error and Warning Messages Statistics  ----------------------------------------------------------* 
 |                                                                                                                 | 
 |  times   message                                                                                                | 
 |                                                                                                                 | 
 |      0   no errors or warnings to report                                                                        | 
 |                                                                                                                 | 
 *-------  End PYTHIA Error and Warning Messages Statistics  ------------------------------------------------------* 

 *-------  PYTHIA Error and Warning Messages Statistics  ----------------------------------------------------------* 
 |                                                                                                                 | 
 |  times   message                                                                                                | 
 |                                                                                                                 | 
 |      0   no errors or warnings to report                                                                        | 
 |                                                                                                                 | 
 *-------  End PYTHIA Error and Warning Messages Statistics  ------------------------------------------------------* 

------------------------------------
GenXsecAnalyzer:
------------------------------------
Before Filter: total cross section = 0.000e+00 +- 0.000e+00 pb
Filter efficiency (taking into account weights)= (10) / (10) = 1.000e+00 +- 0.000e+00
Filter efficiency (event-level)= (10) / (10) = 1.000e+00 +- 0.000e+00    [TO BE USED IN MCM]

After filter: final cross section = 0.000e+00 +- 0.000e+00 pb
After filter: final fraction of events with negative weights = 0.000e+00 +- 0.000e+00
After filter: final equivalent lumi for 1M events (1/fb) = 0.000e+00 +- 0.000e+00

We have determined that this is simulation (if not, rerun cmsDriver.py with --data)
with DB:
entry file:step1.root
Step: DIGI Spec: ['pdigi_valid']
Step: L1 Spec: 
Step: DIGI2RAW Spec: 
Step: HLT Spec: ['@relval2026']
Step: ENDJOB Spec: 
customising the process with customizeHLTforMC from HLTrigger/Configuration/customizeHLTforMC
Starting  cmsRun  step2_DIGI_L1_DIGI2RAW_HLT.py
%MSG-i AlpakaService:  (NoModuleName) 22-Apr-2026 12:55:05 CEST pre-events
AlpakaServiceSerialSync succesfully initialised.
Found 1 device:
  - Intel(R) Xeon(R) Silver 4210R CPU @ 2.40GHz
%MSG
22-Apr-2026 12:55:08 CEST  Initiating request to open file file:step1.root
22-Apr-2026 12:55:09 CEST  Successfully opened file file:step1.root
Begin processing the 1st record. Run 1, Event 6, LumiSection 1 on stream 0 at 22-Apr-2026 12:55:59.915 CEST
#--------------------------------------------------------------------------
#                         FastJet release 3.4.1
#                 M. Cacciari, G.P. Salam and G. Soyez                  
#     A software package for jet finding and analysis at colliders      
#                           http://fastjet.fr                           
#                                                                             
# Please cite EPJC72(2012)1896 [arXiv:1111.6097] if you use this package
# for scientific work and optionally PLB641(2006)57 [hep-ph/0512210].   
#                                                                       
# FastJet is provided without warranty under the GNU GPL v2 or higher.  
# It uses T. Chan's closest pair algorithm, S. Fortune's Voronoi code
# and 3rd party plugin jet algorithms. See COPYING file for details.
#--------------------------------------------------------------------------
Begin processing the 2nd record. Run 1, Event 7, LumiSection 1 on stream 0 at 22-Apr-2026 12:56:12.266 CEST
Begin processing the 3rd record. Run 1, Event 8, LumiSection 1 on stream 0 at 22-Apr-2026 12:56:14.124 CEST
Begin processing the 4th record. Run 1, Event 9, LumiSection 1 on stream 0 at 22-Apr-2026 12:56:15.915 CEST
%MSG-w DTTSPhi:  DTTrigProd:simDtTriggerPrimitiveDigis  22-Apr-2026 12:56:17 CEST Run: 1 Event: 9
addTracoT: preview not present in TRACO trigger or its code=0  trigger not added!
%MSG
Begin processing the 5th record. Run 1, Event 10, LumiSection 1 on stream 0 at 22-Apr-2026 12:56:17.716 CEST
22-Apr-2026 12:56:19 CEST  Closed file file:step1.root
```