### PR TITLE
[16_1_X] Support for a 6-bit slope in the CSC OTMB emulator and unpacker

### DIFF
--- a/CalibMuon/CSCCalibration/python/CSCCustomizeBendingAngle_cfi.py
+++ b/CalibMuon/CSCCalibration/python/CSCCustomizeBendingAngle_cfi.py
@@ -1,0 +1,14 @@
+def set_6bit_gemcsc_bending_LUTs(process):
+  process.CSCL1TPLookupTableEP.esDiffToSlopeME11bFiles = [
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1b_even_layer1.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1b_odd_layer1.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1b_even_layer2.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1b_odd_layer2.txt",
+  ]
+  process.CSCL1TPLookupTableEP.esDiffToSlopeME11aFiles = [
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1a_even_layer1.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1a_odd_layer1.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1a_even_layer2.txt",
+    "L1Trigger/CSCTriggerPrimitives/data/GEMCSC/BendingAngle/GEMCSC_SlopeAmendment_6bit_NoCOSI_ME1a_odd_layer2.txt",
+  ]
+  return process

--- a/CondFormats/CSCObjects/interface/CSCL1TPLookupTableME11ILT.h
+++ b/CondFormats/CSCObjects/interface/CSCL1TPLookupTableME11ILT.h
@@ -3,149 +3,80 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <vector>
+#include <string_view>
+#include <initializer_list>
+#include <utility>
+
+#define DECLARE_CSCL1TP_LUT(NAME)    \
+private:                             \
+  std::vector<unsigned> NAME##_;     \
+                                     \
+public:                              \
+  void set_##NAME(t_lut lut);        \
+  unsigned NAME(unsigned idx) const; \
+  unsigned NAME##_bit_width() const
+
+#define DEFINE_CSCL1TP_LUT(CLASS, NAME)                                \
+  void CLASS::set_##NAME(t_lut lut) { NAME##_ = std::move(lut); }      \
+  unsigned CLASS::NAME(unsigned idx) const { return NAME##_.at(idx); } \
+  unsigned CLASS::NAME##_bit_width() const { return CSCL1TPLookupTableUtils::get_lut_bit_width(NAME##_); }
+
+struct CSCL1TPLookupTableUtils {
+  using t_lut = std::vector<unsigned>;
+
+  static unsigned get_lut_bit_width(const t_lut& lut);
+  static unsigned get_common_lut_bit_width(std::initializer_list<unsigned> luts_bit_width,
+                                           std::string_view lut_group_name);
+};
 
 class CSCL1TPLookupTableME11ILT {
 public:
-  CSCL1TPLookupTableME11ILT();
+  using t_lut = CSCL1TPLookupTableUtils::t_lut;
 
-  ~CSCL1TPLookupTableME11ILT() {}
+  DECLARE_CSCL1TP_LUT(GEM_pad_CSC_es_ME11b_even);
+  DECLARE_CSCL1TP_LUT(GEM_pad_CSC_es_ME11a_even);
+  DECLARE_CSCL1TP_LUT(GEM_pad_CSC_es_ME11b_odd);
+  DECLARE_CSCL1TP_LUT(GEM_pad_CSC_es_ME11a_odd);
 
-  typedef std::vector<unsigned> t_lut;
+  DECLARE_CSCL1TP_LUT(GEM_roll_CSC_min_wg_ME11_even);
+  DECLARE_CSCL1TP_LUT(GEM_roll_CSC_max_wg_ME11_even);
+  DECLARE_CSCL1TP_LUT(GEM_roll_CSC_min_wg_ME11_odd);
+  DECLARE_CSCL1TP_LUT(GEM_roll_CSC_max_wg_ME11_odd);
 
-  // setters
-  void set_GEM_pad_CSC_es_ME11b_even(t_lut lut);
-  void set_GEM_pad_CSC_es_ME11a_even(t_lut lut);
-  void set_GEM_pad_CSC_es_ME11b_odd(t_lut lut);
-  void set_GEM_pad_CSC_es_ME11a_odd(t_lut lut);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_2to1_L1_ME11a_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_2to1_L1_ME11a_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_3to1_L1_ME11a_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_3to1_L1_ME11a_odd);
 
-  void set_GEM_roll_CSC_min_wg_ME11_even(t_lut lut);
-  void set_GEM_roll_CSC_max_wg_ME11_even(t_lut lut);
-  void set_GEM_roll_CSC_min_wg_ME11_odd(t_lut lut);
-  void set_GEM_roll_CSC_max_wg_ME11_odd(t_lut lut);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_2to1_L1_ME11b_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_2to1_L1_ME11b_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_3to1_L1_ME11b_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_3to1_L1_ME11b_odd);
 
-  // GEM-CSC trigger: slope correction
-  void set_CSC_slope_cosi_2to1_L1_ME11a_even(t_lut lut);
-  void set_CSC_slope_cosi_2to1_L1_ME11a_odd(t_lut lut);
-  void set_CSC_slope_cosi_3to1_L1_ME11a_even(t_lut lut);
-  void set_CSC_slope_cosi_3to1_L1_ME11a_odd(t_lut lut);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_corr_L1_ME11a_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_corr_L1_ME11b_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_corr_L1_ME11a_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_corr_L1_ME11b_odd);
 
-  void set_CSC_slope_cosi_2to1_L1_ME11b_even(t_lut lut);
-  void set_CSC_slope_cosi_2to1_L1_ME11b_odd(t_lut lut);
-  void set_CSC_slope_cosi_3to1_L1_ME11b_even(t_lut lut);
-  void set_CSC_slope_cosi_3to1_L1_ME11b_odd(t_lut lut);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L1_ME11a_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L1_ME11b_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L1_ME11a_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L1_ME11b_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L2_ME11a_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L2_ME11b_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L2_ME11a_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L2_ME11b_odd);
 
-  void set_CSC_slope_cosi_corr_L1_ME11a_even(t_lut lut);
-  void set_CSC_slope_cosi_corr_L1_ME11b_even(t_lut lut);
-  void set_CSC_slope_cosi_corr_L1_ME11a_odd(t_lut lut);
-  void set_CSC_slope_cosi_corr_L1_ME11b_odd(t_lut lut);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L1_ME11a_even);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L1_ME11a_odd);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L1_ME11b_even);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L1_ME11b_odd);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L2_ME11a_even);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L2_ME11a_odd);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L2_ME11b_even);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L2_ME11b_odd);
 
-  void set_CSC_slope_corr_L1_ME11a_even(t_lut lut);
-  void set_CSC_slope_corr_L1_ME11b_even(t_lut lut);
-  void set_CSC_slope_corr_L1_ME11a_odd(t_lut lut);
-  void set_CSC_slope_corr_L1_ME11b_odd(t_lut lut);
-  void set_CSC_slope_corr_L2_ME11a_even(t_lut lut);
-  void set_CSC_slope_corr_L2_ME11b_even(t_lut lut);
-  void set_CSC_slope_corr_L2_ME11a_odd(t_lut lut);
-  void set_CSC_slope_corr_L2_ME11b_odd(t_lut lut);
-
-  void set_es_diff_slope_L1_ME11a_even(t_lut lut);
-  void set_es_diff_slope_L1_ME11a_odd(t_lut lut);
-  void set_es_diff_slope_L1_ME11b_even(t_lut lut);
-  void set_es_diff_slope_L1_ME11b_odd(t_lut lut);
-  void set_es_diff_slope_L2_ME11a_even(t_lut lut);
-  void set_es_diff_slope_L2_ME11a_odd(t_lut lut);
-  void set_es_diff_slope_L2_ME11b_even(t_lut lut);
-  void set_es_diff_slope_L2_ME11b_odd(t_lut lut);
-
-  // getters
-  unsigned GEM_pad_CSC_es_ME11b_even(unsigned pad) const;
-  unsigned GEM_pad_CSC_es_ME11a_even(unsigned pad) const;
-  unsigned GEM_pad_CSC_es_ME11b_odd(unsigned pad) const;
-  unsigned GEM_pad_CSC_es_ME11a_odd(unsigned pad) const;
-
-  unsigned GEM_roll_CSC_min_wg_ME11_even(unsigned roll) const;
-  unsigned GEM_roll_CSC_max_wg_ME11_even(unsigned roll) const;
-  unsigned GEM_roll_CSC_min_wg_ME11_odd(unsigned roll) const;
-  unsigned GEM_roll_CSC_max_wg_ME11_odd(unsigned roll) const;
-
-  // GEM-CSC trigger: slope correction
-  unsigned CSC_slope_cosi_2to1_L1_ME11a_even(unsigned channel) const;
-  unsigned CSC_slope_cosi_2to1_L1_ME11a_odd(unsigned channel) const;
-  unsigned CSC_slope_cosi_3to1_L1_ME11a_even(unsigned channel) const;
-  unsigned CSC_slope_cosi_3to1_L1_ME11a_odd(unsigned channel) const;
-
-  unsigned CSC_slope_cosi_2to1_L1_ME11b_even(unsigned channel) const;
-  unsigned CSC_slope_cosi_2to1_L1_ME11b_odd(unsigned channel) const;
-  unsigned CSC_slope_cosi_3to1_L1_ME11b_even(unsigned channel) const;
-  unsigned CSC_slope_cosi_3to1_L1_ME11b_odd(unsigned channel) const;
-
-  unsigned CSC_slope_cosi_corr_L1_ME11a_even(unsigned channel) const;
-  unsigned CSC_slope_cosi_corr_L1_ME11b_even(unsigned channel) const;
-  unsigned CSC_slope_cosi_corr_L1_ME11a_odd(unsigned channel) const;
-  unsigned CSC_slope_cosi_corr_L1_ME11b_odd(unsigned channel) const;
-
-  unsigned CSC_slope_corr_L1_ME11a_even(unsigned channel) const;
-  unsigned CSC_slope_corr_L1_ME11b_even(unsigned channel) const;
-  unsigned CSC_slope_corr_L1_ME11a_odd(unsigned channel) const;
-  unsigned CSC_slope_corr_L1_ME11b_odd(unsigned channel) const;
-  unsigned CSC_slope_corr_L2_ME11a_even(unsigned channel) const;
-  unsigned CSC_slope_corr_L2_ME11b_even(unsigned channel) const;
-  unsigned CSC_slope_corr_L2_ME11a_odd(unsigned channel) const;
-  unsigned CSC_slope_corr_L2_ME11b_odd(unsigned channel) const;
-
-  // GEM-CSC trigger: 1/8-strip difference to slope
-  unsigned es_diff_slope_L1_ME11a_even(unsigned es_diff) const;
-  unsigned es_diff_slope_L1_ME11a_odd(unsigned es_diff) const;
-  unsigned es_diff_slope_L1_ME11b_even(unsigned es_diff) const;
-  unsigned es_diff_slope_L1_ME11b_odd(unsigned es_diff) const;
-  unsigned es_diff_slope_L2_ME11a_even(unsigned es_diff) const;
-  unsigned es_diff_slope_L2_ME11a_odd(unsigned es_diff) const;
-  unsigned es_diff_slope_L2_ME11b_even(unsigned es_diff) const;
-  unsigned es_diff_slope_L2_ME11b_odd(unsigned es_diff) const;
-
-private:
-  t_lut GEM_pad_CSC_es_ME11b_even_;
-  t_lut GEM_pad_CSC_es_ME11a_even_;
-  t_lut GEM_pad_CSC_es_ME11b_odd_;
-  t_lut GEM_pad_CSC_es_ME11a_odd_;
-
-  t_lut GEM_roll_CSC_min_wg_ME11_even_;
-  t_lut GEM_roll_CSC_max_wg_ME11_even_;
-  t_lut GEM_roll_CSC_min_wg_ME11_odd_;
-  t_lut GEM_roll_CSC_max_wg_ME11_odd_;
-
-  t_lut CSC_slope_cosi_2to1_L1_ME11a_even_;
-  t_lut CSC_slope_cosi_2to1_L1_ME11a_odd_;
-  t_lut CSC_slope_cosi_3to1_L1_ME11a_even_;
-  t_lut CSC_slope_cosi_3to1_L1_ME11a_odd_;
-
-  t_lut CSC_slope_cosi_2to1_L1_ME11b_even_;
-  t_lut CSC_slope_cosi_2to1_L1_ME11b_odd_;
-  t_lut CSC_slope_cosi_3to1_L1_ME11b_even_;
-  t_lut CSC_slope_cosi_3to1_L1_ME11b_odd_;
-
-  t_lut CSC_slope_cosi_corr_L1_ME11a_even_;
-  t_lut CSC_slope_cosi_corr_L1_ME11b_even_;
-  t_lut CSC_slope_cosi_corr_L1_ME11a_odd_;
-  t_lut CSC_slope_cosi_corr_L1_ME11b_odd_;
-
-  t_lut CSC_slope_corr_L1_ME11a_even_;
-  t_lut CSC_slope_corr_L1_ME11b_even_;
-  t_lut CSC_slope_corr_L1_ME11a_odd_;
-  t_lut CSC_slope_corr_L1_ME11b_odd_;
-  t_lut CSC_slope_corr_L2_ME11a_even_;
-  t_lut CSC_slope_corr_L2_ME11b_even_;
-  t_lut CSC_slope_corr_L2_ME11a_odd_;
-  t_lut CSC_slope_corr_L2_ME11b_odd_;
-
-  t_lut es_diff_slope_L1_ME11a_even_;
-  t_lut es_diff_slope_L1_ME11a_odd_;
-  t_lut es_diff_slope_L1_ME11b_even_;
-  t_lut es_diff_slope_L1_ME11b_odd_;
-  t_lut es_diff_slope_L2_ME11a_even_;
-  t_lut es_diff_slope_L2_ME11a_odd_;
-  t_lut es_diff_slope_L2_ME11b_even_;
-  t_lut es_diff_slope_L2_ME11b_odd_;
+  unsigned es_diff_slope_bit_width() const;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/CSCObjects/interface/CSCL1TPLookupTableME21ILT.h
+++ b/CondFormats/CSCObjects/interface/CSCL1TPLookupTableME21ILT.h
@@ -1,113 +1,38 @@
 #ifndef CondFormats_CSCObjects_CSCL1TPLookupTableME21ILT_h
 #define CondFormats_CSCObjects_CSCL1TPLookupTableME21ILT_h
 
-#include "CondFormats/Serialization/interface/Serializable.h"
-#include <vector>
+#include "CSCL1TPLookupTableME11ILT.h"
 
 class CSCL1TPLookupTableME21ILT {
 public:
-  CSCL1TPLookupTableME21ILT();
+  using t_lut = CSCL1TPLookupTableUtils::t_lut;
 
-  ~CSCL1TPLookupTableME21ILT() {}
+  DECLARE_CSCL1TP_LUT(GEM_pad_CSC_es_ME21_even);
+  DECLARE_CSCL1TP_LUT(GEM_pad_CSC_es_ME21_odd);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L1_CSC_min_wg_ME21_even);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L1_CSC_max_wg_ME21_even);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L1_CSC_min_wg_ME21_odd);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L1_CSC_max_wg_ME21_odd);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L2_CSC_min_wg_ME21_even);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L2_CSC_max_wg_ME21_even);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L2_CSC_min_wg_ME21_odd);
+  DECLARE_CSCL1TP_LUT(GEM_roll_L2_CSC_max_wg_ME21_odd);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L1_ME21_even);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L1_ME21_odd);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L2_ME21_even);
+  DECLARE_CSCL1TP_LUT(es_diff_slope_L2_ME21_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_2to1_L1_ME21_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_2to1_L1_ME21_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_3to1_L1_ME21_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_3to1_L1_ME21_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_corr_L1_ME21_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_cosi_corr_L1_ME21_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L1_ME21_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L1_ME21_odd);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L2_ME21_even);
+  DECLARE_CSCL1TP_LUT(CSC_slope_corr_L2_ME21_odd);
 
-  typedef std::vector<unsigned> t_lut;
-
-  // setters
-  void set_GEM_pad_CSC_es_ME21_even(t_lut lut);
-  void set_GEM_pad_CSC_es_ME21_odd(t_lut lut);
-
-  void set_GEM_roll_L1_CSC_min_wg_ME21_even(t_lut lut);
-  void set_GEM_roll_L1_CSC_max_wg_ME21_even(t_lut lut);
-  void set_GEM_roll_L1_CSC_min_wg_ME21_odd(t_lut lut);
-  void set_GEM_roll_L1_CSC_max_wg_ME21_odd(t_lut lut);
-
-  void set_GEM_roll_L2_CSC_min_wg_ME21_even(t_lut lut);
-  void set_GEM_roll_L2_CSC_max_wg_ME21_even(t_lut lut);
-  void set_GEM_roll_L2_CSC_min_wg_ME21_odd(t_lut lut);
-  void set_GEM_roll_L2_CSC_max_wg_ME21_odd(t_lut lut);
-
-  void set_es_diff_slope_L1_ME21_even(t_lut lut);
-  void set_es_diff_slope_L1_ME21_odd(t_lut lut);
-  void set_es_diff_slope_L2_ME21_even(t_lut lut);
-  void set_es_diff_slope_L2_ME21_odd(t_lut lut);
-
-  void set_CSC_slope_cosi_2to1_L1_ME21_even(t_lut lut);
-  void set_CSC_slope_cosi_2to1_L1_ME21_odd(t_lut lut);
-  void set_CSC_slope_cosi_3to1_L1_ME21_even(t_lut lut);
-  void set_CSC_slope_cosi_3to1_L1_ME21_odd(t_lut lut);
-
-  void set_CSC_slope_cosi_corr_L1_ME21_even(t_lut lut);
-  void set_CSC_slope_cosi_corr_L1_ME21_odd(t_lut lut);
-
-  void set_CSC_slope_corr_L1_ME21_even(t_lut lut);
-  void set_CSC_slope_corr_L1_ME21_odd(t_lut lut);
-  void set_CSC_slope_corr_L2_ME21_even(t_lut lut);
-  void set_CSC_slope_corr_L2_ME21_odd(t_lut lut);
-
-  // getters
-  unsigned GEM_pad_CSC_es_ME21_even(unsigned pad) const;
-  unsigned GEM_pad_CSC_es_ME21_odd(unsigned pad) const;
-
-  unsigned GEM_roll_L1_CSC_min_wg_ME21_even(unsigned roll) const;
-  unsigned GEM_roll_L1_CSC_max_wg_ME21_even(unsigned roll) const;
-  unsigned GEM_roll_L1_CSC_min_wg_ME21_odd(unsigned roll) const;
-  unsigned GEM_roll_L1_CSC_max_wg_ME21_odd(unsigned roll) const;
-
-  unsigned GEM_roll_L2_CSC_min_wg_ME21_even(unsigned roll) const;
-  unsigned GEM_roll_L2_CSC_max_wg_ME21_even(unsigned roll) const;
-  unsigned GEM_roll_L2_CSC_min_wg_ME21_odd(unsigned roll) const;
-  unsigned GEM_roll_L2_CSC_max_wg_ME21_odd(unsigned roll) const;
-
-  unsigned CSC_slope_cosi_2to1_L1_ME21_even(unsigned slope) const;
-  unsigned CSC_slope_cosi_2to1_L1_ME21_odd(unsigned slope) const;
-  unsigned CSC_slope_cosi_3to1_L1_ME21_even(unsigned slope) const;
-  unsigned CSC_slope_cosi_3to1_L1_ME21_odd(unsigned slope) const;
-
-  unsigned CSC_slope_cosi_corr_L1_ME21_even(unsigned slope) const;
-  unsigned CSC_slope_cosi_corr_L1_ME21_odd(unsigned slope) const;
-
-  unsigned CSC_slope_corr_L1_ME21_even(unsigned slope) const;
-  unsigned CSC_slope_corr_L1_ME21_odd(unsigned slope) const;
-  unsigned CSC_slope_corr_L2_ME21_even(unsigned slope) const;
-  unsigned CSC_slope_corr_L2_ME21_odd(unsigned slope) const;
-
-  // GEM-CSC trigger: 1/8-strip difference to slope
-  unsigned es_diff_slope_L1_ME21_even(unsigned es_diff) const;
-  unsigned es_diff_slope_L1_ME21_odd(unsigned es_diff) const;
-  unsigned es_diff_slope_L2_ME21_even(unsigned es_diff) const;
-  unsigned es_diff_slope_L2_ME21_odd(unsigned es_diff) const;
-
-private:
-  std::vector<unsigned> GEM_pad_CSC_es_ME21_even_;
-  std::vector<unsigned> GEM_pad_CSC_es_ME21_odd_;
-
-  std::vector<unsigned> GEM_roll_L1_CSC_min_wg_ME21_even_;
-  std::vector<unsigned> GEM_roll_L1_CSC_max_wg_ME21_even_;
-  std::vector<unsigned> GEM_roll_L1_CSC_min_wg_ME21_odd_;
-  std::vector<unsigned> GEM_roll_L1_CSC_max_wg_ME21_odd_;
-
-  std::vector<unsigned> GEM_roll_L2_CSC_min_wg_ME21_even_;
-  std::vector<unsigned> GEM_roll_L2_CSC_max_wg_ME21_even_;
-  std::vector<unsigned> GEM_roll_L2_CSC_min_wg_ME21_odd_;
-  std::vector<unsigned> GEM_roll_L2_CSC_max_wg_ME21_odd_;
-
-  std::vector<unsigned> CSC_slope_cosi_2to1_L1_ME21_even_;
-  std::vector<unsigned> CSC_slope_cosi_2to1_L1_ME21_odd_;
-  std::vector<unsigned> CSC_slope_cosi_3to1_L1_ME21_even_;
-  std::vector<unsigned> CSC_slope_cosi_3to1_L1_ME21_odd_;
-
-  std::vector<unsigned> CSC_slope_cosi_corr_L1_ME21_even_;
-  std::vector<unsigned> CSC_slope_cosi_corr_L1_ME21_odd_;
-
-  std::vector<unsigned> CSC_slope_corr_L1_ME21_even_;
-  std::vector<unsigned> CSC_slope_corr_L1_ME21_odd_;
-  std::vector<unsigned> CSC_slope_corr_L2_ME21_even_;
-  std::vector<unsigned> CSC_slope_corr_L2_ME21_odd_;
-
-  std::vector<unsigned> es_diff_slope_L1_ME21_even_;
-  std::vector<unsigned> es_diff_slope_L1_ME21_odd_;
-  std::vector<unsigned> es_diff_slope_L2_ME21_even_;
-  std::vector<unsigned> es_diff_slope_L2_ME21_odd_;
+  unsigned es_diff_slope_bit_width() const;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/CSCObjects/src/CSCL1TPLookupTableME11ILT.cc
+++ b/CondFormats/CSCObjects/src/CSCL1TPLookupTableME11ILT.cc
@@ -1,333 +1,79 @@
 #include "CondFormats/CSCObjects/interface/CSCL1TPLookupTableME11ILT.h"
-
-CSCL1TPLookupTableME11ILT::CSCL1TPLookupTableME11ILT()
-    : GEM_pad_CSC_es_ME11b_even_(0),
-      GEM_pad_CSC_es_ME11a_even_(0),
-      GEM_pad_CSC_es_ME11b_odd_(0),
-      GEM_pad_CSC_es_ME11a_odd_(0),
-
-      GEM_roll_CSC_min_wg_ME11_even_(0),
-      GEM_roll_CSC_max_wg_ME11_even_(0),
-      GEM_roll_CSC_min_wg_ME11_odd_(0),
-      GEM_roll_CSC_max_wg_ME11_odd_(0),
-
-      CSC_slope_cosi_2to1_L1_ME11a_even_(0),
-      CSC_slope_cosi_2to1_L1_ME11a_odd_(0),
-      CSC_slope_cosi_3to1_L1_ME11a_even_(0),
-      CSC_slope_cosi_3to1_L1_ME11a_odd_(0),
-
-      CSC_slope_cosi_2to1_L1_ME11b_even_(0),
-      CSC_slope_cosi_2to1_L1_ME11b_odd_(0),
-      CSC_slope_cosi_3to1_L1_ME11b_even_(0),
-      CSC_slope_cosi_3to1_L1_ME11b_odd_(0),
-
-      CSC_slope_cosi_corr_L1_ME11a_even_(0),
-      CSC_slope_cosi_corr_L1_ME11b_even_(0),
-      CSC_slope_cosi_corr_L1_ME11a_odd_(0),
-      CSC_slope_cosi_corr_L1_ME11b_odd_(0),
-
-      CSC_slope_corr_L1_ME11a_even_(0),
-      CSC_slope_corr_L1_ME11b_even_(0),
-      CSC_slope_corr_L1_ME11a_odd_(0),
-      CSC_slope_corr_L1_ME11b_odd_(0),
-      CSC_slope_corr_L2_ME11a_even_(0),
-      CSC_slope_corr_L2_ME11b_even_(0),
-      CSC_slope_corr_L2_ME11a_odd_(0),
-      CSC_slope_corr_L2_ME11b_odd_(0),
-
-      es_diff_slope_L1_ME11a_even_(0),
-      es_diff_slope_L1_ME11a_odd_(0),
-      es_diff_slope_L1_ME11b_even_(0),
-      es_diff_slope_L1_ME11b_odd_(0),
-      es_diff_slope_L2_ME11a_even_(0),
-      es_diff_slope_L2_ME11a_odd_(0),
-      es_diff_slope_L2_ME11b_even_(0),
-      es_diff_slope_L2_ME11b_odd_(0) {}
-
-// GEM-CSC trigger: coordinate conversion
-void CSCL1TPLookupTableME11ILT::set_GEM_pad_CSC_es_ME11b_even(t_lut lut) {
-  GEM_pad_CSC_es_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_GEM_pad_CSC_es_ME11a_even(t_lut lut) {
-  GEM_pad_CSC_es_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_GEM_pad_CSC_es_ME11b_odd(t_lut lut) { GEM_pad_CSC_es_ME11b_odd_ = std::move(lut); }
-
-void CSCL1TPLookupTableME11ILT::set_GEM_pad_CSC_es_ME11a_odd(t_lut lut) { GEM_pad_CSC_es_ME11a_odd_ = std::move(lut); }
-
-void CSCL1TPLookupTableME11ILT::set_GEM_roll_CSC_min_wg_ME11_even(t_lut lut) {
-  GEM_roll_CSC_min_wg_ME11_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_GEM_roll_CSC_max_wg_ME11_even(t_lut lut) {
-  GEM_roll_CSC_max_wg_ME11_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_GEM_roll_CSC_min_wg_ME11_odd(t_lut lut) {
-  GEM_roll_CSC_min_wg_ME11_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_GEM_roll_CSC_max_wg_ME11_odd(t_lut lut) {
-  GEM_roll_CSC_max_wg_ME11_odd_ = std::move(lut);
-}
-
-// GEM-CSC trigger: slope correction
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_2to1_L1_ME11a_even(t_lut lut) {
-  CSC_slope_cosi_2to1_L1_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_2to1_L1_ME11b_even(t_lut lut) {
-  CSC_slope_cosi_2to1_L1_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_2to1_L1_ME11a_odd(t_lut lut) {
-  CSC_slope_cosi_2to1_L1_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_2to1_L1_ME11b_odd(t_lut lut) {
-  CSC_slope_cosi_2to1_L1_ME11b_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_3to1_L1_ME11a_even(t_lut lut) {
-  CSC_slope_cosi_3to1_L1_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_3to1_L1_ME11b_even(t_lut lut) {
-  CSC_slope_cosi_3to1_L1_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_3to1_L1_ME11a_odd(t_lut lut) {
-  CSC_slope_cosi_3to1_L1_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_3to1_L1_ME11b_odd(t_lut lut) {
-  CSC_slope_cosi_3to1_L1_ME11b_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_corr_L1_ME11a_even(t_lut lut) {
-  CSC_slope_cosi_corr_L1_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_corr_L1_ME11b_even(t_lut lut) {
-  CSC_slope_cosi_corr_L1_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_corr_L1_ME11a_odd(t_lut lut) {
-  CSC_slope_cosi_corr_L1_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_cosi_corr_L1_ME11b_odd(t_lut lut) {
-  CSC_slope_cosi_corr_L1_ME11b_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L1_ME11a_even(t_lut lut) {
-  CSC_slope_corr_L1_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L1_ME11b_even(t_lut lut) {
-  CSC_slope_corr_L1_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L1_ME11a_odd(t_lut lut) {
-  CSC_slope_corr_L1_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L1_ME11b_odd(t_lut lut) {
-  CSC_slope_corr_L1_ME11b_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L1_ME11a_even(t_lut lut) {
-  es_diff_slope_L1_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L1_ME11a_odd(t_lut lut) {
-  es_diff_slope_L1_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L1_ME11b_even(t_lut lut) {
-  es_diff_slope_L1_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L1_ME11b_odd(t_lut lut) {
-  es_diff_slope_L1_ME11b_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L2_ME11a_even(t_lut lut) {
-  CSC_slope_corr_L2_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L2_ME11b_even(t_lut lut) {
-  CSC_slope_corr_L2_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L2_ME11a_odd(t_lut lut) {
-  CSC_slope_corr_L2_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_CSC_slope_corr_L2_ME11b_odd(t_lut lut) {
-  CSC_slope_corr_L2_ME11b_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L2_ME11a_even(t_lut lut) {
-  es_diff_slope_L2_ME11a_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L2_ME11a_odd(t_lut lut) {
-  es_diff_slope_L2_ME11a_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L2_ME11b_even(t_lut lut) {
-  es_diff_slope_L2_ME11b_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME11ILT::set_es_diff_slope_L2_ME11b_odd(t_lut lut) {
-  es_diff_slope_L2_ME11b_odd_ = std::move(lut);
-}
-
-// GEM-CSC trigger: coordinate conversion
-unsigned CSCL1TPLookupTableME11ILT::GEM_pad_CSC_es_ME11b_even(unsigned pad) const {
-  return GEM_pad_CSC_es_ME11b_even_.at(pad);
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_pad_CSC_es_ME11a_even(unsigned pad) const {
-  return GEM_pad_CSC_es_ME11a_even_.at(pad);
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_pad_CSC_es_ME11b_odd(unsigned pad) const {
-  return GEM_pad_CSC_es_ME11b_odd_.at(pad);
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_pad_CSC_es_ME11a_odd(unsigned pad) const {
-  return GEM_pad_CSC_es_ME11a_odd_.at(pad);
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_roll_CSC_min_wg_ME11_even(unsigned roll) const {
-  return GEM_roll_CSC_min_wg_ME11_even_[roll];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_roll_CSC_max_wg_ME11_even(unsigned roll) const {
-  return GEM_roll_CSC_max_wg_ME11_even_[roll];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_roll_CSC_min_wg_ME11_odd(unsigned roll) const {
-  return GEM_roll_CSC_min_wg_ME11_odd_[roll];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::GEM_roll_CSC_max_wg_ME11_odd(unsigned roll) const {
-  return GEM_roll_CSC_max_wg_ME11_odd_[roll];
-}
-
-// GEM-CSC trigger: slope correction
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_2to1_L1_ME11a_even(unsigned slope) const {
-  return CSC_slope_cosi_2to1_L1_ME11a_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_2to1_L1_ME11b_even(unsigned slope) const {
-  return CSC_slope_cosi_2to1_L1_ME11b_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_2to1_L1_ME11a_odd(unsigned slope) const {
-  return CSC_slope_cosi_2to1_L1_ME11a_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_2to1_L1_ME11b_odd(unsigned slope) const {
-  return CSC_slope_cosi_2to1_L1_ME11b_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_3to1_L1_ME11a_even(unsigned slope) const {
-  return CSC_slope_cosi_3to1_L1_ME11a_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_3to1_L1_ME11b_even(unsigned slope) const {
-  return CSC_slope_cosi_3to1_L1_ME11b_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_3to1_L1_ME11a_odd(unsigned slope) const {
-  return CSC_slope_cosi_3to1_L1_ME11a_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_3to1_L1_ME11b_odd(unsigned slope) const {
-  return CSC_slope_cosi_3to1_L1_ME11b_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_corr_L1_ME11a_even(unsigned slope) const {
-  return CSC_slope_cosi_corr_L1_ME11a_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_corr_L1_ME11b_even(unsigned slope) const {
-  return CSC_slope_cosi_corr_L1_ME11b_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_corr_L1_ME11a_odd(unsigned slope) const {
-  return CSC_slope_cosi_corr_L1_ME11a_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_cosi_corr_L1_ME11b_odd(unsigned slope) const {
-  return CSC_slope_cosi_corr_L1_ME11b_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L1_ME11a_even(unsigned slope) const {
-  return CSC_slope_corr_L1_ME11a_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L1_ME11b_even(unsigned slope) const {
-  return CSC_slope_corr_L1_ME11b_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L1_ME11a_odd(unsigned slope) const {
-  return CSC_slope_corr_L1_ME11a_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L1_ME11b_odd(unsigned slope) const {
-  return CSC_slope_corr_L1_ME11b_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L1_ME11a_even(unsigned es_diff) const {
-  return es_diff_slope_L1_ME11a_even_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L1_ME11a_odd(unsigned es_diff) const {
-  return es_diff_slope_L1_ME11a_odd_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L1_ME11b_even(unsigned es_diff) const {
-  return es_diff_slope_L1_ME11b_even_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L1_ME11b_odd(unsigned es_diff) const {
-  return es_diff_slope_L1_ME11b_odd_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L2_ME11a_even(unsigned slope) const {
-  return CSC_slope_corr_L2_ME11a_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L2_ME11b_even(unsigned slope) const {
-  return CSC_slope_corr_L2_ME11b_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L2_ME11a_odd(unsigned slope) const {
-  return CSC_slope_corr_L2_ME11a_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::CSC_slope_corr_L2_ME11b_odd(unsigned slope) const {
-  return CSC_slope_corr_L2_ME11b_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L2_ME11a_even(unsigned es_diff) const {
-  return es_diff_slope_L2_ME11a_even_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L2_ME11a_odd(unsigned es_diff) const {
-  return es_diff_slope_L2_ME11a_odd_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L2_ME11b_even(unsigned es_diff) const {
-  return es_diff_slope_L2_ME11b_even_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_L2_ME11b_odd(unsigned es_diff) const {
-  return es_diff_slope_L2_ME11b_odd_[es_diff];
-}
+#include "FWCore/Utilities/interface/Exception.h"
+#include <algorithm>
+
+unsigned CSCL1TPLookupTableUtils::get_lut_bit_width(const std::vector<unsigned>& lut) {
+  const auto iter = std::max_element(lut.begin(), lut.end());
+  return iter == lut.end() || *iter == 0 ? 0 : std::bit_width(*iter);
+}
+
+unsigned CSCL1TPLookupTableUtils::get_common_lut_bit_width(std::initializer_list<unsigned> luts_bit_width,
+                                                           std::string_view lut_group_name) {
+  const auto min_max = std::minmax(luts_bit_width);
+  if (min_max.first != min_max.second)
+    throw cms::Exception("InvalidLookupTable")
+        << "Inconsistent bit widths among " << lut_group_name << " LUTs: " << min_max.first << " vs " << min_max.second;
+  return min_max.first;
+}
+
+#define DEFINE_LUT(NAME) DEFINE_CSCL1TP_LUT(CSCL1TPLookupTableME11ILT, NAME)
+
+DEFINE_LUT(GEM_pad_CSC_es_ME11b_even);
+DEFINE_LUT(GEM_pad_CSC_es_ME11a_even);
+DEFINE_LUT(GEM_pad_CSC_es_ME11b_odd);
+DEFINE_LUT(GEM_pad_CSC_es_ME11a_odd);
+
+DEFINE_LUT(GEM_roll_CSC_min_wg_ME11_even);
+DEFINE_LUT(GEM_roll_CSC_max_wg_ME11_even);
+DEFINE_LUT(GEM_roll_CSC_min_wg_ME11_odd);
+DEFINE_LUT(GEM_roll_CSC_max_wg_ME11_odd);
+
+DEFINE_LUT(CSC_slope_cosi_2to1_L1_ME11a_even);
+DEFINE_LUT(CSC_slope_cosi_2to1_L1_ME11a_odd);
+DEFINE_LUT(CSC_slope_cosi_3to1_L1_ME11a_even);
+DEFINE_LUT(CSC_slope_cosi_3to1_L1_ME11a_odd);
+
+DEFINE_LUT(CSC_slope_cosi_2to1_L1_ME11b_even);
+DEFINE_LUT(CSC_slope_cosi_2to1_L1_ME11b_odd);
+DEFINE_LUT(CSC_slope_cosi_3to1_L1_ME11b_even);
+DEFINE_LUT(CSC_slope_cosi_3to1_L1_ME11b_odd);
+
+DEFINE_LUT(CSC_slope_cosi_corr_L1_ME11a_even);
+DEFINE_LUT(CSC_slope_cosi_corr_L1_ME11b_even);
+DEFINE_LUT(CSC_slope_cosi_corr_L1_ME11a_odd);
+DEFINE_LUT(CSC_slope_cosi_corr_L1_ME11b_odd);
+
+DEFINE_LUT(CSC_slope_corr_L1_ME11a_even);
+DEFINE_LUT(CSC_slope_corr_L1_ME11b_even);
+DEFINE_LUT(CSC_slope_corr_L1_ME11a_odd);
+DEFINE_LUT(CSC_slope_corr_L1_ME11b_odd);
+DEFINE_LUT(CSC_slope_corr_L2_ME11a_even);
+DEFINE_LUT(CSC_slope_corr_L2_ME11b_even);
+DEFINE_LUT(CSC_slope_corr_L2_ME11a_odd);
+DEFINE_LUT(CSC_slope_corr_L2_ME11b_odd);
+
+DEFINE_LUT(es_diff_slope_L1_ME11a_even);
+DEFINE_LUT(es_diff_slope_L1_ME11a_odd);
+DEFINE_LUT(es_diff_slope_L1_ME11b_even);
+DEFINE_LUT(es_diff_slope_L1_ME11b_odd);
+DEFINE_LUT(es_diff_slope_L2_ME11a_even);
+DEFINE_LUT(es_diff_slope_L2_ME11a_odd);
+DEFINE_LUT(es_diff_slope_L2_ME11b_even);
+DEFINE_LUT(es_diff_slope_L2_ME11b_odd);
+
+unsigned CSCL1TPLookupTableME11ILT::es_diff_slope_bit_width() const {
+  return CSCL1TPLookupTableUtils::get_common_lut_bit_width(
+      {
+          es_diff_slope_L1_ME11a_even_bit_width(),
+          es_diff_slope_L1_ME11a_odd_bit_width(),
+          es_diff_slope_L1_ME11b_even_bit_width(),
+          es_diff_slope_L1_ME11b_odd_bit_width(),
+          es_diff_slope_L2_ME11a_even_bit_width(),
+          es_diff_slope_L2_ME11a_odd_bit_width(),
+          es_diff_slope_L2_ME11b_even_bit_width(),
+          es_diff_slope_L2_ME11b_odd_bit_width(),
+      },
+      "es_diff_slope");
+}
+
+#undef DEFINE_LUT

--- a/CondFormats/CSCObjects/src/CSCL1TPLookupTableME21ILT.cc
+++ b/CondFormats/CSCObjects/src/CSCL1TPLookupTableME21ILT.cc
@@ -1,221 +1,41 @@
 #include "CondFormats/CSCObjects/interface/CSCL1TPLookupTableME21ILT.h"
 
-CSCL1TPLookupTableME21ILT::CSCL1TPLookupTableME21ILT()
-    : GEM_pad_CSC_es_ME21_even_(0),
-      GEM_pad_CSC_es_ME21_odd_(0),
+#define DEFINE_LUT(NAME) DEFINE_CSCL1TP_LUT(CSCL1TPLookupTableME21ILT, NAME)
 
-      GEM_roll_L1_CSC_min_wg_ME21_even_(0),
-      GEM_roll_L1_CSC_max_wg_ME21_even_(0),
-      GEM_roll_L1_CSC_min_wg_ME21_odd_(0),
-      GEM_roll_L1_CSC_max_wg_ME21_odd_(0),
+DEFINE_LUT(GEM_pad_CSC_es_ME21_even);
+DEFINE_LUT(GEM_pad_CSC_es_ME21_odd);
+DEFINE_LUT(GEM_roll_L1_CSC_min_wg_ME21_even);
+DEFINE_LUT(GEM_roll_L1_CSC_max_wg_ME21_even);
+DEFINE_LUT(GEM_roll_L1_CSC_min_wg_ME21_odd);
+DEFINE_LUT(GEM_roll_L1_CSC_max_wg_ME21_odd);
+DEFINE_LUT(GEM_roll_L2_CSC_min_wg_ME21_even);
+DEFINE_LUT(GEM_roll_L2_CSC_max_wg_ME21_even);
+DEFINE_LUT(GEM_roll_L2_CSC_min_wg_ME21_odd);
+DEFINE_LUT(GEM_roll_L2_CSC_max_wg_ME21_odd);
+DEFINE_LUT(es_diff_slope_L1_ME21_even);
+DEFINE_LUT(es_diff_slope_L1_ME21_odd);
+DEFINE_LUT(es_diff_slope_L2_ME21_even);
+DEFINE_LUT(es_diff_slope_L2_ME21_odd);
+DEFINE_LUT(CSC_slope_cosi_2to1_L1_ME21_even);
+DEFINE_LUT(CSC_slope_cosi_2to1_L1_ME21_odd);
+DEFINE_LUT(CSC_slope_cosi_3to1_L1_ME21_even);
+DEFINE_LUT(CSC_slope_cosi_3to1_L1_ME21_odd);
+DEFINE_LUT(CSC_slope_cosi_corr_L1_ME21_even);
+DEFINE_LUT(CSC_slope_cosi_corr_L1_ME21_odd);
+DEFINE_LUT(CSC_slope_corr_L1_ME21_even);
+DEFINE_LUT(CSC_slope_corr_L1_ME21_odd);
+DEFINE_LUT(CSC_slope_corr_L2_ME21_even);
+DEFINE_LUT(CSC_slope_corr_L2_ME21_odd);
 
-      GEM_roll_L2_CSC_min_wg_ME21_even_(0),
-      GEM_roll_L2_CSC_max_wg_ME21_even_(0),
-      GEM_roll_L2_CSC_min_wg_ME21_odd_(0),
-      GEM_roll_L2_CSC_max_wg_ME21_odd_(0),
-
-      CSC_slope_cosi_2to1_L1_ME21_even_(0),
-      CSC_slope_cosi_2to1_L1_ME21_odd_(0),
-      CSC_slope_cosi_3to1_L1_ME21_even_(0),
-      CSC_slope_cosi_3to1_L1_ME21_odd_(0),
-
-      CSC_slope_cosi_corr_L1_ME21_even_(0),
-      CSC_slope_cosi_corr_L1_ME21_odd_(0),
-
-      CSC_slope_corr_L1_ME21_even_(0),
-      CSC_slope_corr_L1_ME21_odd_(0),
-      CSC_slope_corr_L2_ME21_even_(0),
-      CSC_slope_corr_L2_ME21_odd_(0),
-
-      es_diff_slope_L1_ME21_even_(0),
-      es_diff_slope_L1_ME21_odd_(0),
-      es_diff_slope_L2_ME21_even_(0),
-      es_diff_slope_L2_ME21_odd_(0) {}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_pad_CSC_es_ME21_even(t_lut lut) { GEM_pad_CSC_es_ME21_even_ = std::move(lut); }
-
-void CSCL1TPLookupTableME21ILT::set_GEM_pad_CSC_es_ME21_odd(t_lut lut) { GEM_pad_CSC_es_ME21_odd_ = std::move(lut); }
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L1_CSC_min_wg_ME21_even(t_lut lut) {
-  GEM_roll_L1_CSC_min_wg_ME21_even_ = std::move(lut);
+unsigned CSCL1TPLookupTableME21ILT::es_diff_slope_bit_width() const {
+  return CSCL1TPLookupTableUtils::get_common_lut_bit_width(
+      {
+          es_diff_slope_L1_ME21_even_bit_width(),
+          es_diff_slope_L1_ME21_odd_bit_width(),
+          es_diff_slope_L2_ME21_even_bit_width(),
+          es_diff_slope_L2_ME21_odd_bit_width(),
+      },
+      "es_diff_slope");
 }
 
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L1_CSC_max_wg_ME21_even(t_lut lut) {
-  GEM_roll_L1_CSC_max_wg_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L1_CSC_min_wg_ME21_odd(t_lut lut) {
-  GEM_roll_L1_CSC_min_wg_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L1_CSC_max_wg_ME21_odd(t_lut lut) {
-  GEM_roll_L1_CSC_max_wg_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L2_CSC_min_wg_ME21_even(t_lut lut) {
-  GEM_roll_L2_CSC_min_wg_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L2_CSC_max_wg_ME21_even(t_lut lut) {
-  GEM_roll_L2_CSC_max_wg_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L2_CSC_min_wg_ME21_odd(t_lut lut) {
-  GEM_roll_L2_CSC_min_wg_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_GEM_roll_L2_CSC_max_wg_ME21_odd(t_lut lut) {
-  GEM_roll_L2_CSC_max_wg_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_cosi_2to1_L1_ME21_even(t_lut lut) {
-  CSC_slope_cosi_2to1_L1_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_cosi_2to1_L1_ME21_odd(t_lut lut) {
-  CSC_slope_cosi_2to1_L1_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_cosi_3to1_L1_ME21_even(t_lut lut) {
-  CSC_slope_cosi_3to1_L1_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_cosi_3to1_L1_ME21_odd(t_lut lut) {
-  CSC_slope_cosi_3to1_L1_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_cosi_corr_L1_ME21_even(t_lut lut) {
-  CSC_slope_cosi_corr_L1_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_cosi_corr_L1_ME21_odd(t_lut lut) {
-  CSC_slope_cosi_corr_L1_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_corr_L1_ME21_even(t_lut lut) {
-  CSC_slope_corr_L1_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_corr_L1_ME21_odd(t_lut lut) {
-  CSC_slope_corr_L1_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_es_diff_slope_L1_ME21_even(t_lut lut) {
-  es_diff_slope_L1_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_es_diff_slope_L1_ME21_odd(t_lut lut) {
-  es_diff_slope_L1_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_corr_L2_ME21_even(t_lut lut) {
-  CSC_slope_corr_L2_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_CSC_slope_corr_L2_ME21_odd(t_lut lut) {
-  CSC_slope_corr_L2_ME21_odd_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_es_diff_slope_L2_ME21_even(t_lut lut) {
-  es_diff_slope_L2_ME21_even_ = std::move(lut);
-}
-
-void CSCL1TPLookupTableME21ILT::set_es_diff_slope_L2_ME21_odd(t_lut lut) {
-  es_diff_slope_L2_ME21_odd_ = std::move(lut);
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_pad_CSC_es_ME21_even(unsigned pad) const {
-  return GEM_pad_CSC_es_ME21_even_[pad];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_pad_CSC_es_ME21_odd(unsigned pad) const {
-  return GEM_pad_CSC_es_ME21_odd_[pad];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L1_CSC_min_wg_ME21_even(unsigned roll) const {
-  return GEM_roll_L1_CSC_min_wg_ME21_even_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L1_CSC_max_wg_ME21_even(unsigned roll) const {
-  return GEM_roll_L1_CSC_max_wg_ME21_even_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L1_CSC_min_wg_ME21_odd(unsigned roll) const {
-  return GEM_roll_L1_CSC_min_wg_ME21_odd_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L1_CSC_max_wg_ME21_odd(unsigned roll) const {
-  return GEM_roll_L1_CSC_max_wg_ME21_odd_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L2_CSC_min_wg_ME21_even(unsigned roll) const {
-  return GEM_roll_L2_CSC_min_wg_ME21_even_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L2_CSC_max_wg_ME21_even(unsigned roll) const {
-  return GEM_roll_L2_CSC_max_wg_ME21_even_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L2_CSC_min_wg_ME21_odd(unsigned roll) const {
-  return GEM_roll_L2_CSC_min_wg_ME21_odd_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::GEM_roll_L2_CSC_max_wg_ME21_odd(unsigned roll) const {
-  return GEM_roll_L2_CSC_max_wg_ME21_odd_[roll];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_cosi_2to1_L1_ME21_even(unsigned slope) const {
-  return CSC_slope_cosi_2to1_L1_ME21_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_cosi_2to1_L1_ME21_odd(unsigned slope) const {
-  return CSC_slope_cosi_2to1_L1_ME21_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_cosi_3to1_L1_ME21_even(unsigned slope) const {
-  return CSC_slope_cosi_3to1_L1_ME21_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_cosi_3to1_L1_ME21_odd(unsigned slope) const {
-  return CSC_slope_cosi_3to1_L1_ME21_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_cosi_corr_L1_ME21_even(unsigned slope) const {
-  return CSC_slope_cosi_corr_L1_ME21_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_cosi_corr_L1_ME21_odd(unsigned slope) const {
-  return CSC_slope_cosi_corr_L1_ME21_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_corr_L1_ME21_even(unsigned slope) const {
-  return CSC_slope_corr_L1_ME21_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_corr_L1_ME21_odd(unsigned slope) const {
-  return CSC_slope_corr_L1_ME21_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::es_diff_slope_L1_ME21_even(unsigned es_diff) const {
-  return es_diff_slope_L1_ME21_even_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::es_diff_slope_L1_ME21_odd(unsigned es_diff) const {
-  return es_diff_slope_L1_ME21_odd_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_corr_L2_ME21_even(unsigned slope) const {
-  return CSC_slope_corr_L2_ME21_even_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::CSC_slope_corr_L2_ME21_odd(unsigned slope) const {
-  return CSC_slope_corr_L2_ME21_odd_[slope];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::es_diff_slope_L2_ME21_even(unsigned es_diff) const {
-  return es_diff_slope_L2_ME21_even_[es_diff];
-}
-
-unsigned CSCL1TPLookupTableME21ILT::es_diff_slope_L2_ME21_odd(unsigned es_diff) const {
-  return es_diff_slope_L2_ME21_odd_[es_diff];
-}
+#undef DEFINE_LUT

--- a/DQM/CSCMonitorModule/data/emuDQMBooking.xml
+++ b/DQM/CSCMonitorModule/data/emuDQMBooking.xml
@@ -1297,6 +1297,27 @@
                 <Name>Event_Display_XY</Name>
 	</Histogram>
 
+	<Histogram>
+                <Prefix>EMU</Prefix>
+                <SetNdivisionsX>36</SetNdivisionsX>
+                <SetNdivisionsY>8</SetNdivisionsY>
+                <SetOption>textcolz</SetOption>
+                <SetOptStat>e</SetOptStat>
+		<SetYLabels>1='z- LCT1/GEMLy1'|2='z- LCT1/GEMLy0'|3='z- LCT0/GEMLy1'|4='z- LCT0/GEMLy0'|5='z+ LCT0/GEMLy0'|6='z+ LCT0/GEMLy1'|7='z+ LCT1/GEMLy0'|8='z+ LCT1/GEMLy1'|</SetYLabels>
+                <Title>ME11s Correlated LCTs GEM Layers</Title>
+                <Type>h2</Type>
+                <XBins>36</XBins>
+                <XMax>37</XMax>
+                <XMin>1</XMin>
+                <XTitle>ME11 chambers</XTitle>
+                <YBins>8</YBins>
+                <YMax>8</YMax>
+                <YMin>0</YMin>
+                <YTitle>LCT# / GEM Layer</YTitle>
+                <Name>ME11_Corr_LCT_Run3b_GEM_Layers</Name>
+        </Histogram>
+
+
         <!-- DDU Histograms -->
 
 	<Histogram>
@@ -3910,6 +3931,45 @@
                 <XTitle>Run3 5-bit CLCT Pattern ID</XTitle>
                 <YTitle>Number of events</YTitle>
                 <Name>Corr_LCT_Run3_PatternID</Name>
+        </Histogram>
+
+	<Histogram>
+		<Folder>TMB</Folder>
+		<Prefix>CSC</Prefix>
+		<SetLabelSizeX>0.025</SetLabelSizeX>
+		<SetMinimum>0</SetMinimum>
+		<SetNdivisionsX>64</SetNdivisionsX>
+                <SetOption>texthist</SetOption>
+		<SetOptStat>e</SetOptStat>
+		<Title>Run3b 6-bits LCT%d CLCT slope/bend distribution</Title>
+		<Type>h1</Type>
+		<XBins>64</XBins>
+		<XMax>64</XMax>
+		<XMin>0</XMin>
+                <XTitle>Run3b 6-bits LCT%d CLCT slope/bend</XTitle>
+                <YTitle>Number of events</YTitle>
+		<Name from="0" to="1">Corr_LCT%d_Run3b_Slope</Name>
+        </Histogram>
+
+
+        <Histogram>
+		<Folder>TMB</Folder>
+                <Prefix>CSC</Prefix>
+		<SetNdivisionsX>2</SetNdivisionsX>
+                <SetNdivisionsY>2</SetNdivisionsY>
+                <SetOption>textcolz</SetOption>
+		<SetOptStat>e</SetOptStat>
+		<Title>Correlated LCTs GEM Layers</Title>
+		<Type>h2</Type>
+		<XBins>2</XBins>
+		<XMax>2</XMax>
+		<XMin>0</XMin>
+		<XTitle>GEM Layer</XTitle>
+		<YBins>2</YBins>
+		<YMax>2</YMax>
+		<YMin>0</YMin>
+                <YTitle>LCT #</YTitle>
+		<Name>Corr_LCT_Run3b_GEM_Layers</Name>
         </Histogram>
 
         <Histogram>

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_EventProcessor_processCSC.cc
@@ -871,12 +871,18 @@ namespace cscdqm {
           bool isRun3_df = false;
           bool isGEM_df = false;
           bool isTMB_hybrid_df = false;
+          bool isOTMB_ME11_Run3b = false;
           if (tmbHeader->FirmwareVersion() == 2020) {
-            // revision code major part: 0x0 - Run3 df, 0x1 - is legacy Run2 df
+            // revision code major part: 0x0 - Run3 df, 0x1 - is legacy Run2 df, 0x2 - Run3b df
             if (((tmbHeader->FirmwareRevision() >> 5) & 0xF) == 0x0)
               isRun3_df = true;
-            if (((tmbHeader->FirmwareRevision() >> 9) & 0xF) == 0x3)
+            if (((tmbHeader->FirmwareRevision() >> 9) & 0xF) == 0x3) {
               isGEM_df = true;
+              if (((tmbHeader->FirmwareRevision() >> 5) & 0xF) == 0x2) {
+                isRun3_df = true;
+                isOTMB_ME11_Run3b = true;
+              }
+            }
             if (((tmbHeader->FirmwareRevision() >> 9) & 0xF) == 0x4)
               isTMB_hybrid_df = true;
             /** Summary plot for chambers with detected (O)TMB Run3 data format */
@@ -1069,7 +1075,7 @@ namespace cscdqm {
                 mo->Fill(tmbHeader->clctHMT(), tmbHeader->alctHMT());
               }
 
-              if (getCSCHisto(h::CSC_CORR_LCT_RUN3_PATTERN_ID, crateID, dmbID, mo)) {
+              if (getCSCHisto(h::CSC_CORR_LCT_RUN3_PATTERN_ID, crateID, dmbID, mo) && !isOTMB_ME11_Run3b) {
                 mo->Fill(tmbHeader->run3_CLCT_patternID());
               }
             }
@@ -1166,7 +1172,7 @@ namespace cscdqm {
             }
 
             if (lct == 0) {
-              if (corr_lctsDatasTmp[lct].isRun3() || isTMB_hybrid_df) {
+              if (corr_lctsDatasTmp[lct].isRun3() || isTMB_hybrid_df || isOTMB_ME11_Run3b) {
                 /// Summary occupancy plot for combined HMT bits sent to MPC
                 if (getEMUHisto(h::EMU_CSC_LCT_HMT_REPORTING, mo)) {
                   if (corr_lctsDatasTmp[lct].getHMT() > 0)
@@ -1217,7 +1223,7 @@ namespace cscdqm {
 
           if (!corr_lctsDatas.empty()) {
             if (corr_lctsDatasTmp[0].isRun3()) {
-              if (getCSCHisto(h::CSC_CORR_LCT0_VS_LCT1_RUN3_PATTERN, crateID, dmbID, mo)) {
+              if (getCSCHisto(h::CSC_CORR_LCT0_VS_LCT1_RUN3_PATTERN, crateID, dmbID, mo) && !isOTMB_ME11_Run3b) {
                 int lct1_pattern = corr_lctsDatasTmp[1].getRun3Pattern();
                 if (!corr_lctsDatasTmp[1].isValid())
                   lct1_pattern = -1;
@@ -1228,7 +1234,7 @@ namespace cscdqm {
 
           for (uint32_t lct = 0; lct < corr_lctsDatas.size(); lct++) {
             /*
-                  LOG_DEBUG << "CorrelatedLCT Digis dump: "
+                  LOG_INFO << "CorrelatedLCT Digis dump: "
                             << "CorrLCT" << lct << " isRun3:" << corr_lctsDatasTmp[lct].isRun3()
                             << ", isValid: " << corr_lctsDatasTmp[lct].isValid()
                             << ", getStrip: " << corr_lctsDatasTmp[lct].getStrip()
@@ -1236,7 +1242,7 @@ namespace cscdqm {
                             << ", getQuality: " << corr_lctsDatasTmp[lct].getQuality()
                             << ", getFractionalStrip: " <<  corr_lctsDatasTmp[lct].getFractionalStrip()
                             << ", getQuartStrip: " << corr_lctsDatasTmp[lct].getQuartStripBit()
-                            << ", getEightStrip: " << corr_lctsDatasTmp[lct].getEightStripBit()
+                            << ", getEightStrip: " << corr_lctsDatasTmp[lct].getEighthStripBit()
                             << ",\n getSlope: " << corr_lctsDatasTmp[lct].getSlope() << std::dec
                             << ", getBend: " << corr_lctsDatasTmp[lct].getBend()
                             << ", getBX: " << corr_lctsDatasTmp[lct].getBX()
@@ -1245,7 +1251,7 @@ namespace cscdqm {
                             // << ", getRun3PatternID: " << std::dec << corr_lctsDatasTmp[lct].getRun3PatternID()
                             << ", getHMT: " << corr_lctsDatasTmp[lct].getHMT()
 			    << std::dec;
-*/
+			*/
             if (getCSCHisto(h::CSC_CORR_LCTXX_HITS_DISTRIBUTION, crateID, dmbID, lct, mo)) {
               mo->Fill(corr_lctsDatas[lct].getStrip(), corr_lctsDatas[lct].getKeyWG());
             }
@@ -1258,22 +1264,48 @@ namespace cscdqm {
               mo->Fill(corr_lctsDatas[lct].getStrip(2));
             }
 
-            if (corr_lctsDatas[lct].isRun3()) {
-              if (getCSCHisto(h::CSC_CORR_LCTXX_KEY_QUARTSTRIP, crateID, dmbID, lct, mo)) {
-                mo->Fill(corr_lctsDatas[lct].getStrip(4));
-              }
+            if (corr_lctsDatas[lct].isRun3() || isOTMB_ME11_Run3b) {
+              if (!isTMB_hybrid_df) {
+                if (getCSCHisto(h::CSC_CORR_LCTXX_KEY_QUARTSTRIP, crateID, dmbID, lct, mo)) {
+                  mo->Fill(corr_lctsDatas[lct].getStrip(4));
+                }
 
-              if (getCSCHisto(h::CSC_CORR_LCTXX_KEY_EIGHTSTRIP, crateID, dmbID, lct, mo)) {
-                mo->Fill(corr_lctsDatas[lct].getStrip(8));
-              }
+                if (getCSCHisto(h::CSC_CORR_LCTXX_KEY_EIGHTSTRIP, crateID, dmbID, lct, mo)) {
+                  mo->Fill(corr_lctsDatas[lct].getStrip(8));
+                }
 
-              if (getCSCHisto(h::CSC_CORR_LCTXX_RUN3_TO_RUN2_PATTERN, crateID, dmbID, lct, mo)) {
-                int bend = corr_lctsDatas[lct].getSlope() + ((corr_lctsDatas[lct].getBend() & 0x1) << 4);
-                mo->Fill(bend, corr_lctsDatas[lct].getPattern());
-              }
+                if (getCSCHisto(h::CSC_CORR_LCTXX_RUN3_TO_RUN2_PATTERN, crateID, dmbID, lct, mo)) {
+                  int bend = corr_lctsDatas[lct].getSlope() + ((corr_lctsDatas[lct].getBend() & 0x1) << 4);
+                  mo->Fill(bend, corr_lctsDatas[lct].getPattern());
+                }
 
-              if (getCSCHisto(h::CSC_CORR_LCTXX_BEND_VS_SLOPE, crateID, dmbID, lct, mo)) {
-                mo->Fill(corr_lctsDatas[lct].getSlope(), corr_lctsDatas[lct].getBend());
+                if (getCSCHisto(h::CSC_CORR_LCTXX_BEND_VS_SLOPE, crateID, dmbID, lct, mo)) {
+                  mo->Fill(corr_lctsDatas[lct].getSlope(), corr_lctsDatas[lct].getBend());
+                }
+
+                /// Fill Run3-b ME11-GEM LCT format histograms
+                if (isOTMB_ME11_Run3b) {
+                  if (getCSCHisto(h::CSC_CORR_LCTXX_RUN3B_SLOPE, crateID, dmbID, lct, mo)) {
+                    mo->Fill(corr_lctsDatasTmp[lct].getSlopeEx());
+                  }
+                  /// Check CSC-GEM match only ME11 quality
+                  if ((corr_lctsDatasTmp[lct].getQuality() == 5) || (corr_lctsDatasTmp[lct].getQuality() == 7)) {
+                    if (getCSCHisto(h::CSC_CORR_LCT_RUN3B_GEM_LAYERS, crateID, dmbID, mo)) {
+                      mo->Fill(corr_lctsDatasTmp[lct].getGemLayerUsedForSlopeComputation(), lct);
+                    }
+                    /// Fill summary histogram
+                    if (getEMUHisto(h::EMU_ME11_CORR_LCT_RUN3B_GEM_LAYERS, mo)) {
+                      if (cid.endcap() == 1) {  // z+
+                        mo->Fill(cscPosition,
+                                 4 + (lct * 2 + corr_lctsDatasTmp[lct].getGemLayerUsedForSlopeComputation()));
+                      }
+                      if (cid.endcap() == 2) {  // z-
+                        mo->Fill(cscPosition,
+                                 3 - (lct * 2 + corr_lctsDatasTmp[lct].getGemLayerUsedForSlopeComputation()));
+                      }
+                    }
+                  }
+                }
               }
 
               if (getCSCHisto(h::CSC_CORR_LCTXX_KEY_STRIP_TYPE, crateID, dmbID, lct, mo)) {
@@ -1309,7 +1341,7 @@ namespace cscdqm {
               }
 
               if (!alctsDatas.empty() && getCSCHisto(h::CSC_RUN3_HMT_COINCIDENCE_MATCH, crateID, dmbID, mo) &&
-                  corr_lctsDatasTmp[0].isRun3() && (corr_lctsDatasTmp[0].getHMT() > 0) &&
+                  (corr_lctsDatasTmp[0].isRun3() || isOTMB_ME11_Run3b) && (corr_lctsDatasTmp[0].getHMT() > 0) &&
                   (corr_lctsDatasTmp[0].getHMT() <= 0xF) && alctsDatas[0].isValid()) {
                 mo->Fill(1);  // Run3 HMT+ALCT match
               }

--- a/DQM/CSCMonitorModule/plugins/CSCDQM_HistoNames.icc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_HistoNames.icc
@@ -487,7 +487,10 @@ namespace h {
   HIST_ID(EMU_CSC_ANODE_HMT_ALCT_REPORTING)                     \
   HIST_ID(EMU_CSC_TMB_RUN3_DATA_FORMAT)                         \
   HIST_ID(EMU_CSC_TMB_RUN3_CCLUT_MODE)                          \
-  HIST_ID(EMU_CSC_RUN3_ALCT_FORMAT)
+  HIST_ID(EMU_CSC_RUN3_ALCT_FORMAT)                             \
+  HIST_ID(CSC_CORR_LCTXX_RUN3B_SLOPE)                           \
+  HIST_ID(CSC_CORR_LCT_RUN3B_GEM_LAYERS)                        \
+  HIST_ID(EMU_ME11_CORR_LCT_RUN3B_GEM_LAYERS)
 
 #define HIST_NAME_TABLE                                         \
   HIST_NAME("Actual_DMB_CFEB_DAV_Frequency")                    \
@@ -946,7 +949,10 @@ namespace h {
   HIST_NAME("CSC_Anode_HMT_ALCT_Reporting")                     \
   HIST_NAME("CSC_TMB_Run3_Data_Format")                         \
   HIST_NAME("CSC_TMB_Run3_CCLUT_Mode")                          \
-  HIST_NAME("CSC_ALCT_Run3_Format")
+  HIST_NAME("CSC_ALCT_Run3_Format")                             \
+  HIST_NAME("Corr_LCT%d_Run3b_Slope")                           \
+  HIST_NAME("Corr_LCT_Run3b_GEM_Layers")                        \
+  HIST_NAME("ME11_Corr_LCT_Run3b_GEM_Layers")
 
 #define HIST_ID(a) a,
   enum HistoId { HIST_ID_TABLE };

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -18,7 +18,7 @@
 
 class CSCCorrelatedLCTDigi {
 public:
-  enum class Version { Legacy = 0, Run3 };
+  enum class Version { Legacy = 0, Run3, Run3HR };
   // for data vs emulator studies
   enum LCTBXMask { kBXDataMask = 0x1 };
 
@@ -113,8 +113,11 @@ public:
   /// return the Run-3 pattern ID
   uint16_t getRun3Pattern() const { return run3_pattern_; }
 
-  /// return the slope
-  uint16_t getSlope() const { return run3_slope_; }
+  /// return the slope with the 4 bits resolution (for backward compatibility).
+  uint16_t getSlope() const;
+  // return the slope with extended resolution. The raw slope resolution is 4 bits for Legacy and Run3, and 6 bits for Run3HR. If resolution=0, return raw slope value with the full resolution.
+  uint16_t getSlopeEx(uint16_t resolution = 0) const;
+  uint16_t getRawSlopeResolution() const { return version_ == Version::Run3HR ? 6 : 4; }
 
   /// slope in number of half-strips/layer
   /// negative means left-bending
@@ -205,9 +208,10 @@ public:
   void setHMT(const uint16_t h);
 
   /// Distinguish Run-1/2 from Run-3
-  bool isRun3() const { return version_ == Version::Run3; }
+  bool isRun3() const { return version_ == Version::Run3 || version_ == Version::Run3HR; }
 
-  void setRun3(const bool isRun3);
+  Version getVersion() const { return version_; }
+  void setVersion(const Version version) { version_ = version; }
 
   int getType() const { return type_; }
 

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -134,7 +134,21 @@ uint16_t CSCCorrelatedLCTDigi::getHMT() const { return (isRun3() ? hmt : std::nu
 
 void CSCCorrelatedLCTDigi::setHMT(const uint16_t h) { hmt = isRun3() ? h : std::numeric_limits<uint16_t>::max(); }
 
-void CSCCorrelatedLCTDigi::setRun3(const bool isRun3) { version_ = isRun3 ? Version::Run3 : Version::Legacy; }
+uint16_t CSCCorrelatedLCTDigi::getSlope() const {
+  return version_ == Version::Run3HR ? (run3_slope_ >> 2) : run3_slope_;
+}
+
+uint16_t CSCCorrelatedLCTDigi::getSlopeEx(uint16_t resolution) const {
+  if (resolution > 16)
+    throw cms::Exception("InvalidSlopeResolution")
+        << "Requested slope resolution " << resolution << " is larger than 16 bits, which is not supported.";
+  const uint16_t rawResolution = getRawSlopeResolution();
+  if (resolution == 0 || resolution == rawResolution)
+    return run3_slope_;
+  if (resolution > rawResolution)
+    return run3_slope_ << (resolution - rawResolution);
+  return run3_slope_ >> (rawResolution - resolution);
+}
 
 /// Comparison
 bool CSCCorrelatedLCTDigi::operator==(const CSCCorrelatedLCTDigi& rhs) const {
@@ -161,8 +175,9 @@ std::ostream& operator<<(std::ostream& o, const CSCCorrelatedLCTDigi& digi) {
   if (digi.isRun3())
     return o << "CSC LCT #" << digi.getTrknmb() << ": Valid = " << digi.isValid() << " BX = " << digi.getBX()
              << " Run-2 Pattern = " << digi.getPattern() << " Run-3 Pattern = " << digi.getRun3Pattern()
-             << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend() << " Slope = " << digi.getSlope()
-             << "\n"
+             << " Quality = " << digi.getQuality() << " Bend = " << digi.getBend() << " Slope = " << digi.getSlopeEx()
+             << " Slope resolution = " << digi.getRawSlopeResolution() << " bits"
+             << " GemLayer = " << digi.getGemLayerUsedForSlopeComputation() << "\n"
              << " KeyHalfStrip = " << digi.getStrip() << " KeyQuartStrip = " << digi.getStrip(4)
              << " KeyEighthStrip = " << digi.getStrip(8) << " KeyWireGroup = " << digi.getKeyWG()
              << " Type (SIM) = " << digi.getType() << " MPC Link = " << digi.getMPCLink();

--- a/DataFormats/L1TMuon/src/EMTFHit.cc
+++ b/DataFormats/L1TMuon/src/EMTFHit.cc
@@ -92,7 +92,7 @@ namespace l1t {
     lct.setEighthStripBit(eighth_bit);
     lct.setSlope(slope);
     lct.setRun3Pattern(pattern_run3);
-    lct.setRun3(isRun3);
+    lct.setVersion(isRun3 ? CSCCorrelatedLCTDigi::Version::Run3 : CSCCorrelatedLCTDigi::Version::Legacy);
 
     return lct;
     // Added Run 3 parameters - EY 04.07.22

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader.h
@@ -27,6 +27,7 @@ struct CSCTMBHeader2020_TMB;
 struct CSCTMBHeader2020_CCLUT;
 struct CSCTMBHeader2020_GEM;
 struct CSCTMBHeader2020_Run2;
+struct CSCTMBHeader2020_GEM_Run3b;
 
 class CSCTMBHeader {
 public:
@@ -64,6 +65,7 @@ public:
   CSCTMBHeader2020_CCLUT tmbHeader2020_CCLUT() const;
   CSCTMBHeader2020_GEM tmbHeader2020_GEM() const;
   CSCTMBHeader2020_Run2 tmbHeader2020_Run2() const;
+  CSCTMBHeader2020_GEM tmbHeader2020_GEM_Run3b() const;
 
   uint16_t NTBins() const { return theHeaderFormat->NTBins(); }
   uint16_t NCFEBs() const { return theHeaderFormat->NCFEBs(); }

--- a/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_GEM_Run3b.h
+++ b/EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_GEM_Run3b.h
@@ -1,0 +1,172 @@
+#ifndef EventFilter_CSCRawToDigi_CSCTMBHeader2020_GEM_Run3b_h
+#define EventFilter_CSCRawToDigi_CSCTMBHeader2020_GEM_Run3b_h
+#include "EventFilter/CSCRawToDigi/interface/CSCVTMBHeaderFormat.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+
+struct CSCTMBHeader2020_GEM_Run3b : public CSCVTMBHeaderFormat {
+  enum { NWORDS = 43 };
+  CSCTMBHeader2020_GEM_Run3b();
+  CSCTMBHeader2020_GEM_Run3b(const unsigned short* buf);
+  void setEventInformation(const CSCDMBHeader& dmbHeader) override;
+
+  uint16_t BXNCount() const override { return bits.bxnCount; }
+  uint16_t ALCTMatchTime() const override { return bits.matchWin; }
+  void setALCTMatchTime(uint16_t alctmatchtime) override { bits.matchWin = alctmatchtime & 0xF; }
+  uint16_t CLCTOnly() const override { return bits.clctOnly; }
+  uint16_t ALCTOnly() const override { return bits.alctOnly; }
+  uint16_t TMBMatch() const override { return bits.tmbMatch; }
+  uint16_t Bxn0Diff() const override { return 0; }
+  uint16_t Bxn1Diff() const override { return 0; }
+  uint16_t L1ANumber() const override { return bits.l1aNumber; }
+  uint16_t NTBins() const override { return bits.nTBins; }
+  uint16_t NCFEBs() const override { return bits.nCFEBs; }
+  void setNCFEBs(uint16_t ncfebs) override { bits.nCFEBs = ncfebs & 0x7F; }
+  uint16_t firmwareRevision() const override { return bits.firmRevCode; }
+  uint16_t syncError() const override { return bits.syncError; }
+  uint16_t syncErrorCLCT() const override { return bits.clct_sync_err; }
+  uint16_t syncErrorMPC0() const override { return 0; }
+  uint16_t syncErrorMPC1() const override { return 0; }
+  uint16_t L1AMatchTime() const override { return bits.pop_l1a_match_win; }
+
+  // == Run 3 CSC-GEM Trigger Format
+  uint16_t clct0_ComparatorCode() const override { return bits.clct0_comparator_code; }
+  uint16_t clct1_ComparatorCode() const override { return bits.clct1_comparator_code; }
+  uint16_t clct0_xky() const override { return bits.clct0_xky; }
+  uint16_t clct1_xky() const override { return bits.clct1_xky; }
+  uint16_t hmt_nhits() const override {
+    return ((bits.hmt_nhits_bit0 & 0x1) + ((bits.hmt_nhits_bit1 & 0x1) << 1) +
+            ((bits.hmt_nhits_bits_high & 0x1F) << 2));
+  }
+  uint16_t hmt_ALCTMatchTime() const override { return bits.hmt_match_win; }
+  uint16_t alctHMT() const override { return bits.anode_hmt; }
+  uint16_t clctHMT() const override { return bits.cathode_hmt; }
+  uint16_t gem_enabled_fibers() const override { return (bits.gem_enabled_fibers_ & 0xF); }
+  uint16_t gem_fifo_tbins() const override { return bits.fifo_tbins_gem_; }
+  uint16_t gem_fifo_pretrig() const override { return bits.fifo_pretrig_gem_; }
+  uint16_t gem_zero_suppress() const override { return bits.gem_zero_suppression_; }
+  uint16_t gem_sync_dataword() const override {
+    return ((bits.lct0_nogem) + (bits.lct0_with_gemA << 1) + (bits.lct0_with_gemB << 2) + (bits.lct0_with_copad << 3) +
+            (bits.lct1_nogem << 4) + (bits.lct1_with_gemA << 5) + (bits.lct1_with_gemB << 6) +
+            (bits.lct1_with_copad << 7) + (bits.gemA_vpf << 8) + (bits.gemB_vpf << 9) + (bits.gemA_over_flow << 10) +
+            (bits.gemB_over_flow << 11) + (bits.gemA_sync << 12) + (bits.gemB_sync << 13) + (bits.gems_sync << 14));
+  }
+  uint16_t gem_timing_dataword() const override {
+    return ((bits.num_copad & 0xF) + ((bits.gem_delay & 0xF) << 4) + ((bits.gem_clct_win & 0xF) << 8) +
+            ((bits.alct_gem_win & 0x7) << 12));
+  }
+  uint16_t run3_CLCT_patternID()
+      const override {  // Run3-b MPC-LCT format for ME11s with GEMs does not use Run3 CLCT pattern IDs
+    return 0;
+  }
+  // ==
+
+  ///returns CLCT digis
+  std::vector<CSCCLCTDigi> CLCTDigis(uint32_t idlayer) override;
+  ///returns CorrelatedLCT digis
+  std::vector<CSCCorrelatedLCTDigi> CorrelatedLCTDigis(uint32_t idlayer) const override;
+  ///returns lct HMT Shower digi
+  CSCShowerDigi showerDigi(uint32_t idlayer) const override;
+  ///returns anode HMT Shower digi
+  CSCShowerDigi anodeShowerDigi(uint32_t idlayer) const override;
+  ///returns cathode HMT Shower digi
+  CSCShowerDigi cathodeShowerDigi(uint32_t idlayer) const override;
+
+  /// in 16-bit words.  Add olne because we include beginning(b0c) and
+  /// end (e0c) flags
+  unsigned short int sizeInWords() const override { return NWORDS; }
+
+  unsigned short int NHeaderFrames() const override { return bits.nHeaderFrames; }
+  /// returns the first data word
+  unsigned short* data() override { return (unsigned short*)(&bits); }
+  bool check() const override { return bits.e0bline == 0x6e0b; }
+
+  /// for data packing
+  void addCLCT0(const CSCCLCTDigi& digi) override;
+  void addCLCT1(const CSCCLCTDigi& digi) override;
+  void addALCT0(const CSCALCTDigi& digi) override;
+  void addALCT1(const CSCALCTDigi& digi) override;
+  void addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) override;
+  void addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) override;
+  void addShower(const CSCShowerDigi& digi) override;
+  void addAnodeShower(const CSCShowerDigi& digi) override;
+  void addCathodeShower(const CSCShowerDigi& digi) override;
+
+  void swapCLCTs(CSCCLCTDigi& digi1, CSCCLCTDigi& digi2);
+
+  void print(std::ostream& os) const override;
+
+  struct {
+    // 0
+    unsigned b0cline : 16;
+    unsigned bxnCount : 12, dduCode1 : 3, flag1 : 1;
+    unsigned l1aNumber : 12, dduCode2 : 3, flag2 : 1;
+    unsigned readoutCounter : 12, dduCode3 : 3, flag3 : 1;
+    // 4
+    unsigned boardID : 5, cscID : 4, runID : 4, stackOvf : 1, syncError : 1, flag4 : 1;
+    unsigned nHeaderFrames : 6, fifoMode : 3, r_type : 2, l1atype : 2, hasBuf : 1, bufFull : 1, flag5 : 1;
+    unsigned bd_status : 15, flag6 : 1;
+    unsigned firmRevCode : 15, flag7 : 1;
+    // 8
+    unsigned bxnPreTrigger : 12, tmb_clct0_discard : 1, tmb_clct1_discard : 1, clock_lock_lost : 1, flag8 : 1;
+    unsigned preTrigCounter : 15, flag9 : 1;
+    unsigned clct0_comparator_code : 12, clct0_xky : 2, hmt_nhits_bit0 : 1, flag10 : 1;  // 12-bits comp code fw version
+    unsigned clctCounterLow : 15, flag11 : 1;
+    // 12
+    unsigned lct0_nogem : 1, lct0_with_gemA : 1, lct0_with_gemB : 1, lct0_with_copad : 1, lct1_nogem : 1,
+        lct1_with_gemA : 1, lct1_with_gemB : 1, lct1_with_copad : 1, gemA_vpf : 1, gemB_vpf : 1, gemA_over_flow : 1,
+        gemB_over_flow : 1, gemA_sync : 1, gemB_sync : 1, gems_sync : 1, flag12 : 1;
+    unsigned trigCounter : 15, flag13 : 1;
+    unsigned clct1_comparator_code : 12, clct1_xky : 2, hmt_nhits_bit1 : 1, flag14 : 1;  // 12-bits comp code fw version
+    unsigned alctCounterLow : 15, flag15 : 1;
+    // 16
+    unsigned num_copad : 4, gem_delay : 4, gem_clct_win : 4, alct_gem_win : 3, flag16 : 1;
+    unsigned uptimeCounterLow : 15, flag17 : 1;
+    unsigned uptimeCounterHigh : 15, flag18 : 1;
+    unsigned nCFEBs : 3, nTBins : 5, fifoPretrig : 5, scopeExists : 1, vmeExists : 1, flag19 : 1;
+    // 20
+    unsigned hitThresh : 3, pidThresh : 4, nphThresh : 3, pid_thresh_postdrift : 4, staggerCSC : 1, flag20 : 1;
+    unsigned triadPersist : 4, dmbThresh : 3, alct_delay : 4, clct_width : 4, flag21 : 1;
+    unsigned trigSourceVect : 9, clct0_slope : 4, clct0_LR_bend : 1, clct1_LR_bend : 1, flag22 : 1;
+    unsigned activeCFEBs : 5, readCFEBs : 5, pop_l1a_match_win : 4, aff_source : 1, flag23 : 1;
+    // 24
+    unsigned tmbMatch : 1, alctOnly : 1, clctOnly : 1, matchWin : 4, noALCT : 1, oneALCT : 1, oneCLCT : 1, twoALCT : 1,
+        twoCLCT : 1, dupeALCT : 1, dupeCLCT : 1, lctRankErr : 1, flag24 : 1;
+    unsigned clct0_valid : 1, clct0_quality : 3, clct0_shape : 4, clct0_key_low : 7, flag25 : 1;
+    unsigned clct1_valid : 1, clct1_quality : 3, clct1_shape : 4, clct1_key_low : 7, flag26 : 1;
+    unsigned clct0_key_high : 1, clct1_key_high : 1, clct_bxn : 2, clct_sync_err : 1, clct0Invalid : 1,
+        clct1Invalid : 1, clct1Busy : 1, parity_err_cfeb_ram : 5, parity_err_rpc : 1, parity_err_summary : 1,
+        flag27 : 1;
+    // 28
+    unsigned alct0Valid : 1, alct0Quality : 2, alct0Amu : 1, alct0Key : 7, clct1_slope : 4, flag28 : 1;
+    unsigned alct1Valid : 1, alct1Quality : 2, alct1Amu : 1, alct1Key : 7, drift_delay : 2, bcb_read_enable : 1,
+        hs_layer_trig : 1, flag29 : 1;
+    unsigned hmt_nhits_bits_high : 5, alct_ecc_err : 2, cfeb_badbits_found : 5, cfeb_badbits_blocked : 1, alctCfg : 1,
+        bx0_match : 1, flag30 : 1;
+    unsigned MPC_Muon0_alct_key_wire : 7, MPC_Muon0_clct_bend_run3b_extra : 2, MPC_Muon1_clct_bend_run3b_extra : 2,
+        MPC_Muon0_lct_quality : 3, MPC_Muon0_clct_QuarterStrip : 1, flag31 : 1;
+    // 32
+    unsigned MPC_Muon0_clct_key_halfstrip : 8, MPC_Muon0_clct_LR : 1, MPC_Muon0_clct_EighthStrip : 1,
+        MPC_Muon_alct_bxn : 1, MPC_Muon0_clct_bx0 : 1, MPC_Muon0_clct_bend_low : 3, flag32 : 1;
+    unsigned MPC_Muon1_alct_key_wire : 7, MPC_Muon0_GEM_layer : 1, MPC_Muon_HMT_high : 2, MPC_Muon1_GEM_layer : 1,
+        MPC_Muon1_lct_quality : 3, MPC_Muon1_clct_QuarterStrip : 1, flag33 : 1;
+    unsigned MPC_Muon1_clct_key_halfstrip : 8, MPC_Muon1_clct_LR : 1, MPC_Muon1_clct_EighthStrip : 1,
+        MPC_Muon_HMT_bit0 : 1, MPC_Muon1_clct_bx0 : 1, MPC_Muon1_clct_bend_low : 3, flag34 : 1;
+    unsigned MPC_Muon0_lct_vpf : 1, MPC_Muon0_clct_bend_high : 1, MPC_Muon1_lct_vpf : 1, MPC_Muon1_clct_bend_high : 1,
+        MPCDelay : 4, MPCAccept : 2, CFEBsEnabled : 5, flag35 : 1;
+    // 36
+    unsigned gem_enabled_fibers_ : 4, gem_zero_suppression_ : 1, fifo_tbins_gem_ : 5, fifo_pretrig_gem_ : 5, flag36 : 1;
+    unsigned r_wr_buf_adr : 11, r_wr_buf_ready : 1, wr_buf_ready : 1, buf_q_full : 1, buf_q_empty : 1, flag37 : 1;
+    unsigned r_buf_fence_dist : 11, buf_q_ovf_err : 1, buf_q_udf_err : 1, buf_q_adr_err : 1, buf_stalled : 1,
+        flag38 : 1;
+    unsigned buf_fence_cnt : 12, reverse_hs_csc : 1, reverse_hs_me1a : 1, reverse_hs_me1b : 1, flag39 : 1;
+    // 40
+    unsigned activeCFEBs_2 : 2, readCFEBs_2 : 2, cfeb_badbits_found_2 : 2, parity_err_cfeb_ram_2 : 2,
+        CFEBsEnabled_2 : 2, buf_fence_cnt_is_peak : 1, gem_csc_bend_enable : 1, trig_source_vec : 2, tmb_trig_pulse : 1,
+        flag40 : 1;
+    unsigned run3_trig_df : 1, gem_enable : 1, hmt_match_win : 4, tmb_alct_only_ro : 1, tmb_clct_only_ro : 1,
+        tmb_match_ro : 1, tmb_trig_keep : 1, tmb_non_trig_keep : 1, cathode_hmt : 2, anode_hmt : 2, flag41 : 1;
+    unsigned e0bline : 16;
+  } bits;
+};
+
+#endif

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader.cc
@@ -9,6 +9,7 @@
 #include "EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_CCLUT.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_GEM.h"
 #include "EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_Run2.h"
+#include "EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_GEM_Run3b.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -32,6 +33,7 @@ CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision)
       bool isTMB_Run2_fw = false;
       bool isTMB_hybrid_fw = false;  /// Copper TMB hybrid fw Run2 CLCT + Run3 LCT/MPC + anode-only HMT (March 2022)
       bool isRun2_df = false;
+      bool isGEM_Run3b_fw = false;                          /// 2026 ME11 with GEMs OTMB Run3-v MPC-LCT format changes
       unsigned df_version = (firmwareRevision >> 9) & 0xF;  // 4-bits Data Format version
       unsigned major_ver = (firmwareRevision >> 5) & 0xF;   // 4-bits major version part
       // unsigned minor_ver = firmwareRevision & 0x1F;         // 5-bits minor version part
@@ -41,6 +43,8 @@ CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision)
           break;
         case 0x3:
           isGEM_fw = true;
+          if (major_ver == 2)
+            isGEM_Run3b_fw = true;
           break;
         case 0x2:
           isCCLUT_HMT_fw = true;
@@ -65,7 +69,11 @@ CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision)
         if (isRun2_df) {
           theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_Run2(firmwareRevision));
         } else {
-          theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM());
+          if (isGEM_Run3b_fw) {
+            theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM_Run3b());
+          } else {
+            theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM());
+          }
         }
       } else if (isCCLUT_HMT_fw) {
         if (isRun2_df) {
@@ -96,12 +104,20 @@ CSCTMBHeader::CSCTMBHeader(int firmwareVersion, int firmwareRevision)
       /* Revisions > 0x6000 - OTMB firmwares, < 0x42D5 - new TMB revisions in 2016 */
       if ((firmwareRevision >= 0x6000) || (firmwareRevision < 0x42D5)) {
         bool isGEMfirmware = false;
+        bool isGEM_Run3b_fw = false;
         /* There are OTMB2013 firmware versions exist, which reports firmwareRevision code = 0x0 */
         if ((firmwareRevision < 0x4000) && (firmwareRevision > 0x0)) { /* New (O)TMB firmware revision format */
-          if (((firmwareRevision >> 9) & 0x3) == 0x3)
+          if (((firmwareRevision >> 9) & 0x3) == 0x3) {
             isGEMfirmware = true;
+            if (((firmwareRevision >> 5) & 0xF) == 0x2)
+              isGEM_Run3b_fw = true;
+          }
           if (isGEMfirmware) {
-            theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM());
+            if (isGEM_Run3b_fw) {
+              theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM_Run3b());
+            } else {
+              theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM());
+            }
           } else {
             theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2013());
           }
@@ -143,6 +159,7 @@ CSCTMBHeader::CSCTMBHeader(const unsigned short *buf) : theHeaderFormat() {
         bool isTMB_Run2_fw = false;
         bool isTMB_hybrid_fw = false;  /// Copper TMB hybrid fw Run2 CLCT + Run3 LCT/MPC + anode-only HMT (March 2022)
         bool isRun2_df = false;
+        bool isGEM_Run3b_fw = false;  /// 2026 ME11+GE11 Run3-b MPC-LCT format OTMB fw
         unsigned firmwareRevision = theHeaderFormat->firmwareRevision();
         /* There are OTMB2013 firmware versions exist, which reports firmwareRevision code = 0x0 */
         if ((firmwareRevision < 0x4000) && (firmwareRevision > 0x0)) { /* New (O)TMB firmware revision format */
@@ -156,6 +173,8 @@ CSCTMBHeader::CSCTMBHeader(const unsigned short *buf) : theHeaderFormat() {
               break;
             case 0x3:
               isGEM_fw = true;
+              if (major_ver == 2)
+                isGEM_Run3b_fw = true;
               break;
             case 0x2:
               isCCLUT_HMT_fw = true;
@@ -180,6 +199,8 @@ CSCTMBHeader::CSCTMBHeader(const unsigned short *buf) : theHeaderFormat() {
           if (isGEM_fw) {
             if (isRun2_df) {
               theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_Run2(buf));
+            } else if (isGEM_Run3b_fw) {
+              theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM_Run3b(buf));
             } else {
               theHeaderFormat = std::shared_ptr<CSCVTMBHeaderFormat>(new CSCTMBHeader2020_GEM(buf));
             }
@@ -364,6 +385,8 @@ void CSCTMBHeader::selfTest(int firmwareVersion, int firmwareRevision) {
         bool isTMB_Run2_fw = false;
         bool isTMB_hybrid_fw = false;
         bool isRun2_df = false;
+        // bool isGEM_Run3b_fw = false;
+
         unsigned df_version = (firmwareRevision >> 9) & 0xF;  // 4-bits Data Format version
         unsigned major_ver = (firmwareRevision >> 5) & 0xF;   // 4-bits major version part
         // unsigned minor_ver = firmwareRevision & 0x1F;         // 5-bits minor version part
@@ -373,6 +396,7 @@ void CSCTMBHeader::selfTest(int firmwareVersion, int firmwareRevision) {
             break;
           case 0x3:
             isGEM_fw = true;
+            // if (major_ver == 2) isGEM_Run3b_fw = true;
             break;
           case 0x2:
             isCCLUT_HMT_fw = true;

--- a/EventFilter/CSCRawToDigi/src/CSCTMBHeader2020_GEM_Run3b.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCTMBHeader2020_GEM_Run3b.cc
@@ -1,0 +1,420 @@
+#include "EventFilter/CSCRawToDigi/interface/CSCTMBHeader2020_GEM_Run3b.h"
+#include "EventFilter/CSCRawToDigi/interface/CSCDMBHeader.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+const std::vector<std::pair<unsigned, unsigned> >
+    run3_pattern_lookup_tbl = {{0, 0}, {0, 1}, {0, 2}, {0, 3}, {0, 4},  /// Valid LCT0, invalid LCT1 combination. Check LCT1 vpf
+                               {0, 0}, {0, 1}, {0, 2}, {0, 3}, {0, 4}, {1, 0}, {1, 1}, {1, 2}, {1, 3},
+                               {1, 4}, {2, 0}, {2, 1}, {2, 2}, {2, 3}, {2, 4}, {3, 0}, {3, 1}, {3, 2},
+                               {3, 3}, {3, 4}, {4, 0}, {4, 1}, {4, 2}, {4, 3}, {4, 4}};  /// pattern IDs 30,31 are reserved
+
+const unsigned run2_pattern_lookup_tbl[2][16] = {{10, 10, 10, 8, 8, 8, 6, 6, 6, 4, 4, 4, 2, 2, 2, 2},
+                                                 {10, 10, 10, 9, 9, 9, 7, 7, 7, 5, 5, 5, 3, 3, 3, 3}};
+
+CSCTMBHeader2020_GEM_Run3b::CSCTMBHeader2020_GEM_Run3b() {
+  bzero(data(), sizeInWords() * 2);
+  bits.nHeaderFrames = 42;
+  bits.e0bline = 0x6E0B;
+  bits.b0cline = 0xDB0C;
+  bits.firmRevCode = 0x601;
+  bits.nTBins = 12;
+  bits.nCFEBs = 7;
+  /// Set default GEM-OTMB readout configuration
+  /// 12 time bins, all 4 GEM fibers enabled
+  bits.fifo_tbins_gem_ = 12;
+  bits.gem_enabled_fibers_ = 0xf;
+}
+
+CSCTMBHeader2020_GEM_Run3b::CSCTMBHeader2020_GEM_Run3b(const unsigned short* buf) {
+  memcpy(data(), buf, sizeInWords() * 2);
+}
+
+void CSCTMBHeader2020_GEM_Run3b::setEventInformation(const CSCDMBHeader& dmbHeader) {
+  bits.cscID = dmbHeader.dmbID();
+  bits.l1aNumber = dmbHeader.l1a();
+  bits.bxnCount = dmbHeader.bxn();
+}
+
+///returns CLCT digis
+std::vector<CSCCLCTDigi> CSCTMBHeader2020_GEM_Run3b::CLCTDigis(uint32_t idlayer) {
+  std::vector<CSCCLCTDigi> result;
+  unsigned halfstrip = bits.clct0_key_low + (bits.clct0_key_high << 7);
+  unsigned strip = halfstrip % 32;
+  // CLCT0 1/4 strip bit
+  bool quartstrip = (bits.clct0_xky >> 1) & 0x1;
+  // CLCT1 1/8 strip bit
+  bool eighthstrip = bits.clct0_xky & 0x1;
+  unsigned cfeb = halfstrip / 32;
+
+  /// CLCT0 LR bend and slope are from dedicated header fields
+  unsigned run3_pattern = bits.clct0_shape & 0x7;  // 3-bit Run3 CLCT PatternID
+  unsigned bend = bits.clct0_LR_bend;
+  unsigned slope = bits.clct0_slope;
+  unsigned run2_pattern = run2_pattern_lookup_tbl[bend][slope];
+
+  CSCCLCTDigi digi0(bits.clct0_valid,
+                    bits.clct0_quality,
+                    run2_pattern,
+                    1,
+                    bend,
+                    strip,
+                    cfeb,
+                    bits.clct_bxn,
+                    1,
+                    bits.bxnPreTrigger,
+                    bits.clct0_comparator_code,
+                    CSCCLCTDigi::Version::Run3,
+                    quartstrip,
+                    eighthstrip,
+                    run3_pattern,
+                    slope);
+
+  halfstrip = bits.clct1_key_low + (bits.clct1_key_high << 7);
+  strip = halfstrip % 32;
+  // CLCT0 1/4 strip bit
+  quartstrip = (bits.clct1_xky >> 1) & 0x1;
+  // CLCT1 1/8 strip bit
+  eighthstrip = bits.clct1_xky & 0x1;
+  cfeb = halfstrip / 32;
+
+  // CLCT LR bend and slope are from dedicated header fields
+  run3_pattern = bits.clct1_shape & 0x7;  // 3-bit Run3 CLCT PatternID
+  bend = bits.clct1_LR_bend;
+  slope = bits.clct1_slope;
+  run2_pattern = run2_pattern_lookup_tbl[bend][slope];
+
+  CSCCLCTDigi digi1(bits.clct1_valid,
+                    bits.clct1_quality,
+                    run2_pattern,
+                    1,
+                    bend,
+                    strip,
+                    cfeb,
+                    bits.clct_bxn,
+                    2,
+                    bits.bxnPreTrigger,
+                    bits.clct1_comparator_code,
+                    CSCCLCTDigi::Version::Run3,
+                    quartstrip,
+                    eighthstrip,
+                    run3_pattern,
+                    slope);
+
+  result.push_back(digi0);
+  result.push_back(digi1);
+  return result;
+}
+
+///returns CorrelatedLCT digis
+std::vector<CSCCorrelatedLCTDigi> CSCTMBHeader2020_GEM_Run3b::CorrelatedLCTDigis(uint32_t idlayer) const {
+  std::vector<CSCCorrelatedLCTDigi> result;
+  /// for the zeroth MPC word:
+  unsigned strip = bits.MPC_Muon0_clct_key_halfstrip;  //this goes from 0-223
+  unsigned slope = (bits.MPC_Muon0_clct_bend_low & 0x7) | (bits.MPC_Muon0_clct_bend_high << 3);
+  unsigned hmt =
+      bits.MPC_Muon_HMT_bit0 | ((bits.MPC_Muon_HMT_high & 0x3) << 1);  // HighMultiplicityTrigger for (Run3-b 3-bits)
+  // unsigned clct_pattern_id = bits.MPC_Muon_clct_pattern_low | (bits.MPC_Muon_clct_pattern_bit5 << 4); // Run3-b CLCT pattern is gone
+
+  unsigned run2_pattern = run2_pattern_lookup_tbl[bits.MPC_Muon0_clct_LR][slope];
+  unsigned run3_pattern = 0;                                                   // Run3-b CLCT pattern is gone
+  unsigned run3b_slope = (slope << 2) | bits.MPC_Muon0_clct_bend_run3b_extra;  // Run3b 6-bits slope
+  // unsigned run3b_slope = slope;
+
+  CSCCorrelatedLCTDigi digi(1,
+                            bits.MPC_Muon0_lct_vpf,
+                            bits.MPC_Muon0_lct_quality,
+                            bits.MPC_Muon0_alct_key_wire,
+                            strip,
+                            run2_pattern,
+                            bits.MPC_Muon0_clct_LR,
+                            bits.MPC_Muon_alct_bxn,
+                            0,
+                            bits.MPC_Muon0_clct_bx0,
+                            0,
+                            0,
+                            CSCCorrelatedLCTDigi::Version::Run3HR,
+                            bits.MPC_Muon0_clct_QuarterStrip,
+                            bits.MPC_Muon0_clct_EighthStrip,
+                            run3_pattern,
+                            run3b_slope);
+  digi.setHMT(hmt);
+  digi.setGemLayerUsedForSlopeComputation(bits.MPC_Muon0_GEM_layer);  // Run3-b ME11 with GE11 GEM layer information
+  // digi.setRun3bSlopeExtraBits(bits.MPC_Muon0_clct_bend_run3b_extra); // Run3-b extra bits for more precise slope/bend
+  result.push_back(digi);
+  /// for the first MPC word:
+  strip = bits.MPC_Muon1_clct_key_halfstrip;  //this goes from 0-223
+  slope = (bits.MPC_Muon1_clct_bend_low & 0x7) | (bits.MPC_Muon1_clct_bend_high << 3);
+  run2_pattern = run2_pattern_lookup_tbl[bits.MPC_Muon1_clct_LR][slope];
+  run3_pattern = 0;                                                   // Run3-b CLCT pattern is gone
+  run3b_slope = (slope << 2) | bits.MPC_Muon1_clct_bend_run3b_extra;  // Run3b 6-bits slope
+  // run3b_slope = slope;
+
+  digi = CSCCorrelatedLCTDigi(2,
+                              bits.MPC_Muon1_lct_vpf,
+                              bits.MPC_Muon1_lct_quality,
+                              bits.MPC_Muon1_alct_key_wire,
+                              strip,
+                              run2_pattern,
+                              bits.MPC_Muon1_clct_LR,
+                              bits.MPC_Muon_alct_bxn,
+                              0,
+                              bits.MPC_Muon1_clct_bx0,
+                              0,
+                              0,
+                              CSCCorrelatedLCTDigi::Version::Run3HR,
+                              bits.MPC_Muon1_clct_QuarterStrip,
+                              bits.MPC_Muon1_clct_EighthStrip,
+                              run3_pattern,
+                              run3b_slope);
+  digi.setHMT(hmt);
+  digi.setGemLayerUsedForSlopeComputation(bits.MPC_Muon1_GEM_layer);  // Run3-b ME11 with GE11 GEM layer information
+  // digi.setRun3bSlopeExtraBits(bits.MPC_Muon1_clct_bend_run3b_extra); // Run3-b extra bits for more precise slope/bend
+  result.push_back(digi);
+  return result;
+}
+
+CSCShowerDigi CSCTMBHeader2020_GEM_Run3b::showerDigi(uint32_t idlayer) const {
+  unsigned hmt_bits = bits.MPC_Muon_HMT_bit0 | (bits.MPC_Muon_HMT_high << 1);  // HighMultiplicityTrigger bits
+  uint16_t cscid = bits.cscID;  // ??? What is 4-bits CSC Id in CSshowerDigi
+  //L1A_TMB_WINDOW is not included in below formula
+  //correct version:  CSCConstants::LCT_CENTRAL_BX - bits.pop_l1a_match_win + L1A_TMB_WINDOW/2;
+  // same for anode HMT and cathode HMT. offline analysis would take care of this
+  uint16_t bx = CSCConstants::LCT_CENTRAL_BX - bits.pop_l1a_match_win;
+  //LCTshower with showerType = 3.  comparatorNHits from hmt_nhits() and wireNHits is not available
+  CSCShowerDigi result(hmt_bits & 0x3,
+                       (hmt_bits >> 2) & 0x3,
+                       cscid,
+                       bx,
+                       CSCShowerDigi::ShowerType::kLCTShower,
+                       0,
+                       hmt_nhits());  // 2-bits intime, 2-bits out of time
+  return result;
+}
+
+CSCShowerDigi CSCTMBHeader2020_GEM_Run3b::anodeShowerDigi(uint32_t idlayer) const {
+  uint16_t cscid = bits.cscID;
+  uint16_t bx = CSCConstants::LCT_CENTRAL_BX - bits.pop_l1a_match_win;
+  //ALCT shower with showerType = 1. wireNHits is not available from unpack data
+  CSCShowerDigi result(
+      bits.anode_hmt & 0x3, 0, cscid, bx, CSCShowerDigi::ShowerType::kALCTShower, 0, 0);  // 2-bits intime, no out of time
+  return result;
+}
+
+CSCShowerDigi CSCTMBHeader2020_GEM_Run3b::cathodeShowerDigi(uint32_t idlayer) const {
+  uint16_t cscid = bits.cscID;
+  uint16_t bx = CSCConstants::LCT_CENTRAL_BX - bits.pop_l1a_match_win - bits.hmt_match_win + 3;
+  //CLCT shower with showerType = 2. comparatorNHits from hmt_nhits()
+  CSCShowerDigi result(bits.cathode_hmt & 0x3,
+                       0,
+                       cscid,
+                       bx,
+                       CSCShowerDigi::ShowerType::kCLCTShower,
+                       0,
+                       hmt_nhits());  // 2-bits intime, no out of time
+  return result;
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addALCT0(const CSCALCTDigi& digi) {
+  throw cms::Exception("In CSC TMBHeaderFormat 2007, ALCTs belong in  ALCT header");
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addALCT1(const CSCALCTDigi& digi) {
+  throw cms::Exception("In CSC TMBHeaderFormat 2007, ALCTs belong in  ALCT header");
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addCLCT0(const CSCCLCTDigi& digi) {
+  unsigned halfStrip = digi.getKeyStrip();
+  unsigned pattern = digi.getRun3Pattern();
+  bits.clct0_valid = digi.isValid();
+  bits.clct0_quality = digi.getQuality();
+  bits.clct0_shape = pattern;
+  // first 7 bits of halfstrip
+  bits.clct0_key_low = halfStrip & (0x7F);
+  // most-significant (8th) bit
+  bits.clct0_key_high = (halfStrip >> 7) & (0x1);
+  bits.clct_bxn = digi.getBX();
+  bits.bxnPreTrigger = digi.getFullBX();
+  bits.clct0_comparator_code = digi.getCompCode();
+  bits.clct0_xky = (digi.getEighthStripBit() & 0x1) + ((digi.getQuartStripBit() & 0x1) << 1);
+  bits.clct0_LR_bend = digi.getBend();
+  bits.clct0_slope = digi.getSlope();
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addCLCT1(const CSCCLCTDigi& digi) {
+  unsigned halfStrip = digi.getKeyStrip();
+  unsigned pattern = digi.getRun3Pattern();
+  bits.clct1_valid = digi.isValid();
+  bits.clct1_quality = digi.getQuality();
+  bits.clct1_shape = pattern;
+  // first 7 bits of halfstrip
+  bits.clct1_key_low = halfStrip & (0x7F);
+  // most-significant (8th) bit
+  bits.clct1_key_high = (halfStrip >> 7) & (0x1);
+  // There is just one BX field common for CLCT0 and CLCT1 (since both
+  // are latched at the same BX); set it in addCLCT0().
+  bits.bxnPreTrigger = digi.getFullBX();
+  bits.clct1_comparator_code = digi.getCompCode();
+  bits.clct1_xky = (digi.getEighthStripBit() & 0x1) + ((digi.getQuartStripBit() & 0x1) << 1);
+  bits.clct1_LR_bend = digi.getBend();
+  bits.clct1_slope = digi.getSlope();
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addCorrelatedLCT0(const CSCCorrelatedLCTDigi& digi) {
+  bits.MPC_Muon0_lct_vpf = digi.isValid();
+  bits.MPC_Muon0_alct_key_wire = digi.getKeyWG();
+  bits.MPC_Muon0_clct_key_halfstrip = digi.getStrip(2) & 0xFF;
+  bits.MPC_Muon0_clct_QuarterStrip = digi.getQuartStripBit() & 0x1;
+  bits.MPC_Muon0_clct_EighthStrip = digi.getEighthStripBit() & 0x1;
+  bits.MPC_Muon0_lct_quality = digi.getQuality() & 0x7;
+
+  // Run3-b 6-bits slope/bend
+  bits.MPC_Muon0_clct_bend_low = (digi.getSlopeEx() >> 2) & 0x7;
+  bits.MPC_Muon0_clct_bend_high = (digi.getSlopeEx() >> 5) & 0x1;
+  bits.MPC_Muon0_clct_bend_run3b_extra = digi.getSlopeEx() & 0x3;
+  bits.MPC_Muon0_clct_LR = digi.getBend() & 0x1;
+  bits.MPC_Muon_HMT_bit0 = digi.getHMT() & 0x1;
+  bits.MPC_Muon_HMT_high = (digi.getHMT() >> 1) & 0x3;                   // Run3-b MPC-LCT HMT is 3-bits
+  bits.MPC_Muon0_GEM_layer = digi.getGemLayerUsedForSlopeComputation();  // Run3-b ME11 with GE11 GEM layer information
+  bits.MPC_Muon_alct_bxn = digi.getBX();
+  bits.MPC_Muon0_clct_bx0 = digi.getBX0();
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addCorrelatedLCT1(const CSCCorrelatedLCTDigi& digi) {
+  bits.MPC_Muon1_lct_vpf = digi.isValid();
+  bits.MPC_Muon1_alct_key_wire = digi.getKeyWG();
+  bits.MPC_Muon1_clct_key_halfstrip = digi.getStrip(2) & 0xFF;
+  bits.MPC_Muon1_clct_QuarterStrip = digi.getQuartStripBit() & 0x1;
+  bits.MPC_Muon1_clct_EighthStrip = digi.getEighthStripBit() & 0x1;
+  bits.MPC_Muon1_lct_quality = digi.getQuality() & 0x7;
+
+  // Run3-b 6-bits slope/bend
+  bits.MPC_Muon1_clct_bend_low = (digi.getSlopeEx() >> 2) & 0x7;
+  bits.MPC_Muon1_clct_bend_high = (digi.getSlopeEx() >> 5) & 0x1;
+  bits.MPC_Muon1_clct_bend_run3b_extra = digi.getSlopeEx() & 0x3;
+  bits.MPC_Muon1_clct_LR = digi.getBend() & 0x1;
+  bits.MPC_Muon_HMT_bit0 = digi.getHMT() & 0x1;
+  bits.MPC_Muon_HMT_high = (digi.getHMT() >> 1) & 0x3;                   // Run3-b MPC-LCT HMT is 3-bits
+  bits.MPC_Muon1_GEM_layer = digi.getGemLayerUsedForSlopeComputation();  // Run3-b ME11 with GE11 GEM layer information
+  bits.MPC_Muon_alct_bxn = digi.getBX();
+  bits.MPC_Muon1_clct_bx0 = digi.getBX0();
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addShower(const CSCShowerDigi& digi) {
+  uint16_t hmt_bits = (digi.bitsInTime() & 0x3) + ((digi.bitsOutOfTime() & 0x3) << 2);
+  //not valid LCT shower, then in-time bits must be 0
+  if (not digi.isValid())
+    hmt_bits = ((digi.bitsOutOfTime() & 0x3) << 2);
+  bits.MPC_Muon_HMT_bit0 = hmt_bits & 0x1;
+  bits.MPC_Muon_HMT_high = (hmt_bits >> 1) & 0x3;
+  //to keep pop_l1a_match_win
+  if (digi.isValid())
+    bits.pop_l1a_match_win = CSCConstants::LCT_CENTRAL_BX - digi.getBX();
+  else
+    bits.pop_l1a_match_win = 3;  //default value
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addAnodeShower(const CSCShowerDigi& digi) {
+  uint16_t hmt_bits = digi.bitsInTime() & 0x3;
+  if (not digi.isValid())
+    hmt_bits = 0;
+  bits.anode_hmt = hmt_bits;
+  if (not(bits.MPC_Muon_HMT_bit0 or bits.MPC_Muon_HMT_high) and digi.isValid())
+    bits.pop_l1a_match_win = CSCConstants::LCT_CENTRAL_BX - digi.getBX();
+  else if (not(digi.isValid()))
+    bits.pop_l1a_match_win = 3;  //default value
+}
+
+void CSCTMBHeader2020_GEM_Run3b::addCathodeShower(const CSCShowerDigi& digi) {
+  uint16_t hmt_bits = digi.bitsInTime() & 0x3;
+  if (not digi.isValid())
+    hmt_bits = 0;
+  bits.cathode_hmt = hmt_bits;
+  bits.hmt_nhits_bit0 = digi.getComparatorNHits() & 0x1;
+  bits.hmt_nhits_bit1 = (digi.getComparatorNHits() >> 1) & 0x1;
+  bits.hmt_nhits_bits_high = (digi.getComparatorNHits() >> 2) & 0x1F;
+  if (bits.MPC_Muon_HMT_bit0 or bits.MPC_Muon_HMT_high or bits.anode_hmt) {
+    //pop_l1a_match_win is assigned
+    bits.hmt_match_win = CSCConstants::LCT_CENTRAL_BX - bits.pop_l1a_match_win + 3 - digi.getBX();
+  } else if (digi.isValid()) {
+    bits.pop_l1a_match_win = 3;  //default value
+    bits.hmt_match_win = CSCConstants::LCT_CENTRAL_BX - digi.getBX();
+  } else {
+    bits.pop_l1a_match_win = 3;  //default value
+    bits.hmt_match_win = 0;      //no HMT case
+  }
+}
+
+void CSCTMBHeader2020_GEM_Run3b::print(std::ostream& os) const {
+  os << "...............(O)TMB2020 ME11 GEM/CCLUT/HMT Header.................."
+     << "\n";
+  os << std::hex << "BOC LINE " << bits.b0cline << " EOB " << bits.e0bline << "\n";
+  os << std::hex << "FW revision: 0x" << bits.firmRevCode << "\n";
+  os << std::dec << "fifoMode = " << bits.fifoMode << ", nTBins = " << bits.nTBins << "\n";
+  os << "boardID = " << bits.boardID << ", cscID = " << bits.cscID << "\n";
+  os << "l1aNumber = " << bits.l1aNumber << ", bxnCount = " << bits.bxnCount << "\n";
+  os << "trigSourceVect = " << bits.trigSourceVect << ", run3_trig_df = " << bits.run3_trig_df
+     << ", gem_enable = " << bits.gem_enable << ", gem_csc_bend_enable = " << bits.gem_csc_bend_enable
+     << ", activeCFEBs = 0x" << std::hex << (bits.activeCFEBs | (bits.activeCFEBs_2 << 5)) << ", readCFEBs = 0x"
+     << std::hex << (bits.readCFEBs | (bits.readCFEBs_2 << 5)) << std::dec << "\n";
+  os << "bxnPreTrigger = " << bits.bxnPreTrigger << "\n";
+  os << "ALCT location in CLCT window " << bits.matchWin << " L1A location in TMB window " << bits.pop_l1a_match_win
+     << " ALCT in cathde HMT window " << bits.hmt_match_win << "\n";
+  os << "tmbMatch = " << bits.tmbMatch << " alctOnly = " << bits.alctOnly << " clctOnly = " << bits.clctOnly << "\n";
+
+  os << "readoutCounter: " << std::dec << bits.readoutCounter << ", buf_q_ovf: " << bits.stackOvf
+     << ", sync_err: " << bits.syncError << ", has_buf: " << bits.hasBuf << ", buf_stalled: " << bits.bufFull << "\n";
+  os << "r_wr_buf_adr: 0x" << std::hex << bits.r_wr_buf_adr << ", r_wr_buf_ready: " << bits.r_wr_buf_ready
+     << ", wr_buf_ready: " << bits.wr_buf_ready << ", buf_q_full: " << bits.buf_q_full
+     << ", buf_q_empty: " << bits.buf_q_empty << ",\nr_buf_fence_dist: 0x" << bits.r_buf_fence_dist
+     << ", buf_q_ovf_err: " << bits.buf_q_ovf_err << ", buf_q_udf_err: " << bits.buf_q_udf_err
+     << ", buf_q_adr_err: " << bits.buf_q_adr_err << ", buf_stalled: " << bits.buf_stalled << ",\nbuf_fence_cnt: 0x"
+     << bits.buf_fence_cnt << ", reverse_hs_csc: " << bits.reverse_hs_csc
+     << ", reverse_hs_me1a: " << bits.reverse_hs_me1a << ", reverse_hs_me1b: " << bits.reverse_hs_me1b << std::dec
+     << "\n";
+  os << "CLCT Words:\n"
+     << " bits.clct0_valid = " << bits.clct0_valid << " bits.clct0_shape = " << bits.clct0_shape
+     << " bits.clct0_quality = " << bits.clct0_quality
+     << " halfstrip = " << (bits.clct0_key_low + (bits.clct0_key_high << 7)) << "\n";
+  os << " bits.clct0_xky = " << bits.clct0_xky << " bits.clct0_comparator_code = " << bits.clct0_comparator_code
+     << " bits.clct0_LR_bend = " << bits.clct0_LR_bend << " bits.clct0_slope = " << bits.clct0_slope << "\n";
+
+  os << " bits.clct1_valid = " << bits.clct1_valid << " bits.clct1_shape = " << bits.clct1_shape
+     << " bits.clct1_quality = " << bits.clct1_quality
+     << " halfstrip = " << (bits.clct1_key_low + (bits.clct1_key_high << 7)) << "\n";
+  os << " bits.clct1_xky = " << bits.clct1_xky << " bits.clct1_comparator_code = " << bits.clct1_comparator_code
+     << " bits.clct1_LR_bend = " << bits.clct1_LR_bend << " bits.clct1_slope = " << bits.clct1_slope << "\n";
+
+  os << "MPC Words:\n"
+     << " LCT0 valid = " << bits.MPC_Muon0_lct_vpf << " key WG = " << bits.MPC_Muon0_alct_key_wire
+     << " key halfstrip = " << bits.MPC_Muon0_clct_key_halfstrip
+     << " 1/4strip flag = " << bits.MPC_Muon0_clct_QuarterStrip
+     << " 1/8strip flag = " << bits.MPC_Muon0_clct_EighthStrip << "\n"
+     << " quality = " << bits.MPC_Muon0_lct_quality << " 6bits slope/bend = "
+     << ((bits.MPC_Muon0_clct_bend_run3b_extra & 0x3) | ((bits.MPC_Muon0_clct_bend_low & 0x7) << 2) |
+         (bits.MPC_Muon0_clct_bend_high << 5))
+     << " (extra bend bits = " << bits.MPC_Muon0_clct_bend_run3b_extra << ")"
+     << " L/R bend = " << bits.MPC_Muon0_clct_LR << " LCT0_GEM layer = " << bits.MPC_Muon0_GEM_layer << "\n";
+
+  os << " LCT1 valid = " << bits.MPC_Muon1_lct_vpf << " key WG = " << bits.MPC_Muon1_alct_key_wire
+     << " key halfstrip = " << bits.MPC_Muon1_clct_key_halfstrip
+     << " 1/4strip flag = " << bits.MPC_Muon1_clct_QuarterStrip
+     << " 1/8strip flag = " << bits.MPC_Muon1_clct_EighthStrip << "\n"
+     << " quality = " << bits.MPC_Muon1_lct_quality << " 6bits slope/bend = "
+     << ((bits.MPC_Muon1_clct_bend_run3b_extra & 0x3) | ((bits.MPC_Muon1_clct_bend_low & 0x7) << 2) |
+         (bits.MPC_Muon1_clct_bend_high << 5))
+     << " (extra bend bits = " << bits.MPC_Muon1_clct_bend_run3b_extra << ")"
+     << " L/R bend = " << bits.MPC_Muon1_clct_LR << " LCT1_GEM layer = " << bits.MPC_Muon1_GEM_layer << "\n";
+
+  os << " HMT = " << (bits.MPC_Muon_HMT_bit0 | (bits.MPC_Muon_HMT_high << 1)) << ", alctHMT = " << bits.anode_hmt
+     << ", clctHMT = " << bits.cathode_hmt << " cathode nhits " << hmt_nhits() << "\n";
+
+  // os << "..................CLCT....................." << "\n";
+  os << "GEM Data:\n"
+     << " gem_enabled_fibers = 0x" << std::hex << gem_enabled_fibers() << std::dec
+     << " gem_fifo_tbins = " << gem_fifo_tbins() << " gem_fifo_pretrig = " << gem_fifo_pretrig()
+     << " gem_zero_suppress = " << gem_zero_suppress() << " gem_csc_bend_enable = " << bits.gem_csc_bend_enable
+     << " gem_sync_dataword = 0x" << std::hex << gem_sync_dataword() << " gem_timing_dataword = 0x" << std::hex
+     << gem_timing_dataword() << std::dec << "\n";
+  os << " gem num_copad: " << bits.num_copad << ", gem_delay: " << bits.gem_delay
+     << ", gem_clct_win: " << bits.gem_clct_win << ", alct_gem_win: " << bits.alct_gem_win << "\n";
+}

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
@@ -114,6 +114,13 @@ private:
   // Construct LCT from CSC and GEM information. ALCT+2GEM
   void constructLCTsGEM(const CSCALCTDigi& alct, const GEMInternalCluster& gem, CSCCorrelatedLCTDigi& lct) const;
 
+  void fillBaseInfo(CSCCorrelatedLCTDigi& lct) const;
+  void fillCCLUTInfo(CSCCorrelatedLCTDigi& lct,
+                     const CSCCLCTDigi* clct,
+                     const GEMInternalCluster* gem,
+                     const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                     const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) const;
+
   // LCTs are sorted by quality. If there are two with the same quality,
   // then the sorting is done by the slope
   void sortLCTs(std::vector<CSCCorrelatedLCTDigi>& lcts) const;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <algorithm>
 
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h"
 CSCGEMMotherboard::CSCGEMMotherboard(unsigned endcap,
@@ -47,7 +48,7 @@ void CSCGEMMotherboard::clear() { clusterProc_->clear(); }
 //function to convert GEM-CSC amended signed slope into Run2 legacy pattern number
 uint16_t CSCGEMMotherboard::Run2PatternConverter(const int slope) const {
   unsigned sign = std::signbit(slope);
-  unsigned slope_ = abs(slope);
+  unsigned slope_ = std::abs(slope);
   uint16_t Run2Pattern = 0;
 
   if (slope_ < 3)
@@ -493,6 +494,69 @@ void CSCGEMMotherboard::correlateLCTsGEM(const CSCALCTDigi& ALCT,
   }
 }
 
+void CSCGEMMotherboard::fillBaseInfo(CSCCorrelatedLCTDigi& thisLCT) const {
+  thisLCT.setValid(true);
+  thisLCT.setMPCLink(0);
+  thisLCT.setBX0(0);
+  thisLCT.setSyncErr(0);
+  thisLCT.setCSCID(theTrigChamber);
+  thisLCT.setTrknmb(0);  // will be set later after sorting
+}
+
+void CSCGEMMotherboard::fillCCLUTInfo(CSCCorrelatedLCTDigi& thisLCT,
+                                      const CSCCLCTDigi* clct,
+                                      const GEMInternalCluster* gem,
+                                      const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                                      const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) const {
+  if (!runCCLUT_)
+    return;
+  CSCCorrelatedLCTDigi::Version version = CSCCorrelatedLCTDigi::Version::Run3;
+  if (lookupTableME11ILT || lookupTableME21ILT) {
+    const auto me11_n_bits =
+        lookupTableME11ILT ? std::make_optional(lookupTableME11ILT->es_diff_slope_bit_width()) : std::nullopt;
+    const auto me21_n_bits =
+        lookupTableME21ILT ? std::make_optional(lookupTableME21ILT->es_diff_slope_bit_width()) : std::nullopt;
+    if (me11_n_bits.has_value() && me21_n_bits.has_value() && me11_n_bits != me21_n_bits) {
+      throw cms::Exception("CSCGEMMotherboard")
+          << "Mismatch in ES diff slope bit width between ME11 and ME21 LUTs! ME11: " << *me11_n_bits
+          << " bits, ME21: " << *me21_n_bits << " bits. This may lead to incorrect slope and pattern assignment.";
+    }
+    const unsigned n_bits = me11_n_bits.has_value() ? *me11_n_bits : *me21_n_bits;
+    if (n_bits != 4 && n_bits != 6) {
+      throw cms::Exception("CSCGEMMotherboard")
+          << "Unsupported ES diff slope bit width in LUTs! Expected 4 or 6 bits, but got " << n_bits << " bits.";
+    }
+    if (n_bits == 6)
+      version = CSCCorrelatedLCTDigi::Version::Run3HR;
+  }
+  thisLCT.setVersion(version);
+  if (clct) {
+    if (assign_gem_csc_bending_ && gem && gem->isValid()) {
+      //calculate new slope from strip difference between CLCT and associated GEM
+      const int slope = cscGEMMatcher_->calculateGEMCSCBending(*clct, *gem, lookupTableME11ILT, lookupTableME21ILT);
+      const int gemLayer = gem->isMatchingLayer1() ? 1 : (gem->isMatchingLayer2() ? 2 : 0);
+      thisLCT.setGemLayerUsedForSlopeComputation(gemLayer);
+      thisLCT.setSlope(std::abs(slope));
+      thisLCT.setBend(std::signbit(slope));
+      thisLCT.setPattern(Run2PatternConverter(slope));
+    } else {
+      unsigned clct_slope = clct->getSlope();
+      if (version == CSCCorrelatedLCTDigi::Version::Run3HR)
+        clct_slope *= 4;
+      thisLCT.setSlope(clct_slope);
+    }
+    thisLCT.setQuartStripBit(clct->getQuartStripBit());
+    thisLCT.setEighthStripBit(clct->getEighthStripBit());
+    thisLCT.setRun3Pattern(clct->getRun3Pattern());
+  } else {
+    thisLCT.setSlope(0);
+    thisLCT.setQuartStripBit(false);
+    thisLCT.setEighthStripBit(false);
+    // ALCT-2GEM type LCTs do not bend in the chamber
+    thisLCT.setRun3Pattern(4);
+  }
+}
+
 // Construct LCT from CSC and GEM information. Option ALCT-CLCT-GEM
 void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct,
                                          const CSCCLCTDigi& clct,
@@ -500,7 +564,7 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct,
                                          const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
                                          const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
                                          CSCCorrelatedLCTDigi& thisLCT) const {
-  thisLCT.setValid(true);
+  fillBaseInfo(thisLCT);
   if (gem.isCoincidence())
     thisLCT.setType(CSCCorrelatedLCTDigi::ALCTCLCT2GEM);
   else if (gem.isValid())
@@ -512,58 +576,29 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct,
   thisLCT.setGEM1(gem.mid1());
   thisLCT.setGEM2(gem.mid2());
   thisLCT.setPattern(encodePattern(clct.getPattern()));
-  thisLCT.setMPCLink(0);
-  thisLCT.setBX0(0);
-  thisLCT.setSyncErr(0);
-  thisLCT.setCSCID(theTrigChamber);
-  thisLCT.setTrknmb(0);  // will be set later after sorting
   thisLCT.setWireGroup(alct.getKeyWG());
   thisLCT.setStrip(clct.getKeyStrip());
   thisLCT.setBend(clct.getBend());
   thisLCT.setBX(alct.getBX());
-  if (runCCLUT_) {
-    thisLCT.setRun3(true);
-    if (assign_gem_csc_bending_ &&
-        gem.isValid()) {  //calculate new slope from strip difference between CLCT and associated GEM
-      int slope = cscGEMMatcher_->calculateGEMCSCBending(clct, gem, lookupTableME11ILT, lookupTableME21ILT);
-      thisLCT.setSlope(abs(slope));
-      thisLCT.setBend(std::signbit(slope));
-      thisLCT.setPattern(Run2PatternConverter(slope));
-    } else
-      thisLCT.setSlope(clct.getSlope());
-    thisLCT.setQuartStripBit(clct.getQuartStripBit());
-    thisLCT.setEighthStripBit(clct.getEighthStripBit());
-    thisLCT.setRun3Pattern(clct.getRun3Pattern());
-  }
+
+  fillCCLUTInfo(thisLCT, &clct, &gem, lookupTableME11ILT, lookupTableME21ILT);
 }
 
 // Construct LCT from CSC and GEM information. Option ALCT-CLCT
 void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& aLCT,
                                          const CSCCLCTDigi& cLCT,
                                          CSCCorrelatedLCTDigi& thisLCT) const {
-  thisLCT.setValid(true);
+  fillBaseInfo(thisLCT);
   thisLCT.setType(CSCCorrelatedLCTDigi::ALCTCLCT);
   thisLCT.setALCT(getBXShiftedALCT(aLCT));
   thisLCT.setCLCT(getBXShiftedCLCT(cLCT));
   thisLCT.setPattern(encodePattern(cLCT.getPattern()));
-  thisLCT.setMPCLink(0);
-  thisLCT.setBX0(0);
-  thisLCT.setSyncErr(0);
-  thisLCT.setCSCID(theTrigChamber);
-  thisLCT.setTrknmb(0);  // will be set later after sorting
   thisLCT.setWireGroup(aLCT.getKeyWG());
   thisLCT.setStrip(cLCT.getKeyStrip());
   thisLCT.setBend(cLCT.getBend());
   thisLCT.setBX(aLCT.getBX());
   thisLCT.setQuality(qualityAssignment_->findQuality(aLCT, cLCT));
-  if (runCCLUT_) {
-    thisLCT.setRun3(true);
-    // 4-bit slope value derived with the CCLUT algorithm
-    thisLCT.setSlope(cLCT.getSlope());
-    thisLCT.setQuartStripBit(cLCT.getQuartStripBit());
-    thisLCT.setEighthStripBit(cLCT.getEighthStripBit());
-    thisLCT.setRun3Pattern(cLCT.getRun3Pattern());
-  }
+  fillCCLUTInfo(thisLCT, &cLCT, nullptr, nullptr, nullptr);
 }
 
 // Construct LCT from CSC and GEM information. Option CLCT-2GEM
@@ -572,76 +607,43 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCCLCTDigi& clct,
                                          const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
                                          const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
                                          CSCCorrelatedLCTDigi& thisLCT) const {
-  thisLCT.setValid(true);
+  fillBaseInfo(thisLCT);
   thisLCT.setType(CSCCorrelatedLCTDigi::CLCT2GEM);
   thisLCT.setQuality(qualityAssignment_->findQuality(clct, gem));
   thisLCT.setCLCT(getBXShiftedCLCT(clct));
   thisLCT.setGEM1(gem.mid1());
   thisLCT.setGEM2(gem.mid2());
   thisLCT.setPattern(encodePattern(clct.getPattern()));
-  thisLCT.setMPCLink(0);
-  thisLCT.setBX0(0);
-  thisLCT.setSyncErr(0);
-  thisLCT.setCSCID(theTrigChamber);
-  thisLCT.setTrknmb(0);  // will be set later after sorting
   thisLCT.setWireGroup(gem.getKeyWG());
   thisLCT.setStrip(clct.getKeyStrip());
   thisLCT.setBend(clct.getBend());
   thisLCT.setBX(gem.bx());
-  if (runCCLUT_) {
-    thisLCT.setRun3(true);
-    if (assign_gem_csc_bending_ &&
-        gem.isValid()) {  //calculate new slope from strip difference between CLCT and associated GEM
-      int slope = cscGEMMatcher_->calculateGEMCSCBending(clct, gem, lookupTableME11ILT, lookupTableME21ILT);
-      thisLCT.setSlope(abs(slope));
-      thisLCT.setBend(pow(-1, std::signbit(slope)));
-      thisLCT.setPattern(Run2PatternConverter(slope));
-    } else
-      thisLCT.setSlope(clct.getSlope());
-    thisLCT.setQuartStripBit(clct.getQuartStripBit());
-    thisLCT.setEighthStripBit(clct.getEighthStripBit());
-    thisLCT.setRun3Pattern(clct.getRun3Pattern());
-  }
+  fillCCLUTInfo(thisLCT, &clct, &gem, lookupTableME11ILT, lookupTableME21ILT);
 }
 
 // Construct LCT from CSC and GEM information. Option ALCT-2GEM
 void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct,
                                          const GEMInternalCluster& gem,
                                          CSCCorrelatedLCTDigi& thisLCT) const {
-  thisLCT.setValid(true);
+  fillBaseInfo(thisLCT);
   thisLCT.setType(CSCCorrelatedLCTDigi::ALCT2GEM);
   thisLCT.setQuality(qualityAssignment_->findQuality(alct, gem));
   thisLCT.setALCT(getBXShiftedALCT(alct));
   thisLCT.setGEM1(gem.mid1());
   thisLCT.setGEM2(gem.mid2());
   thisLCT.setPattern(10);
-  thisLCT.setMPCLink(0);
-  thisLCT.setBX0(0);
-  thisLCT.setSyncErr(0);
-  thisLCT.setCSCID(theTrigChamber);
-  thisLCT.setTrknmb(0);  // will be set later after sorting
   thisLCT.setWireGroup(alct.getKeyWG());
   thisLCT.setStrip(gem.getKeyStrip());
   thisLCT.setBend(0);
   thisLCT.setBX(alct.getBX());
-  if (runCCLUT_) {
-    thisLCT.setRun3(true);
-    thisLCT.setSlope(0);
-    thisLCT.setQuartStripBit(false);
-    thisLCT.setEighthStripBit(false);
-    // ALCT-2GEM type LCTs do not bend in the chamber
-    thisLCT.setRun3Pattern(4);
-  }
+  fillCCLUTInfo(thisLCT, nullptr, &gem, nullptr, nullptr);
 }
 
 void CSCGEMMotherboard::sortLCTs(std::vector<CSCCorrelatedLCTDigi>& lcts) const {
   // LCTs are sorted by quality. If there are two with the same quality, then the sorting is done by the slope
   std::sort(lcts.begin(), lcts.end(), [](const CSCCorrelatedLCTDigi& lct1, const CSCCorrelatedLCTDigi& lct2) -> bool {
-    if (lct1.getQuality() > lct2.getQuality())
-      return lct1.getQuality() > lct2.getQuality();
-    else if (lct1.getQuality() == lct2.getQuality())
-      return lct1.getSlope() < lct2.getSlope();
-    else
-      return false;
+    if (lct1.getQuality() == lct2.getQuality())
+      return lct1.getSlopeEx() < lct2.getSlopeEx();
+    return lct1.getQuality() > lct2.getQuality();
   });
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -521,7 +521,7 @@ void CSCMotherboard::constructLCTs(
   thisLCT.setBX(bx);
   thisLCT.setQuality(qualityAssignment_->findQuality(aLCT, cLCT));
   if (runCCLUT_) {
-    thisLCT.setRun3(true);
+    thisLCT.setVersion(CSCCorrelatedLCTDigi::Version::Run3);
     // 4-bit slope value derived with the CCLUT algorithm
     thisLCT.setSlope(cLCT.getSlope());
     thisLCT.setQuartStripBit(cLCT.getQuartStripBit());

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing
 from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+from CalibMuon.CSCCalibration.CSCCustomizeBendingAngle_cfi import set_6bit_gemcsc_bending_LUTs
 
 options = VarParsing('analysis')
 options.register("unpack", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
@@ -58,6 +59,8 @@ options.register("dropNonMuonCollections", True, VarParsing.multiplicity.singlet
                  "Option to drop most non-muon collections generally considered unnecessary for GEM/CSC analysis")
 options.register("dqmOutputFile", "step_DQM.root", VarParsing.multiplicity.singleton, VarParsing.varType.string,
                  "Name of the DQM output file. Default: step_DQM.root")
+options.register("use6BitGEMCSCBendingAngle", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Set to True if you want to use 6 bit LUTs for the GEM-CSC bending angle in the CSCGEMMatcher.")
 options.parseArguments()
 
 process_era = Run3
@@ -79,6 +82,11 @@ process.load("CalibMuon.CSCCalibration.CSCL1TPLookupTableEP_cff")
 process.load('L1Trigger.L1TGEM.simGEMDigis_cff')
 process.load("DQM.L1TMonitor.L1TdeCSCTPG_cfi")
 process.load("DQM.L1TMonitor.L1TdeGEMTPG_cfi")
+
+
+if options.use6BitGEMCSCBendingAngle:
+      process = set_6bit_gemcsc_bending_LUTs(process)
+
 
 process.maxEvents = cms.untracked.PSet(
       input = cms.untracked.int32(options.maxEvents)


### PR DESCRIPTION
#### PR description:

This PR adds support for a 6-bit slope to the CSC OTMB emulator code and corresponding changes to the CSC unpacking to support OTMB LCT ME11 GEM data format changes. The default emulator behavior remains unchanged (4-bit slope), and a customization function is provided to switch to the new format for R&D purposes. The changes are in line with the new proposed OTMB LCT data format discussed [here](https://indico.cern.ch/event/1491198/#sc-3-6-gem-csc-bending-angle-o).

#### PR validation:

Validation results were presented and blessed at the CSC general meeting https://indico.cern.ch/event/1678096/#24-validation-of-otmb-run3-lct

#### This PR is a backport into the CMSSW_16_1_X release cycle to be used for 2026 heavy ion data taking
Original PRs: https://github.com/cms-sw/cmssw/pull/50633 https://github.com/cms-sw/cmssw/pull/50745 
Backport PR into CMSSW_16_0_X: https://github.com/cms-sw/cmssw/pull/50789