### PR TITLE
[16.1] Configure `ProcessAcceleratorAlpaka` in python dumps

### DIFF
--- a/HeterogeneousCore/AlpakaCore/python/ProcessAcceleratorAlpaka.py
+++ b/HeterogeneousCore/AlpakaCore/python/ProcessAcceleratorAlpaka.py
@@ -62,10 +62,10 @@ class ProcessAcceleratorAlpaka(cms.ProcessAccelerator):
     accelerators that the concrete ProcessAccelerators (like
     ProcessAcceleratorCUDA) define.
     """
-    def __init__(self):
+    def __init__(self, backend = None, synchronize = False):
         super(ProcessAcceleratorAlpaka, self).__init__()
-        self._backend = None
-        self._synchronize = False
+        self._backend = backend
+        self._synchronize = synchronize
 
     # User-facing interface
     def setBackend(self, backend):
@@ -73,6 +73,15 @@ class ProcessAcceleratorAlpaka(cms.ProcessAccelerator):
 
     def setSynchronize(self, synchronize):
         self._synchronize = synchronize
+
+    # Include the ProcessAcceleratorAlpaka configuration in the python dumps
+    def dumpPythonImpl(self, options) -> str:
+        args = []
+        if self._backend is not None:
+            args.append(options.indentation() + f"backend = '{self._backend}'")
+        if self._synchronize != False:
+            args.append(options.indentation() + f"synchronize = {self._synchronize}")
+        return ',\n'.join(args)
 
     # Framework-facing interface
     def moduleTypeResolver(self, accelerators):

--- a/HeterogeneousCore/AlpakaCore/test/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaCore/test/BuildFile.xml
@@ -2,6 +2,14 @@
   <flags ALPAKA_BACKENDS="1"/>
 </test>
 
+<test name="testProcessAcceleratorAlpaka" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/AlpakaCore/test/testProcessAcceleratorAlpaka.py">
+  <flags ALPAKA_BACKENDS="1"/>
+</test>
+
+<test name="testProcessAcceleratorAlpakaDump" command="edmConfigDump ${LOCALTOP}/src/HeterogeneousCore/AlpakaCore/test/testProcessAcceleratorAlpaka.py > dump.py &amp;&amp; cmsRun dump.py">
+  <flags ALPAKA_BACKENDS="1"/>
+</test>
+
 <bin name="testAlpakaFriendlyClassNames" file="alpaka/testFriendlyClassNames.cc">
   <use name="alpaka"/>
   <use name="catch2"/>

--- a/HeterogeneousCore/AlpakaCore/test/testProcessAcceleratorAlpaka.py
+++ b/HeterogeneousCore/AlpakaCore/test/testProcessAcceleratorAlpaka.py
@@ -1,0 +1,52 @@
+import os
+import sys
+
+# choose a different alpaka backend depending on the SCRAM test being run
+try:
+    backend = os.environ['SCRAM_ALPAKA_BACKEND']
+except:
+    backend = 'SerialSync'
+
+# map the alpaka backends to the process accelerators
+accelerators = {
+    'SerialSync': 'cpu',
+    'CudaAsync':  'gpu-nvidia',
+    'ROCmAsync':  'gpu-amd'
+}
+
+# map the alpaka backends to the names used by the ProcessAcceleratorAlpaka
+backends = {
+    'SerialSync': 'serial_sync',
+    'CudaAsync':  'cuda_async',
+    'ROCmAsync':  'rocm_async'
+}
+
+print(f"Testing the alpaka backend {backend} using the process accelerator {accelerators[backend]}", file=sys.stderr)
+
+import FWCore.ParameterSet.Config as cms
+from HeterogeneousCore.AlpakaCore.functions import *
+
+process = cms.Process('Test')
+
+process.maxEvents.input = 10
+
+process.source = cms.Source('EmptySource')
+
+process.load('Configuration.StandardSequences.Accelerators_cff')
+process.load('HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi')
+process.ProcessAcceleratorAlpaka.setBackend(backends[backend])
+
+process.alpakaBackendProducer = cms.EDProducer('AlpakaBackendProducer@alpaka')
+
+process.alpakaBackendFilter = cms.EDFilter('AlpakaBackendFilter',
+  producer = cms.InputTag('alpakaBackendProducer', 'backend'),
+  backends = cms.vstring(backend)
+)
+
+process.mustRun = cms.EDProducer("edmtest::MustRunIntProducer", ivalue=cms.int32(1))
+process.mustNotRun = cms.EDProducer("FailingProducer")
+
+process.SelectedBackend = cms.Path(process.alpakaBackendProducer + process.alpakaBackendFilter + process.mustRun)
+process.AnyOtherBackend = cms.Path(process.alpakaBackendProducer + ~process.alpakaBackendFilter + process.mustNotRun)
+
+process.options.wantSummary = True


### PR DESCRIPTION
#### PR description:

Include the `ProcessAcceleratorAlpaka` configuration in the python dumps, _e.g._
```python
process.ProcessAcceleratorAlpaka = ProcessAcceleratorAlpaka(
    synchronize = True
)
```

#### PR validation:

All unit tests pass, including the new ones introduced to test this functionality.s -->

#### Backport status:

Backport of #50839.