### PR TITLE
[130X] Fix for long-lived slepton simulation

### DIFF
--- a/Configuration/ProcessModifiers/python/fixLongLivedSleptonSim_cff.py
+++ b/Configuration/ProcessModifiers/python/fixLongLivedSleptonSim_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# Designed to disable a bug affecting long lived slepton decays in HepMC-G4 interface
+fixLongLivedSleptonSim = cms.Modifier()

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -277,6 +277,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         MinPhiCut = cms.double(-3.14159265359), ## (radians)
         MaxPhiCut = cms.double(3.14159265359),  ## according to CMS conventions
         ApplyLumiMonitorCuts = cms.bool(False), ## primary for lumi monitors
+        IsSlepton = cms.bool(False),
         Verbosity = cms.untracked.int32(0),
         PDGselection = cms.PSet(
             PDGfilterSel = cms.bool(False), ## filter out unwanted particles
@@ -714,4 +715,12 @@ phase2_common.toModify(g4SimHits,
 from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 hgcaltb.toModify(g4SimHits,
                  OnlySDs = ['AHcalSensitiveDetector', 'HGCSensitiveDetector', 'HGCalTB1601SensitiveDetector', 'HcalTB06BeamDetector']
+)
+
+##
+## Fix for long-lived slepton simulation
+##
+from Configuration.ProcessModifiers.fixLongLivedSleptonSim_cff import fixLongLivedSleptonSim
+fixLongLivedSleptonSim.toModify( g4SimHits,
+                                 Generator = dict(IsSlepton = True)
 )

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -45,6 +45,7 @@ private:
   bool fEtaCuts;
   bool fPhiCuts;
   bool fFiductialCuts;
+  bool fSlepton;
   double theMinPhiCut;
   double theMaxPhiCut;
   double theMinEtaCut;

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -25,6 +25,7 @@ Generator::Generator(const ParameterSet &p)
       fPtransCut(p.getParameter<bool>("ApplyPtransCut")),
       fEtaCuts(p.getParameter<bool>("ApplyEtaCuts")),
       fPhiCuts(p.getParameter<bool>("ApplyPhiCuts")),
+      fSlepton(p.getParameter<bool>("IsSlepton")),
       theMinPhiCut(p.getParameter<double>("MinPhiCut")),  // in radians (CMS standard)
       theMaxPhiCut(p.getParameter<double>("MaxPhiCut")),
       theMinEtaCut(p.getParameter<double>("MinEtaCut")),
@@ -365,7 +366,7 @@ void Generator::HepMC2G4(const HepMC::GenEvent *evt_orig, G4Event *g4evt) {
           // Decay chain outside the fiducial cylinder defined by theRDecLenCut
           // are used for Geant4 tracking with predefined decay channel
           // In the case of decay in vacuum particle is not tracked by Geant4
-        } else if (2 == status && x2 * x2 + y2 * y2 >= theDecRCut2 && std::abs(z2) < Z_hector) {
+        } else if (2 == status && x2 * x2 + y2 * y2 >= theDecRCut2 && (fSlepton || std::abs(z2) < Z_hector)) {
           toBeAdded = true;
           if (verbose > 1)
             edm::LogVerbatim("SimG4CoreGenerator") << "GenParticle barcode = " << (*pitr)->barcode() << " passed case 2"
@@ -475,7 +476,14 @@ void Generator::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC::GenPartic
       LogDebug("SimG4CoreGenerator::::particleAssignDaughters")
           << "Assigning a " << (*vpdec)->pdg_id() << " as daughter of a " << vp->pdg_id() << " status=" << status;
 
-    if ((status == 2 || (status == 23 && std::abs(vp->pdg_id()) == 1000015) || (status > 50 && status < 100)) &&
+    bool isInList;
+    if (fSlepton) {
+      std::vector<int> fParticleList = {1000011, 1000013, 1000015, 2000011, 2000013, 2000015};
+      isInList = (std::find(fParticleList.begin(), fParticleList.end(), std::abs(vp->pdg_id())) != fParticleList.end());
+    } else {
+      isInList = std::abs(vp->pdg_id()) == 1000015;
+    }
+    if ((status == 2 || (status == 23 && isInList) || (status > 50 && status < 100)) &&
         (*vpdec)->end_vertex() != nullptr) {
       double x2 = (*vpdec)->end_vertex()->position().x();
       double y2 = (*vpdec)->end_vertex()->position().y();


### PR DESCRIPTION
#### PR description:

This PR is a plain backport of https://github.com/cms-sw/cmssw/pull/47165 and https://github.com/cms-sw/cmssw/pull/47197. A backport to 13_0_X release cycle is needed to generate signal samples according to Summer23 MC campaign.
A new process modifier for GEN-SIM step is introduced to fix the simulation of gen particles in long-lived slepton signals. In particular, it fixes the handling of daughter particles in slepton decays. For more details, see [1].

[1] https://indico.cern.ch/event/1476269/#6-plan-for-displaced-dimuon-an

#### PR validation:

See original PRs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/47165 and https://github.com/cms-sw/cmssw/pull/47197, aimed for Summer23-like MC generation.

@civanch @kpedro88