### PR TITLE
Introduce two-kernel iterative `prefixScan`

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/prefixScan.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/prefixScan.h
@@ -5,6 +5,7 @@
 
 #include "FWCore/Utilities/interface/CMSUnrollLoop.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 namespace cms::alpakatools {
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
@@ -134,10 +135,10 @@ namespace cms::alpakatools {
   }
 
   // Throws an exception with a message containing the shared memory requirements and limit.
-  void throwSharedMemoryLimitExceeded(size_t nElements,
-                                      uint32_t nBlocks,
-                                      size_t requiredSharedMem,
-                                      size_t sharedMemLimit);
+  void throwSharedMemoryLimitExceeded(const size_t nElements,
+                                      const uint32_t nBlocks,
+                                      const size_t requiredSharedMem,
+                                      const size_t sharedMemLimit);
 
   // Verify shared memory requirements
   template <alpaka::concepts::Acc TAcc, typename TSize>
@@ -238,6 +239,156 @@ namespace cms::alpakatools {
       }
     }
   };
+
+  // Two kernel approach, not shared-memory limited.
+  // Kernel A: scan one level (tile per block) and emit one block sum per block.
+  // It is called recursively until the block sums array is reduced to one element, orchestration happens on host.
+  // Kernel B: add scanned block offsets to each block (except block 0).
+
+  // Kernel A
+  template <typename T>
+  struct scanTilesWriteBlockSums {
+    template <alpaka::concepts::Acc TAcc>
+    ALPAKA_FN_ACC void operator()(
+        const TAcc& acc, T const* ci, T* co, uint32_t size, T* blockSums, std::size_t warpSize) const {
+      T* ws = nullptr;
+      if constexpr (!requires_single_thread_per_block_v<TAcc>) {
+        ws = alpaka::getDynSharedMem<T>(acc);
+      }
+
+      const auto elementsPerBlock = alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u];
+      const auto blockIdx = alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u];
+      const auto threadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u];
+
+      auto off = elementsPerBlock * blockIdx;
+      if (off >= size)
+        return;
+
+      auto n = alpaka::math::min(acc, elementsPerBlock, size - off);
+      blockPrefixScan(acc, ci + off, co + off, static_cast<int32_t>(n), ws);
+
+      if (threadIdx == 0u) {
+        blockSums[blockIdx] = co[off + n - 1];
+      }
+    }
+  };
+
+  // Kernel B
+  template <typename T>
+  struct addScannedBlockOffsets {
+    template <alpaka::concepts::Acc TAcc>
+    ALPAKA_FN_ACC void operator()(const TAcc& acc, T* data, uint32_t size, T const* scannedBlockSums) const {
+      const auto elementsPerBlock = alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u];
+      const auto blockIdx = alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u];
+      const auto threadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u];
+
+      if (blockIdx == 0u)
+        return;
+
+      T const add = scannedBlockSums[blockIdx - 1u];
+      uint32_t begin = elementsPerBlock * blockIdx;
+      uint32_t end = alpaka::math::min(acc, begin + elementsPerBlock, size);
+      for (auto i = begin + threadIdx; i < end; i += elementsPerBlock) {
+        data[i] += add;
+      }
+    }
+  };
+
+  // Helper struct and function to compute the number of levels and block sizes for the two-kernel prefix scan.
+  // 3 levels (0, 1, 2) can cover up to 1024^3 ~ 10^9 elements, enough for any realistic use case
+  constexpr uint32_t iterativePrefixScanThreads = 1024u;
+  constexpr uint32_t iterativePrefixScanMaxLevels = 3;
+  struct PrefixScanLevelPlan {
+    uint32_t nLevels = 0;
+    std::vector<uint32_t> levelSize;
+    std::vector<uint32_t> levelBlocks;
+  };
+
+  // Throws an exception with a message containing the requested iterations and the set compile-time limit
+  void throwIterativePrefixScanMaxLevelsExceeded(const size_t nElements, const uint32_t nLevels);
+
+  ALPAKA_FN_INLINE static PrefixScanLevelPlan makePrefixScanLevelPlan(uint32_t nElements) {
+    PrefixScanLevelPlan p;
+    if (nElements == 0u) {
+      return p;
+    }
+
+    p.levelSize.reserve(iterativePrefixScanMaxLevels);
+    p.levelBlocks.reserve(iterativePrefixScanMaxLevels);
+
+    p.nLevels = 1u;
+    p.levelSize.emplace_back(nElements);
+    p.levelBlocks.emplace_back((nElements + iterativePrefixScanThreads - 1u) / iterativePrefixScanThreads);
+
+    while (p.levelBlocks[p.nLevels - 1u] > 1u) {
+      if (p.nLevels >= iterativePrefixScanMaxLevels) {
+        throwIterativePrefixScanMaxLevelsExceeded(nElements, p.nLevels);
+      }
+      p.levelSize.emplace_back(p.levelBlocks[p.nLevels - 1u]);
+      p.levelBlocks.emplace_back((p.levelSize[p.nLevels] + iterativePrefixScanThreads - 1u) /
+                                 iterativePrefixScanThreads);
+      ++p.nLevels;
+    }
+    return p;
+  }
+
+  template <alpaka::concepts::Acc TAcc, typename TQueue, typename T>
+  ALPAKA_FN_INLINE static void iterativePrefixScan(T* input, T* output, uint32_t size, TQueue& queue) {
+    if (size == 0u) {
+      return;
+    }
+
+    if constexpr (!requires_single_thread_per_block_v<TAcc>) {
+      auto const plan = makePrefixScanLevelPlan(size);
+      assert(plan.nLevels > 0);
+
+      std::vector<cms::alpakatools::device_buffer<alpaka::Dev<TQueue>, T[]>> blockSumsBuffers;
+      blockSumsBuffers.reserve(plan.nLevels);
+      for (uint32_t l = 0; l < plan.nLevels; ++l) {
+        blockSumsBuffers.emplace_back(cms::alpakatools::make_device_buffer<T[]>(queue, plan.levelBlocks[l]));
+      }
+
+      auto const warpSize = alpaka::getPreferredWarpSize(alpaka::getDev(queue));
+
+      // Kernel A on level-0 input data
+      auto workDiv = cms::alpakatools::make_workdiv<TAcc>(plan.levelBlocks[0], iterativePrefixScanThreads);
+      alpaka::exec<TAcc>(queue,
+                         workDiv,
+                         scanTilesWriteBlockSums<T>{},
+                         input,
+                         output,
+                         plan.levelSize[0],
+                         blockSumsBuffers[0].data(),
+                         warpSize);
+
+      // Iterative use of kernel A on block-sum levels
+      for (uint32_t l = 1; l < plan.nLevels; ++l) {
+        auto workDiv = cms::alpakatools::make_workdiv<TAcc>(plan.levelBlocks[l], iterativePrefixScanThreads);
+        alpaka::exec<TAcc>(queue,
+                           workDiv,
+                           scanTilesWriteBlockSums<T>{},
+                           blockSumsBuffers[l - 1].data(),
+                           blockSumsBuffers[l - 1].data(),
+                           plan.levelSize[l],
+                           blockSumsBuffers[l].data(),
+                           warpSize);
+      }
+
+      // Kernel B from top-1 down to level 0
+      for (int32_t l = static_cast<int32_t>(plan.nLevels) - 2; l >= 0; --l) {
+        auto workDiv = cms::alpakatools::make_workdiv<TAcc>(plan.levelBlocks[l], iterativePrefixScanThreads);
+        T* levelData = (l == 0) ? output : blockSumsBuffers[l - 1].data();
+        alpaka::exec<TAcc>(
+            queue, workDiv, addScannedBlockOffsets<T>{}, levelData, plan.levelSize[l], blockSumsBuffers[l].data());
+      }
+    } else {
+      output[0] = input[0];
+      for (uint32_t i = 1; i < size; ++i) {
+        output[i] = input[i] + output[i - 1];
+      }
+    }
+  }
+
 }  // namespace cms::alpakatools
 
 // declare the amount of block shared memory used by the multiBlockPrefixScan kernel
@@ -263,6 +414,39 @@ namespace alpaka::trait {
       } else {
         return sizeof(T) * (warpSize + numBlocks);
       }
+    }
+  };
+
+  // Two-kernel approach requires only workspace for the first kernel, which is sized to the warp size.
+  // Kernel A
+  template <alpaka::concepts::Acc TAcc, typename T>
+  struct BlockSharedMemDynSizeBytes<cms::alpakatools::scanTilesWriteBlockSums<T>, TAcc> {
+    template <typename TVec>
+    ALPAKA_FN_HOST_ACC static std::size_t getBlockSharedMemDynSizeBytes(
+        cms::alpakatools::scanTilesWriteBlockSums<T> const& /* kernel */,
+        TVec const& /* blockThreadExtent */,
+        TVec const& /* threadElemExtent */,
+        T const* /* ci */,
+        T const* /* co */,
+        uint32_t /* size */,
+        T* /* blockSums */,
+        // This trait function does not receive the accelerator object to look up the warp size
+        std::size_t warpSize) {
+      if constexpr (cms::alpakatools::requires_single_thread_per_block_v<TAcc>) {
+        return 0;
+      } else {
+        return sizeof(T) * warpSize;
+      }
+    }
+  };
+
+  // Kernel B does not require shared memory.
+  template <alpaka::concepts::Acc TAcc, typename T>
+  struct BlockSharedMemDynSizeBytes<cms::alpakatools::addScannedBlockOffsets<T>, TAcc> {
+    template <typename TVec>
+    ALPAKA_FN_HOST_ACC static std::size_t getBlockSharedMemDynSizeBytes(
+        cms::alpakatools::addScannedBlockOffsets<T> const&, TVec const&, TVec const&, T const*, uint32_t, T const*) {
+      return 0;
     }
   };
 

--- a/HeterogeneousCore/AlpakaInterface/src/prefixScan.cc
+++ b/HeterogeneousCore/AlpakaInterface/src/prefixScan.cc
@@ -10,8 +10,18 @@ namespace cms::alpakatools {
                                       const size_t requiredSharedMem,
                                       const size_t sharedMemLimit) {
     throw cms::Exception("SharedMemoryLimitExceeded")
-        << "OneToManyAssoc: Shared memory limit exceeded for prefix scan of " << nElements << " elements in " << nBlocks
+        << "Shared memory limit exceeded for prefix scan of " << nElements << " elements in " << nBlocks
         << " blocks. Required shared memory: " << requiredSharedMem << " bytes. Shared memory limit: " << sharedMemLimit
         << " bytes.";
   }
+
+  void throwIterativePrefixScanMaxLevelsExceeded(const size_t nElements, const uint32_t nLevels) {
+    throw cms::Exception("IterativePrefixScanMaxLevelsExceeded")
+        << "Requested an iterative prefix scan for " << nElements << " elements.\n"
+        << "The problem was split into " << nLevels
+        << " levels, which exceeds the maximum supported number of levels of " << iterativePrefixScanMaxLevels
+        << " (enough for " << iterativePrefixScanThreads << "^" << iterativePrefixScanMaxLevels << " elements).\n"
+        << "Consider increasing the value of iterativePrefixScanMaxLevels or reducing the problem's size.";
+  }
+
 }  // namespace cms::alpakatools

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testPrefixScan.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testPrefixScan.dev.cc
@@ -223,6 +223,39 @@ int main() {
 
       alpaka::wait(queue);  // input_d and output1_d end of scope
     }  // ksize
+
+    // ITERATIVE PREFIXSCAN (TWO-KERNEL)
+    // with ksize=6 num_items = 2e8 above reasonable limits for physics and intermediate objects.
+    std::cout << "iterative two-kernel prefix scan" << std::endl;
+    num_items = 200;
+    for (int ksize = 1; ksize < 7; ++ksize) {
+      num_items *= 10;
+
+      auto input_d = make_device_buffer<uint32_t[]>(queue, num_items);
+      auto output_d = make_device_buffer<uint32_t[]>(queue, num_items);
+
+      const auto nThreads = 1024;
+      const auto nBlocks = divide_up_by(num_items, nThreads);
+      const auto workDiv = make_workdiv<Acc1D>(nBlocks, nThreads);
+
+      alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, init(), input_d.data(), 1, num_items));
+
+      // Build the level plan
+      auto plan = makePrefixScanLevelPlan(num_items);
+      std::cout << "Iterative prefix scan plan for " << num_items << " items with " << iterativePrefixScanThreads
+                << " threads per block. Problem divided into " << plan.nLevels << " levels:" << std::endl;
+      for (uint32_t l = 0; l < plan.nLevels; ++l) {
+        std::cout << "  Level " << l << ": size = " << plan.levelSize[l] << ", blocks = " << plan.levelBlocks[l]
+                  << std::endl;
+      }
+
+      iterativePrefixScan<Acc1D>(input_d.data(), output_d.data(), num_items, queue);
+      alpaka::wait(queue);
+
+      alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, verify(), output_d.data(), num_items));
+
+      alpaka::wait(queue);  // input_d and output_d end of scope
+    }
   }
 
   return 0;


### PR DESCRIPTION
#### PR description:

This PR introduces `cms::alpakatools::iterativePrefixScan` a two-kernel solution to perform a prefix scan on GPU. The new implementation is mostly meant to address and remove the shared memory limit of the current [`multiBlockPrefixScan`](https://github.com/cms-sw/cmssw/blob/e38ffb66b72775681a950c7019dd04133df699b9/HeterogeneousCore/AlpakaInterface/interface/prefixScan.h#L156) implementation, as documented in #50376. 

#### Main developments 
- Implemented two new kernels (and a few helper functions) 
- Full orchestration, memory allocation and kernel launches in `cms::alpakatools::iterativePrefixScan`

- CPU backends execute the regular serial prefix scan

- GPU backends go through a two-kernel approach:
- Kernel A (`scanTilesWriteBlockSums`): 
    - Each block runs a `blockPrefixScan` on its own data
    - Thread 0 of each block writes the resulting sum in an array stored in global memory (`blockSums[blockIdx]`)
    - No synchronization across blocks (Blelloch implementation)
- Kernel B (`addScannedBlockOffsets`):
    - Block 0 does nothing (prefix 0 by construction)
    - All other blocks add `blockSums[blockIdx - 1]` to all their respective elements

A helper function (`makePrefixScanLevelPlan`) computes how many recursion levels are needed to cover the full problem. The first level is made up of `nElements` / 1024 blocks (with 1024 threads per block). For each other level the number of elements is the number of blocks from the previous level and the corresponding number of blocks is computed as for level 0. The loop ends when a single block can cover the remaining elements.
Although the new implementation is not technically limited, it is set to process at most 1024^3 > 10^9 elements, with an exception guarding the limit. 

`cms::alpakatools::iterativePrefixScan` contains the full orchestration logic:
- Allocate the array(s) to store per-level block sums
- Run Kernel A
    - On the input data, writing block sums to `sums[0]`
    - Recursively on `sums[l-1]`, writing results to `sums[l]`
    - Total number of calls equals the number of levels (at most 3, in the current configuration)
- Run Kernel B bottom-up
    - Recursively add `sums[l]` into `sums[l-1]`
    - Finally add `sums[0]` to the input data
    - Total number of calls equals the number of required levels minus 1

A full plan and execution chain for the currently enforced limit (1024^3 elements) would look like the following:
```
Iterative prefix scan plan for 1073741824 items with 1024 threads per block. Problem divided into 3 levels:
  Level 0: size = 1073741824, blocks = 1048576
  Level 1: size = 1048576, blocks = 1024
  Level 2: size = 1024, blocks = 1
Running iterative prefix scan for 1073741824 elements with 3 levels
Launching kernel A for level 0 with 1048576 blocks and 1024 threads per block
Launching kernel A for level 1 with 1024 blocks and 1024 threads per block
Launching kernel A for level 2 with 1 blocks and 1024 threads per block
Launching kernel B for level 1 with 1024 blocks and 1024 threads per block
Launching kernel B for level 0 with 1048576 blocks and 1024 threads per block
```
As a side effect of the different scheduling and resources usage, the iterative approach shows significantly improved kernel timing, especially as the number of input elements increases, as it is shown in the following plot

<img width="1338" height="1141" alt="image" src="https://github.com/user-attachments/assets/cf1a6549-20b9-4d9e-a2d5-274cf76b6154" />

More benchmark details and full comparisons can be found in two presentations at the GPU meeting ([27/04](https://indico.cern.ch/event/1678554/#1-prefix-scan-studies) and [04/05](https://indico.cern.ch/event/1680788/#3-prefix-scan-studies)).

Another PR is planned to introduce a generic `cms::alpakatools::prefixScan` that would be able to launch the most suitable prefix scan implementation depending on the number of elements. That PR would also take care of finding and replacing call sites for the existing prefix scan implementation.

#### PR validation:

I have added a new test case in `HeterogeneousCore/AlpakaInterface/test/alpaka/testPrefixScan.dev.cc` to execute and verify the result of the new iterative prefix scan on a varying number of elements.