### PR TITLE
Reimplement MPI event synchronisation with async barriers

### DIFF
--- a/HeterogeneousCore/MPICore/interface/MPIChannel.h
+++ b/HeterogeneousCore/MPICore/interface/MPIChannel.h
@@ -27,14 +27,9 @@ public:
   MPIChannel() = default;
   MPIChannel(MPI_Comm comm, int destination) : comm_(comm), dest_(destination), sync_(false) {}
 
-  MPIChannel(MPIChannel const& other) : comm_(other.comm_), dest_(other.dest_), sync_(false) {}
+  MPIChannel(MPIChannel const& other) = delete;
 
-  MPIChannel& operator=(MPIChannel const& other) {
-    comm_ = other.comm_;
-    dest_ = other.dest_;
-    sync_ = false;
-    return *this;
-  }
+  MPIChannel& operator=(MPIChannel const& other) = delete;
 
   MPIChannel(MPIChannel&& other) : comm_(other.comm_), dest_(other.dest_), sync_(other.sync_) { other.sync_ = false; }
 
@@ -58,7 +53,7 @@ public:
   MPIChannel duplicate() const;
 
   std::unique_ptr<MPIChannel> syncChannel() const {
-    auto channel = std::make_unique<MPIChannel>(*this);
+    auto channel = std::make_unique<MPIChannel>(comm_, dest_);
     channel->sync_ = true;
     return channel;
   }

--- a/HeterogeneousCore/MPICore/interface/MPIChannel.h
+++ b/HeterogeneousCore/MPICore/interface/MPIChannel.h
@@ -2,8 +2,9 @@
 #define HeterogeneousCore_MPICore_interface_MPIChannel_h
 
 // C++ standard library headers
-#include <bitset>
-#include <iostream>
+#include <atomic>
+#include <memory>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 
@@ -22,41 +23,54 @@
 #include "HeterogeneousCore/TrivialSerialisation/interface/ReaderBase.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/WriterBase.h"
 
-class MPIChannel {
+// Avoid false sharing by aligning the whole class to a cache line.
+class alignas(64) MPIChannel {
 public:
   MPIChannel() = default;
-  MPIChannel(MPI_Comm comm, int destination) : comm_(comm), dest_(destination), sync_(false) {}
+  MPIChannel(MPI_Comm comm, int destination) : comm_(comm), dest_(destination) {}
 
   MPIChannel(MPIChannel const& other) = delete;
 
   MPIChannel& operator=(MPIChannel const& other) = delete;
 
-  MPIChannel(MPIChannel&& other) : comm_(other.comm_), dest_(other.dest_), sync_(other.sync_) { other.sync_ = false; }
+  MPIChannel(MPIChannel&& other) : comm_(other.comm_), request_(other.request_), dest_(other.dest_) {
+    ChannelStatus status = kInvalid;
+    other.status_.exchange(status, std::memory_order::acq_rel);
+    status_.store(status, std::memory_order::acq_rel);
+    other.comm_ = MPI_COMM_NULL;
+    other.request_ = MPI_REQUEST_NULL;
+    other.dest_ = MPI_UNDEFINED;
+  }
 
   MPIChannel& operator=(MPIChannel&& other) {
+    ChannelStatus status = kInvalid;
+    other.status_.exchange(status, std::memory_order::acq_rel);
+    status_.store(status, std::memory_order::acq_rel);
     comm_ = other.comm_;
+    request_ = other.request_;
     dest_ = other.dest_;
-    sync_ = other.sync_;
-    other.sync_ = false;
+    other.comm_ = MPI_COMM_NULL;
+    other.request_ = MPI_REQUEST_NULL;
+    other.dest_ = MPI_UNDEFINED;
     return *this;
   }
 
-  ~MPIChannel() {
-    // make sure both endpoints have completed processing the event(s) that were transmitted
-    if (sync_) {
-      MPI_Barrier(comm_);
-    }
-  }
+  // mark the channel as busy
+  void acquire();
 
-  // build a new MPIChannel that uses a duplicate of the underlying communicator and the same destination
+  // make sure both processes have completed processing the event that was transmitted
+  void sync();
+
+  // Build a new MPIChannel that uses a duplicate of the underlying communicator and the same destination.
+  // The new channel will be in a "ready" state.
   // Note: this is a blocking collective operation.
-  MPIChannel duplicate() const;
+  std::unique_ptr<MPIChannel> duplicate(int slot) const;
 
-  std::unique_ptr<MPIChannel> syncChannel() const {
-    auto channel = std::make_unique<MPIChannel>(comm_, dest_);
-    channel->sync_ = true;
-    return channel;
-  }
+  // check whether this channel can be used to transmit a new event
+  bool ready();
+
+  // wait until this channel can be used to transmit a new event
+  void wait();
 
   // close the underlying communicator and reset the MPIChannel to an invalid state
   // Note: this is a blocking collective operation.
@@ -91,11 +105,11 @@ public:
   }
 
   // signal a new event, and transmit the EventAuxiliary
-  void sendEvent(edm::EventAuxiliary const& aux, unsigned int sid) { sendEventAuxiliary_(aux, sid); }
+  void sendEvent(edm::EventAuxiliary const& aux, unsigned int slot) { sendEventAuxiliary_(aux, slot); }
 
   // start processing a new event, and receive the EventAuxiliary
-  MPI_Status receiveEvent(edm::EventAuxiliary& aux, unsigned int& sid, MPI_Message& message) {
-    return receiveEventAuxiliary_(aux, sid, message);
+  MPI_Status receiveEvent(edm::EventAuxiliary& aux, unsigned int& slot, MPI_Message& message) {
+    return receiveEventAuxiliary_(aux, slot, message);
   }
 
   void sendMetadata(int instance, std::shared_ptr<ProductMetadataBuilder> meta);
@@ -151,12 +165,12 @@ private:
   // serialize an EDM object to a simplified representation that can be transmitted as an MPI message
   void edmToBuffer_(EDM_MPI_RunAuxiliary_t& buffer, edm::RunAuxiliary const& aux);
   void edmToBuffer_(EDM_MPI_LuminosityBlockAuxiliary_t& buffer, edm::LuminosityBlockAuxiliary const& aux);
-  void edmToBuffer_(EDM_MPI_EventAuxiliary_t& buffer, edm::EventAuxiliary const& aux, unsigned int sid);
+  void edmToBuffer_(EDM_MPI_EventAuxiliary_t& buffer, edm::EventAuxiliary const& aux, unsigned int slot);
 
   // deserialize an EDM object from a simplified representation transmitted as an MPI message
   void edmFromBuffer_(EDM_MPI_RunAuxiliary_t const& buffer, edm::RunAuxiliary& aux);
   void edmFromBuffer_(EDM_MPI_LuminosityBlockAuxiliary_t const& buffer, edm::LuminosityBlockAuxiliary& aux);
-  void edmFromBuffer_(EDM_MPI_EventAuxiliary_t const& buffer, edm::EventAuxiliary& aux, unsigned int& sid);
+  void edmFromBuffer_(EDM_MPI_EventAuxiliary_t const& buffer, edm::EventAuxiliary& aux, unsigned int& slot);
 
   // fill and send an EDM_MPI_Empty_t buffer
   void sendEmpty_(int tag);
@@ -168,11 +182,11 @@ private:
   void sendLuminosityBlockAuxiliary_(int tag, edm::LuminosityBlockAuxiliary const& aux);
 
   // fill and send an EDM_MPI_EventAuxiliary_t buffer
-  void sendEventAuxiliary_(edm::EventAuxiliary const& aux, unsigned int sid);
+  void sendEventAuxiliary_(edm::EventAuxiliary const& aux, unsigned int slot);
 
   // receive an EDM_MPI_EventAuxiliary_t buffer and populate an edm::EventAuxiliary
-  MPI_Status receiveEventAuxiliary_(edm::EventAuxiliary& aux, unsigned int& sid, int source, int tag);
-  MPI_Status receiveEventAuxiliary_(edm::EventAuxiliary& aux, unsigned int& sid, MPI_Message& message);
+  MPI_Status receiveEventAuxiliary_(edm::EventAuxiliary& aux, unsigned int& slot, int source, int tag);
+  MPI_Status receiveEventAuxiliary_(edm::EventAuxiliary& aux, unsigned int& slot, MPI_Message& message);
 
   // this is what is used for sending when product is of raw fundamental type
   template <typename T>
@@ -194,14 +208,27 @@ private:
     MPI_Mrecv(&product, size, MPI_BYTE, &message, MPI_STATUS_IGNORE);
   }
 
+  enum ChannelStatus {
+    kInvalid = 0,
+    kReady,  // the channel is unused
+    kBusy,   // the channel has been acquired, and can be used for transmitting/receiving data
+    kSync    // the channel has been released, and is waiting for the barrier to complete
+  };
+
   // MPI communicator
   MPI_Comm comm_ = MPI_COMM_NULL;
+
+  // MPI request used to check the barrier at the end of each event
+  MPI_Request request_ = MPI_REQUEST_NULL;
 
   // MPI remote rank
   int dest_ = MPI_UNDEFINED;
 
-  // whether the MPI channel should use a barrier to synchronise both endpoints when it's being destructed
-  bool sync_;
+  int slot_ = -1;
+
+  // Note: the status_ flag is accessed atomically because it can be written to and read from by
+  // different threads.
+  std::atomic<ChannelStatus> status_ = kInvalid;
 };
 
 #endif  // HeterogeneousCore_MPICore_interface_MPIChannel_h

--- a/HeterogeneousCore/MPICore/interface/MPIToken.h
+++ b/HeterogeneousCore/MPICore/interface/MPIToken.h
@@ -1,5 +1,5 @@
-#ifndef HeterogeneousCore_MPICore_MPIToken_h
-#define HeterogeneousCore_MPICore_MPIToken_h
+#ifndef HeterogeneousCore_MPICore_interface_MPIToken_h
+#define HeterogeneousCore_MPICore_interface_MPIToken_h
 
 // C++ standard library headers
 #include <memory>
@@ -13,7 +13,7 @@ public:
   MPIToken() = default;
 
   // user-defined constructor
-  explicit MPIToken(std::shared_ptr<MPIChannel> channel) : channel_(channel) {}
+  explicit MPIToken(MPIChannel& channel);
 
   // access the data member
   MPIChannel* channel() const { return channel_.get(); }
@@ -23,4 +23,4 @@ private:
   std::shared_ptr<MPIChannel> channel_;
 };
 
-#endif  // HeterogeneousCore_MPICore_MPIToken_h
+#endif  // HeterogeneousCore_MPICore_interface_MPIToken_h

--- a/HeterogeneousCore/MPICore/interface/messages.h
+++ b/HeterogeneousCore/MPICore/interface/messages.h
@@ -102,7 +102,7 @@ struct EDM_MPI_EventAuxiliary_t : public EDM_MPI_Header_t {
   uint32_t run;               // edm::RunNumber_t
   uint32_t lumi;              // edm::LuminosityBlockNumber_t
   uint32_t event;             // edm::EventNumber_t
-  uint32_t streamId;          // edm::StreamID
+  uint32_t slotId;            // MPIChannel index
 };
 
 // corresponding MPI type

--- a/HeterogeneousCore/MPICore/plugins/MPIController.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIController.cc
@@ -72,8 +72,8 @@ private:
   }
 
   MPI_Comm comm_ = MPI_COMM_NULL;
-  std::vector<MPIChannel> channels_;
-  std::vector<std::optional<MPIChannel>> streams_;
+  std::vector<MPIChannel> followers_;
+  std::vector<std::vector<std::unique_ptr<MPIChannel>>> channels_;
   edm::EDPutTokenT<MPIToken> token_;
   Mode mode_;
 };
@@ -145,7 +145,8 @@ MPIController::MPIController(edm::ParameterSet const& config)
                           << " in MPI_COMM_WORLD, mapped to ranks 0, 1 in their private communicator.";
       // The follower process always has rank 1 in the new communicator.
       follower = 1;
-      channels_.emplace_back(comm, follower);
+      followers_.emplace_back(comm, follower);
+      channels_.emplace_back();
     }
   } else if (mode_ == kIntercommunicator) {
     // Use an intercommunicator to let two groups of processes communicate with each other.
@@ -174,7 +175,8 @@ MPIController::MPIController(edm::ParameterSet const& config)
           << "The current implementation supports only two processes: one controller and one source.";
     }
     edm::LogInfo("MPI") << "Client connected to " << size << (size == 1 ? " server" : " servers");
-    channels_.emplace_back(comm_, 0);
+    followers_.emplace_back(comm_, 0);
+    channels_.emplace_back();
   } else {
     // Invalid mode.
     throw edm::Exception(edm::errors::Configuration)
@@ -184,11 +186,15 @@ MPIController::MPIController(edm::ParameterSet const& config)
 
 MPIController::~MPIController() {
   // Disconnect the per-stream communicators.
-  for (auto& stream : streams_) {
-    // TODO move this to end stream
-    if (stream) {
-      stream->reset();
+  for (auto& channels : channels_) {
+    for (auto& channel : channels) {
+      channel->reset();
     }
+  }
+
+  // Disconnect the per-follower communicators.
+  for (auto& follower : followers_) {
+    follower.reset();
   }
 
   // Close the intercommunicator.
@@ -199,8 +205,8 @@ MPIController::~MPIController() {
 
 void MPIController::beginJob() {
   // signal the connection
-  for (auto& channel : channels_) {
-    channel.sendConnect();
+  for (auto& follower : followers_) {
+    follower.sendConnect();
   }
 
   /* is there a way to access all known process histories ?
@@ -214,8 +220,8 @@ void MPIController::beginJob() {
 
 void MPIController::endJob() {
   // signal the disconnection
-  for (auto& channel : channels_) {
-    channel.sendDisconnect();
+  for (auto& follower : followers_) {
+    follower.sendDisconnect();
   }
 }
 
@@ -225,9 +231,9 @@ void MPIController::beginRun(edm::Run const& run, edm::EventSetup const& setup) 
    * Ideally the ProcessHistoryID stored in the run.runAuxiliary() should be the correct one, and
    * we could simply do
 
-  for (auto& channel: channels_) {
-    channel.sendBeginRun(run.runAuxiliary());
-    channel.sendProduct(0, run.processHistory());
+  for (auto& follower: followers_) {
+    follower.sendBeginRun(run.runAuxiliary());
+    follower.sendProduct(0, run.processHistory());
   }
 
    * Instead, it looks like the ProcessHistoryID stored in the run.runAuxiliary() is that of the
@@ -237,11 +243,11 @@ void MPIController::beginRun(edm::Run const& run, edm::EventSetup const& setup) 
    */
   auto aux = run.runAuxiliary();
   aux.setProcessHistoryID(run.processHistory().id());
-  for (auto& channel : channels_) {
-    channel.sendBeginRun(aux);
+  for (auto& follower : followers_) {
+    follower.sendBeginRun(aux);
 
     // transmit the ProcessHistory
-    channel.sendProduct(0, run.processHistory());
+    follower.sendProduct(0, run.processHistory());
   }
 }
 
@@ -251,8 +257,8 @@ void MPIController::endRun(edm::Run const& run, edm::EventSetup const& setup) {
    * Ideally the ProcessHistoryID stored in the run.runAuxiliary() should be the correct one, and
    * we could simply do
 
-  for (auto& channel: channels_) {
-    channel.sendEndRun(run.runAuxiliary());
+  for (auto& follower: followers_) {
+    follower.sendEndRun(run.runAuxiliary());
   }
 
    * Instead, it looks like the ProcessHistoryID stored in the run.runAuxiliary() is that of the
@@ -262,8 +268,8 @@ void MPIController::endRun(edm::Run const& run, edm::EventSetup const& setup) {
    */
   auto aux = run.runAuxiliary();
   aux.setProcessHistoryID(run.processHistory().id());
-  for (auto& channel : channels_) {
-    channel.sendEndRun(aux);
+  for (auto& follower : followers_) {
+    follower.sendEndRun(aux);
   }
 }
 
@@ -273,8 +279,8 @@ void MPIController::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::
    * Ideally the ProcessHistoryID stored in the lumi.luminosityBlockAuxiliary() should be the
    * correct one, and we could simply do
 
-  for (auto& channel: channels_) {
-    channel.sendBeginLuminosityBlock(lumi.luminosityBlockAuxiliary());
+  for (auto& follower: followers_) {
+    follower.sendBeginLuminosityBlock(lumi.luminosityBlockAuxiliary());
   }
 
    * Instead, it looks like the ProcessHistoryID stored in the lumi.luminosityBlockAuxiliary() is
@@ -284,19 +290,28 @@ void MPIController::beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::
    */
   auto aux = lumi.luminosityBlockAuxiliary();
   aux.setProcessHistoryID(lumi.processHistory().id());
-  for (auto& channel : channels_) {
-    channel.sendBeginLuminosityBlock(aux);
+  for (auto& follower : followers_) {
+    follower.sendBeginLuminosityBlock(aux);
   }
 }
 
 void MPIController::endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) {
+  // The MPIController is a "one" module that supports only a single luminosity block at a time.
+  // Before proceeding to the next luminosity block, make sure that all events from the current
+  // one have been processed.
+  for (auto& channels : channels_) {
+    for (auto& channel : channels) {
+      channel->wait();
+    }
+  }
+
   // signal the end of luminosity block
   /* FIXME
    * Ideally the ProcessHistoryID stored in the lumi.luminosityBlockAuxiliary() should be the
    * correct one, and we could simply do
 
-  for (auto& channel: channels_) {
-    channel.sendEndLuminosityBlock(lumi.luminosityBlockAuxiliary());
+  for (auto& follower: followers_) {
+    follower.sendEndLuminosityBlock(lumi.luminosityBlockAuxiliary());
   }
 
    * Instead, it looks like the ProcessHistoryID stored in the lumi.luminosityBlockAuxiliary() is
@@ -306,44 +321,55 @@ void MPIController::endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::Ev
    */
   auto aux = lumi.luminosityBlockAuxiliary();
   aux.setProcessHistoryID(lumi.processHistory().id());
-  for (auto& channel : channels_) {
-    channel.sendEndLuminosityBlock(aux);
+  for (auto& follower : followers_) {
+    follower.sendEndLuminosityBlock(aux);
   }
 }
 
 void MPIController::produce(edm::Event& event, edm::EventSetup const& setup) {
-  {
-    edm::LogInfo log("MPI");
-    log << "processing run " << event.run() << ", lumi " << event.luminosityBlock() << ", event " << event.id().event();
-    log << "\nprocess history:    " << event.processHistory();
-    log << "\nprocess history id: " << event.processHistory().id();
-    log << "\nprocess history id: " << event.eventAuxiliary().processHistoryID() << " (from eventAuxiliary)";
-    log << "\nisRealData " << event.eventAuxiliary().isRealData();
-    log << "\nexperimentType " << event.eventAuxiliary().experimentType();
-    log << "\nbunchCrossing " << event.eventAuxiliary().bunchCrossing();
-    log << "\norbitNumber " << event.eventAuxiliary().orbitNumber();
-    log << "\nstoreNumber " << event.eventAuxiliary().storeNumber();
-    log << "\nprocessHistoryID " << event.eventAuxiliary().processHistoryID();
-    log << "\nprocessGUID " << edm::Guid(event.eventAuxiliary().processGUID(), true).toString();
-  }
+  LogDebug("MPI")  //
+      << "processing run " << event.run() << ", lumi " << event.luminosityBlock() << ", event "
+      << event.id().event()                                                                                 //
+      << "\nprocess history:    " << event.processHistory()                                                 //
+      << "\nprocess history id: " << event.processHistory().id()                                            //
+      << "\nprocess history id: " << event.eventAuxiliary().processHistoryID() << " (from eventAuxiliary)"  //
+      << "\nisRealData " << event.eventAuxiliary().isRealData()                                             //
+      << "\nexperimentType " << event.eventAuxiliary().experimentType()                                     //
+      << "\nbunchCrossing " << event.eventAuxiliary().bunchCrossing()                                       //
+      << "\norbitNumber " << event.eventAuxiliary().orbitNumber()                                           //
+      << "\nstoreNumber " << event.eventAuxiliary().storeNumber()                                           //
+      << "\nprocessHistoryID " << event.eventAuxiliary().processHistoryID()                                 //
+      << "\nprocessGUID " << edm::Guid(event.eventAuxiliary().processGUID(), true).toString();
 
-  // use the channel associated to the framework stream
+  // Choose the follower associated to the framework stream, in a round-robin fashion.
   unsigned int sid = event.streamID().value();
+  auto& follower = followers_[sid % followers_.size()];
+  auto& channels = channels_[sid % followers_.size()];
 
-  // signal a new event, and transmit the EventAuxiliary
-  auto& channel = channels_[sid % channels_.size()];
-  channel.sendEvent(event.eventAuxiliary(), event.streamID().value());
+  // Look for a channel that is ready to send a new event
+  unsigned int slot = channels.size();
+  bool found = false;
+  for (unsigned int i = 0; i < channels.size(); ++i) {
+    if (channels[i]->ready()) {
+      slot = i;
+      found = true;
+      break;
+    }
+  }
 
-  // keep a duplicate of the MPIChannel for each framework stream
-  if (sid >= streams_.size()) {
-    streams_.resize(sid + 1);
+  // Signal a new event, and transmit the EventAuxiliary and channel slot to use.
+  follower.sendEvent(event.eventAuxiliary(), slot);
+
+  // If no channels were ready, allocate a new one.
+  if (not found) {
+    // Note: this is done after sending the slot to the MPISource,
+    // so that it may call controller_.duplicate(slot) at the same time.
+    channels.emplace_back(follower.duplicate(slot));
   }
-  if (not streams_[sid]) {
-    // TODO move this to begin stream
-    streams_[sid] = channel.duplicate();
-  }
-  // create a new channel object reusing the same communicator that will synchronise at the end of the event
-  event.emplace(token_, streams_[sid]->syncChannel());
+
+  // The destructor of the last copy of the token will call channels[slot]->sync().
+  // The channel is ready to send a new event after the call is made by both local and remote processes.
+  event.emplace(token_, *channels[slot]);
 }
 
 void MPIController::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HeterogeneousCore/MPICore/plugins/MPIController.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIController.cc
@@ -90,7 +90,7 @@ MPIController::MPIController(edm::ParameterSet const& config)
 
   if (mode_ == kCommWorld) {
     // All processes are in MPI_COMM_WORLD.
-    edm::LogAbsolute("MPI") << "MPIController in " << ModeDescription[mode_] << " mode.";
+    edm::LogInfo("MPI") << "MPIController in " << ModeDescription[mode_] << " mode.";
 
     // Check how many processes are there in MPI_COMM_WORLD.
     int size;
@@ -141,8 +141,8 @@ MPIController::MPIController(edm::ParameterSet const& config)
       MPI_Comm_create_group(MPI_COMM_WORLD, comm_group, 0, &comm);
       MPI_Group_free(&world_group);
       MPI_Group_free(&comm_group);
-      edm::LogAbsolute("MPI") << "The controller and follower processes have ranks " << rank << ", " << follower
-                              << " in MPI_COMM_WORLD, mapped to ranks 0, 1 in their private communicator.";
+      edm::LogInfo("MPI") << "The controller and follower processes have ranks " << rank << ", " << follower
+                          << " in MPI_COMM_WORLD, mapped to ranks 0, 1 in their private communicator.";
       // The follower process always has rank 1 in the new communicator.
       follower = 1;
       channels_.emplace_back(comm, follower);
@@ -150,7 +150,7 @@ MPIController::MPIController(edm::ParameterSet const& config)
   } else if (mode_ == kIntercommunicator) {
     // Use an intercommunicator to let two groups of processes communicate with each other.
     // The current implementation supports only two processes: one controller and one source.
-    edm::LogAbsolute("MPI") << "MPISource in " << ModeDescription[mode_] << " mode.";
+    edm::LogInfo("MPI") << "MPIController in " << ModeDescription[mode_] << " mode.";
 
     // Check how many processes are there in MPI_COMM_WORLD
     int size;
@@ -164,7 +164,7 @@ MPIController::MPIController(edm::ParameterSet const& config)
     std::string name = config.getUntrackedParameter<std::string>("name", "server");
     char port[MPI_MAX_PORT_NAME];
     MPI_Lookup_name(name.c_str(), MPI_INFO_NULL, port);
-    edm::LogAbsolute("MPI") << "Trying to connect to the MPI server on port " << port;
+    edm::LogInfo("MPI") << "Trying to connect to the MPI server on port " << port;
 
     // Create an intercommunicator and connect to the server.
     MPI_Comm_connect(port, MPI_INFO_NULL, 0, MPI_COMM_SELF, &comm_);
@@ -173,7 +173,7 @@ MPIController::MPIController(edm::ParameterSet const& config)
       throw edm::Exception(edm::errors::Configuration)
           << "The current implementation supports only two processes: one controller and one source.";
     }
-    edm::LogAbsolute("MPI") << "Client connected to " << size << (size == 1 ? " server" : " servers");
+    edm::LogInfo("MPI") << "Client connected to " << size << (size == 1 ? " server" : " servers");
     channels_ = {MPIChannel(comm_, 0)};
   } else {
     // Invalid mode.
@@ -205,9 +205,9 @@ void MPIController::beginJob() {
 
   /* is there a way to access all known process histories ?
   edm::ProcessHistoryRegistry const& registry = * edm::ProcessHistoryRegistry::instance();
-  edm::LogAbsolute("MPI") << "ProcessHistoryRegistry:";
+  edm::LogInfo("MPI") << "ProcessHistoryRegistry:";
   for (auto const& keyval: registry) {
-    edm::LogAbsolute("MPI") << keyval.first << ": " << keyval.second;
+    edm::LogInfo("MPI") << keyval.first << ": " << keyval.second;
   }
   */
 }
@@ -342,7 +342,7 @@ void MPIController::produce(edm::Event& event, edm::EventSetup const& setup) {
     // TODO move this to begin stream
     streams_[sid] = channel.duplicate();
   }
-  // create a new channel object reusing the same communicator that will synchronise at the end pf the event
+  // create a new channel object reusing the same communicator that will synchronise at the end of the event
   event.emplace(token_, streams_[sid]->syncChannel());
 }
 

--- a/HeterogeneousCore/MPICore/plugins/MPIController.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIController.cc
@@ -174,7 +174,7 @@ MPIController::MPIController(edm::ParameterSet const& config)
           << "The current implementation supports only two processes: one controller and one source.";
     }
     edm::LogInfo("MPI") << "Client connected to " << size << (size == 1 ? " server" : " servers");
-    channels_ = {MPIChannel(comm_, 0)};
+    channels_.emplace_back(comm_, 0);
   } else {
     // Invalid mode.
     throw edm::Exception(edm::errors::Configuration)

--- a/HeterogeneousCore/MPICore/plugins/MPIReporter.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIReporter.cc
@@ -28,7 +28,7 @@ MPIReporter::MPIReporter(edm::ParameterSet const& config) : token_(consumes<MPIT
 
 void MPIReporter::analyze(edm::Event const& event, edm::EventSetup const& setup) {
   {
-    edm::LogAbsolute log("MPI");
+    edm::LogInfo log("MPI");
     log << "stream " << event.streamID() << ": processing run " << event.run() << ", lumi " << event.luminosityBlock()
         << ", event " << event.id().event();
     log << "\nprocess history:    " << event.processHistory();
@@ -45,7 +45,7 @@ void MPIReporter::analyze(edm::Event const& event, edm::EventSetup const& setup)
 
   auto const& token = event.get(token_);
   {
-    edm::LogAbsolute log("MPI");
+    edm::LogInfo log("MPI");
     log << "got the MPIToken opaque wrapper around the MPIChannel at " << &token;
   }
 }

--- a/HeterogeneousCore/MPICore/plugins/MPISource.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISource.cc
@@ -1,5 +1,5 @@
 // C++ headers
-#include <optional>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -66,15 +66,15 @@ private:
 
   char port_[MPI_MAX_PORT_NAME];
   MPI_Comm comm_ = MPI_COMM_NULL;
-  MPIChannel channel_;
-  std::vector<std::optional<MPIChannel>> streams_;
+  MPIChannel controller_;
+  std::vector<std::unique_ptr<MPIChannel>> channels_;
   edm::EDPutTokenT<MPIToken> token_;
   Mode mode_;
 
   edm::ProcessHistory history_;
 
   // temporary value used to pass information from setRunAndEventInfo() to produce()
-  unsigned int controller_sid_ = edm::StreamID::invalidStreamID();
+  MPIChannel* channel_ = nullptr;
 };
 
 MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescription const& desc)
@@ -147,7 +147,7 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
                         << " in MPI_COMM_WORLD, mapped to ranks 0, 1 in their private communicator.";
     // The remote process always has rank 0 in the new communicator.
     remote = 0;
-    channel_ = MPIChannel(comm_, remote);
+    controller_ = MPIChannel(comm_, remote);
   } else if (mode_ == kIntercommunicator) {
     // Use an intercommunicator to let two groups of processes communicate with each other.
     // The current implementation supports only two processes: one controller and one source.
@@ -177,7 +177,7 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
 
     MPI_Comm_accept(port_, MPI_INFO_NULL, 0, MPI_COMM_SELF, &comm_);
     edm::LogInfo("MPI") << "Connection accepted.";
-    channel_ = MPIChannel(comm_, 0);
+    controller_ = MPIChannel(comm_, 0);
   } else {
     // Invalid mode.
     throw edm::Exception(edm::errors::Configuration)
@@ -192,13 +192,13 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
 }
 
 MPISource::~MPISource() {
-  // Disconnect the per-stream communicators.
-  for (auto& stream : streams_) {
-    // TODO move this to end stream
-    if (stream) {
-      stream->reset();
+  // Disconnect the communicators.
+  for (auto& channel : channels_) {
+    if (channel) {
+      channel->reset();
     }
   }
+  controller_.reset();
 
   if (mode_ == kIntercommunicator) {
     // Close the intercommunicator.
@@ -276,7 +276,7 @@ bool MPISource::setRunAndEventInfo(edm::EventID& event,
 
         // receive the ProcessHistory
         history_.clear();
-        channel_.receiveProduct(0, history_);
+        controller_.receiveProduct(0, history_);
         history_.initializeTransients();
         /*
         if (processHistoryRegistryForUpdate().registerProcessHistory(history_)) {
@@ -325,24 +325,19 @@ bool MPISource::setRunAndEventInfo(edm::EventID& event,
       case EDM_MPI_ProcessEvent: {
         // receive the EventAuxiliary
         edm::EventAuxiliary aux;
-        unsigned int sid;
-        status = channel_.receiveEvent(aux, sid, message);
-        if (sid == edm::StreamID::invalidStreamID()) {
-          throw cms::Exception("InvalidValue")
-              << "The MPISource has received an EDM_MPI_ProcessEvent with invalid stream id.";
+        unsigned int slot;
+        status = controller_.receiveEvent(aux, slot, message);
+
+        // use the same communicator that the MPIController will use for this event
+        if (slot >= channels_.size()) {
+          channels_.resize(slot + 1);
+        }
+        if (not channels_[slot]) {
+          channels_[slot] = controller_.duplicate(slot);
         }
 
-        // keep a duplicate of the MPIChannel for each controller's framework stream
-        if (sid >= streams_.size()) {
-          streams_.resize(sid + 1);
-        }
-        if (not streams_[sid]) {
-          // TODO move this to begin stream
-          streams_[sid] = channel_.duplicate();
-        }
-
-        // store the controller's framework stream to reuse it in produce()
-        controller_sid_ = sid;
+        // store the channel to use it in produce()
+        channel_ = channels_[slot].get();
 
         // extract the rank of the other process (currently unused)
         int source = status.MPI_SOURCE;
@@ -368,9 +363,13 @@ bool MPISource::setRunAndEventInfo(edm::EventID& event,
 }
 
 void MPISource::produce(edm::Event& event) {
-  // create a new channel object reusing the same communicator that will synchronise at the end of the event
-  event.emplace(token_, streams_[controller_sid_]->syncChannel());
-  controller_sid_ = edm::StreamID::invalidStreamID();
+  // Wait for the barrier to be cleared by the MPI software in the local process.
+  channel_->wait();
+
+  // The destructor of the last copy of the token will call channel_->sync().
+  // The channel is ready to receive a new event after the call is made by both local and remote processes.
+  event.emplace(token_, *channel_);
+  channel_ = nullptr;
 }
 
 void MPISource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HeterogeneousCore/MPICore/plugins/MPISource.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISource.cc
@@ -93,7 +93,7 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
 
   if (mode_ == kCommWorld) {
     // All processes are in MPI_COMM_WORLD.
-    edm::LogAbsolute("MPI") << "MPISource in " << ModeDescription[mode_] << " mode.";
+    edm::LogInfo("MPI") << "MPISource in " << ModeDescription[mode_] << " mode.";
 
     // Check how many processes are there in MPI_COMM_WORLD
     int size;
@@ -143,15 +143,15 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
     MPI_Comm_create_group(MPI_COMM_WORLD, comm_group, 0, &comm_);
     MPI_Group_free(&world_group);
     MPI_Group_free(&comm_group);
-    edm::LogAbsolute("MPI") << "The MPIController process and MPISource have ranks " << remote << ", " << rank
-                            << " in MPI_COMM_WORLD, mapped to ranks 0, 1 in their private communicator.";
+    edm::LogInfo("MPI") << "The MPIController process and MPISource have ranks " << remote << ", " << rank
+                        << " in MPI_COMM_WORLD, mapped to ranks 0, 1 in their private communicator.";
     // The remote process always has rank 0 in the new communicator.
     remote = 0;
     channel_ = MPIChannel(comm_, remote);
   } else if (mode_ == kIntercommunicator) {
     // Use an intercommunicator to let two groups of processes communicate with each other.
     // The current implementation supports only two processes: one controller and one source.
-    edm::LogAbsolute("MPI") << "MPISource in " << ModeDescription[mode_] << " mode.";
+    edm::LogInfo("MPI") << "MPISource in " << ModeDescription[mode_] << " mode.";
 
     // Check how many processes are there in MPI_COMM_WORLD
     int size;
@@ -173,10 +173,10 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
     MPI_Publish_name(name.c_str(), port_info, port_);
 
     // Create an intercommunicator and accept a client connection.
-    edm::LogAbsolute("MPI") << "Waiting for a connection to the MPI server at port " << port_;
+    edm::LogInfo("MPI") << "Waiting for a connection to the MPI server at port " << port_;
 
     MPI_Comm_accept(port_, MPI_INFO_NULL, 0, MPI_COMM_SELF, &comm_);
-    edm::LogAbsolute("MPI") << "Connection accepted.";
+    edm::LogInfo("MPI") << "Connection accepted.";
     channel_ = MPIChannel(comm_, 0);
   } else {
     // Invalid mode.
@@ -188,7 +188,7 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
   MPI_Status status;
   EDM_MPI_Empty_t buffer;
   MPI_Recv(&buffer, 1, EDM_MPI_Empty, MPI_ANY_SOURCE, EDM_MPI_Connect, comm_, &status);
-  edm::LogAbsolute("MPI") << "connected from " << status.MPI_SOURCE;
+  edm::LogInfo("MPI") << "connected from " << status.MPI_SOURCE;
 }
 
 MPISource::~MPISource() {
@@ -278,9 +278,11 @@ bool MPISource::setRunAndEventInfo(edm::EventID& event,
         history_.clear();
         channel_.receiveProduct(0, history_);
         history_.initializeTransients();
+        /*
         if (processHistoryRegistryForUpdate().registerProcessHistory(history_)) {
-          edm::LogAbsolute("MPI") << "new ProcessHistory registered: " << history_;
+          edm::LogInfo("MPI") << "new ProcessHistory registered: " << history_;
         }
+        */
 
         // receive the next message
         break;
@@ -366,7 +368,7 @@ bool MPISource::setRunAndEventInfo(edm::EventID& event,
 }
 
 void MPISource::produce(edm::Event& event) {
-  // create a new channel object reusing the same communicator that will synchronise at the end pf the event
+  // create a new channel object reusing the same communicator that will synchronise at the end of the event
   event.emplace(token_, streams_[controller_sid_]->syncChannel());
   controller_sid_ = edm::StreamID::invalidStreamID();
 }

--- a/HeterogeneousCore/MPICore/src/MPIChannel.cc
+++ b/HeterogeneousCore/MPICore/src/MPIChannel.cc
@@ -1,9 +1,8 @@
 // C++ standard library headers
-#include <array>
 #include <cassert>
 #include <cstring>
-#include <iostream>
-#include <tuple>
+#include <memory>
+#include <string>
 
 // ROOT headers
 #include <TBufferFile.h>
@@ -36,11 +35,92 @@ namespace {
 }  // namespace
 
 // build a new MPIChannel that uses a duplicate of the underlying communicator and the same destination
-MPIChannel MPIChannel::duplicate() const {
+std::unique_ptr<MPIChannel> MPIChannel::duplicate(int slot) const {
   // This is a blocking collective operation.
   MPI_Comm newcomm;
   MPI_Comm_dup(comm_, &newcomm);
-  return MPIChannel(newcomm, dest_);
+  auto channel = std::make_unique<MPIChannel>(newcomm, dest_);
+  channel->status_.store(kReady, std::memory_order_release);
+  channel->slot_ = slot;
+  LogDebug("MPI") << "channel " << slot << " transitioned to kReady";
+  return channel;
+}
+
+// mark the channel as busy
+void MPIChannel::acquire() {
+  auto status = status_.load(std::memory_order_acquire);
+  if (status != kReady) {
+    throw cms::Exception("MPI") << "MPIChannel " << slot_ << " is in an invalide state";
+  }
+  assert(request_ == MPI_REQUEST_NULL);
+  status_.store(kBusy, std::memory_order_release);
+  LogDebug("MPI") << "channel " << slot_ << " transitioned to kBusy";
+}
+
+// make sure both processes have completed processing the event that was transmitted
+// Note: this is a non-blocking collective operation.
+void MPIChannel::sync() {
+  auto status = status_.load(std::memory_order_acquire);
+  if (status != kBusy) {
+    throw cms::Exception("MPI") << "MPIChannel " << slot_ << " is in an invalide state";
+  }
+  assert(request_ == MPI_REQUEST_NULL);
+  MPI_Ibarrier(comm_, &request_);
+  assert(request_ != MPI_REQUEST_NULL);
+  status_.store(kSync, std::memory_order_release);
+  LogDebug("MPI") << "channel " << slot_ << " transitioned to kSync";
+}
+
+// check whether this channel can be used to transmit a new event
+bool MPIChannel::ready() {
+  auto status = status_.load(std::memory_order_acquire);
+  if (status == kInvalid) {
+    throw cms::Exception("MPI") << "MPIChannel " << slot_ << " is in an invalide state";
+  } else if (status == kReady) {
+    return true;
+  } else if (status == kBusy) {
+    return false;
+  } else if (status == kSync) {
+    int flag = 0;
+    assert(request_ != MPI_REQUEST_NULL);
+    // TODO check status and return value
+    MPI_Test(&request_, &flag, MPI_STATUS_IGNORE);
+    if (flag) {
+      // if the barrier was reached, MPI_Test resets the request object to MPI_REQUEST_NULL
+      assert(request_ == MPI_REQUEST_NULL);
+      status_.store(kReady, std::memory_order_release);
+      LogDebug("MPI") << "channel " << slot_ << " transitioned to kReady";
+      return true;
+    } else {
+      assert(request_ != MPI_REQUEST_NULL);
+      LogDebug("MPI") << "channel " << slot_ << " in kSync DID NOT transition to kReady";
+      return false;
+    }
+  }
+  __builtin_unreachable();
+}
+
+// wait until this channel can be used to transmit a new event
+void MPIChannel::wait() {
+  auto status = status_.load(std::memory_order_acquire);
+  if (status == kInvalid) {
+    throw cms::Exception("MPI") << "MPIChannel " << slot_ << " is in an invalide state";
+  } else if (status == kReady) {
+    return;
+  } else if (status == kBusy) {
+    throw cms::Exception("MPI") << "MPIChannel::wait() cannot resolve a kBusy status";
+    return;
+  } else if (status == kSync) {
+    assert(request_ != MPI_REQUEST_NULL);
+    // TODO check status and return value
+    MPI_Wait(&request_, MPI_STATUS_IGNORE);
+    // if the barrier was reached, MPI_Test resets the request object to MPI_REQUEST_NULL
+    assert(request_ == MPI_REQUEST_NULL);
+    status_.store(kReady, std::memory_order_release);
+    LogDebug("MPI") << "channel " << slot_ << " transitioned to kReady";
+    return;
+  }
+  __builtin_unreachable();
 }
 
 // close the underlying communicator and reset the MPIChannel to an invalid state
@@ -83,7 +163,7 @@ void MPIChannel::edmToBuffer_(EDM_MPI_LuminosityBlockAuxiliary_t& buffer, edm::L
 }
 
 // fill an edm::EventAuxiliary object from an EDM_MPI_EventAuxiliary buffer
-void MPIChannel::edmFromBuffer_(EDM_MPI_EventAuxiliary_t const& buffer, edm::EventAuxiliary& aux, unsigned int& sid) {
+void MPIChannel::edmFromBuffer_(EDM_MPI_EventAuxiliary_t const& buffer, edm::EventAuxiliary& aux, unsigned int& slot) {
   aux = edm::EventAuxiliary({buffer.run, buffer.lumi, buffer.event},
                             std::string(buffer.processGuid, std::size(buffer.processGuid)),
                             edm::Timestamp(buffer.time),
@@ -94,11 +174,11 @@ void MPIChannel::edmFromBuffer_(EDM_MPI_EventAuxiliary_t const& buffer, edm::Eve
                             buffer.orbitNumber);
   aux.setProcessHistoryID(
       edm::ProcessHistoryID(std::string(buffer.processHistoryID, std::size(buffer.processHistoryID))));
-  sid = buffer.streamId;
+  slot = buffer.slotId;
 }
 
 // fill an EDM_MPI_EventAuxiliary buffer from an edm::EventAuxiliary object
-void MPIChannel::edmToBuffer_(EDM_MPI_EventAuxiliary_t& buffer, edm::EventAuxiliary const& aux, unsigned int sid) {
+void MPIChannel::edmToBuffer_(EDM_MPI_EventAuxiliary_t& buffer, edm::EventAuxiliary const& aux, unsigned int slot) {
   copy_and_fill(buffer.processHistoryID, aux.processHistoryID().compactForm());
   copy_and_fill(buffer.processGuid, aux.processGUID());
   buffer.time = aux.time().value();
@@ -110,7 +190,7 @@ void MPIChannel::edmToBuffer_(EDM_MPI_EventAuxiliary_t& buffer, edm::EventAuxili
   buffer.run = aux.id().run();
   buffer.lumi = aux.id().luminosityBlock();
   buffer.event = aux.id().event();
-  buffer.streamId = sid;
+  buffer.slotId = slot;
 }
 
 // fill and send an EDM_MPI_Empty_t buffer
@@ -137,33 +217,33 @@ void MPIChannel::sendLuminosityBlockAuxiliary_(int tag, edm::LuminosityBlockAuxi
 }
 
 // fill and send an EDM_MPI_EventAuxiliary_t buffer
-void MPIChannel::sendEventAuxiliary_(edm::EventAuxiliary const& aux, unsigned int sid) {
+void MPIChannel::sendEventAuxiliary_(edm::EventAuxiliary const& aux, unsigned int slot) {
   EDM_MPI_EventAuxiliary_t buffer;
   buffer.messageTag = EDM_MPI_ProcessEvent;
-  edmToBuffer_(buffer, aux, sid);
+  edmToBuffer_(buffer, aux, slot);
   MPI_Send(&buffer, 1, EDM_MPI_EventAuxiliary, dest_, EDM_MPI_ProcessEvent, comm_);
 }
 
 /*
 // receive an EDM_MPI_EventAuxiliary_t buffer and populate an edm::EventAuxiliary
-MPI_Status MPIChannel::receiveEventAuxiliary_(edm::EventAuxiliary& aux, unsigned int& sid, int source, int tag) {
+MPI_Status MPIChannel::receiveEventAuxiliary_(edm::EventAuxiliary& aux, unsigned int& slot, int source, int tag) {
   MPI_Status status;
   EDM_MPI_EventAuxiliary_t buffer;
   MPI_Recv(&buffer, 1, EDM_MPI_EventAuxiliary, source, tag, comm_, &status);
-  edmFromBuffer_(buffer, aux, sid);
+  edmFromBuffer_(buffer, aux, slot);
   return status;
 }
 */
 
 // receive an EDM_MPI_EventAuxiliary_t buffer and populate an edm::EventAuxiliary
-MPI_Status MPIChannel::receiveEventAuxiliary_(edm::EventAuxiliary& aux, unsigned int& sid, MPI_Message& message) {
+MPI_Status MPIChannel::receiveEventAuxiliary_(edm::EventAuxiliary& aux, unsigned int& slot, MPI_Message& message) {
   MPI_Status status = {};
   EDM_MPI_EventAuxiliary_t buffer;
 #ifdef EDM_ML_DEBUG
   memset(&buffer, 0x00, sizeof(buffer));
 #endif
   status.MPI_ERROR = MPI_Mrecv(&buffer, 1, EDM_MPI_EventAuxiliary, &message, &status);
-  edmFromBuffer_(buffer, aux, sid);
+  edmFromBuffer_(buffer, aux, slot);
   return status;
 }
 

--- a/HeterogeneousCore/MPICore/src/MPIToken.cc
+++ b/HeterogeneousCore/MPICore/src/MPIToken.cc
@@ -1,0 +1,8 @@
+#include "HeterogeneousCore/MPICore/interface/MPIChannel.h"
+#include "HeterogeneousCore/MPICore/interface/MPIToken.h"
+
+// Store the MPIChannel in a shared_ptr so that copies of the MPIToken can refer to the same MPIChannel.
+// When the last MPIToken is destroyed, the shared_ptr will call MPIChannel::sync() insyead of deleting it.
+MPIToken::MPIToken(MPIChannel& channel) : channel_(&channel, [](MPIChannel* ptr) { ptr->sync(); }) {
+  channel_->acquire();
+}

--- a/HeterogeneousCore/MPICore/src/messages.cc
+++ b/HeterogeneousCore/MPICore/src/messages.cc
@@ -60,7 +60,7 @@ void EDM_MPI_build_types_() {
                    run,                       // edm::RunNumber_t
                    lumi,                      // edm::LuminosityBlockNumber_t
                    event,                     // edm::EventNumber_t
-                   streamId);                 // edm::StreamID
+                   slotId);                   // MPIChannel index
 
   EDM_MPI_MessageType[EDM_MPI_Connect] = EDM_MPI_Empty;                                  //
   EDM_MPI_MessageType[EDM_MPI_Disconnect] = EDM_MPI_Empty;                               //

--- a/HeterogeneousCore/MPICore/test/controller_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_cfg.py
@@ -9,6 +9,12 @@ process.options.numberOfConcurrentLuminosityBlocks = 1
 process.options.numberOfConcurrentRuns = 1
 process.options.wantSummary = False
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from eventlist_cff import eventlist

--- a/HeterogeneousCore/MPICore/test/controller_complex_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_complex_cfg.py
@@ -15,6 +15,12 @@ process.options.wantSummary = False
 process.source = cms.Source("EmptySource")
 process.maxEvents.input = 10
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from HeterogeneousCore.MPICore.modules import *

--- a/HeterogeneousCore/MPICore/test/controller_filters_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_filters_cfg.py
@@ -12,6 +12,12 @@ process.options.wantSummary = False
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from eventlist_cff import eventlist

--- a/HeterogeneousCore/MPICore/test/controller_multi_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_multi_cfg.py
@@ -9,6 +9,12 @@ process.options.numberOfConcurrentLuminosityBlocks = 1
 process.options.numberOfConcurrentRuns = 1
 process.options.wantSummary = False
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from eventlist_cff import eventlist

--- a/HeterogeneousCore/MPICore/test/controller_multi_rr_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_multi_rr_cfg.py
@@ -9,6 +9,12 @@ process.options.numberOfConcurrentLuminosityBlocks = 1
 process.options.numberOfConcurrentRuns = 1
 process.options.wantSummary = False
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from eventlist_cff import eventlist

--- a/HeterogeneousCore/MPICore/test/controller_rr_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_rr_cfg.py
@@ -9,6 +9,12 @@ process.options.numberOfConcurrentLuminosityBlocks = 1
 process.options.numberOfConcurrentRuns = 1
 process.options.wantSummary = False
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from eventlist_cff import eventlist

--- a/HeterogeneousCore/MPICore/test/controller_soa_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_soa_cfg.py
@@ -15,6 +15,12 @@ process.options.wantSummary = False
 process.source = cms.Source("EmptySource")
 process.maxEvents.input = 10
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 # produce and send a portable object, a portable collection, and some portable multicollections

--- a/HeterogeneousCore/MPICore/test/controller_too_many_streams_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_too_many_streams_cfg.py
@@ -22,6 +22,12 @@ process.options.numberOfConcurrentLuminosityBlocks = 1
 process.options.numberOfConcurrentRuns = 1
 process.options.wantSummary = False
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from eventlist_cff import eventlist

--- a/HeterogeneousCore/MPICore/test/follower_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_cfg.py
@@ -8,6 +8,12 @@ process.options.numberOfConcurrentLuminosityBlocks = 2
 process.options.numberOfConcurrentRuns = 2
 process.options.wantSummary = False
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from HeterogeneousCore.MPICore.modules import *

--- a/HeterogeneousCore/MPICore/test/follower_complex_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_complex_cfg.py
@@ -6,6 +6,12 @@ process.options.numberOfThreads = 4
 process.options.numberOfStreams = 4
 process.options.wantSummary = False
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from HeterogeneousCore.MPICore.modules import *

--- a/HeterogeneousCore/MPICore/test/follower_filters_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_filters_cfg.py
@@ -8,6 +8,12 @@ process.options.numberOfConcurrentLuminosityBlocks = 2
 process.options.numberOfConcurrentRuns = 2
 process.options.wantSummary = False
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from HeterogeneousCore.MPICore.modules import MPISource, MPIReceiver, MPISender

--- a/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py
@@ -8,6 +8,12 @@ process.options.numberOfConcurrentLuminosityBlocks = 2
 process.options.numberOfConcurrentRuns = 2
 process.options.wantSummary = False
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from HeterogeneousCore.MPICore.modules import *

--- a/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py
@@ -8,6 +8,12 @@ process.options.numberOfConcurrentLuminosityBlocks = 2
 process.options.numberOfConcurrentRuns = 2
 process.options.wantSummary = False
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from HeterogeneousCore.MPICore.modules import *

--- a/HeterogeneousCore/MPICore/test/follower_soa_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_soa_cfg.py
@@ -6,6 +6,12 @@ process.options.numberOfThreads = 4
 process.options.numberOfStreams = 4
 process.options.wantSummary = False
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from HeterogeneousCore.MPICore.modules import *

--- a/HeterogeneousCore/MPICore/test/follower_too_many_streams_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_too_many_streams_cfg.py
@@ -8,6 +8,12 @@ process.options.numberOfConcurrentLuminosityBlocks = 2
 process.options.numberOfConcurrentRuns = 2
 process.options.wantSummary = False
 
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
 
 from HeterogeneousCore.MPICore.modules import *


### PR DESCRIPTION
#### PR description:

Reimplement MPI event synchronisation with async barriers.
Use a variable number of MPI channels to improve the efficiency when the controller and follower processes use a different number of framework streams.

#### PR validation:

Unit tests pass.

Validation with the HLT menu pass.