### PR TITLE
Add automatic eval and freeze to PyTorch

### DIFF
--- a/PhysicsTools/PyTorch/interface/Model.h
+++ b/PhysicsTools/PyTorch/interface/Model.h
@@ -13,17 +13,34 @@ namespace cms::torch {
   // - https://docs.pytorch.org/cppdocs/api/classtorch_1_1nn_1_1_module.html#class-module
   class Model {
   public:
-    explicit Model(const std::string &model_path) : model_(cms::torch::load(model_path)), device_(::torch::kCPU) {}
+    explicit Model(const std::string &model_path, bool auto_freeze = true)
+        : model_(cms::torch::load(model_path)), device_(::torch::kCPU), auto_freeze_(auto_freeze) {
+      model_.eval();
+    }
 
-    explicit Model(const std::string &model_path, ::torch::Device dev)
-        : model_(cms::torch::load(model_path, dev)), device_(dev) {}
+    explicit Model(const std::string &model_path, ::torch::Device dev, bool auto_freeze = true)
+        : model_(cms::torch::load(model_path, dev)), device_(dev), auto_freeze_(auto_freeze) {
+      model_.eval();
+    }
 
     // Move model to specified device memory space. Async load by specifying `non_blocking` (in default stream if not overridden by the caller)
     void to(::torch::Device dev, const bool non_blocking = false) {
       if (dev == device_)
         return;
+
+      assert(!is_frozen_ && "Model is frozen, cannot be moved to another device!");
       model_.to(dev, non_blocking);
       device_ = dev;
+      if (auto_freeze_) {
+        freeze();
+      }
+    }
+
+    void freeze() {
+      if (!is_frozen_) {
+        model_ = ::torch::jit::freeze(model_);
+        is_frozen_ = true;
+      }
     }
 
     // Forward pass (inference) of model, returns torch::IValue (multi output support). Match native torchlib interface.
@@ -39,6 +56,9 @@ namespace cms::torch {
   protected:
     ::torch::jit::script::Module model_;  // underlying JIT model
     ::torch::Device device_;              // device where the model is allocated (default CPU)
+    const bool
+        auto_freeze_;  // flag to indicate if the model should be automatically frozen after loading or moving to device
+    bool is_frozen_ = false;  // flag to indicate if the model is frozen
   };
 
 }  // namespace cms::torch

--- a/PhysicsTools/PyTorchAlpaka/README.md
+++ b/PhysicsTools/PyTorchAlpaka/README.md
@@ -12,6 +12,15 @@ Examples demonstrating the interoperability of PyTorch with Alpaka in the CMSSW 
 - *TinyResNet* emulate more complex scenario with `Eigen::Matrix` and how one can implement image-like Tensor implementation
 - *MulitHeadNet* handle networks that return more than one output tensor 
 
+## Model behavior
+
+The `Model` wrapper automatically sets the loaded TorchScript module to evaluation mode (`eval()`).
+
+By default, the model is automatically frozen using the `torch::jit::freeze()` function at construction time, either when a device is specified or when the model is first moved.
+You can skip this optimization step by setting `auto_freeze=false` when calling the model constructor.
+**Important:** Once a model is frozen, it cannot be moved to another device. Attempting to do so will trigger a runtime assertion.
+
+
 ## Direct Inference on SoA 
 The interface provides a converter to dynamically wrap SoA data into one or more `torch::tensors` without the need to copy data (or minimal copy overhead).
 

--- a/PhysicsTools/PyTorchAlpaka/interface/alpaka/AlpakaModel.h
+++ b/PhysicsTools/PyTorchAlpaka/interface/alpaka/AlpakaModel.h
@@ -26,10 +26,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::torch {
     // The string-only constructor with to() method is preferred way to keep async.
     // Loads model to alpaka accelerator specified memory space.
     // Note that this is done in default stream, i.e. synchronously.
-    explicit AlpakaModel(const std::string &model_path, const Device &dev)
-        : cms::torch::Model(model_path, cms::torch::alpakatools::getDevice(dev)) {}
-    explicit AlpakaModel(const std::string &model_path, const Queue &queue)
-        : cms::torch::Model(model_path, cms::torch::alpakatools::getDevice(queue)) {}
+    explicit AlpakaModel(const std::string &model_path, const Device &dev, bool auto_freeze = true)
+        : cms::torch::Model(model_path, cms::torch::alpakatools::getDevice(dev), auto_freeze) {}
+    explicit AlpakaModel(const std::string &model_path, const Queue &queue, bool auto_freeze = true)
+        : cms::torch::Model(model_path, cms::torch::alpakatools::getDevice(queue), auto_freeze) {}
 
     // Forward pass (inference) of model with SoA metadata input/output.
     // Allows to run inference directly using SoA portable objects/collections without excessive copies and conversions.


### PR DESCRIPTION
The PR is part of some studies conducted with @valsdav 
## PR Description

This PR updates the Model wrapper. 

All loaded TorchScript models are now automatically set to evaluation mode ([eval()](https://docs.pytorch.org/docs/2.8/generated/torch.jit.ScriptModule.html#torch.jit.ScriptModule.eval)) upon construction. This ensures inference-only behavior without requiring manual configuration.

Moreover, by default models are automatically optimized using [torch::jit::freeze():](https://docs.pytorch.org/docs/2.8/generated/torch.jit.freeze.html#torch.jit.freeze)
Freezing occurs either at construction or when the model is first moved to a device.
This behavior can be disabled by setting `auto_freeze = false` in the constructor.