### PR TITLE
Refactor control of Source in EventProcessor

### DIFF
--- a/FWCore/Concurrency/interface/SerialTaskQueue.h
+++ b/FWCore/Concurrency/interface/SerialTaskQueue.h
@@ -117,7 +117,7 @@ namespace edm {
        * \param[in] iAction Must be a functor that takes no arguments and return no values.
        */
     template <typename T>
-    void push(oneapi::tbb::task_group&, const T& iAction);
+    void push(oneapi::tbb::task_group&, T&& iAction);
 
   private:
     /** Base class for all tasks held by the SerialTaskQueue */
@@ -140,7 +140,8 @@ namespace edm {
     template <typename T>
     class QueuedTask : public TaskBase {
     public:
-      QueuedTask(oneapi::tbb::task_group& iGroup, const T& iAction) : TaskBase(&iGroup), m_action(iAction) {}
+      QueuedTask(oneapi::tbb::task_group& iGroup, T&& iAction)
+          : TaskBase(&iGroup), m_action(std::forward<T>(iAction)) {}
 
     private:
       void execute() final;
@@ -166,8 +167,8 @@ namespace edm {
   };
 
   template <typename T>
-  void SerialTaskQueue::push(oneapi::tbb::task_group& iGroup, const T& iAction) {
-    QueuedTask<T>* pTask{new QueuedTask<T>{iGroup, iAction}};
+  void SerialTaskQueue::push(oneapi::tbb::task_group& iGroup, T&& iAction) {
+    QueuedTask<T>* pTask{new QueuedTask<T>{iGroup, std::forward<T>(iAction)}};
     pushTask(pTask);
   }
 

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -31,6 +31,7 @@ configured in the user's main() function, and is set running.
 #include "FWCore/Framework/interface/SignallingProductRegistryFiller.h"
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Framework/interface/SourceStatus.h"
+#include "FWCore/Framework/interface/SourceCoordinator.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -189,10 +190,7 @@ namespace edm {
     // The following functions are used by the code implementing
     // transition handling.
 
-    [[nodiscard]] SourceStatus findNextTransitionType();
-    void nextTransitionTypeThatIsNotTheSameRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                                    WaitingTaskHolder nextTask,
-                                                    SourceStatus& oSourceStatus);
+    [[nodiscard]] SourceStatus thread_unsafe_peekNextTransitionType();
 
     void readFile();
     bool fileBlockValid() { return fb_.get() != nullptr; }
@@ -209,7 +207,7 @@ namespace edm {
     void prepareForNextLoop();
     bool shouldWeCloseOutput() const;
 
-    void doErrorStuff();
+    void doErrorStuff(InputSource::ItemType iType);
 
     void beginProcessBlock(bool& beginProcessBlockSucceeded);
     void inputProcessBlocks();
@@ -233,11 +231,6 @@ namespace edm {
     void globalEndLumiAsync(WaitingTaskHolder, std::shared_ptr<LuminosityBlockProcessingStatus>);
     void streamEndLumiAsync(WaitingTaskHolder, unsigned int iStreamIndex);
     void endUnfinishedLumi(bool cleaningUpAfterException);
-    void readProcessBlock(ProcessBlockPrincipal&);
-    std::shared_ptr<RunPrincipal> readRun();
-    void readAndMergeRun(RunProcessingStatus&);
-    std::shared_ptr<LuminosityBlockPrincipal> readLuminosityBlock(std::shared_ptr<RunPrincipal> rp);
-    void readAndMergeLumi(LuminosityBlockProcessingStatus&);
     using ProcessBlockType = PrincipalCache::ProcessBlockType;
     void writeProcessBlockAsync(WaitingTaskHolder, ProcessBlockType);
     void writeRunAsync(WaitingTaskHolder, RunPrincipal const&, MergeableRunProductMetadata const*);
@@ -267,35 +260,15 @@ namespace edm {
                        std::shared_ptr<RunProcessingStatus> iRunStatus,
                        WaitingTaskHolder iNextTask,
                        SourceStatus& oSourceStatus);
-    void readAndMergeRunEntriesAsync(std::shared_ptr<RunProcessingStatus>,
-                                     WaitingTaskHolder,
-                                     SourceStatus& oSourceStatus);
-    void readAndMergeLumiEntriesAsync(std::shared_ptr<LuminosityBlockProcessingStatus>,
-                                      WaitingTaskHolder,
-                                      SourceStatus& oSourceStatus);
 
     void handleNextItemAfterMergingRunEntriesAsync(std::shared_ptr<RunProcessingStatus>,
                                                    WaitingTaskHolder,
                                                    SourceStatus& oStatus);
 
-    struct ReadNextEventForStreamResult {
-      //If didCallReadEvent and stopLumi are both false, then we are in the middle of a file transition
-      bool didCallReadEvent;
-      bool stopLumi;
-      InputSource::ItemType nextTransitionType;
-      bool mustStartNextLumiOrEndRun = false;
-    };
-    ReadNextEventForStreamResult readNextEventForStream(unsigned int iStreamIndex,
-                                                        LuminosityBlockProcessingStatus&,
-                                                        SourceStatus& oSourceStatus);
-
     void handleNextEventForStreamAsync(std::exception_ptr const*,
                                        WaitingTaskHolder,
                                        unsigned int iStreamIndex,
                                        SourceStatus& oSourceStatus);
-
-    //read the next event using Stream iStreamIndex
-    void readEvent(unsigned int iStreamIndex);
 
     //process the already read event using Stream iStreamIndex
     void processEventAsync(WaitingTaskHolder iHolder, unsigned int iStreamIndex);
@@ -333,7 +306,6 @@ namespace edm {
     edm::propagate_const<std::shared_ptr<BranchIDListHelper>> branchIDListHelper_;
     edm::propagate_const<std::shared_ptr<ProcessBlockHelper>> processBlockHelper_;
     ServiceToken serviceToken_;
-    edm::propagate_const<std::unique_ptr<InputSource>> input_;
     edm::propagate_const<std::unique_ptr<ModuleTypeResolverMaker const>> moduleTypeResolverMaker_;
     edm::propagate_const<std::unique_ptr<eventsetup::EventSetupsController>> espController_;
     edm::propagate_const<std::shared_ptr<eventsetup::EventSetupProvider>> esp_;
@@ -366,8 +338,8 @@ namespace edm {
     std::atomic<bool> deferredExceptionPtrIsSet_;
     std::exception_ptr deferredExceptionPtr_;
 
-    SharedResourcesAcquirer sourceResourcesAcquirer_;
-    std::shared_ptr<std::recursive_mutex> sourceMutex_;
+    SourceCoordinator sourceCoordinator_;
+
     PrincipalCache principalCache_;
     bool beginJobCalled_;
     bool beginJobStartedModules_ = false;

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -287,12 +287,14 @@ namespace edm {
       InputSource::ItemType nextTransitionType;
       bool mustStartNextLumiOrEndRun = false;
     };
-    ReadNextEventForStreamResult readNextEventForStream(bool earlierTaskFailed,
-                                                        unsigned int iStreamIndex,
+    ReadNextEventForStreamResult readNextEventForStream(unsigned int iStreamIndex,
                                                         LuminosityBlockProcessingStatus&,
                                                         SourceStatus& oSourceStatus);
 
-    void handleNextEventForStreamAsync(WaitingTaskHolder, unsigned int iStreamIndex, SourceStatus& oSourceStatus);
+    void handleNextEventForStreamAsync(std::exception_ptr const*,
+                                       WaitingTaskHolder,
+                                       unsigned int iStreamIndex,
+                                       SourceStatus& oSourceStatus);
 
     //read the next event using Stream iStreamIndex
     void readEvent(unsigned int iStreamIndex);

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -258,7 +258,7 @@ namespace edm {
     void readAndMergeRunEntriesAsync(std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder);
     void readAndMergeLumiEntriesAsync(std::shared_ptr<LuminosityBlockProcessingStatus>, WaitingTaskHolder);
 
-    void handleNextItemAfterMergingRunEntries(std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder);
+    void handleNextItemAfterMergingRunEntriesAsync(std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder);
 
     bool readNextEventForStream(WaitingTaskHolder const&, unsigned int iStreamIndex, LuminosityBlockProcessingStatus&);
 

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -190,9 +190,9 @@ namespace edm {
     // transition handling.
 
     [[nodiscard]] SourceStatus findNextTransitionType();
-    void nextTransitionTypeAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                 WaitingTaskHolder nextTask,
-                                 SourceStatus& oSourceStatus);
+    void nextTransitionTypeThatIsNotTheSameRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
+                                                    WaitingTaskHolder nextTask,
+                                                    SourceStatus& oSourceStatus);
 
     void readFile();
     bool fileBlockValid() { return fb_.get() != nullptr; }
@@ -362,7 +362,7 @@ namespace edm {
     std::atomic<bool> exceptionMessageRuns_;
     std::atomic<bool> exceptionMessageLumis_;
     bool forceLooperToEnd_;
-    bool looperBeginJobRun_;
+    std::atomic<bool> looperBeginJobRun_;
     bool forceESCacheClearOnNewRun_;
 
     PreallocationConfiguration preallocations_;

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -261,12 +261,10 @@ namespace edm {
     void init(std::shared_ptr<ProcessDesc>& processDesc, ServiceToken const& token, serviceregistry::ServiceLegacy);
 
     void readRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
-                      WaitingTaskHolder const& iCheckSharedTask,
                       WaitingTaskHolder iNextTask,
                       SourceStatus& oSourceStatus);
     void readLumiAsync(std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus,
                        std::shared_ptr<RunProcessingStatus> iRunStatus,
-                       WaitingTaskHolder iCheckSharedTask,
                        WaitingTaskHolder iNextTask,
                        SourceStatus& oSourceStatus);
     void readAndMergeRunEntriesAsync(std::shared_ptr<RunProcessingStatus>,

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -189,7 +189,7 @@ namespace edm {
     // The following functions are used by the code implementing
     // transition handling.
 
-    [[nodiscard]] SourceStatus nextTransitionType();
+    [[nodiscard]] SourceStatus findNextTransitionType();
     void nextTransitionTypeAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
                                  WaitingTaskHolder nextTask,
                                  SourceStatus& oSourceStatus);

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -372,7 +372,8 @@ namespace edm {
     bool beginJobCalled_;
     bool beginJobStartedModules_ = false;
     bool beginJobSucceeded_ = false;
-    bool shouldWeStop_;
+    //set by looper during event processing, but read by multiple threads, so needs to be atomic
+    std::atomic<bool> shouldWeStop_;
     bool fileModeNoMerge_;
     std::string exceptionMessageFiles_;
     std::atomic<bool> exceptionMessageRuns_;

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -260,6 +260,15 @@ namespace edm {
     // init() is used by only by constructors
     void init(std::shared_ptr<ProcessDesc>& processDesc, ServiceToken const& token, serviceregistry::ServiceLegacy);
 
+    void readRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
+                      WaitingTaskHolder const& iCheckSharedTask,
+                      WaitingTaskHolder iNextTask,
+                      SourceStatus& oSourceStatus);
+    void readLumiAsync(std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus,
+                       std::shared_ptr<RunProcessingStatus> iRunStatus,
+                       WaitingTaskHolder iCheckSharedTask,
+                       WaitingTaskHolder iNextTask,
+                       SourceStatus& oSourceStatus);
     void readAndMergeRunEntriesAsync(std::shared_ptr<RunProcessingStatus>,
                                      WaitingTaskHolder,
                                      SourceStatus& oSourceStatus);

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -59,7 +59,6 @@ namespace edm {
   class LuminosityBlockPrincipal;
   class LuminosityBlockProcessingStatus;
   class RunProcessingStatus;
-  class IOVSyncValue;
   class ModuleTypeResolverMaker;
 
   namespace eventsetup {
@@ -214,19 +213,18 @@ namespace edm {
     void endProcessBlock(bool cleaningUpAfterException, bool beginProcessBlockSucceeded);
 
     SourceStatus processRuns(SourceStatus const& iStatus);
-    void beginRunAsync(IOVSyncValue const&, WaitingTaskHolder, SourceStatus& oStatus);
+    void beginRunAsync(RunAuxiliary const&, WaitingTaskHolder);
     void streamBeginRunAsync(unsigned int iStream, std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder) noexcept;
     void releaseBeginRunResources(unsigned int iStream);
-    void endRunAsync(std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder, SourceStatus& oStatus) noexcept;
+    void endRunAsync(std::shared_ptr<RunProcessingStatus>,
+                     std::optional<RunAuxiliary> const&,
+                     WaitingTaskHolder) noexcept;
     void handleEndRunExceptions(std::exception_ptr, WaitingTaskHolder const&);
     void globalEndRunAsync(WaitingTaskHolder, std::shared_ptr<RunProcessingStatus>);
     void streamEndRunAsync(WaitingTaskHolder, unsigned int iStreamIndex);
-    SourceStatus endUnfinishedRun(bool cleaningUpAfterException);
-    void beginLumiAsync(IOVSyncValue const&,
-                        std::shared_ptr<RunProcessingStatus>,
-                        WaitingTaskHolder,
-                        SourceStatus& oStatus);
-    void continueLumiAsync(WaitingTaskHolder, SourceStatus& oSourceStatus);
+    void endUnfinishedRun(bool cleaningUpAfterException);
+    void beginLumiAsync(std::shared_ptr<RunProcessingStatus>, LuminosityBlockAuxiliary const&, WaitingTaskHolder);
+    void continueLumiAsync(WaitingTaskHolder, SourceStatus const& oSourceStatus);
     void handleEndLumiExceptions(std::exception_ptr, WaitingTaskHolder const&);
     void globalEndLumiAsync(WaitingTaskHolder, std::shared_ptr<LuminosityBlockProcessingStatus>);
     void streamEndLumiAsync(WaitingTaskHolder, unsigned int iStreamIndex);
@@ -254,21 +252,19 @@ namespace edm {
     void init(std::shared_ptr<ProcessDesc>& processDesc, ServiceToken const& token, serviceregistry::ServiceLegacy);
 
     void readRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
+                      RunAuxiliary const& iRunAux,
                       WaitingTaskHolder iNextTask,
-                      SourceStatus& oSourceStatus);
+                      SourceStatus& oNextStatus);
     void readLumiAsync(std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus,
                        std::shared_ptr<RunProcessingStatus> iRunStatus,
-                       WaitingTaskHolder iNextTask,
-                       SourceStatus& oSourceStatus);
+                       LuminosityBlockAuxiliary const& iLumiAux,
+                       WaitingTaskHolder iNextTask);
 
     void handleNextItemAfterMergingRunEntriesAsync(std::shared_ptr<RunProcessingStatus>,
                                                    WaitingTaskHolder,
-                                                   SourceStatus& oStatus);
+                                                   SourceStatus const& oStatus);
 
-    void handleNextEventForStreamAsync(std::exception_ptr const*,
-                                       WaitingTaskHolder,
-                                       unsigned int iStreamIndex,
-                                       SourceStatus& oSourceStatus);
+    void handleNextEventForStreamAsync(std::exception_ptr const*, unsigned int iStreamIndex, WaitingTaskHolder);
 
     //process the already read event using Stream iStreamIndex
     void processEventAsync(WaitingTaskHolder iHolder, unsigned int iStreamIndex);

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -30,6 +30,7 @@ configured in the user's main() function, and is set running.
 #include "FWCore/Framework/interface/PrincipalCache.h"
 #include "FWCore/Framework/interface/SignallingProductRegistryFiller.h"
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
+#include "FWCore/Framework/interface/SourceStatus.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -188,9 +189,10 @@ namespace edm {
     // The following functions are used by the code implementing
     // transition handling.
 
-    InputSource::ItemTypeInfo nextTransitionType();
-    InputSource::ItemTypeInfo lastTransitionType() const { return lastSourceTransition_; }
-    void nextTransitionTypeAsync(std::shared_ptr<RunProcessingStatus> iRunStatus, WaitingTaskHolder nextTask);
+    [[nodiscard]] SourceStatus nextTransitionType();
+    void nextTransitionTypeAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
+                                 WaitingTaskHolder nextTask,
+                                 SourceStatus& oSourceStatus);
 
     void readFile();
     bool fileBlockValid() { return fb_.get() != nullptr; }
@@ -213,17 +215,20 @@ namespace edm {
     void inputProcessBlocks();
     void endProcessBlock(bool cleaningUpAfterException, bool beginProcessBlockSucceeded);
 
-    InputSource::ItemType processRuns();
-    void beginRunAsync(IOVSyncValue const&, WaitingTaskHolder);
+    SourceStatus processRuns(SourceStatus const& iStatus);
+    void beginRunAsync(IOVSyncValue const&, WaitingTaskHolder, SourceStatus& oStatus);
     void streamBeginRunAsync(unsigned int iStream, std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder) noexcept;
     void releaseBeginRunResources(unsigned int iStream);
-    void endRunAsync(std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder);
+    void endRunAsync(std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder, SourceStatus& oStatus) noexcept;
     void handleEndRunExceptions(std::exception_ptr, WaitingTaskHolder const&);
     void globalEndRunAsync(WaitingTaskHolder, std::shared_ptr<RunProcessingStatus>);
     void streamEndRunAsync(WaitingTaskHolder, unsigned int iStreamIndex);
-    void endUnfinishedRun(bool cleaningUpAfterException);
-    void beginLumiAsync(IOVSyncValue const&, std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder);
-    void continueLumiAsync(WaitingTaskHolder);
+    SourceStatus endUnfinishedRun(bool cleaningUpAfterException);
+    void beginLumiAsync(IOVSyncValue const&,
+                        std::shared_ptr<RunProcessingStatus>,
+                        WaitingTaskHolder,
+                        SourceStatus& oStatus);
+    void continueLumiAsync(WaitingTaskHolder, SourceStatus& oSourceStatus);
     void handleEndLumiExceptions(std::exception_ptr, WaitingTaskHolder const&);
     void globalEndLumiAsync(WaitingTaskHolder, std::shared_ptr<LuminosityBlockProcessingStatus>);
     void streamEndLumiAsync(WaitingTaskHolder, unsigned int iStreamIndex);
@@ -255,14 +260,23 @@ namespace edm {
     // init() is used by only by constructors
     void init(std::shared_ptr<ProcessDesc>& processDesc, ServiceToken const& token, serviceregistry::ServiceLegacy);
 
-    void readAndMergeRunEntriesAsync(std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder);
-    void readAndMergeLumiEntriesAsync(std::shared_ptr<LuminosityBlockProcessingStatus>, WaitingTaskHolder);
+    void readAndMergeRunEntriesAsync(std::shared_ptr<RunProcessingStatus>,
+                                     WaitingTaskHolder,
+                                     SourceStatus& oSourceStatus);
+    void readAndMergeLumiEntriesAsync(std::shared_ptr<LuminosityBlockProcessingStatus>,
+                                      WaitingTaskHolder,
+                                      SourceStatus& oSourceStatus);
 
-    void handleNextItemAfterMergingRunEntriesAsync(std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder);
+    void handleNextItemAfterMergingRunEntriesAsync(std::shared_ptr<RunProcessingStatus>,
+                                                   WaitingTaskHolder,
+                                                   SourceStatus& oStatus);
 
-    bool readNextEventForStream(WaitingTaskHolder const&, unsigned int iStreamIndex, LuminosityBlockProcessingStatus&);
+    bool readNextEventForStream(WaitingTaskHolder const&,
+                                unsigned int iStreamIndex,
+                                LuminosityBlockProcessingStatus&,
+                                SourceStatus& oSourceStatus);
 
-    void handleNextEventForStreamAsync(WaitingTaskHolder, unsigned int iStreamIndex);
+    void handleNextEventForStreamAsync(WaitingTaskHolder, unsigned int iStreamIndex, SourceStatus& oSourceStatus);
 
     //read the next event using Stream iStreamIndex
     void readEvent(unsigned int iStreamIndex);
@@ -288,9 +302,6 @@ namespace edm {
     void throwAboutModulesRequiringLuminosityBlockSynchronization() const;
     void warnAboutModulesRequiringRunSynchronization() const;
 
-    bool needToCallNext() const { return needToCallNext_; }
-    void setNeedToCallNext(bool val) { needToCallNext_ = val; }
-
     //------------------------------------------------------------------
     //
     // Data members below.
@@ -307,7 +318,6 @@ namespace edm {
     edm::propagate_const<std::shared_ptr<ProcessBlockHelper>> processBlockHelper_;
     ServiceToken serviceToken_;
     edm::propagate_const<std::unique_ptr<InputSource>> input_;
-    InputSource::ItemTypeInfo lastSourceTransition_;
     edm::propagate_const<std::unique_ptr<ModuleTypeResolverMaker const>> moduleTypeResolverMaker_;
     edm::propagate_const<std::unique_ptr<eventsetup::EventSetupsController>> espController_;
     edm::propagate_const<std::shared_ptr<eventsetup::EventSetupProvider>> esp_;
@@ -361,7 +371,6 @@ namespace edm {
 
     bool printDependencies_ = false;
     bool deleteNonConsumedUnscheduledModules_ = true;
-    bool needToCallNext_ = true;
   };  // class EventProcessor
 
   //--------------------------------------------------------------------

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -280,10 +280,17 @@ namespace edm {
                                                    WaitingTaskHolder,
                                                    SourceStatus& oStatus);
 
-    bool readNextEventForStream(WaitingTaskHolder const&,
-                                unsigned int iStreamIndex,
-                                LuminosityBlockProcessingStatus&,
-                                SourceStatus& oSourceStatus);
+    struct ReadNextEventForStreamResult {
+      bool didCallReadEvent;
+      bool stopLumi;
+      bool pauseForFileTransition;
+      InputSource::ItemType nextTransitionType;
+      bool mustStartNextLumiOrEndRun = false;
+    };
+    ReadNextEventForStreamResult readNextEventForStream(bool earlierTaskFailed,
+                                                        unsigned int iStreamIndex,
+                                                        LuminosityBlockProcessingStatus&,
+                                                        SourceStatus& oSourceStatus);
 
     void handleNextEventForStreamAsync(WaitingTaskHolder, unsigned int iStreamIndex, SourceStatus& oSourceStatus);
 

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -281,9 +281,9 @@ namespace edm {
                                                    SourceStatus& oStatus);
 
     struct ReadNextEventForStreamResult {
+      //If didCallReadEvent and stopLumi are both false, then we are in the middle of a file transition
       bool didCallReadEvent;
       bool stopLumi;
-      bool pauseForFileTransition;
       InputSource::ItemType nextTransitionType;
       bool mustStartNextLumiOrEndRun = false;
     };

--- a/FWCore/Framework/interface/SourceCoordinator.h
+++ b/FWCore/Framework/interface/SourceCoordinator.h
@@ -1,0 +1,127 @@
+#ifndef FWCore_Framework_SourceCoordinator_h
+#define FWCore_Framework_SourceCoordinator_h
+// -*- C++ -*-
+// Package:     FWCore/Framework
+// Class  :     SourceCoordinator
+// Description: This class is responsible for coordinating the source and the state machine
+// Original Author:  Chris Jones
+
+#include "FWCore/Framework/interface/InputSource.h"
+#include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/Framework/interface/SourceStatus.h"
+#include <memory>
+#include <mutex>
+#include <tuple>
+
+namespace edm {
+  class RunProcessingStatus;
+  class LuminosityBlockProcessingStatus;
+  class HistoryAppender;
+  class EventPrincipal;
+  class RunPrincipal;
+  class LuminosityBlockPrincipal;
+  class WaitingTaskHolder;
+
+  class SourceCoordinator {
+  public:
+    explicit SourceCoordinator(SharedResourcesAcquirer&& sourceResourcesAcquirer,
+                               std::shared_ptr<std::recursive_mutex> sourceMutex,
+                               ServiceToken& token)
+        : serviceToken_(token),
+          sourceResourcesAcquirer_(std::move(sourceResourcesAcquirer)),
+          sourceMutex_(sourceMutex) {}
+
+    void setSignals(ActivityRegistry& iRegistry) {
+      earlyTerminationSignal_ = &iRegistry.preSourceEarlyTerminationSignal_;
+      preSourceNextTransitionSignal_ = &iRegistry.preSourceNextTransitionSignal_;
+      postSourceNextTransitionSignal_ = &iRegistry.postSourceNextTransitionSignal_;
+    }
+
+    void setSource(std::unique_ptr<InputSource> input) { input_ = std::move(input); }
+    void releaseSource() { input_ = nullptr; }
+    ProductRegistry const& productRegistry() const { return input_->productRegistry(); }
+    void beginJob(ProductRegistry const&);
+    void endJob();
+    std::tuple<std::shared_ptr<edm::FileBlock>, ProductRegistry const*> readFile();
+    void closeFile(FileBlock*, bool cleaningUpAfterException);
+
+    bool randomAccess() const;
+    ProcessingController::ForwardState forwardState();
+    ProcessingController::ReverseState reverseState();
+    void skipEvents(int n);
+    bool goToEvent(EventID const& transition);
+
+    void rewind();
+
+    void fillProcessBlockHelper();
+    bool nextProcessBlock(ProcessBlockPrincipal& processBlockPrincipal);
+    void readProcessBlock(ProcessBlockPrincipal& processBlockPrincipal);
+
+    void peekNextTransitionTypeThatIsNotTheSameRunAsync(RunNumber_t run,
+                                                        const ProcessHistoryID& reducedProcessHistoryID,
+                                                        SourceStatus& lastTransition,
+                                                        WaitingTaskHolder nextTask);
+
+    void readNewRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
+                         ProcessContext const& processContext,
+                         HistoryAppender& historyAppender,
+                         SourceStatus& lastTransition,
+                         WaitingTaskHolder iHolder);
+    void readNewLuminosityBlockAsync(std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus,
+                                     ProcessContext const& processContext,
+                                     HistoryAppender& historyAppender,
+                                     SourceStatus& lastTransition,
+                                     WaitingTaskHolder iHolder);
+    struct ReadNextEventForStreamResult {
+      //If didCallReadEvent and stopLumi are both false, then we are in the middle of a file transition
+      bool didCallReadEvent;
+      bool stopLumi;
+      InputSource::ItemType nextTransitionType;
+      bool mustStartNextLumiOrEndRun = false;
+    };
+
+    void readNextEventForStreamAsync(EventPrincipal& event,
+                                     ProcessContext& processContext,
+                                     LuminosityBlockProcessingStatus& iStatus,
+                                     RunProcessingStatus& runStatus,
+                                     bool earlierTaskFailed,
+                                     bool needToStop,
+                                     ReadNextEventForStreamResult& oResult,
+                                     SourceStatus& oSourceStatus,
+                                     WaitingTaskHolder iTask);
+
+    bool mergeRunIfNeeded(RunPrincipal& iRunPrincipal);
+    bool mergeLuminosityBlockIfNeeded(LuminosityBlockPrincipal& iLumiPrincipal);
+
+    [[nodiscard]] SourceStatus thread_unsafe_peekNextTransitionType();
+
+  private:
+    void readAndMergeRun(RunPrincipal& iRunPrincipal);
+    void readRun(RunPrincipal& iRunPrincipal, HistoryAppender& historyAppender);
+
+    void readLuminosityBlock(LuminosityBlockPrincipal& iLumiPrincipal, HistoryAppender& historyAppender);
+    void readAndMergeLuminosityBlock(LuminosityBlockPrincipal& iLumiPrincipal);
+    ReadNextEventForStreamResult readNextEventForStream(EventPrincipal& event,
+                                                        ProcessContext& processContext,
+                                                        LuminosityBlockProcessingStatus& iStatus,
+                                                        RunProcessingStatus& runStatus);
+
+    void readEvent(EventPrincipal& event,
+                   ProcessContext& processContext,
+                   LuminosityBlockProcessingStatus& lumiStatus,
+                   RunProcessingStatus& runStatus);
+    edm::propagate_const<std::unique_ptr<InputSource>> input_;
+    ServiceToken& serviceToken_;
+    SharedResourcesAcquirer sourceResourcesAcquirer_;
+    std::shared_ptr<std::recursive_mutex> sourceMutex_;
+    SourceStatus sourceStatus_;
+
+    ActivityRegistry::PreSourceEarlyTermination* earlyTerminationSignal_ = nullptr;
+    ActivityRegistry::PreSourceNextTransition* preSourceNextTransitionSignal_ = nullptr;
+    ActivityRegistry::PostSourceNextTransition* postSourceNextTransitionSignal_ = nullptr;
+  };
+}  // namespace edm
+#endif

--- a/FWCore/Framework/interface/SourceCoordinator.h
+++ b/FWCore/Framework/interface/SourceCoordinator.h
@@ -8,10 +8,10 @@
 
 #include "FWCore/Framework/interface/InputSource.h"
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
-#include "FWCore/Utilities/interface/propagate_const.h"
-#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
-#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/Framework/interface/SourceStatus.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 #include <memory>
 #include <mutex>
 #include <tuple>

--- a/FWCore/Framework/interface/SourceCoordinator.h
+++ b/FWCore/Framework/interface/SourceCoordinator.h
@@ -73,7 +73,6 @@ namespace edm {
     void readNewLuminosityBlockAsync(std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus,
                                      ProcessContext const& processContext,
                                      HistoryAppender& historyAppender,
-                                     SourceStatus& lastTransition,
                                      WaitingTaskHolder iHolder);
     struct ReadNextEventForStreamResult {
       //If didCallReadEvent and stopLumi are both false, then we are in the middle of a file transition

--- a/FWCore/Framework/interface/SourceStatus.h
+++ b/FWCore/Framework/interface/SourceStatus.h
@@ -27,8 +27,8 @@ namespace edm {
       nextTransitionType_ = InputSource::ItemTypeInfo{iType};
     }
 
-    bool needToCallNext() const noexcept { return needToCallNext_; }
-    void setNeedToCallNext(bool val) noexcept { needToCallNext_ = val; }
+    bool needToAskSourceForNext() const noexcept { return needToCallNext_; }
+    void setNeedToAskSourceForNext(bool val) noexcept { needToCallNext_ = val; }
 
     edm::RunAuxiliary const* runAuxiliary() const noexcept {
       if (auto p = std::get_if<RunAuxiliary>(&currentRunOrLumiAux_)) {

--- a/FWCore/Framework/interface/SourceStatus.h
+++ b/FWCore/Framework/interface/SourceStatus.h
@@ -1,0 +1,64 @@
+#ifndef FWCore_Framework_SourceStatus_h
+#define FWCore_Framework_SourceStatus_h
+// Package:     FWCore/Framework
+// Class  :     SourceStatus
+/// Description: Keep status information about the source
+//
+#include "FWCore/Framework/interface/InputSource.h"
+
+#include "DataFormats/Provenance/interface/RunAuxiliary.h"
+#include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
+
+#include <variant>
+namespace edm {
+  class SourceStatus {
+  public:
+    SourceStatus() = default;
+    explicit SourceStatus(InputSource::ItemTypeInfo const& iType) noexcept : nextTransitionType_(iType) {}
+    explicit SourceStatus(InputSource::ItemType iType) noexcept : nextTransitionType_(iType) {}
+    SourceStatus(SourceStatus const&) noexcept = default;
+    SourceStatus(SourceStatus&&) noexcept = default;
+    SourceStatus& operator=(SourceStatus const&) noexcept = default;
+    SourceStatus& operator=(SourceStatus&&) noexcept = default;
+
+    InputSource::ItemTypeInfo nextTransitionType() const noexcept { return nextTransitionType_; }
+    void setNextTransitionType(InputSource::ItemTypeInfo const& iType) noexcept { nextTransitionType_ = iType; }
+    void setNextTransitionType(InputSource::ItemType iType) noexcept {
+      nextTransitionType_ = InputSource::ItemTypeInfo{iType};
+    }
+
+    bool needToCallNext() const noexcept { return needToCallNext_; }
+    void setNeedToCallNext(bool val) noexcept { needToCallNext_ = val; }
+
+    edm::RunAuxiliary const* runAuxiliary() const noexcept {
+      if (auto p = std::get_if<RunAuxiliary>(&currentRunOrLumiAux_)) {
+        return p;
+      }
+      return nullptr;
+    }
+    edm::LuminosityBlockAuxiliary const* lumiAuxiliary() const noexcept {
+      if (auto p = std::get_if<LuminosityBlockAuxiliary>(&currentRunOrLumiAux_)) {
+        return p;
+      }
+      return nullptr;
+    }
+    edm::ProcessHistoryID const& reducedProcessHistoryID() const noexcept {
+      if (reducedProcessHistoryID_) {
+        return *reducedProcessHistoryID_;
+      }
+      static const edm::ProcessHistoryID emptyID;
+      return emptyID;
+    }
+
+    void setRunAuxiliary(edm::RunAuxiliary const& aux) { currentRunOrLumiAux_ = aux; }
+    void setLuminosityBlockAuxiliary(edm::LuminosityBlockAuxiliary const& aux) { currentRunOrLumiAux_ = aux; }
+    void setReducedProcessHistoryID(edm::ProcessHistoryID const& id) { reducedProcessHistoryID_ = id; }
+
+  private:
+    InputSource::ItemTypeInfo nextTransitionType_{InputSource::ItemType::IsInvalid};
+    std::variant<std::monostate, RunAuxiliary, LuminosityBlockAuxiliary> currentRunOrLumiAux_{};
+    std::optional<edm::ProcessHistoryID> reducedProcessHistoryID_;
+    bool needToCallNext_ = true;
+  };
+}  // namespace edm
+#endif

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -877,7 +877,7 @@ namespace edm {
     };
   }  // namespace
 
-  SourceStatus EventProcessor::nextTransitionType() {
+  SourceStatus EventProcessor::findNextTransitionType() {
     SendSourceTerminationSignalIfException sentry(actReg_.get());
     SourceStatus returnValue;
     {
@@ -918,7 +918,7 @@ namespace edm {
             ServiceRegistry::Operate operate(serviceToken_);
             std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
             assert(lastTransition.needToCallNext());
-            lastTransition = nextTransitionType();
+            lastTransition = findNextTransitionType();
             if (lastTransition.nextTransitionType() == InputSource::ItemType::IsRun &&
                 runStatus->runPrincipal()->run() == lastTransition.runAuxiliary()->run() &&
                 runStatus->runPrincipal()->reducedProcessHistoryID() == lastTransition.reducedProcessHistoryID()) {
@@ -1181,7 +1181,7 @@ namespace edm {
              runStatus->runPrincipal()->reducedProcessHistoryID() == returnValue.reducedProcessHistoryID()) {
         readAndMergeRun(*runStatus);
         assert(returnValue.needToCallNext());
-        returnValue = nextTransitionType();
+        returnValue = findNextTransitionType();
       }
 
       returnValue.setNeedToCallNext(false);
@@ -1871,7 +1871,7 @@ namespace edm {
              status->lumiPrincipal()->luminosityBlock() == oSourceStatus.lumiAuxiliary()->luminosityBlock()) {
         readAndMergeLumi(*status);
         assert(not oSourceStatus.needToCallNext());
-        oSourceStatus = nextTransitionType();
+        oSourceStatus = findNextTransitionType();
         //Need to tell event processing loop that we called nextTransitionType while merging lumis so it doesn't call it again and possibly skip entries
         oSourceStatus.setNeedToCallNext(false);
       }
@@ -2139,7 +2139,7 @@ namespace edm {
             ServiceRegistry::Operate operate(serviceToken_);
 
             std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-            oSourceStatus = nextTransitionType();
+            oSourceStatus = findNextTransitionType();
             oSourceStatus.setNeedToCallNext(false);
 
             while (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsRun and
@@ -2155,7 +2155,7 @@ namespace edm {
                 return;
               }
               assert(not oSourceStatus.needToCallNext());
-              oSourceStatus = nextTransitionType();
+              oSourceStatus = findNextTransitionType();
               oSourceStatus.setNeedToCallNext(false);
             }
           } catch (...) {
@@ -2176,7 +2176,7 @@ namespace edm {
 
             std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
 
-            oSourceStatus = nextTransitionType();
+            oSourceStatus = findNextTransitionType();
             oSourceStatus.setNeedToCallNext(false);
 
             while (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsLumi and
@@ -2188,7 +2188,7 @@ namespace edm {
                 return;
               }
               assert(not oSourceStatus.needToCallNext());
-              oSourceStatus = nextTransitionType();
+              oSourceStatus = findNextTransitionType();
               //Need to tell event processing loop that we called nextTransitionType while merging lumis so it doesn't call it again and possibly skip entries
               oSourceStatus.setNeedToCallNext(false);
             }
@@ -2277,7 +2277,7 @@ namespace edm {
 
     auto findTransitionType = [this](SourceStatus& oSourceStatus) -> InputSource::ItemType {
       if (oSourceStatus.needToCallNext()) {
-        oSourceStatus = nextTransitionType();
+        oSourceStatus = findNextTransitionType();
       }
       oSourceStatus.setNeedToCallNext(true);
       return oSourceStatus.nextTransitionType();

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1087,21 +1087,17 @@ namespace edm {
 
   SourceStatus EventProcessor::processRuns(SourceStatus const& iStatus) {
     FinalWaitingTask waitTask{taskGroup_};
-    SourceStatus returnValue = iStatus;
-    assert(returnValue.nextTransitionType() == InputSource::ItemType::IsRun);
+    assert(iStatus.nextTransitionType() == InputSource::ItemType::IsRun);
     if (streamRunActive_ == 0) {
       assert(streamLumiActive_ == 0);
 
-      beginRunAsync(
-          IOVSyncValue(EventID(returnValue.runAuxiliary()->run(), 0, 0), returnValue.runAuxiliary()->beginTime()),
-          WaitingTaskHolder{taskGroup_, &waitTask},
-          returnValue);
+      beginRunAsync(*iStatus.runAuxiliary(), WaitingTaskHolder{taskGroup_, &waitTask});
     } else {
       assert(streamRunActive_ == preallocations_.numberOfStreams());
 
       auto runStatus = streamRunStatus_[0];
       assert(runStatus);
-      if (returnValue.nextTransitionType() == InputSource::ItemType::IsRun) {
+      if (iStatus.nextTransitionType() == InputSource::ItemType::IsRun) {
         assert(runStatus->runPrincipal());
         auto& runPrincipal = *runStatus->runPrincipal();
         //If a file open happened and we are continuing the Run we may need
@@ -1114,19 +1110,19 @@ namespace edm {
           sourceCoordinator_.mergeRunIfNeeded(runPrincipal);
         }
       }
-      returnValue = sourceCoordinator_.thread_unsafe_peekNextTransitionType();
+      auto newStatus = sourceCoordinator_.thread_unsafe_peekNextTransitionType();
 
       WaitingTaskHolder holder{taskGroup_, &waitTask};
       runStatus->setHolderOfTaskInProcessRuns(holder);
       if (streamLumiActive_ > 0) {
         assert(streamLumiActive_ == preallocations_.numberOfStreams());
-        continueLumiAsync(std::move(holder), returnValue);
+        continueLumiAsync(std::move(holder), newStatus);
       } else {
-        handleNextItemAfterMergingRunEntriesAsync(std::move(runStatus), std::move(holder), returnValue);
+        handleNextItemAfterMergingRunEntriesAsync(std::move(runStatus), std::move(holder), newStatus);
       }
     }
     waitTask.wait();
-    return returnValue;
+    return sourceCoordinator_.thread_unsafe_peekNextTransitionType();
   }
 
   namespace {
@@ -1143,23 +1139,23 @@ namespace edm {
   }  // namespace
 
   void EventProcessor::readRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
+                                    RunAuxiliary const& iRunAux,
                                     WaitingTaskHolder iNextTask,
-                                    SourceStatus& oSourceStatus) {
+                                    SourceStatus& oNextStatus) {
     auto rp = principalCache_.getAvailableRunPrincipalPtr();
     //a new file may have been opened since the last use of this Run
     rp->possiblyUpdateAfterAddition(preg());
-    rp->setAux(*oSourceStatus.runAuxiliary());
+    rp->setAux(iRunAux);
     iRunStatus->setRunPrincipal(rp);
-    sourceCoordinator_.readNewRunAsync(iRunStatus, processContext_, *historyAppender_, oSourceStatus, iNextTask);
+    sourceCoordinator_.readNewRunAsync(iRunStatus, processContext_, *historyAppender_, oNextStatus, iNextTask);
   }
 
-  void EventProcessor::beginRunAsync(IOVSyncValue const& iSync,
-                                     WaitingTaskHolder iHolder,
-                                     SourceStatus& oSourceStatus) {
+  void EventProcessor::beginRunAsync(RunAuxiliary const& iRunAux, WaitingTaskHolder iHolder) {
     if (iHolder.taskHasFailed()) {
       return;
     }
 
+    IOVSyncValue iSync{EventID(iRunAux.run(), 0, 0), iRunAux.beginTime()};
     actReg_->esSyncIOVQueuingSignal_.emit(iSync);
 
     auto runStatus = std::make_shared<RunProcessingStatus>(preallocations_.numberOfStreams(), iHolder);
@@ -1173,7 +1169,7 @@ namespace edm {
                                                            actReg_.get(),
                                                            serviceToken_,
                                                            forceESCacheClearOnNewRun_);
-    }) | chain::then([this, runStatus, &oSourceStatus](std::exception_ptr const* iException, auto nextTask) {
+    }) | chain::then([this, runStatus, iRunAux](std::exception_ptr const* iException, auto nextTask) {
       CMS_SA_ALLOW try {
         if (iException) {
           WaitingTaskHolder copyHolder(nextTask);
@@ -1184,8 +1180,7 @@ namespace edm {
 
         runQueue_->pushAndPause(
             *nextTask.group(),
-            [this, postRunQueueTask = nextTask, runStatus, &oSourceStatus](
-                edm::LimitedTaskQueue::Resumer iResumer) mutable {
+            [this, postRunQueueTask = nextTask, runStatus, iRunAux](edm::LimitedTaskQueue::Resumer iResumer) mutable {
               CMS_SA_ALLOW try {
                 if (postRunQueueTask.taskHasFailed()) {
                   releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
@@ -1196,8 +1191,10 @@ namespace edm {
                 runStatus->setResumer(std::move(iResumer));
                 bool expectedLooperNotBegun = false;
 
-                chain::first([this, runStatus, &oSourceStatus](auto nextTask) mutable {
-                  readRunAsync(runStatus, nextTask, oSourceStatus);
+                std::unique_ptr<SourceStatus> newSourceStatus = std::make_unique<SourceStatus>();
+                auto pNewStatus = newSourceStatus.get();
+                chain::first([this, runStatus, iRunAux, pNewStatus](auto nextTask) mutable {
+                  readRunAsync(runStatus, iRunAux, nextTask, *pNewStatus);
                 }) | chain::then([this, runStatus](std::exception_ptr const* iException, auto nextTask) mutable {
                   if (iException) {
                     //handle exception from readRunAsync
@@ -1269,75 +1266,75 @@ namespace edm {
                                     ServiceRegistry::Operate operateLooper(serviceToken_);
                                     looper_->doBeginRun(*runStatus->runPrincipal(), es, &processContext_);
                                   }) |
-                    chain::then(
-                        [this, runStatus, &oSourceStatus](std::exception_ptr const* iException, auto holder) mutable {
-                          if (iException) {
-                            WaitingTaskHolder copyHolder(holder);
-                            copyHolder.doneWaiting(*iException);
-                          } else {
-                            runStatus->globalBeginDidSucceed();
-                          }
-                          if (runStatus->stopBeforeProcessingRun()) {
-                            // We just quit now if there was a failure when merging runs
-                            releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
-                                *runStatus, queueWhichWaitsForIOVsToFinish_);
-                            return;
-                          }
-                          CMS_SA_ALLOW try {
-                            // Under normal circumstances, this task runs after endRun has completed for all streams
-                            // and global endLumi has completed for all lumis contained in this run
-                            //NOTE: this task does not hold open any waiting task. Instead only once the task is run does
-                            // it acquire the waiting task presently being held by the runStatus. This is on purpose as
-                            // the globalEndRun task might have to wait between new file opennings before it gets run.
-                            auto globalEndRunTask =
-                                edm::make_waiting_task([this, runStatus](std::exception_ptr const*) mutable {
-                                  auto tmp = runStatus->releaseHolderOfTaskInProcessRuns();
-                                  assert(tmp);
-                                  WaitingTaskHolder taskHolder = *tmp;
-                                  globalEndRunAsync(std::move(taskHolder), std::move(runStatus));
-                                });
-                            runStatus->setGlobalEndRunHolder(WaitingTaskHolder{*holder.group(), globalEndRunTask});
-                          } catch (...) {
-                            releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
-                                *runStatus, queueWhichWaitsForIOVsToFinish_);
-                            holder.doneWaiting(std::current_exception());
-                            return;
-                          }
-
-                          // After this point we are committed to end the run via endRunAsync
-
-                          ServiceRegistry::Operate operate(serviceToken_);
-
-                          // The only purpose of the pause is to cause stream begin run to execute before
-                          // global begin lumi in the single threaded case (maintains consistency with
-                          // the order that existed before concurrent runs were implemented).
-                          PauseQueueSentry pauseQueueSentry(streamQueuesInserter_);
-
-                          CMS_SA_ALLOW try {
-                            streamQueuesInserter_.push(*holder.group(), [this, runStatus, holder]() mutable {
-                              for (auto i : std::views::iota(0U, preallocations_.numberOfStreams())) {
-                                CMS_SA_ALLOW try {
-                                  streamQueues_[i].push(*holder.group(), [this, i, runStatus, holder]() mutable {
-                                    streamBeginRunAsync(i, std::move(runStatus), std::move(holder));
-                                  });
-                                } catch (...) {
-                                  if (runStatus->streamFinishedBeginRun()) {
-                                    WaitingTaskHolder copyHolder(holder);
-                                    copyHolder.doneWaiting(std::current_exception());
-                                    releaseBeginRunResourcesAfterFailure(*runStatus, queueWhichWaitsForIOVsToFinish_);
-                                    exceptionRunStatus_ = runStatus;
-                                  }
-                                }
-                              }
+                    chain::then([this, runStatus, sourceStatus = std::move(newSourceStatus)](
+                                    std::exception_ptr const* iException, auto holder) mutable {
+                      if (iException) {
+                        WaitingTaskHolder copyHolder(holder);
+                        copyHolder.doneWaiting(*iException);
+                      } else {
+                        runStatus->globalBeginDidSucceed();
+                      }
+                      if (runStatus->stopBeforeProcessingRun()) {
+                        // We just quit now if there was a failure when merging runs
+                        releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
+                                                                                    queueWhichWaitsForIOVsToFinish_);
+                        return;
+                      }
+                      CMS_SA_ALLOW try {
+                        // Under normal circumstances, this task runs after endRun has completed for all streams
+                        // and global endLumi has completed for all lumis contained in this run
+                        //NOTE: this task does not hold open any waiting task. Instead only once the task is run does
+                        // it acquire the waiting task presently being held by the runStatus. This is on purpose as
+                        // the globalEndRun task might have to wait between new file opennings before it gets run.
+                        auto globalEndRunTask =
+                            edm::make_waiting_task([this, runStatus](std::exception_ptr const*) mutable {
+                              auto tmp = runStatus->releaseHolderOfTaskInProcessRuns();
+                              assert(tmp);
+                              WaitingTaskHolder taskHolder = *tmp;
+                              globalEndRunAsync(std::move(taskHolder), std::move(runStatus));
                             });
-                          } catch (...) {
-                            WaitingTaskHolder copyHolder(holder);
-                            copyHolder.doneWaiting(std::current_exception());
-                            releaseBeginRunResourcesAfterFailure(*runStatus, queueWhichWaitsForIOVsToFinish_);
-                            exceptionRunStatus_ = runStatus;
+                        runStatus->setGlobalEndRunHolder(WaitingTaskHolder{*holder.group(), globalEndRunTask});
+                      } catch (...) {
+                        releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
+                                                                                    queueWhichWaitsForIOVsToFinish_);
+                        holder.doneWaiting(std::current_exception());
+                        return;
+                      }
+
+                      // After this point we are committed to end the run via endRunAsync
+
+                      ServiceRegistry::Operate operate(serviceToken_);
+
+                      // The only purpose of the pause is to cause stream begin run to execute before
+                      // global begin lumi in the single threaded case (maintains consistency with
+                      // the order that existed before concurrent runs were implemented).
+                      PauseQueueSentry pauseQueueSentry(streamQueuesInserter_);
+
+                      CMS_SA_ALLOW try {
+                        streamQueuesInserter_.push(*holder.group(), [this, runStatus, holder]() mutable {
+                          for (auto i : std::views::iota(0U, preallocations_.numberOfStreams())) {
+                            CMS_SA_ALLOW try {
+                              streamQueues_[i].push(*holder.group(), [this, i, runStatus, holder]() mutable {
+                                streamBeginRunAsync(i, std::move(runStatus), std::move(holder));
+                              });
+                            } catch (...) {
+                              if (runStatus->streamFinishedBeginRun()) {
+                                WaitingTaskHolder copyHolder(holder);
+                                copyHolder.doneWaiting(std::current_exception());
+                                releaseBeginRunResourcesAfterFailure(*runStatus, queueWhichWaitsForIOVsToFinish_);
+                                exceptionRunStatus_ = runStatus;
+                              }
+                            }
                           }
-                          handleNextItemAfterMergingRunEntriesAsync(runStatus, holder, oSourceStatus);
-                        }) |
+                        });
+                      } catch (...) {
+                        WaitingTaskHolder copyHolder(holder);
+                        copyHolder.doneWaiting(std::current_exception());
+                        releaseBeginRunResourcesAfterFailure(*runStatus, queueWhichWaitsForIOVsToFinish_);
+                        exceptionRunStatus_ = runStatus;
+                      }
+                      handleNextItemAfterMergingRunEntriesAsync(runStatus, holder, *sourceStatus);
+                    }) |
                     chain::runLast(postRunQueueTask);
               } catch (...) {
                 releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
@@ -1391,8 +1388,8 @@ namespace edm {
   }
 
   void EventProcessor::endRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                   WaitingTaskHolder iHolder,
-                                   SourceStatus& oStatus) noexcept {
+                                   std::optional<RunAuxiliary> const& iRunAuxiliary,
+                                   WaitingTaskHolder iHolder) noexcept {
     RunPrincipal& runPrincipal = *iRunStatus->runPrincipal();
     iRunStatus->setEndTime();
     IOVSyncValue ts(
@@ -1411,7 +1408,7 @@ namespace edm {
                                                            queueWhichWaitsForIOVsToFinish_,
                                                            actReg_.get(),
                                                            serviceToken_);
-    }) | chain::then([this, iRunStatus, &oStatus](std::exception_ptr const* iException, auto nextTask) {
+    }) | chain::then([this, iRunStatus, iRunAuxiliary](std::exception_ptr const* iException, auto nextTask) {
       if (iException) {
         iRunStatus->setEndingEventSetupSucceeded(false);
         handleEndRunExceptions(*iException, nextTask);
@@ -1431,12 +1428,8 @@ namespace edm {
         }
       });
 
-      if (oStatus.nextTransitionType() == InputSource::ItemType::IsRun) {
-        CMS_SA_ALLOW try {
-          beginRunAsync(IOVSyncValue(EventID(oStatus.runAuxiliary()->run(), 0, 0), oStatus.runAuxiliary()->beginTime()),
-                        nextTask,
-                        oStatus);
-        } catch (...) {
+      if (iRunAuxiliary) {
+        CMS_SA_ALLOW try { beginRunAsync(*iRunAuxiliary, nextTask); } catch (...) {
           WaitingTaskHolder copyHolder(nextTask);
           copyHolder.doneWaiting(std::current_exception());
         }
@@ -1577,8 +1570,7 @@ namespace edm {
     }
   }
 
-  SourceStatus EventProcessor::endUnfinishedRun(bool cleaningUpAfterException) {
-    SourceStatus returnValue{InputSource::ItemType::IsStop};
+  void EventProcessor::endUnfinishedRun(bool cleaningUpAfterException) {
     if (streamRunActive_ > 0) {
       FinalWaitingTask waitTask{taskGroup_};
 
@@ -1586,10 +1578,10 @@ namespace edm {
       runStatus->setCleaningUpAfterException(cleaningUpAfterException);
       WaitingTaskHolder holder{taskGroup_, &waitTask};
       runStatus->setHolderOfTaskInProcessRuns(holder);
-      endRunAsync(streamRunStatus_[0], std::move(holder), returnValue);
+      endRunAsync(streamRunStatus_[0], std::nullopt, std::move(holder));
       waitTask.wait();
     }
-    return returnValue;
+    return;
   }
 
   namespace {
@@ -1620,21 +1612,20 @@ namespace edm {
 
   void EventProcessor::readLumiAsync(std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus,
                                      std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                     WaitingTaskHolder iNextTask,
-                                     SourceStatus& oSourceStatus) {
+                                     LuminosityBlockAuxiliary const& iLumiAux,
+                                     WaitingTaskHolder iNextTask) {
     auto lbp = principalCache_.getAvailableLumiPrincipalPtr();
     iLumiStatus->setLumiPrincipal(lbp);
     //A new file may have been opened since the last use of the LuminosityBlock
     lbp->possiblyUpdateAfterAddition(preg());
-    lbp->setAux(*oSourceStatus.lumiAuxiliary());
+    lbp->setAux(iLumiAux);
     lbp->setRunPrincipal(iRunStatus->runPrincipal());
-    sourceCoordinator_.readNewLuminosityBlockAsync(
-        iLumiStatus, processContext_, *historyAppender_, oSourceStatus, iNextTask);
+    sourceCoordinator_.readNewLuminosityBlockAsync(iLumiStatus, processContext_, *historyAppender_, iNextTask);
   }
-  void EventProcessor::beginLumiAsync(IOVSyncValue const& iSync,
-                                      std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                      edm::WaitingTaskHolder iHolder,
-                                      SourceStatus& oSourceStatus) {
+  void EventProcessor::beginLumiAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
+                                      LuminosityBlockAuxiliary const& iLumiAux,
+                                      edm::WaitingTaskHolder iHolder) {
+    IOVSyncValue iSync(EventID(iLumiAux.run(), iLumiAux.luminosityBlock(), 0), iLumiAux.beginTime());
     actReg_->esSyncIOVQueuingSignal_.emit(iSync);
 
     auto status = std::make_shared<LuminosityBlockProcessingStatus>();
@@ -1646,7 +1637,7 @@ namespace edm {
                                                            queueWhichWaitsForIOVsToFinish_,
                                                            actReg_.get(),
                                                            serviceToken_);
-    }) | chain::then([this, status, iRunStatus, &oSourceStatus](std::exception_ptr const* iException, auto nextTask) {
+    }) | chain::then([this, status, iRunStatus, iLumiAux](std::exception_ptr const* iException, auto nextTask) {
       CMS_SA_ALLOW try {
         //the call to doneWaiting will cause the count to decrement
         if (iException) {
@@ -1656,12 +1647,12 @@ namespace edm {
 
         lumiQueue_->pushAndPause(
             *nextTask.group(),
-            [this, postLumiQueueTask = nextTask, status, iRunStatus, &oSourceStatus](
+            [this, postLumiQueueTask = nextTask, status, iRunStatus, iLumiAux](
                 edm::LimitedTaskQueue::Resumer iResumer) mutable {
               CMS_SA_ALLOW try {
                 if (postLumiQueueTask.taskHasFailed()) {
                   releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
-                  endRunAsync(iRunStatus, postLumiQueueTask, oSourceStatus);
+                  endRunAsync(iRunStatus, std::nullopt, postLumiQueueTask);
                   return;
                 }
 
@@ -1670,125 +1661,100 @@ namespace edm {
                 using namespace edm::waiting_task::chain;
 
                 status->setResumer(std::move(iResumer));
-                chain::first([this, status, iRunStatus, &oSourceStatus](auto nextTask) mutable {
-                  readLumiAsync(status, iRunStatus, nextTask, oSourceStatus);
-                }) |
-                    then([this, status, iRunStatus, &oSourceStatus](std::exception_ptr const* iException,
-                                                                    auto nextTask) mutable {
-                      if (iException) {
-                        //deal with possible failure from readLumiAsync
-                        releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
-                        nextTask.doneWaiting(*iException);
-                        endRunAsync(iRunStatus, nextTask, oSourceStatus);
-                        return;
-                      }
-                    }) |
-                    chain::ifThen(rng.isAvailable() and rng->consumer() != nullptr,
-                                  [this, status](auto nextTask) {
-                                    //handle RandomNumberGenerator prefetching and preBeginLumi
-                                    assert(status->lumiPrincipal() != nullptr);
-                                    auto& lumiPrincipal = *status->lumiPrincipal();
-                                    prefetchForRandomNumberGeneratorAsync(
-                                        std::move(nextTask), lumiPrincipal, serviceToken_);
-                                  }) |
-                    ifThen(rng.isAvailable() and rng->consumer() != nullptr,
-                           [this, status](auto nextTask) {
-                             ServiceRegistry::Operate operate(serviceToken_);
-                             Service<RandomNumberGenerator> rng;
-                             auto& lumiPrincipal = *status->lumiPrincipal();
-                             LuminosityBlock lb(lumiPrincipal, ModuleDescription(), nullptr, false);
-                             lb.setConsumer(rng->consumer());
-                             rng->preBeginLumi(lb);
-                           }) |
-                    then([this, status](auto nextTask) {
-                      EventSetupImpl const& es = status->eventSetupImpl();
-                      auto& lumiPrincipal = *status->lumiPrincipal();
-                      LumiTransitionInfo transitionInfo(lumiPrincipal, es);
-                      using Traits = OccurrenceTraits<LuminosityBlockPrincipal, TransitionActionGlobalBegin>;
-                      schedule_->processOneGlobalAsync<Traits>(nextTask, transitionInfo, serviceToken_);
-                    }) |
-                    ifThen(looper_,
-                           [this, status](auto nextTask) {
-                             EventSetupImpl const& es = status->eventSetupImpl();
-                             looper_->prefetchAsync(nextTask,
-                                                    serviceToken_,
-                                                    Transition::BeginLuminosityBlock,
-                                                    *(status->lumiPrincipal()),
-                                                    es);
-                           }) |
-                    ifThen(looper_,
-                           [this, status](auto nextTask) {
-                             ServiceRegistry::Operate operateLooper(serviceToken_);
-                             looper_->doBeginLuminosityBlock(
-                                 *(status->lumiPrincipal()), status->eventSetupImpl(), &processContext_);
-                           }) |
-                    then([this, status, iRunStatus, &oSourceStatus](std::exception_ptr const* iException,
-                                                                    auto holder) mutable {
-                      status->setGlobalEndRunHolder(iRunStatus->globalEndRunHolder());
+                chain::first([this, status, iRunStatus, iLumiAux](auto nextTask) mutable {
+                  readLumiAsync(status, iRunStatus, iLumiAux, nextTask);
+                }) | then([this, status, iRunStatus](std::exception_ptr const* iException, auto nextTask) mutable {
+                  if (iException) {
+                    //deal with possible failure from readLumiAsync
+                    releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
+                    nextTask.doneWaiting(*iException);
+                    endRunAsync(iRunStatus, std::nullopt, nextTask);
+                    return;
+                  }
+                }) | chain::ifThen(rng.isAvailable() and rng->consumer() != nullptr, [this, status](auto nextTask) {
+                  //handle RandomNumberGenerator prefetching and preBeginLumi
+                  assert(status->lumiPrincipal() != nullptr);
+                  auto& lumiPrincipal = *status->lumiPrincipal();
+                  prefetchForRandomNumberGeneratorAsync(std::move(nextTask), lumiPrincipal, serviceToken_);
+                }) | ifThen(rng.isAvailable() and rng->consumer() != nullptr, [this, status](auto nextTask) {
+                  ServiceRegistry::Operate operate(serviceToken_);
+                  Service<RandomNumberGenerator> rng;
+                  auto& lumiPrincipal = *status->lumiPrincipal();
+                  LuminosityBlock lb(lumiPrincipal, ModuleDescription(), nullptr, false);
+                  lb.setConsumer(rng->consumer());
+                  rng->preBeginLumi(lb);
+                }) | then([this, status](auto nextTask) {
+                  EventSetupImpl const& es = status->eventSetupImpl();
+                  auto& lumiPrincipal = *status->lumiPrincipal();
+                  LumiTransitionInfo transitionInfo(lumiPrincipal, es);
+                  using Traits = OccurrenceTraits<LuminosityBlockPrincipal, TransitionActionGlobalBegin>;
+                  schedule_->processOneGlobalAsync<Traits>(nextTask, transitionInfo, serviceToken_);
+                }) | ifThen(looper_, [this, status](auto nextTask) {
+                  EventSetupImpl const& es = status->eventSetupImpl();
+                  looper_->prefetchAsync(
+                      nextTask, serviceToken_, Transition::BeginLuminosityBlock, *(status->lumiPrincipal()), es);
+                }) | ifThen(looper_, [this, status](auto nextTask) {
+                  ServiceRegistry::Operate operateLooper(serviceToken_);
+                  looper_->doBeginLuminosityBlock(
+                      *(status->lumiPrincipal()), status->eventSetupImpl(), &processContext_);
+                }) | then([this, status, iRunStatus](std::exception_ptr const* iException, auto holder) mutable {
+                  status->setGlobalEndRunHolder(iRunStatus->globalEndRunHolder());
 
-                      if (iException) {
-                        WaitingTaskHolder copyHolder(holder);
-                        copyHolder.doneWaiting(*iException);
-                        globalEndLumiAsync(holder, status);
-                        endRunAsync(iRunStatus, holder, oSourceStatus);
-                      } else {
-                        status->globalBeginDidSucceed();
+                  if (iException) {
+                    WaitingTaskHolder copyHolder(holder);
+                    copyHolder.doneWaiting(*iException);
+                    globalEndLumiAsync(holder, status);
+                    endRunAsync(iRunStatus, std::nullopt, holder);
+                  } else {
+                    status->globalBeginDidSucceed();
 
-                        EventSetupImpl const& es = status->eventSetupImpl();
-                        using Traits = OccurrenceTraits<LuminosityBlockPrincipal, TransitionActionStreamBegin>;
+                    EventSetupImpl const& es = status->eventSetupImpl();
+                    using Traits = OccurrenceTraits<LuminosityBlockPrincipal, TransitionActionStreamBegin>;
 
-                        streamQueuesInserter_.push(
-                            *holder.group(), [this, status, holder, &es, &oSourceStatus]() mutable {
-                              for (auto i : std::views::iota(0U, preallocations_.numberOfStreams())) {
-                                streamQueues_[i].push(
-                                    *holder.group(), [this, i, status, holder, &es, &oSourceStatus]() mutable {
-                                      //the status increments the number of streams here if successful
-                                      if (!status->shouldStreamStartLumi()) {
-                                        return;
-                                      }
-                                      streamQueues_[i].pause();
+                    streamQueuesInserter_.push(*holder.group(), [this, status, holder, &es]() mutable {
+                      for (auto i : std::views::iota(0U, preallocations_.numberOfStreams())) {
+                        streamQueues_[i].push(*holder.group(), [this, i, status, holder, &es]() mutable {
+                          //the status increments the number of streams here if successful
+                          if (!status->shouldStreamStartLumi()) {
+                            return;
+                          }
+                          streamQueues_[i].pause();
 
-                                      auto& event = principalCache_.eventPrincipal(i);
-                                      auto lp = status->lumiPrincipal().get();
-                                      streamLumiStatus_[i] = std::move(status);
-                                      ++streamLumiActive_;
-                                      event.setLuminosityBlockPrincipal(lp);
-                                      LumiTransitionInfo transitionInfo(*lp, es);
-                                      using namespace edm::waiting_task::chain;
-                                      chain::first([this, i, &transitionInfo](auto nextTask) {
-                                        schedule_->processOneStreamAsync<Traits>(
-                                            std::move(nextTask), i, transitionInfo, serviceToken_);
-                                      }) |
-                                          then([this, i, &oSourceStatus](
-                                                   std::exception_ptr const* exceptionFromBeginStreamLumi,
-                                                   auto nextTask) {
-                                            handleNextEventForStreamAsync(
-                                                exceptionFromBeginStreamLumi, std::move(nextTask), i, oSourceStatus);
-                                          }) |
-                                          runLast(std::move(holder));
-                                    });
-                              }  // end for loop over streams
-                            });
-                      }
-                    }) |
-                    runLast(postLumiQueueTask);
+                          auto& event = principalCache_.eventPrincipal(i);
+                          auto lp = status->lumiPrincipal().get();
+                          streamLumiStatus_[i] = std::move(status);
+                          ++streamLumiActive_;
+                          event.setLuminosityBlockPrincipal(lp);
+                          LumiTransitionInfo transitionInfo(*lp, es);
+                          using namespace edm::waiting_task::chain;
+                          chain::first([this, i, &transitionInfo](auto nextTask) {
+                            schedule_->processOneStreamAsync<Traits>(
+                                std::move(nextTask), i, transitionInfo, serviceToken_);
+                          }) | then([this, i](std::exception_ptr const* exceptionFromBeginStreamLumi, auto nextTask) {
+                            handleNextEventForStreamAsync(exceptionFromBeginStreamLumi, i, std::move(nextTask));
+                          }) | runLast(std::move(holder));
+                        });
+                      }  // end for loop over streams
+                    });
+                  }
+                }) | runLast(postLumiQueueTask);
               } catch (...) {
                 releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
                 WaitingTaskHolder copyHolder(postLumiQueueTask);
                 copyHolder.doneWaiting(std::current_exception());
-                endRunAsync(iRunStatus, postLumiQueueTask, oSourceStatus);
+                endRunAsync(iRunStatus, std::nullopt, postLumiQueueTask);
               }
             });  // task in lumiQueue
       } catch (...) {
         releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
         WaitingTaskHolder copyHolder(nextTask);
         copyHolder.doneWaiting(std::current_exception());
-        endRunAsync(iRunStatus, nextTask, oSourceStatus);
+        endRunAsync(iRunStatus, std::nullopt, nextTask);
       }
     }) | chain::runLast(std::move(iHolder));
   }
 
-  void EventProcessor::continueLumiAsync(edm::WaitingTaskHolder iHolder, SourceStatus& oSourceStatus) {
+  void EventProcessor::continueLumiAsync(edm::WaitingTaskHolder iHolder, SourceStatus const& oSourceStatus) {
     chain::first([this, &oSourceStatus](auto nextTask) {
       //all streams are sharing the same status at the moment
       auto status = streamLumiStatus_[0];  //read from streamLumiActive_ happened in calling routine
@@ -1809,18 +1775,14 @@ namespace edm {
 
         sourceCoordinator_.mergeLuminosityBlockIfNeeded(lumiPrincipal);
       }
-      oSourceStatus = sourceCoordinator_.thread_unsafe_peekNextTransitionType();
-    }) | chain::then([this, &oSourceStatus](auto nextTask) mutable {
+    }) | chain::then([this](auto nextTask) mutable {
       unsigned int streamIndex = 0;
       oneapi::tbb::task_arena arena{oneapi::tbb::task_arena::attach()};
       for (; streamIndex < preallocations_.numberOfStreams() - 1; ++streamIndex) {
-        arena.enqueue([this, streamIndex, h = nextTask, &oSourceStatus]() {
-          handleNextEventForStreamAsync(nullptr, h, streamIndex, oSourceStatus);
-        });
+        arena.enqueue([this, streamIndex, h = nextTask]() { handleNextEventForStreamAsync(nullptr, streamIndex, h); });
       }
-      nextTask.group()->run([this, streamIndex, h = std::move(nextTask), &oSourceStatus]() {
-        handleNextEventForStreamAsync(nullptr, h, streamIndex, oSourceStatus);
-      });
+      nextTask.group()->run(
+          [this, streamIndex, h = std::move(nextTask)]() { handleNextEventForStreamAsync(nullptr, streamIndex, h); });
     }) | chain::runLast(std::move(iHolder));
   }
 
@@ -1999,51 +1961,53 @@ namespace edm {
 
   void EventProcessor::handleNextItemAfterMergingRunEntriesAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
                                                                  WaitingTaskHolder iHolder,
-                                                                 SourceStatus& oSourceStatus) {
-    chain::first([this, iRunStatus, &oSourceStatus](auto nextTask) mutable {
-      if (oSourceStatus.needToCallNext()) {
+                                                                 SourceStatus const& iSourceStatus) {
+    std::unique_ptr<SourceStatus> sourceStatus = std::make_unique<SourceStatus>(iSourceStatus);
+    auto* pSourceStatus = sourceStatus.get();
+    chain::first([this, iRunStatus, pSourceStatus](auto nextTask) mutable {
+      if (pSourceStatus->needToAskSourceForNext()) {
         sourceCoordinator_.peekNextTransitionTypeThatIsNotTheSameRunAsync(
             iRunStatus->runPrincipal()->run(),
             iRunStatus->runPrincipal()->reducedProcessHistoryID(),
-            oSourceStatus,
+            *pSourceStatus,
             std::move(nextTask));
       }
-    }) | chain::then([this, iRunStatus, &oSourceStatus](std::exception_ptr const* iException, auto nextTask) {
-      ServiceRegistry::Operate operate(serviceToken_);
-      if (iException) {
-        WaitingTaskHolder copyHolder(nextTask);
-        copyHolder.doneWaiting(*iException);
-      }
-      if (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsFile) {
-        nextTask.doneWaiting(std::exception_ptr());
-        iRunStatus->setHolderOfTaskInProcessRunsDoneWaiting();
-        return;
-      }
-      if (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsLumi && !nextTask.taskHasFailed()) {
-        CMS_SA_ALLOW try {
-          beginLumiAsync(
-              IOVSyncValue(
-                  EventID(oSourceStatus.lumiAuxiliary()->run(), oSourceStatus.lumiAuxiliary()->luminosityBlock(), 0),
-                  oSourceStatus.lumiAuxiliary()->beginTime()),
-              iRunStatus,
-              nextTask,
-              oSourceStatus);
-          return;
-        } catch (...) {
-          WaitingTaskHolder copyHolder(nextTask);
-          copyHolder.doneWaiting(std::current_exception());
-        }
-      }
-      // Note that endRunAsync will call beginRunAsync for the following run
-      // if appropriate.
-      endRunAsync(iRunStatus, std::move(nextTask), oSourceStatus);
-    }) | chain::runLast(std::move(iHolder));
+    }) |
+        chain::then([this, iRunStatus, sourceStatus = std::move(sourceStatus)](std::exception_ptr const* iException,
+                                                                               auto nextTask) {
+          ServiceRegistry::Operate operate(serviceToken_);
+          if (iException) {
+            WaitingTaskHolder copyHolder(nextTask);
+            copyHolder.doneWaiting(*iException);
+          }
+          if (sourceStatus->nextTransitionType() == InputSource::ItemType::IsFile) {
+            nextTask.doneWaiting(std::exception_ptr());
+            iRunStatus->setHolderOfTaskInProcessRunsDoneWaiting();
+            return;
+          }
+          if (sourceStatus->nextTransitionType() == InputSource::ItemType::IsLumi && !nextTask.taskHasFailed()) {
+            CMS_SA_ALLOW try {
+              beginLumiAsync(iRunStatus, *sourceStatus->lumiAuxiliary(), nextTask);
+              return;
+            } catch (...) {
+              WaitingTaskHolder copyHolder(nextTask);
+              copyHolder.doneWaiting(std::current_exception());
+            }
+          }
+          // Note that endRunAsync will call beginRunAsync for the following run
+          // if appropriate.
+          std::optional<RunAuxiliary> runAux;
+          if (sourceStatus->nextTransitionType() == InputSource::ItemType::IsRun) {
+            runAux = *sourceStatus->runAuxiliary();
+          }
+          endRunAsync(iRunStatus, runAux, std::move(nextTask));
+        }) |
+        chain::runLast(std::move(iHolder));
   }
 
   void EventProcessor::handleNextEventForStreamAsync(std::exception_ptr const* iExceptionPtr,
-                                                     WaitingTaskHolder iTask,
                                                      unsigned int iStreamIndex,
-                                                     SourceStatus& oSourceStatus) {
+                                                     WaitingTaskHolder iTask) {
     if (iExceptionPtr) {
       WaitingTaskHolder copyHolder(iTask);
       copyHolder.doneWaiting(*iExceptionPtr);
@@ -2058,8 +2022,10 @@ namespace edm {
     auto resultFromReadNextEventForStream = std::make_unique<SourceCoordinator::ReadNextEventForStreamResult>(false);
     auto* ptrToResultFromReadNextEventForStream = resultFromReadNextEventForStream.get();
     bool needToStop = shouldWeStop();
+    auto sourceStatus = std::make_unique<SourceStatus>();
+    auto* pSourceStatus = sourceStatus.get();
     chain::first(
-        [this, iStreamIndex, &oSourceStatus, earlierTaskFailed, ptrToResultFromReadNextEventForStream, needToStop](
+        [this, iStreamIndex, pSourceStatus, earlierTaskFailed, ptrToResultFromReadNextEventForStream, needToStop](
             auto nextTask) mutable {
           auto& event = principalCache_.eventPrincipal(iStreamIndex);
           // a new file may have been read since the last time this event was used
@@ -2072,12 +2038,12 @@ namespace edm {
                                                          earlierTaskFailed,
                                                          needToStop,
                                                          *ptrToResultFromReadNextEventForStream,
-                                                         oSourceStatus,
+                                                         *pSourceStatus,
                                                          nextTask);
         }) |
         chain::then([this,
                      iStreamIndex,
-                     &oSourceStatus,
+                     sourceStatus = std::move(sourceStatus),
                      retValue = std::move(resultFromReadNextEventForStream),
                      possibleFailedTask = iTask](std::exception_ptr const* iEventException,
                                                  WaitingTaskHolder iNextTask) mutable {
@@ -2089,9 +2055,9 @@ namespace edm {
             }
             if (retValue->didCallReadEvent) {
               chain::first([this, iStreamIndex](auto nextTask) mutable { processEventAsync(nextTask, iStreamIndex); }) |
-                  chain::then([this, iStreamIndex, &oSourceStatus](std::exception_ptr const* iEventException,
-                                                                   WaitingTaskHolder iNextTask) mutable {
-                    handleNextEventForStreamAsync(iEventException, std::move(iNextTask), iStreamIndex, oSourceStatus);
+                  chain::then([this, iStreamIndex](std::exception_ptr const* iEventException,
+                                                   WaitingTaskHolder iNextTask) mutable {
+                    handleNextEventForStreamAsync(iEventException, iStreamIndex, std::move(iNextTask));
                   }) |
                   chain::runLast(iNextTask);
             } else {
@@ -2101,26 +2067,26 @@ namespace edm {
                   if (retValue->nextTransitionType == InputSource::ItemType::IsLumi &&
                       !possibleFailedTask.taskHasFailed()) {
                     CMS_SA_ALLOW try {
-                      beginLumiAsync(IOVSyncValue(EventID(oSourceStatus.lumiAuxiliary()->run(),
-                                                          oSourceStatus.lumiAuxiliary()->luminosityBlock(),
-                                                          0),
-                                                  oSourceStatus.lumiAuxiliary()->beginTime()),
-                                     streamRunStatus_[iStreamIndex],
-                                     iNextTask,
-                                     oSourceStatus);
+                      beginLumiAsync(streamRunStatus_[iStreamIndex], *sourceStatus->lumiAuxiliary(), iNextTask);
                     } catch (...) {
                       WaitingTaskHolder copyHolder(iNextTask);
                       copyHolder.doneWaiting(std::current_exception());
-                      endRunAsync(streamRunStatus_[iStreamIndex], iNextTask, oSourceStatus);
+                      endRunAsync(streamRunStatus_[iStreamIndex], std::nullopt, iNextTask);
                     }
                   } else {
                     // If appropriate, this will also start the next run.
-                    endRunAsync(streamRunStatus_[iStreamIndex], iNextTask, oSourceStatus);
+                    std::optional<RunAuxiliary> runAux;
+                    if (sourceStatus->nextTransitionType() == InputSource::ItemType::IsRun) {
+                      runAux = *sourceStatus->runAuxiliary();
+                    }
+                    endRunAsync(streamRunStatus_[iStreamIndex], runAux, iNextTask);
                   }
                 }
                 streamEndLumiAsync(iNextTask, iStreamIndex);
               } else {
-                //if both of these conditions are false, then we must have had a file transition and we need to pause the stream until all streams are ready to continue. Note that in this case we do not call endRunAsync or beginLumiAsync here. The stream will just pause until the lumi is ended or the next lumi is started at which point it will be resumed and endRunAsync or beginLumiAsync will be called at that time if appropriate.
+                //if both of these conditions are false, then we must have had a file transition and we need to pause the stream until all streams are ready to continue.
+                // Note that in this case we do not call endRunAsync or beginLumiAsync here. The stream will just pause until the lumi is ended or the next lumi is started at
+                // which point it will be resumed and endRunAsync or beginLumiAsync will be called at that time if appropriate.
                 assert(not retValue->didCallReadEvent and not retValue->stopLumi);
                 auto runStatus = streamRunStatus_[iStreamIndex].get();
                 assert(runStatus);

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1211,6 +1211,39 @@ namespace edm {
       iStatus.resumeGlobalRunQueue();
     }
   }  // namespace
+
+  void EventProcessor::readRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
+                                    WaitingTaskHolder const& iCheckSharedTask,
+                                    WaitingTaskHolder iNextTask,
+                                    SourceStatus& oSourceStatus) {
+    sourceResourcesAcquirer_.serialQueueChain().push(
+        *iNextTask.group(), [this, iRunStatus, iCheckSharedTask, iNextTask, &oSourceStatus]() mutable {
+          CMS_SA_ALLOW try {
+            ServiceRegistry::Operate operate(serviceToken_);
+
+            if (iCheckSharedTask.taskHasFailed()) {
+              releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*iRunStatus, queueWhichWaitsForIOVsToFinish_);
+              return;
+            }
+
+            {
+              std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
+              iRunStatus->setRunPrincipal(readRun());
+
+              RunPrincipal& runPrincipal = *iRunStatus->runPrincipal();
+              {
+                SendSourceTerminationSignalIfException sentry(actReg_.get());
+                input_->doBeginRun(runPrincipal, &processContext_);
+                sentry.completedSuccessfully();
+              }
+            }
+          } catch (...) {
+            iNextTask.doneWaiting(std::current_exception());
+            releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*iRunStatus, queueWhichWaitsForIOVsToFinish_);
+          }
+        });
+  }
+
   void EventProcessor::beginRunAsync(IOVSyncValue const& iSync,
                                      WaitingTaskHolder iHolder,
                                      SourceStatus& oSourceStatus) {
@@ -1254,37 +1287,10 @@ namespace edm {
                 runStatus->setResumer(std::move(iResumer));
                 bool expectedLooperNotBegun = false;
 
-                chain::first([this, postSourceTask = postRunQueueTask, runStatus, &oSourceStatus](
-                                 auto nextTask) mutable {
-                  sourceResourcesAcquirer_.serialQueueChain().push(
-                      *postSourceTask.group(), [this, postSourceTask, runStatus, nextTask, &oSourceStatus]() mutable {
-                        CMS_SA_ALLOW try {
-                          ServiceRegistry::Operate operate(serviceToken_);
-
-                          if (postSourceTask.taskHasFailed()) {
-                            releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
-                                *runStatus, queueWhichWaitsForIOVsToFinish_);
-                            return;
-                          }
-
-                          {
-                            std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-                            runStatus->setRunPrincipal(readRun());
-
-                            RunPrincipal& runPrincipal = *runStatus->runPrincipal();
-                            {
-                              SendSourceTerminationSignalIfException sentry(actReg_.get());
-                              input_->doBeginRun(runPrincipal, &processContext_);
-                              sentry.completedSuccessfully();
-                            }
-                          }
-                        } catch (...) {
-                          nextTask.doneWaiting(std::current_exception());
-                          releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
-                                                                                      queueWhichWaitsForIOVsToFinish_);
-                        }
-                      });
-                }) |
+                chain::first(
+                    [this, postSourceTask = postRunQueueTask, runStatus, &oSourceStatus](auto nextTask) mutable {
+                      readRunAsync(runStatus, postSourceTask, nextTask, oSourceStatus);
+                    }) |
                     chain::ifThen(looper_ and looperBeginJobRun_.compare_exchange_strong(expectedLooperNotBegun, true),
                                   [this, runStatus](auto nextTask) mutable {
                                     try {
@@ -1705,6 +1711,40 @@ namespace edm {
 
   }  // namespace
 
+  void EventProcessor::readLumiAsync(std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus,
+                                     std::shared_ptr<RunProcessingStatus> iRunStatus,
+                                     WaitingTaskHolder iCheckSharedTask,
+                                     WaitingTaskHolder iNextTask,
+                                     SourceStatus& oSourceStatus) {
+    sourceResourcesAcquirer_.serialQueueChain().push(
+        *iNextTask.group(), [this, iLumiStatus, iRunStatus, iCheckSharedTask, iNextTask, &oSourceStatus]() mutable {
+          CMS_SA_ALLOW try {
+            ServiceRegistry::Operate operate(serviceToken_);
+
+            if (iCheckSharedTask.taskHasFailed()) {
+              releaseLumiResourcesAfterFailure(*iLumiStatus, queueWhichWaitsForIOVsToFinish_);
+              endRunAsync(iRunStatus, iNextTask, oSourceStatus);
+              return;
+            }
+
+            {
+              std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
+              iLumiStatus->setLumiPrincipal(readLuminosityBlock(iRunStatus->runPrincipal()));
+
+              LuminosityBlockPrincipal& lumiPrincipal = *iLumiStatus->lumiPrincipal();
+              {
+                SendSourceTerminationSignalIfException sentry(actReg_.get());
+                input_->doBeginLumi(lumiPrincipal, &processContext_);
+                sentry.completedSuccessfully();
+              }
+            }
+          } catch (...) {
+            releaseLumiResourcesAfterFailure(*iLumiStatus, queueWhichWaitsForIOVsToFinish_);
+            iNextTask.doneWaiting(std::current_exception());
+            endRunAsync(iRunStatus, iNextTask, oSourceStatus);
+          }
+        });
+  }
   void EventProcessor::beginLumiAsync(IOVSyncValue const& iSync,
                                       std::shared_ptr<RunProcessingStatus> iRunStatus,
                                       edm::WaitingTaskHolder iHolder,
@@ -1745,36 +1785,7 @@ namespace edm {
 
                 status->setResumer(std::move(iResumer));
                 chain::first([this, postLumiQueueTask, status, iRunStatus, &oSourceStatus](auto nextTask) mutable {
-                  sourceResourcesAcquirer_.serialQueueChain().push(
-                      *postLumiQueueTask.group(),
-                      [this, postSourceTask = postLumiQueueTask, nextTask, status, iRunStatus, &oSourceStatus]() mutable {
-                        CMS_SA_ALLOW try {
-                          ServiceRegistry::Operate operate(serviceToken_);
-
-                          if (postSourceTask.taskHasFailed()) {
-                            releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
-                            endRunAsync(iRunStatus, postSourceTask, oSourceStatus);
-                            return;
-                          }
-
-                          {
-                            std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-                            status->setLumiPrincipal(readLuminosityBlock(iRunStatus->runPrincipal()));
-
-                            LuminosityBlockPrincipal& lumiPrincipal = *status->lumiPrincipal();
-                            {
-                              SendSourceTerminationSignalIfException sentry(actReg_.get());
-                              input_->doBeginLumi(lumiPrincipal, &processContext_);
-                              sentry.completedSuccessfully();
-                            }
-                          }
-                        } catch (...) {
-                          releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
-                          WaitingTaskHolder copyHolder(nextTask);
-                          copyHolder.doneWaiting(std::current_exception());
-                          endRunAsync(iRunStatus, nextTask, oSourceStatus);
-                        }
-                      });
+                  readLumiAsync(status, iRunStatus, postLumiQueueTask, nextTask, oSourceStatus);
                 }) |
                     chain::ifThen(rng.isAvailable() and rng->consumer() != nullptr,
                                   [this, status](auto nextTask) {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -908,9 +908,9 @@ namespace edm {
     return returnValue;
   }
 
-  void EventProcessor::nextTransitionTypeAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                               WaitingTaskHolder nextTask,
-                                               SourceStatus& lastTransition) {
+  void EventProcessor::nextTransitionTypeThatIsNotTheSameRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
+                                                                  WaitingTaskHolder nextTask,
+                                                                  SourceStatus& lastTransition) {
     auto group = nextTask.group();
     sourceResourcesAcquirer_.serialQueueChain().push(
         *group, [this, runStatus = std::move(iRunStatus), nextHolder = std::move(nextTask), &lastTransition]() mutable {
@@ -1252,158 +1252,180 @@ namespace edm {
                 }
 
                 runStatus->setResumer(std::move(iResumer));
+                bool expectedLooperNotBegun = false;
 
-                sourceResourcesAcquirer_.serialQueueChain().push(
-                    *postRunQueueTask.group(),
-                    [this, postSourceTask = postRunQueueTask, runStatus, &oSourceStatus]() mutable {
-                      CMS_SA_ALLOW try {
-                        ServiceRegistry::Operate operate(serviceToken_);
+                chain::first([this, postSourceTask = postRunQueueTask, runStatus, &oSourceStatus](
+                                 auto nextTask) mutable {
+                  sourceResourcesAcquirer_.serialQueueChain().push(
+                      *postSourceTask.group(), [this, postSourceTask, runStatus, nextTask, &oSourceStatus]() mutable {
+                        CMS_SA_ALLOW try {
+                          ServiceRegistry::Operate operate(serviceToken_);
 
-                        if (postSourceTask.taskHasFailed()) {
-                          releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
-                                                                                      queueWhichWaitsForIOVsToFinish_);
-                          return;
-                        }
-
-                        {
-                          std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-                          runStatus->setRunPrincipal(readRun());
-
-                          RunPrincipal& runPrincipal = *runStatus->runPrincipal();
-                          {
-                            SendSourceTerminationSignalIfException sentry(actReg_.get());
-                            input_->doBeginRun(runPrincipal, &processContext_);
-                            sentry.completedSuccessfully();
-                          }
-                        }
-
-                        EventSetupImpl const& es = runStatus->eventSetupImpl();
-                        if (looper_ && looperBeginJobRun_ == false) {
-                          looper_->copyInfo(ScheduleInfo(schedule_.get()));
-
-                          oneapi::tbb::task_group group;
-                          FinalWaitingTask waitTask{group};
-                          using namespace edm::waiting_task::chain;
-                          chain::first([this, &es](auto nextTask) {
-                            looper_->esPrefetchAsync(nextTask, es, Transition::BeginRun, serviceToken_);
-                          }) | then([this, &es](auto nextTask) mutable {
-                            looper_->beginOfJob(es);
-                            looperBeginJobRun_ = true;
-                            looper_->doStartingNewLoop();
-                          }) | runLast(WaitingTaskHolder(group, &waitTask));
-                          waitTask.wait();
-                        }
-
-                        using namespace edm::waiting_task::chain;
-                        chain::first([this, runStatus, &oSourceStatus](auto nextTask) mutable {
-                          CMS_SA_ALLOW try {
-                            if (oSourceStatus.nextTransitionType().itemPosition() !=
-                                InputSource::ItemPosition::LastItemToBeMerged) {
-                              readAndMergeRunEntriesAsync(runStatus, nextTask, oSourceStatus);
-                            } else {
-                              oSourceStatus.setNeedToCallNext(true);
-                            }
-                          } catch (...) {
-                            runStatus->setStopBeforeProcessingRun(true);
-                            nextTask.doneWaiting(std::current_exception());
-                          }
-                        }) | then([this, runStatus, &es](auto nextTask) {
-                          if (runStatus->stopBeforeProcessingRun()) {
+                          if (postSourceTask.taskHasFailed()) {
+                            releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
+                                *runStatus, queueWhichWaitsForIOVsToFinish_);
                             return;
                           }
-                          RunTransitionInfo transitionInfo(*runStatus->runPrincipal(), es);
-                          using Traits = OccurrenceTraits<RunPrincipal, TransitionActionGlobalBegin>;
-                          schedule_->processOneGlobalAsync<Traits>(nextTask, transitionInfo, serviceToken_);
-                        }) |
-                            ifThen(looper_,
-                                   [this, runStatus, &es](auto nextTask) {
-                                     if (runStatus->stopBeforeProcessingRun()) {
-                                       return;
-                                     }
-                                     looper_->prefetchAsync(
-                                         nextTask, serviceToken_, Transition::BeginRun, *runStatus->runPrincipal(), es);
-                                   }) |
-                            ifThen(looper_,
-                                   [this, runStatus, &es](auto nextTask) {
-                                     if (runStatus->stopBeforeProcessingRun()) {
-                                       return;
-                                     }
-                                     ServiceRegistry::Operate operateLooper(serviceToken_);
-                                     looper_->doBeginRun(*runStatus->runPrincipal(), es, &processContext_);
-                                   }) |
-                            then([this, runStatus, &oSourceStatus](std::exception_ptr const* iException,
-                                                                   auto holder) mutable {
-                              if (iException) {
-                                WaitingTaskHolder copyHolder(holder);
-                                copyHolder.doneWaiting(*iException);
-                              } else {
-                                runStatus->globalBeginDidSucceed();
-                              }
-                              if (runStatus->stopBeforeProcessingRun()) {
-                                // We just quit now if there was a failure when merging runs
-                                releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
-                                    *runStatus, queueWhichWaitsForIOVsToFinish_);
-                                return;
-                              }
-                              CMS_SA_ALLOW try {
-                                // Under normal circumstances, this task runs after endRun has completed for all streams
-                                // and global endLumi has completed for all lumis contained in this run
-                                auto globalEndRunTask =
-                                    edm::make_waiting_task([this, runStatus](std::exception_ptr const*) mutable {
-                                      WaitingTaskHolder taskHolder = runStatus->holderOfTaskInProcessRuns();
-                                      runStatus->holderOfTaskInProcessRuns().doneWaiting(std::exception_ptr{});
-                                      globalEndRunAsync(std::move(taskHolder), std::move(runStatus));
-                                    });
-                                runStatus->setGlobalEndRunHolder(WaitingTaskHolder{*holder.group(), globalEndRunTask});
-                              } catch (...) {
-                                releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
-                                    *runStatus, queueWhichWaitsForIOVsToFinish_);
-                                holder.doneWaiting(std::current_exception());
-                                return;
-                              }
 
-                              // After this point we are committed to end the run via endRunAsync
+                          {
+                            std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
+                            runStatus->setRunPrincipal(readRun());
 
-                              ServiceRegistry::Operate operate(serviceToken_);
-
-                              // The only purpose of the pause is to cause stream begin run to execute before
-                              // global begin lumi in the single threaded case (maintains consistency with
-                              // the order that existed before concurrent runs were implemented).
-                              PauseQueueSentry pauseQueueSentry(streamQueuesInserter_);
-
-                              CMS_SA_ALLOW try {
-                                streamQueuesInserter_.push(*holder.group(), [this, runStatus, holder]() mutable {
-                                  for (auto i : std::views::iota(0U, preallocations_.numberOfStreams())) {
-                                    CMS_SA_ALLOW try {
-                                      streamQueues_[i].push(*holder.group(), [this, i, runStatus, holder]() mutable {
-                                        streamBeginRunAsync(i, std::move(runStatus), std::move(holder));
-                                      });
+                            RunPrincipal& runPrincipal = *runStatus->runPrincipal();
+                            {
+                              SendSourceTerminationSignalIfException sentry(actReg_.get());
+                              input_->doBeginRun(runPrincipal, &processContext_);
+                              sentry.completedSuccessfully();
+                            }
+                          }
+                        } catch (...) {
+                          nextTask.doneWaiting(std::current_exception());
+                          releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
+                                                                                      queueWhichWaitsForIOVsToFinish_);
+                        }
+                      });
+                }) |
+                    chain::ifThen(looper_ and looperBeginJobRun_.compare_exchange_strong(expectedLooperNotBegun, true),
+                                  [this, runStatus](auto nextTask) mutable {
+                                    try {
+                                      looper_->copyInfo(ScheduleInfo(schedule_.get()));
                                     } catch (...) {
-                                      if (runStatus->streamFinishedBeginRun()) {
-                                        WaitingTaskHolder copyHolder(holder);
-                                        copyHolder.doneWaiting(std::current_exception());
-                                        releaseBeginRunResourcesAfterFailure(*runStatus,
-                                                                             queueWhichWaitsForIOVsToFinish_);
-                                        exceptionRunStatus_ = runStatus;
-                                      }
+                                      nextTask.doneWaiting(std::current_exception());
+                                      releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
+                                          *runStatus, queueWhichWaitsForIOVsToFinish_);
                                     }
-                                  }
-                                });
-                              } catch (...) {
-                                WaitingTaskHolder copyHolder(holder);
-                                copyHolder.doneWaiting(std::current_exception());
-                                releaseBeginRunResourcesAfterFailure(*runStatus, queueWhichWaitsForIOVsToFinish_);
-                                exceptionRunStatus_ = runStatus;
-                              }
-                              handleNextItemAfterMergingRunEntriesAsync(runStatus, holder, oSourceStatus);
-                            }) |
-                            runLast(postSourceTask);
+                                  }) |
+                    chain::ifThen(looper_ and looperBeginJobRun_.load(),
+                                  [this, runStatus](auto nextTask) mutable {
+                                    CMS_SA_ALLOW try {
+                                      EventSetupImpl const& es = runStatus->eventSetupImpl();
+                                      looper_->esPrefetchAsync(nextTask, es, Transition::BeginRun, serviceToken_);
+                                    } catch (...) {
+                                      nextTask.doneWaiting(std::current_exception());
+                                      releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
+                                          *runStatus, queueWhichWaitsForIOVsToFinish_);
+                                    }
+                                  }) |
+                    chain::ifThen(looper_ and looperBeginJobRun_.load(),
+                                  [this, runStatus](auto nextTask) mutable {
+                                    CMS_SA_ALLOW try {
+                                      EventSetupImpl const& es = runStatus->eventSetupImpl();
+                                      looper_->beginOfJob(es);
+                                      looper_->doStartingNewLoop();
+
+                                    } catch (...) {
+                                      nextTask.doneWaiting(std::current_exception());
+                                      releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
+                                          *runStatus, queueWhichWaitsForIOVsToFinish_);
+                                    }
+                                  }) |
+                    chain::then([this, runStatus, &oSourceStatus](auto nextTask) mutable {
+                      CMS_SA_ALLOW try {
+                        if (oSourceStatus.nextTransitionType().itemPosition() !=
+                            InputSource::ItemPosition::LastItemToBeMerged) {
+                          readAndMergeRunEntriesAsync(runStatus, nextTask, oSourceStatus);
+                        } else {
+                          oSourceStatus.setNeedToCallNext(true);
+                        }
                       } catch (...) {
-                        releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
-                                                                                    queueWhichWaitsForIOVsToFinish_);
-                        postSourceTask.doneWaiting(std::current_exception());
+                        runStatus->setStopBeforeProcessingRun(true);
+                        nextTask.doneWaiting(std::current_exception());
                       }
-                    });  // task in sourceResourcesAcquirer
+                    }) |
+                    chain::then([this, runStatus](auto nextTask) {
+                      if (runStatus->stopBeforeProcessingRun()) {
+                        return;
+                      }
+                      EventSetupImpl const& es = runStatus->eventSetupImpl();
+                      RunTransitionInfo transitionInfo(*runStatus->runPrincipal(), es);
+                      using Traits = OccurrenceTraits<RunPrincipal, TransitionActionGlobalBegin>;
+                      schedule_->processOneGlobalAsync<Traits>(nextTask, transitionInfo, serviceToken_);
+                    }) |
+                    chain::ifThen(looper_,
+                                  [this, runStatus](auto nextTask) {
+                                    EventSetupImpl const& es = runStatus->eventSetupImpl();
+
+                                    if (runStatus->stopBeforeProcessingRun()) {
+                                      return;
+                                    }
+                                    looper_->prefetchAsync(
+                                        nextTask, serviceToken_, Transition::BeginRun, *runStatus->runPrincipal(), es);
+                                  }) |
+                    chain::ifThen(looper_,
+                                  [this, runStatus](auto nextTask) {
+                                    EventSetupImpl const& es = runStatus->eventSetupImpl();
+                                    if (runStatus->stopBeforeProcessingRun()) {
+                                      return;
+                                    }
+                                    ServiceRegistry::Operate operateLooper(serviceToken_);
+                                    looper_->doBeginRun(*runStatus->runPrincipal(), es, &processContext_);
+                                  }) |
+                    chain::then(
+                        [this, runStatus, &oSourceStatus](std::exception_ptr const* iException, auto holder) mutable {
+                          if (iException) {
+                            WaitingTaskHolder copyHolder(holder);
+                            copyHolder.doneWaiting(*iException);
+                          } else {
+                            runStatus->globalBeginDidSucceed();
+                          }
+                          if (runStatus->stopBeforeProcessingRun()) {
+                            // We just quit now if there was a failure when merging runs
+                            releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
+                                *runStatus, queueWhichWaitsForIOVsToFinish_);
+                            return;
+                          }
+                          CMS_SA_ALLOW try {
+                            // Under normal circumstances, this task runs after endRun has completed for all streams
+                            // and global endLumi has completed for all lumis contained in this run
+                            auto globalEndRunTask =
+                                edm::make_waiting_task([this, runStatus](std::exception_ptr const*) mutable {
+                                  WaitingTaskHolder taskHolder = runStatus->holderOfTaskInProcessRuns();
+                                  runStatus->holderOfTaskInProcessRuns().doneWaiting(std::exception_ptr{});
+                                  globalEndRunAsync(std::move(taskHolder), std::move(runStatus));
+                                });
+                            runStatus->setGlobalEndRunHolder(WaitingTaskHolder{*holder.group(), globalEndRunTask});
+                          } catch (...) {
+                            releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
+                                *runStatus, queueWhichWaitsForIOVsToFinish_);
+                            holder.doneWaiting(std::current_exception());
+                            return;
+                          }
+
+                          // After this point we are committed to end the run via endRunAsync
+
+                          ServiceRegistry::Operate operate(serviceToken_);
+
+                          // The only purpose of the pause is to cause stream begin run to execute before
+                          // global begin lumi in the single threaded case (maintains consistency with
+                          // the order that existed before concurrent runs were implemented).
+                          PauseQueueSentry pauseQueueSentry(streamQueuesInserter_);
+
+                          CMS_SA_ALLOW try {
+                            streamQueuesInserter_.push(*holder.group(), [this, runStatus, holder]() mutable {
+                              for (auto i : std::views::iota(0U, preallocations_.numberOfStreams())) {
+                                CMS_SA_ALLOW try {
+                                  streamQueues_[i].push(*holder.group(), [this, i, runStatus, holder]() mutable {
+                                    streamBeginRunAsync(i, std::move(runStatus), std::move(holder));
+                                  });
+                                } catch (...) {
+                                  if (runStatus->streamFinishedBeginRun()) {
+                                    WaitingTaskHolder copyHolder(holder);
+                                    copyHolder.doneWaiting(std::current_exception());
+                                    releaseBeginRunResourcesAfterFailure(*runStatus, queueWhichWaitsForIOVsToFinish_);
+                                    exceptionRunStatus_ = runStatus;
+                                  }
+                                }
+                              }
+                            });
+                          } catch (...) {
+                            WaitingTaskHolder copyHolder(holder);
+                            copyHolder.doneWaiting(std::current_exception());
+                            releaseBeginRunResourcesAfterFailure(*runStatus, queueWhichWaitsForIOVsToFinish_);
+                            exceptionRunStatus_ = runStatus;
+                          }
+                          handleNextItemAfterMergingRunEntriesAsync(runStatus, holder, oSourceStatus);
+                        }) |
+                    chain::runLast(postRunQueueTask);
               } catch (...) {
                 releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
                                                                             queueWhichWaitsForIOVsToFinish_);
@@ -1717,139 +1739,142 @@ namespace edm {
                   return;
                 }
 
+                ServiceRegistry::Operate operate(serviceToken_);
+                Service<RandomNumberGenerator> rng;
+                using namespace edm::waiting_task::chain;
+
                 status->setResumer(std::move(iResumer));
+                chain::first([this, postLumiQueueTask, status, iRunStatus, &oSourceStatus](auto nextTask) mutable {
+                  sourceResourcesAcquirer_.serialQueueChain().push(
+                      *postLumiQueueTask.group(),
+                      [this, postSourceTask = postLumiQueueTask, nextTask, status, iRunStatus, &oSourceStatus]() mutable {
+                        CMS_SA_ALLOW try {
+                          ServiceRegistry::Operate operate(serviceToken_);
 
-                sourceResourcesAcquirer_.serialQueueChain().push(
-                    *postLumiQueueTask.group(),
-                    [this, postSourceTask = postLumiQueueTask, status, iRunStatus, &oSourceStatus]() mutable {
-                      CMS_SA_ALLOW try {
-                        ServiceRegistry::Operate operate(serviceToken_);
-
-                        if (postSourceTask.taskHasFailed()) {
-                          releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
-                          endRunAsync(iRunStatus, postSourceTask, oSourceStatus);
-                          return;
-                        }
-
-                        {
-                          std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-                          status->setLumiPrincipal(readLuminosityBlock(iRunStatus->runPrincipal()));
-
-                          LuminosityBlockPrincipal& lumiPrincipal = *status->lumiPrincipal();
-                          {
-                            SendSourceTerminationSignalIfException sentry(actReg_.get());
-                            input_->doBeginLumi(lumiPrincipal, &processContext_);
-                            sentry.completedSuccessfully();
+                          if (postSourceTask.taskHasFailed()) {
+                            releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
+                            endRunAsync(iRunStatus, postSourceTask, oSourceStatus);
+                            return;
                           }
+
+                          {
+                            std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
+                            status->setLumiPrincipal(readLuminosityBlock(iRunStatus->runPrincipal()));
+
+                            LuminosityBlockPrincipal& lumiPrincipal = *status->lumiPrincipal();
+                            {
+                              SendSourceTerminationSignalIfException sentry(actReg_.get());
+                              input_->doBeginLumi(lumiPrincipal, &processContext_);
+                              sentry.completedSuccessfully();
+                            }
+                          }
+                        } catch (...) {
+                          releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
+                          WaitingTaskHolder copyHolder(nextTask);
+                          copyHolder.doneWaiting(std::current_exception());
+                          endRunAsync(iRunStatus, nextTask, oSourceStatus);
                         }
-                        LuminosityBlockPrincipal& lumiPrincipal = *status->lumiPrincipal();
-                        Service<RandomNumberGenerator> rng;
+                      });
+                }) |
+                    chain::ifThen(rng.isAvailable() and rng->consumer() != nullptr,
+                                  [this, status](auto nextTask) {
+                                    //handle RandomNumberGenerator prefetching and preBeginLumi
+                                    assert(status->lumiPrincipal() != nullptr);
+                                    auto& lumiPrincipal = *status->lumiPrincipal();
+                                    prefetchForRandomNumberGeneratorAsync(
+                                        std::move(nextTask), lumiPrincipal, serviceToken_);
+                                  }) |
+                    ifThen(rng.isAvailable() and rng->consumer() != nullptr,
+                           [this, status](auto nextTask) {
+                             ServiceRegistry::Operate operate(serviceToken_);
+                             Service<RandomNumberGenerator> rng;
+                             auto& lumiPrincipal = *status->lumiPrincipal();
+                             LuminosityBlock lb(lumiPrincipal, ModuleDescription(), nullptr, false);
+                             lb.setConsumer(rng->consumer());
+                             rng->preBeginLumi(lb);
+                           }) |
+                    then([this, status, &oSourceStatus](auto nextTask) mutable {
+                      if (oSourceStatus.nextTransitionType().itemPosition() !=
+                          InputSource::ItemPosition::LastItemToBeMerged) {
+                        readAndMergeLumiEntriesAsync(std::move(status), std::move(nextTask), oSourceStatus);
+                      } else {
+                        oSourceStatus.setNeedToCallNext(true);
+                      }
+                    }) |
+                    then([this, status](auto nextTask) {
+                      EventSetupImpl const& es = status->eventSetupImpl();
+                      auto& lumiPrincipal = *status->lumiPrincipal();
+                      LumiTransitionInfo transitionInfo(lumiPrincipal, es);
+                      using Traits = OccurrenceTraits<LuminosityBlockPrincipal, TransitionActionGlobalBegin>;
+                      schedule_->processOneGlobalAsync<Traits>(nextTask, transitionInfo, serviceToken_);
+                    }) |
+                    ifThen(looper_,
+                           [this, status](auto nextTask) {
+                             EventSetupImpl const& es = status->eventSetupImpl();
+                             looper_->prefetchAsync(nextTask,
+                                                    serviceToken_,
+                                                    Transition::BeginLuminosityBlock,
+                                                    *(status->lumiPrincipal()),
+                                                    es);
+                           }) |
+                    ifThen(looper_,
+                           [this, status](auto nextTask) {
+                             ServiceRegistry::Operate operateLooper(serviceToken_);
+                             looper_->doBeginLuminosityBlock(
+                                 *(status->lumiPrincipal()), status->eventSetupImpl(), &processContext_);
+                           }) |
+                    then([this, status, iRunStatus, &oSourceStatus](std::exception_ptr const* iException,
+                                                                    auto holder) mutable {
+                      status->setGlobalEndRunHolder(iRunStatus->globalEndRunHolder());
+
+                      if (iException) {
+                        WaitingTaskHolder copyHolder(holder);
+                        copyHolder.doneWaiting(*iException);
+                        globalEndLumiAsync(holder, status);
+                        endRunAsync(iRunStatus, holder, oSourceStatus);
+                      } else {
+                        status->globalBeginDidSucceed();
 
                         EventSetupImpl const& es = status->eventSetupImpl();
+                        using Traits = OccurrenceTraits<LuminosityBlockPrincipal, TransitionActionStreamBegin>;
 
-                        using namespace edm::waiting_task::chain;
-                        chain::firstIf(rng.isAvailable() and rng->consumer() != nullptr,
-                                       [this, &lumiPrincipal](auto nextTask) {
-                                         //handle RandomNumberGenerator prefetching and preBeginLumi
-                                         chain::first([this, &lumiPrincipal](auto nextTask) {
-                                           prefetchForRandomNumberGeneratorAsync(
-                                               std::move(nextTask), lumiPrincipal, serviceToken_);
-                                         }) | then([this, &lumiPrincipal](auto nextTask) {
-                                           ServiceRegistry::Operate operate(serviceToken_);
-                                           Service<RandomNumberGenerator> rng;
-                                           if (rng.isAvailable()) {
-                                             LuminosityBlock lb(lumiPrincipal, ModuleDescription(), nullptr, false);
-                                             lb.setConsumer(rng->consumer());
-                                             rng->preBeginLumi(lb);
-                                           }
-                                         }) | runLast(nextTask);
-                                       }) |
-                            then([this, status, &oSourceStatus](auto nextTask) mutable {
-                              if (oSourceStatus.nextTransitionType().itemPosition() !=
-                                  InputSource::ItemPosition::LastItemToBeMerged) {
-                                readAndMergeLumiEntriesAsync(std::move(status), std::move(nextTask), oSourceStatus);
-                              } else {
-                                oSourceStatus.setNeedToCallNext(true);
-                              }
-                            }) |
-                            then([this, status, &es, &lumiPrincipal](auto nextTask) {
-                              LumiTransitionInfo transitionInfo(lumiPrincipal, es);
-                              using Traits = OccurrenceTraits<LuminosityBlockPrincipal, TransitionActionGlobalBegin>;
-                              schedule_->processOneGlobalAsync<Traits>(nextTask, transitionInfo, serviceToken_);
-                            }) |
-                            ifThen(looper_,
-                                   [this, status, &es](auto nextTask) {
-                                     looper_->prefetchAsync(nextTask,
-                                                            serviceToken_,
-                                                            Transition::BeginLuminosityBlock,
-                                                            *(status->lumiPrincipal()),
-                                                            es);
-                                   }) |
-                            ifThen(looper_,
-                                   [this, status, &es](auto nextTask) {
-                                     ServiceRegistry::Operate operateLooper(serviceToken_);
-                                     looper_->doBeginLuminosityBlock(*(status->lumiPrincipal()), es, &processContext_);
-                                   }) |
-                            then([this, status, iRunStatus, &oSourceStatus](std::exception_ptr const* iException,
-                                                                            auto holder) mutable {
-                              status->setGlobalEndRunHolder(iRunStatus->globalEndRunHolder());
+                        streamQueuesInserter_.push(
+                            *holder.group(), [this, status, holder, &es, &oSourceStatus]() mutable {
+                              for (auto i : std::views::iota(0U, preallocations_.numberOfStreams())) {
+                                streamQueues_[i].push(
+                                    *holder.group(), [this, i, status, holder, &es, &oSourceStatus]() mutable {
+                                      if (!status->shouldStreamStartLumi()) {
+                                        return;
+                                      }
+                                      streamQueues_[i].pause();
 
-                              if (iException) {
-                                WaitingTaskHolder copyHolder(holder);
-                                copyHolder.doneWaiting(*iException);
-                                globalEndLumiAsync(holder, status);
-                                endRunAsync(iRunStatus, holder, oSourceStatus);
-                              } else {
-                                status->globalBeginDidSucceed();
-
-                                EventSetupImpl const& es = status->eventSetupImpl();
-                                using Traits = OccurrenceTraits<LuminosityBlockPrincipal, TransitionActionStreamBegin>;
-
-                                streamQueuesInserter_.push(
-                                    *holder.group(), [this, status, holder, &es, &oSourceStatus]() mutable {
-                                      for (auto i : std::views::iota(0U, preallocations_.numberOfStreams())) {
-                                        streamQueues_[i].push(
-                                            *holder.group(), [this, i, status, holder, &es, &oSourceStatus]() mutable {
-                                              if (!status->shouldStreamStartLumi()) {
-                                                return;
-                                              }
-                                              streamQueues_[i].pause();
-
-                                              auto& event = principalCache_.eventPrincipal(i);
-                                              auto lp = status->lumiPrincipal().get();
-                                              streamLumiStatus_[i] = std::move(status);
-                                              ++streamLumiActive_;
-                                              event.setLuminosityBlockPrincipal(lp);
-                                              LumiTransitionInfo transitionInfo(*lp, es);
-                                              using namespace edm::waiting_task::chain;
-                                              chain::first([this, i, &transitionInfo](auto nextTask) {
-                                                schedule_->processOneStreamAsync<Traits>(
-                                                    std::move(nextTask), i, transitionInfo, serviceToken_);
-                                              }) |
-                                                  then([this, i, &oSourceStatus](
-                                                           std::exception_ptr const* exceptionFromBeginStreamLumi,
-                                                           auto nextTask) {
-                                                    if (exceptionFromBeginStreamLumi) {
-                                                      WaitingTaskHolder copyHolder(nextTask);
-                                                      copyHolder.doneWaiting(*exceptionFromBeginStreamLumi);
-                                                    }
-                                                    handleNextEventForStreamAsync(
-                                                        std::move(nextTask), i, oSourceStatus);
-                                                  }) |
-                                                  runLast(std::move(holder));
-                                            });
-                                      }  // end for loop over streams
+                                      auto& event = principalCache_.eventPrincipal(i);
+                                      auto lp = status->lumiPrincipal().get();
+                                      streamLumiStatus_[i] = std::move(status);
+                                      ++streamLumiActive_;
+                                      event.setLuminosityBlockPrincipal(lp);
+                                      LumiTransitionInfo transitionInfo(*lp, es);
+                                      using namespace edm::waiting_task::chain;
+                                      chain::first([this, i, &transitionInfo](auto nextTask) {
+                                        schedule_->processOneStreamAsync<Traits>(
+                                            std::move(nextTask), i, transitionInfo, serviceToken_);
+                                      }) |
+                                          then([this, i, &oSourceStatus](
+                                                   std::exception_ptr const* exceptionFromBeginStreamLumi,
+                                                   auto nextTask) {
+                                            if (exceptionFromBeginStreamLumi) {
+                                              WaitingTaskHolder copyHolder(nextTask);
+                                              copyHolder.doneWaiting(*exceptionFromBeginStreamLumi);
+                                            }
+                                            handleNextEventForStreamAsync(std::move(nextTask), i, oSourceStatus);
+                                          }) |
+                                          runLast(std::move(holder));
                                     });
-                              }
-                            }) |
-                            runLast(postSourceTask);
-                      } catch (...) {
-                        releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
-                        WaitingTaskHolder copyHolder(postSourceTask);
-                        copyHolder.doneWaiting(std::current_exception());
-                        endRunAsync(iRunStatus, postSourceTask, oSourceStatus);
+                              }  // end for loop over streams
+                            });
                       }
-                    });  // task in sourceResourcesAcquirer
+                    }) |
+                    runLast(postLumiQueueTask);
               } catch (...) {
                 releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
                 WaitingTaskHolder copyHolder(postLumiQueueTask);
@@ -2208,7 +2233,7 @@ namespace edm {
                                                                  SourceStatus& oSourceStatus) {
     chain::first([this, iRunStatus, &oSourceStatus](auto nextTask) mutable {
       if (oSourceStatus.needToCallNext()) {
-        nextTransitionTypeAsync(std::move(iRunStatus), std::move(nextTask), oSourceStatus);
+        nextTransitionTypeThatIsNotTheSameRunAsync(std::move(iRunStatus), std::move(nextTask), oSourceStatus);
       }
     }) | chain::then([this, iRunStatus, &oSourceStatus](std::exception_ptr const* iException, auto nextTask) {
       ServiceRegistry::Operate operate(serviceToken_);

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1199,6 +1199,18 @@ namespace edm {
     return returnValue;
   }
 
+  namespace {
+    void releaseBeginRunResourcesAfterFailure(RunProcessingStatus& iStatus, edm::SerialTaskQueue& iQueue) {
+      iStatus.resetBeginResources();
+      iQueue.resume();
+    }
+    void releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(RunProcessingStatus& iStatus,
+                                                                     edm::SerialTaskQueue& iQueue) {
+      iStatus.resetBeginResources();
+      iQueue.resume();
+      iStatus.resumeGlobalRunQueue();
+    }
+  }  // namespace
   void EventProcessor::beginRunAsync(IOVSyncValue const& iSync,
                                      WaitingTaskHolder iHolder,
                                      SourceStatus& oSourceStatus) {
@@ -1234,8 +1246,8 @@ namespace edm {
                 edm::LimitedTaskQueue::Resumer iResumer) mutable {
               CMS_SA_ALLOW try {
                 if (postRunQueueTask.taskHasFailed()) {
-                  runStatus->resetBeginResources();
-                  queueWhichWaitsForIOVsToFinish_.resume();
+                  releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
+                                                                              queueWhichWaitsForIOVsToFinish_);
                   return;
                 }
 
@@ -1248,9 +1260,8 @@ namespace edm {
                         ServiceRegistry::Operate operate(serviceToken_);
 
                         if (postSourceTask.taskHasFailed()) {
-                          runStatus->resetBeginResources();
-                          queueWhichWaitsForIOVsToFinish_.resume();
-                          runStatus->resumeGlobalRunQueue();
+                          releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
+                                                                                      queueWhichWaitsForIOVsToFinish_);
                           return;
                         }
 
@@ -1330,9 +1341,8 @@ namespace edm {
                               }
                               if (runStatus->stopBeforeProcessingRun()) {
                                 // We just quit now if there was a failure when merging runs
-                                runStatus->resetBeginResources();
-                                queueWhichWaitsForIOVsToFinish_.resume();
-                                runStatus->resumeGlobalRunQueue();
+                                releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
+                                    *runStatus, queueWhichWaitsForIOVsToFinish_);
                                 return;
                               }
                               CMS_SA_ALLOW try {
@@ -1346,9 +1356,8 @@ namespace edm {
                                     });
                                 runStatus->setGlobalEndRunHolder(WaitingTaskHolder{*holder.group(), globalEndRunTask});
                               } catch (...) {
-                                runStatus->resetBeginResources();
-                                queueWhichWaitsForIOVsToFinish_.resume();
-                                runStatus->resumeGlobalRunQueue();
+                                releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
+                                    *runStatus, queueWhichWaitsForIOVsToFinish_);
                                 holder.doneWaiting(std::current_exception());
                                 return;
                               }
@@ -1373,8 +1382,8 @@ namespace edm {
                                       if (runStatus->streamFinishedBeginRun()) {
                                         WaitingTaskHolder copyHolder(holder);
                                         copyHolder.doneWaiting(std::current_exception());
-                                        runStatus->resetBeginResources();
-                                        queueWhichWaitsForIOVsToFinish_.resume();
+                                        releaseBeginRunResourcesAfterFailure(*runStatus,
+                                                                             queueWhichWaitsForIOVsToFinish_);
                                         exceptionRunStatus_ = runStatus;
                                       }
                                     }
@@ -1383,30 +1392,26 @@ namespace edm {
                               } catch (...) {
                                 WaitingTaskHolder copyHolder(holder);
                                 copyHolder.doneWaiting(std::current_exception());
-                                runStatus->resetBeginResources();
-                                queueWhichWaitsForIOVsToFinish_.resume();
+                                releaseBeginRunResourcesAfterFailure(*runStatus, queueWhichWaitsForIOVsToFinish_);
                                 exceptionRunStatus_ = runStatus;
                               }
                               handleNextItemAfterMergingRunEntriesAsync(runStatus, holder, oSourceStatus);
                             }) |
                             runLast(postSourceTask);
                       } catch (...) {
-                        runStatus->resetBeginResources();
-                        queueWhichWaitsForIOVsToFinish_.resume();
-                        runStatus->resumeGlobalRunQueue();
+                        releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
+                                                                                    queueWhichWaitsForIOVsToFinish_);
                         postSourceTask.doneWaiting(std::current_exception());
                       }
                     });  // task in sourceResourcesAcquirer
               } catch (...) {
-                runStatus->resetBeginResources();
-                queueWhichWaitsForIOVsToFinish_.resume();
-                runStatus->resumeGlobalRunQueue();
+                releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
+                                                                            queueWhichWaitsForIOVsToFinish_);
                 postRunQueueTask.doneWaiting(std::current_exception());
               }
             });  // task in runQueue
       } catch (...) {
-        runStatus->resetBeginResources();
-        queueWhichWaitsForIOVsToFinish_.resume();
+        releaseBeginRunResourcesAfterFailure(*runStatus, queueWhichWaitsForIOVsToFinish_);
         nextTask.doneWaiting(std::current_exception());
       }
     }) | chain::runLast(std::move(iHolder));
@@ -1671,6 +1676,11 @@ namespace edm {
         }
       }
     }
+    void releaseLumiResourcesAfterFailure(LuminosityBlockProcessingStatus& iStatus, edm::SerialTaskQueue& iQueue) {
+      iStatus.resetResources();
+      iQueue.resume();
+    }
+
   }  // namespace
 
   void EventProcessor::beginLumiAsync(IOVSyncValue const& iSync,
@@ -1702,8 +1712,7 @@ namespace edm {
                 edm::LimitedTaskQueue::Resumer iResumer) mutable {
               CMS_SA_ALLOW try {
                 if (postLumiQueueTask.taskHasFailed()) {
-                  status->resetResources();
-                  queueWhichWaitsForIOVsToFinish_.resume();
+                  releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
                   endRunAsync(iRunStatus, postLumiQueueTask, oSourceStatus);
                   return;
                 }
@@ -1717,8 +1726,7 @@ namespace edm {
                         ServiceRegistry::Operate operate(serviceToken_);
 
                         if (postSourceTask.taskHasFailed()) {
-                          status->resetResources();
-                          queueWhichWaitsForIOVsToFinish_.resume();
+                          releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
                           endRunAsync(iRunStatus, postSourceTask, oSourceStatus);
                           return;
                         }
@@ -1836,24 +1844,21 @@ namespace edm {
                             }) |
                             runLast(postSourceTask);
                       } catch (...) {
-                        status->resetResources();
-                        queueWhichWaitsForIOVsToFinish_.resume();
+                        releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
                         WaitingTaskHolder copyHolder(postSourceTask);
                         copyHolder.doneWaiting(std::current_exception());
                         endRunAsync(iRunStatus, postSourceTask, oSourceStatus);
                       }
                     });  // task in sourceResourcesAcquirer
               } catch (...) {
-                status->resetResources();
-                queueWhichWaitsForIOVsToFinish_.resume();
+                releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
                 WaitingTaskHolder copyHolder(postLumiQueueTask);
                 copyHolder.doneWaiting(std::current_exception());
                 endRunAsync(iRunStatus, postLumiQueueTask, oSourceStatus);
               }
             });  // task in lumiQueue
       } catch (...) {
-        status->resetResources();
-        queueWhichWaitsForIOVsToFinish_.resume();
+        releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
         WaitingTaskHolder copyHolder(nextTask);
         copyHolder.doneWaiting(std::current_exception());
         endRunAsync(iRunStatus, nextTask, oSourceStatus);

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -228,7 +228,6 @@ namespace edm {
         preg_(),
         branchIDListHelper_(),
         serviceToken_(),
-        input_(),
         moduleTypeResolverMaker_(makeModuleTypeResolverMaker(*parameterSet)),
         espController_(std::make_unique<eventsetup::EventSetupsController>(moduleTypeResolverMaker_.get())),
         esp_(),
@@ -239,8 +238,9 @@ namespace edm {
         fb_(),
         looper_(),
         deferredExceptionPtrIsSet_(false),
-        sourceResourcesAcquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first),
-        sourceMutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
+        sourceCoordinator_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first,
+                           SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second,
+                           serviceToken_),
         principalCache_(),
         beginJobCalled_(false),
         shouldWeStop_(false),
@@ -263,7 +263,6 @@ namespace edm {
         preg_(),
         branchIDListHelper_(),
         serviceToken_(),
-        input_(),
         moduleTypeResolverMaker_(makeModuleTypeResolverMaker(*parameterSet)),
         espController_(std::make_unique<eventsetup::EventSetupsController>(moduleTypeResolverMaker_.get())),
         esp_(),
@@ -274,8 +273,9 @@ namespace edm {
         fb_(),
         looper_(),
         deferredExceptionPtrIsSet_(false),
-        sourceResourcesAcquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first),
-        sourceMutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
+        sourceCoordinator_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first,
+                           SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second,
+                           serviceToken_),
         principalCache_(),
         beginJobCalled_(false),
         shouldWeStop_(false),
@@ -298,7 +298,6 @@ namespace edm {
         preg_(),
         branchIDListHelper_(),
         serviceToken_(),
-        input_(),
         moduleTypeResolverMaker_(makeModuleTypeResolverMaker(*processDesc->getProcessPSet())),
         espController_(std::make_unique<eventsetup::EventSetupsController>(moduleTypeResolverMaker_.get())),
         esp_(),
@@ -309,8 +308,9 @@ namespace edm {
         fb_(),
         looper_(),
         deferredExceptionPtrIsSet_(false),
-        sourceResourcesAcquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first),
-        sourceMutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
+        sourceCoordinator_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first,
+                           SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second,
+                           serviceToken_),
         principalCache_(),
         beginJobCalled_(false),
         shouldWeStop_(false),
@@ -440,6 +440,7 @@ namespace edm {
     serviceToken_ = items.addTNS(*parameterSet, token);
     items.actReg_->postServicesConstructionSignal_.emit();
 
+    sourceCoordinator_.setSignals(*items.actReg_);
     //make the services available
     ServiceRegistry::Operate operate(serviceToken_);
 
@@ -502,22 +503,24 @@ namespace edm {
                 *parameterSet, tns, preallocations_, &processContext_, moduleTypeResolverMaker_.get());
           });
 
+          std::unique_ptr<InputSource> input;
           group.run([&, this]() {
             ServiceRegistry::Operate operate(serviceToken_);
-            input_ = makeInput(sourceID,
-                               *parameterSet,
-                               *common,
-                               items.branchIDListHelper(),
-                               get_underlying_safe(processBlockHelper_),
-                               items.actReg_,
-                               items.processConfiguration(),
-                               preallocations_);
+            input = makeInput(sourceID,
+                              *parameterSet,
+                              *common,
+                              items.branchIDListHelper(),
+                              get_underlying_safe(processBlockHelper_),
+                              items.actReg_,
+                              items.processConfiguration(),
+                              preallocations_);
           });
 
           group.wait();
+          sourceCoordinator_.setSource(std::move(input));
         }
 
-        items.preg()->addFromInput(input_->productRegistry());
+        items.preg()->addFromInput(sourceCoordinator_.productRegistry());
         {
           items.actReg_->preFinishScheduleSignal_.emit();
           auto guard = makeGuard([&items]() { items.actReg_->postFinishScheduleSignal_.emit(); });
@@ -593,7 +596,7 @@ namespace edm {
       espController_ = nullptr;
       esp_ = nullptr;
       schedule_ = nullptr;
-      input_ = nullptr;
+      sourceCoordinator_.releaseSource();
       looper_ = nullptr;
       actReg_ = nullptr;
       throw;
@@ -610,7 +613,7 @@ namespace edm {
     espController_ = nullptr;
     esp_ = nullptr;
     schedule_ = nullptr;
-    input_ = nullptr;
+    sourceCoordinator_.releaseSource();
     looper_ = nullptr;
     actReg_ = nullptr;
 
@@ -707,7 +710,7 @@ namespace edm {
 
     actReg_->eventSetupConfigurationSignal_.emit(esRecordsToProductResolverIndices, processContext_);
     try {
-      convertException::wrap([&]() { input_->doBeginJob(*preg_); });
+      convertException::wrap([&]() { sourceCoordinator_.beginJob(*preg_); });
     } catch (cms::Exception& ex) {
       ex.addContext("Calling beginJob for the source");
       throw;
@@ -827,7 +830,7 @@ namespace edm {
 
     if (beginJobStartedModules_) {
       schedule_->endJob(c);
-      c.call(std::bind(&InputSource::doEndJob, input_.get()));
+      c.call([this]() { sourceCoordinator_.endJob(); });
       if (looper_) {
         c.call(std::bind(&EDLooperBase::endOfJob, looper()));
       }
@@ -855,82 +858,8 @@ namespace edm {
 #include "TransitionProcessors.icc"
   }
 
-  bool EventProcessor::checkForAsyncStopRequest(StatusCode& returnCode) {
-    bool returnValue = false;
-
-    // Look for a shutdown signal
-    if (shutdown_flag.load(std::memory_order_acquire)) {
-      returnValue = true;
-      edm::LogSystem("ShutdownSignal") << "an external signal was sent to shutdown the job early.";
-      edm::Service<edm::JobReport> jr;
-      jr->reportShutdownSignal();
-      returnCode = epSignal;
-    }
-    return returnValue;
-  }
-
-  namespace {
-    struct SourceNextGuard {
-      SourceNextGuard(edm::ActivityRegistry& iReg) : act_(iReg) { iReg.preSourceNextTransitionSignal_.emit(); }
-      ~SourceNextGuard() { act_.postSourceNextTransitionSignal_.emit(); }
-      edm::ActivityRegistry& act_;
-    };
-  }  // namespace
-
-  SourceStatus EventProcessor::findNextTransitionType() {
-    SendSourceTerminationSignalIfException sentry(actReg_.get());
-    SourceStatus returnValue;
-    {
-      SourceNextGuard guard(*actReg_.get());
-      //For now, do nothing with InputSource::IsSynchronize
-      InputSource::ItemTypeInfo itemTypeInfo;
-      do {
-        itemTypeInfo = input_->nextItemType();
-      } while (itemTypeInfo == InputSource::ItemType::IsSynchronize);
-      returnValue.setNextTransitionType(itemTypeInfo);
-      if (returnValue.nextTransitionType().itemType() == InputSource::ItemType::IsRun) {
-        returnValue.setRunAuxiliary(*input_->runAuxiliary());
-        returnValue.setReducedProcessHistoryID(input_->reducedProcessHistoryID());
-      } else if (returnValue.nextTransitionType().itemType() == InputSource::ItemType::IsLumi) {
-        returnValue.setLuminosityBlockAuxiliary(*input_->luminosityBlockAuxiliary());
-        returnValue.setReducedProcessHistoryID(input_->reducedProcessHistoryID());
-      }
-    }
-    sentry.completedSuccessfully();
-
-    StatusCode returnCode = epSuccess;
-
-    if (checkForAsyncStopRequest(returnCode)) {
-      actReg_->preSourceEarlyTerminationSignal_.emit(TerminationOrigin::ExternalSignal);
-      returnValue.setNextTransitionType(InputSource::ItemType::IsStop);
-    }
-
-    return returnValue;
-  }
-
-  void EventProcessor::nextTransitionTypeThatIsNotTheSameRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                                                  WaitingTaskHolder nextTask,
-                                                                  SourceStatus& lastTransition) {
-    auto group = nextTask.group();
-    sourceResourcesAcquirer_.serialQueueChain().push(
-        *group, [this, runStatus = std::move(iRunStatus), nextHolder = std::move(nextTask), &lastTransition]() mutable {
-          CMS_SA_ALLOW try {
-            ServiceRegistry::Operate operate(serviceToken_);
-            std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-            assert(lastTransition.needToCallNext());
-            lastTransition = findNextTransitionType();
-            if (lastTransition.nextTransitionType() == InputSource::ItemType::IsRun &&
-                runStatus->runPrincipal()->run() == lastTransition.runAuxiliary()->run() &&
-                runStatus->runPrincipal()->reducedProcessHistoryID() == lastTransition.reducedProcessHistoryID()) {
-              throw Exception(errors::LogicError)
-                  << "InputSource claimed previous Run Entry was last to be merged in this file,\n"
-                  << "but the next entry has the same run number and reduced ProcessHistoryID.\n"
-                  << "This is probably a bug in the InputSource. Please report to the Core group.\n";
-            }
-          } catch (...) {
-            nextHolder.doneWaiting(std::current_exception());
-          }
-        });
+  [[nodiscard]] SourceStatus EventProcessor::thread_unsafe_peekNextTransitionType() {
+    return sourceCoordinator_.thread_unsafe_peekNextTransitionType();
   }
 
   EventProcessor::StatusCode EventProcessor::runToCompletion() {
@@ -963,7 +892,7 @@ namespace edm {
           }
           if (trans.nextTransitionType() != InputSource::ItemType::IsStop) {
             //problem with the source
-            doErrorStuff();
+            doErrorStuff(trans.nextTransitionType().itemType());
 
             throw cms::Exception("BadTransition")
                 << "Unexpected transition change " << static_cast<int>(trans.nextTransitionType().itemType());
@@ -1009,13 +938,12 @@ namespace edm {
       streamRunStatus_[0]->runPrincipal()->preReadFile();
     }
 
-    auto oldCacheID = input_->productRegistry().cacheIdentifier();
-    fb_ = input_->readFile();
+    auto [fb, sourceReg] = sourceCoordinator_.readFile();
+    fb_ = std::move(fb);
     //incase the input's registry changed
-    if (input_->productRegistry().cacheIdentifier() != oldCacheID) {
+    if (sourceReg) {
       auto temp = std::make_shared<edm::ProductRegistry>(*preg_);
-      temp->merge(
-          input_->productRegistry(), fb_ ? fb_->fileName() : std::string(), ProductDescription::FromInputToCurrent);
+      temp->merge(*sourceReg, fb_ ? fb_->fileName() : std::string(), ProductDescription::FromInputToCurrent);
       preg_ = std::move(temp);
     }
     if (preallocations_.numberOfStreams() > 1 and preallocations_.numberOfThreads() > 1) {
@@ -1027,7 +955,7 @@ namespace edm {
   void EventProcessor::closeInputFile(bool cleaningUpAfterException) {
     if (fileBlockValid()) {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
-      input_->closeFile(fb_.get(), cleaningUpAfterException);
+      sourceCoordinator_.closeFile(fb_.get(), cleaningUpAfterException);
       sentry.completedSuccessfully();
     }
   }
@@ -1085,18 +1013,15 @@ namespace edm {
     return true;
   }
 
-  void EventProcessor::rewindInput() {
-    input_->repeat();
-    input_->rewind();
-  }
+  void EventProcessor::rewindInput() { sourceCoordinator_.rewind(); }
 
   void EventProcessor::prepareForNextLoop() { looper_->prepareForNextLoop(esp_.get()); }
 
   bool EventProcessor::shouldWeCloseOutput() const { return schedule_->shouldWeCloseOutput(); }
 
-  void EventProcessor::doErrorStuff() {
-    LogError("StateMachine") << "The EventProcessor state machine encountered an unexpected event\n"
-                             << "and went to the error state\n"
+  void EventProcessor::doErrorStuff(InputSource::ItemType itemType) {
+    LogError("StateMachine") << "The EventProcessor state machine encountered an unexpected event transition of type ("
+                             << static_cast<int>(itemType) << ")\nand went to the error state\n"
                              << "Will attempt to terminate processing normally\n"
                              << "(IF using the looper the next loop will be attempted)\n"
                              << "This likely indicates a bug in an input module or corrupted input or both\n";
@@ -1118,10 +1043,10 @@ namespace edm {
   }
 
   void EventProcessor::inputProcessBlocks() {
-    input_->fillProcessBlockHelper();
+    sourceCoordinator_.fillProcessBlockHelper();
     ProcessBlockPrincipal& processBlockPrincipal = principalCache_.inputProcessBlockPrincipal();
-    while (input_->nextProcessBlock(processBlockPrincipal)) {
-      readProcessBlock(processBlockPrincipal);
+    while (sourceCoordinator_.nextProcessBlock(processBlockPrincipal)) {
+      sourceCoordinator_.readProcessBlock(processBlockPrincipal);
 
       using Traits = OccurrenceTraits<ProcessBlockPrincipal, TransitionActionProcessBlockInput>;
       FinalWaitingTask globalWaitTask{taskGroup_};
@@ -1175,16 +1100,21 @@ namespace edm {
       assert(streamRunActive_ == preallocations_.numberOfStreams());
 
       auto runStatus = streamRunStatus_[0];
+      assert(runStatus);
+      if (returnValue.nextTransitionType() == InputSource::ItemType::IsRun) {
+        assert(runStatus->runPrincipal());
+        auto& runPrincipal = *runStatus->runPrincipal();
+        //If a file open happened and we are continuing the Run we may need
+        // to do the update
+        runPrincipal.possiblyUpdateAfterAddition(preg());
 
-      while (returnValue.nextTransitionType() == InputSource::ItemType::IsRun and
-             runStatus->runPrincipal()->run() == returnValue.runAuxiliary()->run() and
-             runStatus->runPrincipal()->reducedProcessHistoryID() == returnValue.reducedProcessHistoryID()) {
-        readAndMergeRun(*runStatus);
-        assert(returnValue.needToCallNext());
-        returnValue = findNextTransitionType();
+        if (runPrincipal.run() == iStatus.runAuxiliary()->run() and
+            runPrincipal.reducedProcessHistoryID() == iStatus.reducedProcessHistoryID()) {
+          runPrincipal.mergeAuxiliary(*iStatus.runAuxiliary());
+          sourceCoordinator_.mergeRunIfNeeded(runPrincipal);
+        }
       }
-
-      returnValue.setNeedToCallNext(false);
+      returnValue = sourceCoordinator_.thread_unsafe_peekNextTransitionType();
 
       WaitingTaskHolder holder{taskGroup_, &waitTask};
       runStatus->setHolderOfTaskInProcessRuns(holder);
@@ -1215,25 +1145,12 @@ namespace edm {
   void EventProcessor::readRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
                                     WaitingTaskHolder iNextTask,
                                     SourceStatus& oSourceStatus) {
-    sourceResourcesAcquirer_.serialQueueChain().push(
-        *iNextTask.group(), [this, iRunStatus, iNextTask, &oSourceStatus]() mutable {
-          CMS_SA_ALLOW try {
-            ServiceRegistry::Operate operate(serviceToken_);
-            {
-              std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-              iRunStatus->setRunPrincipal(readRun());
-
-              RunPrincipal& runPrincipal = *iRunStatus->runPrincipal();
-              {
-                SendSourceTerminationSignalIfException sentry(actReg_.get());
-                input_->doBeginRun(runPrincipal, &processContext_);
-                sentry.completedSuccessfully();
-              }
-            }
-          } catch (...) {
-            iNextTask.doneWaiting(std::current_exception());
-          }
-        });
+    auto rp = principalCache_.getAvailableRunPrincipalPtr();
+    //a new file may have been opened since the last use of this Run
+    rp->possiblyUpdateAfterAddition(preg());
+    rp->setAux(*oSourceStatus.runAuxiliary());
+    iRunStatus->setRunPrincipal(rp);
+    sourceCoordinator_.readNewRunAsync(iRunStatus, processContext_, *historyAppender_, oSourceStatus, iNextTask);
   }
 
   void EventProcessor::beginRunAsync(IOVSyncValue const& iSync,
@@ -1281,29 +1198,15 @@ namespace edm {
 
                 chain::first([this, runStatus, &oSourceStatus](auto nextTask) mutable {
                   readRunAsync(runStatus, nextTask, oSourceStatus);
+                }) | chain::then([this, runStatus](std::exception_ptr const* iException, auto nextTask) mutable {
+                  if (iException) {
+                    //handle exception from readRunAsync
+                    WaitingTaskHolder copyHolder(nextTask);
+                    copyHolder.doneWaiting(*iException);
+                    releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus,
+                                                                                queueWhichWaitsForIOVsToFinish_);
+                  }
                 }) |
-                    chain::then(
-                        [this, runStatus, &oSourceStatus](std::exception_ptr const* iException, auto nextTask) mutable {
-                          if (iException) {
-                            //handle exception from readRunAsync
-                            WaitingTaskHolder copyHolder(nextTask);
-                            copyHolder.doneWaiting(*iException);
-                            releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
-                                *runStatus, queueWhichWaitsForIOVsToFinish_);
-                            return;
-                          }
-                          CMS_SA_ALLOW try {
-                            if (oSourceStatus.nextTransitionType().itemPosition() !=
-                                InputSource::ItemPosition::LastItemToBeMerged) {
-                              readAndMergeRunEntriesAsync(runStatus, nextTask, oSourceStatus);
-                            } else {
-                              oSourceStatus.setNeedToCallNext(true);
-                            }
-                          } catch (...) {
-                            runStatus->setStopBeforeProcessingRun(true);
-                            nextTask.doneWaiting(std::current_exception());
-                          }
-                        }) |
                     chain::ifThen(looper_ and looperBeginJobRun_.compare_exchange_strong(expectedLooperNotBegun, true),
                                   [this, runStatus](const std::exception_ptr* iException, auto nextTask) mutable {
                                     try {
@@ -1383,10 +1286,14 @@ namespace edm {
                           CMS_SA_ALLOW try {
                             // Under normal circumstances, this task runs after endRun has completed for all streams
                             // and global endLumi has completed for all lumis contained in this run
+                            //NOTE: this task does not hold open any waiting task. Instead only once the task is run does
+                            // it acquire the waiting task presently being held by the runStatus. This is on purpose as
+                            // the globalEndRun task might have to wait between new file opennings before it gets run.
                             auto globalEndRunTask =
                                 edm::make_waiting_task([this, runStatus](std::exception_ptr const*) mutable {
-                                  WaitingTaskHolder taskHolder = runStatus->holderOfTaskInProcessRuns();
-                                  runStatus->holderOfTaskInProcessRuns().doneWaiting(std::exception_ptr{});
+                                  auto tmp = runStatus->releaseHolderOfTaskInProcessRuns();
+                                  assert(tmp);
+                                  WaitingTaskHolder taskHolder = *tmp;
                                   globalEndRunAsync(std::move(taskHolder), std::move(runStatus));
                                 });
                             runStatus->setGlobalEndRunHolder(WaitingTaskHolder{*holder.group(), globalEndRunTask});
@@ -1715,26 +1622,14 @@ namespace edm {
                                      std::shared_ptr<RunProcessingStatus> iRunStatus,
                                      WaitingTaskHolder iNextTask,
                                      SourceStatus& oSourceStatus) {
-    sourceResourcesAcquirer_.serialQueueChain().push(
-        *iNextTask.group(), [this, iLumiStatus, iRunStatus, iNextTask, &oSourceStatus]() mutable {
-          CMS_SA_ALLOW try {
-            ServiceRegistry::Operate operate(serviceToken_);
-
-            {
-              std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-              iLumiStatus->setLumiPrincipal(readLuminosityBlock(iRunStatus->runPrincipal()));
-
-              LuminosityBlockPrincipal& lumiPrincipal = *iLumiStatus->lumiPrincipal();
-              {
-                SendSourceTerminationSignalIfException sentry(actReg_.get());
-                input_->doBeginLumi(lumiPrincipal, &processContext_);
-                sentry.completedSuccessfully();
-              }
-            }
-          } catch (...) {
-            iNextTask.doneWaiting(std::current_exception());
-          }
-        });
+    auto lbp = principalCache_.getAvailableLumiPrincipalPtr();
+    iLumiStatus->setLumiPrincipal(lbp);
+    //A new file may have been opened since the last use of the LuminosityBlock
+    lbp->possiblyUpdateAfterAddition(preg());
+    lbp->setAux(*oSourceStatus.lumiAuxiliary());
+    lbp->setRunPrincipal(iRunStatus->runPrincipal());
+    sourceCoordinator_.readNewLuminosityBlockAsync(
+        iLumiStatus, processContext_, *historyAppender_, oSourceStatus, iNextTask);
   }
   void EventProcessor::beginLumiAsync(IOVSyncValue const& iSync,
                                       std::shared_ptr<RunProcessingStatus> iRunStatus,
@@ -1743,7 +1638,7 @@ namespace edm {
     actReg_->esSyncIOVQueuingSignal_.emit(iSync);
 
     auto status = std::make_shared<LuminosityBlockProcessingStatus>();
-    chain::first([this, &iSync, &status, &oSourceStatus](auto nextTask) {
+    chain::first([this, &iSync, &status](auto nextTask) {
       espController_->runOrQueueEventSetupForInstanceAsync(iSync,
                                                            nextTask,
                                                            status->endIOVWaitingTasks(),
@@ -1786,12 +1681,6 @@ namespace edm {
                         nextTask.doneWaiting(*iException);
                         endRunAsync(iRunStatus, nextTask, oSourceStatus);
                         return;
-                      }
-                      if (oSourceStatus.nextTransitionType().itemPosition() !=
-                          InputSource::ItemPosition::LastItemToBeMerged) {
-                        readAndMergeLumiEntriesAsync(std::move(status), std::move(nextTask), oSourceStatus);
-                      } else {
-                        oSourceStatus.setNeedToCallNext(true);
                       }
                     }) |
                     chain::ifThen(rng.isAvailable() and rng->consumer() != nullptr,
@@ -1903,16 +1792,24 @@ namespace edm {
     chain::first([this, &oSourceStatus](auto nextTask) {
       //all streams are sharing the same status at the moment
       auto status = streamLumiStatus_[0];  //read from streamLumiActive_ happened in calling routine
-      status->thread_unsafe_setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kProcessing);
+      status->resetEventProcessingStateToProcessing();
 
-      while (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsLumi and
-             status->lumiPrincipal()->luminosityBlock() == oSourceStatus.lumiAuxiliary()->luminosityBlock()) {
-        readAndMergeLumi(*status);
-        assert(not oSourceStatus.needToCallNext());
-        oSourceStatus = findNextTransitionType();
-        //Need to tell event processing loop that we called nextTransitionType while merging lumis so it doesn't call it again and possibly skip entries
-        oSourceStatus.setNeedToCallNext(false);
+      if (oSourceStatus.nextTransitionType() != InputSource::ItemType::IsLumi) {
+        nextTask.doneWaiting(std::exception_ptr());
+        return;
       }
+      assert(status->lumiPrincipal() != nullptr);
+      auto& lumiPrincipal = *status->lumiPrincipal();
+      //If a file was opened and the LuminosityBlock is continuing
+      // we may need to do the update
+      lumiPrincipal.possiblyUpdateAfterAddition(preg());
+      assert(oSourceStatus.lumiAuxiliary() != nullptr);
+      if (oSourceStatus.lumiAuxiliary()->luminosityBlock() == lumiPrincipal.luminosityBlock()) {
+        lumiPrincipal.mergeAuxiliary(*oSourceStatus.lumiAuxiliary());
+
+        sourceCoordinator_.mergeLuminosityBlockIfNeeded(lumiPrincipal);
+      }
+      oSourceStatus = sourceCoordinator_.thread_unsafe_peekNextTransitionType();
     }) | chain::then([this, &oSourceStatus](auto nextTask) mutable {
       unsigned int streamIndex = 0;
       oneapi::tbb::task_arena arena{oneapi::tbb::task_arena::attach()};
@@ -2060,73 +1957,6 @@ namespace edm {
     }
   }
 
-  void EventProcessor::readProcessBlock(ProcessBlockPrincipal& processBlockPrincipal) {
-    SendSourceTerminationSignalIfException sentry(actReg_.get());
-    input_->readProcessBlock(processBlockPrincipal);
-    sentry.completedSuccessfully();
-  }
-
-  std::shared_ptr<RunPrincipal> EventProcessor::readRun() {
-    auto rp = principalCache_.getAvailableRunPrincipalPtr();
-    //a new file may have been opened since the last use of this Run
-    rp->possiblyUpdateAfterAddition(preg());
-    assert(rp);
-    rp->setAux(*input_->runAuxiliary());
-    {
-      SendSourceTerminationSignalIfException sentry(actReg_.get());
-      input_->readRun(*rp, *historyAppender_);
-      sentry.completedSuccessfully();
-    }
-    assert(input_->reducedProcessHistoryID() == rp->reducedProcessHistoryID());
-    return rp;
-  }
-
-  void EventProcessor::readAndMergeRun(RunProcessingStatus& iStatus) {
-    RunPrincipal& runPrincipal = *iStatus.runPrincipal();
-    //If a file open happened and we are continuing the Run we may need
-    // to do the update
-    runPrincipal.possiblyUpdateAfterAddition(preg());
-
-    runPrincipal.mergeAuxiliary(*input_->runAuxiliary());
-    {
-      SendSourceTerminationSignalIfException sentry(actReg_.get());
-      input_->readAndMergeRun(runPrincipal);
-      sentry.completedSuccessfully();
-    }
-  }
-
-  std::shared_ptr<LuminosityBlockPrincipal> EventProcessor::readLuminosityBlock(std::shared_ptr<RunPrincipal> rp) {
-    auto lbp = principalCache_.getAvailableLumiPrincipalPtr();
-    //A new file may have been opened since the last use of the LuminosityBlock
-    lbp->possiblyUpdateAfterAddition(preg());
-    assert(lbp);
-    lbp->setAux(*input_->luminosityBlockAuxiliary());
-    {
-      SendSourceTerminationSignalIfException sentry(actReg_.get());
-      input_->readLuminosityBlock(*lbp, *historyAppender_);
-      sentry.completedSuccessfully();
-    }
-    lbp->setRunPrincipal(std::move(rp));
-    return lbp;
-  }
-
-  void EventProcessor::readAndMergeLumi(LuminosityBlockProcessingStatus& iStatus) {
-    auto& lumiPrincipal = *iStatus.lumiPrincipal();
-    assert(lumiPrincipal.aux().sameIdentity(*input_->luminosityBlockAuxiliary()) or
-           input_->processHistoryRegistry().reducedProcessHistoryID(lumiPrincipal.aux().processHistoryID()) ==
-               input_->processHistoryRegistry().reducedProcessHistoryID(
-                   input_->luminosityBlockAuxiliary()->processHistoryID()));
-    //If a file was opened and the LuminosityBlock is continuing
-    // we may need to do the update
-    lumiPrincipal.possiblyUpdateAfterAddition(preg());
-    lumiPrincipal.mergeAuxiliary(*input_->luminosityBlockAuxiliary());
-    {
-      SendSourceTerminationSignalIfException sentry(actReg_.get());
-      input_->readAndMergeLumi(*iStatus.lumiPrincipal());
-      sentry.completedSuccessfully();
-    }
-  }
-
   void EventProcessor::writeProcessBlockAsync(WaitingTaskHolder task, ProcessBlockType processBlockType) {
     ServiceRegistry::Operate op(serviceToken_);
     // Don't move task because the lifetime of the task should be greater than the lifetime of the Operate object
@@ -2167,81 +1997,16 @@ namespace edm {
     iStatus.lumiPrincipal()->clearPrincipal();
   }
 
-  void EventProcessor::readAndMergeRunEntriesAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                                   WaitingTaskHolder iHolder,
-                                                   SourceStatus& oSourceStatus) {
-    auto group = iHolder.group();
-    sourceResourcesAcquirer_.serialQueueChain().push(
-        *group, [this, status = std::move(iRunStatus), holder = std::move(iHolder), &oSourceStatus]() mutable {
-          CMS_SA_ALLOW try {
-            ServiceRegistry::Operate operate(serviceToken_);
-
-            std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-            oSourceStatus = findNextTransitionType();
-            oSourceStatus.setNeedToCallNext(false);
-
-            while (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsRun and
-                   status->runPrincipal()->run() == oSourceStatus.runAuxiliary()->run() and
-                   status->runPrincipal()->reducedProcessHistoryID() == oSourceStatus.reducedProcessHistoryID()) {
-              if (status->holderOfTaskInProcessRuns().taskHasFailed()) {
-                status->setStopBeforeProcessingRun(true);
-                return;
-              }
-              readAndMergeRun(*status);
-              if (oSourceStatus.nextTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
-                oSourceStatus.setNeedToCallNext(true);
-                return;
-              }
-              assert(not oSourceStatus.needToCallNext());
-              oSourceStatus = findNextTransitionType();
-              oSourceStatus.setNeedToCallNext(false);
-            }
-          } catch (...) {
-            status->setStopBeforeProcessingRun(true);
-            holder.doneWaiting(std::current_exception());
-          }
-        });
-  }
-
-  void EventProcessor::readAndMergeLumiEntriesAsync(std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus,
-                                                    WaitingTaskHolder iHolder,
-                                                    SourceStatus& oSourceStatus) {
-    auto group = iHolder.group();
-    sourceResourcesAcquirer_.serialQueueChain().push(
-        *group, [this, iLumiStatus = std::move(iLumiStatus), holder = std::move(iHolder), &oSourceStatus]() mutable {
-          CMS_SA_ALLOW try {
-            ServiceRegistry::Operate operate(serviceToken_);
-
-            std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-
-            oSourceStatus = findNextTransitionType();
-            oSourceStatus.setNeedToCallNext(false);
-
-            while (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsLumi and
-                   iLumiStatus->lumiPrincipal()->luminosityBlock() ==
-                       oSourceStatus.lumiAuxiliary()->luminosityBlock()) {
-              readAndMergeLumi(*iLumiStatus);
-              if (oSourceStatus.nextTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
-                oSourceStatus.setNeedToCallNext(true);
-                return;
-              }
-              assert(not oSourceStatus.needToCallNext());
-              oSourceStatus = findNextTransitionType();
-              //Need to tell event processing loop that we called nextTransitionType while merging lumis so it doesn't call it again and possibly skip entries
-              oSourceStatus.setNeedToCallNext(false);
-            }
-          } catch (...) {
-            holder.doneWaiting(std::current_exception());
-          }
-        });
-  }
-
   void EventProcessor::handleNextItemAfterMergingRunEntriesAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
                                                                  WaitingTaskHolder iHolder,
                                                                  SourceStatus& oSourceStatus) {
     chain::first([this, iRunStatus, &oSourceStatus](auto nextTask) mutable {
       if (oSourceStatus.needToCallNext()) {
-        nextTransitionTypeThatIsNotTheSameRunAsync(std::move(iRunStatus), std::move(nextTask), oSourceStatus);
+        sourceCoordinator_.peekNextTransitionTypeThatIsNotTheSameRunAsync(
+            iRunStatus->runPrincipal()->run(),
+            iRunStatus->runPrincipal()->reducedProcessHistoryID(),
+            oSourceStatus,
+            std::move(nextTask));
       }
     }) | chain::then([this, iRunStatus, &oSourceStatus](std::exception_ptr const* iException, auto nextTask) {
       ServiceRegistry::Operate operate(serviceToken_);
@@ -2250,7 +2015,8 @@ namespace edm {
         copyHolder.doneWaiting(*iException);
       }
       if (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsFile) {
-        iRunStatus->holderOfTaskInProcessRuns().doneWaiting(std::exception_ptr{});
+        nextTask.doneWaiting(std::exception_ptr());
+        iRunStatus->setHolderOfTaskInProcessRunsDoneWaiting();
         return;
       }
       if (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsLumi && !nextTask.taskHasFailed()) {
@@ -2274,64 +2040,6 @@ namespace edm {
     }) | chain::runLast(std::move(iHolder));
   }
 
-  EventProcessor::ReadNextEventForStreamResult EventProcessor::readNextEventForStream(
-      unsigned int iStreamIndex, LuminosityBlockProcessingStatus& iStatus, SourceStatus& oSourceStatus) {
-    // This function returns true if it successfully reads an event for the stream and that
-    // requires both that an event is next and there are no problems or requests to stop.
-
-    ServiceRegistry::Operate operate(serviceToken_);
-
-    // need to use lock in addition to the serial task queue because
-    // of delayed provenance reading and reading data in response to
-    // edm::Refs etc
-    std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-
-    // If we didn't already call nextTransitionType while merging lumis, call it here.
-    // This asks the input source what is next and also checks for signals.
-
-    auto findTransitionType = [this](SourceStatus& oSourceStatus) -> InputSource::ItemType {
-      if (oSourceStatus.needToCallNext()) {
-        oSourceStatus = findNextTransitionType();
-      }
-      oSourceStatus.setNeedToCallNext(true);
-      return oSourceStatus.nextTransitionType();
-    };
-    InputSource::ItemType itemType = findTransitionType(oSourceStatus);
-
-    if (InputSource::ItemType::IsEvent != itemType) {
-      // IsFile may continue processing the lumi and
-      // looper_ can cause the input source to declare a new IsRun which is actually
-      // just a continuation of the previous run
-      if (InputSource::ItemType::IsStop == itemType or InputSource::ItemType::IsLumi == itemType or
-          (InputSource::ItemType::IsRun == itemType and
-           (iStatus.lumiPrincipal()->run() != oSourceStatus.runAuxiliary()->run() or
-            iStatus.lumiPrincipal()->runPrincipal().reducedProcessHistoryID() !=
-                oSourceStatus.reducedProcessHistoryID()))) {
-        if (itemType == InputSource::ItemType::IsLumi &&
-            iStatus.lumiPrincipal()->luminosityBlock() == oSourceStatus.lumiAuxiliary()->luminosityBlock()) {
-          throw Exception(errors::LogicError)
-              << "InputSource claimed previous Lumi Entry was last to be merged in this file,\n"
-              << "but the next lumi entry has the same lumi number.\n"
-              << "This is probably a bug in the InputSource. Please report to the Core group.\n";
-        }
-        iStatus.thread_unsafe_setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
-      } else {
-        iStatus.thread_unsafe_setEventProcessingState(
-            LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition);
-      }
-      return {.didCallReadEvent = false,
-              .stopLumi = iStatus.thread_unsafe_eventProcessingState() ==
-                          LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi,
-              .nextTransitionType = oSourceStatus.nextTransitionType(),
-              .mustStartNextLumiOrEndRun = false};
-    }
-    readEvent(iStreamIndex);
-    return {.didCallReadEvent = true,
-            .stopLumi = false,
-            .nextTransitionType = oSourceStatus.nextTransitionType(),
-            .mustStartNextLumiOrEndRun = false};
-  }
-
   void EventProcessor::handleNextEventForStreamAsync(std::exception_ptr const* iExceptionPtr,
                                                      WaitingTaskHolder iTask,
                                                      unsigned int iStreamIndex,
@@ -2341,82 +2049,32 @@ namespace edm {
       copyHolder.doneWaiting(*iExceptionPtr);
       //we do not return here because we want the code in the chain to properly handle ending the lumi and run if needed, which is handled by the same code for exceptions as for normal end of lumi/run
     }
+    assert(streamLumiStatus_[iStreamIndex]);
     if (streamLumiStatus_[iStreamIndex]->haveStartedNextLumiOrEndedRun()) {
       streamEndLumiAsync(iTask, iStreamIndex);
       return;
     }
     bool earlierTaskFailed = iTask.taskHasFailed();
-    auto resultFromReadNextEventForStream = std::make_unique<ReadNextEventForStreamResult>(false);
-    ReadNextEventForStreamResult* ptrToResultFromReadNextEventForStream = resultFromReadNextEventForStream.get();
-    chain::first([this, iStreamIndex, &oSourceStatus, earlierTaskFailed, ptrToResultFromReadNextEventForStream](
-                     auto nextTask) mutable {
-      auto group = nextTask.group();
-      sourceResourcesAcquirer_.serialQueueChain().push(
-          *group,
-          [this,
-           earlierTaskFailed,
-           iTask = std::move(nextTask),
-           iStreamIndex,
-           &oSourceStatus,
-           ptrToResultFromReadNextEventForStream]() mutable {
-            bool aFailureHappened = earlierTaskFailed;
-            if (not earlierTaskFailed) {
-              auto status = streamLumiStatus_[iStreamIndex].get();
+    auto resultFromReadNextEventForStream = std::make_unique<SourceCoordinator::ReadNextEventForStreamResult>(false);
+    auto* ptrToResultFromReadNextEventForStream = resultFromReadNextEventForStream.get();
+    bool needToStop = shouldWeStop();
+    chain::first(
+        [this, iStreamIndex, &oSourceStatus, earlierTaskFailed, ptrToResultFromReadNextEventForStream, needToStop](
+            auto nextTask) mutable {
+          auto& event = principalCache_.eventPrincipal(iStreamIndex);
+          // a new file may have been read since the last time this event was used
+          event.possiblyUpdateAfterAddition(preg());
 
-              // Did another stream already stop or pause this lumi?
-              if (status->thread_unsafe_eventProcessingState() !=
-                  LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
-                *ptrToResultFromReadNextEventForStream = {
-                    .didCallReadEvent = false,
-                    .stopLumi = status->thread_unsafe_eventProcessingState() ==
-                                LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi,
-                    .nextTransitionType = oSourceStatus.nextTransitionType(),
-                    .mustStartNextLumiOrEndRun = false};
-              } else if (shouldWeStop()) {
-                // Are output modules or the looper requesting we stop?
-                oSourceStatus.setNextTransitionType(InputSource::ItemType::IsStop);
-                status->thread_unsafe_setEventProcessingState(
-                    LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
-                *ptrToResultFromReadNextEventForStream = {.didCallReadEvent = false,
-                                                          .stopLumi = true,
-                                                          .nextTransitionType = InputSource::ItemType::IsStop,
-                                                          .mustStartNextLumiOrEndRun = false};
-              } else {
-                CMS_SA_ALLOW try {
-                  ServiceRegistry::Operate operate(serviceToken_);
-                  *ptrToResultFromReadNextEventForStream = readNextEventForStream(iStreamIndex, *status, oSourceStatus);
-                } catch (...) {
-                  aFailureHappened = true;
-                  WaitingTaskHolder copyHolder(iTask);
-                  copyHolder.doneWaiting(std::current_exception());
-                }
-              }
-            }
-            if (aFailureHappened) {
-              // We want all streams to stop or all streams to pause. If we are already in the
-              // middle of pausing streams, then finish pausing all of them and the lumi will be
-              // ended later. Otherwise, just end it now.
-              auto status = streamLumiStatus_[iStreamIndex].get();
-              if (status->thread_unsafe_eventProcessingState() ==
-                  LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
-                status->thread_unsafe_setEventProcessingState(
-                    LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
-              }
-              *ptrToResultFromReadNextEventForStream = {.didCallReadEvent = false,
-                                                        .stopLumi = true,
-                                                        .nextTransitionType = InputSource::ItemType::IsStop,
-                                                        .mustStartNextLumiOrEndRun = false};
-            }
-
-            auto status = streamLumiStatus_[iStreamIndex].get();
-            if (not ptrToResultFromReadNextEventForStream->didCallReadEvent and
-                status->thread_unsafe_eventProcessingState() ==
-                    LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi and
-                status->startNextLumiOrEndRun()) {
-              ptrToResultFromReadNextEventForStream->mustStartNextLumiOrEndRun = true;
-            }
-          });
-    }) |
+          sourceCoordinator_.readNextEventForStreamAsync(event,
+                                                         processContext_,
+                                                         *streamLumiStatus_[iStreamIndex],
+                                                         *streamRunStatus_[iStreamIndex],
+                                                         earlierTaskFailed,
+                                                         needToStop,
+                                                         *ptrToResultFromReadNextEventForStream,
+                                                         oSourceStatus,
+                                                         nextTask);
+        }) |
         chain::then([this,
                      iStreamIndex,
                      &oSourceStatus,
@@ -2465,10 +2123,8 @@ namespace edm {
                 //if both of these conditions are false, then we must have had a file transition and we need to pause the stream until all streams are ready to continue. Note that in this case we do not call endRunAsync or beginLumiAsync here. The stream will just pause until the lumi is ended or the next lumi is started at which point it will be resumed and endRunAsync or beginLumiAsync will be called at that time if appropriate.
                 assert(not retValue->didCallReadEvent and not retValue->stopLumi);
                 auto runStatus = streamRunStatus_[iStreamIndex].get();
-
-                if (runStatus->holderOfTaskInProcessRuns().hasTask()) {
-                  runStatus->holderOfTaskInProcessRuns().doneWaiting(std::exception_ptr{});
-                }
+                assert(runStatus);
+                runStatus->setHolderOfTaskInProcessRunsDoneWaiting();
               }
             }
           } catch (...) {
@@ -2477,21 +2133,6 @@ namespace edm {
           }
         }) |
         chain::runLast(iTask);
-  }
-
-  void EventProcessor::readEvent(unsigned int iStreamIndex) {
-    //TODO this will have to become per stream
-    auto& event = principalCache_.eventPrincipal(iStreamIndex);
-    StreamContext streamContext(event.streamID(), &processContext_);
-    // a new file may have been read since the last time this event was used
-    event.possiblyUpdateAfterAddition(preg());
-
-    SendSourceTerminationSignalIfException sentry(actReg_.get());
-    input_->readEvent(event, streamContext);
-
-    streamRunStatus_[iStreamIndex]->updateLastTimestamp(input_->timestamp());
-    streamLumiStatus_[iStreamIndex]->updateLastTimestamp(input_->timestamp());
-    sentry.completedSuccessfully();
   }
 
   void EventProcessor::processEventAsync(WaitingTaskHolder iHolder, unsigned int iStreamIndex) {
@@ -2557,9 +2198,9 @@ namespace edm {
   }
 
   void EventProcessor::processEventWithLooper(EventPrincipal& iPrincipal, unsigned int iStreamIndex) {
-    bool randomAccess = input_->randomAccess();
-    ProcessingController::ForwardState forwardState = input_->forwardState();
-    ProcessingController::ReverseState reverseState = input_->reverseState();
+    bool randomAccess = sourceCoordinator_.randomAccess();
+    ProcessingController::ForwardState forwardState = sourceCoordinator_.forwardState();
+    ProcessingController::ReverseState reverseState = sourceCoordinator_.reverseState();
     ProcessingController pc(forwardState, reverseState, randomAccess);
 
     EDLooperBase::Status status = EDLooperBase::kContinue;
@@ -2571,9 +2212,9 @@ namespace edm {
       bool succeeded = true;
       if (randomAccess) {
         if (pc.requestedTransition() == ProcessingController::kToPreviousEvent) {
-          input_->skipEvents(-2);
+          sourceCoordinator_.skipEvents(-2);
         } else if (pc.requestedTransition() == ProcessingController::kToSpecifiedEvent) {
-          succeeded = input_->goToEvent(pc.specifiedEventTransition());
+          succeeded = sourceCoordinator_.goToEvent(pc.specifiedEventTransition());
         }
       }
       pc.setLastOperationSucceeded(succeeded);

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -2277,33 +2277,48 @@ namespace edm {
     }) | chain::runLast(std::move(iHolder));
   }
 
-  bool EventProcessor::readNextEventForStream(WaitingTaskHolder const& iTask,
-                                              unsigned int iStreamIndex,
-                                              LuminosityBlockProcessingStatus& iStatus,
-                                              SourceStatus& oSourceStatus) {
+  EventProcessor::ReadNextEventForStreamResult EventProcessor::readNextEventForStream(
+      bool earlierTaskFailed,
+      unsigned int iStreamIndex,
+      LuminosityBlockProcessingStatus& iStatus,
+      SourceStatus& oSourceStatus) {
     // This function returns true if it successfully reads an event for the stream and that
     // requires both that an event is next and there are no problems or requests to stop.
 
-    if (iTask.taskHasFailed()) {
+    if (earlierTaskFailed) {
       // We want all streams to stop or all streams to pause. If we are already in the
       // middle of pausing streams, then finish pausing all of them and the lumi will be
       // ended later. Otherwise, just end it now.
       if (iStatus.eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
         iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
       }
-      return false;
+      return {.didCallReadEvent = false,
+              .stopLumi = true,
+              .pauseForFileTransition = false,
+              .nextTransitionType = InputSource::ItemType::IsStop,
+              .mustStartNextLumiOrEndRun = false};
     }
 
     // Did another stream already stop or pause this lumi?
     if (iStatus.eventProcessingState() != LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
-      return false;
+      return {.didCallReadEvent = false,
+              .stopLumi =
+                  iStatus.eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi,
+              .pauseForFileTransition = iStatus.eventProcessingState() ==
+                                        LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition,
+              .nextTransitionType = oSourceStatus.nextTransitionType(),
+              .mustStartNextLumiOrEndRun = false};
     }
 
     // Are output modules or the looper requesting we stop?
     if (shouldWeStop()) {
       oSourceStatus.setNextTransitionType(InputSource::ItemType::IsStop);
       iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
-      return false;
+      return {.didCallReadEvent = false,
+              .stopLumi = true,
+              .pauseForFileTransition = false,
+              .nextTransitionType = InputSource::ItemType::IsStop,
+              .mustStartNextLumiOrEndRun = false};
     }
 
     ServiceRegistry::Operate operate(serviceToken_);
@@ -2345,10 +2360,20 @@ namespace edm {
       } else {
         iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition);
       }
-      return false;
+      return {.didCallReadEvent = false,
+              .stopLumi =
+                  iStatus.eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi,
+              .pauseForFileTransition = iStatus.eventProcessingState() ==
+                                        LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition,
+              .nextTransitionType = oSourceStatus.nextTransitionType(),
+              .mustStartNextLumiOrEndRun = false};
     }
     readEvent(iStreamIndex);
-    return true;
+    return {.didCallReadEvent = true,
+            .stopLumi = false,
+            .pauseForFileTransition = false,
+            .nextTransitionType = oSourceStatus.nextTransitionType(),
+            .mustStartNextLumiOrEndRun = false};
   }
 
   void EventProcessor::handleNextEventForStreamAsync(WaitingTaskHolder iTask,
@@ -2358,56 +2383,93 @@ namespace edm {
       streamEndLumiAsync(iTask, iStreamIndex);
       return;
     }
-    auto group = iTask.group();
-    sourceResourcesAcquirer_.serialQueueChain().push(
-        *group, [this, iTask = std::move(iTask), iStreamIndex, &oSourceStatus]() mutable {
-          CMS_SA_ALLOW try {
+    bool earlierTaskFailed = iTask.taskHasFailed();
+    auto resultFromReadNextEventForStream = std::make_unique<ReadNextEventForStreamResult>(false);
+    ReadNextEventForStreamResult* ptrToResultFromReadNextEventForStream = resultFromReadNextEventForStream.get();
+    chain::first([this, iStreamIndex, &oSourceStatus, earlierTaskFailed, ptrToResultFromReadNextEventForStream](
+                     auto nextTask) mutable {
+      auto group = nextTask.group();
+      sourceResourcesAcquirer_.serialQueueChain().push(
+          *group,
+          [this,
+           earlierTaskFailed,
+           iTask = std::move(nextTask),
+           iStreamIndex,
+           &oSourceStatus,
+           ptrToResultFromReadNextEventForStream]() mutable {
+            CMS_SA_ALLOW try {
+              auto status = streamLumiStatus_[iStreamIndex].get();
+              ServiceRegistry::Operate operate(serviceToken_);
+              *ptrToResultFromReadNextEventForStream =
+                  readNextEventForStream(earlierTaskFailed, iStreamIndex, *status, oSourceStatus);
+            } catch (...) {
+              WaitingTaskHolder copyHolder(iTask);
+              copyHolder.doneWaiting(std::current_exception());
+              return;
+            }
             auto status = streamLumiStatus_[iStreamIndex].get();
-            ServiceRegistry::Operate operate(serviceToken_);
-
-            if (readNextEventForStream(iTask, iStreamIndex, *status, oSourceStatus)) {
-              auto recursionTask = make_waiting_task(
-                  [this, iTask, iStreamIndex, &oSourceStatus](std::exception_ptr const* iEventException) mutable {
+            //only one thread can call status->noMoreEventsInLumi so call in source queue.
+            if (not ptrToResultFromReadNextEventForStream->didCallReadEvent and
+                status->eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi and
+                not status->haveStartedNextLumiOrEndedRun()) {
+              status->noMoreEventsInLumi();
+              status->startNextLumiOrEndRun();
+              ptrToResultFromReadNextEventForStream->mustStartNextLumiOrEndRun = true;
+            }
+          });
+    }) |
+        chain::then([this,
+                     iStreamIndex,
+                     &oSourceStatus,
+                     retValue = std::move(resultFromReadNextEventForStream),
+                     possibleFailedTask = iTask](std::exception_ptr const* iEventException,
+                                                 WaitingTaskHolder iNextTask) mutable {
+          CMS_SA_ALLOW try {
+            if (iEventException) {
+              std::rethrow_exception(*iEventException);
+            }
+            if (retValue->didCallReadEvent) {
+              chain::first([this, iStreamIndex](auto nextTask) mutable { processEventAsync(nextTask, iStreamIndex); }) |
+                  chain::then([this, iStreamIndex, &oSourceStatus](std::exception_ptr const* iEventException,
+                                                                   WaitingTaskHolder iNextTask) mutable {
                     if (iEventException) {
-                      WaitingTaskHolder copyHolder(iTask);
+                      //applying to a copy keeps the original iNextTask from starting.
+                      WaitingTaskHolder copyHolder(iNextTask);
                       copyHolder.doneWaiting(*iEventException);
                       // Intentionally, we don't return here. The recursive call to
                       // handleNextEvent takes care of immediately ending the run properly
                       // using the same code it uses to end the run in other situations.
                     }
-                    handleNextEventForStreamAsync(std::move(iTask), iStreamIndex, oSourceStatus);
-                  });
-
-              processEventAsync(WaitingTaskHolder(*iTask.group(), recursionTask), iStreamIndex);
+                    handleNextEventForStreamAsync(std::move(iNextTask), iStreamIndex, oSourceStatus);
+                  }) |
+                  chain::runLast(iNextTask);
             } else {
               // the stream will stop processing this lumi now
-              if (status->eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi) {
-                if (not status->haveStartedNextLumiOrEndedRun()) {
-                  status->noMoreEventsInLumi();
-                  status->startNextLumiOrEndRun();
-                  if (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsLumi && !iTask.taskHasFailed()) {
+              if (retValue->stopLumi) {
+                if (retValue->mustStartNextLumiOrEndRun) {
+                  if (retValue->nextTransitionType == InputSource::ItemType::IsLumi &&
+                      !possibleFailedTask.taskHasFailed()) {
                     CMS_SA_ALLOW try {
                       beginLumiAsync(IOVSyncValue(EventID(oSourceStatus.lumiAuxiliary()->run(),
                                                           oSourceStatus.lumiAuxiliary()->luminosityBlock(),
                                                           0),
                                                   oSourceStatus.lumiAuxiliary()->beginTime()),
                                      streamRunStatus_[iStreamIndex],
-                                     iTask,
+                                     iNextTask,
                                      oSourceStatus);
                     } catch (...) {
-                      WaitingTaskHolder copyHolder(iTask);
+                      WaitingTaskHolder copyHolder(iNextTask);
                       copyHolder.doneWaiting(std::current_exception());
-                      endRunAsync(streamRunStatus_[iStreamIndex], iTask, oSourceStatus);
+                      endRunAsync(streamRunStatus_[iStreamIndex], iNextTask, oSourceStatus);
                     }
                   } else {
                     // If appropriate, this will also start the next run.
-                    endRunAsync(streamRunStatus_[iStreamIndex], iTask, oSourceStatus);
+                    endRunAsync(streamRunStatus_[iStreamIndex], iNextTask, oSourceStatus);
                   }
                 }
-                streamEndLumiAsync(iTask, iStreamIndex);
+                streamEndLumiAsync(iNextTask, iStreamIndex);
               } else {
-                assert(status->eventProcessingState() ==
-                       LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition);
+                assert(retValue->pauseForFileTransition);
                 auto runStatus = streamRunStatus_[iStreamIndex].get();
 
                 if (runStatus->holderOfTaskInProcessRuns().hasTask()) {
@@ -2416,11 +2478,12 @@ namespace edm {
               }
             }
           } catch (...) {
-            WaitingTaskHolder copyHolder(iTask);
+            WaitingTaskHolder copyHolder(iNextTask);
             copyHolder.doneWaiting(std::current_exception());
-            handleNextEventForStreamAsync(std::move(iTask), iStreamIndex, oSourceStatus);
+            handleNextEventForStreamAsync(std::move(iNextTask), iStreamIndex, oSourceStatus);
           }
-        });
+        }) |
+        chain::runLast(iTask);
   }
 
   void EventProcessor::readEvent(unsigned int iStreamIndex) {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1873,11 +1873,8 @@ namespace edm {
                                           then([this, i, &oSourceStatus](
                                                    std::exception_ptr const* exceptionFromBeginStreamLumi,
                                                    auto nextTask) {
-                                            if (exceptionFromBeginStreamLumi) {
-                                              WaitingTaskHolder copyHolder(nextTask);
-                                              copyHolder.doneWaiting(*exceptionFromBeginStreamLumi);
-                                            }
-                                            handleNextEventForStreamAsync(std::move(nextTask), i, oSourceStatus);
+                                            handleNextEventForStreamAsync(
+                                                exceptionFromBeginStreamLumi, std::move(nextTask), i, oSourceStatus);
                                           }) |
                                           runLast(std::move(holder));
                                     });
@@ -1921,11 +1918,11 @@ namespace edm {
       oneapi::tbb::task_arena arena{oneapi::tbb::task_arena::attach()};
       for (; streamIndex < preallocations_.numberOfStreams() - 1; ++streamIndex) {
         arena.enqueue([this, streamIndex, h = nextTask, &oSourceStatus]() {
-          handleNextEventForStreamAsync(h, streamIndex, oSourceStatus);
+          handleNextEventForStreamAsync(nullptr, h, streamIndex, oSourceStatus);
         });
       }
       nextTask.group()->run([this, streamIndex, h = std::move(nextTask), &oSourceStatus]() {
-        handleNextEventForStreamAsync(h, streamIndex, oSourceStatus);
+        handleNextEventForStreamAsync(nullptr, h, streamIndex, oSourceStatus);
       });
     }) | chain::runLast(std::move(iHolder));
   }
@@ -2278,26 +2275,9 @@ namespace edm {
   }
 
   EventProcessor::ReadNextEventForStreamResult EventProcessor::readNextEventForStream(
-      bool earlierTaskFailed,
-      unsigned int iStreamIndex,
-      LuminosityBlockProcessingStatus& iStatus,
-      SourceStatus& oSourceStatus) {
+      unsigned int iStreamIndex, LuminosityBlockProcessingStatus& iStatus, SourceStatus& oSourceStatus) {
     // This function returns true if it successfully reads an event for the stream and that
     // requires both that an event is next and there are no problems or requests to stop.
-
-    if (earlierTaskFailed) {
-      // We want all streams to stop or all streams to pause. If we are already in the
-      // middle of pausing streams, then finish pausing all of them and the lumi will be
-      // ended later. Otherwise, just end it now.
-      if (iStatus.eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
-        iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
-      }
-      return {.didCallReadEvent = false,
-              .stopLumi = true,
-              .pauseForFileTransition = false,
-              .nextTransitionType = InputSource::ItemType::IsStop,
-              .mustStartNextLumiOrEndRun = false};
-    }
 
     // Did another stream already stop or pause this lumi?
     if (iStatus.eventProcessingState() != LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
@@ -2376,9 +2356,15 @@ namespace edm {
             .mustStartNextLumiOrEndRun = false};
   }
 
-  void EventProcessor::handleNextEventForStreamAsync(WaitingTaskHolder iTask,
+  void EventProcessor::handleNextEventForStreamAsync(std::exception_ptr const* iExceptionPtr,
+                                                     WaitingTaskHolder iTask,
                                                      unsigned int iStreamIndex,
                                                      SourceStatus& oSourceStatus) {
+    if (iExceptionPtr) {
+      WaitingTaskHolder copyHolder(iTask);
+      copyHolder.doneWaiting(*iExceptionPtr);
+      //we do not return here because we want the code in the chain to properly handle ending the lumi and run if needed, which is handled by the same code for exceptions as for normal end of lumi/run
+    }
     if (streamLumiStatus_[iStreamIndex]->haveStartedNextLumiOrEndedRun()) {
       streamEndLumiAsync(iTask, iStreamIndex);
       return;
@@ -2397,16 +2383,34 @@ namespace edm {
            iStreamIndex,
            &oSourceStatus,
            ptrToResultFromReadNextEventForStream]() mutable {
-            CMS_SA_ALLOW try {
-              auto status = streamLumiStatus_[iStreamIndex].get();
-              ServiceRegistry::Operate operate(serviceToken_);
-              *ptrToResultFromReadNextEventForStream =
-                  readNextEventForStream(earlierTaskFailed, iStreamIndex, *status, oSourceStatus);
-            } catch (...) {
-              WaitingTaskHolder copyHolder(iTask);
-              copyHolder.doneWaiting(std::current_exception());
-              return;
+            bool aFailureHappened = earlierTaskFailed;
+            if (not earlierTaskFailed) {
+              CMS_SA_ALLOW try {
+                auto status = streamLumiStatus_[iStreamIndex].get();
+                ServiceRegistry::Operate operate(serviceToken_);
+                *ptrToResultFromReadNextEventForStream = readNextEventForStream(iStreamIndex, *status, oSourceStatus);
+              } catch (...) {
+                aFailureHappened = true;
+                WaitingTaskHolder copyHolder(iTask);
+                copyHolder.doneWaiting(std::current_exception());
+              }
             }
+            if (aFailureHappened) {
+              // We want all streams to stop or all streams to pause. If we are already in the
+              // middle of pausing streams, then finish pausing all of them and the lumi will be
+              // ended later. Otherwise, just end it now.
+              auto status = streamLumiStatus_[iStreamIndex].get();
+              if (status->eventProcessingState() ==
+                  LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
+                status->setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
+              }
+              *ptrToResultFromReadNextEventForStream = {.didCallReadEvent = false,
+                                                        .stopLumi = true,
+                                                        .pauseForFileTransition = false,
+                                                        .nextTransitionType = InputSource::ItemType::IsStop,
+                                                        .mustStartNextLumiOrEndRun = false};
+            }
+
             auto status = streamLumiStatus_[iStreamIndex].get();
             //only one thread can call status->noMoreEventsInLumi so call in source queue.
             if (not ptrToResultFromReadNextEventForStream->didCallReadEvent and
@@ -2426,21 +2430,15 @@ namespace edm {
                                                  WaitingTaskHolder iNextTask) mutable {
           CMS_SA_ALLOW try {
             if (iEventException) {
-              std::rethrow_exception(*iEventException);
+              WaitingTaskHolder copyHolder(iNextTask);
+              copyHolder.doneWaiting(*iEventException);
+              //NOTE: the ptrToResultFromReadNextEventForStream has already been set to deal with how the exception should be handled, so we don't need to do anything else here.
             }
             if (retValue->didCallReadEvent) {
               chain::first([this, iStreamIndex](auto nextTask) mutable { processEventAsync(nextTask, iStreamIndex); }) |
                   chain::then([this, iStreamIndex, &oSourceStatus](std::exception_ptr const* iEventException,
                                                                    WaitingTaskHolder iNextTask) mutable {
-                    if (iEventException) {
-                      //applying to a copy keeps the original iNextTask from starting.
-                      WaitingTaskHolder copyHolder(iNextTask);
-                      copyHolder.doneWaiting(*iEventException);
-                      // Intentionally, we don't return here. The recursive call to
-                      // handleNextEvent takes care of immediately ending the run properly
-                      // using the same code it uses to end the run in other situations.
-                    }
-                    handleNextEventForStreamAsync(std::move(iNextTask), iStreamIndex, oSourceStatus);
+                    handleNextEventForStreamAsync(iEventException, std::move(iNextTask), iStreamIndex, oSourceStatus);
                   }) |
                   chain::runLast(iNextTask);
             } else {
@@ -2480,7 +2478,6 @@ namespace edm {
           } catch (...) {
             WaitingTaskHolder copyHolder(iNextTask);
             copyHolder.doneWaiting(std::current_exception());
-            handleNextEventForStreamAsync(std::move(iNextTask), iStreamIndex, oSourceStatus);
           }
         }) |
         chain::runLast(iTask);

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1189,7 +1189,6 @@ namespace edm {
                 }
 
                 runStatus->setResumer(std::move(iResumer));
-                bool expectedLooperNotBegun = false;
 
                 std::unique_ptr<SourceStatus> newSourceStatus = std::make_unique<SourceStatus>();
                 auto pNewStatus = newSourceStatus.get();
@@ -1204,39 +1203,30 @@ namespace edm {
                                                                                 queueWhichWaitsForIOVsToFinish_);
                   }
                 }) |
-                    chain::ifThen(looper_ and looperBeginJobRun_.compare_exchange_strong(expectedLooperNotBegun, true),
+                    chain::ifThen(looper_ and not looperBeginJobRun_.exchange(true),
                                   [this, runStatus](const std::exception_ptr* iException, auto nextTask) mutable {
-                                    try {
-                                      looper_->copyInfo(ScheduleInfo(schedule_.get()));
-                                    } catch (...) {
-                                      nextTask.doneWaiting(std::current_exception());
-                                      releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
-                                          *runStatus, queueWhichWaitsForIOVsToFinish_);
-                                    }
-                                  }) |
-                    chain::ifThen(looper_ and looperBeginJobRun_.load(),
-                                  [this, runStatus](auto nextTask) mutable {
-                                    CMS_SA_ALLOW try {
-                                      EventSetupImpl const& es = runStatus->eventSetupImpl();
-                                      looper_->esPrefetchAsync(nextTask, es, Transition::BeginRun, serviceToken_);
-                                    } catch (...) {
-                                      nextTask.doneWaiting(std::current_exception());
-                                      releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
-                                          *runStatus, queueWhichWaitsForIOVsToFinish_);
-                                    }
-                                  }) |
-                    chain::ifThen(looper_ and looperBeginJobRun_.load(),
-                                  [this, runStatus](auto nextTask) mutable {
-                                    CMS_SA_ALLOW try {
-                                      EventSetupImpl const& es = runStatus->eventSetupImpl();
-                                      looper_->beginOfJob(es);
-                                      looper_->doStartingNewLoop();
+                                    chain::first([this, runStatus](auto nextTask) mutable {
+                                      CMS_SA_ALLOW try {
+                                        looper_->copyInfo(ScheduleInfo(schedule_.get()));
+                                        EventSetupImpl const& es = runStatus->eventSetupImpl();
+                                        looper_->esPrefetchAsync(nextTask, es, Transition::BeginRun, serviceToken_);
+                                      } catch (...) {
+                                        nextTask.doneWaiting(std::current_exception());
+                                        releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
+                                            *runStatus, queueWhichWaitsForIOVsToFinish_);
+                                      }
+                                    }) | chain::then([this, runStatus](auto nextTask) mutable {
+                                      CMS_SA_ALLOW try {
+                                        EventSetupImpl const& es = runStatus->eventSetupImpl();
+                                        looper_->beginOfJob(es);
+                                        looper_->doStartingNewLoop();
 
-                                    } catch (...) {
-                                      nextTask.doneWaiting(std::current_exception());
-                                      releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
-                                          *runStatus, queueWhichWaitsForIOVsToFinish_);
-                                    }
+                                      } catch (...) {
+                                        nextTask.doneWaiting(std::current_exception());
+                                        releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
+                                            *runStatus, queueWhichWaitsForIOVsToFinish_);
+                                      }
+                                    }) | chain::runLast(nextTask);
                                   }) |
                     chain::then([this, runStatus](auto nextTask) {
                       if (runStatus->stopBeforeProcessingRun()) {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -877,41 +877,51 @@ namespace edm {
     };
   }  // namespace
 
-  InputSource::ItemTypeInfo EventProcessor::nextTransitionType() {
+  SourceStatus EventProcessor::nextTransitionType() {
     SendSourceTerminationSignalIfException sentry(actReg_.get());
-    InputSource::ItemTypeInfo itemTypeInfo;
+    SourceStatus returnValue;
     {
       SourceNextGuard guard(*actReg_.get());
       //For now, do nothing with InputSource::IsSynchronize
+      InputSource::ItemTypeInfo itemTypeInfo;
       do {
         itemTypeInfo = input_->nextItemType();
       } while (itemTypeInfo == InputSource::ItemType::IsSynchronize);
+      returnValue.setNextTransitionType(itemTypeInfo);
+      if (returnValue.nextTransitionType().itemType() == InputSource::ItemType::IsRun) {
+        returnValue.setRunAuxiliary(*input_->runAuxiliary());
+        returnValue.setReducedProcessHistoryID(input_->reducedProcessHistoryID());
+      } else if (returnValue.nextTransitionType().itemType() == InputSource::ItemType::IsLumi) {
+        returnValue.setLuminosityBlockAuxiliary(*input_->luminosityBlockAuxiliary());
+        returnValue.setReducedProcessHistoryID(input_->reducedProcessHistoryID());
+      }
     }
-    lastSourceTransition_ = itemTypeInfo;
     sentry.completedSuccessfully();
 
     StatusCode returnCode = epSuccess;
 
     if (checkForAsyncStopRequest(returnCode)) {
       actReg_->preSourceEarlyTerminationSignal_.emit(TerminationOrigin::ExternalSignal);
-      lastSourceTransition_ = InputSource::ItemTypeInfo::isStop();
+      returnValue.setNextTransitionType(InputSource::ItemType::IsStop);
     }
 
-    return lastSourceTransition_;
+    return returnValue;
   }
 
   void EventProcessor::nextTransitionTypeAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                               WaitingTaskHolder nextTask) {
+                                               WaitingTaskHolder nextTask,
+                                               SourceStatus& lastTransition) {
     auto group = nextTask.group();
     sourceResourcesAcquirer_.serialQueueChain().push(
-        *group, [this, runStatus = std::move(iRunStatus), nextHolder = std::move(nextTask)]() mutable {
+        *group, [this, runStatus = std::move(iRunStatus), nextHolder = std::move(nextTask), &lastTransition]() mutable {
           CMS_SA_ALLOW try {
             ServiceRegistry::Operate operate(serviceToken_);
             std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-            nextTransitionType();
-            if (lastTransitionType() == InputSource::ItemType::IsRun &&
-                runStatus->runPrincipal()->run() == input_->run() &&
-                runStatus->runPrincipal()->reducedProcessHistoryID() == input_->reducedProcessHistoryID()) {
+            assert(lastTransition.needToCallNext());
+            lastTransition = nextTransitionType();
+            if (lastTransition.nextTransitionType() == InputSource::ItemType::IsRun &&
+                runStatus->runPrincipal()->run() == lastTransition.runAuxiliary()->run() &&
+                runStatus->runPrincipal()->reducedProcessHistoryID() == lastTransition.reducedProcessHistoryID()) {
               throw Exception(errors::LogicError)
                   << "InputSource claimed previous Run Entry was last to be merged in this file,\n"
                   << "but the next entry has the same run number and reduced ProcessHistoryID.\n"
@@ -933,7 +943,6 @@ namespace edm {
     std::unique_ptr<ActivityRegistry, decltype(endSignal)> guard(actReg_.get(), endSignal);
     try {
       FilesProcessor fp(fileModeNoMerge_);
-
       convertException::wrap([&]() {
         bool firstTime = true;
         do {
@@ -952,11 +961,12 @@ namespace edm {
           if (deferredExceptionPtrIsSet_.load()) {
             std::rethrow_exception(deferredExceptionPtr_);
           }
-          if (trans != InputSource::ItemType::IsStop) {
+          if (trans.nextTransitionType() != InputSource::ItemType::IsStop) {
             //problem with the source
             doErrorStuff();
 
-            throw cms::Exception("BadTransition") << "Unexpected transition change " << static_cast<int>(trans);
+            throw cms::Exception("BadTransition")
+                << "Unexpected transition change " << static_cast<int>(trans.nextTransitionType().itemType());
           }
         } while (not endOfLoop());
       });  // convertException::wrap
@@ -1150,60 +1160,66 @@ namespace edm {
     processBlockPrincipal.clearPrincipal();
   }
 
-  InputSource::ItemType EventProcessor::processRuns() {
+  SourceStatus EventProcessor::processRuns(SourceStatus const& iStatus) {
     FinalWaitingTask waitTask{taskGroup_};
-    assert(lastTransitionType() == InputSource::ItemType::IsRun);
+    SourceStatus returnValue = iStatus;
+    assert(returnValue.nextTransitionType() == InputSource::ItemType::IsRun);
     if (streamRunActive_ == 0) {
       assert(streamLumiActive_ == 0);
 
-      beginRunAsync(IOVSyncValue(EventID(input_->run(), 0, 0), input_->runAuxiliary()->beginTime()),
-                    WaitingTaskHolder{taskGroup_, &waitTask});
+      beginRunAsync(
+          IOVSyncValue(EventID(returnValue.runAuxiliary()->run(), 0, 0), returnValue.runAuxiliary()->beginTime()),
+          WaitingTaskHolder{taskGroup_, &waitTask},
+          returnValue);
     } else {
       assert(streamRunActive_ == preallocations_.numberOfStreams());
 
       auto runStatus = streamRunStatus_[0];
 
-      while (lastTransitionType() == InputSource::ItemType::IsRun and
-             runStatus->runPrincipal()->run() == input_->run() and
-             runStatus->runPrincipal()->reducedProcessHistoryID() == input_->reducedProcessHistoryID()) {
+      while (returnValue.nextTransitionType() == InputSource::ItemType::IsRun and
+             runStatus->runPrincipal()->run() == returnValue.runAuxiliary()->run() and
+             runStatus->runPrincipal()->reducedProcessHistoryID() == returnValue.reducedProcessHistoryID()) {
         readAndMergeRun(*runStatus);
-        nextTransitionType();
+        assert(returnValue.needToCallNext());
+        returnValue = nextTransitionType();
       }
 
-      setNeedToCallNext(false);
+      returnValue.setNeedToCallNext(false);
 
       WaitingTaskHolder holder{taskGroup_, &waitTask};
       runStatus->setHolderOfTaskInProcessRuns(holder);
       if (streamLumiActive_ > 0) {
         assert(streamLumiActive_ == preallocations_.numberOfStreams());
-        continueLumiAsync(std::move(holder));
+        continueLumiAsync(std::move(holder), returnValue);
       } else {
-        handleNextItemAfterMergingRunEntriesAsync(std::move(runStatus), std::move(holder));
+        handleNextItemAfterMergingRunEntriesAsync(std::move(runStatus), std::move(holder), returnValue);
       }
     }
     waitTask.wait();
-    return lastTransitionType();
+    return returnValue;
   }
 
-  void EventProcessor::beginRunAsync(IOVSyncValue const& iSync, WaitingTaskHolder iHolder) {
+  void EventProcessor::beginRunAsync(IOVSyncValue const& iSync,
+                                     WaitingTaskHolder iHolder,
+                                     SourceStatus& oSourceStatus) {
     if (iHolder.taskHasFailed()) {
       return;
     }
 
     actReg_->esSyncIOVQueuingSignal_.emit(iSync);
 
-    auto status = std::make_shared<RunProcessingStatus>(preallocations_.numberOfStreams(), iHolder);
+    auto runStatus = std::make_shared<RunProcessingStatus>(preallocations_.numberOfStreams(), iHolder);
 
-    chain::first([this, &status, iSync](auto nextTask) {
+    chain::first([this, &runStatus, iSync](auto nextTask) {
       espController_->runOrQueueEventSetupForInstanceAsync(iSync,
                                                            nextTask,
-                                                           status->endIOVWaitingTasks(),
-                                                           status->eventSetupImplPtr(),
+                                                           runStatus->endIOVWaitingTasks(),
+                                                           runStatus->eventSetupImplPtr(),
                                                            queueWhichWaitsForIOVsToFinish_,
                                                            actReg_.get(),
                                                            serviceToken_,
                                                            forceESCacheClearOnNewRun_);
-    }) | chain::then([this, status](std::exception_ptr const* iException, auto nextTask) {
+    }) | chain::then([this, runStatus, &oSourceStatus](std::exception_ptr const* iException, auto nextTask) {
       CMS_SA_ALLOW try {
         if (iException) {
           WaitingTaskHolder copyHolder(nextTask);
@@ -1214,33 +1230,35 @@ namespace edm {
 
         runQueue_->pushAndPause(
             *nextTask.group(),
-            [this, postRunQueueTask = nextTask, status](edm::LimitedTaskQueue::Resumer iResumer) mutable {
+            [this, postRunQueueTask = nextTask, runStatus, &oSourceStatus](
+                edm::LimitedTaskQueue::Resumer iResumer) mutable {
               CMS_SA_ALLOW try {
                 if (postRunQueueTask.taskHasFailed()) {
-                  status->resetBeginResources();
+                  runStatus->resetBeginResources();
                   queueWhichWaitsForIOVsToFinish_.resume();
                   return;
                 }
 
-                status->setResumer(std::move(iResumer));
+                runStatus->setResumer(std::move(iResumer));
 
                 sourceResourcesAcquirer_.serialQueueChain().push(
-                    *postRunQueueTask.group(), [this, postSourceTask = postRunQueueTask, status]() mutable {
+                    *postRunQueueTask.group(),
+                    [this, postSourceTask = postRunQueueTask, runStatus, &oSourceStatus]() mutable {
                       CMS_SA_ALLOW try {
                         ServiceRegistry::Operate operate(serviceToken_);
 
                         if (postSourceTask.taskHasFailed()) {
-                          status->resetBeginResources();
+                          runStatus->resetBeginResources();
                           queueWhichWaitsForIOVsToFinish_.resume();
-                          status->resumeGlobalRunQueue();
+                          runStatus->resumeGlobalRunQueue();
                           return;
                         }
 
                         {
                           std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
-                          status->setRunPrincipal(readRun());
+                          runStatus->setRunPrincipal(readRun());
 
-                          RunPrincipal& runPrincipal = *status->runPrincipal();
+                          RunPrincipal& runPrincipal = *runStatus->runPrincipal();
                           {
                             SendSourceTerminationSignalIfException sentry(actReg_.get());
                             input_->doBeginRun(runPrincipal, &processContext_);
@@ -1248,7 +1266,7 @@ namespace edm {
                           }
                         }
 
-                        EventSetupImpl const& es = status->eventSetupImpl();
+                        EventSetupImpl const& es = runStatus->eventSetupImpl();
                         if (looper_ && looperBeginJobRun_ == false) {
                           looper_->copyInfo(ScheduleInfo(schedule_.get()));
 
@@ -1266,121 +1284,128 @@ namespace edm {
                         }
 
                         using namespace edm::waiting_task::chain;
-                        chain::first([this, status](auto nextTask) mutable {
+                        chain::first([this, runStatus, &oSourceStatus](auto nextTask) mutable {
                           CMS_SA_ALLOW try {
-                            if (lastTransitionType().itemPosition() != InputSource::ItemPosition::LastItemToBeMerged) {
-                              readAndMergeRunEntriesAsync(status, nextTask);
+                            if (oSourceStatus.nextTransitionType().itemPosition() !=
+                                InputSource::ItemPosition::LastItemToBeMerged) {
+                              readAndMergeRunEntriesAsync(runStatus, nextTask, oSourceStatus);
                             } else {
-                              setNeedToCallNext(true);
+                              oSourceStatus.setNeedToCallNext(true);
                             }
                           } catch (...) {
-                            status->setStopBeforeProcessingRun(true);
+                            runStatus->setStopBeforeProcessingRun(true);
                             nextTask.doneWaiting(std::current_exception());
                           }
-                        }) | then([this, status, &es](auto nextTask) {
-                          if (status->stopBeforeProcessingRun()) {
+                        }) | then([this, runStatus, &es](auto nextTask) {
+                          if (runStatus->stopBeforeProcessingRun()) {
                             return;
                           }
-                          RunTransitionInfo transitionInfo(*status->runPrincipal(), es);
+                          RunTransitionInfo transitionInfo(*runStatus->runPrincipal(), es);
                           using Traits = OccurrenceTraits<RunPrincipal, TransitionActionGlobalBegin>;
                           schedule_->processOneGlobalAsync<Traits>(nextTask, transitionInfo, serviceToken_);
-                        }) | ifThen(looper_, [this, status, &es](auto nextTask) {
-                          if (status->stopBeforeProcessingRun()) {
-                            return;
-                          }
-                          looper_->prefetchAsync(
-                              nextTask, serviceToken_, Transition::BeginRun, *status->runPrincipal(), es);
-                        }) | ifThen(looper_, [this, status, &es](auto nextTask) {
-                          if (status->stopBeforeProcessingRun()) {
-                            return;
-                          }
-                          ServiceRegistry::Operate operateLooper(serviceToken_);
-                          looper_->doBeginRun(*status->runPrincipal(), es, &processContext_);
-                        }) | then([this, status](std::exception_ptr const* iException, auto holder) mutable {
-                          if (iException) {
-                            WaitingTaskHolder copyHolder(holder);
-                            copyHolder.doneWaiting(*iException);
-                          } else {
-                            status->globalBeginDidSucceed();
-                          }
-
-                          if (status->stopBeforeProcessingRun()) {
-                            // We just quit now if there was a failure when merging runs
-                            status->resetBeginResources();
-                            queueWhichWaitsForIOVsToFinish_.resume();
-                            status->resumeGlobalRunQueue();
-                            return;
-                          }
-                          CMS_SA_ALLOW try {
-                            // Under normal circumstances, this task runs after endRun has completed for all streams
-                            // and global endLumi has completed for all lumis contained in this run
-                            auto globalEndRunTask =
-                                edm::make_waiting_task([this, status](std::exception_ptr const*) mutable {
-                                  WaitingTaskHolder taskHolder = status->holderOfTaskInProcessRuns();
-                                  status->holderOfTaskInProcessRuns().doneWaiting(std::exception_ptr{});
-                                  globalEndRunAsync(std::move(taskHolder), std::move(status));
-                                });
-                            status->setGlobalEndRunHolder(WaitingTaskHolder{*holder.group(), globalEndRunTask});
-                          } catch (...) {
-                            status->resetBeginResources();
-                            queueWhichWaitsForIOVsToFinish_.resume();
-                            status->resumeGlobalRunQueue();
-                            holder.doneWaiting(std::current_exception());
-                            return;
-                          }
-
-                          // After this point we are committed to end the run via endRunAsync
-
-                          ServiceRegistry::Operate operate(serviceToken_);
-
-                          // The only purpose of the pause is to cause stream begin run to execute before
-                          // global begin lumi in the single threaded case (maintains consistency with
-                          // the order that existed before concurrent runs were implemented).
-                          PauseQueueSentry pauseQueueSentry(streamQueuesInserter_);
-
-                          CMS_SA_ALLOW try {
-                            streamQueuesInserter_.push(*holder.group(), [this, status, holder]() mutable {
-                              for (auto i : std::views::iota(0U, preallocations_.numberOfStreams())) {
-                                CMS_SA_ALLOW try {
-                                  streamQueues_[i].push(*holder.group(), [this, i, status, holder]() mutable {
-                                    streamBeginRunAsync(i, std::move(status), std::move(holder));
-                                  });
-                                } catch (...) {
-                                  if (status->streamFinishedBeginRun()) {
-                                    WaitingTaskHolder copyHolder(holder);
-                                    copyHolder.doneWaiting(std::current_exception());
-                                    status->resetBeginResources();
-                                    queueWhichWaitsForIOVsToFinish_.resume();
-                                    exceptionRunStatus_ = status;
-                                  }
-                                }
+                        }) |
+                            ifThen(looper_,
+                                   [this, runStatus, &es](auto nextTask) {
+                                     if (runStatus->stopBeforeProcessingRun()) {
+                                       return;
+                                     }
+                                     looper_->prefetchAsync(
+                                         nextTask, serviceToken_, Transition::BeginRun, *runStatus->runPrincipal(), es);
+                                   }) |
+                            ifThen(looper_,
+                                   [this, runStatus, &es](auto nextTask) {
+                                     if (runStatus->stopBeforeProcessingRun()) {
+                                       return;
+                                     }
+                                     ServiceRegistry::Operate operateLooper(serviceToken_);
+                                     looper_->doBeginRun(*runStatus->runPrincipal(), es, &processContext_);
+                                   }) |
+                            then([this, runStatus, &oSourceStatus](std::exception_ptr const* iException,
+                                                                   auto holder) mutable {
+                              if (iException) {
+                                WaitingTaskHolder copyHolder(holder);
+                                copyHolder.doneWaiting(*iException);
+                              } else {
+                                runStatus->globalBeginDidSucceed();
                               }
-                            });
-                          } catch (...) {
-                            WaitingTaskHolder copyHolder(holder);
-                            copyHolder.doneWaiting(std::current_exception());
-                            status->resetBeginResources();
-                            queueWhichWaitsForIOVsToFinish_.resume();
-                            exceptionRunStatus_ = status;
-                          }
-                          handleNextItemAfterMergingRunEntriesAsync(status, holder);
-                        }) | runLast(postSourceTask);
+                              if (runStatus->stopBeforeProcessingRun()) {
+                                // We just quit now if there was a failure when merging runs
+                                runStatus->resetBeginResources();
+                                queueWhichWaitsForIOVsToFinish_.resume();
+                                runStatus->resumeGlobalRunQueue();
+                                return;
+                              }
+                              CMS_SA_ALLOW try {
+                                // Under normal circumstances, this task runs after endRun has completed for all streams
+                                // and global endLumi has completed for all lumis contained in this run
+                                auto globalEndRunTask =
+                                    edm::make_waiting_task([this, runStatus](std::exception_ptr const*) mutable {
+                                      WaitingTaskHolder taskHolder = runStatus->holderOfTaskInProcessRuns();
+                                      runStatus->holderOfTaskInProcessRuns().doneWaiting(std::exception_ptr{});
+                                      globalEndRunAsync(std::move(taskHolder), std::move(runStatus));
+                                    });
+                                runStatus->setGlobalEndRunHolder(WaitingTaskHolder{*holder.group(), globalEndRunTask});
+                              } catch (...) {
+                                runStatus->resetBeginResources();
+                                queueWhichWaitsForIOVsToFinish_.resume();
+                                runStatus->resumeGlobalRunQueue();
+                                holder.doneWaiting(std::current_exception());
+                                return;
+                              }
+
+                              // After this point we are committed to end the run via endRunAsync
+
+                              ServiceRegistry::Operate operate(serviceToken_);
+
+                              // The only purpose of the pause is to cause stream begin run to execute before
+                              // global begin lumi in the single threaded case (maintains consistency with
+                              // the order that existed before concurrent runs were implemented).
+                              PauseQueueSentry pauseQueueSentry(streamQueuesInserter_);
+
+                              CMS_SA_ALLOW try {
+                                streamQueuesInserter_.push(*holder.group(), [this, runStatus, holder]() mutable {
+                                  for (auto i : std::views::iota(0U, preallocations_.numberOfStreams())) {
+                                    CMS_SA_ALLOW try {
+                                      streamQueues_[i].push(*holder.group(), [this, i, runStatus, holder]() mutable {
+                                        streamBeginRunAsync(i, std::move(runStatus), std::move(holder));
+                                      });
+                                    } catch (...) {
+                                      if (runStatus->streamFinishedBeginRun()) {
+                                        WaitingTaskHolder copyHolder(holder);
+                                        copyHolder.doneWaiting(std::current_exception());
+                                        runStatus->resetBeginResources();
+                                        queueWhichWaitsForIOVsToFinish_.resume();
+                                        exceptionRunStatus_ = runStatus;
+                                      }
+                                    }
+                                  }
+                                });
+                              } catch (...) {
+                                WaitingTaskHolder copyHolder(holder);
+                                copyHolder.doneWaiting(std::current_exception());
+                                runStatus->resetBeginResources();
+                                queueWhichWaitsForIOVsToFinish_.resume();
+                                exceptionRunStatus_ = runStatus;
+                              }
+                              handleNextItemAfterMergingRunEntriesAsync(runStatus, holder, oSourceStatus);
+                            }) |
+                            runLast(postSourceTask);
                       } catch (...) {
-                        status->resetBeginResources();
+                        runStatus->resetBeginResources();
                         queueWhichWaitsForIOVsToFinish_.resume();
-                        status->resumeGlobalRunQueue();
+                        runStatus->resumeGlobalRunQueue();
                         postSourceTask.doneWaiting(std::current_exception());
                       }
                     });  // task in sourceResourcesAcquirer
               } catch (...) {
-                status->resetBeginResources();
+                runStatus->resetBeginResources();
                 queueWhichWaitsForIOVsToFinish_.resume();
-                status->resumeGlobalRunQueue();
+                runStatus->resumeGlobalRunQueue();
                 postRunQueueTask.doneWaiting(std::current_exception());
               }
             });  // task in runQueue
       } catch (...) {
-        status->resetBeginResources();
+        runStatus->resetBeginResources();
         queueWhichWaitsForIOVsToFinish_.resume();
         nextTask.doneWaiting(std::current_exception());
       }
@@ -1425,7 +1450,9 @@ namespace edm {
     streamQueues_[iStream].resume();
   }
 
-  void EventProcessor::endRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus, WaitingTaskHolder iHolder) {
+  void EventProcessor::endRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
+                                   WaitingTaskHolder iHolder,
+                                   SourceStatus& oStatus) noexcept {
     RunPrincipal& runPrincipal = *iRunStatus->runPrincipal();
     iRunStatus->setEndTime();
     IOVSyncValue ts(
@@ -1444,7 +1471,7 @@ namespace edm {
                                                            queueWhichWaitsForIOVsToFinish_,
                                                            actReg_.get(),
                                                            serviceToken_);
-    }) | chain::then([this, iRunStatus](std::exception_ptr const* iException, auto nextTask) {
+    }) | chain::then([this, iRunStatus, &oStatus](std::exception_ptr const* iException, auto nextTask) {
       if (iException) {
         iRunStatus->setEndingEventSetupSucceeded(false);
         handleEndRunExceptions(*iException, nextTask);
@@ -1464,9 +1491,11 @@ namespace edm {
         }
       });
 
-      if (lastTransitionType() == InputSource::ItemType::IsRun) {
+      if (oStatus.nextTransitionType() == InputSource::ItemType::IsRun) {
         CMS_SA_ALLOW try {
-          beginRunAsync(IOVSyncValue(EventID(input_->run(), 0, 0), input_->runAuxiliary()->beginTime()), nextTask);
+          beginRunAsync(IOVSyncValue(EventID(oStatus.runAuxiliary()->run(), 0, 0), oStatus.runAuxiliary()->beginTime()),
+                        nextTask,
+                        oStatus);
         } catch (...) {
           WaitingTaskHolder copyHolder(nextTask);
           copyHolder.doneWaiting(std::current_exception());
@@ -1608,7 +1637,8 @@ namespace edm {
     }
   }
 
-  void EventProcessor::endUnfinishedRun(bool cleaningUpAfterException) {
+  SourceStatus EventProcessor::endUnfinishedRun(bool cleaningUpAfterException) {
+    SourceStatus returnValue{InputSource::ItemType::IsStop};
     if (streamRunActive_ > 0) {
       FinalWaitingTask waitTask{taskGroup_};
 
@@ -1616,10 +1646,10 @@ namespace edm {
       runStatus->setCleaningUpAfterException(cleaningUpAfterException);
       WaitingTaskHolder holder{taskGroup_, &waitTask};
       runStatus->setHolderOfTaskInProcessRuns(holder);
-      lastSourceTransition_ = InputSource::ItemTypeInfo::isStop();
-      endRunAsync(streamRunStatus_[0], std::move(holder));
+      endRunAsync(streamRunStatus_[0], std::move(holder), returnValue);
       waitTask.wait();
     }
+    return returnValue;
   }
 
   namespace {
@@ -1645,11 +1675,12 @@ namespace edm {
 
   void EventProcessor::beginLumiAsync(IOVSyncValue const& iSync,
                                       std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                      edm::WaitingTaskHolder iHolder) {
+                                      edm::WaitingTaskHolder iHolder,
+                                      SourceStatus& oSourceStatus) {
     actReg_->esSyncIOVQueuingSignal_.emit(iSync);
 
     auto status = std::make_shared<LuminosityBlockProcessingStatus>();
-    chain::first([this, &iSync, &status](auto nextTask) {
+    chain::first([this, &iSync, &status, &oSourceStatus](auto nextTask) {
       espController_->runOrQueueEventSetupForInstanceAsync(iSync,
                                                            nextTask,
                                                            status->endIOVWaitingTasks(),
@@ -1657,7 +1688,7 @@ namespace edm {
                                                            queueWhichWaitsForIOVsToFinish_,
                                                            actReg_.get(),
                                                            serviceToken_);
-    }) | chain::then([this, status, iRunStatus](std::exception_ptr const* iException, auto nextTask) {
+    }) | chain::then([this, status, iRunStatus, &oSourceStatus](std::exception_ptr const* iException, auto nextTask) {
       CMS_SA_ALLOW try {
         //the call to doneWaiting will cause the count to decrement
         if (iException) {
@@ -1667,12 +1698,13 @@ namespace edm {
 
         lumiQueue_->pushAndPause(
             *nextTask.group(),
-            [this, postLumiQueueTask = nextTask, status, iRunStatus](edm::LimitedTaskQueue::Resumer iResumer) mutable {
+            [this, postLumiQueueTask = nextTask, status, iRunStatus, &oSourceStatus](
+                edm::LimitedTaskQueue::Resumer iResumer) mutable {
               CMS_SA_ALLOW try {
                 if (postLumiQueueTask.taskHasFailed()) {
                   status->resetResources();
                   queueWhichWaitsForIOVsToFinish_.resume();
-                  endRunAsync(iRunStatus, postLumiQueueTask);
+                  endRunAsync(iRunStatus, postLumiQueueTask, oSourceStatus);
                   return;
                 }
 
@@ -1680,14 +1712,14 @@ namespace edm {
 
                 sourceResourcesAcquirer_.serialQueueChain().push(
                     *postLumiQueueTask.group(),
-                    [this, postSourceTask = postLumiQueueTask, status, iRunStatus]() mutable {
+                    [this, postSourceTask = postLumiQueueTask, status, iRunStatus, &oSourceStatus]() mutable {
                       CMS_SA_ALLOW try {
                         ServiceRegistry::Operate operate(serviceToken_);
 
                         if (postSourceTask.taskHasFailed()) {
                           status->resetResources();
                           queueWhichWaitsForIOVsToFinish_.resume();
-                          endRunAsync(iRunStatus, postSourceTask);
+                          endRunAsync(iRunStatus, postSourceTask, oSourceStatus);
                           return;
                         }
 
@@ -1724,12 +1756,12 @@ namespace edm {
                                            }
                                          }) | runLast(nextTask);
                                        }) |
-                            then([this, status](auto nextTask) mutable {
-                              if (lastTransitionType().itemPosition() !=
+                            then([this, status, &oSourceStatus](auto nextTask) mutable {
+                              if (oSourceStatus.nextTransitionType().itemPosition() !=
                                   InputSource::ItemPosition::LastItemToBeMerged) {
-                                readAndMergeLumiEntriesAsync(std::move(status), std::move(nextTask));
+                                readAndMergeLumiEntriesAsync(std::move(status), std::move(nextTask), oSourceStatus);
                               } else {
-                                setNeedToCallNext(true);
+                                oSourceStatus.setNeedToCallNext(true);
                               }
                             }) |
                             then([this, status, &es, &lumiPrincipal](auto nextTask) {
@@ -1750,51 +1782,56 @@ namespace edm {
                                      ServiceRegistry::Operate operateLooper(serviceToken_);
                                      looper_->doBeginLuminosityBlock(*(status->lumiPrincipal()), es, &processContext_);
                                    }) |
-                            then([this, status, iRunStatus](std::exception_ptr const* iException, auto holder) mutable {
+                            then([this, status, iRunStatus, &oSourceStatus](std::exception_ptr const* iException,
+                                                                            auto holder) mutable {
                               status->setGlobalEndRunHolder(iRunStatus->globalEndRunHolder());
 
                               if (iException) {
                                 WaitingTaskHolder copyHolder(holder);
                                 copyHolder.doneWaiting(*iException);
                                 globalEndLumiAsync(holder, status);
-                                endRunAsync(iRunStatus, holder);
+                                endRunAsync(iRunStatus, holder, oSourceStatus);
                               } else {
                                 status->globalBeginDidSucceed();
 
                                 EventSetupImpl const& es = status->eventSetupImpl();
                                 using Traits = OccurrenceTraits<LuminosityBlockPrincipal, TransitionActionStreamBegin>;
 
-                                streamQueuesInserter_.push(*holder.group(), [this, status, holder, &es]() mutable {
-                                  for (auto i : std::views::iota(0U, preallocations_.numberOfStreams())) {
-                                    streamQueues_[i].push(*holder.group(), [this, i, status, holder, &es]() mutable {
-                                      if (!status->shouldStreamStartLumi()) {
-                                        return;
-                                      }
-                                      streamQueues_[i].pause();
+                                streamQueuesInserter_.push(
+                                    *holder.group(), [this, status, holder, &es, &oSourceStatus]() mutable {
+                                      for (auto i : std::views::iota(0U, preallocations_.numberOfStreams())) {
+                                        streamQueues_[i].push(
+                                            *holder.group(), [this, i, status, holder, &es, &oSourceStatus]() mutable {
+                                              if (!status->shouldStreamStartLumi()) {
+                                                return;
+                                              }
+                                              streamQueues_[i].pause();
 
-                                      auto& event = principalCache_.eventPrincipal(i);
-                                      auto lp = status->lumiPrincipal().get();
-                                      streamLumiStatus_[i] = std::move(status);
-                                      ++streamLumiActive_;
-                                      event.setLuminosityBlockPrincipal(lp);
-                                      LumiTransitionInfo transitionInfo(*lp, es);
-                                      using namespace edm::waiting_task::chain;
-                                      chain::first([this, i, &transitionInfo](auto nextTask) {
-                                        schedule_->processOneStreamAsync<Traits>(
-                                            std::move(nextTask), i, transitionInfo, serviceToken_);
-                                      }) |
-                                          then([this, i](std::exception_ptr const* exceptionFromBeginStreamLumi,
-                                                         auto nextTask) {
-                                            if (exceptionFromBeginStreamLumi) {
-                                              WaitingTaskHolder copyHolder(nextTask);
-                                              copyHolder.doneWaiting(*exceptionFromBeginStreamLumi);
-                                            }
-                                            handleNextEventForStreamAsync(std::move(nextTask), i);
-                                          }) |
-                                          runLast(std::move(holder));
+                                              auto& event = principalCache_.eventPrincipal(i);
+                                              auto lp = status->lumiPrincipal().get();
+                                              streamLumiStatus_[i] = std::move(status);
+                                              ++streamLumiActive_;
+                                              event.setLuminosityBlockPrincipal(lp);
+                                              LumiTransitionInfo transitionInfo(*lp, es);
+                                              using namespace edm::waiting_task::chain;
+                                              chain::first([this, i, &transitionInfo](auto nextTask) {
+                                                schedule_->processOneStreamAsync<Traits>(
+                                                    std::move(nextTask), i, transitionInfo, serviceToken_);
+                                              }) |
+                                                  then([this, i, &oSourceStatus](
+                                                           std::exception_ptr const* exceptionFromBeginStreamLumi,
+                                                           auto nextTask) {
+                                                    if (exceptionFromBeginStreamLumi) {
+                                                      WaitingTaskHolder copyHolder(nextTask);
+                                                      copyHolder.doneWaiting(*exceptionFromBeginStreamLumi);
+                                                    }
+                                                    handleNextEventForStreamAsync(
+                                                        std::move(nextTask), i, oSourceStatus);
+                                                  }) |
+                                                  runLast(std::move(holder));
+                                            });
+                                      }  // end for loop over streams
                                     });
-                                  }  // end for loop over streams
-                                });
                               }
                             }) |
                             runLast(postSourceTask);
@@ -1803,7 +1840,7 @@ namespace edm {
                         queueWhichWaitsForIOVsToFinish_.resume();
                         WaitingTaskHolder copyHolder(postSourceTask);
                         copyHolder.doneWaiting(std::current_exception());
-                        endRunAsync(iRunStatus, postSourceTask);
+                        endRunAsync(iRunStatus, postSourceTask, oSourceStatus);
                       }
                     });  // task in sourceResourcesAcquirer
               } catch (...) {
@@ -1811,7 +1848,7 @@ namespace edm {
                 queueWhichWaitsForIOVsToFinish_.resume();
                 WaitingTaskHolder copyHolder(postLumiQueueTask);
                 copyHolder.doneWaiting(std::current_exception());
-                endRunAsync(iRunStatus, postLumiQueueTask);
+                endRunAsync(iRunStatus, postLumiQueueTask, oSourceStatus);
               }
             });  // task in lumiQueue
       } catch (...) {
@@ -1819,30 +1856,36 @@ namespace edm {
         queueWhichWaitsForIOVsToFinish_.resume();
         WaitingTaskHolder copyHolder(nextTask);
         copyHolder.doneWaiting(std::current_exception());
-        endRunAsync(iRunStatus, nextTask);
+        endRunAsync(iRunStatus, nextTask, oSourceStatus);
       }
     }) | chain::runLast(std::move(iHolder));
   }
 
-  void EventProcessor::continueLumiAsync(edm::WaitingTaskHolder iHolder) {
-    chain::first([this](auto nextTask) {
+  void EventProcessor::continueLumiAsync(edm::WaitingTaskHolder iHolder, SourceStatus& oSourceStatus) {
+    chain::first([this, &oSourceStatus](auto nextTask) {
       //all streams are sharing the same status at the moment
       auto status = streamLumiStatus_[0];  //read from streamLumiActive_ happened in calling routine
       status->setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kProcessing);
 
-      while (lastTransitionType() == InputSource::ItemType::IsLumi and
-             status->lumiPrincipal()->luminosityBlock() == input_->luminosityBlock()) {
+      while (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsLumi and
+             status->lumiPrincipal()->luminosityBlock() == oSourceStatus.lumiAuxiliary()->luminosityBlock()) {
         readAndMergeLumi(*status);
-        nextTransitionType();
+        assert(not oSourceStatus.needToCallNext());
+        oSourceStatus = nextTransitionType();
+        //Need to tell event processing loop that we called nextTransitionType while merging lumis so it doesn't call it again and possibly skip entries
+        oSourceStatus.setNeedToCallNext(false);
       }
-    }) | chain::then([this](auto nextTask) mutable {
+    }) | chain::then([this, &oSourceStatus](auto nextTask) mutable {
       unsigned int streamIndex = 0;
       oneapi::tbb::task_arena arena{oneapi::tbb::task_arena::attach()};
       for (; streamIndex < preallocations_.numberOfStreams() - 1; ++streamIndex) {
-        arena.enqueue([this, streamIndex, h = nextTask]() { handleNextEventForStreamAsync(h, streamIndex); });
+        arena.enqueue([this, streamIndex, h = nextTask, &oSourceStatus]() {
+          handleNextEventForStreamAsync(h, streamIndex, oSourceStatus);
+        });
       }
-      nextTask.group()->run(
-          [this, streamIndex, h = std::move(nextTask)]() { handleNextEventForStreamAsync(h, streamIndex); });
+      nextTask.group()->run([this, streamIndex, h = std::move(nextTask), &oSourceStatus]() {
+        handleNextEventForStreamAsync(h, streamIndex, oSourceStatus);
+      });
     }) | chain::runLast(std::move(iHolder));
   }
 
@@ -2087,31 +2130,33 @@ namespace edm {
   }
 
   void EventProcessor::readAndMergeRunEntriesAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                                   WaitingTaskHolder iHolder) {
+                                                   WaitingTaskHolder iHolder,
+                                                   SourceStatus& oSourceStatus) {
     auto group = iHolder.group();
     sourceResourcesAcquirer_.serialQueueChain().push(
-        *group, [this, status = std::move(iRunStatus), holder = std::move(iHolder)]() mutable {
+        *group, [this, status = std::move(iRunStatus), holder = std::move(iHolder), &oSourceStatus]() mutable {
           CMS_SA_ALLOW try {
             ServiceRegistry::Operate operate(serviceToken_);
 
             std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
+            oSourceStatus = nextTransitionType();
+            oSourceStatus.setNeedToCallNext(false);
 
-            nextTransitionType();
-            setNeedToCallNext(false);
-
-            while (lastTransitionType() == InputSource::ItemType::IsRun and
-                   status->runPrincipal()->run() == input_->run() and
-                   status->runPrincipal()->reducedProcessHistoryID() == input_->reducedProcessHistoryID()) {
+            while (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsRun and
+                   status->runPrincipal()->run() == oSourceStatus.runAuxiliary()->run() and
+                   status->runPrincipal()->reducedProcessHistoryID() == oSourceStatus.reducedProcessHistoryID()) {
               if (status->holderOfTaskInProcessRuns().taskHasFailed()) {
                 status->setStopBeforeProcessingRun(true);
                 return;
               }
               readAndMergeRun(*status);
-              if (lastTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
-                setNeedToCallNext(true);
+              if (oSourceStatus.nextTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
+                oSourceStatus.setNeedToCallNext(true);
                 return;
               }
-              nextTransitionType();
+              assert(not oSourceStatus.needToCallNext());
+              oSourceStatus = nextTransitionType();
+              oSourceStatus.setNeedToCallNext(false);
             }
           } catch (...) {
             status->setStopBeforeProcessingRun(true);
@@ -2121,26 +2166,31 @@ namespace edm {
   }
 
   void EventProcessor::readAndMergeLumiEntriesAsync(std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus,
-                                                    WaitingTaskHolder iHolder) {
+                                                    WaitingTaskHolder iHolder,
+                                                    SourceStatus& oSourceStatus) {
     auto group = iHolder.group();
     sourceResourcesAcquirer_.serialQueueChain().push(
-        *group, [this, iLumiStatus = std::move(iLumiStatus), holder = std::move(iHolder)]() mutable {
+        *group, [this, iLumiStatus = std::move(iLumiStatus), holder = std::move(iHolder), &oSourceStatus]() mutable {
           CMS_SA_ALLOW try {
             ServiceRegistry::Operate operate(serviceToken_);
 
             std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
 
-            nextTransitionType();
-            setNeedToCallNext(false);
+            oSourceStatus = nextTransitionType();
+            oSourceStatus.setNeedToCallNext(false);
 
-            while (lastTransitionType() == InputSource::ItemType::IsLumi and
-                   iLumiStatus->lumiPrincipal()->luminosityBlock() == input_->luminosityBlock()) {
+            while (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsLumi and
+                   iLumiStatus->lumiPrincipal()->luminosityBlock() ==
+                       oSourceStatus.lumiAuxiliary()->luminosityBlock()) {
               readAndMergeLumi(*iLumiStatus);
-              if (lastTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
-                setNeedToCallNext(true);
+              if (oSourceStatus.nextTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
+                oSourceStatus.setNeedToCallNext(true);
                 return;
               }
-              nextTransitionType();
+              assert(not oSourceStatus.needToCallNext());
+              oSourceStatus = nextTransitionType();
+              //Need to tell event processing loop that we called nextTransitionType while merging lumis so it doesn't call it again and possibly skip entries
+              oSourceStatus.setNeedToCallNext(false);
             }
           } catch (...) {
             holder.doneWaiting(std::current_exception());
@@ -2149,27 +2199,31 @@ namespace edm {
   }
 
   void EventProcessor::handleNextItemAfterMergingRunEntriesAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                                            WaitingTaskHolder iHolder) {
-    chain::first([this, iRunStatus](auto nextTask) mutable {
-      if (needToCallNext()) {
-        nextTransitionTypeAsync(std::move(iRunStatus), std::move(nextTask));
+                                                                 WaitingTaskHolder iHolder,
+                                                                 SourceStatus& oSourceStatus) {
+    chain::first([this, iRunStatus, &oSourceStatus](auto nextTask) mutable {
+      if (oSourceStatus.needToCallNext()) {
+        nextTransitionTypeAsync(std::move(iRunStatus), std::move(nextTask), oSourceStatus);
       }
-    }) | chain::then([this, iRunStatus](std::exception_ptr const* iException, auto nextTask) {
+    }) | chain::then([this, iRunStatus, &oSourceStatus](std::exception_ptr const* iException, auto nextTask) {
       ServiceRegistry::Operate operate(serviceToken_);
       if (iException) {
         WaitingTaskHolder copyHolder(nextTask);
         copyHolder.doneWaiting(*iException);
       }
-      if (lastTransitionType() == InputSource::ItemType::IsFile) {
+      if (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsFile) {
         iRunStatus->holderOfTaskInProcessRuns().doneWaiting(std::exception_ptr{});
         return;
       }
-      if (lastTransitionType() == InputSource::ItemType::IsLumi && !nextTask.taskHasFailed()) {
+      if (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsLumi && !nextTask.taskHasFailed()) {
         CMS_SA_ALLOW try {
-          beginLumiAsync(IOVSyncValue(EventID(input_->run(), input_->luminosityBlock(), 0),
-                                      input_->luminosityBlockAuxiliary()->beginTime()),
-                         iRunStatus,
-                         nextTask);
+          beginLumiAsync(
+              IOVSyncValue(
+                  EventID(oSourceStatus.lumiAuxiliary()->run(), oSourceStatus.lumiAuxiliary()->luminosityBlock(), 0),
+                  oSourceStatus.lumiAuxiliary()->beginTime()),
+              iRunStatus,
+              nextTask,
+              oSourceStatus);
           return;
         } catch (...) {
           WaitingTaskHolder copyHolder(nextTask);
@@ -2178,13 +2232,14 @@ namespace edm {
       }
       // Note that endRunAsync will call beginRunAsync for the following run
       // if appropriate.
-      endRunAsync(iRunStatus, std::move(nextTask));
+      endRunAsync(iRunStatus, std::move(nextTask), oSourceStatus);
     }) | chain::runLast(std::move(iHolder));
   }
 
   bool EventProcessor::readNextEventForStream(WaitingTaskHolder const& iTask,
                                               unsigned int iStreamIndex,
-                                              LuminosityBlockProcessingStatus& iStatus) {
+                                              LuminosityBlockProcessingStatus& iStatus,
+                                              SourceStatus& oSourceStatus) {
     // This function returns true if it successfully reads an event for the stream and that
     // requires both that an event is next and there are no problems or requests to stop.
 
@@ -2205,7 +2260,7 @@ namespace edm {
 
     // Are output modules or the looper requesting we stop?
     if (shouldWeStop()) {
-      lastSourceTransition_ = InputSource::ItemTypeInfo::isStop();
+      oSourceStatus.setNextTransitionType(InputSource::ItemType::IsStop);
       iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
       return false;
     }
@@ -2220,8 +2275,14 @@ namespace edm {
     // If we didn't already call nextTransitionType while merging lumis, call it here.
     // This asks the input source what is next and also checks for signals.
 
-    InputSource::ItemType itemType = needToCallNext() ? nextTransitionType() : lastTransitionType();
-    setNeedToCallNext(true);
+    auto findTransitionType = [this](SourceStatus& oSourceStatus) -> InputSource::ItemType {
+      if (oSourceStatus.needToCallNext()) {
+        oSourceStatus = nextTransitionType();
+      }
+      oSourceStatus.setNeedToCallNext(true);
+      return oSourceStatus.nextTransitionType();
+    };
+    InputSource::ItemType itemType = findTransitionType(oSourceStatus);
 
     if (InputSource::ItemType::IsEvent != itemType) {
       // IsFile may continue processing the lumi and
@@ -2229,10 +2290,11 @@ namespace edm {
       // just a continuation of the previous run
       if (InputSource::ItemType::IsStop == itemType or InputSource::ItemType::IsLumi == itemType or
           (InputSource::ItemType::IsRun == itemType and
-           (iStatus.lumiPrincipal()->run() != input_->run() or
-            iStatus.lumiPrincipal()->runPrincipal().reducedProcessHistoryID() != input_->reducedProcessHistoryID()))) {
+           (iStatus.lumiPrincipal()->run() != oSourceStatus.runAuxiliary()->run() or
+            iStatus.lumiPrincipal()->runPrincipal().reducedProcessHistoryID() !=
+                oSourceStatus.reducedProcessHistoryID()))) {
         if (itemType == InputSource::ItemType::IsLumi &&
-            iStatus.lumiPrincipal()->luminosityBlock() == input_->luminosityBlock()) {
+            iStatus.lumiPrincipal()->luminosityBlock() == oSourceStatus.lumiAuxiliary()->luminosityBlock()) {
           throw Exception(errors::LogicError)
               << "InputSource claimed previous Lumi Entry was last to be merged in this file,\n"
               << "but the next lumi entry has the same lumi number.\n"
@@ -2248,70 +2310,76 @@ namespace edm {
     return true;
   }
 
-  void EventProcessor::handleNextEventForStreamAsync(WaitingTaskHolder iTask, unsigned int iStreamIndex) {
+  void EventProcessor::handleNextEventForStreamAsync(WaitingTaskHolder iTask,
+                                                     unsigned int iStreamIndex,
+                                                     SourceStatus& oSourceStatus) {
     if (streamLumiStatus_[iStreamIndex]->haveStartedNextLumiOrEndedRun()) {
       streamEndLumiAsync(iTask, iStreamIndex);
       return;
     }
     auto group = iTask.group();
-    sourceResourcesAcquirer_.serialQueueChain().push(*group, [this, iTask = std::move(iTask), iStreamIndex]() mutable {
-      CMS_SA_ALLOW try {
-        auto status = streamLumiStatus_[iStreamIndex].get();
-        ServiceRegistry::Operate operate(serviceToken_);
+    sourceResourcesAcquirer_.serialQueueChain().push(
+        *group, [this, iTask = std::move(iTask), iStreamIndex, &oSourceStatus]() mutable {
+          CMS_SA_ALLOW try {
+            auto status = streamLumiStatus_[iStreamIndex].get();
+            ServiceRegistry::Operate operate(serviceToken_);
 
-        if (readNextEventForStream(iTask, iStreamIndex, *status)) {
-          auto recursionTask =
-              make_waiting_task([this, iTask, iStreamIndex](std::exception_ptr const* iEventException) mutable {
-                if (iEventException) {
-                  WaitingTaskHolder copyHolder(iTask);
-                  copyHolder.doneWaiting(*iEventException);
-                  // Intentionally, we don't return here. The recursive call to
-                  // handleNextEvent takes care of immediately ending the run properly
-                  // using the same code it uses to end the run in other situations.
-                }
-                handleNextEventForStreamAsync(std::move(iTask), iStreamIndex);
-              });
+            if (readNextEventForStream(iTask, iStreamIndex, *status, oSourceStatus)) {
+              auto recursionTask = make_waiting_task(
+                  [this, iTask, iStreamIndex, &oSourceStatus](std::exception_ptr const* iEventException) mutable {
+                    if (iEventException) {
+                      WaitingTaskHolder copyHolder(iTask);
+                      copyHolder.doneWaiting(*iEventException);
+                      // Intentionally, we don't return here. The recursive call to
+                      // handleNextEvent takes care of immediately ending the run properly
+                      // using the same code it uses to end the run in other situations.
+                    }
+                    handleNextEventForStreamAsync(std::move(iTask), iStreamIndex, oSourceStatus);
+                  });
 
-          processEventAsync(WaitingTaskHolder(*iTask.group(), recursionTask), iStreamIndex);
-        } else {
-          // the stream will stop processing this lumi now
-          if (status->eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi) {
-            if (not status->haveStartedNextLumiOrEndedRun()) {
-              status->noMoreEventsInLumi();
-              status->startNextLumiOrEndRun();
-              if (lastTransitionType() == InputSource::ItemType::IsLumi && !iTask.taskHasFailed()) {
-                CMS_SA_ALLOW try {
-                  beginLumiAsync(IOVSyncValue(EventID(input_->run(), input_->luminosityBlock(), 0),
-                                              input_->luminosityBlockAuxiliary()->beginTime()),
-                                 streamRunStatus_[iStreamIndex],
-                                 iTask);
-                } catch (...) {
-                  WaitingTaskHolder copyHolder(iTask);
-                  copyHolder.doneWaiting(std::current_exception());
-                  endRunAsync(streamRunStatus_[iStreamIndex], iTask);
+              processEventAsync(WaitingTaskHolder(*iTask.group(), recursionTask), iStreamIndex);
+            } else {
+              // the stream will stop processing this lumi now
+              if (status->eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi) {
+                if (not status->haveStartedNextLumiOrEndedRun()) {
+                  status->noMoreEventsInLumi();
+                  status->startNextLumiOrEndRun();
+                  if (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsLumi && !iTask.taskHasFailed()) {
+                    CMS_SA_ALLOW try {
+                      beginLumiAsync(IOVSyncValue(EventID(oSourceStatus.lumiAuxiliary()->run(),
+                                                          oSourceStatus.lumiAuxiliary()->luminosityBlock(),
+                                                          0),
+                                                  oSourceStatus.lumiAuxiliary()->beginTime()),
+                                     streamRunStatus_[iStreamIndex],
+                                     iTask,
+                                     oSourceStatus);
+                    } catch (...) {
+                      WaitingTaskHolder copyHolder(iTask);
+                      copyHolder.doneWaiting(std::current_exception());
+                      endRunAsync(streamRunStatus_[iStreamIndex], iTask, oSourceStatus);
+                    }
+                  } else {
+                    // If appropriate, this will also start the next run.
+                    endRunAsync(streamRunStatus_[iStreamIndex], iTask, oSourceStatus);
+                  }
                 }
+                streamEndLumiAsync(iTask, iStreamIndex);
               } else {
-                // If appropriate, this will also start the next run.
-                endRunAsync(streamRunStatus_[iStreamIndex], iTask);
+                assert(status->eventProcessingState() ==
+                       LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition);
+                auto runStatus = streamRunStatus_[iStreamIndex].get();
+
+                if (runStatus->holderOfTaskInProcessRuns().hasTask()) {
+                  runStatus->holderOfTaskInProcessRuns().doneWaiting(std::exception_ptr{});
+                }
               }
             }
-            streamEndLumiAsync(iTask, iStreamIndex);
-          } else {
-            assert(status->eventProcessingState() ==
-                   LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition);
-            auto runStatus = streamRunStatus_[iStreamIndex].get();
-
-            if (runStatus->holderOfTaskInProcessRuns().hasTask()) {
-              runStatus->holderOfTaskInProcessRuns().doneWaiting(std::exception_ptr{});
-            }
+          } catch (...) {
+            WaitingTaskHolder copyHolder(iTask);
+            copyHolder.doneWaiting(std::current_exception());
+            handleNextEventForStreamAsync(std::move(iTask), iStreamIndex, oSourceStatus);
           }
-        }
-      } catch (...) {
-        WaitingTaskHolder copyHolder(iTask);
-        copyHolder.doneWaiting(std::current_exception());
-        handleNextEventForStreamAsync(std::move(iTask), iStreamIndex);
-      }
-    });
+        });
   }
 
   void EventProcessor::readEvent(unsigned int iStreamIndex) {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1854,6 +1854,7 @@ namespace edm {
                               for (auto i : std::views::iota(0U, preallocations_.numberOfStreams())) {
                                 streamQueues_[i].push(
                                     *holder.group(), [this, i, status, holder, &es, &oSourceStatus]() mutable {
+                                      //the status increments the number of streams here if successful
                                       if (!status->shouldStreamStartLumi()) {
                                         return;
                                       }
@@ -1903,7 +1904,7 @@ namespace edm {
     chain::first([this, &oSourceStatus](auto nextTask) {
       //all streams are sharing the same status at the moment
       auto status = streamLumiStatus_[0];  //read from streamLumiActive_ happened in calling routine
-      status->setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kProcessing);
+      status->thread_unsafe_setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kProcessing);
 
       while (oSourceStatus.nextTransitionType() == InputSource::ItemType::IsLumi and
              status->lumiPrincipal()->luminosityBlock() == oSourceStatus.lumiAuxiliary()->luminosityBlock()) {
@@ -2047,7 +2048,7 @@ namespace edm {
       if (streamLumiActive_ > 0) {
         FinalWaitingTask globalWaitTask{taskGroup_};
         assert(streamLumiActive_ == preallocations_.numberOfStreams());
-        streamLumiStatus_[0]->noMoreEventsInLumi();
+        streamLumiStatus_[0]->startNextLumiOrEndRun();
         streamLumiStatus_[0]->setCleaningUpAfterException(cleaningUpAfterException);
         {
           WaitingTaskHolder holder{taskGroup_, &globalWaitTask};
@@ -2280,12 +2281,11 @@ namespace edm {
     // requires both that an event is next and there are no problems or requests to stop.
 
     // Did another stream already stop or pause this lumi?
-    if (iStatus.eventProcessingState() != LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
+    if (iStatus.thread_unsafe_eventProcessingState() !=
+        LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
       return {.didCallReadEvent = false,
-              .stopLumi =
-                  iStatus.eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi,
-              .pauseForFileTransition = iStatus.eventProcessingState() ==
-                                        LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition,
+              .stopLumi = iStatus.thread_unsafe_eventProcessingState() ==
+                          LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi,
               .nextTransitionType = oSourceStatus.nextTransitionType(),
               .mustStartNextLumiOrEndRun = false};
     }
@@ -2293,10 +2293,9 @@ namespace edm {
     // Are output modules or the looper requesting we stop?
     if (shouldWeStop()) {
       oSourceStatus.setNextTransitionType(InputSource::ItemType::IsStop);
-      iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
+      iStatus.thread_unsafe_setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
       return {.didCallReadEvent = false,
               .stopLumi = true,
-              .pauseForFileTransition = false,
               .nextTransitionType = InputSource::ItemType::IsStop,
               .mustStartNextLumiOrEndRun = false};
     }
@@ -2336,22 +2335,20 @@ namespace edm {
               << "but the next lumi entry has the same lumi number.\n"
               << "This is probably a bug in the InputSource. Please report to the Core group.\n";
         }
-        iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
+        iStatus.thread_unsafe_setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
       } else {
-        iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition);
+        iStatus.thread_unsafe_setEventProcessingState(
+            LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition);
       }
       return {.didCallReadEvent = false,
-              .stopLumi =
-                  iStatus.eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi,
-              .pauseForFileTransition = iStatus.eventProcessingState() ==
-                                        LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition,
+              .stopLumi = iStatus.thread_unsafe_eventProcessingState() ==
+                          LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi,
               .nextTransitionType = oSourceStatus.nextTransitionType(),
               .mustStartNextLumiOrEndRun = false};
     }
     readEvent(iStreamIndex);
     return {.didCallReadEvent = true,
             .stopLumi = false,
-            .pauseForFileTransition = false,
             .nextTransitionType = oSourceStatus.nextTransitionType(),
             .mustStartNextLumiOrEndRun = false};
   }
@@ -2400,24 +2397,22 @@ namespace edm {
               // middle of pausing streams, then finish pausing all of them and the lumi will be
               // ended later. Otherwise, just end it now.
               auto status = streamLumiStatus_[iStreamIndex].get();
-              if (status->eventProcessingState() ==
+              if (status->thread_unsafe_eventProcessingState() ==
                   LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
-                status->setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
+                status->thread_unsafe_setEventProcessingState(
+                    LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
               }
               *ptrToResultFromReadNextEventForStream = {.didCallReadEvent = false,
                                                         .stopLumi = true,
-                                                        .pauseForFileTransition = false,
                                                         .nextTransitionType = InputSource::ItemType::IsStop,
                                                         .mustStartNextLumiOrEndRun = false};
             }
 
             auto status = streamLumiStatus_[iStreamIndex].get();
-            //only one thread can call status->noMoreEventsInLumi so call in source queue.
             if (not ptrToResultFromReadNextEventForStream->didCallReadEvent and
-                status->eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi and
-                not status->haveStartedNextLumiOrEndedRun()) {
-              status->noMoreEventsInLumi();
-              status->startNextLumiOrEndRun();
+                status->thread_unsafe_eventProcessingState() ==
+                    LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi and
+                status->startNextLumiOrEndRun()) {
               ptrToResultFromReadNextEventForStream->mustStartNextLumiOrEndRun = true;
             }
           });
@@ -2467,7 +2462,8 @@ namespace edm {
                 }
                 streamEndLumiAsync(iNextTask, iStreamIndex);
               } else {
-                assert(retValue->pauseForFileTransition);
+                //if both of these conditions are false, then we must have had a file transition and we need to pause the stream until all streams are ready to continue. Note that in this case we do not call endRunAsync or beginLumiAsync here. The stream will just pause until the lumi is ended or the next lumi is started at which point it will be resumed and endRunAsync or beginLumiAsync will be called at that time if appropriate.
+                assert(not retValue->didCallReadEvent and not retValue->stopLumi);
                 auto runStatus = streamRunStatus_[iStreamIndex].get();
 
                 if (runStatus->holderOfTaskInProcessRuns().hasTask()) {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1178,7 +1178,7 @@ namespace edm {
         assert(streamLumiActive_ == preallocations_.numberOfStreams());
         continueLumiAsync(std::move(holder));
       } else {
-        handleNextItemAfterMergingRunEntries(std::move(runStatus), std::move(holder));
+        handleNextItemAfterMergingRunEntriesAsync(std::move(runStatus), std::move(holder));
       }
     }
     waitTask.wait();
@@ -1363,7 +1363,7 @@ namespace edm {
                             queueWhichWaitsForIOVsToFinish_.resume();
                             exceptionRunStatus_ = status;
                           }
-                          handleNextItemAfterMergingRunEntries(status, holder);
+                          handleNextItemAfterMergingRunEntriesAsync(status, holder);
                         }) | runLast(postSourceTask);
                       } catch (...) {
                         status->resetBeginResources();
@@ -2148,7 +2148,7 @@ namespace edm {
         });
   }
 
-  void EventProcessor::handleNextItemAfterMergingRunEntries(std::shared_ptr<RunProcessingStatus> iRunStatus,
+  void EventProcessor::handleNextItemAfterMergingRunEntriesAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
                                                             WaitingTaskHolder iHolder) {
     chain::first([this, iRunStatus](auto nextTask) mutable {
       if (needToCallNext()) {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1213,19 +1213,12 @@ namespace edm {
   }  // namespace
 
   void EventProcessor::readRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                    WaitingTaskHolder const& iCheckSharedTask,
                                     WaitingTaskHolder iNextTask,
                                     SourceStatus& oSourceStatus) {
     sourceResourcesAcquirer_.serialQueueChain().push(
-        *iNextTask.group(), [this, iRunStatus, iCheckSharedTask, iNextTask, &oSourceStatus]() mutable {
+        *iNextTask.group(), [this, iRunStatus, iNextTask, &oSourceStatus]() mutable {
           CMS_SA_ALLOW try {
             ServiceRegistry::Operate operate(serviceToken_);
-
-            if (iCheckSharedTask.taskHasFailed()) {
-              releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*iRunStatus, queueWhichWaitsForIOVsToFinish_);
-              return;
-            }
-
             {
               std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
               iRunStatus->setRunPrincipal(readRun());
@@ -1239,7 +1232,6 @@ namespace edm {
             }
           } catch (...) {
             iNextTask.doneWaiting(std::current_exception());
-            releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*iRunStatus, queueWhichWaitsForIOVsToFinish_);
           }
         });
   }
@@ -1287,12 +1279,33 @@ namespace edm {
                 runStatus->setResumer(std::move(iResumer));
                 bool expectedLooperNotBegun = false;
 
-                chain::first(
-                    [this, postSourceTask = postRunQueueTask, runStatus, &oSourceStatus](auto nextTask) mutable {
-                      readRunAsync(runStatus, postSourceTask, nextTask, oSourceStatus);
-                    }) |
+                chain::first([this, runStatus, &oSourceStatus](auto nextTask) mutable {
+                  readRunAsync(runStatus, nextTask, oSourceStatus);
+                }) |
+                    chain::then(
+                        [this, runStatus, &oSourceStatus](std::exception_ptr const* iException, auto nextTask) mutable {
+                          if (iException) {
+                            //handle exception from readRunAsync
+                            WaitingTaskHolder copyHolder(nextTask);
+                            copyHolder.doneWaiting(*iException);
+                            releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(
+                                *runStatus, queueWhichWaitsForIOVsToFinish_);
+                            return;
+                          }
+                          CMS_SA_ALLOW try {
+                            if (oSourceStatus.nextTransitionType().itemPosition() !=
+                                InputSource::ItemPosition::LastItemToBeMerged) {
+                              readAndMergeRunEntriesAsync(runStatus, nextTask, oSourceStatus);
+                            } else {
+                              oSourceStatus.setNeedToCallNext(true);
+                            }
+                          } catch (...) {
+                            runStatus->setStopBeforeProcessingRun(true);
+                            nextTask.doneWaiting(std::current_exception());
+                          }
+                        }) |
                     chain::ifThen(looper_ and looperBeginJobRun_.compare_exchange_strong(expectedLooperNotBegun, true),
-                                  [this, runStatus](auto nextTask) mutable {
+                                  [this, runStatus](const std::exception_ptr* iException, auto nextTask) mutable {
                                     try {
                                       looper_->copyInfo(ScheduleInfo(schedule_.get()));
                                     } catch (...) {
@@ -1325,19 +1338,6 @@ namespace edm {
                                           *runStatus, queueWhichWaitsForIOVsToFinish_);
                                     }
                                   }) |
-                    chain::then([this, runStatus, &oSourceStatus](auto nextTask) mutable {
-                      CMS_SA_ALLOW try {
-                        if (oSourceStatus.nextTransitionType().itemPosition() !=
-                            InputSource::ItemPosition::LastItemToBeMerged) {
-                          readAndMergeRunEntriesAsync(runStatus, nextTask, oSourceStatus);
-                        } else {
-                          oSourceStatus.setNeedToCallNext(true);
-                        }
-                      } catch (...) {
-                        runStatus->setStopBeforeProcessingRun(true);
-                        nextTask.doneWaiting(std::current_exception());
-                      }
-                    }) |
                     chain::then([this, runStatus](auto nextTask) {
                       if (runStatus->stopBeforeProcessingRun()) {
                         return;
@@ -1713,19 +1713,12 @@ namespace edm {
 
   void EventProcessor::readLumiAsync(std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus,
                                      std::shared_ptr<RunProcessingStatus> iRunStatus,
-                                     WaitingTaskHolder iCheckSharedTask,
                                      WaitingTaskHolder iNextTask,
                                      SourceStatus& oSourceStatus) {
     sourceResourcesAcquirer_.serialQueueChain().push(
-        *iNextTask.group(), [this, iLumiStatus, iRunStatus, iCheckSharedTask, iNextTask, &oSourceStatus]() mutable {
+        *iNextTask.group(), [this, iLumiStatus, iRunStatus, iNextTask, &oSourceStatus]() mutable {
           CMS_SA_ALLOW try {
             ServiceRegistry::Operate operate(serviceToken_);
-
-            if (iCheckSharedTask.taskHasFailed()) {
-              releaseLumiResourcesAfterFailure(*iLumiStatus, queueWhichWaitsForIOVsToFinish_);
-              endRunAsync(iRunStatus, iNextTask, oSourceStatus);
-              return;
-            }
 
             {
               std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
@@ -1739,9 +1732,7 @@ namespace edm {
               }
             }
           } catch (...) {
-            releaseLumiResourcesAfterFailure(*iLumiStatus, queueWhichWaitsForIOVsToFinish_);
             iNextTask.doneWaiting(std::current_exception());
-            endRunAsync(iRunStatus, iNextTask, oSourceStatus);
           }
         });
   }
@@ -1784,9 +1775,25 @@ namespace edm {
                 using namespace edm::waiting_task::chain;
 
                 status->setResumer(std::move(iResumer));
-                chain::first([this, postLumiQueueTask, status, iRunStatus, &oSourceStatus](auto nextTask) mutable {
-                  readLumiAsync(status, iRunStatus, postLumiQueueTask, nextTask, oSourceStatus);
+                chain::first([this, status, iRunStatus, &oSourceStatus](auto nextTask) mutable {
+                  readLumiAsync(status, iRunStatus, nextTask, oSourceStatus);
                 }) |
+                    then([this, status, iRunStatus, &oSourceStatus](std::exception_ptr const* iException,
+                                                                    auto nextTask) mutable {
+                      if (iException) {
+                        //deal with possible failure from readLumiAsync
+                        releaseLumiResourcesAfterFailure(*status, queueWhichWaitsForIOVsToFinish_);
+                        nextTask.doneWaiting(*iException);
+                        endRunAsync(iRunStatus, nextTask, oSourceStatus);
+                        return;
+                      }
+                      if (oSourceStatus.nextTransitionType().itemPosition() !=
+                          InputSource::ItemPosition::LastItemToBeMerged) {
+                        readAndMergeLumiEntriesAsync(std::move(status), std::move(nextTask), oSourceStatus);
+                      } else {
+                        oSourceStatus.setNeedToCallNext(true);
+                      }
+                    }) |
                     chain::ifThen(rng.isAvailable() and rng->consumer() != nullptr,
                                   [this, status](auto nextTask) {
                                     //handle RandomNumberGenerator prefetching and preBeginLumi
@@ -1804,14 +1811,6 @@ namespace edm {
                              lb.setConsumer(rng->consumer());
                              rng->preBeginLumi(lb);
                            }) |
-                    then([this, status, &oSourceStatus](auto nextTask) mutable {
-                      if (oSourceStatus.nextTransitionType().itemPosition() !=
-                          InputSource::ItemPosition::LastItemToBeMerged) {
-                        readAndMergeLumiEntriesAsync(std::move(status), std::move(nextTask), oSourceStatus);
-                      } else {
-                        oSourceStatus.setNeedToCallNext(true);
-                      }
-                    }) |
                     then([this, status](auto nextTask) {
                       EventSetupImpl const& es = status->eventSetupImpl();
                       auto& lumiPrincipal = *status->lumiPrincipal();
@@ -2280,26 +2279,6 @@ namespace edm {
     // This function returns true if it successfully reads an event for the stream and that
     // requires both that an event is next and there are no problems or requests to stop.
 
-    // Did another stream already stop or pause this lumi?
-    if (iStatus.thread_unsafe_eventProcessingState() !=
-        LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
-      return {.didCallReadEvent = false,
-              .stopLumi = iStatus.thread_unsafe_eventProcessingState() ==
-                          LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi,
-              .nextTransitionType = oSourceStatus.nextTransitionType(),
-              .mustStartNextLumiOrEndRun = false};
-    }
-
-    // Are output modules or the looper requesting we stop?
-    if (shouldWeStop()) {
-      oSourceStatus.setNextTransitionType(InputSource::ItemType::IsStop);
-      iStatus.thread_unsafe_setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
-      return {.didCallReadEvent = false,
-              .stopLumi = true,
-              .nextTransitionType = InputSource::ItemType::IsStop,
-              .mustStartNextLumiOrEndRun = false};
-    }
-
     ServiceRegistry::Operate operate(serviceToken_);
 
     // need to use lock in addition to the serial task queue because
@@ -2382,14 +2361,35 @@ namespace edm {
            ptrToResultFromReadNextEventForStream]() mutable {
             bool aFailureHappened = earlierTaskFailed;
             if (not earlierTaskFailed) {
-              CMS_SA_ALLOW try {
-                auto status = streamLumiStatus_[iStreamIndex].get();
-                ServiceRegistry::Operate operate(serviceToken_);
-                *ptrToResultFromReadNextEventForStream = readNextEventForStream(iStreamIndex, *status, oSourceStatus);
-              } catch (...) {
-                aFailureHappened = true;
-                WaitingTaskHolder copyHolder(iTask);
-                copyHolder.doneWaiting(std::current_exception());
+              auto status = streamLumiStatus_[iStreamIndex].get();
+
+              // Did another stream already stop or pause this lumi?
+              if (status->thread_unsafe_eventProcessingState() !=
+                  LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
+                *ptrToResultFromReadNextEventForStream = {
+                    .didCallReadEvent = false,
+                    .stopLumi = status->thread_unsafe_eventProcessingState() ==
+                                LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi,
+                    .nextTransitionType = oSourceStatus.nextTransitionType(),
+                    .mustStartNextLumiOrEndRun = false};
+              } else if (shouldWeStop()) {
+                // Are output modules or the looper requesting we stop?
+                oSourceStatus.setNextTransitionType(InputSource::ItemType::IsStop);
+                status->thread_unsafe_setEventProcessingState(
+                    LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
+                *ptrToResultFromReadNextEventForStream = {.didCallReadEvent = false,
+                                                          .stopLumi = true,
+                                                          .nextTransitionType = InputSource::ItemType::IsStop,
+                                                          .mustStartNextLumiOrEndRun = false};
+              } else {
+                CMS_SA_ALLOW try {
+                  ServiceRegistry::Operate operate(serviceToken_);
+                  *ptrToResultFromReadNextEventForStream = readNextEventForStream(iStreamIndex, *status, oSourceStatus);
+                } catch (...) {
+                  aFailureHappened = true;
+                  WaitingTaskHolder copyHolder(iTask);
+                  copyHolder.doneWaiting(std::current_exception());
+                }
               }
             }
             if (aFailureHappened) {

--- a/FWCore/Framework/src/LuminosityBlockProcessingStatus.cc
+++ b/FWCore/Framework/src/LuminosityBlockProcessingStatus.cc
@@ -25,31 +25,11 @@ namespace edm {
   }
 
   bool LuminosityBlockProcessingStatus::shouldStreamStartLumi() {
-    if (state_ == State::kNoMoreEvents)
+    if (haveStartedNextLumiOrEndedRun())
       return false;
 
-    bool changed = false;
-    do {
-      auto expected = State::kRunning;
-      changed = state_.compare_exchange_strong(expected, State::kUpdating);
-      if (expected == State::kNoMoreEvents)
-        return false;
-    } while (changed == false);
-
     ++nStreamsProcessingLumi_;
-    state_ = State::kRunning;
     return true;
-  }
-
-  void LuminosityBlockProcessingStatus::noMoreEventsInLumi() {
-    bool changed = false;
-    do {
-      auto expected = State::kRunning;
-      changed = state_.compare_exchange_strong(expected, State::kUpdating);
-      assert(expected != State::kNoMoreEvents);
-    } while (changed == false);
-    nStreamsStillProcessingLumi_.store(nStreamsProcessingLumi_);
-    state_ = State::kNoMoreEvents;
   }
 
   void LuminosityBlockProcessingStatus::setEndTime() {

--- a/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
+++ b/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
@@ -67,8 +67,7 @@ namespace edm {
     void globalEndRunHolderDoneWaiting() { globalEndRunHolder_.doneWaiting(std::exception_ptr{}); }
 
     bool shouldStreamStartLumi();
-    void noMoreEventsInLumi();
-    bool streamFinishedLumi() { return 0 == (--nStreamsStillProcessingLumi_); }
+    bool streamFinishedLumi() { return 0 == (--nStreamsProcessingLumi_); }
 
     //These should only be called while in the InputSource's task queue
     void updateLastTimestamp(edm::Timestamp const& iTime) {
@@ -81,12 +80,14 @@ namespace edm {
     //Called once all events in Lumi have been processed
     void setEndTime();
 
+    //these should only be called while in the source's task queue
     enum class EventProcessingState { kProcessing, kPauseForFileTransition, kStopLumi };
-    EventProcessingState eventProcessingState() const { return eventProcessingState_; }
-    void setEventProcessingState(EventProcessingState val) { eventProcessingState_ = val; }
+    EventProcessingState thread_unsafe_eventProcessingState() const { return eventProcessingState_; }
+    void thread_unsafe_setEventProcessingState(EventProcessingState val) { eventProcessingState_ = val; }
 
     bool haveStartedNextLumiOrEndedRun() const { return startedNextLumiOrEndedRun_.load(); }
-    void startNextLumiOrEndRun() { startedNextLumiOrEndedRun_.store(true); }
+    //returns true if this is the first time it is called and false otherwise
+    bool startNextLumiOrEndRun() { return not startedNextLumiOrEndedRun_.exchange(true); }
 
     bool didGlobalBeginSucceed() const { return globalBeginSucceeded_; }
     void globalBeginDidSucceed() { globalBeginSucceeded_ = true; }
@@ -102,10 +103,7 @@ namespace edm {
     WaitingTaskList endIOVWaitingTasks_;
     edm::WaitingTaskHolder globalEndRunHolder_;
     edm::Timestamp endTime_{};
-    CMS_THREAD_GUARD(state_) unsigned int nStreamsProcessingLumi_ { 0 };
-    std::atomic<unsigned int> nStreamsStillProcessingLumi_{0};
-    enum class State { kRunning, kUpdating, kNoMoreEvents };
-    std::atomic<State> state_{State::kRunning};
+    std::atomic<unsigned int> nStreamsProcessingLumi_{0};
     EventProcessingState eventProcessingState_{EventProcessingState::kProcessing};
     std::atomic<char> endTimeSetStatus_{0};
     std::atomic<bool> startedNextLumiOrEndedRun_{false};

--- a/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
+++ b/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
@@ -82,8 +82,12 @@ namespace edm {
 
     //these should only be called while in the source's task queue
     enum class EventProcessingState { kProcessing, kPauseForFileTransition, kStopLumi };
-    EventProcessingState thread_unsafe_eventProcessingState() const { return eventProcessingState_; }
-    void thread_unsafe_setEventProcessingState(EventProcessingState val) { eventProcessingState_ = val; }
+    EventProcessingState eventProcessingState() const { return eventProcessingState_.load(); }
+    bool setEventProcessingState(EventProcessingState val) {
+      EventProcessingState expected = EventProcessingState::kProcessing;
+      return eventProcessingState_.compare_exchange_strong(expected, val);
+    }
+    void resetEventProcessingStateToProcessing() { eventProcessingState_.store(EventProcessingState::kProcessing); }
 
     bool haveStartedNextLumiOrEndedRun() const { return startedNextLumiOrEndedRun_.load(); }
     //returns true if this is the first time it is called and false otherwise
@@ -104,7 +108,7 @@ namespace edm {
     edm::WaitingTaskHolder globalEndRunHolder_;
     edm::Timestamp endTime_{};
     std::atomic<unsigned int> nStreamsProcessingLumi_{0};
-    EventProcessingState eventProcessingState_{EventProcessingState::kProcessing};
+    std::atomic<EventProcessingState> eventProcessingState_{EventProcessingState::kProcessing};
     std::atomic<char> endTimeSetStatus_{0};
     std::atomic<bool> startedNextLumiOrEndedRun_{false};
     bool globalBeginSucceeded_{false};

--- a/FWCore/Framework/src/RunProcessingStatus.cc
+++ b/FWCore/Framework/src/RunProcessingStatus.cc
@@ -15,6 +15,23 @@ namespace edm {
         nStreamsStillProcessingBeginRun_(iNStreams),
         nStreamsStillProcessingRun_(iNStreams) {}
 
+  std::optional<WaitingTaskHolder> RunProcessingStatus::releaseHolderOfTaskInProcessRuns() {
+    if (not holderOfTaskInProcessRunsIsDone_.exchange(true)) {
+      return std::move(holderOfTaskInProcessRuns_);
+    }
+    return std::nullopt;
+  }
+  void RunProcessingStatus::setHolderOfTaskInProcessRuns(WaitingTaskHolder const& holder) {
+    holderOfTaskInProcessRuns_ = holder;
+    holderOfTaskInProcessRunsIsDone_ = false;
+  }
+  void RunProcessingStatus::setHolderOfTaskInProcessRunsDoneWaiting() {
+    auto temp = releaseHolderOfTaskInProcessRuns();
+    if (temp) {
+      temp->doneWaiting(std::exception_ptr{});
+    }
+  }
+
   void RunProcessingStatus::resetBeginResources() {
     endIOVWaitingTasks_.doneWaiting(std::exception_ptr{});
     eventSetupImpl_.reset();

--- a/FWCore/Framework/src/RunProcessingStatus.h
+++ b/FWCore/Framework/src/RunProcessingStatus.h
@@ -23,6 +23,7 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
 
 namespace edm {
 
@@ -36,8 +37,9 @@ namespace edm {
     RunProcessingStatus(RunProcessingStatus const&) = delete;
     RunProcessingStatus const& operator=(RunProcessingStatus const&) = delete;
 
-    WaitingTaskHolder& holderOfTaskInProcessRuns() { return holderOfTaskInProcessRuns_; }
-    void setHolderOfTaskInProcessRuns(WaitingTaskHolder const& holder) { holderOfTaskInProcessRuns_ = holder; }
+    std::optional<WaitingTaskHolder> releaseHolderOfTaskInProcessRuns();
+    void setHolderOfTaskInProcessRuns(WaitingTaskHolder const& holder);
+    void setHolderOfTaskInProcessRunsDoneWaiting();
 
     void setResumer(LimitedTaskQueue::Resumer iResumer) { globalRunQueueResumer_ = std::move(iResumer); }
     void resumeGlobalRunQueue() {
@@ -93,7 +95,7 @@ namespace edm {
     void setEndingEventSetupSucceeded(bool val) { endingEventSetupSucceeded_ = val; }
 
   private:
-    WaitingTaskHolder holderOfTaskInProcessRuns_;
+    std::optional<WaitingTaskHolder> holderOfTaskInProcessRuns_;
     LimitedTaskQueue::Resumer globalRunQueueResumer_;
     std::shared_ptr<RunPrincipal> runPrincipal_;
     std::shared_ptr<const EventSetupImpl> eventSetupImpl_;
@@ -109,6 +111,7 @@ namespace edm {
     bool cleaningUpAfterException_{false};
     bool stopBeforeProcessingRun_{false};
     bool endingEventSetupSucceeded_{true};
+    std::atomic<bool> holderOfTaskInProcessRunsIsDone_{false};
   };
 }  // namespace edm
 

--- a/FWCore/Framework/src/SourceCoordinator.cc
+++ b/FWCore/Framework/src/SourceCoordinator.cc
@@ -22,7 +22,6 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 
 #include <cassert>
-#include <iostream>  //CDJ DEBUGGING
 namespace {
   struct SourceNextGuard {
     SourceNextGuard(edm::ActivityRegistry::PreSourceNextTransition* iPre,
@@ -58,7 +57,7 @@ namespace edm {
     assert(sourceStatus_.nextTransitionType().itemType() == InputSource::ItemType::IsFile);
     auto oldCacheID = input_->productRegistry().cacheIdentifier();
     auto fb = input_->readFile();
-    sourceStatus_.setNeedToCallNext(true);
+    sourceStatus_.setNeedToAskSourceForNext(true);
     //incase the input's registry changed
     ProductRegistry const* preg = nullptr;
     if (input_->productRegistry().cacheIdentifier() != oldCacheID) {
@@ -76,18 +75,18 @@ namespace edm {
   ProcessingController::ForwardState SourceCoordinator::forwardState() { return input_->forwardState(); }
   ProcessingController::ReverseState SourceCoordinator::reverseState() { return input_->reverseState(); }
   void SourceCoordinator::skipEvents(int n) {
-    sourceStatus_.setNeedToCallNext(true);
+    sourceStatus_.setNeedToAskSourceForNext(true);
     input_->skipEvents(n);
   }
   bool SourceCoordinator::goToEvent(EventID const& transition) {
-    sourceStatus_.setNeedToCallNext(true);
+    sourceStatus_.setNeedToAskSourceForNext(true);
     return input_->goToEvent(transition);
   }
 
   void SourceCoordinator::rewind() {
     input_->repeat();
     input_->rewind();
-    sourceStatus_.setNeedToCallNext(true);
+    sourceStatus_.setNeedToAskSourceForNext(true);
   }
 
   void SourceCoordinator::fillProcessBlockHelper() { input_->fillProcessBlockHelper(); }
@@ -116,7 +115,7 @@ namespace edm {
   }  // namespace
 
   SourceStatus SourceCoordinator::thread_unsafe_peekNextTransitionType() {
-    if (sourceStatus_.needToCallNext()) {
+    if (sourceStatus_.needToAskSourceForNext()) {
       TerminationGuard sentry(earlyTerminationSignal_);
       {
         SourceNextGuard guard(preSourceNextTransitionSignal_, postSourceNextTransitionSignal_);
@@ -126,7 +125,7 @@ namespace edm {
           itemTypeInfo = input_->nextItemType();
         } while (itemTypeInfo == InputSource::ItemType::IsSynchronize);
         sourceStatus_.setNextTransitionType(itemTypeInfo);
-        sourceStatus_.setNeedToCallNext(false);
+        sourceStatus_.setNeedToAskSourceForNext(false);
         if (sourceStatus_.nextTransitionType().itemType() == InputSource::ItemType::IsRun) {
           sourceStatus_.setRunAuxiliary(*input_->runAuxiliary());
           sourceStatus_.setReducedProcessHistoryID(input_->reducedProcessHistoryID());
@@ -170,11 +169,10 @@ namespace edm {
   }
 
   void SourceCoordinator::readRun(RunPrincipal& iRunPrincipal, HistoryAppender& historyAppender) {
-    iRunPrincipal.setAux(*input_->runAuxiliary());
     {
       TerminationGuard sentry(earlyTerminationSignal_);
       input_->readRun(iRunPrincipal, historyAppender);
-      sourceStatus_.setNeedToCallNext(true);
+      sourceStatus_.setNeedToAskSourceForNext(true);
       sentry.completedSuccessfully();
     }
     assert(input_->reducedProcessHistoryID() == iRunPrincipal.reducedProcessHistoryID());
@@ -184,7 +182,7 @@ namespace edm {
     {
       TerminationGuard sentry(earlyTerminationSignal_);
       input_->readAndMergeRun(runPrincipal);
-      sourceStatus_.setNeedToCallNext(true);
+      sourceStatus_.setNeedToAskSourceForNext(true);
       sentry.completedSuccessfully();
     }
   }
@@ -202,7 +200,7 @@ namespace edm {
             {
               std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
               readRun(*iRunStatus->runPrincipal(), historyAppender);
-              sourceStatus_.setNeedToCallNext(true);
+              sourceStatus_.setNeedToAskSourceForNext(true);
 
               RunPrincipal& runPrincipal = *iRunStatus->runPrincipal();
               {
@@ -222,7 +220,7 @@ namespace edm {
                    iRunStatus->runPrincipal()->run() == lastTransition.runAuxiliary()->run() and
                    iRunStatus->runPrincipal()->reducedProcessHistoryID() == lastTransition.reducedProcessHistoryID()) {
               readAndMergeRun(*iRunStatus->runPrincipal());
-              sourceStatus_.setNeedToCallNext(true);
+              sourceStatus_.setNeedToAskSourceForNext(true);
               lastTransition = sourceStatus_;
               if (lastTransition.nextTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
                 return;
@@ -241,7 +239,7 @@ namespace edm {
     {
       TerminationGuard sentry(earlyTerminationSignal_);
       input_->readLuminosityBlock(iLumiPrincipal, historyAppender);
-      sourceStatus_.setNeedToCallNext(true);
+      sourceStatus_.setNeedToAskSourceForNext(true);
       sentry.completedSuccessfully();
     }
   }
@@ -255,7 +253,7 @@ namespace edm {
     {
       TerminationGuard sentry(earlyTerminationSignal_);
       input_->readAndMergeLumi(lumiPrincipal);
-      sourceStatus_.setNeedToCallNext(true);
+      sourceStatus_.setNeedToAskSourceForNext(true);
       sentry.completedSuccessfully();
     }
   }
@@ -263,11 +261,9 @@ namespace edm {
   void SourceCoordinator::readNewLuminosityBlockAsync(std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus,
                                                       ProcessContext const& processContext,
                                                       HistoryAppender& historyAppender,
-                                                      SourceStatus& lastTransition,
                                                       WaitingTaskHolder iNextTask) {
     sourceResourcesAcquirer_.serialQueueChain().push(
-        *iNextTask.group(),
-        [this, iLumiStatus, &processContext, &historyAppender, &lastTransition, iNextTask]() mutable {
+        *iNextTask.group(), [this, iLumiStatus, &processContext, &historyAppender, iNextTask]() mutable {
           CMS_SA_ALLOW try {
             ServiceRegistry::Operate operate(serviceToken_);
 
@@ -283,15 +279,13 @@ namespace edm {
               }
               // useful for online processing where can be a long break between Run and Lumi transitions being returned by the InputSource
               if (sourceStatus_.nextTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
-                lastTransition = sourceStatus_;
                 return;
               }
-              lastTransition = thread_unsafe_peekNextTransitionType();
+              auto lastTransition = thread_unsafe_peekNextTransitionType();
               while (lastTransition.nextTransitionType() == InputSource::ItemType::IsLumi and
                      iLumiStatus->lumiPrincipal()->luminosityBlock() ==
                          lastTransition.lumiAuxiliary()->luminosityBlock()) {
                 readAndMergeLuminosityBlock(*iLumiStatus->lumiPrincipal());
-                lastTransition = sourceStatus_;
                 if (lastTransition.nextTransitionType().itemPosition() ==
                     InputSource::ItemPosition::LastItemToBeMerged) {
                   return;
@@ -314,8 +308,6 @@ namespace edm {
            iRunPrincipal.reducedProcessHistoryID() == lastTransition.reducedProcessHistoryID()) {
       returnValue = true;
       readAndMergeRun(iRunPrincipal);
-      sourceStatus_.setNeedToCallNext(true);
-      lastTransition = sourceStatus_;
       if (lastTransition.nextTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
         return true;
       }
@@ -346,7 +338,7 @@ namespace edm {
 
     TerminationGuard sentry(earlyTerminationSignal_);
     input_->readEvent(event, streamContext);
-    sourceStatus_.setNeedToCallNext(true);
+    sourceStatus_.setNeedToAskSourceForNext(true);
 
     runStatus.updateLastTimestamp(input_->timestamp());
     lumiStatus.updateLastTimestamp(input_->timestamp());
@@ -438,7 +430,7 @@ namespace edm {
             } else if (needToStop) {
               //we need to do this change in the source queue to synchronize sourceStatus_
               sourceStatus_.setNextTransitionType(InputSource::ItemType::IsStop);
-              sourceStatus_.setNeedToCallNext(false);
+              sourceStatus_.setNeedToAskSourceForNext(false);
               iLumiStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
               oResult = {.didCallReadEvent = false,
                          .stopLumi = true,

--- a/FWCore/Framework/src/SourceCoordinator.cc
+++ b/FWCore/Framework/src/SourceCoordinator.cc
@@ -192,8 +192,10 @@ namespace edm {
                                           HistoryAppender& historyAppender,
                                           SourceStatus& lastTransition,
                                           WaitingTaskHolder iHolder) {
+    auto group = iHolder.group();
     sourceResourcesAcquirer_.serialQueueChain().push(
-        *iHolder.group(), [this, iRunStatus, &historyAppender, &processContext, &lastTransition, iHolder]() mutable {
+        *group,
+        [this, iRunStatus, &historyAppender, &processContext, &lastTransition, iHolder = std::move(iHolder)]() mutable {
           CMS_SA_ALLOW try {
             ServiceRegistry::Operate operate(serviceToken_);
 
@@ -262,11 +264,11 @@ namespace edm {
                                                       ProcessContext const& processContext,
                                                       HistoryAppender& historyAppender,
                                                       WaitingTaskHolder iNextTask) {
+    auto group = iNextTask.group();
     sourceResourcesAcquirer_.serialQueueChain().push(
-        *iNextTask.group(), [this, iLumiStatus, &processContext, &historyAppender, iNextTask]() mutable {
+        *group, [this, iLumiStatus, &processContext, &historyAppender, iNextTask = std::move(iNextTask)]() mutable {
           CMS_SA_ALLOW try {
             ServiceRegistry::Operate operate(serviceToken_);
-
             {
               std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
               assert(iLumiStatus);

--- a/FWCore/Framework/src/SourceCoordinator.cc
+++ b/FWCore/Framework/src/SourceCoordinator.cc
@@ -1,0 +1,481 @@
+#include "FWCore/Framework/interface/SourceCoordinator.h"
+
+#include "FWCore/Framework/interface/SourceStatus.h"
+#include "FWCore/Framework/src/LuminosityBlockProcessingStatus.h"
+#include "FWCore/Framework/src/RunProcessingStatus.h"
+
+#include "FWCore/Framework/interface/InputSource.h"
+#include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
+#include "FWCore/Framework/interface/EventPrincipal.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/MessageLogger/interface/JobReport.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/UnixSignalHandlers.h"
+
+#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
+
+#include <cassert>
+#include <iostream>  //CDJ DEBUGGING
+namespace {
+  struct SourceNextGuard {
+    SourceNextGuard(edm::ActivityRegistry::PreSourceNextTransition* iPre,
+                    edm::ActivityRegistry::PostSourceNextTransition* iPost)
+        : signal_(iPost) {
+      if (iPre) {
+        iPre->emit();
+      }
+    }
+    ~SourceNextGuard() noexcept(false) {
+      if (signal_)
+        signal_->emit();
+    }
+    edm::ActivityRegistry::PostSourceNextTransition* signal_;
+  };
+
+  struct TerminationGuard {
+    TerminationGuard(edm::ActivityRegistry::PreSourceEarlyTermination* iSignal) : signal_(iSignal) {}
+    void completedSuccessfully() { signal_ = nullptr; }
+    ~TerminationGuard() noexcept(false) {
+      if (signal_)
+        signal_->emit(edm::TerminationOrigin::ExceptionFromThisContext);
+    }
+    edm::ActivityRegistry::PreSourceEarlyTermination* signal_;
+  };
+}  // namespace
+
+namespace edm {
+
+  void SourceCoordinator::beginJob(ProductRegistry const& iRegistry) { input_->doBeginJob(iRegistry); }
+  void SourceCoordinator::endJob() { input_->doEndJob(); }
+  std::tuple<std::shared_ptr<edm::FileBlock>, ProductRegistry const*> SourceCoordinator::readFile() {
+    assert(sourceStatus_.nextTransitionType().itemType() == InputSource::ItemType::IsFile);
+    auto oldCacheID = input_->productRegistry().cacheIdentifier();
+    auto fb = input_->readFile();
+    sourceStatus_.setNeedToCallNext(true);
+    //incase the input's registry changed
+    ProductRegistry const* preg = nullptr;
+    if (input_->productRegistry().cacheIdentifier() != oldCacheID) {
+      preg = &input_->productRegistry();
+    }
+    return {std::move(fb), preg};
+  }
+  void SourceCoordinator::closeFile(FileBlock* fileBlock, bool cleaningUpAfterException) {
+    TerminationGuard sentry(earlyTerminationSignal_);
+    input_->closeFile(fileBlock, cleaningUpAfterException);
+    sentry.completedSuccessfully();
+  }
+
+  bool SourceCoordinator::randomAccess() const { return input_->randomAccess(); }
+  ProcessingController::ForwardState SourceCoordinator::forwardState() { return input_->forwardState(); }
+  ProcessingController::ReverseState SourceCoordinator::reverseState() { return input_->reverseState(); }
+  void SourceCoordinator::skipEvents(int n) {
+    sourceStatus_.setNeedToCallNext(true);
+    input_->skipEvents(n);
+  }
+  bool SourceCoordinator::goToEvent(EventID const& transition) {
+    sourceStatus_.setNeedToCallNext(true);
+    return input_->goToEvent(transition);
+  }
+
+  void SourceCoordinator::rewind() {
+    input_->repeat();
+    input_->rewind();
+    sourceStatus_.setNeedToCallNext(true);
+  }
+
+  void SourceCoordinator::fillProcessBlockHelper() { input_->fillProcessBlockHelper(); }
+  bool SourceCoordinator::nextProcessBlock(ProcessBlockPrincipal& processBlockPrincipal) {
+    return input_->nextProcessBlock(processBlockPrincipal);
+  }
+  void SourceCoordinator::readProcessBlock(ProcessBlockPrincipal& processBlockPrincipal) {
+    TerminationGuard sentry(earlyTerminationSignal_);
+    input_->readProcessBlock(processBlockPrincipal);
+    sentry.completedSuccessfully();
+  }
+
+  namespace {
+    bool checkForAsyncStopRequest() {
+      bool returnValue = false;
+
+      // Look for a shutdown signal
+      if (edm::shutdown_flag.load(std::memory_order_acquire)) {
+        returnValue = true;
+        edm::LogSystem("ShutdownSignal") << "an external signal was sent to shutdown the job early.";
+        edm::Service<edm::JobReport> jr;
+        jr->reportShutdownSignal();
+      }
+      return returnValue;
+    }
+  }  // namespace
+
+  SourceStatus SourceCoordinator::thread_unsafe_peekNextTransitionType() {
+    if (sourceStatus_.needToCallNext()) {
+      TerminationGuard sentry(earlyTerminationSignal_);
+      {
+        SourceNextGuard guard(preSourceNextTransitionSignal_, postSourceNextTransitionSignal_);
+        //For now, do nothing with InputSource::IsSynchronize
+        InputSource::ItemTypeInfo itemTypeInfo;
+        do {
+          itemTypeInfo = input_->nextItemType();
+        } while (itemTypeInfo == InputSource::ItemType::IsSynchronize);
+        sourceStatus_.setNextTransitionType(itemTypeInfo);
+        sourceStatus_.setNeedToCallNext(false);
+        if (sourceStatus_.nextTransitionType().itemType() == InputSource::ItemType::IsRun) {
+          sourceStatus_.setRunAuxiliary(*input_->runAuxiliary());
+          sourceStatus_.setReducedProcessHistoryID(input_->reducedProcessHistoryID());
+        } else if (sourceStatus_.nextTransitionType().itemType() == InputSource::ItemType::IsLumi) {
+          sourceStatus_.setLuminosityBlockAuxiliary(*input_->luminosityBlockAuxiliary());
+          sourceStatus_.setReducedProcessHistoryID(input_->reducedProcessHistoryID());
+        }
+      }
+      sentry.completedSuccessfully();
+
+      if (checkForAsyncStopRequest()) {
+        earlyTerminationSignal_->emit(TerminationOrigin::ExternalSignal);
+        sourceStatus_.setNextTransitionType(InputSource::ItemType::IsStop);
+      }
+    }
+    return sourceStatus_;
+  }
+  void SourceCoordinator::peekNextTransitionTypeThatIsNotTheSameRunAsync(RunNumber_t run,
+                                                                         const ProcessHistoryID& reducedProcessHistoryID,
+                                                                         SourceStatus& lastTransition,
+                                                                         WaitingTaskHolder nextTask) {
+    auto group = nextTask.group();
+    sourceResourcesAcquirer_.serialQueueChain().push(
+        *group, [this, run, reducedProcessHistoryID, nextHolder = std::move(nextTask), &lastTransition]() mutable {
+          CMS_SA_ALLOW try {
+            ServiceRegistry::Operate operate(serviceToken_);
+            std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
+            lastTransition = thread_unsafe_peekNextTransitionType();
+            if (lastTransition.nextTransitionType() == InputSource::ItemType::IsRun &&
+                run == lastTransition.runAuxiliary()->run() &&
+                reducedProcessHistoryID == lastTransition.reducedProcessHistoryID()) {
+              throw Exception(errors::LogicError)
+                  << "InputSource claimed previous Run Entry was last to be merged in this file,\n"
+                  << "but the next entry has the same run number and reduced ProcessHistoryID.\n"
+                  << "This is probably a bug in the InputSource. Please report to the Core group.\n";
+            }
+          } catch (...) {
+            nextHolder.doneWaiting(std::current_exception());
+          }
+        });
+  }
+
+  void SourceCoordinator::readRun(RunPrincipal& iRunPrincipal, HistoryAppender& historyAppender) {
+    iRunPrincipal.setAux(*input_->runAuxiliary());
+    {
+      TerminationGuard sentry(earlyTerminationSignal_);
+      input_->readRun(iRunPrincipal, historyAppender);
+      sourceStatus_.setNeedToCallNext(true);
+      sentry.completedSuccessfully();
+    }
+    assert(input_->reducedProcessHistoryID() == iRunPrincipal.reducedProcessHistoryID());
+  }
+  void SourceCoordinator::readAndMergeRun(RunPrincipal& runPrincipal) {
+    runPrincipal.mergeAuxiliary(*input_->runAuxiliary());
+    {
+      TerminationGuard sentry(earlyTerminationSignal_);
+      input_->readAndMergeRun(runPrincipal);
+      sourceStatus_.setNeedToCallNext(true);
+      sentry.completedSuccessfully();
+    }
+  }
+
+  void SourceCoordinator::readNewRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
+                                          ProcessContext const& processContext,
+                                          HistoryAppender& historyAppender,
+                                          SourceStatus& lastTransition,
+                                          WaitingTaskHolder iHolder) {
+    sourceResourcesAcquirer_.serialQueueChain().push(
+        *iHolder.group(), [this, iRunStatus, &historyAppender, &processContext, &lastTransition, iHolder]() mutable {
+          CMS_SA_ALLOW try {
+            ServiceRegistry::Operate operate(serviceToken_);
+
+            {
+              std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
+              readRun(*iRunStatus->runPrincipal(), historyAppender);
+              sourceStatus_.setNeedToCallNext(true);
+
+              RunPrincipal& runPrincipal = *iRunStatus->runPrincipal();
+              {
+                TerminationGuard sentry(earlyTerminationSignal_);
+                input_->doBeginRun(runPrincipal, &processContext);
+                sentry.completedSuccessfully();
+              }
+              // useful for online processing where can be a long break between Run and Lumi transitions being returned by the InputSource
+              if (sourceStatus_.nextTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
+                lastTransition = sourceStatus_;
+                return;
+              }
+            }
+            lastTransition = thread_unsafe_peekNextTransitionType();
+
+            while (lastTransition.nextTransitionType() == InputSource::ItemType::IsRun and
+                   iRunStatus->runPrincipal()->run() == lastTransition.runAuxiliary()->run() and
+                   iRunStatus->runPrincipal()->reducedProcessHistoryID() == lastTransition.reducedProcessHistoryID()) {
+              readAndMergeRun(*iRunStatus->runPrincipal());
+              sourceStatus_.setNeedToCallNext(true);
+              lastTransition = sourceStatus_;
+              if (lastTransition.nextTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
+                return;
+              }
+              lastTransition = thread_unsafe_peekNextTransitionType();
+            }
+          } catch (...) {
+            iHolder.doneWaiting(std::current_exception());
+          }
+        });
+  }
+
+  void SourceCoordinator::readLuminosityBlock(LuminosityBlockPrincipal& iLumiPrincipal,
+                                              HistoryAppender& historyAppender) {
+    iLumiPrincipal.setAux(*input_->luminosityBlockAuxiliary());
+    {
+      TerminationGuard sentry(earlyTerminationSignal_);
+      input_->readLuminosityBlock(iLumiPrincipal, historyAppender);
+      sourceStatus_.setNeedToCallNext(true);
+      sentry.completedSuccessfully();
+    }
+  }
+
+  void SourceCoordinator::readAndMergeLuminosityBlock(LuminosityBlockPrincipal& lumiPrincipal) {
+    assert(lumiPrincipal.aux().sameIdentity(*input_->luminosityBlockAuxiliary()) or
+           input_->processHistoryRegistry().reducedProcessHistoryID(lumiPrincipal.aux().processHistoryID()) ==
+               input_->processHistoryRegistry().reducedProcessHistoryID(
+                   input_->luminosityBlockAuxiliary()->processHistoryID()));
+    lumiPrincipal.mergeAuxiliary(*input_->luminosityBlockAuxiliary());
+    {
+      TerminationGuard sentry(earlyTerminationSignal_);
+      input_->readAndMergeLumi(lumiPrincipal);
+      sourceStatus_.setNeedToCallNext(true);
+      sentry.completedSuccessfully();
+    }
+  }
+
+  void SourceCoordinator::readNewLuminosityBlockAsync(std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus,
+                                                      ProcessContext const& processContext,
+                                                      HistoryAppender& historyAppender,
+                                                      SourceStatus& lastTransition,
+                                                      WaitingTaskHolder iNextTask) {
+    sourceResourcesAcquirer_.serialQueueChain().push(
+        *iNextTask.group(),
+        [this, iLumiStatus, &processContext, &historyAppender, &lastTransition, iNextTask]() mutable {
+          CMS_SA_ALLOW try {
+            ServiceRegistry::Operate operate(serviceToken_);
+
+            {
+              std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
+              assert(iLumiStatus);
+              assert(iLumiStatus->lumiPrincipal());
+              readLuminosityBlock(*iLumiStatus->lumiPrincipal(), historyAppender);
+              {
+                TerminationGuard sentry(earlyTerminationSignal_);
+                input_->doBeginLumi(*iLumiStatus->lumiPrincipal(), &processContext);
+                sentry.completedSuccessfully();
+              }
+              // useful for online processing where can be a long break between Run and Lumi transitions being returned by the InputSource
+              if (sourceStatus_.nextTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
+                lastTransition = sourceStatus_;
+                return;
+              }
+              lastTransition = thread_unsafe_peekNextTransitionType();
+              while (lastTransition.nextTransitionType() == InputSource::ItemType::IsLumi and
+                     iLumiStatus->lumiPrincipal()->luminosityBlock() ==
+                         lastTransition.lumiAuxiliary()->luminosityBlock()) {
+                readAndMergeLuminosityBlock(*iLumiStatus->lumiPrincipal());
+                lastTransition = sourceStatus_;
+                if (lastTransition.nextTransitionType().itemPosition() ==
+                    InputSource::ItemPosition::LastItemToBeMerged) {
+                  return;
+                }
+                lastTransition = thread_unsafe_peekNextTransitionType();
+              }
+            }
+          } catch (...) {
+            iNextTask.doneWaiting(std::current_exception());
+          }
+        });
+  }
+
+  bool SourceCoordinator::mergeRunIfNeeded(RunPrincipal& iRunPrincipal) {
+    bool returnValue = false;
+    auto lastTransition = thread_unsafe_peekNextTransitionType();
+
+    while (lastTransition.nextTransitionType() == InputSource::ItemType::IsRun and
+           iRunPrincipal.run() == lastTransition.runAuxiliary()->run() and
+           iRunPrincipal.reducedProcessHistoryID() == lastTransition.reducedProcessHistoryID()) {
+      returnValue = true;
+      readAndMergeRun(iRunPrincipal);
+      sourceStatus_.setNeedToCallNext(true);
+      lastTransition = sourceStatus_;
+      if (lastTransition.nextTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
+        return true;
+      }
+      lastTransition = thread_unsafe_peekNextTransitionType();
+    }
+    return returnValue;
+  }
+  bool SourceCoordinator::mergeLuminosityBlockIfNeeded(LuminosityBlockPrincipal& iLumiPrincipal) {
+    bool returnValue = false;
+    auto lastTransition = thread_unsafe_peekNextTransitionType();
+    while (lastTransition.nextTransitionType() == InputSource::ItemType::IsLumi and
+           iLumiPrincipal.luminosityBlock() == lastTransition.lumiAuxiliary()->luminosityBlock()) {
+      returnValue = true;
+      readAndMergeLuminosityBlock(iLumiPrincipal);
+      if (lastTransition.nextTransitionType().itemPosition() == InputSource::ItemPosition::LastItemToBeMerged) {
+        return true;
+      }
+      lastTransition = thread_unsafe_peekNextTransitionType();
+    }
+    return returnValue;
+  }
+
+  void SourceCoordinator::readEvent(EventPrincipal& event,
+                                    ProcessContext& processContext,
+                                    LuminosityBlockProcessingStatus& lumiStatus,
+                                    RunProcessingStatus& runStatus) {
+    StreamContext streamContext(event.streamID(), &processContext);
+
+    TerminationGuard sentry(earlyTerminationSignal_);
+    input_->readEvent(event, streamContext);
+    sourceStatus_.setNeedToCallNext(true);
+
+    runStatus.updateLastTimestamp(input_->timestamp());
+    lumiStatus.updateLastTimestamp(input_->timestamp());
+    sentry.completedSuccessfully();
+  }
+
+  SourceCoordinator::ReadNextEventForStreamResult SourceCoordinator::readNextEventForStream(
+      EventPrincipal& event,
+      ProcessContext& processContext,
+      LuminosityBlockProcessingStatus& iStatus,
+      RunProcessingStatus& runStatus) {
+    // This function returns true if it successfully reads an event for the stream and that
+    // requires both that an event is next and there are no problems or requests to stop.
+
+    ServiceRegistry::Operate operate(serviceToken_);
+
+    // need to use lock in addition to the serial task queue because
+    // of delayed provenance reading and reading data in response to
+    // edm::Refs etc
+    std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
+
+    InputSource::ItemType itemType = thread_unsafe_peekNextTransitionType().nextTransitionType();
+
+    if (InputSource::ItemType::IsEvent != itemType) {
+      // IsFile may continue processing the lumi and
+      // looper_ can cause the input source to declare a new IsRun which is actually
+      // just a continuation of the previous run
+      if (InputSource::ItemType::IsStop == itemType or InputSource::ItemType::IsLumi == itemType or
+          (InputSource::ItemType::IsRun == itemType and
+           (iStatus.lumiPrincipal()->run() != sourceStatus_.runAuxiliary()->run() or
+            iStatus.lumiPrincipal()->runPrincipal().reducedProcessHistoryID() !=
+                sourceStatus_.reducedProcessHistoryID()))) {
+        if (itemType == InputSource::ItemType::IsLumi &&
+            iStatus.lumiPrincipal()->luminosityBlock() == sourceStatus_.lumiAuxiliary()->luminosityBlock()) {
+          throw Exception(errors::LogicError)
+              << "InputSource claimed previous Lumi Entry was last to be merged in this file,\n"
+              << "but the next lumi entry has the same lumi number.\n"
+              << "This is probably a bug in the InputSource. Please report to the Core group.\n";
+        }
+        iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
+      } else {
+        iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition);
+      }
+      return {.didCallReadEvent = false,
+              .stopLumi =
+                  iStatus.eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi,
+              .nextTransitionType = sourceStatus_.nextTransitionType(),
+              .mustStartNextLumiOrEndRun = false};
+    }
+    readEvent(event, processContext, iStatus, runStatus);
+    return {.didCallReadEvent = true,
+            .stopLumi = false,
+            .nextTransitionType = sourceStatus_.nextTransitionType(),
+            .mustStartNextLumiOrEndRun = false};
+  }
+
+  void SourceCoordinator::readNextEventForStreamAsync(EventPrincipal& event,
+                                                      ProcessContext& processContext,
+                                                      LuminosityBlockProcessingStatus& iLumiStatus,
+                                                      RunProcessingStatus& runStatus,
+                                                      bool earlierTaskFailed,
+                                                      bool needToStop,
+                                                      ReadNextEventForStreamResult& oResult,
+                                                      SourceStatus& oSourceStatus,
+                                                      WaitingTaskHolder iTask) {
+    auto group = iTask.group();
+    sourceResourcesAcquirer_.serialQueueChain().push(
+        *group,
+        [this,
+         earlierTaskFailed,
+         needToStop,
+         iTask = std::move(iTask),
+         &event,
+         &iLumiStatus,
+         &runStatus,
+         &oResult,
+         &processContext,
+         &oSourceStatus]() mutable {
+          bool aFailureHappened = earlierTaskFailed;
+          if (not earlierTaskFailed) {
+            // Did another stream already stop or pause this lumi?
+            if (iLumiStatus.eventProcessingState() !=
+                LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
+              oResult = {.didCallReadEvent = false,
+                         .stopLumi = iLumiStatus.eventProcessingState() ==
+                                     LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi,
+                         .nextTransitionType = sourceStatus_.nextTransitionType(),
+                         .mustStartNextLumiOrEndRun = false};
+            } else if (needToStop) {
+              //we need to do this change in the source queue to synchronize sourceStatus_
+              sourceStatus_.setNextTransitionType(InputSource::ItemType::IsStop);
+              sourceStatus_.setNeedToCallNext(false);
+              iLumiStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
+              oResult = {.didCallReadEvent = false,
+                         .stopLumi = true,
+                         .nextTransitionType = InputSource::ItemType::IsStop,
+                         .mustStartNextLumiOrEndRun = false};
+            } else {
+              CMS_SA_ALLOW try {
+                ServiceRegistry::Operate operate(serviceToken_);
+                oResult = readNextEventForStream(event, processContext, iLumiStatus, runStatus);
+              } catch (...) {
+                aFailureHappened = true;
+                WaitingTaskHolder copyHolder(iTask);
+                copyHolder.doneWaiting(std::current_exception());
+              }
+            }
+          }
+          if (aFailureHappened) {
+            // We want all streams to stop or all streams to pause. If we are already in the
+            // middle of pausing streams, then finish pausing all of them and the lumi will be
+            // ended later. Otherwise, just end it now.
+            if (iLumiStatus.eventProcessingState() ==
+                LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
+              iLumiStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
+            }
+            oResult = {.didCallReadEvent = false,
+                       .stopLumi = true,
+                       .nextTransitionType = InputSource::ItemType::IsStop,
+                       .mustStartNextLumiOrEndRun = false};
+          }
+
+          if (not oResult.didCallReadEvent and
+              iLumiStatus.eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi and
+              iLumiStatus.startNextLumiOrEndRun()) {
+            oResult.mustStartNextLumiOrEndRun = true;
+          }
+          oSourceStatus = sourceStatus_;
+        });
+  }
+
+}  // namespace edm

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -77,11 +77,11 @@ struct RunResources {
 
 class RunsInFileProcessor {
 public:
-  edm::InputSource::ItemType processRuns(EventProcessor& iEP) {
+  [[nodiscard]] edm::SourceStatus processRuns(EventProcessor& iEP, edm::SourceStatus const& oSourceStatus) {
     if (!runResources_) {
       runResources_ = std::make_unique<RunResources>(iEP);
     }
-    return iEP.processRuns();
+    return iEP.processRuns(oSourceStatus);
   }
 
   void normalEnd() {
@@ -99,20 +99,23 @@ class FilesProcessor {
 public:
   explicit FilesProcessor(bool iDoNotMerge) : doNotMerge_(iDoNotMerge) {}
 
-  edm::InputSource::ItemType processFiles(EventProcessor& iEP) {
+  [[nodiscard]] edm::SourceStatus processFiles(EventProcessor& iEP) {
     bool finished = false;
-    edm::InputSource::ItemType nextTransition = iEP.nextTransitionType();
-    if (nextTransition != edm::InputSource::ItemType::IsFile)
+    auto nextTransition = iEP.nextTransitionType();
+    if (nextTransition.nextTransitionType() != edm::InputSource::ItemType::IsFile)
       return nextTransition;
     do {
-      switch (nextTransition) {
+      switch (nextTransition.nextTransitionType()) {
         case edm::InputSource::ItemType::IsFile: {
           processFile(iEP);
+          //assert(not nextTransition.needToCallNext());
+          bool needToCallNext = nextTransition.needToCallNext();
           nextTransition = iEP.nextTransitionType();
+          nextTransition.setNeedToCallNext(needToCallNext);
           break;
         }
         case edm::InputSource::ItemType::IsRun: {
-          nextTransition = runs_.processRuns(iEP);
+          nextTransition = runs_.processRuns(iEP, nextTransition);
           break;
         }
         default:

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -108,10 +108,7 @@ public:
       switch (nextTransition.nextTransitionType()) {
         case edm::InputSource::ItemType::IsFile: {
           processFile(iEP);
-          //assert(not nextTransition.needToCallNext());
-          bool needToCallNext = nextTransition.needToCallNext();
           nextTransition = iEP.thread_unsafe_peekNextTransitionType();
-          nextTransition.setNeedToCallNext(needToCallNext);
           break;
         }
         case edm::InputSource::ItemType::IsRun: {

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -101,7 +101,7 @@ public:
 
   [[nodiscard]] edm::SourceStatus processFiles(EventProcessor& iEP) {
     bool finished = false;
-    auto nextTransition = iEP.nextTransitionType();
+    auto nextTransition = iEP.findNextTransitionType();
     if (nextTransition.nextTransitionType() != edm::InputSource::ItemType::IsFile)
       return nextTransition;
     do {
@@ -110,7 +110,7 @@ public:
           processFile(iEP);
           //assert(not nextTransition.needToCallNext());
           bool needToCallNext = nextTransition.needToCallNext();
-          nextTransition = iEP.nextTransitionType();
+          nextTransition = iEP.findNextTransitionType();
           nextTransition.setNeedToCallNext(needToCallNext);
           break;
         }

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -101,7 +101,7 @@ public:
 
   [[nodiscard]] edm::SourceStatus processFiles(EventProcessor& iEP) {
     bool finished = false;
-    auto nextTransition = iEP.findNextTransitionType();
+    auto nextTransition = iEP.thread_unsafe_peekNextTransitionType();
     if (nextTransition.nextTransitionType() != edm::InputSource::ItemType::IsFile)
       return nextTransition;
     do {
@@ -110,7 +110,7 @@ public:
           processFile(iEP);
           //assert(not nextTransition.needToCallNext());
           bool needToCallNext = nextTransition.needToCallNext();
-          nextTransition = iEP.findNextTransitionType();
+          nextTransition = iEP.thread_unsafe_peekNextTransitionType();
           nextTransition.setNeedToCallNext(needToCallNext);
           break;
         }

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -245,6 +245,12 @@
   <use name="catch2"/>
 </bin>
 
+<bin name="TestFWCoreFrameworkSourceCoordinator" file="test_catch2_main.cc,sourcecoordinator_t.catch2.cc">
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="catch2"/>
+</bin>
+
 <bin name="TestFWCoreFrameworkeventprincipal" file="eventprincipal_t.catch2.cc,sharedresourcesregistry_t.catch2.cc">
   <use name="DataFormats/Common"/>
   <use name="DataFormats/Provenance"/>

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -44,11 +44,11 @@ namespace edm {
         reachedEndOfInput_(false),
         shouldThrow_(false) {}
 
-  InputSource::ItemType MockEventProcessor::nextTransitionType() {
+  SourceStatus MockEventProcessor::nextTransitionType() {
     token t;
     if (not(input_ >> t)) {
       reachedEndOfInput_ = true;
-      return lastTransition_ = InputSource::ItemType::IsStop;
+      return SourceStatus{InputSource::ItemType::IsStop};
     }
 
     char ch = t.id;
@@ -57,11 +57,11 @@ namespace edm {
     if (ch == 'r') {
       output_ << "    *** nextItemType: Run " << t.value << " ***\n";
       nextRun_ = static_cast<RunNumber_t>(t.value);
-      return lastTransition_ = InputSource::ItemType::IsRun;
+      return SourceStatus{InputSource::ItemType::IsRun};
     } else if (ch == 'l') {
       output_ << "    *** nextItemType: Lumi " << t.value << " ***\n";
       nextLumi_ = static_cast<LuminosityBlockNumber_t>(t.value);
-      return lastTransition_ = InputSource::ItemType::IsLumi;
+      return SourceStatus{InputSource::ItemType::IsLumi};
     } else if (ch == 'e') {
       output_ << "    *** nextItemType: Event ***\n";
       // a special value for test purposes only
@@ -71,7 +71,7 @@ namespace edm {
       } else {
         shouldWeStop_ = false;
       }
-      return lastTransition_ = InputSource::ItemType::IsEvent;
+      return SourceStatus{InputSource::ItemType::IsEvent};
     } else if (ch == 'f') {
       output_ << "    *** nextItemType: File " << t.value << " ***\n";
       // a special value for test purposes only
@@ -79,7 +79,7 @@ namespace edm {
         shouldWeCloseOutput_ = false;
       else
         shouldWeCloseOutput_ = true;
-      return lastTransition_ = InputSource::ItemType::IsFile;
+      return SourceStatus{InputSource::ItemType::IsFile};
     } else if (ch == 's') {
       output_ << "    *** nextItemType: Stop " << t.value << " ***\n";
       // a special value for test purposes only
@@ -87,23 +87,22 @@ namespace edm {
         shouldWeEndLoop_ = false;
       else
         shouldWeEndLoop_ = true;
-      return lastTransition_ = InputSource::ItemType::IsStop;
+      return SourceStatus{InputSource::ItemType::IsStop};
     } else if (ch == 'x') {
       output_ << "    *** nextItemType: Restart " << t.value << " ***\n";
       shouldWeEndLoop_ = t.value;
-      return lastTransition_ = InputSource::ItemType::IsStop;
+      return SourceStatus{InputSource::ItemType::IsStop};
     } else if (ch == 't') {
       output_ << "    *** nextItemType: Throw " << t.value << " ***\n";
       shouldThrow_ = true;
       return nextTransitionType();
     }
-    return lastTransition_ = InputSource::ItemType::IsInvalid;
+    return SourceStatus{InputSource::ItemType::IsInvalid};
   }
 
-  InputSource::ItemType MockEventProcessor::lastTransitionType() const { return lastTransition_; }
-
-  InputSource::ItemType MockEventProcessor::readAndProcessEvents() {
+  SourceStatus MockEventProcessor::readAndProcessEvents() {
     bool first = true;
+    SourceStatus nextTransition;
     do {
       if (first) {
         first = false;
@@ -112,11 +111,12 @@ namespace edm {
       }
       readAndProcessEvent();
       if (shouldWeStop()) {
-        return InputSource::ItemType::IsEvent;
+        return SourceStatus{InputSource::ItemType::IsEvent};
       }
-    } while (nextTransitionType() == InputSource::ItemType::IsEvent);
+      nextTransition = nextTransitionType();
+    } while (nextTransition.nextTransitionType() == InputSource::ItemType::IsEvent);
 
-    return lastTransitionType();
+    return nextTransition;
   }
 
   void MockEventProcessor::runToCompletion() {
@@ -137,7 +137,7 @@ namespace edm {
 
         fp.normalEnd();
 
-        if (trans != InputSource::ItemType::IsStop) {
+        if (trans.nextTransitionType() != InputSource::ItemType::IsStop) {
           //problem with the source
           doErrorStuff();
           break;
@@ -186,11 +186,12 @@ namespace edm {
   void MockEventProcessor::inputProcessBlocks() {}
   void MockEventProcessor::endProcessBlock(bool cleaningUpAfterException, bool beginProcessBlockSucceeded) {}
 
-  InputSource::ItemType MockEventProcessor::processRuns() {
+  SourceStatus MockEventProcessor::processRuns(SourceStatus const& /*oSourceStatus*/) {
     bool finished = false;
-    auto nextTransition = edm::InputSource::ItemType::IsRun;
+    SourceStatus nextTransition;
+    nextTransition.setNextTransitionType(edm::InputSource::ItemType::IsRun);
     do {
-      switch (nextTransition) {
+      switch (nextTransition.nextTransitionType()) {
         case edm::InputSource::ItemType::IsRun: {
           processRun();
           nextTransition = nextTransitionType();
@@ -222,13 +223,15 @@ namespace edm {
     }
   }
 
-  InputSource::ItemType MockEventProcessor::processLumis() {
+  SourceStatus MockEventProcessor::processLumis() {
+    SourceStatus nextTransition;
     if (lumiStatus_ and currentLumiNumber_ == nextLumi_) {
       readAndMergeLumi();
-      if (nextTransitionType() == InputSource::ItemType::IsEvent) {
-        readAndProcessEvents();
+      nextTransition = nextTransitionType();
+      if (nextTransition.nextTransitionType() == InputSource::ItemType::IsEvent) {
+        nextTransition = readAndProcessEvents();
         if (shouldWeStop()) {
-          return edm::InputSource::ItemType::IsStop;
+          return SourceStatus{InputSource::ItemType::IsStop};
         }
       }
     } else {
@@ -239,14 +242,15 @@ namespace edm {
       throwIfNeeded();
       didGlobalBeginLumiSucceed_ = true;
       //Need to do event processing here
-      if (nextTransitionType() == InputSource::ItemType::IsEvent) {
-        readAndProcessEvents();
+      nextTransition = nextTransitionType();
+      if (nextTransition.nextTransitionType() == InputSource::ItemType::IsEvent) {
+        nextTransition = readAndProcessEvents();
         if (shouldWeStop()) {
-          return edm::InputSource::ItemType::IsStop;
+          return SourceStatus{InputSource::ItemType::IsStop};
         }
       }
     }
-    return lastTransitionType();
+    return nextTransition;
   }
 
   void MockEventProcessor::beginRun(RunNumber_t run) {

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -44,7 +44,7 @@ namespace edm {
         reachedEndOfInput_(false),
         shouldThrow_(false) {}
 
-  SourceStatus MockEventProcessor::findNextTransitionType() {
+  SourceStatus MockEventProcessor::thread_unsafe_peekNextTransitionType() {
     token t;
     if (not(input_ >> t)) {
       reachedEndOfInput_ = true;
@@ -95,7 +95,7 @@ namespace edm {
     } else if (ch == 't') {
       output_ << "    *** nextItemType: Throw " << t.value << " ***\n";
       shouldThrow_ = true;
-      return findNextTransitionType();
+      return thread_unsafe_peekNextTransitionType();
     }
     return SourceStatus{InputSource::ItemType::IsInvalid};
   }
@@ -113,7 +113,7 @@ namespace edm {
       if (shouldWeStop()) {
         return SourceStatus{InputSource::ItemType::IsEvent};
       }
-      nextTransition = findNextTransitionType();
+      nextTransition = thread_unsafe_peekNextTransitionType();
     } while (nextTransition.nextTransitionType() == InputSource::ItemType::IsEvent);
 
     return nextTransition;
@@ -194,7 +194,7 @@ namespace edm {
       switch (nextTransition.nextTransitionType()) {
         case edm::InputSource::ItemType::IsRun: {
           processRun();
-          nextTransition = findNextTransitionType();
+          nextTransition = thread_unsafe_peekNextTransitionType();
           break;
         }
         case edm::InputSource::ItemType::IsLumi: {
@@ -227,7 +227,7 @@ namespace edm {
     SourceStatus nextTransition;
     if (lumiStatus_ and currentLumiNumber_ == nextLumi_) {
       readAndMergeLumi();
-      nextTransition = findNextTransitionType();
+      nextTransition = thread_unsafe_peekNextTransitionType();
       if (nextTransition.nextTransitionType() == InputSource::ItemType::IsEvent) {
         nextTransition = readAndProcessEvents();
         if (shouldWeStop()) {
@@ -242,7 +242,7 @@ namespace edm {
       throwIfNeeded();
       didGlobalBeginLumiSucceed_ = true;
       //Need to do event processing here
-      nextTransition = findNextTransitionType();
+      nextTransition = thread_unsafe_peekNextTransitionType();
       if (nextTransition.nextTransitionType() == InputSource::ItemType::IsEvent) {
         nextTransition = readAndProcessEvents();
         if (shouldWeStop()) {

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -44,7 +44,7 @@ namespace edm {
         reachedEndOfInput_(false),
         shouldThrow_(false) {}
 
-  SourceStatus MockEventProcessor::nextTransitionType() {
+  SourceStatus MockEventProcessor::findNextTransitionType() {
     token t;
     if (not(input_ >> t)) {
       reachedEndOfInput_ = true;
@@ -95,7 +95,7 @@ namespace edm {
     } else if (ch == 't') {
       output_ << "    *** nextItemType: Throw " << t.value << " ***\n";
       shouldThrow_ = true;
-      return nextTransitionType();
+      return findNextTransitionType();
     }
     return SourceStatus{InputSource::ItemType::IsInvalid};
   }
@@ -113,7 +113,7 @@ namespace edm {
       if (shouldWeStop()) {
         return SourceStatus{InputSource::ItemType::IsEvent};
       }
-      nextTransition = nextTransitionType();
+      nextTransition = findNextTransitionType();
     } while (nextTransition.nextTransitionType() == InputSource::ItemType::IsEvent);
 
     return nextTransition;
@@ -194,7 +194,7 @@ namespace edm {
       switch (nextTransition.nextTransitionType()) {
         case edm::InputSource::ItemType::IsRun: {
           processRun();
-          nextTransition = nextTransitionType();
+          nextTransition = findNextTransitionType();
           break;
         }
         case edm::InputSource::ItemType::IsLumi: {
@@ -227,7 +227,7 @@ namespace edm {
     SourceStatus nextTransition;
     if (lumiStatus_ and currentLumiNumber_ == nextLumi_) {
       readAndMergeLumi();
-      nextTransition = nextTransitionType();
+      nextTransition = findNextTransitionType();
       if (nextTransition.nextTransitionType() == InputSource::ItemType::IsEvent) {
         nextTransition = readAndProcessEvents();
         if (shouldWeStop()) {
@@ -242,7 +242,7 @@ namespace edm {
       throwIfNeeded();
       didGlobalBeginLumiSucceed_ = true;
       //Need to do event processing here
-      nextTransition = nextTransitionType();
+      nextTransition = findNextTransitionType();
       if (nextTransition.nextTransitionType() == InputSource::ItemType::IsEvent) {
         nextTransition = readAndProcessEvents();
         if (shouldWeStop()) {

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -32,6 +32,7 @@ Original Authors: W. David Dagenhart, Marc Paterno
 
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "FWCore/Framework/interface/InputSource.h"
+#include "FWCore/Framework/interface/SourceStatus.h"
 
 #include <exception>
 #include <ostream>
@@ -52,8 +53,7 @@ namespace edm {
 
     void runToCompletion();
 
-    InputSource::ItemType nextTransitionType();
-    InputSource::ItemType lastTransitionType() const;
+    SourceStatus nextTransitionType();
 
     void readFile();
     bool fileBlockValid() { return true; }
@@ -76,9 +76,9 @@ namespace edm {
     void inputProcessBlocks();
     void endProcessBlock(bool cleaningUpAfterException, bool beginProcessBlockSucceeded);
 
-    InputSource::ItemType processRuns();
+    SourceStatus processRuns(SourceStatus const& oSourceStatus);
     void processRun();
-    InputSource::ItemType processLumis();
+    SourceStatus processLumis();
 
     void beginRun(RunNumber_t run);
 
@@ -106,7 +106,7 @@ namespace edm {
     bool setDeferredException(std::exception_ptr);
 
   private:
-    InputSource::ItemType readAndProcessEvents();
+    SourceStatus readAndProcessEvents();
     void readAndProcessEvent();
     void throwIfNeeded();
     void endLumi();
@@ -118,7 +118,6 @@ namespace edm {
     bool lumiStatus_ = false;
     LuminosityBlockNumber_t currentLumiNumber_ = 0;
     bool didGlobalBeginLumiSucceed_ = false;
-    InputSource::ItemType lastTransition_ = InputSource::ItemType::IsInvalid;
 
     bool currentRun_ = false;
     RunNumber_t currentRunNumber_ = 0;

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -53,7 +53,7 @@ namespace edm {
 
     void runToCompletion();
 
-    SourceStatus nextTransitionType();
+    SourceStatus findNextTransitionType();
 
     void readFile();
     bool fileBlockValid() { return true; }

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -53,7 +53,7 @@ namespace edm {
 
     void runToCompletion();
 
-    SourceStatus findNextTransitionType();
+    SourceStatus thread_unsafe_peekNextTransitionType();
 
     void readFile();
     bool fileBlockValid() { return true; }

--- a/FWCore/Framework/test/sourcecoordinator_t.catch2.cc
+++ b/FWCore/Framework/test/sourcecoordinator_t.catch2.cc
@@ -1,0 +1,129 @@
+#include "catch2/catch_all.hpp"
+
+#include "FWCore/Framework/interface/InputSource.h"
+#include "FWCore/Framework/interface/InputSourceDescription.h"
+#include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
+#include "FWCore/Framework/interface/SourceCoordinator.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
+
+#include <memory>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+namespace {
+  struct TransitionSpec {
+    edm::InputSource::ItemType type;
+    edm::EventID id;
+  };
+
+  class OrderedTransitionSource : public edm::InputSource {
+  public:
+    explicit OrderedTransitionSource(std::vector<TransitionSpec> transitions)
+        : edm::InputSource(edm::ParameterSet{}, edm::InputSourceDescription{}), transitions_(std::move(transitions)) {}
+
+  private:
+    ItemTypeInfo getNextItemType() final {
+      if (nextIndex_ >= transitions_.size()) {
+        return ItemTypeInfo::isStop();
+      }
+      lastTransition_ = transitions_[nextIndex_++];
+      return ItemTypeInfo(lastTransition_.type);
+    }
+
+    std::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_() final {
+      return std::make_shared<edm::RunAuxiliary>(lastTransition_.id.run(), edm::Timestamp(0), edm::Timestamp(10));
+    }
+
+    std::shared_ptr<edm::LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() final {
+      return std::make_shared<edm::LuminosityBlockAuxiliary>(
+          lastTransition_.id.run(), lastTransition_.id.luminosityBlock(), edm::Timestamp(0), edm::Timestamp(10));
+    }
+
+    void readEvent_(edm::EventPrincipal&) final {}
+
+    // Allow SourceCoordinator::skipEvents() to be used as a generic "consume transition" action in this test.
+    void skip(int) final {}
+
+    std::vector<TransitionSpec> transitions_;
+    std::size_t nextIndex_{0};
+    TransitionSpec lastTransition_{edm::InputSource::ItemType::IsStop, edm::EventID{}};
+  };
+
+  std::unique_ptr<edm::SourceCoordinator> makeCoordinator(std::vector<TransitionSpec> transitions,
+                                                          edm::ServiceToken& token) {
+    auto coordinator = std::make_unique<edm::SourceCoordinator>(
+        edm::SharedResourcesAcquirer{}, std::make_shared<std::recursive_mutex>(), token);
+    coordinator->setSource(std::make_unique<OrderedTransitionSource>(std::move(transitions)));
+    return coordinator;
+  }
+}  // namespace
+
+TEST_CASE("SourceCoordinator replays transitions from source", "[Framework]") {
+  edm::ServiceToken token;
+
+  SECTION("replays configured transition order") {
+    auto coordinator = makeCoordinator({{edm::InputSource::ItemType::IsFile, edm::EventID{0, 0, 0}},
+                                        {edm::InputSource::ItemType::IsRun, edm::EventID{1, 0, 0}},
+                                        {edm::InputSource::ItemType::IsLumi, edm::EventID{1, 11, 0}},
+                                        {edm::InputSource::ItemType::IsEvent, edm::EventID{1, 11, 21}},
+                                        {edm::InputSource::ItemType::IsStop, edm::EventID{0, 0, 0}}},
+                                       token);
+
+    auto status = coordinator->thread_unsafe_peekNextTransitionType();
+    REQUIRE(status.nextTransitionType().itemType() == edm::InputSource::ItemType::IsFile);
+
+    // A second peek without consumption must return the cached transition.
+    auto repeated = coordinator->thread_unsafe_peekNextTransitionType();
+    REQUIRE(repeated.nextTransitionType().itemType() == edm::InputSource::ItemType::IsFile);
+
+    auto [fileBlock, productRegistry] = coordinator->readFile();
+    REQUIRE(fileBlock != nullptr);
+    REQUIRE(productRegistry == nullptr);
+
+    status = coordinator->thread_unsafe_peekNextTransitionType();
+    REQUIRE(status.nextTransitionType().itemType() == edm::InputSource::ItemType::IsRun);
+    REQUIRE(status.runAuxiliary() != nullptr);
+    REQUIRE(status.runAuxiliary()->run() == 1);
+    coordinator->skipEvents(0);
+
+    status = coordinator->thread_unsafe_peekNextTransitionType();
+    REQUIRE(status.nextTransitionType().itemType() == edm::InputSource::ItemType::IsLumi);
+    REQUIRE(status.lumiAuxiliary() != nullptr);
+    REQUIRE(status.lumiAuxiliary()->run() == 1);
+    REQUIRE(status.lumiAuxiliary()->luminosityBlock() == 11);
+    coordinator->skipEvents(0);
+
+    status = coordinator->thread_unsafe_peekNextTransitionType();
+    REQUIRE(status.nextTransitionType().itemType() == edm::InputSource::ItemType::IsEvent);
+    coordinator->skipEvents(0);
+
+    status = coordinator->thread_unsafe_peekNextTransitionType();
+    REQUIRE(status.nextTransitionType().itemType() == edm::InputSource::ItemType::IsStop);
+  }
+
+  SECTION("skips synchronize transitions") {
+    auto coordinator = makeCoordinator({{edm::InputSource::ItemType::IsSynchronize, edm::EventID{0, 0, 0}},
+                                        {edm::InputSource::ItemType::IsSynchronize, edm::EventID{0, 0, 0}},
+                                        {edm::InputSource::ItemType::IsFile, edm::EventID{0, 0, 0}},
+                                        {edm::InputSource::ItemType::IsRun, edm::EventID{2, 0, 0}},
+                                        {edm::InputSource::ItemType::IsStop, edm::EventID{0, 0, 0}}},
+                                       token);
+
+    auto status = coordinator->thread_unsafe_peekNextTransitionType();
+    REQUIRE(status.nextTransitionType().itemType() == edm::InputSource::ItemType::IsFile);
+    auto [fileBlock, productRegistry] = coordinator->readFile();
+    REQUIRE(fileBlock != nullptr);
+    REQUIRE(productRegistry == nullptr);
+
+    status = coordinator->thread_unsafe_peekNextTransitionType();
+    REQUIRE(status.nextTransitionType().itemType() == edm::InputSource::ItemType::IsRun);
+    REQUIRE(status.runAuxiliary() != nullptr);
+    REQUIRE(status.runAuxiliary()->run() == 2);
+    coordinator->skipEvents(0);
+
+    status = coordinator->thread_unsafe_peekNextTransitionType();
+    REQUIRE(status.nextTransitionType().itemType() == edm::InputSource::ItemType::IsStop);
+  }
+}

--- a/FWCore/Framework/test/transition_test.sh
+++ b/FWCore/Framework/test/transition_test.sh
@@ -21,3 +21,5 @@ LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 (cmsRun ${LOCAL_TEST_DIR}/transition_test_cfg.py 14 ) || die 'Failure running cmsRun transition_test_cfg.py 14' $?
 (cmsRun ${LOCAL_TEST_DIR}/transition_test_cfg.py 15 ) || die 'Failure running cmsRun transition_test_cfg.py 15' $?
 (cmsRun ${LOCAL_TEST_DIR}/transition_test_cfg.py 16 ) || die 'Failure running cmsRun transition_test_cfg.py 16' $?
+(cmsRun ${LOCAL_TEST_DIR}/transition_test_cfg.py 17 ) || die 'Failure running cmsRun transition_test_cfg.py 17' $?
+(cmsRun ${LOCAL_TEST_DIR}/transition_test_cfg.py 18 ) || die 'Failure running cmsRun transition_test_cfg.py 18' $?

--- a/FWCore/Framework/test/transition_test_cfg.py
+++ b/FWCore/Framework/test/transition_test_cfg.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-import sys
+import argparse
 
 def chooseTrans(index):
     d = (
@@ -364,19 +364,68 @@ def chooseTrans(index):
                         cms.PSet(type = cms.untracked.string("IsStop"),
                                  id = cms.untracked.EventID(0,0,0))
                         ) ],
+                        ["Less events than streams", #18
+    cms.untracked.VPSet(
+                        cms.PSet(type = cms.untracked.string("IsFile"),
+                                 id = cms.untracked.EventID(0,0,0)),
+                        cms.PSet(type = cms.untracked.string("IsRun"),
+                                 id = cms.untracked.EventID(1,0,0)),
+                        cms.PSet(type = cms.untracked.string("IsLumi"),
+                                 id = cms.untracked.EventID(1,1,0)),
+                        cms.PSet(type = cms.untracked.string("IsEvent"),
+                                 id = cms.untracked.EventID(1,1,1)),
+                         cms.PSet(type = cms.untracked.string("IsLumi"),
+                                 id = cms.untracked.EventID(1,2,0)),
+                         cms.PSet(type = cms.untracked.string("IsEvent"),
+                                 id = cms.untracked.EventID(1,2,2)),
+                         cms.PSet(type = cms.untracked.string("IsLumi"),
+                                 id = cms.untracked.EventID(1,3,0)),
+                         cms.PSet(type = cms.untracked.string("IsEvent"),
+                                 id = cms.untracked.EventID(1,3,3)),
+                         cms.PSet(type = cms.untracked.string("IsLumi"),
+                                 id = cms.untracked.EventID(1,4,0)),
+                         cms.PSet(type = cms.untracked.string("IsEvent"),
+                                 id = cms.untracked.EventID(1,4,4)),
+                        cms.PSet(type = cms.untracked.string("IsStop"),
+                                 id = cms.untracked.EventID(0,0,0))
+                        ) ],
     )
     print('****************************************')
     print('Test:', d[index][0])
     print('****************************************')
     return d[index][1]
 
-trans = chooseTrans(int(sys.argv[1]))
+def parse_args():
+     parser = argparse.ArgumentParser(
+          description="Run a transition test configuration."
+     )
+     parser.add_argument(
+          "test_index",
+          type=int,
+          help="Index of the transition test to run.",
+     )
+     parser.add_argument(
+          "--tracer",
+          action="store_true",
+          help="Enable the Tracer service.",
+     )
+     parser.add_argument(
+          "--threads",
+          type=int,
+          default=2,
+          help="Number of threads to run with (default: 2).",
+     )
+     return parser.parse_args()
+
+args = parse_args()
+trans = chooseTrans(args.test_index)
 
 process = cms.Process("TEST")
 process.source = cms.Source("TestSource", 
                             transitions = trans)
-#process.add_(cms.Service("Tracer"))
 process.add_(cms.Service("CheckTransitions", 
                          transitions = trans))
-process.options = cms.untracked.PSet(numberOfThreads = cms.untracked.uint32(2),
-                                     numberOfStreams = cms.untracked.uint32(0))
+process.options = cms.untracked.PSet(numberOfThreads = cms.untracked.uint32(args.threads),
+                                     numberOfStreams = cms.untracked.uint32(2))
+if args.tracer:
+    process.add_(cms.Service("Tracer"))

--- a/FWCore/Services/plugins/CheckTransitions.cc
+++ b/FWCore/Services/plugins/CheckTransitions.cc
@@ -44,7 +44,6 @@ namespace edm {
       enum class Transition { IsInvalid, IsStop, IsFile, IsRun, IsLumi, IsEvent };
 
       CheckTransitions(const ParameterSet&, ActivityRegistry&);
-      ~CheckTransitions() noexcept(false);
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -78,7 +77,6 @@ namespace edm {
       oneapi::tbb::concurrent_vector<std::tuple<Phase, edm::EventID, int>> m_seenTransitions;
       std::vector<std::pair<Transition, edm::EventID>> m_expectedTransitions;
       int m_nstreams = 0;
-      bool m_failed = false;
     };
   }  // namespace service
 }  // namespace edm
@@ -220,12 +218,6 @@ CheckTransitions::CheckTransitions(ParameterSet const& iPS, ActivityRegistry& iR
   iRegistry.watchPreEvent(this, &CheckTransitions::preEvent);
 }
 
-CheckTransitions::~CheckTransitions() noexcept(false) {
-  if (m_failed) {
-    throw edm::Exception(errors::EventProcessorFailure) << "incorrect transtions";
-  }
-}
-
 void CheckTransitions::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   ParameterSetDescription desc;
   desc.setComment("Checks that the transitions specified occur during the job.");
@@ -244,21 +236,23 @@ void CheckTransitions::postEndJob() {
 
   std::vector<std::tuple<Phase, edm::EventID, int>> orderedSeen;
   orderedSeen.reserve(m_seenTransitions.size());
+  //std::cout << "Seen transitions: " << std::endl;
   for (auto const& i : m_seenTransitions) {
-    //      std::cout <<i.first.m_run<<" "<<i.first.m_lumi<<" "<<i.first.m_event<<" "<<i.second<<std::endl;
     auto s = std::get<2>(i);
     if (std::get<1>(i).event() > 0) {
       s = -2;
     }
     orderedSeen.emplace_back(std::get<0>(i), std::get<1>(i), s);
+    //std::cout <<std::get<1>(i)<<" "<<s<<std::endl;
   }
   std::sort(orderedSeen.begin(), orderedSeen.end());
 
   auto orderedExpected = expectedV;
   std::sort(orderedExpected.begin(), orderedExpected.end());
-  /*   for(auto const& i: expectedV) {
-   std::cout <<i.first.m_run<<" "<<i.first.m_lumi<<" "<<i.first.m_event<<" "<<i.second<<std::endl;
-   } */
+  /*std::cout << "Expected transitions: " << std::endl;
+     for(auto const& i: expectedV) {
+   std::cout <<std::get<1>(i)<<" "<<std::get<2>(i)<<std::endl;
+  }*/
 
   unsigned int nSkippedStreamLumiTransitions = 0;
 
@@ -272,6 +266,7 @@ void CheckTransitions::postEndJob() {
   // transitions are skipped.
   std::set<std::tuple<Phase, edm::EventID, int>> seenGlobalBeginLumi;
   std::set<std::tuple<Phase, edm::EventID, int>> seenStreamBeginLumi;
+  bool failed = false;
 
   auto itOS = orderedSeen.begin();
   for (auto itOE = orderedExpected.begin(); itOE != orderedExpected.end(); ++itOE) {
@@ -304,25 +299,28 @@ void CheckTransitions::postEndJob() {
       auto syncOS = std::get<1>(*itOS);
       std::cout << "Different ordering " << syncOE << " " << std::get<2>(*itOE) << "\n"
                 << "                   " << syncOS << " " << std::get<2>(*itOS) << "\n";
-      m_failed = true;
+      failed = true;
     }
     ++itOS;
   }
 
   if (seenGlobalBeginLumi != seenStreamBeginLumi) {
     std::cout << "We didn't see at least one stream begin lumi for every global begin lumi" << std::endl;
-    m_failed = true;
+    failed = true;
   }
 
   if (expectedSkippedStreamEndLumi != seenSkippedStreamEndLumi) {
     std::cout << "Skipped stream begin and end lumi transitions do not match" << std::endl;
-    m_failed = true;
+    failed = true;
   }
 
   if (orderedSeen.size() + nSkippedStreamLumiTransitions != orderedExpected.size()) {
     std::cout << "Wrong number of transition " << orderedSeen.size() << " " << orderedExpected.size() << std::endl;
-    m_failed = true;
-    return;
+    failed = true;
+  }
+
+  if (failed) {
+    throw edm::Exception(errors::EventProcessorFailure) << "incorrect transitions";
   }
 }
 


### PR DESCRIPTION
#### PR description:

- moved details of handling of the Source to its own dedicated class, SourceCoordinator
- less code now is run within the Source's serial task queue
- did some simplification of the scheduling
- Run and Lumi merging now happens within the routine that reads the initial transition.

#### PR validation:

Code compiles, all framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/2190