### PR TITLE
UBSAN: For NanoAOD, added DataFormats/RPCRecHit dependency to avoid link error

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -50,6 +50,7 @@
   <use name="SimDataFormats/Associations"/>
   <use name="SimDataFormats/TrackingAnalysis"/>
   <use name="SimTracker/Common"/>
+  <use name="DataFormats/RPCRecHit"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 <library file="rntuple/*.cc" name="PhysicsToolsNanoAODRNuplePlugins">


### PR DESCRIPTION
This PR proposes to explicitly add `DataFormats/RPCRecHit` dependency for `PhysicsTools/NanoAOD/plugins` to fix the linking error for UBSAN IBs
```
  bin/ld.bfd: tmp/el8_amd64_gcc13/src/PhysicsTools/NanoAOD/plugins/PhysicsToolsNanoAODPlugins/dtMDSshowerTableProducer.cc.o:(.data.rel+0xc58): undefined reference to `typeinfo for RPCRecHit'
```

`RPCRecHit`  is needed due to `RPCRecHitCollection` used by following in this plugin
```
./cscMDSshowerTableProducer.cc:#include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
./cscMDSshowerTableProducer.cc:        rpchitToken_(consumes<RPCRecHitCollection>(iConfig.getParameter<edm::InputTag>("rpcLabel"))),
./cscMDSshowerTableProducer.cc:  edm::EDGetTokenT<RPCRecHitCollection> rpchitToken_;
./dtMDSshowerTableProducer.cc:#include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
./dtMDSshowerTableProducer.cc:        rpchitToken_(consumes<RPCRecHitCollection>(iConfig.getParameter<edm::InputTag>("rpcLabel"))),
./dtMDSshowerTableProducer.cc:  edm::EDGetTokenT<RPCRecHitCollection> rpchitToken_;

```