### PR TITLE
RFC: Use `__COUNTER__` instead of `__LINE__` to declare unique variables

### DIFF
--- a/CondCore/ESSources/interface/registration_macros.h
+++ b/CondCore/ESSources/interface/registration_macros.h
@@ -32,7 +32,7 @@
 
 #define ONLY_REGISTER_PLUGIN(record_, type_)                                                \
   typedef ProductResolverWrapper<record_, type_> EDM_PLUGIN_SYM(ProductResolver, __LINE__); \
-  DEFINE_EDM_PLUGIN2(cond::ProductResolverFactory, EDM_PLUGIN_SYM(ProductResolver, __LINE__), #record_ "@NewProxy")
+  DEFINE_EDM_PLUGIN(cond::ProductResolverFactory, EDM_PLUGIN_SYM(ProductResolver, __LINE__), #record_ "@NewProxy")
 
 #define REGISTER_PLUGIN(record_, type_)      \
   INSTANTIATE_RESOLVER(record_, type_)       \
@@ -48,7 +48,7 @@
 
 #define ONLY_REGISTER_PLUGIN_INIT(record_, type_, initializer_)                                           \
   typedef ProductResolverWrapper<record_, type_, initializer_> EDM_PLUGIN_SYM(ProductResolver, __LINE__); \
-  DEFINE_EDM_PLUGIN2(cond::ProductResolverFactory, EDM_PLUGIN_SYM(ProductResolver, __LINE__), #record_ "@NewProxy")
+  DEFINE_EDM_PLUGIN(cond::ProductResolverFactory, EDM_PLUGIN_SYM(ProductResolver, __LINE__), #record_ "@NewProxy")
 
 #define REGISTER_PLUGIN_INIT(record_, type_, initializer_)      \
   INSTANTIATE_RESOLVER_INIT(record_, type_, initializer_)       \

--- a/FWCore/ParameterSet/interface/ValidatedPluginMacros.h
+++ b/FWCore/ParameterSet/interface/ValidatedPluginMacros.h
@@ -25,11 +25,11 @@
 #include "FWCore/ParameterSet/interface/PluginDescriptionAdaptor.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 
-#define DEFINE_EDM_VALIDATED_PLUGIN(factory, type, name)                                                   \
-  DEFINE_EDM_PLUGIN(factory, type, name);                                                                  \
-  using EDM_PLUGIN_SYM(adaptor_t, __LINE__) = edm::PluginDescriptionAdaptor<factory::CreatedType, type>;   \
-  DEFINE_EDM_PLUGIN2(edmplugin::PluginFactory<edm::PluginDescriptionAdaptorBase<factory::CreatedType>*()>, \
-                     EDM_PLUGIN_SYM(adaptor_t, __LINE__),                                                  \
-                     name)
+#define DEFINE_EDM_VALIDATED_PLUGIN(factory, type, name)                                                  \
+  DEFINE_EDM_PLUGIN(factory, type, name);                                                                 \
+  using EDM_PLUGIN_SYM(adaptor_t, __LINE__) = edm::PluginDescriptionAdaptor<factory::CreatedType, type>;  \
+  DEFINE_EDM_PLUGIN(edmplugin::PluginFactory<edm::PluginDescriptionAdaptorBase<factory::CreatedType>*()>, \
+                    EDM_PLUGIN_SYM(adaptor_t, __LINE__),                                                  \
+                    name)
 
 #endif

--- a/FWCore/PluginManager/interface/PluginFactory.h
+++ b/FWCore/PluginManager/interface/PluginFactory.h
@@ -121,7 +121,4 @@ namespace edmplugin {
 #define EDM_PLUGIN_SYM2(x, y) x##y
 
 #define DEFINE_EDM_PLUGIN(factory, type, name) \
-  static const factory::PMaker<type> EDM_PLUGIN_SYM(s_maker, __LINE__)(name)
-
-#define DEFINE_EDM_PLUGIN2(factory, type, name) \
-  static const factory::PMaker<type> EDM_PLUGIN_SYM(s_maker2_, __LINE__)(name)
+  static const factory::PMaker<type> EDM_PLUGIN_SYM(s_maker, __COUNTER__)(name)

--- a/HeterogeneousCore/TrivialSerialisation/interface/SerialiserFactory.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/SerialiserFactory.h
@@ -18,6 +18,6 @@ namespace ngt {
 // more suitable for Python configuration files.
 #define DEFINE_TRIVIAL_SERIALISER_PLUGIN(TYPE)                                           \
   DEFINE_EDM_PLUGIN(ngt::SerialiserFactory, ngt::Serialiser<TYPE>, typeid(TYPE).name()); \
-  DEFINE_EDM_PLUGIN2(ngt::SerialiserFactory, ngt::Serialiser<TYPE>, EDM_STRINGIZE(TYPE))
+  DEFINE_EDM_PLUGIN(ngt::SerialiserFactory, ngt::Serialiser<TYPE>, EDM_STRINGIZE(TYPE))
 
 #endif  // HeterogeneousCore_TrivialSerialisation_interface_SerialiserFactory_h

--- a/HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h
+++ b/HeterogeneousCore/TrivialSerialisation/interface/alpaka/SerialiserFactoryDevice.h
@@ -19,12 +19,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
 // to it (it is attached here). The plugin is registered under both the mangled
 // typeid name and EDM_STRINGIZE(TYPE). EDM_STRINGIZE(TYPE) is more
 // human-readable, and thus more suitable for Python configuration files.
-#define DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(TYPE)                                                   \
-  DEFINE_EDM_PLUGIN(ALPAKA_ACCELERATOR_NAMESPACE::ngt::SerialiserFactoryDevice,                         \
-                    ALPAKA_ACCELERATOR_NAMESPACE::ngt::Serialiser<ALPAKA_ACCELERATOR_NAMESPACE::TYPE>,  \
-                    typeid(edm::DeviceProduct<ALPAKA_ACCELERATOR_NAMESPACE::TYPE>).name());             \
-  DEFINE_EDM_PLUGIN2(ALPAKA_ACCELERATOR_NAMESPACE::ngt::SerialiserFactoryDevice,                        \
-                     ALPAKA_ACCELERATOR_NAMESPACE::ngt::Serialiser<ALPAKA_ACCELERATOR_NAMESPACE::TYPE>, \
-                     EDM_STRINGIZE(TYPE))
+#define DEFINE_TRIVIAL_SERIALISER_PLUGIN_DEVICE(TYPE)                                                  \
+  DEFINE_EDM_PLUGIN(ALPAKA_ACCELERATOR_NAMESPACE::ngt::SerialiserFactoryDevice,                        \
+                    ALPAKA_ACCELERATOR_NAMESPACE::ngt::Serialiser<ALPAKA_ACCELERATOR_NAMESPACE::TYPE>, \
+                    typeid(edm::DeviceProduct<ALPAKA_ACCELERATOR_NAMESPACE::TYPE>).name());            \
+  DEFINE_EDM_PLUGIN(ALPAKA_ACCELERATOR_NAMESPACE::ngt::SerialiserFactoryDevice,                        \
+                    ALPAKA_ACCELERATOR_NAMESPACE::ngt::Serialiser<ALPAKA_ACCELERATOR_NAMESPACE::TYPE>, \
+                    EDM_STRINGIZE(TYPE))
 
 #endif  // HeterogeneousCore_TrivialSerialisation_interface_alpaka_SerialiserFactoryDevice_h


### PR DESCRIPTION
#### PR description:

The various framework plug-in macros use `__LINE__` to generate unique identifiers.
This is slightly cumbersome when one macro needs to expand to multiple symbols, because `__LINE__` would have the same value for all of them, leading to solutions like `DEFINE_EDM_PLUGIN2` that uses a different stem than `DEFINE_EDM_PLUGIN` to avoid conflicts.

This PR suggests the possibility of using `__COUNTER__` instead of `__LINE__` to generate unique variables.

#### PR validation:

Code builds.