### PR TITLE
[EVOLUTION_X] Move `reco::JetFlavourInfoMatchingCollection` and `reco::SingleTauDiscriminatorContainer` to `io_v1` namespace

### DIFF
--- a/DataFormats/JetMatching/interface/JetFlavourInfoMatching.h
+++ b/DataFormats/JetMatching/interface/JetFlavourInfoMatching.h
@@ -12,16 +12,21 @@ namespace reco {
   typedef edm::AssociationVector<edm::RefToBaseProd<reco::Jet>, std::vector<reco::JetFlavourInfo> >
       JetFlavourInfoMatchingCollectionBase;
 
-  class JetFlavourInfoMatchingCollection : public JetFlavourInfoMatchingCollectionBase {
-  public:
-    JetFlavourInfoMatchingCollection() : JetFlavourInfoMatchingCollectionBase() {}
+  namespace io_v1 {
 
-    JetFlavourInfoMatchingCollection(const reco::CaloJetRefProd &ref)
-        : JetFlavourInfoMatchingCollectionBase(edm::RefToBaseProd<reco::Jet>(ref)) {}
+    class JetFlavourInfoMatchingCollection : public reco::JetFlavourInfoMatchingCollectionBase {
+    public:
+      JetFlavourInfoMatchingCollection() : reco::JetFlavourInfoMatchingCollectionBase() {}
 
-    JetFlavourInfoMatchingCollection(const JetFlavourInfoMatchingCollectionBase &v)
-        : JetFlavourInfoMatchingCollectionBase(v) {}
-  };
+      JetFlavourInfoMatchingCollection(const reco::CaloJetRefProd &ref)
+          : reco::JetFlavourInfoMatchingCollectionBase(edm::RefToBaseProd<reco::Jet>(ref)) {}
+
+      JetFlavourInfoMatchingCollection(const reco::JetFlavourInfoMatchingCollectionBase &v)
+          : reco::JetFlavourInfoMatchingCollectionBase(v) {}
+    };
+
+  }  // namespace io_v1
+  using JetFlavourInfoMatchingCollection = io_v1::JetFlavourInfoMatchingCollection;
 
   typedef JetFlavourInfoMatchingCollection::value_type JetFlavourInfoMatching;
 

--- a/DataFormats/JetMatching/src/classes_def.xml
+++ b/DataFormats/JetMatching/src/classes_def.xml
@@ -8,15 +8,15 @@
   <class name="reco::JetFlavourInfoMatchingCollectionBase">
     <field name="transientVector_" transient="true"/>
   </class>
-  <class name="reco::JetFlavourInfoMatchingCollection" ClassVersion="3">
-   <version ClassVersion="3" checksum="4221335161"/>
+  <class name="reco::io_v1::JetFlavourInfoMatchingCollection" ClassVersion="3">
+   <version ClassVersion="3" checksum="3071743479"/>
     <!-- <field name="transientVector_" transient="true"/> -->
     <!-- <field name="fixed_" transient="true"/> -->
   </class>
   <class name="reco::JetFlavourInfoMatchingRef"/>
   <class name="reco::JetFlavourInfoMatchingRefProd"/>
   <class name="reco::JetFlavourInfoMatchingRefVector"/>
-  <class name="edm::Wrapper<reco::JetFlavourInfoMatchingCollection>"/>
+  <class name="edm::Wrapper<reco::io_v1::JetFlavourInfoMatchingCollection>"/>
 
   <class name="reco::JetFlavour" ClassVersion="10">
    <version ClassVersion="10" checksum="2885862487"/>

--- a/DataFormats/TauReco/interface/TauDiscriminatorContainer.h
+++ b/DataFormats/TauReco/interface/TauDiscriminatorContainer.h
@@ -6,13 +6,16 @@
 #include <vector>
 
 namespace reco {
-  struct SingleTauDiscriminatorContainer {
-    std::vector<float> rawValues;     // stores floating point discriminators, like MVA raw values or pt sums.
-    std::vector<bool> workingPoints;  // stores boolean discriminators computed with the raw values.
+  namespace io_v1 {
+    struct SingleTauDiscriminatorContainer {
+      std::vector<float> rawValues;     // stores floating point discriminators, like MVA raw values or pt sums.
+      std::vector<bool> workingPoints;  // stores boolean discriminators computed with the raw values.
 
-    SingleTauDiscriminatorContainer() {}
-    SingleTauDiscriminatorContainer(float rawInit) { rawValues.push_back(rawInit); }
-  };
+      SingleTauDiscriminatorContainer() {}
+      SingleTauDiscriminatorContainer(float rawInit) { rawValues.push_back(rawInit); }
+    };
+  }  // namespace io_v1
+  using SingleTauDiscriminatorContainer = io_v1::SingleTauDiscriminatorContainer;
 
   typedef edm::ValueMap<SingleTauDiscriminatorContainer> TauDiscriminatorContainer;
 }  // namespace reco

--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -31,12 +31,12 @@
   <class name="reco::PFTauDiscriminatorRefVector"/>
   <class name="edm::Wrapper<reco::io_v1::PFTauDiscriminator>"/>
 
-  <class name="reco::SingleTauDiscriminatorContainer" ClassVersion="3">
-    <version ClassVersion="3" checksum="2968610760"/>
+  <class name="reco::io_v1::SingleTauDiscriminatorContainer" ClassVersion="3">
+    <version ClassVersion="3" checksum="4047255174"/>
   </class>
-  <class name="std::vector<reco::SingleTauDiscriminatorContainer>"/>
-  <class name="edm::ValueMap<reco::SingleTauDiscriminatorContainer>"/>
-  <class name="edm::Wrapper<edm::ValueMap<reco::SingleTauDiscriminatorContainer> >"/> 
+  <class name="std::vector<reco::io_v1::SingleTauDiscriminatorContainer>"/>
+  <class name="edm::ValueMap<reco::io_v1::SingleTauDiscriminatorContainer>"/>
+  <class name="edm::Wrapper<edm::ValueMap<reco::io_v1::SingleTauDiscriminatorContainer> >"/>
 
   <class name="reco::JetPiZeroAssociationBase">
     <field name="transientVector_" transient="true"/>


### PR DESCRIPTION
#### PR description:

Resolves https://github.com/cms-sw/framework-team/issues/2182

#### PR validation:

Code compiles