### PR TITLE
[EVOLUTION_X] Reset class versions to 3 in l1

### DIFF
--- a/DataFormats/L1DTTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1DTTrackFinder/src/classes_def.xml
@@ -1,12 +1,11 @@
 
 <lcgdict>
 
- <class name="L1MuDTChambPhDigi" ClassVersion="11">
-  <version ClassVersion="11" checksum="165624804"/>
-  <version ClassVersion="10" checksum="4002141935"/>
+ <class name="L1MuDTChambPhDigi" ClassVersion="3">
+  <version ClassVersion="3" checksum="165624804"/>
  </class>
- <class name="L1MuDTChambThDigi" ClassVersion="10">
-  <version ClassVersion="10" checksum="2095116117"/>
+ <class name="L1MuDTChambThDigi" ClassVersion="3">
+  <version ClassVersion="3" checksum="2095116117"/>
  </class>
  <class name="L1MuDTTrackCand" ClassVersion="3">
   <version ClassVersion="3" checksum="3593607678"/>

--- a/DataFormats/L1GlobalTrigger/src/classes_def.xml
+++ b/DataFormats/L1GlobalTrigger/src/classes_def.xml
@@ -1,31 +1,29 @@
 <lcgdict>
-  <class name="L1GtfeWord" ClassVersion="10">
-   <version ClassVersion="10" checksum="3339021130"/>
+  <class name="L1GtfeWord" ClassVersion="3">
+   <version ClassVersion="3" checksum="3339021130"/>
   </class>
   <class name="edm::Wrapper<L1GtfeWord>" splitLevel="0"/>
 
-  <class name="L1GtfeExtWord" ClassVersion="11">
-   <version ClassVersion="11" checksum="1852962113"/>
-   <version ClassVersion="10" checksum="4067988117"/>
+  <class name="L1GtfeExtWord" ClassVersion="3">
+   <version ClassVersion="3" checksum="1852962113"/>
   </class>
   <class name="edm::Wrapper<L1GtfeExtWord>" splitLevel="0"/>
 
-  <class name="L1TcsWord" ClassVersion="11">
-   <version ClassVersion="11" checksum="4260556162"/>
-   <version ClassVersion="10" checksum="2663215739"/>
+  <class name="L1TcsWord" ClassVersion="3">
+   <version ClassVersion="3" checksum="4260556162"/>
   </class>
   <class name="edm::Wrapper<L1TcsWord>" splitLevel="0"/>
 
-  <class name="L1GtFdlWord" ClassVersion="10">
-   <version ClassVersion="10" checksum="3749331160"/>
+  <class name="L1GtFdlWord" ClassVersion="3">
+   <version ClassVersion="3" checksum="3749331160"/>
   </class>
   <class name="edm::Wrapper<L1GtFdlWord>" splitLevel="0"/>
   
   <class name="std::vector<L1GtFdlWord>"/>
   <class name="edm::Wrapper<std::vector<L1GtFdlWord> >" splitLevel="0"/>
 
-  <class name="L1GtPsbWord" ClassVersion="10">
-   <version ClassVersion="10" checksum="4164985273"/>
+  <class name="L1GtPsbWord" ClassVersion="3">
+   <version ClassVersion="3" checksum="4164985273"/>
   </class>
   <class name="edm::Wrapper<L1GtPsbWord>" splitLevel="0"/>
   
@@ -33,8 +31,8 @@
   <class name="edm::Wrapper<std::vector<L1GtPsbWord> >" splitLevel="0"/>
  
  
-  <class name="L1GlobalTriggerReadoutSetup" ClassVersion="10">
-   <version ClassVersion="10" checksum="2071076145"/>
+  <class name="L1GlobalTriggerReadoutSetup" ClassVersion="3">
+   <version ClassVersion="3" checksum="2071076145"/>
   </class>
   <class name="edm::Wrapper<L1GlobalTriggerReadoutSetup>" splitLevel="0"/>
   
@@ -43,74 +41,72 @@
   </class>
   <class name="edm::Wrapper<io_v1::L1GlobalTriggerReadoutRecord>" splitLevel="0"/>
   
-  <class name="L1GlobalTriggerEvmReadoutRecord" ClassVersion="10">
-   <version ClassVersion="10" checksum="3816973918"/>
+  <class name="L1GlobalTriggerEvmReadoutRecord" ClassVersion="3">
+   <version ClassVersion="3" checksum="3816973918"/>
   </class>
   <class name="edm::Wrapper<L1GlobalTriggerEvmReadoutRecord>" splitLevel="0"/>
 
-  <class name="L1GlobalTriggerObjectMap" ClassVersion="11">
-   <version ClassVersion="11" checksum="3562485483"/>
-   <version ClassVersion="10" checksum="744814082"/>
+  <class name="L1GlobalTriggerObjectMap" ClassVersion="3">
+   <version ClassVersion="3" checksum="3562485483"/>
   </class>
   <class name="edm::Wrapper<L1GlobalTriggerObjectMap>" splitLevel="0"/>
 
   <class name="std::vector<L1GlobalTriggerObjectMap>"/>
   <class name="edm::Wrapper<std::vector<L1GlobalTriggerObjectMap> >" splitLevel="0"/>
 
-  <class name="L1GlobalTriggerObjectMapRecord" ClassVersion="10">
-   <version ClassVersion="10" checksum="3799476908"/>
+  <class name="L1GlobalTriggerObjectMapRecord" ClassVersion="3">
+   <version ClassVersion="3" checksum="3799476908"/>
   </class>
   <class name="edm::Wrapper<L1GlobalTriggerObjectMapRecord>" splitLevel="0"/>
 
-  <class name="L1GlobalTriggerObjectMaps::AlgorithmResult" ClassVersion="10">
-   <version ClassVersion="10" checksum="3647962944"/>
+  <class name="L1GlobalTriggerObjectMaps::AlgorithmResult" ClassVersion="3">
+   <version ClassVersion="3" checksum="3647962944"/>
   </class>
   <class name="std::vector<L1GlobalTriggerObjectMaps::AlgorithmResult>"/>
 
-  <class name="L1GlobalTriggerObjectMaps::ConditionResult" ClassVersion="10">
-   <version ClassVersion="10" checksum="3470739114"/>
+  <class name="L1GlobalTriggerObjectMaps::ConditionResult" ClassVersion="3">
+   <version ClassVersion="3" checksum="3470739114"/>
   </class>
   <class name="std::vector<L1GlobalTriggerObjectMaps::ConditionResult>"/>
 
-  <class name="L1GlobalTriggerObjectMaps" ClassVersion="10">
-   <version ClassVersion="10" checksum="3817566121"/>
+  <class name="L1GlobalTriggerObjectMaps" ClassVersion="3">
+   <version ClassVersion="3" checksum="3817566121"/>
   </class>
   <class name="edm::Wrapper<L1GlobalTriggerObjectMaps>"/>
 
-  <class name="L1GlobalTriggerRecord" ClassVersion="10">
-   <version ClassVersion="10" checksum="3463234758"/>
+  <class name="L1GlobalTriggerRecord" ClassVersion="3">
+   <version ClassVersion="3" checksum="3463234758"/>
   </class>
   <class name="edm::Wrapper<L1GlobalTriggerRecord>" splitLevel="0"/>
 
-  <class name="L1GtTechnicalTrigger" ClassVersion="10">
-   <version ClassVersion="10" checksum="38955916"/>
+  <class name="L1GtTechnicalTrigger" ClassVersion="3">
+   <version ClassVersion="3" checksum="38955916"/>
   </class>
   <class name="edm::Wrapper<L1GtTechnicalTrigger>" splitLevel="0"/>
 
   <class name="std::vector<L1GtTechnicalTrigger>"/>
   <class name="edm::Wrapper<std::vector<L1GtTechnicalTrigger> >" splitLevel="0"/>
 
-  <class name="L1GtTechnicalTriggerRecord" ClassVersion="10">
-   <version ClassVersion="10" checksum="3203568288"/>
+  <class name="L1GtTechnicalTriggerRecord" ClassVersion="3">
+   <version ClassVersion="3" checksum="3203568288"/>
   </class>
   <class name="edm::Wrapper<L1GtTechnicalTriggerRecord>" splitLevel="0"/>
 
   <class name="std::vector<L1GtObject>"/>
   <class name="std::vector<std::vector<L1GtObject> >"/>
 
-  <class name="L1GtLogicParser::OperandToken" ClassVersion="10">
-   <version ClassVersion="10" checksum="599247693"/>
+  <class name="L1GtLogicParser::OperandToken" ClassVersion="3">
+   <version ClassVersion="3" checksum="599247693"/>
   </class>
   <class name="std::vector<L1GtLogicParser::OperandToken>"/>
 
-  <class name="L1GtLogicParser::TokenRPN" ClassVersion="11">
-   <version ClassVersion="11" checksum="1759531300"/>
-   <version ClassVersion="10" checksum="535147936"/>
+  <class name="L1GtLogicParser::TokenRPN" ClassVersion="3">
+   <version ClassVersion="3" checksum="1759531300"/>
   </class>
   <class name="std::vector<L1GtLogicParser::TokenRPN>"/>
 
-  <class name="L1GtTriggerMenuLite" ClassVersion="10">
-   <version ClassVersion="10" checksum="851367861"/>
+  <class name="L1GtTriggerMenuLite" ClassVersion="3">
+   <version ClassVersion="3" checksum="851367861"/>
   </class>
   <class name="edm::Wrapper<L1GtTriggerMenuLite>" splitLevel="0"/>
 

--- a/DataFormats/L1TGlobal/src/classes_def.xml
+++ b/DataFormats/L1TGlobal/src/classes_def.xml
@@ -63,9 +63,8 @@
   </class>
   <class name="std::vector<GlobalLogicParser::OperandToken>"/>
 
-  <class name="GlobalLogicParser::TokenRPN" ClassVersion="11">
-   <version ClassVersion="11" checksum="2556920576"/>
-    <version ClassVersion="10" checksum="1759531300"/>
+  <class name="GlobalLogicParser::TokenRPN" ClassVersion="3">
+   <version ClassVersion="3" checksum="2556920576"/>
   </class>
   <class name="std::vector<GlobalLogicParser::TokenRPN>"/>
   

--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -88,16 +88,16 @@
   <class name="L1MuKBMTrack"/>
 
 
-  <class name="L1MuBMSecProcId" ClassVersion="10">
-    <version ClassVersion="10" checksum="3768381571"/>
+  <class name="L1MuBMSecProcId" ClassVersion="3">
+    <version ClassVersion="3" checksum="3768381571"/>
   </class>
 
-  <class name="L1MuBMAddressArray" ClassVersion="10">
-    <version ClassVersion="10" checksum="1391538870"/>
+  <class name="L1MuBMAddressArray" ClassVersion="3">
+    <version ClassVersion="3" checksum="1391538870"/>
   </class>
 
-  <class name="L1MuBMTrackSegLoc" ClassVersion="10">
-    <version ClassVersion="10" checksum="1894920440"/>
+  <class name="L1MuBMTrackSegLoc" ClassVersion="3">
+    <version ClassVersion="3" checksum="1894920440"/>
   </class>
 
   <class name="L1MuBMTrackCollection"/>

--- a/DataFormats/L1TMuonPhase2/src/classes_def.xml
+++ b/DataFormats/L1TMuonPhase2/src/classes_def.xml
@@ -37,9 +37,8 @@
     </class>
     <class name="l1t::phase2::EMTFHitCollection"/>
     <class name="edm::Wrapper<l1t::phase2::EMTFHitCollection>"/>
-    <class name="l1t::phase2::EMTFTrack" ClassVersion="4">
-      <version ClassVersion="3" checksum="972508279"/>
-      <version ClassVersion="4" checksum="3868553580"/>
+    <class name="l1t::phase2::EMTFTrack" ClassVersion="3">
+      <version ClassVersion="3" checksum="3868553580"/>
     </class>
     <class name="l1t::phase2::EMTFTrackCollection"/>
     <class name="edm::Wrapper<l1t::phase2::EMTFTrackCollection>"/>

--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -24,16 +24,8 @@
   <class name="edm::Wrapper<vector<edm::Ref<vector<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > > > >" />
   <class name="edm::RefVector<std::vector<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >,TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >,edm::refhelper::FindUsingAdvance<std::vector<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >,TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > >" />
   <class name="edm::Wrapper<edm::RefVector<std::vector<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >,TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > >,edm::refhelper::FindUsingAdvance<std::vector<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > >,TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > > >" />
-  <class name="TTTrack_TrackWord" ClassVersion="4">
-   <version ClassVersion="4" checksum="133238749"/>
-   <version ClassVersion="3" checksum="4186150061"/>
-   <ioread sourceClass = "TTTrack_TrackWord" version="[-3]" targetClass="TTTrack_TrackWord"
-    source="unsigned int iRinv; unsigned int iphi; unsigned int itanl; unsigned int iz0; unsigned int id0; unsigned int ichi2XY; unsigned int ichi2Z; unsigned int iBendChi2; unsigned int ispare; unsigned int iHitPattern;" target="">
-    <![CDATA[
-      TTTrack_TrackWord tmp(1, onfile.iRinv, onfile.iphi, onfile.itanl, onfile.iz0, onfile.id0, onfile.ichi2XY, onfile.ichi2Z, onfile.iBendChi2, onfile.iHitPattern, 0, 0);
-      *newObj=tmp;
-    ]]>
-   </ioread>
+  <class name="TTTrack_TrackWord" ClassVersion="3">
+   <version ClassVersion="3" checksum="133238749"/>
   </class>
   <class name="std::vector<TTTrack_TrackWord>"/>
   <class name="edm::Wrapper<std::vector<TTTrack_TrackWord> >"/>

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -146,10 +146,9 @@
   <class name="l1extra::L1EtMissParticle" ClassVersion="3">
    <version ClassVersion="3" checksum="2918830125"/>
   </class>
-  <class name="l1extra::L1ParticleMap" ClassVersion="11">
-   <version ClassVersion="11" checksum="3029280877"/>
+  <class name="l1extra::L1ParticleMap" ClassVersion="3">
+   <version ClassVersion="3" checksum="3029280877"/>
    <field name="indexCombosState_" transient="true"/>
-   <version ClassVersion="10" checksum="72905536"/>
   </class>
   <class name="l1extra::L1HFRings" ClassVersion="3">
    <version ClassVersion="3" checksum="2328198394"/>
@@ -168,8 +167,8 @@
   <class name="edm::Wrapper<std::vector<l1extra::L1ParticleMap> >"/>
   <class name="edm::Wrapper<std::vector<l1extra::L1HFRings> >"/>
 
-  <class name="HOTPDigiTwinMux" ClassVersion="14">
-    <version ClassVersion="14" checksum="66417560"/>
+  <class name="HOTPDigiTwinMux" ClassVersion="3">
+    <version ClassVersion="3" checksum="66417560"/>
   </class>
   <class name="std::vector<HOTPDigiTwinMux>"/>
   <class name="edm::SortedCollection<HOTPDigiTwinMux,edm::StrictWeakOrdering<HOTPDigiTwinMux> >"/>
@@ -208,21 +207,19 @@
 
   <class name="std::vector<l1extra::L1ParticleMap::L1ObjectType>"/>
 
-  <class name="GltDEDigi" ClassVersion="10">
-   <version ClassVersion="10" checksum="1378084374"/>
+  <class name="GltDEDigi" ClassVersion="3">
+   <version ClassVersion="3" checksum="1378084374"/>
   </class>
-  <class name="L1MonitorDigi" ClassVersion="10">
-   <version ClassVersion="10" checksum="2151016500"/>
+  <class name="L1MonitorDigi" ClassVersion="3">
+   <version ClassVersion="3" checksum="2151016500"/>
   </class>
 
-  <class name="L1DataEmulDigi" ClassVersion="10">
-   <version ClassVersion="10" checksum="634833762"/>
+  <class name="L1DataEmulDigi" ClassVersion="3">
+   <version ClassVersion="3" checksum="634833762"/>
   </class>
   <class name="std::vector<L1DataEmulDigi>"/>
-  <class name="L1DataEmulRecord" ClassVersion="12">
-   <version ClassVersion="12" checksum="3255820845"/>
-   <version ClassVersion="11" checksum="3617630969"/>
-   <version ClassVersion="10" checksum="466303541"/>
+  <class name="L1DataEmulRecord" ClassVersion="3">
+   <version ClassVersion="3" checksum="3255820845"/>
   </class>
   <class name="edm::Wrapper<L1DataEmulRecord>"/>
 
@@ -267,8 +264,8 @@
   <class name="std::vector<io_v1::L1TriggerError>"/>
   <class name="edm::Wrapper<std::vector<io_v1::L1TriggerError> >"/>
 
-  <class name="l1t::L1DataEmulResult" ClassVersion="10">
-    <version ClassVersion="10" checksum="604440326"/>
+  <class name="l1t::L1DataEmulResult" ClassVersion="3">
+    <version ClassVersion="3" checksum="604440326"/>
   </class>
   <class name="l1t::L1DataEmulResultBxCollection"/>
   <class name="std::vector<l1t::L1DataEmulResult>"/>

--- a/DataFormats/LTCDigi/src/classes_def.xml
+++ b/DataFormats/LTCDigi/src/classes_def.xml
@@ -1,7 +1,6 @@
 <lcgdict>
-<class name="LTCDigi" ClassVersion="11">
- <version ClassVersion="11" checksum="596026425"/>
- <version ClassVersion="10" checksum="3405171392"/>
+<class name="LTCDigi" ClassVersion="3">
+ <version ClassVersion="3" checksum="596026425"/>
 </class>
 <class name="std::vector<LTCDigi>"/>
 <class name="edm::Wrapper<std::vector<LTCDigi> >" splitLevel="0"/>


### PR DESCRIPTION
#### PR description:

One batch of resetting class version to 3 in EVOLUTION_X. The `GlobalObjectMap` and related types were left untouched because of being used in RAW.

Resolves https://github.com/cms-sw/framework-team/issues/2191

#### PR validation:

Code compiles