### PR TITLE
Ignore Io_v1 when generating the class friendly name

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -43,7 +43,7 @@ namespace edm {
       return std::regex_replace(iIn, reAllSpaces, emptyString);
     }
     static std::regex const reWrapper("edm::Wrapper<(.*)>");
-    static std::regex const reVersion("::io_v[0-9]+::");
+    static std::regex const reVersion("io_v[0-9]+::");
     static std::regex const reString("std::basic_string<char>");
     static std::regex const reString2("std::string");
     static std::regex const reString3("std::basic_string<char,std::char_traits<char> >");
@@ -117,7 +117,7 @@ namespace edm {
       static std::regex const reArray("\\[\\]");
 
       std::string name = regex_replace(iIn, reWrapper, "$1");
-      name = regex_replace(name, reVersion, "::");
+      name = regex_replace(name, reVersion, "");
       name = regex_replace(name, rePointer, "ptr");
       name = regex_replace(name, reArray, "As");
       name = regex_replace(name, reAIKR, "");

--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -43,6 +43,7 @@ namespace edm {
       return std::regex_replace(iIn, reAllSpaces, emptyString);
     }
     static std::regex const reWrapper("edm::Wrapper<(.*)>");
+    static std::regex const reVersion("::io_v[0-9]+::");
     static std::regex const reString("std::basic_string<char>");
     static std::regex const reString2("std::string");
     static std::regex const reString3("std::basic_string<char,std::char_traits<char> >");
@@ -116,6 +117,7 @@ namespace edm {
       static std::regex const reArray("\\[\\]");
 
       std::string name = regex_replace(iIn, reWrapper, "$1");
+      name = regex_replace(name, reVersion, "::");
       name = regex_replace(name, rePointer, "ptr");
       name = regex_replace(name, reArray, "As");
       name = regex_replace(name, reAIKR, "");


### PR DESCRIPTION
#### PR description:

- this is already in EVOLUTION branch

#### PR validation:

Code works in EVOLUTION.

resolves https://github.com/cms-sw/framework-team/issues/2198