### PR TITLE
[mini2mini] Add and PATIsolatedTrackRekeyer

### DIFF
--- a/DataFormats/PatCandidates/interface/IsolatedTrack.h
+++ b/DataFormats/PatCandidates/interface/IsolatedTrack.h
@@ -113,6 +113,8 @@ namespace pat {
 
     int fromPV() const { return fromPV_; }
 
+    int trackQuality() const { return trackQuality_; }
+
     bool isHighPurityTrack() const {
       return (trackQuality_ & (1 << reco::TrackBase::highPurity)) >> reco::TrackBase::highPurity;
     }

--- a/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackRekeyer.cc
@@ -1,0 +1,94 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/PatCandidates/interface/IsolatedTrack.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+#include "DataFormats/Common/interface/Association.h"
+
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include <vector>
+
+class PATIsolatedTrackRekeyer : public edm::stream::EDProducer<> {
+private:
+  using IsoTracksC = std::vector<pat::IsolatedTrack>;
+  using PackedCandsC = pat::PackedCandidateCollection;
+
+  edm::EDGetTokenT<IsoTracksC> input_tracks_token_;
+  edm::EDGetTokenT<PackedCandsC> packed_cands_token_;
+  edm::EDGetTokenT<PackedCandsC> lost_cands_token_;
+
+public:
+  PATIsolatedTrackRekeyer(edm::ParameterSet const& params)
+      : input_tracks_token_{consumes<IsoTracksC>(params.getParameter<edm::InputTag>("src"))},
+        packed_cands_token_{consumes<PackedCandsC>(params.getParameter<edm::InputTag>("packedCands"))},
+        lost_cands_token_{consumes<PackedCandsC>(params.getParameter<edm::InputTag>("lostTrackCands"))} {
+    produces<IsoTracksC>();
+  }
+
+  ~PATIsolatedTrackRekeyer() override = default;
+
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
+    auto out_tracks = std::make_unique<std::vector<pat::IsolatedTrack>>();
+
+    edm::Handle<std::vector<pat::IsolatedTrack>> input_tracks;
+    iEvent.getByToken(input_tracks_token_, input_tracks);
+
+    edm::Handle<pat::PackedCandidateCollection> packed_cands;
+    iEvent.getByToken(packed_cands_token_, packed_cands);
+
+    edm::Handle<pat::PackedCandidateCollection> lost_cands;
+    iEvent.getByToken(lost_cands_token_, lost_cands);
+
+    for (const auto& track : *input_tracks) {
+      // copy original pat object and append to vector
+
+      auto const cand_ref = edm::Ref(packed_cands, track.packedCandRef().key());
+      auto const near_ref = track.nearestPFPackedCandRef().isNonnull()
+                                ? edm::Ref(packed_cands, track.packedCandRef().key())
+                                : track.nearestPFPackedCandRef();
+      auto const lost_ref = track.nearestLostTrackPackedCandRef().isNonnull()
+                                ? edm::Ref(lost_cands, track.packedCandRef().key())
+                                : track.nearestLostTrackPackedCandRef();
+
+      out_tracks->emplace_back((pat::IsolatedTrack(track.pfIsolationDR03(),
+                                                   track.miniPFIsolation(),
+                                                   track.matchedCaloJetEmEnergy(),
+                                                   track.matchedCaloJetHadEnergy(),
+                                                   track.pfLepOverlap(),
+                                                   track.pfNeutralSum(),
+                                                   track.p4(),
+                                                   track.charge(),
+                                                   track.pdgId(),
+                                                   track.dz(),
+                                                   track.dxy(),
+                                                   track.dzError(),
+                                                   track.dxyError(),
+                                                   track.hitPattern(),
+                                                   track.dEdxStrip(),
+                                                   track.dEdxPixel(),
+                                                   track.fromPV(),
+                                                   track.trackQuality(),
+                                                   track.crossedEcalStatus(),
+                                                   track.crossedHcalStatus(),
+                                                   track.deltaEta(),
+                                                   track.deltaPhi(),
+                                                   cand_ref,
+                                                   near_ref,
+                                                   lost_ref)));
+    }
+
+    iEvent.put(std::move(out_tracks));
+  }
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PATIsolatedTrackRekeyer);

--- a/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_tools.py
@@ -455,6 +455,16 @@ def miniAODFromMiniAOD_customizeCommon(process):
     )
 
 
+    addToProcessAndTask("isolatedTracks", cms.EDProducer("PATIsolatedTrackRekeyer",
+        src = cms.InputTag("isolatedTracks", processName=cms.InputTag.skipCurrentProcess()),
+        packedCands = cms.InputTag("packedPFCandidates",processName=cms.InputTag.currentProcess()),
+        lostTrackCands = cms.InputTag("lostTracks",processName=cms.InputTag.skipCurrentProcess()),
+
+      ),
+      process, task
+    )
+
+
     _modified_run2_task = task.copyAndExclude([getattr(process,thisone) for thisone in ['slimmedDisplacedMuons']])
     from PhysicsTools.PatAlgos.patRefitVertexProducer_cfi import patRefitVertexProducer
     process.offlineSlimmedPrimaryVerticesWithBS = patRefitVertexProducer.clone(
@@ -485,7 +495,8 @@ def miniAODFromMiniAOD_customizeCommon(process):
                                        'slimmedLowPtElectrons',
                                        'slimmedKshortVertices',
                                        'slimmedLambdaVertices',
-                                       'slimmedSecondaryVertices']:
+                                       'slimmedSecondaryVertices',
+                                       'isolatedTracks']:
             new_collection_to_keep += '_*' if not '_' in new_collection_to_keep else ''
             mini_output.outputCommands += [
                 f'drop *_{new_collection_to_keep}_*',


### PR DESCRIPTION
#### PR description:

This PR aims to reduce the number of discrepancies that arise when comparing NANO AOD samples produced from MiniAOD v2/v4, depending on whether intermediate MiniAOD v6 are persisted.

#### PR validation:

Variable-by-variable comparison of NANO AOD quantities from files produced running the two above-mentioned workflows on the same initial samples.

I observe a significant decrease of discrepancies if I combine this PR and #50669 (already merged), which is needed because IsoTrack re-keying depends on correct muon re-keying:

https://battilan.web.cern.ch/battilan/crossPOG/MINI2MINI/PR/pr50827andpr50669/