### PR TITLE
Add missing protection for beamspot vertex in Scouting Collection DQM [16_0_X]

### DIFF
--- a/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
+++ b/DQM/HLTEvF/plugins/ScoutingCollectionMonitor.cc
@@ -832,10 +832,11 @@ void ScoutingCollectionMonitor::analyze(const edm::Event& iEvent, const edm::Eve
     };
 
     // compute w.r.t. beamspot
-    auto [dxy_bs, dz_bs] = computeIP(beamspotVertex->x(), beamspotVertex->y(), beamspotVertex->z());
-
-    trkd0BS_ele_hist->Fill(dxy_bs);
-    trkdzBS_ele_hist->Fill(dz_bs);
+    if (beamspotVertex) {
+      auto [dxy_bs, dz_bs] = computeIP(beamspotVertex->x(), beamspotVertex->y(), beamspotVertex->z());
+      trkd0BS_ele_hist->Fill(dxy_bs);
+      trkdzBS_ele_hist->Fill(dz_bs);
+    }
 
     const auto* vtx = findClosestVtx(vmDz[elRef]);
     if (vtx) {


### PR DESCRIPTION
verbatim backport of https://github.com/cms-sw/cmssw/pull/50871

#### PR description:

This PR fixes the issue mentioned https://github.com/cms-sw/cmssw/issues/50866 . We simply added a beamspot vertex protection such that it does not fail in environments where `hltOnlineBeamSpot` is not available. 

#### PR validation:

The fix was prepared in `CMSSW_16_0_7` and having additionally run `scram b code-format` and `scram b code-checks`. Validation similar to https://github.com/cms-sw/cmssw/pull/50719, having tested with:
```
scram b runtests_TestDQMOnlineClient-ngt_dqm_sourceclient
scram b runtests_TestDQMOnlineClient-scouting_dqm_sourceclient
```
and tested as well with:
```
#!/bin/bash -ex

LOCALPATH='/eos/cms/store/group/tsg-phase2/user/jprendi/NERD25/MoreStats/EGammas/HLT/'
echo "Input source: |${LOCALPATH}|"
LOCALFILES=$(ls -1 ${LOCALPATH} | grep Scouting)
ALL_FILES=""
for f in ${LOCALFILES[@]}; do
    ALL_FILES+="file:${LOCALPATH}/${f},"
done

# Remove the last character
ALL_FILES="${ALL_FILES%?}"
echo "Discovered files: $ALL_FILES"

cmsDriver.py step2 -s DQM:hltScoutingCollectionMonitor \
             --conditions 160X_dataRun3_HLT_v1 \
             --datatier DQMIO \
             -n 100 \
             --eventcontent DQMIO \
             --geometry DB:Extended \
             --era Run3_2025 \
             --filein file:$ALL_FILES \
             --fileout file:step2.root \
             --nThreads 24 \
             --python_filename dqm.py \
             --no_exec

cat <<@EOF >> dqm.py 
# import beamspot
from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer as _onlineBeamSpotProducer
process.hltOnlineBeamSpot = _onlineBeamSpotProducer.clone()
process.scoutingCollectionMonitor.onlineMetaDataDigis = "hltOnlineMetaDataDigis"
process.scoutingCollectionMonitor.onlyScouting = True

# best electron track producer
from PhysicsTools.Scouting.Run3ScoutingElectronBestTrackProducer_cfi import Run3ScoutingElectronBestTrackProducer as _Run3ScoutingElectronBestTrackProducer
process.run3ScoutingElectronBestTrack =  _Run3ScoutingElectronBestTrackProducer.clone()

process.dqmoffline_step = cms.EndPath(process.hltOnlineBeamSpot+process.run3ScoutingElectronBestTrack+process.hltScoutingCollectionMonitor+process.hltScoutingTrackMonitor)
@EOF

cmsRun dqm.py >& dqm.log

cmsDriver.py step3 -s HARVESTING:@standardDQM \
         --conditions 160X_dataRun3_HLT_v1 \
         --data \
         --geometry DB:Extended \
         --scenario pp \
         --filetype DQM \
         --era Run3_2025 \
         -n 100 \
         --filein file:step2.root \
         --fileout file:step3.root \
         --no_exec

cmsRun step3_HARVESTING.py >& harvesting.log

```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/50871