### PR TITLE
NGT DQM online client: add monitoring of trigger candidate 4-vectors 

### DIFF
--- a/DQM/HLTEvF/plugins/HLTObjectMonitor.cc
+++ b/DQM/HLTEvF/plugins/HLTObjectMonitor.cc
@@ -220,7 +220,7 @@ HLTObjectMonitor::HLTObjectMonitor(const edm::ParameterSet& iConfig)
   //now do what ever initialization is needed
   debugPrint = false;
 
-  topDirectoryName = "HLT/ObjectMonitor";
+  topDirectoryName = iConfig.getUntrackedParameter<string>("topFolderName");
   mainShifterFolder = topDirectoryName + "/MainShifter";
   backupFolder = topDirectoryName + "/Backup";
 
@@ -866,6 +866,7 @@ double HLTObjectMonitor::get_wall_time() {
 void HLTObjectMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<std::string>("processName", "HLT");
+  desc.addUntracked<std::string>("topFolderName", "HLT/ObjectMonitor");
 
   auto addPSet = [](edm::ParameterSetDescription& desc, const std::string& name) {
     edm::ParameterSetDescription pset;

--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -105,6 +105,13 @@ process.dqmHLTFiltersDQMonitor.triggerResults = 'TriggerResults::HLT'
 process.dqmHLTFiltersDQMonitor.folderName = "NGT/Filters"
 process.dqmHLTFiltersDQMonitor.lightMonitor = True
 
+# Object Monitoring
+process.load("DQM.HLTEvF.FourVectorHLT_cfi")
+process.hltResults.topFolderName = cms.untracked.string("NGT/FourVectorHLT")
+
+process.load("DQM.HLTEvF.HLTObjectMonitor_cfi")
+process.hltObjectMonitor.topFolderName = cms.untracked.string("NGT/ObjectMonitor")
+
 process.p = cms.Path(process.dqmcommon *
                      process.hltOnlineBeamSpot *
                      process.ScoutingTrackMonitorOnline *
@@ -114,6 +121,8 @@ process.p = cms.Path(process.dqmcommon *
                      process.ScoutingDileptonMonitorOnline *
                      process.ScoutingMuonPropertiesMonitorOnline *
                      process.ScoutingPi0MonitorOnline *
+                     process.hltResults *
+                     process.hltObjectMonitor *
                      process.dqmHLTFiltersDQMonitor)
 
 ### process customizations included here

--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -15,7 +15,7 @@ if 'unitTest=True' in sys.argv:
 if unitTest:
   process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
   from DQM.Integration.config.unitteststreamerinputsource_cfi import options
-  process.source.streamLabel = 'streamDQMOnlineScouting' # in test mode use DQMOnlineScouting streamer
+  process.source.streamLabel = "streamDQMTestDataScouting"
 else:
   # for live online DQM in P5
   process.load("DQM.Integration.config.inputsource_cfi")

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -12,7 +12,7 @@
 <test name="TestDQMOnlineClient-hcal_dqm_sourceclient" command="runtest.sh hcal_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-hlt_dqm_clientPB" command="runtest.sh hlt_dqm_clientPB-live_cfg.py"/>
 <test name="TestDQMOnlineClient-hlt_dqm_sourceclient" command="runtest.sh hlt_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-ngt_dqm_sourceclient" command="runtest.sh ngt_dqm_sourceclient-live_cfg.py 398183"/>
+<test name="TestDQMOnlineClient-ngt_dqm_sourceclient" command="runtest.sh ngt_dqm_sourceclient-live_cfg.py 402360"/>
 <test name="TestDQMOnlineClient-scouting_dqm_sourceclient" command="runtest.sh scouting_dqm_sourceclient-live_cfg.py 398183"/>
 <test name="TestDQMOnlineClient-info_dqm_sourceclient" command="runtest.sh info_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-l1tstage2_dqm_sourceclient" command="runtest.sh l1tstage2_dqm_sourceclient-live_cfg.py"/>


### PR DESCRIPTION
#### PR description:

HLT menu `GRun` 2026 v1.2 ([announcement](https://cms-talk.web.cern.ch/t/hlt-grun-menu-v1-2-2026/144363), pull request https://github.com/cms-sw/cmssw/pull/50807) foreseen to be deployed in the final part of 2026, will deliver the `trigger::TriggerEvent` event product to the `DQMTestDataScouting` stream via ticket [CMSHLT-3788](https://its.cern.ch/jira/browse/CMSHLT-3788).
This allows to enable in the NGT client the monitoring of the HLT trigger candidate 4-momenta via modules `FourVectorHLT` (refurbished at https://github.com/cms-sw/cmssw/pull/49610 and https://github.com/cms-sw/cmssw/pull/50637) and `HLTObjectMonitor`. This is achieved in commit c81a5af84e32147c496b246913ccef39ea791246
We profit of this PR to specialize the unit test for `ngt_dqm_sourceclient-live_cfg.py` as the event content of the stream of `DQMOnlineScouting` and `DQMTestDataScouting` have diverged. This is achieved in commit e3dcef32b76e9bfe1c45b78d05ebb3ad9c034d5a

#### PR validation:

Run successfully `scram b runtests_TestDQMOnlineClient-ngt_dqm_sourceclient` in combination with the update at `cms-data` PR https://github.com/cms-data/DQM-Integration/pull/20

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it will be backported down to CMSSW_16_0_X for 2026 NGT demonstrator data-taking purposes.