### PR TITLE
Fix hlt-p2-timing: properly wait and comsume the background processed

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
+++ b/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
@@ -197,12 +197,10 @@ run_benchmark() {
         local PID=$!
 
         # Live output
-        tail -f "$TMP_LOG_FILE" &
+        tail -f --pid=$PID "$TMP_LOG_FILE" &
         local TAIL_PID=$!
 
-        trap "kill $PID $TAIL_PID 2>/dev/null" EXIT
-
-        while ps -p $PID > /dev/null; do
+        while kill -0 $PID 2>/dev/null; do
 
             # Memory
             mem=$(get_current_total_gpu_mem)
@@ -231,7 +229,11 @@ run_benchmark() {
             sleep $MONITOR_INTERVAL
         done
 
-        kill $TAIL_PID 2>/dev/null
+        wait $PID
+
+        #tail should already exit due to --pid=$PID
+        wait $TAIL_PID 2>/dev/null || true
+
         mv "$TMP_LOG_FILE" "${logdir}/output.log"
 
         # Compute mean

--- a/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
+++ b/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
@@ -196,6 +196,9 @@ run_benchmark() {
 
         local PID=$!
 
+        # Ensure cleanup on failure
+        trap 'kill $PID 2>/dev/null || true' EXIT
+        
         # Live output
         tail -f --pid=$PID "$TMP_LOG_FILE" &
         local TAIL_PID=$!


### PR DESCRIPTION
Thsi change keeps the live output of hlt-p2-timing test but also properly wait forback-ground process and consume their exit code. This should fix the failing hlt-p2-timing test in IBs and PRs

If worked fine then this should replace the change in #50867 