### PR TITLE
[HCAL] fix bug that was causing filter to miss stuck digis 

### DIFF
--- a/EventFilter/HcalRawToDigi/plugins/HBHEstuckADCfilter.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HBHEstuckADCfilter.cc
@@ -48,8 +48,8 @@ bool HBHEstuckADCfilter::filter(edm::Event& ev, const edm::EventSetup& set) {
 
   bool result = true;
   for (QIE11DigiCollection::const_iterator itr = theDigis->begin(); itr != theDigis->end(); itr++) {
-    int tsize = (*itr).size();
     const QIE11DataFrame frame = *itr;
+    int tsize = frame.samples();
 
     bool flag = true;
     int adc0 = (frame[0]).adc();


### PR DESCRIPTION
#### PR description:

This PR fixes the "stuck ADC" filter (i.e. a filter that gets rid of and logs events where the QIE11 is in a bad state and outputting a stream of the same nonsense value). This filter was missing stuck ADCs because it was accessing elements of the QIE11DataFrame with indices beyond 7 (there are 8 max samples in normal HB data). With this fix it successfully finds HB stuck digis.

This PR causes two changes: it adds a few warning messages to the terminal output, and it populates the (previously empty) output text file which logs run/lumi/event numbers of events that contain stuck digis.

#### PR validation:

I tested this code by running the filter over a file that contains stuck digis [1] by adding the filter in the cfg file generated by the hcalNano runTheMatrix test workflow 2500.2404. I verified that the output log file successfully tags events where the hcalNano output shows genuine stuck digis.

[1] /store/data/Run2026C/JetMET0/RAW-RECO/TeVJet-PromptReco-v1/000/403/104/00000/794ba30e-58c9-4b0b-8857-93d469b27434.root

#### NB:
This PR is not a backport, but backports may be useful after this is merged.


