### PR TITLE
NanoAOD: remove `saveTriggerResults` parameter from `NanoAOD*OutputModule` (revert #50057)

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
@@ -69,7 +69,6 @@ private:
   int m_eventsSinceFlush{0};
   std::string m_compressionAlgorithm;
   bool m_writeProvenance;
-  bool m_writeTriggerResults;
   bool m_fakeName;  //crab workaround, remove after crab is fixed
   int m_autoFlush;
   edm::ProcessHistoryRegistry m_processHistoryRegistry;
@@ -161,7 +160,6 @@ NanoAODOutputModule::NanoAODOutputModule(edm::ParameterSet const& pset)
       m_compressionLevel(pset.getUntrackedParameter<int>("compressionLevel")),
       m_compressionAlgorithm(pset.getUntrackedParameter<std::string>("compressionAlgorithm")),
       m_writeProvenance(pset.getUntrackedParameter<bool>("saveProvenance", true)),
-      m_writeTriggerResults(pset.getUntrackedParameter<bool>("saveTriggerResults")),
       m_fakeName(pset.getUntrackedParameter<bool>("fakeNameForCrab", false)),
       m_autoFlush(pset.getUntrackedParameter<int>("autoFlush", -10000000)),
       m_processHistoryRegistry() {}
@@ -212,24 +210,19 @@ void NanoAODOutputModule::write(edm::EventForOutput const& iEvent) {
     for (auto& t : m_tables)
       t.fill(iEvent, *m_tree, extensions);
   }
-
-  if (m_writeTriggerResults) {
-    if (!m_triggers_areSorted) {  // sort triggers/flags in inverse processHistory order, to save without any special label the most recent ones
-      std::vector<std::string> pnames;
-      for (auto& p : iEvent.processHistory())
-        pnames.push_back(p.processName());
-      std::sort(m_triggers.begin(), m_triggers.end(), [pnames](TriggerOutputBranches& a, TriggerOutputBranches& b) {
-        return ((std::find(pnames.begin(), pnames.end(), a.processName()) - pnames.begin()) >
-                (std::find(pnames.begin(), pnames.end(), b.processName()) - pnames.begin()));
-      });
-      m_triggers_areSorted = true;
-    }
-    // fill triggers
-    for (auto& t : m_triggers) {
-      t.fill(iEvent, *m_tree);
-    }
+  if (!m_triggers_areSorted) {  // sort triggers/flags in inverse processHistory order, to save without any special label the most recent ones
+    std::vector<std::string> pnames;
+    for (auto& p : iEvent.processHistory())
+      pnames.push_back(p.processName());
+    std::sort(m_triggers.begin(), m_triggers.end(), [pnames](TriggerOutputBranches& a, TriggerOutputBranches& b) {
+      return ((std::find(pnames.begin(), pnames.end(), a.processName()) - pnames.begin()) >
+              (std::find(pnames.begin(), pnames.end(), b.processName()) - pnames.begin()));
+    });
+    m_triggers_areSorted = true;
   }
-
+  // fill triggers
+  for (auto& t : m_triggers)
+    t.fill(iEvent, *m_tree);
   // fill event branches
   for (auto& t : m_evstrings)
     t.fill(iEvent, *m_tree);
@@ -320,12 +313,8 @@ void NanoAODOutputModule::openFile(edm::FileBlock const&) {
   }
   /* Setup file structure here */
   m_tables.clear();
-
-  if (m_writeTriggerResults) {
-    m_triggers.clear();
-    m_triggers_areSorted = false;
-  }
-
+  m_triggers.clear();
+  m_triggers_areSorted = false;
   m_evstrings.clear();
   m_runTables.clear();
   m_lumiTables.clear();
@@ -336,9 +325,7 @@ void NanoAODOutputModule::openFile(edm::FileBlock const&) {
     if (keep.first->className() == "nanoaod::FlatTable")
       m_tables.emplace_back(keep.first, keep.second);
     else if (keep.first->className() == "edm::TriggerResults") {
-      if (m_writeTriggerResults) {
-        m_triggers.emplace_back(keep.first, keep.second);
-      }
+      m_triggers.emplace_back(keep.first, keep.second);
     } else if (keep.first->className() == "std::basic_string<char,std::char_traits<char> >" &&
                keep.first->productInstanceName() == "genModel") {  // friendlyClassName == "String"
       m_evstrings.emplace_back(keep.first, keep.second, true);     // update only at lumiBlock transitions
@@ -427,8 +414,6 @@ void NanoAODOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descr
       ->setComment("Algorithm used to compress data in the ROOT output file, allowed values are ZLIB and LZMA");
   desc.addUntracked<bool>("saveProvenance", true)
       ->setComment("Save process provenance information, e.g. for edmProvDump");
-  desc.addUntracked<bool>("saveTriggerResults", true)
-      ->setComment("Save the content of edm::TriggerResults in dedicated output branches (one per trigger)");
   desc.addUntracked<bool>("fakeNameForCrab", false)
       ->setComment(
           "Change the OutputModule name in the fwk job report to fake PoolOutputModule. This is needed to run on cran "

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
@@ -59,7 +59,6 @@ private:
   std::string m_compressionAlgorithm;
   int m_compressionLevel;
   bool m_writeProvenance;
-  bool m_writeTriggerResults;
   edm::ProcessHistoryRegistry m_processHistoryRegistry;
   edm::JobReport::Token m_jrToken;
 
@@ -122,7 +121,6 @@ NanoAODRNTupleOutputModule::NanoAODRNTupleOutputModule(edm::ParameterSet const& 
       m_compressionAlgorithm(pset.getUntrackedParameter<std::string>("compressionAlgorithm")),
       m_compressionLevel(pset.getUntrackedParameter<int>("compressionLevel")),
       m_writeProvenance(pset.getUntrackedParameter<bool>("saveProvenance", true)),
-      m_writeTriggerResults(pset.getUntrackedParameter<bool>("saveTriggerResults")),
       m_processHistoryRegistry(),
       m_noSplitFields{pset.getUntrackedParameter<std::vector<std::string>>("noSplitFields")},
       m_writeOptions(writeOptions(pset.getUntrackedParameterSet("rntupleWriteOptions"))) {}
@@ -243,9 +241,7 @@ void NanoAODRNTupleOutputModule::initializeNTuple(edm::EventForOutput const& iEv
       iEvent.getByToken(token, handle);
       m_tables.add(token, *handle);
     } else if (keep.first->className() == "edm::TriggerResults") {
-      if (m_writeTriggerResults) {
-        m_triggers.emplace_back(TriggerOutputFields(keep.first->processName(), keep.second));
-      }
+      m_triggers.emplace_back(TriggerOutputFields(keep.first->processName(), keep.second));
     } else if (keep.first->className() == "std::basic_string<char,std::char_traits<char> >" &&
                keep.first->productInstanceName() == "genModel") {
       m_evstrings.registerToken(keep.second);
@@ -254,10 +250,8 @@ void NanoAODRNTupleOutputModule::initializeNTuple(edm::EventForOutput const& iEv
     }
   }
   m_tables.createFields(iEvent, *model);
-  if (m_writeTriggerResults) {
-    for (auto& trigger : m_triggers) {
-      trigger.createFields(iEvent, *model);
-    }
+  for (auto& trigger : m_triggers) {
+    trigger.createFields(iEvent, *model);
   }
   m_evstrings.createFields(*model);
 
@@ -291,10 +285,8 @@ void NanoAODRNTupleOutputModule::write(edm::EventForOutput const& iEvent) {
 
   m_commonFields.fill(iEvent.id());
   m_tables.fill(iEvent);
-  if (m_writeTriggerResults) {
-    for (auto& trigger : m_triggers) {
-      trigger.fill(iEvent);
-    }
+  for (auto& trigger : m_triggers) {
+    trigger.fill(iEvent);
   }
   m_evstrings.fill(iEvent);
   m_ntuple->Fill();
@@ -371,8 +363,6 @@ void NanoAODRNTupleOutputModule::fillDescriptions(edm::ConfigurationDescriptions
   }
   desc.addUntracked<bool>("saveProvenance", true)
       ->setComment("Save process provenance information, e.g. for edmProvDump");
-  desc.addUntracked<bool>("saveTriggerResults", true)
-      ->setComment("Save the content of edm::TriggerResults in dedicated output branches (one per trigger)");
   const std::vector<std::string> keep = {"drop *",
                                          "keep nanoaodFlatTable_*Table_*_*",
                                          "keep edmTriggerResults_*_*_*",


### PR DESCRIPTION
#### PR description:

This PR reverts #50057 (which was integrated in `CMSSW_16_1_0_pre3`).

For what I understand (thanks to #50720), the parameter `saveTriggerResults` introduced in #50057 is redundant, because setting `saveTriggerResults` to `False` in instances of `NanoAODOutputModule` is equivalent to "dropping" the `edm::TriggerResults` products from those OutputModules.

Merely technical, no changes expected in the outputs of PR tests.

Apologies for the back and forth!

#### PR validation:

Took `CMSSW_16_1_0_pre4` (without this PR) and the step2 config of wf `2500.3001` (NanoAOD step), modified the latter config to use
 - (a) `process.NANOAODSIMoutput.saveTriggerResults = cms.untracked.bool(False)` in one case, and
 - (b) `process.NANOAODSIMoutput.outputCommands += ["drop edmTriggerResults_*_*_*"]` in another case,

and verified that the NanoAOD outputs of (a) and (b) have the same branches (and no `edm::TriggerResults`-related branches are present in the output files).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

No backports are necessary (if XPOG requests it, I can backport this PR to `16_1_X` in order to remove this redundant parameter in that cycle).
