### PR TITLE
[161X] Increase thresholds for EE in ECAL DQM Presample monitoring client 

### DIFF
--- a/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
@@ -6,8 +6,8 @@ from DQM.EcalMonitorClient.IntegrityClient_cfi import ecalIntegrityClient
 minChannelEntries = 6
 expectedMean = 200.0
 toleranceLow = 25.0
-toleranceHigh = 60.0
-toleranceHighFwd = 100.0
+toleranceHigh = 80.0
+toleranceHighFwd = 120.0
 toleranceRMS = 6.0
 toleranceRMSFwd = 6.0
 


### PR DESCRIPTION
#### PR description:

This PR updates thresholds for ECAL endcap high eta and forward region in ECAL DQM presample monitoring plots.

#### PR validation:

PR is validated by running the ECAL online DQM configuration.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the backport to `161X`. Master PR is in #50823. Current DQM GUI deployed is `160X`, so backport to both `160X` and `161X` are made. 