### PR TITLE
[EVOLUTION_X] Reset class versions to 3 in simulation in SimDataFormats

### DIFF
--- a/SimDataFormats/CaloHit/src/classes_def.xml
+++ b/SimDataFormats/CaloHit/src/classes_def.xml
@@ -5,8 +5,8 @@
   <class name="std::vector<io_v1::PCaloHit>"/>
   <class name="std::vector<const io_v1::PCaloHit*>"/>
   <class name="edm::Wrapper<std::vector<io_v1::PCaloHit>>" splitLevel="0"/>
-  <class name="HFShowerPhoton" ClassVersion="10">
-   <version ClassVersion="10" checksum="3736969110"/>
+  <class name="HFShowerPhoton" ClassVersion="3">
+   <version ClassVersion="3" checksum="3736969110"/>
   </class>
   <class name="std::vector<HFShowerPhoton>"/>
   <class name="edm::Wrapper<std::vector<HFShowerPhoton> >"/>
@@ -21,25 +21,21 @@
    <version ClassVersion="2" checksum="1661681871"/>
    <version ClassVersion="1" checksum="1661681871"/>
   </class>
-  <class name="HFShowerLibraryEventInfo" ClassVersion="10">
-   <version ClassVersion="10" checksum="1929526838"/>
+  <class name="HFShowerLibraryEventInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="1929526838"/>
   </class>
   <class name="std::vector<HFShowerLibraryEventInfo>"/>
   <class name="edm::Wrapper<HFShowerLibraryEventInfo>" />
   <class name="edm::Wrapper<std::vector<HFShowerLibraryEventInfo> >"/>
   <typedef name="CastorShowerEvent::Point" />
-  <class name="PassiveHit" ClassVersion="15">
-   <version ClassVersion="15" checksum="3886063447"/>
-   <version ClassVersion="14" checksum="3344618767"/>
-   <version ClassVersion="13" checksum="1735297430"/>
-   <version ClassVersion="12" checksum="1168914655"/>
-   <version ClassVersion="11" checksum="2866279991"/>
+  <class name="PassiveHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="3886063447"/>
   </class>
   <class name="std::vector<PassiveHit>"/>
   <class name="std::vector<const PassiveHit*>"/>
   <class name="edm::Wrapper<std::vector<PassiveHit>>" splitLevel="0"/>
-  <class name="MaterialInformation" ClassVersion="16">
-   <version ClassVersion="16" checksum="680156149"/>
+  <class name="MaterialInformation" ClassVersion="3">
+   <version ClassVersion="3" checksum="680156149"/>
   </class>
   <class name="std::vector<MaterialInformation>"/>
   <class name="std::vector<const MaterialInformation*>"/>

--- a/SimDataFormats/CaloTest/src/classes_def.xml
+++ b/SimDataFormats/CaloTest/src/classes_def.xml
@@ -1,23 +1,23 @@
 <lcgdict>
-  <class name="HcalTestHistoClass" ClassVersion="10">
-   <version ClassVersion="10" checksum="4077122487"/>
+  <class name="HcalTestHistoClass" ClassVersion="3">
+   <version ClassVersion="3" checksum="4077122487"/>
   </class>
-  <class name="HcalTestHistoClass::Layer" ClassVersion="10">
-   <version ClassVersion="10" checksum="2361923361"/>
+  <class name="HcalTestHistoClass::Layer" ClassVersion="3">
+   <version ClassVersion="3" checksum="2361923361"/>
   </class>
-  <class name="HcalTestHistoClass::Hit" ClassVersion="10">
-   <version ClassVersion="10" checksum="161472878"/>
+  <class name="HcalTestHistoClass::Hit" ClassVersion="3">
+   <version ClassVersion="3" checksum="161472878"/>
   </class>
-  <class name="HcalTestHistoClass::QIE" ClassVersion="10">
-   <version ClassVersion="10" checksum="4053248214"/>
+  <class name="HcalTestHistoClass::QIE" ClassVersion="3">
+   <version ClassVersion="3" checksum="4053248214"/>
   </class>
   <class name="std::vector<HcalTestHistoClass::Layer>"/>
   <class name="std::vector<HcalTestHistoClass::Hit>"/>
   <class name="std::vector<HcalTestHistoClass::QIE>"/>
   <class name="edm::Wrapper<HcalTestHistoClass>"/>
 
-  <class name="ParticleFlux" ClassVersion="13">
-   <version ClassVersion="13" checksum="2329907515"/>
+  <class name="ParticleFlux" ClassVersion="3">
+   <version ClassVersion="3" checksum="2329907515"/>
   </class>
   <class name="edm::Wrapper<ParticleFlux>"/>
   <class name="ParticleFlux::flux"/>

--- a/SimDataFormats/EcalTestBeam/src/classes_def.xml
+++ b/SimDataFormats/EcalTestBeam/src/classes_def.xml
@@ -1,6 +1,6 @@
 <lcgdict>
-  <class name="PEcalTBInfo" ClassVersion="10">
-   <version ClassVersion="10" checksum="1603772803"/>
+  <class name="PEcalTBInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="1603772803"/>
   </class>
   <class name="edm::Wrapper<PEcalTBInfo>"/>
 </lcgdict>

--- a/SimDataFormats/EncodedEventId/src/classes_def.xml
+++ b/SimDataFormats/EncodedEventId/src/classes_def.xml
@@ -1,6 +1,6 @@
 <lcgdict>
-  <class name="EncodedEventId" ClassVersion="10">
-   <version ClassVersion="10" checksum="541119857"/>
+  <class name="EncodedEventId" ClassVersion="3">
+   <version ClassVersion="3" checksum="541119857"/>
   </class>
   <class name="std::vector<EncodedEventId>"/>
 </lcgdict>

--- a/SimDataFormats/Forward/src/classes_def.xml
+++ b/SimDataFormats/Forward/src/classes_def.xml
@@ -1,15 +1,15 @@
 <lcgdict>
-  <class name="TotemTestHistoClass" ClassVersion="10">
-   <version ClassVersion="10" checksum="599416754"/>
+  <class name="TotemTestHistoClass" ClassVersion="3">
+   <version ClassVersion="3" checksum="599416754"/>
   </class>
-  <class name="TotemTestHistoClass::Hit" ClassVersion="10">
-   <version ClassVersion="10" checksum="4069870155"/>
+  <class name="TotemTestHistoClass::Hit" ClassVersion="3">
+   <version ClassVersion="3" checksum="4069870155"/>
   </class>
   <class name="std::vector<TotemTestHistoClass::Hit>"/>
   <class name="edm::Wrapper<TotemTestHistoClass>"/>
 
-  <class name="LHCTransportLink" ClassVersion="10">
-   <version ClassVersion="10" checksum="159175617"/>
+  <class name="LHCTransportLink" ClassVersion="3">
+   <version ClassVersion="3" checksum="159175617"/>
   </class>
   <class name="std::vector<LHCTransportLink>"/>
   <class name="edm::Wrapper<std::vector<LHCTransportLink>>" splitLevel="0" />

--- a/SimDataFormats/HcalTestBeam/src/classes_def.xml
+++ b/SimDataFormats/HcalTestBeam/src/classes_def.xml
@@ -1,20 +1,20 @@
 <lcgdict>
-  <class name="HcalTB02HistoClass" ClassVersion="10">
-   <version ClassVersion="10" checksum="944394599"/>
+  <class name="HcalTB02HistoClass" ClassVersion="3">
+   <version ClassVersion="3" checksum="944394599"/>
   </class>
   <class name="edm::Wrapper<HcalTB02HistoClass>"/>
-  <class name="PHcalTB04Info" ClassVersion="10">
-   <version ClassVersion="10" checksum="406173511"/>
+  <class name="PHcalTB04Info" ClassVersion="3">
+   <version ClassVersion="3" checksum="406173511"/>
   </class>
   <class name="edm::Wrapper<PHcalTB04Info>"/>
-  <class name="PHcalTB06Info" ClassVersion="10">
-   <version ClassVersion="10" checksum="3969279899"/>
+  <class name="PHcalTB06Info" ClassVersion="3">
+   <version ClassVersion="3" checksum="3969279899"/>
   </class>
-  <class name="PHcalTB06Info::Vtx" ClassVersion="10">
-   <version ClassVersion="10" checksum="4037247532"/>
+  <class name="PHcalTB06Info::Vtx" ClassVersion="3">
+   <version ClassVersion="3" checksum="4037247532"/>
   </class>
-  <class name="PHcalTB06Info::Hit" ClassVersion="10">
-   <version ClassVersion="10" checksum="2273647542"/>
+  <class name="PHcalTB06Info::Hit" ClassVersion="3">
+   <version ClassVersion="3" checksum="2273647542"/>
   </class>
   <class name="std::vector<PHcalTB06Info::Vtx>"/>
   <class name="std::vector<PHcalTB06Info::Hit>"/>

--- a/SimDataFormats/RandomEngine/src/classes_def.xml
+++ b/SimDataFormats/RandomEngine/src/classes_def.xml
@@ -2,10 +2,10 @@
   <class name="edm::Wrapper<edm::RandomEngineStates>" />
   <class name="edm::Wrapper<vector<RandomEngineState> >" />
   <class name="std::vector<RandomEngineState>"/>  
-  <class name="RandomEngineState" ClassVersion="10">
-   <version ClassVersion="10" checksum="3726981328"/>
+  <class name="RandomEngineState" ClassVersion="3">
+   <version ClassVersion="3" checksum="3726981328"/>
   </class>
-  <class name="edm::RandomEngineStates" ClassVersion="10">
-   <version ClassVersion="10" checksum="669222241"/>
+  <class name="edm::RandomEngineStates" ClassVersion="3">
+   <version ClassVersion="3" checksum="669222241"/>
   </class>
 </lcgdict>

--- a/SimDataFormats/ValidationFormats/src/classes_def.xml
+++ b/SimDataFormats/ValidationFormats/src/classes_def.xml
@@ -1,21 +1,21 @@
 <lcgdict>
-  <class name="PGlobalSimHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="2475681360"/>
+  <class name="PGlobalSimHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="2475681360"/>
   </class>
-  <class name="PGlobalSimHit::Vtx" ClassVersion="10">
-   <version ClassVersion="10" checksum="2472465168"/>
+  <class name="PGlobalSimHit::Vtx" ClassVersion="3">
+   <version ClassVersion="3" checksum="2472465168"/>
   </class>
-  <class name="PGlobalSimHit::Trk" ClassVersion="10">
-   <version ClassVersion="10" checksum="1469075425"/>
+  <class name="PGlobalSimHit::Trk" ClassVersion="3">
+   <version ClassVersion="3" checksum="1469075425"/>
   </class>
-  <class name="PGlobalSimHit::CalHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="874524041"/>
+  <class name="PGlobalSimHit::CalHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="874524041"/>
   </class>
-  <class name="PGlobalSimHit::FwdHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="3335786575"/>
+  <class name="PGlobalSimHit::FwdHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="3335786575"/>
   </class>
-  <class name="PGlobalSimHit::BrlHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="1504967606"/>
+  <class name="PGlobalSimHit::BrlHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="1504967606"/>
   </class>
   <class name="std::vector<PGlobalSimHit::Vtx>"/>
   <class name="std::vector<PGlobalSimHit::Trk>"/>
@@ -24,32 +24,32 @@
   <class name="std::vector<PGlobalSimHit::BrlHit>"/>
   <class name="edm::Wrapper<PGlobalSimHit>"/>
 
-  <class name="PGlobalDigi" ClassVersion="10">
-   <version ClassVersion="10" checksum="3608410396"/>
+  <class name="PGlobalDigi" ClassVersion="3">
+   <version ClassVersion="3" checksum="3608410396"/>
   </class>
-  <class name="PGlobalDigi::ECalDigi" ClassVersion="10">
-   <version ClassVersion="10" checksum="2362929189"/>
+  <class name="PGlobalDigi::ECalDigi" ClassVersion="3">
+   <version ClassVersion="3" checksum="2362929189"/>
   </class>
-  <class name="PGlobalDigi::ESCalDigi" ClassVersion="10">
-   <version ClassVersion="10" checksum="1181612450"/>
+  <class name="PGlobalDigi::ESCalDigi" ClassVersion="3">
+   <version ClassVersion="3" checksum="1181612450"/>
   </class>
-  <class name="PGlobalDigi::HCalDigi" ClassVersion="10">
-   <version ClassVersion="10" checksum="2884257254"/>
+  <class name="PGlobalDigi::HCalDigi" ClassVersion="3">
+   <version ClassVersion="3" checksum="2884257254"/>
   </class>
-  <class name="PGlobalDigi::SiStripDigi" ClassVersion="10">
-   <version ClassVersion="10" checksum="2483108654"/>
+  <class name="PGlobalDigi::SiStripDigi" ClassVersion="3">
+   <version ClassVersion="3" checksum="2483108654"/>
   </class>
-  <class name="PGlobalDigi::SiPixelDigi" ClassVersion="10">
-   <version ClassVersion="10" checksum="296132691"/>
+  <class name="PGlobalDigi::SiPixelDigi" ClassVersion="3">
+   <version ClassVersion="3" checksum="296132691"/>
   </class>
-  <class name="PGlobalDigi::DTDigi" ClassVersion="10">
-   <version ClassVersion="10" checksum="1928134513"/>
+  <class name="PGlobalDigi::DTDigi" ClassVersion="3">
+   <version ClassVersion="3" checksum="1928134513"/>
   </class>
-  <class name="PGlobalDigi::CSCstripDigi" ClassVersion="10">
-   <version ClassVersion="10" checksum="932597238"/>
+  <class name="PGlobalDigi::CSCstripDigi" ClassVersion="3">
+   <version ClassVersion="3" checksum="932597238"/>
   </class>
-  <class name="PGlobalDigi::CSCwireDigi" ClassVersion="10">
-   <version ClassVersion="10" checksum="923547918"/>
+  <class name="PGlobalDigi::CSCwireDigi" ClassVersion="3">
+   <version ClassVersion="3" checksum="923547918"/>
   </class>
   <class name="std::vector<PGlobalDigi::ECalDigi>"/>
   <class name="std::vector<PGlobalDigi::ESCalDigi>"/>
@@ -61,29 +61,29 @@
   <class name="std::vector<PGlobalDigi::CSCwireDigi>"/>
   <class name="edm::Wrapper<PGlobalDigi>" splitLevel="0"/>
 
-  <class name="PGlobalRecHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="2378484053"/>
+  <class name="PGlobalRecHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="2378484053"/>
   </class>
-  <class name="PGlobalRecHit::ECalRecHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="2464725595"/>
+  <class name="PGlobalRecHit::ECalRecHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="2464725595"/>
   </class>
-  <class name="PGlobalRecHit::HCalRecHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="4045573289"/>
+  <class name="PGlobalRecHit::HCalRecHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="4045573289"/>
   </class>
-  <class name="PGlobalRecHit::SiStripRecHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="1510299181"/>
+  <class name="PGlobalRecHit::SiStripRecHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="1510299181"/>
   </class>
-  <class name="PGlobalRecHit::SiPixelRecHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="3091348871"/>
+  <class name="PGlobalRecHit::SiPixelRecHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="3091348871"/>
   </class>
-  <class name="PGlobalRecHit::DTRecHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="340236748"/>
+  <class name="PGlobalRecHit::DTRecHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="340236748"/>
   </class>
-  <class name="PGlobalRecHit::CSCRecHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="1176792218"/>
+  <class name="PGlobalRecHit::CSCRecHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="1176792218"/>
   </class>
-  <class name="PGlobalRecHit::RPCRecHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="1286309253"/>
+  <class name="PGlobalRecHit::RPCRecHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="1286309253"/>
   </class>
   <class name="std::vector<PGlobalRecHit::ECalRecHit>"/>
   <class name="std::vector<PGlobalRecHit::HCalRecHit>"/>
@@ -94,41 +94,41 @@
   <class name="std::vector<PGlobalRecHit::RPCRecHit>"/>
   <class name="edm::Wrapper<PGlobalRecHit>"/>
 
-  <class name="PEcalValidInfo" ClassVersion="10">
-   <version ClassVersion="10" checksum="3721976541"/>
+  <class name="PEcalValidInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="3721976541"/>
   </class>
   <class name="edm::Wrapper<PEcalValidInfo>"/>
 
-  <class name="PHcalValidInfoLayer" ClassVersion="10">
-   <version ClassVersion="10" checksum="3685483203"/>
+  <class name="PHcalValidInfoLayer" ClassVersion="3">
+   <version ClassVersion="3" checksum="3685483203"/>
   </class>
-  <class name="PHcalValidInfoNxN" ClassVersion="10">
-   <version ClassVersion="10" checksum="916539230"/>
+  <class name="PHcalValidInfoNxN" ClassVersion="3">
+   <version ClassVersion="3" checksum="916539230"/>
   </class>
-  <class name="PHcalValidInfoJets" ClassVersion="10">
-   <version ClassVersion="10" checksum="3878729576"/>
+  <class name="PHcalValidInfoJets" ClassVersion="3">
+   <version ClassVersion="3" checksum="3878729576"/>
   </class>
   <class name="edm::Wrapper<PHcalValidInfoLayer>"/>
   <class name="edm::Wrapper<PHcalValidInfoNxN>"/>
   <class name="edm::Wrapper<PHcalValidInfoJets>"/>
 
-  <class name="PMuonSimHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="3899830179"/>
+  <class name="PMuonSimHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="3899830179"/>
   </class>
-  <class name="PMuonSimHit::Vtx" ClassVersion="10">
-   <version ClassVersion="10" checksum="3765376416"/>
+  <class name="PMuonSimHit::Vtx" ClassVersion="3">
+   <version ClassVersion="3" checksum="3765376416"/>
   </class>
-  <class name="PMuonSimHit::Trk" ClassVersion="10">
-   <version ClassVersion="10" checksum="394451010"/>
+  <class name="PMuonSimHit::Trk" ClassVersion="3">
+   <version ClassVersion="3" checksum="394451010"/>
   </class>
-  <class name="PMuonSimHit::CSC" ClassVersion="10">
-   <version ClassVersion="10" checksum="3079994217"/>
+  <class name="PMuonSimHit::CSC" ClassVersion="3">
+   <version ClassVersion="3" checksum="3079994217"/>
   </class>
-  <class name="PMuonSimHit::DT" ClassVersion="10">
-   <version ClassVersion="10" checksum="1074081844"/>
+  <class name="PMuonSimHit::DT" ClassVersion="3">
+   <version ClassVersion="3" checksum="1074081844"/>
   </class>
-  <class name="PMuonSimHit::RPC" ClassVersion="10">
-   <version ClassVersion="10" checksum="591845399"/>
+  <class name="PMuonSimHit::RPC" ClassVersion="3">
+   <version ClassVersion="3" checksum="591845399"/>
   </class>
   <class name="std::vector<PMuonSimHit::Vtx>"/>
   <class name="std::vector<PMuonSimHit::Trk>"/>
@@ -137,17 +137,17 @@
   <class name="std::vector<PMuonSimHit::RPC>"/>
   <class name="edm::Wrapper<PMuonSimHit>"/>
 
-  <class name="PTrackerSimHit" ClassVersion="10">
-   <version ClassVersion="10" checksum="2799801898"/>
+  <class name="PTrackerSimHit" ClassVersion="3">
+   <version ClassVersion="3" checksum="2799801898"/>
   </class>
-  <class name="PTrackerSimHit::Vtx" ClassVersion="10">
-   <version ClassVersion="10" checksum="3878707963"/>
+  <class name="PTrackerSimHit::Vtx" ClassVersion="3">
+   <version ClassVersion="3" checksum="3878707963"/>
   </class>
-  <class name="PTrackerSimHit::Trk" ClassVersion="10">
-   <version ClassVersion="10" checksum="2060865915"/>
+  <class name="PTrackerSimHit::Trk" ClassVersion="3">
+   <version ClassVersion="3" checksum="2060865915"/>
   </class>
-  <class name="PTrackerSimHit::Hit" ClassVersion="10">
-   <version ClassVersion="10" checksum="1348837015"/>
+  <class name="PTrackerSimHit::Hit" ClassVersion="3">
+   <version ClassVersion="3" checksum="1348837015"/>
   </class>
   <class name="std::vector<PTrackerSimHit::Vtx>"/>
   <class name="std::vector<PTrackerSimHit::Trk>"/>
@@ -156,27 +156,27 @@
   
   <!--<class name="std::pair<float,float>"/>-->
 
-  <class name="MaterialAccountingStep" ClassVersion="10">
-   <version ClassVersion="10" checksum="1239697155"/>
+  <class name="MaterialAccountingStep" ClassVersion="3">
+   <version ClassVersion="3" checksum="1239697155"/>
   </class>
   <class name="std::vector<MaterialAccountingStep>"/>
   <class name="edm::Wrapper<std::vector<MaterialAccountingStep> >"/>
 
-  <class name="MaterialAccountingDetector" ClassVersion="10">
-   <version ClassVersion="10" checksum="2816241367"/>
+  <class name="MaterialAccountingDetector" ClassVersion="3">
+   <version ClassVersion="3" checksum="2816241367"/>
   </class>
   <class name="std::vector<MaterialAccountingDetector>"/>
   <class name="edm::Wrapper<std::vector<MaterialAccountingDetector> >"/>
   
-  <class name="MaterialAccountingTrack" ClassVersion="10">
-   <version ClassVersion="10" checksum="3618055651"/>
+  <class name="MaterialAccountingTrack" ClassVersion="3">
+   <version ClassVersion="3" checksum="3618055651"/>
     <field name="m_detector"        transient="true"/>
   </class>
   <class name="std::vector<MaterialAccountingTrack>"/>
   <class name="edm::Wrapper<std::vector<MaterialAccountingTrack> >"/>
 
-  <class name="PHGCalValidInfo" ClassVersion="12">
-   <version ClassVersion="12" checksum="3840504732"/>
+  <class name="PHGCalValidInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="3840504732"/>
   </class>
   <class name="edm::Wrapper<PHGCalValidInfo>"/>
 


### PR DESCRIPTION
#### PR description:

One batch of resetting class versions to 3 in EVOLUTION_X. The types used in the shower library should have been left untouched.

Resolves https://github.com/cms-sw/framework-team/issues/2191

#### PR validation:

Code compiles