### PR TITLE
[EVOLUTION_X] Reset class versions to 3 in analysis, alca, db, daq

### DIFF
--- a/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
+++ b/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
@@ -2,8 +2,8 @@
    <class name="susybsm::HSCParticle" ClassVersion="3">
     <version ClassVersion="3" checksum="3986912460"/>
    </class>
-   <class name="susybsm::RPCBetaMeasurement" ClassVersion="10">
-    <version ClassVersion="10" checksum="2621605308"/>
+   <class name="susybsm::RPCBetaMeasurement" ClassVersion="3">
+    <version ClassVersion="3" checksum="2621605308"/>
    </class>
    <class name="susybsm::HSCParticleCollection"/>
    <class name="susybsm::HSCParticleRef"/>
@@ -14,17 +14,16 @@
       <field name="transientMap_" transient="true"/>
    </class>
    <class name="edm::Wrapper<susybsm::TracksEcalRecHitsMap>"/>
-   <class name="susybsm::HSCPIsolation" ClassVersion="10">
-    <version ClassVersion="10" checksum="3676296078"/>
+   <class name="susybsm::HSCPIsolation" ClassVersion="3">
+    <version ClassVersion="3" checksum="3676296078"/>
    </class>
    <class name="susybsm::HSCPIsolationCollection"/>
    <class name="susybsm::HSCPIsolationValueMap"/>
    <class name="edm::Wrapper<susybsm::HSCPIsolation>"/>
    <class name="edm::Wrapper<susybsm::HSCPIsolationCollection>"/>
    <class name="edm::Wrapper<susybsm::HSCPIsolationValueMap>"/>
-   <class name="susybsm::HSCPCaloInfo" ClassVersion="12">
-    <version ClassVersion="12" checksum="2407040083"/>
-    <version ClassVersion="11" checksum="1170741674"/>
+   <class name="susybsm::HSCPCaloInfo" ClassVersion="3">
+    <version ClassVersion="3" checksum="2407040083"/>
    </class>
    <class name="susybsm::HSCPCaloInfoCollection"/>
    <class name="susybsm::HSCPCaloInfoValueMap"/>
@@ -35,8 +34,8 @@
    <class name="edm::Wrapper<susybsm::HSCPCaloInfoCollection>"/>
    <class name="edm::Wrapper<susybsm::HSCPCaloInfoValueMap>"/>
 
-   <class name="susybsm::HSCPDeDxInfo" ClassVersion="13">
-    <version ClassVersion="13" checksum="2821313007"/>
+   <class name="susybsm::HSCPDeDxInfo" ClassVersion="3">
+    <version ClassVersion="3" checksum="2821313007"/>
    </class>
    <class name="susybsm::HSCPDeDxInfoCollection"/>
    <class name="susybsm::HSCPDeDxInfoValueMap"/>

--- a/DataFormats/Alignment/src/classes_def.xml
+++ b/DataFormats/Alignment/src/classes_def.xml
@@ -4,15 +4,14 @@
    <version ClassVersion="3" checksum="1878671762"/>
   </class>
   <class name="std::vector<SiStripLaserRecHit2D>"/>
-  <class name="TkLasBeam" ClassVersion="10">
-   <version ClassVersion="10" checksum="1460656577"/>
+  <class name="TkLasBeam" ClassVersion="3">
+   <version ClassVersion="3" checksum="1460656577"/>
   </class>
   <class name="TkLasBeamCollection"/>
   <class name="edm::Wrapper<TkLasBeamCollection>"/>
 
-  <class name="TkFittedLasBeam" ClassVersion="11">
-   <version ClassVersion="11" checksum="4076174061"/>
-   <version ClassVersion="10" checksum="903692518"/>
+  <class name="TkFittedLasBeam" ClassVersion="3">
+   <version ClassVersion="3" checksum="4076174061"/>
   </class>
   <class name="TkFittedLasBeamCollection"/>
   <class name="edm::Wrapper<TkFittedLasBeamCollection>"/>
@@ -21,8 +20,8 @@
   <class name="AliClusterValueMap"/>
   <class name="edm::ValueMap<AlignmentClusterFlag >"/>
   <class name="edm::Wrapper< edm::ValueMap<AlignmentClusterFlag >  >"/>
-  <class name="AlignmentClusterFlag" ClassVersion="10">
-   <version ClassVersion="10" checksum="3955968420"/>
+  <class name="AlignmentClusterFlag" ClassVersion="3">
+   <version ClassVersion="3" checksum="3955968420"/>
   </class>
   <class name="std::vector<AlignmentClusterFlag>"/>
 

--- a/DataFormats/FEDRawData/src/classes_def.xml
+++ b/DataFormats/FEDRawData/src/classes_def.xml
@@ -8,22 +8,20 @@
   <version ClassVersion="11" checksum="1398850430"/>
   <version ClassVersion="10" checksum="2136542618"/>
  </class>
- <class name="RawDataBuffer" ClassVersion="2">
-  <version ClassVersion="2" checksum="2774327963"/>
+ <class name="RawDataBuffer" ClassVersion="3">
+  <version ClassVersion="3" checksum="2774327963"/>
  </class>
- <class name="FEDHeader" ClassVersion="11">
-  <version ClassVersion="11" checksum="3644215394"/>
-  <version ClassVersion="10" checksum="611523769"/>
+ <class name="FEDHeader" ClassVersion="3">
+  <version ClassVersion="3" checksum="3644215394"/>
  </class>
- <class name="FEDTrailer" ClassVersion="11">
-  <version ClassVersion="11" checksum="2009823250"/>
-  <version ClassVersion="10" checksum="120358665"/>
+ <class name="FEDTrailer" ClassVersion="3">
+  <version ClassVersion="3" checksum="2009823250"/>
  </class>
- <class name="fedh_struct" ClassVersion="10">
-  <version ClassVersion="10" checksum="3158059546"/>
+ <class name="fedh_struct" ClassVersion="3">
+  <version ClassVersion="3" checksum="3158059546"/>
  </class>
- <class name="fedt_struct" ClassVersion="10">
-  <version ClassVersion="10" checksum="1999934329"/>
+ <class name="fedt_struct" ClassVersion="3">
+  <version ClassVersion="3" checksum="1999934329"/>
  </class>
  <class name="edm::Wrapper<FEDRawDataCollection>" splitLevel="0"/>
  <class name="edm::RefProd<FEDRawDataCollection>"/>

--- a/DataFormats/HcalCalibObjects/src/classes_def.xml
+++ b/DataFormats/HcalCalibObjects/src/classes_def.xml
@@ -1,29 +1,21 @@
 <lcgdict>
-  <class name="HOCalibVariables" ClassVersion="17">
-   <version ClassVersion="16" checksum="2161587371"/>
-   <version ClassVersion="17" checksum="1351689277"/>
+  <class name="HOCalibVariables" ClassVersion="3">
+   <version ClassVersion="3" checksum="1351689277"/>
   </class>
-   <ioread sourceClass="HOCalibVariables" targetClass="HOCalibVariables" version="[-16]" target="pileup" source="float inslumi" embed="false">
-    <![CDATA[ pileup = onfile.inslumi; ]]>
-  </ioread>
   <class name="std::vector<HOCalibVariables>"/>
   <class name="edm::Wrapper<std::vector<HOCalibVariables> >"/>
-  <class name="HcalHBHEMuonVariables" ClassVersion="20">
-   <version ClassVersion="17" checksum="1863216916"/>
-   <version ClassVersion="18" checksum="3196858362"/>
-   <version ClassVersion="19" checksum="1430281869"/>
-   <version ClassVersion="20" checksum="1458964595"/>
+  <class name="HcalHBHEMuonVariables" ClassVersion="3">
+   <version ClassVersion="3" checksum="1458964595"/>
   </class>
   <class name="std::vector<HcalHBHEMuonVariables>"/>
   <class name="edm::Wrapper<std::vector<HcalHBHEMuonVariables> >"/>
-  <class name="HcalIsoTrkCalibVariables" ClassVersion="18">
-   <version ClassVersion="17" checksum="3540801245"/>
-   <version ClassVersion="18" checksum="3377355045"/>
+  <class name="HcalIsoTrkCalibVariables" ClassVersion="3">
+   <version ClassVersion="3" checksum="3377355045"/>
   </class>
   <class name="std::vector<HcalIsoTrkCalibVariables>"/>
   <class name="edm::Wrapper<std::vector<HcalIsoTrkCalibVariables> >"/>
-  <class name="HcalIsoTrkEventVariables" ClassVersion="17">
-   <version ClassVersion="17" checksum="4094456915"/>
+  <class name="HcalIsoTrkEventVariables" ClassVersion="3">
+   <version ClassVersion="3" checksum="4094456915"/>
   </class>
   <class name="std::vector<HcalIsoTrkEventVariables>"/>
   <class name="edm::Wrapper<std::vector<HcalIsoTrkEventVariables> >"/>

--- a/DataFormats/TCDS/src/classes_def.xml
+++ b/DataFormats/TCDS/src/classes_def.xml
@@ -4,8 +4,8 @@
   </class>
   <class name="std::vector<L1aInfo>"/>
 
-  <class name="BSTRecord" ClassVersion="4">
-    <version ClassVersion="4" checksum="3132515293"/>
+  <class name="BSTRecord" ClassVersion="3">
+    <version ClassVersion="3" checksum="3132515293"/>
   </class>
 
   <class name="io_v1::TCDSRecord" ClassVersion="3">

--- a/TBDataFormats/EcalTBObjects/src/classes_def.xml
+++ b/TBDataFormats/EcalTBObjects/src/classes_def.xml
@@ -1,33 +1,33 @@
 <lcgdict>
-   <class name="EcalTBTDCSample" ClassVersion="10">
-    <version ClassVersion="10" checksum="3959849637"/>
+   <class name="EcalTBTDCSample" ClassVersion="3">
+    <version ClassVersion="3" checksum="3959849637"/>
    </class>
-   <class name="EcalTBTDCRawInfo" ClassVersion="10">
-    <version ClassVersion="10" checksum="2382038550"/>
+   <class name="EcalTBTDCRawInfo" ClassVersion="3">
+    <version ClassVersion="3" checksum="2382038550"/>
    </class>
    <class name="std::vector<EcalTBTDCSample>"/>
    <class name="edm::Wrapper< EcalTBTDCRawInfo >" id="51B83E58-9F3A-7E74-D37C-7862F62CD62E"/>
-   <class name="EcalTBHodoscopePlaneRawHits" ClassVersion="10">
-    <version ClassVersion="10" checksum="3643975080"/>
+   <class name="EcalTBHodoscopePlaneRawHits" ClassVersion="3">
+    <version ClassVersion="3" checksum="3643975080"/>
    </class>
-   <class name="EcalTBHodoscopeRawInfo" ClassVersion="10">
-    <version ClassVersion="10" checksum="3292505282"/>
+   <class name="EcalTBHodoscopeRawInfo" ClassVersion="3">
+    <version ClassVersion="3" checksum="3292505282"/>
    </class>
    <class name="std::vector<EcalTBHodoscopePlaneRawHits>"/>
    <class name="edm::Wrapper< EcalTBHodoscopeRawInfo >" id="3D1D321A-05BE-28E1-ACE7-1B46D93A3BF5"/>
-   <class name="EcalTBHodoscopeRecInfo" ClassVersion="10">
-    <version ClassVersion="10" checksum="488867480"/>
+   <class name="EcalTBHodoscopeRecInfo" ClassVersion="3">
+    <version ClassVersion="3" checksum="488867480"/>
    </class>
    <class name="edm::Wrapper< EcalTBHodoscopeRecInfo >" id="FBE03DB3-82D9-DA84-3666-8964E84C9080"/>
-   <class name="EcalTBTDCRecInfo" ClassVersion="10">
-    <version ClassVersion="10" checksum="4251405510"/>
+   <class name="EcalTBTDCRecInfo" ClassVersion="3">
+    <version ClassVersion="3" checksum="4251405510"/>
    </class>
    <class name="edm::Wrapper< EcalTBTDCRecInfo >" id="709E9311-641C-F9FB-85B0-0AC689F982DD"/>
-   <class name="EcalTBEventHeader" ClassVersion="10">
-    <version ClassVersion="10" checksum="281518873"/>
+   <class name="EcalTBEventHeader" ClassVersion="3">
+    <version ClassVersion="3" checksum="281518873"/>
    </class>
-   <class name="EcalTBEventHeader::magnetsMeasurement" ClassVersion="10">
-    <version ClassVersion="10" checksum="4174944061"/>
+   <class name="EcalTBEventHeader::magnetsMeasurement" ClassVersion="3">
+    <version ClassVersion="3" checksum="4174944061"/>
    </class>
    <class name="std::vector<EcalTBEventHeader::magnetsMeasurement>"/>
    <class name="edm::Wrapper< EcalTBEventHeader >" id="30CB005B-6BFD-A149-1D96-9279DB5C3441"/>

--- a/TBDataFormats/HcalTBObjects/src/classes_def.xml
+++ b/TBDataFormats/HcalTBObjects/src/classes_def.xml
@@ -1,21 +1,21 @@
 <lcgdict>
-   <class name="HcalTBTriggerData" ClassVersion="10">
-    <version ClassVersion="10" checksum="2056781115"/>
+   <class name="HcalTBTriggerData" ClassVersion="3">
+    <version ClassVersion="3" checksum="2056781115"/>
    </class>
-   <class name="HcalTBRunData" ClassVersion="10">
-    <version ClassVersion="10" checksum="999402897"/>
+   <class name="HcalTBRunData" ClassVersion="3">
+    <version ClassVersion="3" checksum="999402897"/>
    </class>
-   <class name="HcalTBEventPosition" ClassVersion="10">
-    <version ClassVersion="10" checksum="3739969485"/>
+   <class name="HcalTBEventPosition" ClassVersion="3">
+    <version ClassVersion="3" checksum="3739969485"/>
    </class>
-   <class name="HcalTBTiming" ClassVersion="10">
-    <version ClassVersion="10" checksum="976419967"/>
+   <class name="HcalTBTiming" ClassVersion="3">
+    <version ClassVersion="3" checksum="976419967"/>
    </class>
-   <class name="HcalTBBeamCounters" ClassVersion="10">
-    <version ClassVersion="10" checksum="559750594"/>
+   <class name="HcalTBBeamCounters" ClassVersion="3">
+    <version ClassVersion="3" checksum="559750594"/>
    </class>
-   <class name="HcalTBParticleId" ClassVersion="10">
-    <version ClassVersion="10" checksum="3439943138"/>
+   <class name="HcalTBParticleId" ClassVersion="3">
+    <version ClassVersion="3" checksum="3439943138"/>
    </class>
    <class name="edm::Wrapper<HcalTBTriggerData>"/>
    <class name="edm::Wrapper<HcalTBRunData>"/>


### PR DESCRIPTION
#### PR description:

One batch of resetting class versions to 3 in EVOLUTION_X.

The `FEDRawData` versioning was left untouched because it is part of RAW.

Resolves https://github.com/cms-sw/framework-team/issues/2191

#### PR validation:

Code compiles