### PR TITLE
[EVOLUTION_X] Reset class versions to 3 in core

### DIFF
--- a/DataFormats/CLHEP/src/classes_def.xml
+++ b/DataFormats/CLHEP/src/classes_def.xml
@@ -1,24 +1,21 @@
 <lcgdict>
-  <class name="CLHEP::Hep3Vector" ClassVersion="11">
-   <version ClassVersion="11" checksum="3438801427"/>
-   <version ClassVersion="10" checksum="3040806103"/>
+  <class name="CLHEP::Hep3Vector" ClassVersion="3">
+   <version ClassVersion="3" checksum="3438801427"/>
   </class>
-  <class name="CLHEP::HepEulerAngles" ClassVersion="10">
-   <version ClassVersion="10" checksum="2060568599"/>
+  <class name="CLHEP::HepEulerAngles" ClassVersion="3">
+   <version ClassVersion="3" checksum="2060568599"/>
   </class>
-  <class name="CLHEP::HepGenMatrix" ClassVersion="10">
-   <version ClassVersion="10" checksum="1734210912"/>
+  <class name="CLHEP::HepGenMatrix" ClassVersion="3">
+   <version ClassVersion="3" checksum="1734210912"/>
   </class>
-  <class name="CLHEP::HepLorentzVector" ClassVersion="10">
-   <version ClassVersion="10" checksum="2698081358"/>
+  <class name="CLHEP::HepLorentzVector" ClassVersion="3">
+   <version ClassVersion="3" checksum="2698081358"/>
   </class>
-  <class name="CLHEP::HepMatrix" ClassVersion="12">
-   <version ClassVersion="12" checksum="1552769590"/>
-   <version ClassVersion="11" checksum="2283727874"/>
+  <class name="CLHEP::HepMatrix" ClassVersion="3">
+   <version ClassVersion="3" checksum="1552769590"/>
   </class>
-  <class name="CLHEP::HepSymMatrix" ClassVersion="12">
-   <version ClassVersion="12" checksum="4023811106"/>
-   <version ClassVersion="11" checksum="3670575592"/>
+  <class name="CLHEP::HepSymMatrix" ClassVersion="3">
+   <version ClassVersion="3" checksum="4023811106"/>
   </class>
   <class name="std::vector<CLHEP::HepLorentzVector>"/>
 </lcgdict>

--- a/DataFormats/Common/interface/CMS_CLASS_VERSION.h
+++ b/DataFormats/Common/interface/CMS_CLASS_VERSION.h
@@ -14,7 +14,7 @@
       CMS_CLASS_VERSION(<number>)
 
   For classes that have been stored into ROOT files before the addition of the macro, we suggest starting the <number> at 10. This was chosen to be larger than any known number of stored changes to a templated class.
-  For new classes that have never been stored, we suggest starting the <number> at 2 (0 and 1 have special meanings to ROOT).
+  For new classes that have never been stored, we suggest starting the <number> at 3 (0 and 1 have special meanings to ROOT).
  
 */
 //

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -4,14 +4,12 @@
   <version ClassVersion="2" checksum="2150796830"/>
   <version ClassVersion="3" checksum="1936948526"/>
  </class>
- <class name="edm::EDProductGetter" ClassVersion="11">
-  <version ClassVersion="11" checksum="2247759761"/>
-  <version ClassVersion="10" checksum="2702412727"/>
+ <class name="edm::EDProductGetter" ClassVersion="3">
+  <version ClassVersion="3" checksum="2247759761"/>
  </class>
  <!-- RefCore has a custom streamer registered, and without explicit false RNTuple would refuse to split RefCore -->
- <class name="edm::RefCore" ClassVersion="11" rntupleStreamerMode="false">
-  <version ClassVersion="10" checksum="641105393"/>
-  <version ClassVersion="11" checksum="3425324092"/>
+ <class name="edm::RefCore" ClassVersion="3" rntupleStreamerMode="false">
+  <version ClassVersion="3" checksum="3425324092"/>
    <field name="cachePtr_" transient = "true"/>
  </class>
  <ioread sourceClass = "edm::RefCore" version="[1-]" targetClass="edm::RefCore" source="" target="cachePtr_">
@@ -51,8 +49,8 @@
  <class name="edm::reftobase::RefHolderBase" ClassVersion="10">
   <version ClassVersion="10" checksum="133255391"/>
  </class>
- <class name="edm::RefVectorMemberPointersHolder" ClassVersion="2">
-   <version ClassVersion="2" checksum="3080604260"/>
+ <class name="edm::RefVectorMemberPointersHolder" ClassVersion="3">
+   <version ClassVersion="3" checksum="3080604260"/>
    <field name="memberPointers_" transient="true"/>
  </class>
  <ioread sourceClass = "edm::RefVectorMemberPointersHolder" version="[1-]" targetClass="edm::RefVectorMemberPointersHolder" source = "" target="memberPointers_">
@@ -69,8 +67,8 @@
  <class name="edm::Ptr<int>"/>
  <class name="std::vector<edm::Ptr<int> >"/>
  <class name="edm::reftobase::BaseVectorHolder<int>"/>
- <class name="edm::reftobase::RefVectorHolderBase" ClassVersion="10">
-  <version ClassVersion="10" checksum="2803110946"/>
+ <class name="edm::reftobase::RefVectorHolderBase" ClassVersion="3">
+  <version ClassVersion="3" checksum="2803110946"/>
  </class>
  <class name="edm::reftobase::IndirectVectorHolder<int>"/>
  <class name="edm::reftobase::VectorHolder<int, edm::RefVector<std::vector<int>,int,edm::refhelper::FindUsingAdvance<std::vector<int>,int> > >"/>
@@ -78,8 +76,8 @@
  <class name="edm::Wrapper<edm::PtrVector<int> >" splitLevel="0"/>
  <class name="edm::Wrapper<std::vector<edm::Ptr<int> > >" splitLevel="0"/>
  <class name="edm::Wrapper<edm::RefVector<std::vector<int>,int,edm::refhelper::FindUsingAdvance<std::vector<int>,int> > >" splitLevel="0"/>
- <class name="edm::PtrVectorBase" ClassVersion="10">
-  <version ClassVersion="10" checksum="2381000311"/>
+ <class name="edm::PtrVectorBase" ClassVersion="3">
+  <version ClassVersion="3" checksum="2381000311"/>
    <field name ="cachedItems_" transient = "true"/>
  </class>
   <!-- -->
@@ -88,28 +86,24 @@
     ]]>
   </ioread>
    <!-- -->
-<class name="edmNew::dstvdetails::DetSetVectorTrans" ClassVersion="10">
- <version ClassVersion="10" checksum="1132971359"/>
+<class name="edmNew::dstvdetails::DetSetVectorTrans" ClassVersion="3">
+ <version ClassVersion="3" checksum="1132971359"/>
    <field name="m_filling" transient="true"/>
    <field name="m_getter" transient="true"/>
    <field name="m_dataSize" transient="true"/>
 </class>
-<class name="edmNew::dstvdetails::DetSetVectorTrans::Item" ClassVersion="11">
-   <version ClassVersion="10" checksum="1062438024"/>
-   <version ClassVersion="11" checksum="3545691837"/>
+<class name="edmNew::dstvdetails::DetSetVectorTrans::Item" ClassVersion="3">
+   <version ClassVersion="3" checksum="3545691837"/>
 </class>
-<ioread sourceClass="edmNew::dstvdetails::DetSetVectorTrans::Item" version="[1-10]" targetClass="edmNew::dstvdetails::DetSetVectorTrans::Item" source="int offset" target="offset">
-<![CDATA[offset=onfile.offset;]]>
-</ioread>
+
 <class name="std::vector<edmNew::dstvdetails::DetSetVectorTrans::Item>"/>
 
 
-<class name="edm::DataFrame" ClassVersion="11">
- <version ClassVersion="11" checksum="3066866109"/>
- <version ClassVersion="10" checksum="1632285442"/>
+<class name="edm::DataFrame" ClassVersion="3">
+ <version ClassVersion="3" checksum="3066866109"/>
 </class>
-<class name="edm::DataFrameContainer" ClassVersion="10">
- <version ClassVersion="10" checksum="2404115677"/>
+<class name="edm::DataFrameContainer" ClassVersion="3">
+ <version ClassVersion="3" checksum="2404115677"/>
 </class>
 <class name="edm::Wrapper<edm::DataFrameContainer>" splitLevel="0"/>
 
@@ -132,11 +126,11 @@
   <version ClassVersion="10" checksum="547571379"/>
  </class>
  <class name="edm::Wrapper<edm::TriggerResults>" splitLevel="0"/>
- <class name="edm::Other" ClassVersion="10">
-  <version ClassVersion="10" checksum="2949726"/>
+ <class name="edm::Other" ClassVersion="3">
+  <version ClassVersion="3" checksum="2949726"/>
  </class>
- <class name="edm::DoNotSortUponInsertion" ClassVersion="10">
-  <version ClassVersion="10" checksum="862111625"/>
+ <class name="edm::DoNotSortUponInsertion" ClassVersion="3">
+  <version ClassVersion="3" checksum="862111625"/>
  </class>
  <class name="edm::DoNotRecordParents" ClassVersion="10">
   <version ClassVersion="10" checksum="2234517662"/>
@@ -161,37 +155,36 @@
  <class name="edm::io_v1::ErrorSummaryEntry" ClassVersion="3">
   <version ClassVersion="3" checksum="1697264738"/>
  </class>
- <class name="edm::ELseverityLevel" ClassVersion="10">
-  <version ClassVersion="10" checksum="2388166397"/>
+ <class name="edm::ELseverityLevel" ClassVersion="3">
+  <version ClassVersion="3" checksum="2388166397"/>
  </class>
  <class name="std::vector<edm::io_v1::ErrorSummaryEntry>"/>
  <class name="edm::Wrapper<std::vector<edm::io_v1::ErrorSummaryEntry> >"/>
- <class name="edm::MergeableCounter" ClassVersion="10">
-  <version ClassVersion="10" checksum="3792606006"/>
+ <class name="edm::MergeableCounter" ClassVersion="3">
+  <version ClassVersion="3" checksum="3792606006"/>
  </class>
  <class name="edm::Wrapper<edm::MergeableCounter>"/>
 
- <class name="edm::ConditionsInEventBlock" ClassVersion="10">
-  <version ClassVersion="10" checksum="28865621"/>
+ <class name="edm::ConditionsInEventBlock" ClassVersion="3">
+  <version ClassVersion="3" checksum="28865621"/>
  </class>
- <class name="edm::ConditionsInRunBlock" ClassVersion="10">
-  <version ClassVersion="10" checksum="2978236528"/>
+ <class name="edm::ConditionsInRunBlock" ClassVersion="3">
+  <version ClassVersion="3" checksum="2978236528"/>
  </class>
- <class name="edm::ConditionsInLumiBlock" ClassVersion="10">
-  <version ClassVersion="10" checksum="3061695978"/>
+ <class name="edm::ConditionsInLumiBlock" ClassVersion="3">
+  <version ClassVersion="3" checksum="3061695978"/>
  </class>
  <class name="edm::Wrapper<edm::ConditionsInEventBlock>"/>
  <class name="edm::Wrapper<edm::ConditionsInRunBlock>"/>
  <class name="edm::Wrapper<edm::ConditionsInLumiBlock>"/>
- <class name="test_with_dictionaries::IntValue" ClassVersion="10">
-  <version ClassVersion="10" checksum="894112631"/>
+ <class name="test_with_dictionaries::IntValue" ClassVersion="3">
+  <version ClassVersion="3" checksum="894112631"/>
  </class>
- <class name="test_with_dictionaries::IntValue2" ClassVersion="11">
-  <version ClassVersion="11" checksum="2661728085"/>
-  <version ClassVersion="10" checksum="3452516682"/>
+ <class name="test_with_dictionaries::IntValue2" ClassVersion="3">
+  <version ClassVersion="3" checksum="2661728085"/>
  </class>
- <class name="edm::SecondaryEventIDAndFileInfo" ClassVersion="2">
-  <version ClassVersion="2" checksum="3900813088"/>
+ <class name="edm::SecondaryEventIDAndFileInfo" ClassVersion="3">
+  <version ClassVersion="3" checksum="3900813088"/>
  </class>
  <class name="std::vector<edm::SecondaryEventIDAndFileInfo>"/>
 

--- a/DataFormats/FWLite/src/classes_def.xml
+++ b/DataFormats/FWLite/src/classes_def.xml
@@ -1,22 +1,19 @@
 <lcgdict>
-  <class name="fwlite::EventBase" ClassVersion="11">
-   <version ClassVersion="11" checksum="1578521336"/>
-   <version ClassVersion="10" checksum="446550501"/>
+  <class name="fwlite::EventBase" ClassVersion="3">
+   <version ClassVersion="3" checksum="1578521336"/>
   </class>
   <class name="fwlite::Event" ClassVersion="0"/>
   <class name="fwlite::ChainEvent" ClassVersion="0"/>
   <class name="fwlite::MultiChainEvent" ClassVersion="0"/>
-  <class name="fwlite::ErrorThrower" ClassVersion="10">
-   <version ClassVersion="10" checksum="730281206"/>
+  <class name="fwlite::ErrorThrower" ClassVersion="3">
+   <version ClassVersion="3" checksum="730281206"/>
   </class>
-  <class name="fwlite::LuminosityBlockBase" ClassVersion="11">
-   <version ClassVersion="11" checksum="3809636278"/>
-   <version ClassVersion="10" checksum="3045691697"/>
+  <class name="fwlite::LuminosityBlockBase" ClassVersion="3">
+   <version ClassVersion="3" checksum="3809636278"/>
   </class>
   <class name="fwlite::LuminosityBlock" ClassVersion="0"/>
-  <class name="fwlite::RunBase" ClassVersion="11">
-   <version ClassVersion="11" checksum="3335299563"/>
-   <version ClassVersion="10" checksum="3966228119"/>
+  <class name="fwlite::RunBase" ClassVersion="3">
+   <version ClassVersion="3" checksum="3335299563"/>
   </class>
   <class name="fwlite::Run" ClassVersion="0"/>
 </lcgdict>

--- a/DataFormats/Streamer/src/classes_def.xml
+++ b/DataFormats/Streamer/src/classes_def.xml
@@ -1,21 +1,14 @@
 
 <lcgdict>
- <class name="edm::StreamedProduct" ClassVersion="13">
-  <version ClassVersion="13" checksum="87489871"/>
-  <version ClassVersion="12" checksum="855998814"/>
-  <version ClassVersion="10" checksum="512531612"/>
-  <version ClassVersion="11" checksum="1146084488"/>
+ <class name="edm::StreamedProduct" ClassVersion="3">
+  <version ClassVersion="3" checksum="87489871"/>
  </class>
  <class name="std::vector<edm::StreamedProduct>"/>
- <class name="edm::SendEvent" ClassVersion="12">
-  <version ClassVersion="12" checksum="2903161478"/>
-  <version ClassVersion="11" checksum="3216100975"/>
-  <version ClassVersion="10" checksum="747121728"/>
+ <class name="edm::SendEvent" ClassVersion="3">
+  <version ClassVersion="3" checksum="2903161478"/>
  </class>
- <class name="edm::SendJobHeader" ClassVersion="12">
-  <version ClassVersion="12" checksum="3199648792"/>
-  <version ClassVersion="11" checksum="79372782"/>
-  <version ClassVersion="10" checksum="1238072397"/>
+ <class name="edm::SendJobHeader" ClassVersion="3">
+  <version ClassVersion="3" checksum="3199648792"/>
  </class>
  <class name="std::vector<edm::BranchDescription>"/>
 </lcgdict>

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -1,61 +1,55 @@
 <lcgdict>
- <class name="edmtest::DummyProduct" ClassVersion="10">
-  <version ClassVersion="10" checksum="4017626975"/>
+ <class name="edmtest::DummyProduct" ClassVersion="3">
+  <version ClassVersion="3" checksum="4017626975"/>
  </class>
- <class name="edmtest::IntProduct" ClassVersion="10">
-  <version ClassVersion="10" checksum="4286676158"/>
+ <class name="edmtest::IntProduct" ClassVersion="3">
+  <version ClassVersion="3" checksum="4286676158"/>
  </class>
  <class name="std::pair<edmtest::IntProduct, edm::RandomNumberGeneratorState>"/>
  <class name="edmtest::MaybeUninitializedIntProduct" ClassVersion="3">
   <version ClassVersion="3" checksum="3324182225"/>
  </class>
- <class name="edmtest::UInt64Product" ClassVersion="11">
-  <version ClassVersion="11" checksum="3240540910"/>
-  <version ClassVersion="10" checksum="380152127"/>
+ <class name="edmtest::UInt64Product" ClassVersion="3">
+  <version ClassVersion="3" checksum="3240540910"/>
  </class>
- <class name="edmtest::EnumProduct" ClassVersion="11">
-  <version ClassVersion="11" checksum="3817882977"/>
-  <version ClassVersion="10" checksum="3025325436"/>
+ <class name="edmtest::EnumProduct" ClassVersion="3">
+  <version ClassVersion="3" checksum="3817882977"/>
  </class>
  <enum name="edmtest::TheEnumProduct"/>
- <class name="edmtest::ArrayProduct" ClassVersion="10">
-  <version ClassVersion="10" checksum="3635152897"/>
+ <class name="edmtest::ArrayProduct" ClassVersion="3">
+  <version ClassVersion="3" checksum="3635152897"/>
  </class>
- <class name="edmtest::TransientIntProduct" ClassVersion="11">
-  <version ClassVersion="10" checksum="304339852"/>
-  <version ClassVersion="11" checksum="639295444"/>
+ <class name="edmtest::TransientIntProduct" ClassVersion="3">
+  <version ClassVersion="3" checksum="639295444"/>
   <field name="dummy" transient="true"/>
  </class>
  <class name="edmtest::ATransientIntProduct" ClassVersion="3">
   <version ClassVersion="3" checksum="2661369959"/>
   <field name="dummy" transient="true"/>
  </class>
- <class name="edmtest::Int16_tProduct" ClassVersion="10">
-  <version ClassVersion="10" checksum="1443289058"/>
+ <class name="edmtest::Int16_tProduct" ClassVersion="3">
+  <version ClassVersion="3" checksum="1443289058"/>
  </class>
- <class name="edmtest::DoubleProduct" ClassVersion="10">
-  <version ClassVersion="10" checksum="927325064"/>
+ <class name="edmtest::DoubleProduct" ClassVersion="3">
+  <version ClassVersion="3" checksum="927325064"/>
  </class>
- <class name="edmtest::StringProduct" ClassVersion="10">
-  <version ClassVersion="10" checksum="2737503723"/>
+ <class name="edmtest::StringProduct" ClassVersion="3">
+  <version ClassVersion="3" checksum="2737503723"/>
  </class>
- <class name="edmtest::Prodigal" ClassVersion="11">
-  <version ClassVersion="10" checksum="3510691703"/>
-  <version ClassVersion="11" checksum="1159264709"/>
+ <class name="edmtest::Prodigal" ClassVersion="3">
+  <version ClassVersion="3" checksum="1159264709"/>
  </class>
- <class name="edmtest::Simple" ClassVersion="10">
-  <version ClassVersion="10" checksum="2533881336"/>
+ <class name="edmtest::Simple" ClassVersion="3">
+  <version ClassVersion="3" checksum="2533881336"/>
  </class>
- <class name="edmtest::SimpleDerived" ClassVersion="11">
-  <version ClassVersion="10" checksum="3753531674"/>
-  <version ClassVersion="11" checksum="802041948"/>
+ <class name="edmtest::SimpleDerived" ClassVersion="3">
+  <version ClassVersion="3" checksum="802041948"/>
  </class>
- <class name="edmtest::Sortable" ClassVersion="10">
-  <version ClassVersion="10" checksum="1166695033"/>
+ <class name="edmtest::Sortable" ClassVersion="3">
+  <version ClassVersion="3" checksum="1166695033"/>
  </class>
- <class name="edmtest::Unsortable" ClassVersion="11">
-  <version ClassVersion="10" checksum="2720085305"/>
-  <version ClassVersion="11" checksum="3812549796"/>
+ <class name="edmtest::Unsortable" ClassVersion="3">
+  <version ClassVersion="3" checksum="3812549796"/>
  </class>
  <class name="edm::SortedCollection<edmtest::Simple, edm::StrictWeakOrdering<edmtest::Simple> >"/>
  <class name="edm::OwnVector<edmtest::Simple, edm::ClonePolicy<edmtest::Simple> >"/>
@@ -109,17 +103,17 @@
  <class name="edm::Wrapper<edmNew::DetSetVector<edmtest::SimpleDerived> >"/>
 
 
- <class name="edmtest::Thing" ClassVersion="10">
-  <version ClassVersion="10" checksum="2534966692"/>
+ <class name="edmtest::Thing" ClassVersion="3">
+  <version ClassVersion="3" checksum="2534966692"/>
  </class>
- <class name="edmtest::ThingWithMerge" ClassVersion="10">
-  <version ClassVersion="10" checksum="1109971102"/>
+ <class name="edmtest::ThingWithMerge" ClassVersion="3">
+  <version ClassVersion="3" checksum="1109971102"/>
  </class>
- <class name="edmtest::ThingWithIsEqual" ClassVersion="10">
-  <version ClassVersion="10" checksum="1399583220"/>
+ <class name="edmtest::ThingWithIsEqual" ClassVersion="3">
+  <version ClassVersion="3" checksum="1399583220"/>
  </class>
- <class name="edmtest::OtherThing" ClassVersion="10">
-  <version ClassVersion="10" checksum="3424405714"/>
+ <class name="edmtest::OtherThing" ClassVersion="3">
+  <version ClassVersion="3" checksum="3424405714"/>
  </class>
  <class name="std::vector<edmtest::Thing>"/>
  <class name="std::vector<edmtest::OtherThing>"/>
@@ -135,8 +129,8 @@
  <class name="edm::PtrVector<edmtest::Thing>"/>
  <class name="edm::Ref<std::vector<edmtest::Thing>,edmtest::Thing,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Thing>,edmtest::Thing> >"/>
  <class name="edm::RefVector<std::vector<edmtest::Thing>,edmtest::Thing,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Thing>,edmtest::Thing> >"/>
- <class name="edmtest::TrackOfThings" ClassVersion="6">
-  <version ClassVersion="6" checksum="545056495"/>
+ <class name="edmtest::TrackOfThings" ClassVersion="3">
+  <version ClassVersion="3" checksum="545056495"/>
  </class>
  <class name="std::vector<edmtest::TrackOfThings>"/>
  <class name="edm::Wrapper<std::vector<edmtest::TrackOfThings> >"/>
@@ -166,8 +160,8 @@
  <class name="std::vector<edmtest::TrackOfDSVThings>"/>
  <class name="edm::Wrapper<std::vector<edmtest::TrackOfDSVThings> >"/>
 
- <class name="edmtestprod::Simple" ClassVersion="10">
-  <version ClassVersion="10" checksum="2751437416"/>
+ <class name="edmtestprod::Simple" ClassVersion="3">
+  <version ClassVersion="3" checksum="2751437416"/>
  </class>
  <class name="edmtestprod::Ord<edmtestprod::Simple>"/>
  <class name="edmtestprod::StreamTestTmpl<edmtestprod::Ord<edmtestprod::Simple> >"/>
@@ -175,12 +169,12 @@
  <class name="std::vector<edmtestprod::Simple>"/>
  <class name="edm::SortedCollection<edmtestprod::Simple,edm::StrictWeakOrdering<edmtestprod::Simple> >"/>
  <class name="edm::Wrapper<edm::SortedCollection<edmtestprod::Simple,edm::StrictWeakOrdering<edmtestprod::Simple> > >"/>
- <class name="edmtestprod::StreamTestThing" ClassVersion="10">
-  <version ClassVersion="10" checksum="1618121316"/>
+ <class name="edmtestprod::StreamTestThing" ClassVersion="3">
+  <version ClassVersion="3" checksum="1618121316"/>
  </class>
  <class name="edm::Wrapper<edmtestprod::StreamTestThing>"/>
- <class name="edmtestprod::X0123456789012345678901234567890123456789012345678901234567890123456789012345678901" ClassVersion="10">
-  <version ClassVersion="10" checksum="3326113499"/>
+ <class name="edmtestprod::X0123456789012345678901234567890123456789012345678901234567890123456789012345678901" ClassVersion="3">
+  <version ClassVersion="3" checksum="3326113499"/>
  </class>
  <class name="edm::Wrapper<edmtestprod::X0123456789012345678901234567890123456789012345678901234567890123456789012345678901>"/>
  <class name="edmtest::DeleteEarly" ClassVersion="3">
@@ -221,42 +215,42 @@
  <class name="edm::Wrapper<edm::EventID>"/>
  <class name="edm::Wrapper<edm::ProductID>"/>
 
- <class name="edmtest::MissingDictionaryTestA" ClassVersion="10">
-  <version ClassVersion="10" checksum="924871709"/>
+ <class name="edmtest::MissingDictionaryTestA" ClassVersion="3">
+  <version ClassVersion="3" checksum="924871709"/>
  </class>
- <class name="edmtest::MissingDictionaryTestB" ClassVersion="10">
-  <version ClassVersion="10" checksum="3237077045"/>
+ <class name="edmtest::MissingDictionaryTestB" ClassVersion="3">
+  <version ClassVersion="3" checksum="3237077045"/>
  </class>
- <class name="edmtest::MissingDictionaryTestC" ClassVersion="10">
-  <version ClassVersion="10" checksum="276188887"/>
+ <class name="edmtest::MissingDictionaryTestC" ClassVersion="3">
+  <version ClassVersion="3" checksum="276188887"/>
  </class>
- <class name="edmtest::MissingDictionaryTestD" ClassVersion="10">
-  <version ClassVersion="10" checksum="525992233"/>
+ <class name="edmtest::MissingDictionaryTestD" ClassVersion="3">
+  <version ClassVersion="3" checksum="525992233"/>
  </class>
- <class name="edmtest::MissingDictionaryTestE" ClassVersion="10">
-  <version ClassVersion="10" checksum="525992341"/>
+ <class name="edmtest::MissingDictionaryTestE" ClassVersion="3">
+  <version ClassVersion="3" checksum="525992341"/>
  </class>
 <!--
 Commenting this out to intentionally cause the missing dictionary
 exception when running testMissingDictionaryChecking_cfg.py.
- <class name="edmtest::MissingDictionaryTestF" ClassVersion="10">
-  <version ClassVersion="10" checksum="3318785451"/>
+ <class name="edmtest::MissingDictionaryTestF" ClassVersion="3">
+  <version ClassVersion="3" checksum="3318785451"/>
  </class>
 -->
- <class name="edmtest::MissingDictionaryTestG" ClassVersion="10">
-  <version ClassVersion="10" checksum="525992557"/>
+ <class name="edmtest::MissingDictionaryTestG" ClassVersion="3">
+  <version ClassVersion="3" checksum="525992557"/>
  </class>
- <class name="edmtest::MissingDictionaryTestH" ClassVersion="10">
-  <version ClassVersion="10" checksum="525992665"/>
+ <class name="edmtest::MissingDictionaryTestH" ClassVersion="3">
+  <version ClassVersion="3" checksum="525992665"/>
  </class>
- <class name="edmtest::MissingDictionaryTestI" ClassVersion="10">
-  <version ClassVersion="10" checksum="325955792"/>
+ <class name="edmtest::MissingDictionaryTestI" ClassVersion="3">
+  <version ClassVersion="3" checksum="325955792"/>
  </class>
- <class name="edmtest::MissingDictionaryTestJ" ClassVersion="10">
-  <version ClassVersion="10" checksum="525992881"/>
+ <class name="edmtest::MissingDictionaryTestJ" ClassVersion="3">
+  <version ClassVersion="3" checksum="525992881"/>
  </class>
- <class name="edmtest::MissingDictionaryTestK" ClassVersion="10">
-  <version ClassVersion="10" checksum="525992989"/>
+ <class name="edmtest::MissingDictionaryTestK" ClassVersion="3">
+  <version ClassVersion="3" checksum="525992989"/>
  </class>
 
  <class name="std::vector<edmtest::MissingDictionaryTestA>"/>


### PR DESCRIPTION
#### PR description:

One batch of resetting class version to 3 in EVOLUTION_X. Following cases were left out
- `edm::Wrapper<T>` (because of being used in RAW)
- Metadata classes (in `DataFormats/Provenance`, being used in RAW)
- FWLite types with version 0
- Types used in ROOT (TTree) schema evolution test
- `DataFormats/Scouting` because the versioning there already starts from 3 (so not much to gain), and I did not want to spend time in updating their schema evolution tests

Resolves https://github.com/cms-sw/framework-team/issues/2191

#### PR validation:

Code compiles