### PR TITLE
L1S: updates for CaloJet-related plugins [`16_0_X`]

### DIFF
--- a/L1TriggerScouting/OnlineProcessing/plugins/CaloJetBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/CaloJetBxSelector.cc
@@ -1,0 +1,118 @@
+#include <cmath>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "DataFormats/L1Scouting/interface/L1ScoutingCaloJet.h"
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+class CaloJetBxSelector : public edm::global::EDProducer<> {
+public:
+  explicit CaloJetBxSelector(const edm::ParameterSet&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+  edm::EDGetTokenT<l1ScoutingRun3::CaloJetOrbitCollection> const jetsToken_;
+  unsigned int const minNJet_;
+  std::vector<double> const minJetPt_;
+  std::vector<double> const maxJetAbsEta_;
+  std::vector<int> const minJetNConst_;
+};
+
+CaloJetBxSelector::CaloJetBxSelector(const edm::ParameterSet& iPSet)
+    : jetsToken_(consumes(iPSet.getParameter<edm::InputTag>("jetsTag"))),
+      minNJet_(iPSet.getParameter<unsigned int>("minNJet")),
+      minJetPt_(iPSet.getParameter<std::vector<double>>("minJetPt")),
+      maxJetAbsEta_(iPSet.getParameter<std::vector<double>>("maxJetAbsEta")),
+      minJetNConst_(iPSet.getParameter<std::vector<int>>("minJetNConst")) {
+  if (minNJet_ != minJetPt_.size()) {
+    throw cms::Exception("InvalidConfiguration")
+        << "invalid parameter values: \"minNJet\" (" << minNJet_ << ") differs from the size of \"minJetPt\" ("
+        << minJetPt_.size() << ")";
+  }
+
+  if (minNJet_ != maxJetAbsEta_.size()) {
+    throw cms::Exception("InvalidConfiguration")
+        << "invalid parameter values: \"minNJet\" (" << minNJet_ << ") differs from the size of \"maxJetAbsEta\" ("
+        << maxJetAbsEta_.size() << ")";
+  }
+
+  if (minNJet_ != minJetNConst_.size()) {
+    throw cms::Exception("InvalidConfiguration")
+        << "invalid parameter values: \"minNJet\" (" << minNJet_ << ") differs from the size of \"minJetNConst\" ("
+        << minJetNConst_.size() << ")";
+  }
+
+  produces<std::vector<unsigned int>>("SelBx").setBranchAlias("CaloJetSelectedBx");
+}
+
+// ------------ method called for each ORBIT  ------------
+void CaloJetBxSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup&) const {
+  auto const& caloJetsInOrbit = iEvent.get(jetsToken_);
+
+  auto jetBx = std::make_unique<std::vector<unsigned int>>();
+
+  // loop over valid BXs with CaloJets
+  for (auto const bx : caloJetsInOrbit.getFilledBxs()) {
+    if (minNJet_ > 0) {
+      auto const& jets = caloJetsInOrbit.bxIterator(bx);
+
+      // skip BX if the number of jets is below the minimum
+      if (jets.size() < minNJet_) {
+        continue;
+      }
+
+      // check if there are enough jets passing selection requirements (pT, |eta|, #constituents)
+      unsigned int nAccJets{0};
+      for (auto const& jet : jets) {
+        // increment nAccJets if the jet passes all requirements
+        if (jet.pt() >= minJetPt_[nAccJets] and
+            (maxJetAbsEta_[nAccJets] < 0 or std::abs(jet.eta()) < maxJetAbsEta_[nAccJets]) and
+            jet.nConst() >= minJetNConst_[nAccJets]) {
+          ++nAccJets;
+        }
+        // found enough jets, so exit early
+        if (nAccJets == minNJet_) {
+          break;
+        }
+      }
+
+      // skip BX if the number of selected jets is below the minimum
+      if (nAccJets < minNJet_) {
+        continue;
+      }
+    }
+
+    jetBx->emplace_back(bx);
+  }  // end orbit loop
+
+  iEvent.put(std::move(jetBx), "SelBx");
+}
+
+void CaloJetBxSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("jetsTag")->setComment(
+      "Input collection of CaloJets (type: l1ScoutingRun3::CaloJetOrbitCollection)");
+  desc.add<unsigned int>("minNJet", 0)
+      ->setComment("Min number of jets passing min-pT, max-|eta| and min-#constituents requirements (inclusive)");
+  desc.add<std::vector<double>>("minJetPt", {})
+      ->setComment("Min jet-pT thresholds (size must be equal to the value of \"minNJet\")");
+  desc.add<std::vector<double>>("maxJetAbsEta", {})
+      ->setComment(
+          "Max jet-|eta| thresholds (size must be equal to the value of \"minNJet\"; a negative value corresponds to "
+          "not applying the |eta| cut)");
+  desc.add<std::vector<int>>("minJetNConst", {})
+      ->setComment("Thresholds on the min number of jet constituents (size must be equal to the value of \"minNJet\")");
+  descriptions.addDefault(desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(CaloJetBxSelector);

--- a/L1TriggerScouting/OnlineProcessing/plugins/L1ScoutingCaloJetProducer.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/L1ScoutingCaloJetProducer.cc
@@ -1,8 +1,13 @@
 #include <algorithm>
+#include <cmath>
+#include <fstream>
 #include <memory>
+#include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
 #include "DataFormats/L1Scouting/interface/L1ScoutingCaloTower.h"
 #include "DataFormats/L1Scouting/interface/L1ScoutingCaloJet.h"
 #include "DataFormats/Math/interface/libminifloat.h"
@@ -11,6 +16,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/FileInPath.h"
 #include "L1TriggerScouting/Utilities/interface/conversion.h"
 
 #include "fastjet/ClusterSequence.hh"
@@ -25,6 +32,109 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
+  class JetCorrector {
+  public:
+    explicit JetCorrector() = default;
+    explicit JetCorrector(std::string const& filePath) {
+      std::ifstream infile(filePath);
+      if (!infile) {
+        throw cms::Exception("InputError") << "failed to open JetCorrector input file: " << filePath;
+      }
+
+      std::string line{};
+      while (std::getline(infile, line)) {
+        std::istringstream iss(line);
+
+        float ptMin{0.f};
+        float ptMax{0.f};
+        float etaMin{0.f};
+        float etaMax{0.f};
+        int puProxyMin{0};
+        int puProxyMax{0};
+        int formNParams{0};
+        std::string formEvalStr{""};
+
+        if (!(iss >> ptMin >> ptMax >> etaMin >> etaMax >> puProxyMin >> puProxyMax >> formEvalStr >> formNParams)) {
+          throw cms::Exception("InvalidInput")
+              << "failed to read line from input file (invalid format): \"" << line << "\"";
+        }
+
+        if (ptMin <= 0) {
+          throw cms::Exception("InvalidInput")
+              << "invalid value for parameter \"ptMin\" (must be greater than zero): " << ptMin;
+        }
+
+        if (ptMax <= 0) {
+          throw cms::Exception("InvalidInput")
+              << "invalid value for parameter \"ptMax\" (must be greater than zero): " << ptMax;
+        }
+
+        if (ptMin >= ptMax) {
+          throw cms::Exception("InvalidInput") << "inconsistent values for parameters \"ptMin\" and \"ptMax\" (the "
+                                                  "latter must be greater than the former): ptMin="
+                                               << ptMin << " ptMax=" << ptMax;
+        }
+
+        if (etaMin >= etaMax) {
+          throw cms::Exception("InvalidInput") << "inconsistent values for parameters \"etaMin\" and \"etaMax\" (the "
+                                                  "latter must be greater than the former): etaMin="
+                                               << etaMin << " etaMax=" << etaMax;
+        }
+
+        if (puProxyMin > 0 and puProxyMax > 0 and puProxyMin >= puProxyMax) {
+          throw cms::Exception("InvalidInput")
+              << "inconsistent values for parameters \"puProxyMin\" and \"puProxyMax\" (if both are greater than zero, "
+                 "the latter must be greater than the former): puProxyMin="
+              << puProxyMin << " puProxyMax=" << puProxyMax;
+        }
+
+        if (formNParams <= 0) {
+          throw cms::Exception("InvalidInput")
+              << "invalid value for parameter \"formNParams\" (must be greater than zero): " << formNParams;
+        }
+
+        reco::FormulaEvaluator formEval{formEvalStr};
+
+        std::vector<double> formParams(formNParams);
+        for (auto idx = 0; idx < formNParams; ++idx) {
+          if (!(iss >> formParams[idx])) {
+            throw cms::Exception("InvalidInput")
+                << "failed to read line from input file (invalid format, formula parameter #" << idx << "): \"" << line
+                << "\"";
+          }
+        }
+
+        data_.emplace_back(
+            ptMin, ptMax, etaMin, etaMax, puProxyMin, puProxyMax, std::move(formEval), std::move(formParams));
+      }
+    }
+
+    double correction(float const pt, float const eta, int const puProxy) const {
+      for (auto const& entry : data_) {
+        if (eta >= entry.etaMin and eta < entry.etaMax and (entry.puProxyMin < 0 or puProxy >= entry.puProxyMin) and
+            (entry.puProxyMax < 0 or puProxy < entry.puProxyMax)) {
+          std::vector<double> vars{std::clamp(pt, entry.ptMin, entry.ptMax)};
+          return (entry.formulaEvaluator.evaluate(vars, entry.formulaParameters) / vars[0]);
+        }
+      }
+      return 0;
+    }
+
+  private:
+    struct Entry {
+      float ptMin;
+      float ptMax;
+      float etaMin;
+      float etaMax;
+      int puProxyMin;
+      int puProxyMax;
+      reco::FormulaEvaluator formulaEvaluator;
+      std::vector<double> formulaParameters;
+    };
+
+    std::vector<Entry> data_;
+  };
+
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // Number of BXs per orbit
@@ -35,6 +145,14 @@ private:
   double const ptMin_;
   int const towerMinHwEt_;
   int const towerMaxHwEt_;
+
+  bool const applyJECs_;
+  JetCorrector const jetCorrector_;
+  int const jecPUProxyTowerMinHwEt_;
+  int const jecPUProxyTowerMaxHwEt_;
+  int const jecPUProxyTowerMinAbsHwEta_;
+  int const jecPUProxyTowerMaxAbsHwEta_;
+
   int const mantissaPrecision_;
 };
 
@@ -44,6 +162,13 @@ L1ScoutingCaloJetProducer::L1ScoutingCaloJetProducer(const edm::ParameterSet& iP
       ptMin_(iPSet.getParameter<double>("ptMin")),
       towerMinHwEt_(iPSet.getParameter<int>("towerMinHwEt")),
       towerMaxHwEt_(iPSet.getParameter<int>("towerMaxHwEt")),
+      applyJECs_(iPSet.getParameter<bool>("applyJECs")),
+      jetCorrector_(applyJECs_ ? JetCorrector(iPSet.getParameter<edm::FileInPath>("jecFile").fullPath())
+                               : JetCorrector{}),
+      jecPUProxyTowerMinHwEt_(iPSet.getParameter<int>("jecPUProxyTowerMinHwEt")),
+      jecPUProxyTowerMaxHwEt_(iPSet.getParameter<int>("jecPUProxyTowerMaxHwEt")),
+      jecPUProxyTowerMinAbsHwEta_(iPSet.getParameter<int>("jecPUProxyTowerMinAbsHwEta")),
+      jecPUProxyTowerMaxAbsHwEta_(iPSet.getParameter<int>("jecPUProxyTowerMaxAbsHwEta")),
       mantissaPrecision_(iPSet.getParameter<int>("mantissaPrecision")) {
   produces<l1ScoutingRun3::CaloJetOrbitCollection>("CaloJet").setBranchAlias("CaloJetOrbitCollection");
 }
@@ -66,6 +191,7 @@ void L1ScoutingCaloJetProducer::produce(edm::StreamID, edm::Event& iEvent, const
   for (auto const bx : caloTowerCollection.getFilledBxs()) {
     LogTrace("L1ScoutingCaloJetProducer")
         << "[L1ScoutingCaloJetProducer:" << moduleDescription().moduleLabel() << "] BX = " << bx;
+
     LogTrace("L1ScoutingCaloJetProducer") << "[L1ScoutingCaloJetProducer:" << moduleDescription().moduleLabel()
                                           << "]   Inputs (l1ScoutingRun3::CaloTower and fastjet::PseudoJet)";
 
@@ -105,31 +231,82 @@ void L1ScoutingCaloJetProducer::produce(edm::StreamID, edm::Event& iEvent, const
           << " pz=" << pjCTs.back().pz() << " E=" << pjCTs.back().E() << ")";
     }
 
+    // if JECs are applied, compute a per-BX PU proxy used as input to the evaluation of the JECs
+    // (the PU proxy corresponds to the number of CaloTowers passing predefined cuts on hwEt and |hwEta|)
+    int puProxy{0};
+    if (applyJECs_) {
+      for (auto const& ct : cts) {
+        if (not((jecPUProxyTowerMinHwEt_ < 0 or ct.hwEt() >= jecPUProxyTowerMinHwEt_) and
+                (jecPUProxyTowerMaxHwEt_ < 0 or ct.hwEt() <= jecPUProxyTowerMaxHwEt_))) {
+          continue;
+        }
+
+        auto const absHwEta{std::abs(ct.hwEta())};
+        if (not((jecPUProxyTowerMinAbsHwEta_ < 0 or absHwEta >= jecPUProxyTowerMinAbsHwEta_) and
+                (jecPUProxyTowerMaxAbsHwEta_ < 0 or absHwEta <= jecPUProxyTowerMaxAbsHwEta_))) {
+          continue;
+        }
+
+        ++puProxy;
+      }
+
+      LogTrace("L1ScoutingCaloJetProducer") << "[L1ScoutingCaloJetProducer:" << moduleDescription().moduleLabel()
+                                            << "]   PU proxy for JECs (CaloTower multiplicity): " << puProxy;
+    }
+
+    LogTrace("L1ScoutingCaloJetProducer") << "[L1ScoutingCaloJetProducer:" << moduleDescription().moduleLabel()
+                                          << "]   Running jet clustering and applying JECs";
+
     // run the jet clustering with the given jet definition
     fastjet::ClusterSequence clustSeq(pjCTs, jetDef);
 
     // get the resulting jets ordered in pt
-    std::vector<fastjet::PseudoJet> incJets = clustSeq.inclusive_jets(ptMin_);
-
-    LogTrace("L1ScoutingCaloJetProducer") << "[L1ScoutingCaloJetProducer:" << moduleDescription().moduleLabel()
-                                          << "]   Outputs (l1ScoutingRun3::CaloJet)";
+    std::vector<fastjet::PseudoJet> incJets = clustSeq.inclusive_jets();
 
     // fill l1ScoutingRun3::CaloJet objects buffer
     auto& bufferThisBX = caloJetBuffer[bx];
     bufferThisBX.reserve(incJets.size());
-    for (auto const& incJet : incJets) {
+
+    for (auto idx = 0u; idx < incJets.size(); ++idx) {
+      auto const& incJet = incJets[idx];
       int const nConst = incJet.has_constituents() ? incJet.constituents().size() : 0;
-      float const energyCorr = 1.f;  // default value (1), until the option of applying JECs is added
-      bufferThisBX.emplace_back(MiniFloatConverter::reduceMantissaToNbitsRounding(incJet.pt(), mantissaPrecision_),
+      double const energyCorr{applyJECs_ ? jetCorrector_.correction(incJet.pt(), incJet.eta(), puProxy) : 1};
+
+      LogTrace("L1ScoutingCaloJetProducer")
+          << "[L1ScoutingCaloJetProducer:" << moduleDescription().moduleLabel() << "]     [" << idx
+          << "] pt=" << incJet.pt() << " eta=" << incJet.eta() << " phi=" << incJet.phi_std() << " mass=" << incJet.m()
+          << " energyCorr=" << energyCorr << " nConst=" << nConst << " (before JECs and pT cut)";
+
+      if (energyCorr <= 0) {
+        continue;
+      }
+
+      float const jet_pt = incJet.pt() * energyCorr;
+
+      if (jet_pt < ptMin_) {
+        continue;
+      }
+
+      float const jet_mass = incJet.m() * energyCorr;
+
+      LogTrace("L1ScoutingCaloJetProducer")
+          << "[L1ScoutingCaloJetProducer:" << moduleDescription().moduleLabel() << "]     [" << idx << "] pt=" << jet_pt
+          << " eta=" << incJet.eta() << " phi=" << incJet.phi_std() << " mass=" << jet_mass
+          << " energyCorr=" << energyCorr << " nConst=" << nConst << " (after JECs and pT cut)";
+
+      bufferThisBX.emplace_back(MiniFloatConverter::reduceMantissaToNbitsRounding(jet_pt, mantissaPrecision_),
                                 MiniFloatConverter::reduceMantissaToNbitsRounding(incJet.eta(), mantissaPrecision_),
                                 MiniFloatConverter::reduceMantissaToNbitsRounding(incJet.phi_std(), mantissaPrecision_),
-                                MiniFloatConverter::reduceMantissaToNbitsRounding(incJet.m(), mantissaPrecision_),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(jet_mass, mantissaPrecision_),
                                 MiniFloatConverter::reduceMantissaToNbitsRounding(energyCorr, mantissaPrecision_),
                                 nConst);
       ++nCaloJet;
     }
 
     std::sort(bufferThisBX.begin(), bufferThisBX.end(), [](auto const& a, auto const& b) { return a.pt() > b.pt(); });
+
+    LogTrace("L1ScoutingCaloJetProducer") << "[L1ScoutingCaloJetProducer:" << moduleDescription().moduleLabel()
+                                          << "]   Final outputs (l1ScoutingRun3::CaloJet)";
 
 #ifdef EDM_ML_DEBUG
     for (auto idx = 0u; idx < bufferThisBX.size(); ++idx) {
@@ -144,19 +321,46 @@ void L1ScoutingCaloJetProducer::produce(edm::StreamID, edm::Event& iEvent, const
 
   // fill orbit collection with reconstructed jets
   caloJetCollection->fillAndClear(caloJetBuffer, nCaloJet);
+
   iEvent.put(std::move(caloJetCollection), "CaloJet");
 }
 
 void L1ScoutingCaloJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("src");
-  desc.add<double>("akR");
-  desc.add<double>("ptMin");
+
+  desc.add<edm::InputTag>("src")->setComment(
+      "Input collection of CaloTowers (type: l1ScoutingRun3::CaloTowerOrbitCollection)");
+  desc.add<double>("akR")->setComment("Value of R parameter for anti-kt clustering");
+  desc.add<double>("ptMin")->setComment(
+      "Minimum pT of output jets (applies to the corrected jet-pT if applyJECs==True)");
   desc.add<int>("towerMinHwEt", 1)
       ->setComment("Min hwEt (inclusive) of CaloTowers used for jet clustering (ignored if negative)");
   desc.add<int>("towerMaxHwEt", -1)
       ->setComment("Max hwEt (inclusive) of CaloTowers used for jet clustering (ignored if negative)");
+
+  desc.add<bool>("applyJECs", false)
+      ->setComment("Apply jet-energy-scale corrections (and output corrected jets, ordered by their corrected pT)");
+  desc.add<edm::FileInPath>("jecFile")->setComment(
+      "Path to text file containing jet-energy-scale corrections (used only if applyJECs==True)");
+  desc.add<int>("jecPUProxyTowerMinHwEt", 1)
+      ->setComment(
+          "Min CaloTower hwEt (inclusive) used when computing the CaloTower multiplicity taken as PU proxy to evaluate "
+          "JECs (used only if applyJECs==True, and ignored if negative)");
+  desc.add<int>("jecPUProxyTowerMaxHwEt", -1)
+      ->setComment(
+          "Max CaloTower hwEt (inclusive) used when computing the CaloTower multiplicity taken as PU proxy to evaluate "
+          "JECs (used only if applyJECs==True, and ignored if negative)");
+  desc.add<int>("jecPUProxyTowerMinAbsHwEta", 0)
+      ->setComment(
+          "Min CaloTower |hwEta| (inclusive) used when computing the CaloTower multiplicity taken as PU proxy to "
+          "evaluate JECs (used only if applyJECs==True, and ignored if negative)");
+  desc.add<int>("jecPUProxyTowerMaxAbsHwEta", 4)
+      ->setComment(
+          "Max CaloTower |hwEta| (inclusive) used when computing the CaloTower multiplicity taken as PU proxy to "
+          "evaluate JECs (used only if applyJECs==True, and ignored if negative)");
+
   desc.add<int>("mantissaPrecision", 10)->setComment("default float16, change to 23 for float32");
+
   descriptions.addDefault(desc);
 }
 

--- a/L1TriggerScouting/Utilities/plugins/SimpleOrbitFlatTableProducer.cc
+++ b/L1TriggerScouting/Utilities/plugins/SimpleOrbitFlatTableProducer.cc
@@ -300,6 +300,9 @@ typedef SimpleOrbitFlatTableProducer<l1ScoutingRun3::BMTFStub> SimpleL1ScoutingB
 #include "DataFormats/L1Scouting/interface/L1ScoutingCaloTower.h"
 typedef SimpleOrbitFlatTableProducer<l1ScoutingRun3::CaloTower> SimpleL1ScoutingCaloTowerOrbitFlatTableProducer;
 
+#include "DataFormats/L1Scouting/interface/L1ScoutingCaloJet.h"
+typedef SimpleOrbitFlatTableProducer<l1ScoutingRun3::CaloJet> SimpleL1ScoutingCaloJetOrbitFlatTableProducer;
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleL1ScoutingMuonOrbitFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleL1ScoutingEGammaOrbitFlatTableProducer);
@@ -307,3 +310,4 @@ DEFINE_FWK_MODULE(SimpleL1ScoutingTauOrbitFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleL1ScoutingJetOrbitFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleL1ScoutingBMTFStubOrbitFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleL1ScoutingCaloTowerOrbitFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleL1ScoutingCaloJetOrbitFlatTableProducer);


### PR DESCRIPTION
backport of #50785

_Edit_ (Apr-24): the `cmsdist` update related to item (a) below is in https://github.com/cms-sw/cmsdist/pull/10505.

#### PR description:

From the description of #50785:

>This PR includes a few updates (mostly, additions) related to L1-Scouting "CaloJets" (see #48093 and #50304).
> - (a) Updated the plugin `L1ScoutingCaloJetProducer`, adding the possibility to apply jet-energy-scale corrections. This update comes with the addition of one file in `cms-data` (a text file that encodes the energy-scale corrections for L1-Scouting "CaloJets"): [cms-data/L1TriggerScouting-OnlineProcessing#1](https://github.com/cms-data/L1TriggerScouting-OnlineProcessing/pull/1).
> - (b) Added the plugin `CaloJetBxSelector`, which produces the list of BCIDs in an orbit that pass a selection based on L1-Scouting "CaloJets" (this is the counterpart of `JetBxSelector` for `l1ScoutingRun3::CaloJet`).
> - (c) Added an instantiation of `SimpleOrbitFlatTableProducer<T>` for the type `l1ScoutingRun3::CaloJet`, in order to create a NanoAOD table from a product of type `l1ScoutingRun3::CaloJetOrbitCollection`.
>
>This PR does not affect any central workflows in CMSSW, so no changes in the outputs of the PR tests are expected.
> - The minimal goal is to include (the backport of) this PR in 16_0_X for offline work (e.g. to reproduce recent studies on these "CaloJets", see [this slide and links therein](https://indico.cern.ch/event/1574433/contributions/6951895/attachments/3243465/5786556/260323_L1ScoutingWS_Run3CaloTowers.pdf#page=13)).
> - Beyond this minimal goal, if the commissioning of CaloTowers in L1-Scouting is completed before the end of Run 3, having (a) and (b) in a 16_0_X release would give the option of using those updates in the L1-Scouting jobs running at P5.

#### PR validation:

None beyond the validation done for #50785.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#50785

For offline studies in the 2026 pp data-taking cycle, and maybe for L1-Scouting data-taking before the end of Run 3.
