### PR TITLE
Hotfix  for Alpaka MD PF clusterizer  (CPU backend)

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterECLCC.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterECLCC.h
@@ -254,14 +254,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
 
       const int topH = pfClusteringCCLabels.topH();
 
+      if (::cms::alpakatools::once_per_block(acc)) {
+        int i = alpaka::atomicAdd(acc, &pfClusteringCCLabels.posH() /*posH*/, -1, alpaka::hierarchy::Blocks{});
+        v = (i > topH) ? pfClusteringCCLabels[i].workl() : -1;
+      }
+
+      alpaka::syncBlockThreads(acc);
+
       for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
-        if (::cms::alpakatools::once_per_block(acc)) {
-          int i = alpaka::atomicAdd(acc, &pfClusteringCCLabels.posH() /*posH*/, -1, alpaka::hierarchy::Blocks{});
-          v = (i > topH) ? pfClusteringCCLabels[i].workl() : -1;
-        }
-
-        alpaka::syncBlockThreads(acc);
-
         while (v >= 0) {
           for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nClusters)) {
             const int begin_v = pfClusteringEdgeVars[v].mdpf_adjacencyIndex() + idx.local;
@@ -269,6 +269,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
 
             hook(acc, pfClusteringCCLabels, pfClusteringEdgeVars, v, begin_v, end_v, blockDim_x);
           }
+
           if (::cms::alpakatools::once_per_block(acc)) {
             int i = alpaka::atomicAdd(acc, &pfClusteringCCLabels.posH() /*posH*/, -1, alpaka::hierarchy::Blocks{});
             v = (i > topH) ? pfClusteringCCLabels[i].workl() : -1;

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizer.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizer.dev.cc
@@ -67,9 +67,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
     const unsigned int wExtend = alpaka::getPreferredWarpSize(alpaka::getDev(queue));
 
     // for ROCm/CUDA backend should be a multiple of the warp size which can be 32 or 64
+    // for CPU backend must be 1
     const unsigned int threadsPerBlock =
         std::is_same_v<Device, alpaka::DevCpu>
-            ? nClusters
+            ? 1
             : (nClusters > 768 ? 256 : ::cms::alpakatools::round_up_by(nClusters, wExtend));
 
     const unsigned int blocks = ::cms::alpakatools::divide_up_by(nClusters, threadsPerBlock);

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizer.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizer.dev.cc
@@ -66,8 +66,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
 
     const unsigned int wExtend = alpaka::getPreferredWarpSize(alpaka::getDev(queue));
 
-    // for ROCm/CUDA backend should be a multiple of the warp size which can be 32 or 64
-    // for CPU backend must be 1
+    // For ROCm/CUDA backends, this should be a multiple of warp extent,
+    // which can be either 32 or 64.
+    // For the CPU backend, threadsPerBlock effectively represents the number
+    // of elements per thread and must be set to 1, since some compute kernels
+    // rely on thread-private local variables.
     const unsigned int threadsPerBlock =
         std::is_same_v<Device, alpaka::DevCpu>
             ? 1
@@ -96,6 +99,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
     const bool do_opt_prologue = enable_multiblock_prologue && (blocks > 1);
 
     if (do_opt_prologue) {
+      // All multi-block prologue kernels must use the same launch parameters.
       reco::PFMultiDepthECLCCPrologueArgsDeviceCollection prologueArgs{queue, static_cast<int>(nClusters)};
 
       prologueArgs.zeroInitialise(queue);
@@ -230,6 +234,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
       reco::PFMultiDepthECLCCEpilogueArgsDeviceCollection epilogueArgs{queue, static_cast<int>(nClusters)};
 
       epilogueArgs.zeroInitialise(queue);
+
+      // All multi-block epilogue kernels must use the same launch parameters.
 
       alpaka::exec<Acc1D>(queue,
                           ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthConstructLinks.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthConstructLinks.h
@@ -266,7 +266,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       const unsigned int nClusters = mdpfClusteringVars.size();
 
-      const unsigned int blockDim = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
       const unsigned int gridDim = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)[0u];
 
       const double nSigmaEta = nSigma->nSigmaEta;
@@ -275,201 +274,200 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       if (::cms::alpakatools::once_per_grid(acc)) {
         mdpfClusteringCCLabels.size() = nClusters;
         mdpfClusteringCCLabels.ncomponents() = 0;
+
+        const unsigned int blockDim = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
+        ALPAKA_ASSERT_ACC(blockDim % w_extent == 0u);
       }
 
-      for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
-        constexpr unsigned int cluster_tile_size = w_extent;
-        const unsigned int cluster_tiles =
-            (std::is_same_v<Device, alpaka::DevCpu>) ? nClusters : (gridDim + (w_extent - 1)) / w_extent;
-        // Execution domain along destination (target) clusters
-        for (auto idx : ::cms::alpakatools::uniform_group_elements(
-                 acc, group, ::cms::alpakatools::round_up_by(nClusters, w_extent))) {
-          // Reset workl aux array:
-          if (idx.global < nClusters) {
-            mdpfClusteringCCLabels[idx.global].workl() = 0;
-          }
+      constexpr unsigned int cluster_tile_size = w_extent;
+      const unsigned int cluster_tiles =
+          (std::is_same_v<Device, alpaka::DevCpu>) ? nClusters : (gridDim + (w_extent - 1)) / w_extent;
+      // Execution domain along destination (target) clusters
+      for (auto idx : ::cms::alpakatools::uniform_elements(acc, ::cms::alpakatools::round_up_by(nClusters, w_extent))) {
+        // Reset workl aux array:
+        if (idx < nClusters) {
+          mdpfClusteringCCLabels[idx].workl() = 0;
+        }
 
-          // Active-lane mask for this warp iteration:
-          // every warp collective must use a mask that covers all participating lanes;
-          // we additionally OR-in the destination lane to keep it active for result updates.
-          const warp::warp_mask_t init_active_lanes_mask =
-              alpaka::warp::ballot(acc, full_warp_compute || (idx.global < nClusters));
+        // Active-lane mask for this warp iteration:
+        // every warp collective must use a mask that covers all participating lanes;
+        // we additionally OR-in the destination lane to keep it active for result updates.
+        const warp::warp_mask_t init_active_lanes_mask =
+            alpaka::warp::ballot(acc, full_warp_compute || (idx < nClusters));
 
-          // From this point all warp-level collectives must be accompanied with init_active_lanes_mask (or any derived from it) mask:
-          // for example, new_mask = warp::ballot_mask(acc, old_mask, predicate) will generate a new mask that selects a subset of lanes from old_mask
-          // Link parameters (by default store its own global index):
-          PFMDLinkParam selected_link_params(idx.global);
-          // Load destination (target) cluster parameters:
-          const auto dst_cl_params =
-              idx.global < nClusters ? PFMDClusterParam(mdpfClusteringVars[idx.global]) : PFMDClusterParam();
-          // Get warp and lane indices
-          const unsigned int warp_idx = idx.local / w_extent;
-          const unsigned int lane_idx = idx.local % w_extent;
-          // We iterate over source tiles (size = warp extent)
-          // In fact, we process nCluster x nCluster domain, where we distribute tiles over the first dimention (row indices)
-          // and warps over the second one (coloumn indices).
-          // The first dimension corresponds to the "source" clusters, while the second to the destination
-          // (or target) clusters. Note that the resulting link matrix is sparse with just a single entry per coloumn
-          // (that means that each destination cluster may be linked to just a single source cluster)
-          // but it may have up to nCluster-1 non-zero entries per row. Obviously, the matrix has zeros on the diagonal
-          // i.e., self-linking is excluded.
-          // For each destination lane (dst_lane_idx),
-          // lanes in the current warp represent candidate sources within the current tile:
-          //   src_idx = group*blockDim + tile*w_extent + lane_idx
-          // The algorithm selects at most one source per destination and stores it into mdpf_topoId().
+        // From this point all warp-level collectives must be accompanied with init_active_lanes_mask (or any derived from it) mask:
+        // for example, new_mask = warp::ballot_mask(acc, old_mask, predicate) will generate a new mask that selects a subset of lanes from old_mask
+        // Link parameters (by default store its own global index):
+        PFMDLinkParam selected_link_params(idx);
+        // Load destination (target) cluster parameters:
+        const auto dst_cl_params = idx < nClusters ? PFMDClusterParam(mdpfClusteringVars[idx]) : PFMDClusterParam();
+        // Get (grid-wide) warp and lane indices
+        const unsigned int warp_idx = idx / w_extent;
+        const unsigned int lane_idx = idx % w_extent;
+        // We iterate over source tiles (size = warp extent)
+        // In fact, we process nCluster x nCluster domain, where we distribute tiles over the first dimention (row indices)
+        // and warps over the second one (coloumn indices).
+        // The first dimension corresponds to the "source" clusters, while the second to the destination
+        // (or target) clusters. Note that the resulting link matrix is sparse with just a single entry per coloumn
+        // (that means that each destination cluster may be linked to just a single source cluster)
+        // but it may have up to nCluster-1 non-zero entries per row. Obviously, the matrix has zeros on the diagonal
+        // i.e., self-linking is excluded.
+        // For each destination lane (dst_lane_idx),
+        // lanes in the current warp represent candidate sources within the current tile:
+        //   src_idx = tile*w_extent + lane_idx
+        // The algorithm selects at most one source per destination and stores it into mdpf_topoId().
 
-          for (unsigned int tile = 0; tile < cluster_tiles; tile++) {
-            // We call a cluster tile as the 'owner' tile
-            // if the lane index of each thread coincide with the destination cluster index
-            // (in fact, we compare warp index with tile index):
-            const bool is_owner_tile = (warp_idx + group * blockDim) == tile;
-            // A destination cluster params, for 'non-owner' tile load cluster data again:
-            const unsigned int src_idx = tile * cluster_tile_size + lane_idx;
+        for (unsigned int tile = 0; tile < cluster_tiles; tile++) {
+          // We call a cluster tile as the 'owner' tile
+          // if the lane index of each thread coincide with the destination cluster index
+          // (in fact, we compare warp index with tile index):
+          const bool is_owner_tile = warp_idx == tile;
+          // A destination cluster params, for 'non-owner' tile load cluster data again:
+          const unsigned int src_idx = tile * cluster_tile_size + lane_idx;
 
-            const auto src_cl_params =
-                is_owner_tile
-                    ? PFMDClusterParam(dst_cl_params)
-                    : ((src_idx < nClusters) ? PFMDClusterParam(mdpfClusteringVars[src_idx]) : PFMDClusterParam());
+          const auto src_cl_params =
+              is_owner_tile
+                  ? PFMDClusterParam(dst_cl_params)
+                  : ((src_idx < nClusters) ? PFMDClusterParam(mdpfClusteringVars[src_idx]) : PFMDClusterParam());
 
-            // Loop over lanes in the warp.
-            // In fact, iteration lane index coincide with the target cluster index modulo warp extent (target cluster lane index)
-            for (unsigned int dst_lane_idx = 0; dst_lane_idx < w_extent; dst_lane_idx++) {
-              // 1. We need to keep the target cluster lane with dst_lane_idx reserved from divergence
-              const warp::warp_mask_t dst_lane_mask = get_lane_mask(dst_lane_idx);
+          // Loop over lanes in the warp.
+          // In fact, iteration lane index coincide with the target cluster index modulo warp extent (target cluster lane index)
+          for (unsigned int dst_lane_idx = 0; dst_lane_idx < w_extent; dst_lane_idx++) {
+            // 1. We need to keep the target cluster lane with dst_lane_idx reserved from divergence
+            const warp::warp_mask_t dst_lane_mask = get_lane_mask(dst_lane_idx);
 
-              const warp::warp_mask_t active_lanes_mask = init_active_lanes_mask | dst_lane_mask;
+            const warp::warp_mask_t active_lanes_mask = init_active_lanes_mask | dst_lane_mask;
 
-              const bool is_owner_lane = is_owner_tile && (dst_lane_idx == lane_idx);
-              // 2. Broadcast values from dst_lane_idx, this will give us warp-local source cluster depth:
-              const float dst_depth =
-                  warp::shfl_mask(acc, active_lanes_mask, dst_cl_params.depth(), dst_lane_idx, w_extent);
+            const bool is_owner_lane = is_owner_tile && (dst_lane_idx == lane_idx);
+            // 2. Broadcast values from dst_lane_idx, this will give us warp-local source cluster depth:
+            const float dst_depth =
+                warp::shfl_mask(acc, active_lanes_mask, dst_cl_params.depth(), dst_lane_idx, w_extent);
 
-              // 3. Do not link at the same layer and only link inside out:
-              //    Note that if lane_idx == iter_lane_id and is_proper_tile == true, then dz == 0 and the lane is filtered
-              //   (but will be not excluded from active lanes)
-              const auto dz = (static_cast<int>(dst_depth) - static_cast<int>(src_cl_params.depth()));
-              // 4. Select lanes that contain valid candidates, i.e., all lanes for which dz > 0,
-              //    excluding lane_idx = iter_lane_id and is_proper_tile = true
-              warp::warp_mask_t leftover_lanes_mask = warp::ballot_mask(acc, active_lanes_mask, dz > 0);
+            // 3. Do not link at the same layer and only link inside out:
+            //    Note that if lane_idx == iter_lane_id and is_proper_tile == true, then dz == 0 and the lane is filtered
+            //   (but will be not excluded from active lanes)
+            const auto dz = (static_cast<int>(dst_depth) - static_cast<int>(src_cl_params.depth()));
+            // 4. Select lanes that contain valid candidates, i.e., all lanes for which dz > 0,
+            //    excluding lane_idx = iter_lane_id and is_proper_tile = true
+            warp::warp_mask_t leftover_lanes_mask = warp::ballot_mask(acc, active_lanes_mask, dz > 0);
 
-              // 5. If the warp is 'empty' (no valid lanes), start the next iteration
-              //    if no threads detected then coninue, no warp synchronization at the point
-              // Note that lane with id equal to dst_lane_idx must be always active, since it's responsible for storing
-              // result.
-              // 6. Skip if there are no active lanes in the leftover lanes mask (all lanes are filtered and must skip);
-              if (leftover_lanes_mask == 0)
-                continue;
-              // From here on, only lanes in (leftover_lanes_mask | dst_lane_mask) are allowed to call masked collectives.
+            // 5. If the warp is 'empty' (no valid lanes), start the next iteration
+            //    if no threads detected then coninue, no warp synchronization at the point
+            // Note that lane with id equal to dst_lane_idx must be always active, since it's responsible for storing
+            // result.
+            // 6. Skip if there are no active lanes in the leftover lanes mask (all lanes are filtered and must skip);
+            if (leftover_lanes_mask == 0)
+              continue;
+            // From here on, only lanes in (leftover_lanes_mask | dst_lane_mask) are allowed to call masked collectives.
 
-              auto updated_active_lanes_mask =
-                  full_warp_compute ? init_active_lanes_mask : leftover_lanes_mask | dst_lane_mask;
+            auto updated_active_lanes_mask =
+                full_warp_compute ? init_active_lanes_mask : leftover_lanes_mask | dst_lane_mask;
 
-              if (is_work_lane(updated_active_lanes_mask, lane_idx) == false)
-                continue;
+            if (is_work_lane(updated_active_lanes_mask, lane_idx) == false)
+              continue;
 
-              const bool is_valid_lane = (is_owner_lane == false) && is_work_lane(leftover_lanes_mask, lane_idx);
+            const bool is_valid_lane = (is_owner_lane == false) && is_work_lane(leftover_lanes_mask, lane_idx);
 
-              const float dst_eta =
-                  warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.eta(), dst_lane_idx, w_extent);
-              const double dst_etaRMS2 =
-                  warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.etaRMS2(), dst_lane_idx, w_extent);
+            const float dst_eta =
+                warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.eta(), dst_lane_idx, w_extent);
+            const double dst_etaRMS2 =
+                warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.etaRMS2(), dst_lane_idx, w_extent);
 
-              const auto tmp1 = src_cl_params.eta() - dst_eta;
-              const auto deta = is_valid_lane ? tmp1 * tmp1 / (src_cl_params.etaRMS2() + dst_etaRMS2) : 0;
+            const auto tmp1 = src_cl_params.eta() - dst_eta;
+            const auto deta = is_valid_lane ? tmp1 * tmp1 / (src_cl_params.etaRMS2() + dst_etaRMS2) : 0;
 
-              const float dst_phi =
-                  warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.phi(), dst_lane_idx, w_extent);
+            const float dst_phi =
+                warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.phi(), dst_lane_idx, w_extent);
 
-              const double dst_phiRMS2 =
-                  warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.phiRMS2(), dst_lane_idx, w_extent);
+            const double dst_phiRMS2 =
+                warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.phiRMS2(), dst_lane_idx, w_extent);
 
-              const auto tmp2 = is_valid_lane ? ::cms::alpakatools::deltaPhi(acc, src_cl_params.phi(), dst_phi) : 0;
+            const auto tmp2 = is_valid_lane ? ::cms::alpakatools::deltaPhi(acc, src_cl_params.phi(), dst_phi) : 0;
 
-              const auto dphi = is_valid_lane ? tmp2 * tmp2 / (src_cl_params.phiRMS2() + dst_phiRMS2) : 0;
+            const auto dphi = is_valid_lane ? tmp2 * tmp2 / (src_cl_params.phiRMS2() + dst_phiRMS2) : 0;
 
-              const bool pred = is_valid_lane && (deta < nSigmaEta && dphi < nSigmaPhi);
+            const bool pred = is_valid_lane && (deta < nSigmaEta && dphi < nSigmaPhi);
 
-              warp::warp_mask_t next_leftover_lanes_mask = warp::ballot_mask(acc,
-                                                                             updated_active_lanes_mask,
-                                                                             pred);  //update valid candidate mask
+            warp::warp_mask_t next_leftover_lanes_mask = warp::ballot_mask(acc,
+                                                                           updated_active_lanes_mask,
+                                                                           pred);  //update valid candidate mask
 
-              if (next_leftover_lanes_mask == 0)
-                continue;
+            if (next_leftover_lanes_mask == 0)
+              continue;
 
-              leftover_lanes_mask = next_leftover_lanes_mask | dst_lane_mask;
+            leftover_lanes_mask = next_leftover_lanes_mask | dst_lane_mask;
 
-              updated_active_lanes_mask = full_warp_compute ? init_active_lanes_mask : leftover_lanes_mask;
+            updated_active_lanes_mask = full_warp_compute ? init_active_lanes_mask : leftover_lanes_mask;
 
-              if (is_work_lane(updated_active_lanes_mask, lane_idx) == false)
-                continue;
+            if (is_work_lane(updated_active_lanes_mask, lane_idx) == false)
+              continue;
 
-              const float dst_energy =
-                  warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.energy(), dst_lane_idx, w_extent);
+            const float dst_energy =
+                warp::shfl_mask(acc, updated_active_lanes_mask, dst_cl_params.energy(), dst_lane_idx, w_extent);
 
-              // 7. Now start inter-warp pruning:
-              // 7.1 Create warp-local link params (with the latest leftover lane mask);
-              const bool is_non_owner_lane = is_work_lane(next_leftover_lanes_mask, lane_idx);
+            // 7. Now start inter-warp pruning:
+            // 7.1 Create warp-local link params (with the latest leftover lane mask);
+            const bool is_non_owner_lane = is_work_lane(next_leftover_lanes_mask, lane_idx);
 
-              auto candidate_link_params =
-                  is_non_owner_lane
-                      ? PFMDLinkParam(
-                            src_idx, alpaka::math::abs(acc, dz), deta + dphi, dst_energy + src_cl_params.energy())
-                      : PFMDLinkParam(idx.global);
-              // 7.2 Check 3 parameters (dZ, dR, energy) to prune the candidate links:
-              if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
-                if (is_non_owner_lane)
-                  selected_link_params.try_update(candidate_link_params.index(),
-                                                  candidate_link_params.value(PFMDLinkParamKind::DZ),
-                                                  candidate_link_params.value(PFMDLinkParamKind::DR),
-                                                  candidate_link_params.value(PFMDLinkParamKind::ENERGY));
-                continue;
-              } else if constexpr (full_warp_compute) {
-                for (unsigned int iter_idx = 0; iter_idx < w_extent; iter_idx++) {
-                  const int flag = is_non_owner_lane ? 1 : 0;
-                  const int is_valid_candidate = alpaka::warp::shfl(acc, flag, iter_idx);
-                  if (is_valid_candidate) {
-                    const int candidate_idx = alpaka::warp::shfl(acc, candidate_link_params.index(), iter_idx);
-                    const float candidate_dz =
-                        alpaka::warp::shfl(acc, candidate_link_params.value(PFMDLinkParamKind::DZ), iter_idx);
-                    const float candidate_dr =
-                        alpaka::warp::shfl(acc, candidate_link_params.value(PFMDLinkParamKind::DR), iter_idx);
-                    const float candidate_energy =
-                        alpaka::warp::shfl(acc, candidate_link_params.value(PFMDLinkParamKind::ENERGY), iter_idx);
-                    if (lane_idx == dst_lane_idx)
-                      selected_link_params.try_update(candidate_idx, candidate_dz, candidate_dr, candidate_energy);
-                  }
-                }
-                continue;
-              } else {
-                constexpr PFMDLinkParamKind param_kinds[3] = {
-                    PFMDLinkParamKind::DZ, PFMDLinkParamKind::DR, PFMDLinkParamKind::ENERGY};
-
-                for (unsigned int k = 0; k < 3; k++) {
-                  next_leftover_lanes_mask = prune_link(acc,
-                                                        leftover_lanes_mask,
-                                                        selected_link_params,
-                                                        candidate_link_params,
-                                                        lane_idx,
-                                                        dst_lane_idx,
-                                                        param_kinds[k],
-                                                        is_owner_tile);
-                  if (next_leftover_lanes_mask == 0)
-                    break;
-
-                  if (is_work_lane(next_leftover_lanes_mask | dst_lane_mask, lane_idx) == false)
-                    break;  // exit loop for filtered lanes only
-                  // Reset filtered link mask:
-                  leftover_lanes_mask = next_leftover_lanes_mask;
+            auto candidate_link_params =
+                is_non_owner_lane
+                    ? PFMDLinkParam(
+                          src_idx, alpaka::math::abs(acc, dz), deta + dphi, dst_energy + src_cl_params.energy())
+                    : PFMDLinkParam(idx);
+            // 7.2 Check 3 parameters (dZ, dR, energy) to prune the candidate links:
+            if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
+              if (is_non_owner_lane)
+                selected_link_params.try_update(candidate_link_params.index(),
+                                                candidate_link_params.value(PFMDLinkParamKind::DZ),
+                                                candidate_link_params.value(PFMDLinkParamKind::DR),
+                                                candidate_link_params.value(PFMDLinkParamKind::ENERGY));
+              continue;
+            } else if constexpr (full_warp_compute) {
+              for (unsigned int iter_idx = 0; iter_idx < w_extent; iter_idx++) {
+                const int flag = is_non_owner_lane ? 1 : 0;
+                const int is_valid_candidate = alpaka::warp::shfl(acc, flag, iter_idx);
+                if (is_valid_candidate) {
+                  const int candidate_idx = alpaka::warp::shfl(acc, candidate_link_params.index(), iter_idx);
+                  const float candidate_dz =
+                      alpaka::warp::shfl(acc, candidate_link_params.value(PFMDLinkParamKind::DZ), iter_idx);
+                  const float candidate_dr =
+                      alpaka::warp::shfl(acc, candidate_link_params.value(PFMDLinkParamKind::DR), iter_idx);
+                  const float candidate_energy =
+                      alpaka::warp::shfl(acc, candidate_link_params.value(PFMDLinkParamKind::ENERGY), iter_idx);
+                  if (lane_idx == dst_lane_idx)
+                    selected_link_params.try_update(candidate_idx, candidate_dz, candidate_dr, candidate_energy);
                 }
               }
-            }  //end dst lane id
-          }  //end all (full!) tiles
-          // Store linked cluster id (or self index, if isolated)
-          if (idx.global < nClusters) {
-            mdpfClusteringCCLabels[idx.global].mdpf_topoId() = selected_link_params.index();
-          }
-        }  // end uniform_group_elements
-      }  //end uniform_groups
+              continue;
+            } else {
+              constexpr PFMDLinkParamKind param_kinds[3] = {
+                  PFMDLinkParamKind::DZ, PFMDLinkParamKind::DR, PFMDLinkParamKind::ENERGY};
+
+              for (unsigned int k = 0; k < 3; k++) {
+                next_leftover_lanes_mask = prune_link(acc,
+                                                      leftover_lanes_mask,
+                                                      selected_link_params,
+                                                      candidate_link_params,
+                                                      lane_idx,
+                                                      dst_lane_idx,
+                                                      param_kinds[k],
+                                                      is_owner_tile);
+                if (next_leftover_lanes_mask == 0)
+                  break;
+
+                if (is_work_lane(next_leftover_lanes_mask | dst_lane_mask, lane_idx) == false)
+                  break;  // exit loop for filtered lanes only
+                // Reset filtered link mask:
+                leftover_lanes_mask = next_leftover_lanes_mask;
+              }
+            }
+          }  //end dst lane id
+        }  //end all (full!) tiles
+        // Store linked cluster id (or self index, if isolated)
+        if (idx < nClusters) {
+          mdpfClusteringCCLabels[idx].mdpf_topoId() = selected_link_params.index();
+        }
+      }  // end uniform_group_elements
     }
   };
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogue.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogue.h
@@ -161,6 +161,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       //block-local number of components
       unsigned int& localNComponents = alpaka::declareSharedVar<uint32_t, __COUNTER__>(acc);
 
+      // Warning: This algorithm relies on thread-private variables (vertex_idx, rep_idx)
+      // For correctness on non-GPU architectures, the launch parameters
+      // must guarantee that these variables remain private to each thread.
+
       for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
         if (group > 0)
           continue;

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogueMultiBlock.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogueMultiBlock.h
@@ -46,39 +46,42 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       const unsigned int nVertices = pfClusteringCCLabels.size();
 
-      for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
-        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
-          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+      if (::cms::alpakatools::once_per_grid(acc)) {
+        const unsigned int blockDim = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
+        ALPAKA_ASSERT_ACC(blockDim % w_extent == 0u);
+      }
 
-          const unsigned int vertex_idx = idx.global;
-          const unsigned int rep_idx = pfClusteringCCLabels[vertex_idx].mdpf_topoId();
+      for (auto idx : ::cms::alpakatools::uniform_elements(acc, nVertices)) {
+        const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
 
-          // Load rhfrac sizes (to compute offsets for rechit fractions):
-          const unsigned int rhf_size = pfCluster[vertex_idx].rhfracSize();
+        const unsigned int vertex_idx = idx;
+        const unsigned int rep_idx = pfClusteringCCLabels[vertex_idx].mdpf_topoId();
 
-          const unsigned int lane_idx = idx.local % w_extent;
+        // Load rhfrac sizes (to compute offsets for rechit fractions):
+        const unsigned int rhf_size = pfCluster[vertex_idx].rhfracSize();
 
-          const warp::warp_mask_t subcomp_mask = warp::match_any_mask(acc, active_lanes_mask, rep_idx);
+        const unsigned int lane_idx = idx % w_extent;
 
-          const unsigned int subcomp_rep_idx = get_ls1b_idx(acc, subcomp_mask);
+        const warp::warp_mask_t subcomp_mask = warp::match_any_mask(acc, active_lanes_mask, rep_idx);
 
-          unsigned int subcomp_rhf_offset = warp_sparse_exclusive_sum(acc, subcomp_mask, rhf_size, lane_idx);
+        const unsigned int subcomp_rep_idx = get_ls1b_idx(acc, subcomp_mask);
 
-          unsigned int relative_rhf_offset_stub = 0;
+        unsigned int subcomp_rhf_offset = warp_sparse_exclusive_sum(acc, subcomp_mask, rhf_size, lane_idx);
 
-          if (lane_idx == subcomp_rep_idx) {
-            // Remark: exclusive sum returns total number of elements
-            // (i.e., subcomponent rhf size) for the lowest lane idx in the mask.
-            relative_rhf_offset_stub =
-                alpaka::atomicAdd(acc, &args[rep_idx].ccRHFSize(), subcomp_rhf_offset, alpaka::hierarchy::Blocks{});
-            subcomp_rhf_offset = 0;  // we need to reset local offset for local rep lane.
-          }
+        unsigned int relative_rhf_offset_stub = 0;
 
-          const unsigned int relative_rhf_offset =
-              warp::shfl_mask(acc, subcomp_mask, relative_rhf_offset_stub, subcomp_rep_idx, w_extent);
-          //connected comp rhf offsets for all vertices:
-          args[vertex_idx].ccRHFOffset() = relative_rhf_offset + subcomp_rhf_offset;  // store relative offsets
+        if (lane_idx == subcomp_rep_idx) {
+          // Remark: exclusive sum returns total number of elements
+          // (i.e., subcomponent rhf size) for the lowest lane idx in the mask.
+          relative_rhf_offset_stub =
+              alpaka::atomicAdd(acc, &args[rep_idx].ccRHFSize(), subcomp_rhf_offset, alpaka::hierarchy::Blocks{});
+          subcomp_rhf_offset = 0;  // we need to reset local offset for local rep lane.
         }
+
+        const unsigned int relative_rhf_offset =
+            warp::shfl_mask(acc, subcomp_mask, relative_rhf_offset_stub, subcomp_rep_idx, w_extent);
+        //connected comp rhf offsets for all vertices:
+        args[vertex_idx].ccRHFOffset() = relative_rhf_offset + subcomp_rhf_offset;  // store relative offsets
       }
     }
   };
@@ -131,6 +134,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       unsigned int& localNComponents = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
       unsigned int& isLastBlockDone = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
       unsigned int& topo_block_offset = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
+
+      // Warning: This algorithm relies on thread-private variables (vertex_idx, rep_idx)
+      // For correctness on non-GPU architectures, the launch parameters
+      // must guarantee that these variables remain private to each thread.
 
       for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
         if (::cms::alpakatools::once_per_block(acc)) {

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCFinalizeEpilogue.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCFinalizeEpilogue.h
@@ -78,6 +78,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       unsigned int& nComponents = alpaka::declareSharedVar<uint32_t, __COUNTER__>(acc);
       unsigned int& blockRHFShift = alpaka::declareSharedVar<uint32_t, __COUNTER__>(acc);
 
+      // Warning: This algorithm relies on thread-private variables (vertex_idx, rep_idx)
+      // For correctness on non-GPU architectures, the launch parameters
+      // must guarantee that these variables remain private to each thread.
+
       for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
         if (::cms::alpakatools::once_per_block(acc)) {
           nComponents = outPFCluster.nSeeds();

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologue.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologue.h
@@ -130,291 +130,266 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       const unsigned int nVertices = pfClusteringCCLabels.size();
 
-      if constexpr (std::is_same_v<Device, alpaka::DevCpu> ||
-                    std::is_same_v<alpaka::AccToTag<Acc1D>, alpaka::TagGpuHipRt>) {
-        if (::cms::alpakatools::once_per_grid(acc)) {
-          unsigned int store_idx = 0;
+      const unsigned int blockDim = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
 
-          for (unsigned int dst_idx = 0; dst_idx < nVertices; dst_idx++) {
-            pfClusteringEdgeVars[dst_idx].mdpf_adjacencyIndex() = store_idx;
+      const unsigned int w_items = alpaka::math::min(acc, (blockDim + (w_extent - 1)) / w_extent, max_w_items);
+      // warp_local_nlist and blck_local_nlist plays two roles:
+      // -- neighbor count per vertex during counting,
+      // -- CSR begin-offset per vertex after prefix sums.
+      auto& warp_local_nlist(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
+      auto& blck_local_nlist(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
 
-            const unsigned int base_neigh_idx = pfClusteringCCLabels[dst_idx].mdpf_topoId();
+      // Temporary CSR storage: adjacency_list[0..tot_nnz) built in shared and then copied to global.
+      // Note: adjacency_list capacity is 2*nVertices (worst-case assumption for this graph model).
+      auto& adjacency_list(alpaka::declareSharedVar<unsigned int[2 * max_w_items * w_extent], __COUNTER__>(acc));
 
-            if (dst_idx != base_neigh_idx)
-              pfClusteringEdgeVars[store_idx++].mdpf_adjacencyList() = base_neigh_idx;
+      // Per-warp total offsets used for coarse-grained scan across warps.
+      auto& subdomain_offsets(alpaka::declareSharedVar<unsigned int[w_extent], __COUNTER__>(acc));
 
-            for (unsigned int iter_idx = 0; iter_idx < nVertices; iter_idx++) {
-              if (iter_idx == dst_idx)
-                continue;
+      unsigned int dst_vertex_idx = nVertices;
+      unsigned int src_vertex_idx = nVertices;
 
-              const unsigned int neigh_idx = pfClusteringCCLabels[iter_idx].mdpf_topoId();
+      // Warning: This algorithm relies on thread-private variables (e.g., cached_local_warp_offset etc.)
+      // For correctness on non-GPU architectures, the launch parameters
+      // must guarantee that these variables remain private to each thread.
 
-              if (neigh_idx == dst_idx)
-                pfClusteringEdgeVars[store_idx++].mdpf_adjacencyList() = iter_idx;
-            }
+      for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
+        if (group > 0)
+          continue;
+        // This kernel is intended to run with a single block for the full graph.
+        // (If multi-block support is needed, the CSR construction could be made block-partition aware.)
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          dst_vertex_idx = idx.global;
+
+          src_vertex_idx = pfClusteringCCLabels[dst_vertex_idx].mdpf_topoId();
+
+          // Init offset array with zero if locally isolated (self-connected) otherwise 1:
+          warp_local_nlist[idx.local] = dst_vertex_idx == src_vertex_idx ? 0 : 1;
+          blck_local_nlist[idx.local] = 0;
+
+          if (idx.local < max_w_items) {
+            subdomain_offsets[idx.local] = 0;
           }
-          pfClusteringEdgeVars[nVertices].mdpf_adjacencyIndex() = store_idx;
         }
-        return;
-      } else {
-        const unsigned int blockDim = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
 
-        const unsigned int w_items = alpaka::math::min(acc, (blockDim + (w_extent - 1)) / w_extent, max_w_items);
-        // warp_local_nlist and blck_local_nlist plays two roles:
-        // -- neighbor count per vertex during counting,
-        // -- CSR begin-offset per vertex after prefix sums.
-        auto& warp_local_nlist(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
-        auto& blck_local_nlist(alpaka::declareSharedVar<unsigned int[max_w_items * w_extent], __COUNTER__>(acc));
+        alpaka::syncBlockThreads(acc);
+        // Next, identify:
+        //  - inner (intra-warp) neighbors: vertices within the same warp that share the same base_neighbor
+        //  - outer (inter-warp) neighbors: vertices in other warps that point to a base_neighbor in this warp
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+          // from this point all warp-level operations must be done with active_lanes_mask
+          // or derived mask
+          const unsigned int warp_idx = idx.local / w_extent;
+          const unsigned int lane_idx = idx.local % w_extent;
+          // Lane self-mask (bit corresponding to this lane).
+          const warp::warp_mask_t lane_mask = get_lane_mask(lane_idx);
+          // Identify warp-local domain range:
+          const unsigned int warp_low_boundary = (warp_idx + 0) * w_extent + group * blockDim;
+          const unsigned int warp_high_boundary = (warp_idx + 1) * w_extent + group * blockDim;
 
-        // Temporary CSR storage: adjacency_list[0..tot_nnz) built in shared and then copied to global.
-        // Note: adjacency_list capacity is 2*nVertices (worst-case assumption for this graph model).
-        auto& adjacency_list(alpaka::declareSharedVar<unsigned int[2 * max_w_items * w_extent], __COUNTER__>(acc));
+          // Check, whether this vertex is warp-local
+          // For example (assume a toy model with warp-size equal to 4) we have the following list of neighbors
+          // Neighbors = [2,2,7,0],[3,5,3,7],... that means that target vertex 0 connected to the source vertex 2 (denote as directed edge (0,2))
+          // and so on, that is, (1,2),(2,7),(3,0),(4,3),(5,5),(6,3) and (7,7). Note that vertex 5 is isolated (no neighbors), while vertex 7
+          // has neigbor vertex 2. Now we have 2 warps, namely [2,2,7,0] and [3,5,3,7], where the first one has 3 local edges, that is, (0,2),(1,2),(3,0)
+          // and one inter-warp edge (2,7). The second one contains inter-warp edges only : (4,3) and (6,3)
+          // In our toy model w_extent = 4, warp_idx = 0,1 and
+          // for warp_idx = 0 : warp_low_boundary = 0, warp_high_boundary = 4 (excluded)
+          // for warp_idx = 1 : warp_low_boundary = 4, warp_high_boundary = 8 (excluded)
+          const bool is_warp_local_src_idx =
+              (src_vertex_idx >= warp_low_boundary && src_vertex_idx < warp_high_boundary);
+          // Assign warp lane index to each source vertex, for example, in the toy model vertex 7 is assign to lane 3 (as it can be seen)
+          const unsigned int warp_local_src_vertex_lane_idx =
+              is_warp_local_src_idx ? src_vertex_idx % w_extent : w_extent;
+          // and make corresponding lane mask:
+          const warp::warp_mask_t warp_local_src_vertex_lane_mask = get_lane_mask(warp_local_src_vertex_lane_idx);
+          // We need to exclude all self-connections, like vertices 5 and 7 in the toy model
+          // WARNING: neigh_num counts only directed neighbors. For vertex 7 neigh_num = 0 while it does have a neighbor via directed
+          // edge (2,7)
+          const bool is_self_connected = (src_vertex_idx == dst_vertex_idx);
+          //unsigned int neigh_num = !is_self_connected ? 1 : 0;
+          // Create a local adjacency list (in fact, just masking proper vertices), for a given linked source vertex
+          // For the toy model one gets (warp 0): control_mask = 0x0011 for lane 0, control_mask =0x0011 for lane 1,
+          // control_mask =0x0010 for lane 2 and control_mask =0x0001 for lane 3
+          // For warp 1: one gets control_mask = 0x0101 for lane 4 and same for lane 6 etc.
+          // Here we group lanes by identical src_vertex_idx using match_any. The resulting control_mask selects all lanes
+          // that point to the same src_vertex_idx (within the active lanes).
+          warp::warp_mask_t control_mask = warp::match_any_mask(acc, active_lanes_mask, src_vertex_idx);
+          // Find out representative by lowest index (note that mask will select at least one lane, the very lane that
+          // contains vertex):
+          // For instance , for warp 0 lanes 0 and 1 are have same control mask, 0x0011, so we choose lane 0 is a local "represntative" (lane with the lowest id)
+          // Note that if a vertex is locally or globally isolated (i.e, connected to itself), then it will always represent itself (even though it may
+          // have higher index), i.e., if is_self_connected == true then rep_lane_idx = lane_id :
+          // we choose a single representative lane for this group.
+          // If the source vertex is warp-local, prefer the lane that actually owns src_vertex_idx;
+          // otherwise pick the lowest lane in control_mask.
+          const unsigned int rep_lane_idx = get_ls1b_idx(
+              acc,
+              ((control_mask & warp_local_src_vertex_lane_mask) != 0) ? warp_local_src_vertex_lane_mask : control_mask);
+          // Exclude self-links (v -> v): they are sentinels for isolated vertices and must not appear as edges.
+          if (is_self_connected)
+            control_mask &= ~lane_mask;  // clear representative's own bit
+          // Only the representative writes the group mask.
+          // For warp-local sources we store the group under the 'source vertex index' so that the source vertex
+          // can later account for inbound edges from same-warp destinations.
+          // For non-local sources we keep the group under the destination index as 'outbound inter-warp' bookkeeping.
 
-        // Per-warp total offsets used for coarse-grained scan across warps.
-        auto& subdomain_offsets(alpaka::declareSharedVar<unsigned int[w_extent], __COUNTER__>(acc));
-
-        unsigned int dst_vertex_idx = nVertices;
-        unsigned int src_vertex_idx = nVertices;
-
-        for (auto group : ::cms::alpakatools::uniform_groups(acc)) {
-          if (group > 0)
-            continue;
-          // This kernel is intended to run with a single block for the full graph.
-          // (If multi-block support is needed, the CSR construction could be made block-partition aware.)
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
-            dst_vertex_idx = idx.global;
-
-            src_vertex_idx = pfClusteringCCLabels[dst_vertex_idx].mdpf_topoId();
-
-            // Init offset array with zero if locally isolated (self-connected) otherwise 1:
-            warp_local_nlist[idx.local] = dst_vertex_idx == src_vertex_idx ? 0 : 1;
-            blck_local_nlist[idx.local] = 0;
-
-            if (idx.local < max_w_items) {
-              subdomain_offsets[idx.local] = 0;
+          if (lane_idx == rep_lane_idx) {
+            const unsigned int neigh_num = alpaka::popcount(acc, control_mask);
+            if (is_warp_local_src_idx) {  //i.e, src_vertex_idx is warp-local.
+              warp_local_nlist[src_vertex_idx] += neigh_num;
+            } else {
+              alpaka::atomicAdd(acc, &blck_local_nlist[src_vertex_idx], neigh_num, alpaka::hierarchy::Threads{});
             }
           }
+        }
 
-          alpaka::syncBlockThreads(acc);
-          // Next, identify:
-          //  - inner (intra-warp) neighbors: vertices within the same warp that share the same base_neighbor
-          //  - outer (inter-warp) neighbors: vertices in other warps that point to a base_neighbor in this warp
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
-            const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
-            // from this point all warp-level operations must be done with active_lanes_mask
-            // or derived mask
-            const unsigned int warp_idx = idx.local / w_extent;
-            const unsigned int lane_idx = idx.local % w_extent;
-            // Lane self-mask (bit corresponding to this lane).
-            const warp::warp_mask_t lane_mask = get_lane_mask(lane_idx);
-            // Identify warp-local domain range:
-            const unsigned int warp_low_boundary = (warp_idx + 0) * w_extent + group * blockDim;
-            const unsigned int warp_high_boundary = (warp_idx + 1) * w_extent + group * blockDim;
+        alpaka::syncBlockThreads(acc);
 
-            // Check, whether this vertex is warp-local
-            // For example (assume a toy model with warp-size equal to 4) we have the following list of neighbors
-            // Neighbors = [2,2,7,0],[3,5,3,7],... that means that target vertex 0 connected to the source vertex 2 (denote as directed edge (0,2))
-            // and so on, that is, (1,2),(2,7),(3,0),(4,3),(5,5),(6,3) and (7,7). Note that vertex 5 is isolated (no neighbors), while vertex 7
-            // has neigbor vertex 2. Now we have 2 warps, namely [2,2,7,0] and [3,5,3,7], where the first one has 3 local edges, that is, (0,2),(1,2),(3,0)
-            // and one inter-warp edge (2,7). The second one contains inter-warp edges only : (4,3) and (6,3)
-            // In our toy model w_extent = 4, warp_idx = 0,1 and
-            // for warp_idx = 0 : warp_low_boundary = 0, warp_high_boundary = 4 (excluded)
-            // for warp_idx = 1 : warp_low_boundary = 4, warp_high_boundary = 8 (excluded)
-            const bool is_warp_local_src_idx =
-                (src_vertex_idx >= warp_low_boundary && src_vertex_idx < warp_high_boundary);
-            // Assign warp lane index to each source vertex, for example, in the toy model vertex 7 is assign to lane 3 (as it can be seen)
-            const unsigned int warp_local_src_vertex_lane_idx =
-                is_warp_local_src_idx ? src_vertex_idx % w_extent : w_extent;
-            // and make corresponding lane mask:
-            const warp::warp_mask_t warp_local_src_vertex_lane_mask = get_lane_mask(warp_local_src_vertex_lane_idx);
-            // We need to exclude all self-connections, like vertices 5 and 7 in the toy model
-            // WARNING: neigh_num counts only directed neighbors. For vertex 7 neigh_num = 0 while it does have a neighbor via directed
-            // edge (2,7)
-            const bool is_self_connected = (src_vertex_idx == dst_vertex_idx);
-            //unsigned int neigh_num = !is_self_connected ? 1 : 0;
-            // Create a local adjacency list (in fact, just masking proper vertices), for a given linked source vertex
-            // For the toy model one gets (warp 0): control_mask = 0x0011 for lane 0, control_mask =0x0011 for lane 1,
-            // control_mask =0x0010 for lane 2 and control_mask =0x0001 for lane 3
-            // For warp 1: one gets control_mask = 0x0101 for lane 4 and same for lane 6 etc.
-            // Here we group lanes by identical src_vertex_idx using match_any. The resulting control_mask selects all lanes
-            // that point to the same src_vertex_idx (within the active lanes).
-            warp::warp_mask_t control_mask = warp::match_any_mask(acc, active_lanes_mask, src_vertex_idx);
-            // Find out representative by lowest index (note that mask will select at least one lane, the very lane that
-            // contains vertex):
-            // For instance , for warp 0 lanes 0 and 1 are have same control mask, 0x0011, so we choose lane 0 is a local "represntative" (lane with the lowest id)
-            // Note that if a vertex is locally or globally isolated (i.e, connected to itself), then it will always represent itself (even though it may
-            // have higher index), i.e., if is_self_connected == true then rep_lane_idx = lane_id :
-            // we choose a single representative lane for this group.
-            // If the source vertex is warp-local, prefer the lane that actually owns src_vertex_idx;
-            // otherwise pick the lowest lane in control_mask.
-            const unsigned int rep_lane_idx =
-                get_ls1b_idx(acc,
-                             ((control_mask & warp_local_src_vertex_lane_mask) != 0) ? warp_local_src_vertex_lane_mask
-                                                                                     : control_mask);
-            // Exclude self-links (v -> v): they are sentinels for isolated vertices and must not appear as edges.
-            if (is_self_connected)
-              control_mask &= ~lane_mask;  // clear representative's own bit
-            // Only the representative writes the group mask.
-            // For warp-local sources we store the group under the 'source vertex index' so that the source vertex
-            // can later account for inbound edges from same-warp destinations.
-            // For non-local sources we keep the group under the destination index as 'outbound inter-warp' bookkeeping.
+        unsigned int cached_local_warp_offset = 0;
+        // For the second stage, we compute local offsets for each lane (vertex) in the warp:
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
 
-            if (lane_idx == rep_lane_idx) {
-              const unsigned int neigh_num = alpaka::popcount(acc, control_mask);
-              if (is_warp_local_src_idx) {  //i.e, src_vertex_idx is warp-local.
-                warp_local_nlist[src_vertex_idx] += neigh_num;
-              } else {
-                alpaka::atomicAdd(acc, &blck_local_nlist[src_vertex_idx], neigh_num, alpaka::hierarchy::Threads{});
-              }
+          const auto warp_idx = idx.local / w_extent;
+          const auto lane_idx = idx.local % w_extent;
+
+          const unsigned int nnz =
+              warp_local_nlist[idx.local] + blck_local_nlist[idx.local];  //note that nnz = 0 for idx.local >= nVertices
+
+          //WARNING: unlike a standard exclusive scan, where lane 0 gets 0 (that carries no useful information),
+          //         our lane 0 stores total nnz:
+          // - lanes 1..(w_extent-1) receive the exclusive prefix sum (CSR offsets within the warp),
+          // - lane 0 receives the total sum over the warp (used as the per-warp NNZ aggregate).
+          // Store total local offsets into the private register (but lane 0 gets total nnz):
+          cached_local_warp_offset = warp_sparse_exclusive_sum(acc, active_lanes_mask, nnz, lane_idx);
+          // Store total warp-local nnz into shared mem buffer for the lane id = 0:
+          // local_warp_offset is the per-lane CSR offset within the warp (custom exclusive prefix sum of nnz).
+          if (lane_idx == 0) {
+            subdomain_offsets[warp_idx] = cached_local_warp_offset;
+            // reset local offsets:
+            cached_local_warp_offset = 0;
+          }
+        }
+
+        alpaka::syncBlockThreads(acc);
+
+        // Constract coarse-grained offset (offsets for each warp):
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, w_extent)) {
+          const auto lane_idx = idx.local;
+
+          const auto local_warp_nnz = lane_idx < w_items ? subdomain_offsets[lane_idx] : 0;
+
+          const auto block_local_warp_offset = warp_exclusive_sum(acc, local_warp_nnz, lane_idx);
+
+          if (lane_idx < w_items)
+            subdomain_offsets[lane_idx] = block_local_warp_offset;  //NOTE: lane 0 get total (block) nnz
+        }
+
+        alpaka::syncBlockThreads(acc);
+
+        const unsigned int block_nnz = subdomain_offsets[0];
+
+        // Now we assemble global offsets for each vertex:
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+
+          const unsigned int warp_idx = idx.local / w_extent;
+          const unsigned int lane_idx = idx.local % w_extent;
+
+          const unsigned lane_offset = cached_local_warp_offset;  // 0 for lane_idx = 0
+          // Broadcast warp offset from lane 0 (for warp 0 it's just 0):
+          const unsigned shift = warp_idx != 0 ? subdomain_offsets[warp_idx] : 0;
+
+          unsigned int block_offset = lane_offset + shift;
+
+          // Store final offsets in shared memory:
+          warp_local_nlist[idx.local] += block_offset;
+
+          // Identify warp-local domain range:
+          const unsigned int warp_low_boundary = (warp_idx + 0) * w_extent + group * blockDim;
+          const unsigned int warp_high_boundary = (warp_idx + 1) * w_extent + group * blockDim;
+
+          pfClusteringEdgeVars[dst_vertex_idx].mdpf_adjacencyIndex() = block_offset;
+
+          if (src_vertex_idx != dst_vertex_idx)  // exclude self connection
+            adjacency_list[block_offset++] = src_vertex_idx;
+
+          const bool is_warp_local_src_vertex_idx =
+              (src_vertex_idx >= warp_low_boundary && src_vertex_idx < warp_high_boundary);
+
+          const unsigned int warp_local_src_vertex_lane_idx =
+              is_warp_local_src_vertex_idx ? src_vertex_idx % w_extent : lane_idx;
+
+          // NOTE: the source lane does not know about warp_local_neigh_mask!
+          const unsigned int src_block_adjacency_pos =
+              warp::shfl_mask(acc, active_lanes_mask, block_offset, warp_local_src_vertex_lane_idx, w_extent);
+          // (exclude self-connection):
+          const warp::warp_mask_t coop_mask = warp::ballot_mask(
+              acc, active_lanes_mask, is_warp_local_src_vertex_idx && src_vertex_idx != dst_vertex_idx);
+
+          if (is_work_lane(coop_mask, lane_idx)) {
+            const warp::warp_mask_t warp_local_neigh_mask = warp::match_any_mask(acc, coop_mask, src_vertex_idx);
+
+            if (is_work_lane(warp_local_neigh_mask, lane_idx)) {
+              const unsigned int logical_lane_idx = get_logical_lane_idx(acc, warp_local_neigh_mask, lane_idx);
+
+              adjacency_list[src_block_adjacency_pos + logical_lane_idx] = dst_vertex_idx;
             }
           }
+        }
+        alpaka::syncBlockThreads(acc);
 
-          alpaka::syncBlockThreads(acc);
+        // Store tot_nnz in the global buffer (for single-block exec):
+        if (::cms::alpakatools::once_per_block(acc)) {
+          pfClusteringEdgeVars[nVertices].mdpf_adjacencyIndex() = block_nnz;
+        }
 
-          unsigned int cached_local_warp_offset = 0;
-          // For the second stage, we compute local offsets for each lane (vertex) in the warp:
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
-            const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
 
-            const auto warp_idx = idx.local / w_extent;
-            const auto lane_idx = idx.local % w_extent;
+          const unsigned int warp_idx = idx.local / w_extent;
+          const unsigned int lane_idx = idx.local % w_extent;
 
-            const unsigned int nnz = warp_local_nlist[idx.local] +
-                                     blck_local_nlist[idx.local];  //note that nnz = 0 for idx.local >= nVertices
+          const unsigned int warp_low_boundary = (warp_idx + 0) * w_extent + group * blockDim;
+          const unsigned int warp_high_boundary = (warp_idx + 1) * w_extent + group * blockDim;
 
-            //WARNING: unlike a standard exclusive scan, where lane 0 gets 0 (that carries no useful information),
-            //         our lane 0 stores total nnz:
-            // - lanes 1..(w_extent-1) receive the exclusive prefix sum (CSR offsets within the warp),
-            // - lane 0 receives the total sum over the warp (used as the per-warp NNZ aggregate).
-            // Store total local offsets into the private register (but lane 0 gets total nnz):
-            cached_local_warp_offset = warp_sparse_exclusive_sum(acc, active_lanes_mask, nnz, lane_idx);
-            // Store total warp-local nnz into shared mem buffer for the lane id = 0:
-            // local_warp_offset is the per-lane CSR offset within the warp (custom exclusive prefix sum of nnz).
-            if (lane_idx == 0) {
-              subdomain_offsets[warp_idx] = cached_local_warp_offset;
-              // reset local offsets:
-              cached_local_warp_offset = 0;
-            }
+          const bool is_nonlocal_src_vertex_idx =
+              (src_vertex_idx < warp_low_boundary || src_vertex_idx >= warp_high_boundary);
+
+          // Detect all lanes that have external (inter-warp) neighbors
+          const warp::warp_mask_t outer_totneighs_mask =
+              warp::ballot_mask(acc, active_lanes_mask, is_nonlocal_src_vertex_idx);
+          // Compute neighebor mask (internal or external):
+          const warp::warp_mask_t totneighs_mask = warp::match_any_mask(acc, active_lanes_mask, src_vertex_idx);
+          // Filter out internal neighbors (and clear non-representative lane bits):
+          if (is_work_lane(outer_totneighs_mask, lane_idx)) {
+            const warp::warp_mask_t outer_neigh_mask = totneighs_mask & outer_totneighs_mask;
+
+            const unsigned int rep_lane_idx = get_ls1b_idx(acc, outer_neigh_mask);
+
+            const unsigned int nnz = static_cast<unsigned int>(alpaka::popcount(acc, outer_neigh_mask));
+
+            const unsigned int block_adjacency_pos =
+                rep_lane_idx == lane_idx
+                    ? alpaka::atomicAdd(acc, &warp_local_nlist[src_vertex_idx], nnz, alpaka::hierarchy::Threads{})
+                    : 2 * nVertices;
+
+            const unsigned int src_adjacency_pos =
+                warp::shfl_mask(acc, outer_totneighs_mask, block_adjacency_pos, rep_lane_idx, w_extent);
+
+            const unsigned int logical_lane_idx = get_logical_lane_idx(acc, outer_neigh_mask, lane_idx);
+
+            adjacency_list[src_adjacency_pos + logical_lane_idx] = dst_vertex_idx;
           }
+        }
 
-          alpaka::syncBlockThreads(acc);
+        alpaka::syncBlockThreads(acc);
 
-          // Constract coarse-grained offset (offsets for each warp):
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, w_extent)) {
-            const auto lane_idx = idx.local;
-
-            const auto local_warp_nnz = lane_idx < w_items ? subdomain_offsets[lane_idx] : 0;
-
-            const auto block_local_warp_offset = warp_exclusive_sum(acc, local_warp_nnz, lane_idx);
-
-            if (lane_idx < w_items)
-              subdomain_offsets[lane_idx] = block_local_warp_offset;  //NOTE: lane 0 get total (block) nnz
-          }
-
-          alpaka::syncBlockThreads(acc);
-
-          const unsigned int block_nnz = subdomain_offsets[0];
-
-          // Now we assemble global offsets for each vertex:
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
-            const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
-
-            const unsigned int warp_idx = idx.local / w_extent;
-            const unsigned int lane_idx = idx.local % w_extent;
-
-            const unsigned lane_offset = cached_local_warp_offset;  // 0 for lane_idx = 0
-            // Broadcast warp offset from lane 0 (for warp 0 it's just 0):
-            const unsigned shift = warp_idx != 0 ? subdomain_offsets[warp_idx] : 0;
-
-            unsigned int block_offset = lane_offset + shift;
-
-            // Store final offsets in shared memory:
-            warp_local_nlist[idx.local] += block_offset;
-
-            // Identify warp-local domain range:
-            const unsigned int warp_low_boundary = (warp_idx + 0) * w_extent + group * blockDim;
-            const unsigned int warp_high_boundary = (warp_idx + 1) * w_extent + group * blockDim;
-
-            pfClusteringEdgeVars[dst_vertex_idx].mdpf_adjacencyIndex() = block_offset;
-
-            if (src_vertex_idx != dst_vertex_idx)  // exclude self connection
-              adjacency_list[block_offset++] = src_vertex_idx;
-
-            const bool is_warp_local_src_vertex_idx =
-                (src_vertex_idx >= warp_low_boundary && src_vertex_idx < warp_high_boundary);
-
-            const unsigned int warp_local_src_vertex_lane_idx =
-                is_warp_local_src_vertex_idx ? src_vertex_idx % w_extent : lane_idx;
-
-            // NOTE: the source lane does not know about warp_local_neigh_mask!
-            const unsigned int src_block_adjacency_pos =
-                warp::shfl_mask(acc, active_lanes_mask, block_offset, warp_local_src_vertex_lane_idx, w_extent);
-            // (exclude self-connection):
-            const warp::warp_mask_t coop_mask = warp::ballot_mask(
-                acc, active_lanes_mask, is_warp_local_src_vertex_idx && src_vertex_idx != dst_vertex_idx);
-
-            if (is_work_lane(coop_mask, lane_idx)) {
-              const warp::warp_mask_t warp_local_neigh_mask = warp::match_any_mask(acc, coop_mask, src_vertex_idx);
-
-              if (is_work_lane(warp_local_neigh_mask, lane_idx)) {
-                const unsigned int logical_lane_idx = get_logical_lane_idx(acc, warp_local_neigh_mask, lane_idx);
-
-                adjacency_list[src_block_adjacency_pos + logical_lane_idx] = dst_vertex_idx;
-              }
-            }
-          }
-          alpaka::syncBlockThreads(acc);
-
-          // Store tot_nnz in the global buffer (for single-block exec):
-          if (::cms::alpakatools::once_per_block(acc)) {
-            pfClusteringEdgeVars[nVertices].mdpf_adjacencyIndex() = block_nnz;
-          }
-
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
-            const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
-
-            const unsigned int warp_idx = idx.local / w_extent;
-            const unsigned int lane_idx = idx.local % w_extent;
-
-            const unsigned int warp_low_boundary = (warp_idx + 0) * w_extent + group * blockDim;
-            const unsigned int warp_high_boundary = (warp_idx + 1) * w_extent + group * blockDim;
-
-            const bool is_nonlocal_src_vertex_idx =
-                (src_vertex_idx < warp_low_boundary || src_vertex_idx >= warp_high_boundary);
-
-            // Detect all lanes that have external (inter-warp) neighbors
-            const warp::warp_mask_t outer_totneighs_mask =
-                warp::ballot_mask(acc, active_lanes_mask, is_nonlocal_src_vertex_idx);
-            // Compute neighebor mask (internal or external):
-            const warp::warp_mask_t totneighs_mask = warp::match_any_mask(acc, active_lanes_mask, src_vertex_idx);
-            // Filter out internal neighbors (and clear non-representative lane bits):
-            if (is_work_lane(outer_totneighs_mask, lane_idx)) {
-              const warp::warp_mask_t outer_neigh_mask = totneighs_mask & outer_totneighs_mask;
-
-              const unsigned int rep_lane_idx = get_ls1b_idx(acc, outer_neigh_mask);
-
-              const unsigned int nnz = static_cast<unsigned int>(alpaka::popcount(acc, outer_neigh_mask));
-
-              const unsigned int block_adjacency_pos =
-                  rep_lane_idx == lane_idx
-                      ? alpaka::atomicAdd(acc, &warp_local_nlist[src_vertex_idx], nnz, alpaka::hierarchy::Threads{})
-                      : 2 * nVertices;
-
-              const unsigned int src_adjacency_pos =
-                  warp::shfl_mask(acc, outer_totneighs_mask, block_adjacency_pos, rep_lane_idx, w_extent);
-
-              const unsigned int logical_lane_idx = get_logical_lane_idx(acc, outer_neigh_mask, lane_idx);
-
-              adjacency_list[src_adjacency_pos + logical_lane_idx] = dst_vertex_idx;
-            }
-          }
-
-          alpaka::syncBlockThreads(acc);
-
-          for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
-            for (unsigned int j = idx.local; j < block_nnz; j += nVertices) {
-              pfClusteringEdgeVars[j].mdpf_adjacencyList() = adjacency_list[j];
-            }
+        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
+          for (unsigned int j = idx.local; j < block_nnz; j += nVertices) {
+            pfClusteringEdgeVars[j].mdpf_adjacencyList() = adjacency_list[j];
           }
         }
       }

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologueMultiBlock.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCPrologueMultiBlock.h
@@ -61,6 +61,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         args.blockCount() = 0;
       }
 
+      // WARNING: for correctness blockDim must be the same for all prologue compute kernels.
       for (auto group : ::cms::alpakatools::uniform_groups(acc)) {  //loop over thread blocks
         for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nVertices)) {
           const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
@@ -156,6 +157,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       unsigned int dst_vertex_idx = nVertices;
       unsigned int src_vertex_idx = nVertices;
+
+      // Warning: This algorithm relies on thread-private variables (e.g., cached_warp_local_offset etc.)
+      // For correctness on non-GPU architectures, the launch parameters
+      // must guarantee that these variables remain private to each thread.
 
       for (auto group : ::cms::alpakatools::uniform_groups(acc)) {  //loop over thread blocks
         // This kernel is intended to run with a single block for the full graph.

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthShowerShape.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthShowerShape.h
@@ -141,7 +141,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       const unsigned int w_extent = alpaka::warp::getSize(acc);
 
       for (auto group : ::cms::alpakatools::uniform_groups(acc)) {  //loop over thread blocks
-
+                                                                    // Note that these variables are thread-private.
+        // On GPU backends, each thread processes one cluster element.
+        // On the CPU backend, each thread element  processes one cluster element.
         reduce_t accum_etaSum_div_en{0.};
         reduce_t accum_phiSum_div_en{0.};
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthShowerShape.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthShowerShape.h
@@ -132,18 +132,20 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   const reco::PFClusterDeviceCollection::ConstView pfClusters,
                                   const reco::PFRecHitFractionDeviceCollection::ConstView pfRecHitFracs,
                                   const reco::PFRecHitDeviceCollection::ConstView pfRecHit,
-                                  const float rms2_threshold = 0.1) const {
+                                  const float rms2_threshold = 0.1f) const {
+      constexpr unsigned int w_extent = get_warp_size<Acc1D>();
+
       const unsigned int nClusters = pfClusters.nSeeds();
 
       if (::cms::alpakatools::once_per_grid(acc)) {
         mdpfClusteringVars.size() = nClusters;
+        if constexpr (is_cooperative) {
+          const unsigned int blockDim = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
+          ALPAKA_ASSERT_ACC(blockDim % w_extent == 0u);
+        }
       }
 
-      const unsigned int w_extent = alpaka::warp::getSize(acc);
-
       for (auto idx : ::cms::alpakatools::uniform_elements(acc, nClusters)) {
-        const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
-
         accum_t accum_etaSum_div_en{0.};
         accum_t accum_phiSum_div_en{0.};
         {
@@ -215,8 +217,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
               bool update_params = true;
 
               bool cache_vals = false;
-              // Ensure masks and per-lane state updates from previous iteration are visible before scheduling.
-              warp::syncWarpThreads_mask(acc, active_lanes_mask);
 
               while (update_params) {
                 const warp::warp_mask_t iter_lane_mask = get_lane_mask(iter_lane_idx);
@@ -393,8 +393,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             accum_phiSum_div_en = static_cast<accum_t>(iter_accum_phiSum / pfc_energy);
           }
         }
-        warp::syncWarpThreads_mask(acc, active_lanes_mask);
-
         const double etaRMS2_ = alpaka::math::max(acc, accum_etaSum_div_en, rms2_threshold);
         const double phiRMS2_ = alpaka::math::max(acc, accum_phiSum_div_en, rms2_threshold);
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthShowerShape.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthShowerShape.h
@@ -123,7 +123,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   template <bool is_cooperative = false>
   class ShowerShapeKernel {
   public:
-    using reduce_t = double;
+    using accum_t = double;
+    using reduce_t = float;
     using compute_t = double;
 
     ALPAKA_FN_ACC void operator()(Acc1D const& acc,
@@ -131,7 +132,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   const reco::PFClusterDeviceCollection::ConstView pfClusters,
                                   const reco::PFRecHitFractionDeviceCollection::ConstView pfRecHitFracs,
                                   const reco::PFRecHitDeviceCollection::ConstView pfRecHit,
-                                  const float rms2_threshold = 0.1f) const {
+                                  const float rms2_threshold = 0.1) const {
       const unsigned int nClusters = pfClusters.nSeeds();
 
       if (::cms::alpakatools::once_per_grid(acc)) {
@@ -140,166 +141,265 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       const unsigned int w_extent = alpaka::warp::getSize(acc);
 
-      for (auto group : ::cms::alpakatools::uniform_groups(acc)) {  //loop over thread blocks
-                                                                    // Note that these variables are thread-private.
-        // On GPU backends, each thread processes one cluster element.
-        // On the CPU backend, each thread element  processes one cluster element.
-        reduce_t accum_etaSum_div_en{0.};
-        reduce_t accum_phiSum_div_en{0.};
+      for (auto idx : ::cms::alpakatools::uniform_elements(acc, nClusters)) {
+        const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
 
-        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nClusters)) {
-          const float pfc_energy = pfClusters[idx.global].energy();
+        accum_t accum_etaSum_div_en{0.};
+        accum_t accum_phiSum_div_en{0.};
+        {
+          const auto pfc_energy = pfClusters[idx].energy();
 
-          mdpfClusteringVars[idx.global].depth() = pfClusters[idx.global].depth();
-          mdpfClusteringVars[idx.global].energy() = pfc_energy;
+          mdpfClusteringVars[idx].depth() = pfClusters[idx].depth();
+          mdpfClusteringVars[idx].energy() = pfc_energy;
 
-          const compute_t x_c = pfClusters[idx.global].x();
-          const compute_t y_c = pfClusters[idx.global].y();
-          const compute_t z_c = pfClusters[idx.global].z();
+          const compute_t x_c = pfClusters[idx].x();
+          const compute_t y_c = pfClusters[idx].y();
+          const compute_t z_c = pfClusters[idx].z();
 
-          const float eta_c = static_cast<float>(cms::alpakamath::eta(acc, x_c, y_c, z_c));
-          const float phi_c = static_cast<float>(::cms::alpakatools::phi(acc, x_c, y_c));
+          const reduce_t eta_c = static_cast<reduce_t>(cms::alpakamath::eta(acc, x_c, y_c, z_c));
+          const reduce_t phi_c = static_cast<reduce_t>(::cms::alpakatools::phi(acc, x_c, y_c));
 
-          mdpfClusteringVars[idx.global].eta() = eta_c;
-          mdpfClusteringVars[idx.global].phi() = phi_c;
+          mdpfClusteringVars[idx].eta() = eta_c;
+          mdpfClusteringVars[idx].phi() = phi_c;
 
-          int pfrhf_offset = pfClusters[idx.global].rhfracOffset();
-          int pfrhf_size = pfClusters[idx.global].rhfracSize();
+          int pfrhf_offset = pfClusters[idx].rhfracOffset();
+          int pfrhf_size = pfClusters[idx].rhfracSize();
 
           reduce_t iter_accum_etaSum{0};
           reduce_t iter_accum_phiSum{0};
 
-          constexpr int pfrhf_size_threshold = 32;
+          // Cooperative mode: each "master" lane (iter_lane_idx) owns a PFRecHitFraction span
+          // [pfrhf_offset, pfrhf_offset + pfrhf_size). If that span is longer than 1, we recruit a
+          // subgroup of currently "free" lanes to help process the span in parallel.
+          //
+          // Mask conventions in this scope:
+          // - active_lanes_mask : lanes corresponding to in-range clusters (plus any forced lanes).
+          // - free_lanes_mask   : lanes currently available to be assigned as cooperative workers
+          //                       (subset of active_lanes_mask).
+          //                       if a swap_lanes_mask (see below) is a non-empty set, then free lanes mask
+          //                       also includes lanes for later swap operation
+          // - swap_lanes_mask   : lanes that currently hold state and must be preserved to be swapped out to some free lanes.
+          if constexpr (is_cooperative) {
+            auto addFn = [] ALPAKA_FN_ACC(double a, double b) -> double { return a + b; };
 
-          const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
+            const warp::warp_mask_t active_lanes_mask = alpaka::warp::activemask(acc);
 
-          const warp::warp_mask_t high_occup_lanes_mask =
-              is_cooperative ? warp::ballot_mask(acc, active_lanes_mask, pfrhf_size > pfrhf_size_threshold) : 0;
+            const unsigned int lane_idx = idx % w_extent;
 
-          const unsigned int lane_idx = idx.local % w_extent;
+            const unsigned int eff_w_extent = alpaka::popcount(acc, active_lanes_mask);
 
-          if (!is_cooperative || is_work_lane(high_occup_lanes_mask, lane_idx) == false) {
-            for (int pfrhfrac_idx = pfrhf_offset; pfrhfrac_idx < (pfrhf_offset + pfrhf_size); pfrhfrac_idx++) {
+            // Define iteration parameters:
+            unsigned int iter_lane_idx = 0;
+
+            bool keep_accum = false;
+
+            while (iter_lane_idx < eff_w_extent) {
+              // Identify lanes whose remaining PFRecHitFraction work is exactly one element.
+              // These lanes cannot benefit from recruiting cooperative helpers and are handled by a fast path.
+              // Note: pfrhf_size may have been reduced in a previous iteration due to leftover handling.
+              const warp::warp_mask_t single_worklane_mask = warp::ballot_mask(acc, active_lanes_mask, pfrhf_size == 1);
+
+              // Create temporary per-iteration masks for cooperative scheduling:
+              // -- how many vacant lanes in the warp, i.e., lanes available to become cooperators in this iteration ('free_lanes_mask')
+              // -- how many reserved lanes in the warp ('swap_lanes_mask'); note that free_lanes_mask must also include reserved lanes
+              warp::warp_mask_t free_lanes_mask = active_lanes_mask;
+              warp::warp_mask_t swap_lanes_mask = static_cast<warp::warp_mask_t>(0);
+
+              unsigned int swap_lane_idx{
+                  w_extent};  //assigned to some default value (note that it's outside of the warp range)
+              unsigned int swap_lanes_num{0};  //no lanes in the warp keep iter lane idx for swap operation
+
+              unsigned int proc_lane_idx{w_extent};
+              unsigned int proc_pfrhf_offset{static_cast<unsigned int>(pfrhf_offset)};
+
+              bool update_params = true;
+
+              bool cache_vals = false;
+              // Ensure masks and per-lane state updates from previous iteration are visible before scheduling.
+              warp::syncWarpThreads_mask(acc, active_lanes_mask);
+
+              while (update_params) {
+                const warp::warp_mask_t iter_lane_mask = get_lane_mask(iter_lane_idx);
+
+                const bool is_master_lane = iter_lane_idx == lane_idx;
+                // first we need to check whether the current iter lane itself is vacant.
+                if ((free_lanes_mask & iter_lane_mask) == 0) {
+                  // The current iteration lane is not free: it currently holds state that must be preserved.
+                  // Mark it as reserved-for-swap; later we move its state into an actually free lane.
+                  swap_lanes_mask = swap_lanes_mask | iter_lane_mask;
+                  ++swap_lanes_num;  // number of lanes reserved for swap in this iteration
+
+                  if (is_master_lane && iter_lane_idx != proc_lane_idx)
+                    swap_lane_idx = proc_lane_idx;
+                } else {
+                  // update the free mask (erase master-lane bit):
+                  free_lanes_mask &= ~iter_lane_mask;
+                }
+                // 'iter_lane_idx' is warp-uniform; thus all lanes agree on which lane is the current master.
+                // Check whether the current lane has exactly one element of work remaining.
+                const bool is_single_work_lane = is_work_lane(single_worklane_mask, iter_lane_idx);
+                // Available cooperative subgroup capacity: free lanes minus those reserved to preserve state (swap lanes).
+                // Note: the name 'subgroup' is used here because it does not take into account iterative (master) lane itself.
+                const unsigned int free_subgroup_size = alpaka::popcount(acc, free_lanes_mask) - swap_lanes_num;
+
+                if (is_single_work_lane) {
+                  if (is_master_lane) {
+                    proc_lane_idx = iter_lane_idx;
+                    proc_pfrhf_offset = pfrhf_offset;
+                    cache_vals = true;
+                  }
+                  iter_lane_idx += 1;
+                  update_params = iter_lane_idx < eff_w_extent &&
+                                  (static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) > swap_lanes_num);
+                  continue;
+                }
+
+                const unsigned int proc_pfrhf_size =
+                    is_master_lane ? (pfrhf_size - 1) : 0;  //exclude master lane itself..
+                // Broadcast worksize (all active lanes):
+                const unsigned int iter_pfrhf_size =
+                    warp::shfl_mask(acc, active_lanes_mask, proc_pfrhf_size, iter_lane_idx, w_extent);
+
+                const unsigned int coop_subgroup_size = alpaka::math::min(acc, iter_pfrhf_size, free_subgroup_size);
+
+                // Check which lane can cooperate in the work:
+                // -- it must be vacant (corresponding bit in 'free_lanes_mask' must be set)
+                // -- among free lanes, it must be within the first 'coop_subgroup_size' positions
+                //    (using logical indexing over free_lanes_mask)
+                // -- vacant lanes must not be reserved for swapping operation (which is already taking into account in 'coop_subgroup_size')
+                const bool is_coop_subgroup_lane =
+                    is_work_lane(free_lanes_mask, lane_idx)
+                        ? (get_logical_lane_idx(acc, free_lanes_mask, lane_idx) < coop_subgroup_size)
+                        : false;
+                // Cooperative subgroup lanes are drawn from free_lanes_mask; by construction this excludes the master lane
+                // (because the master lane was already removed from free_lanes_mask earlier).
+                const warp::warp_mask_t coop_subgroup_mask =
+                    warp::ballot_mask(acc, active_lanes_mask, is_coop_subgroup_lane);
+                // Erase corresponding bits in 'free_lanes_mask'
+                free_lanes_mask &= ~coop_subgroup_mask;
+                // Update parameters only for cooperative subgroup lanes (and the master lane):
+                // Broadcast from the current master lane (iter_lane_idx): which lane owns the work and its current offset.
+                // Only the cooperative subgroup lanes and the master lane participate in these shuffles
+                if (is_coop_subgroup_lane || is_master_lane)
+                  proc_lane_idx =
+                      warp::shfl_mask(acc, coop_subgroup_mask | iter_lane_mask, iter_lane_idx, iter_lane_idx, w_extent);
+
+                // Now we need to check whether we need to increment iteration lane index.
+                // Check if worksize less or equal subgroup size, if 'true', increment iter lane index for the next rec hit fraction array:
+                if (iter_pfrhf_size <= free_subgroup_size) {
+                  iter_lane_idx += 1;
+                  if (is_master_lane)
+                    cache_vals = true;  //master lane must store its values in the global arrays later
+                } else if (is_master_lane) {
+                  // Otherwise, the master lane has more work than available helpers; keep a leftover tail.
+                  // We advance pfrhf_offset by (coop helpers + master) and reduce pfrhf_size accordingly.
+                  keep_accum = true;
+                  // update rechit fraction offset for the next iteration
+                  proc_pfrhf_offset = pfrhf_offset;
+                  pfrhf_offset += coop_subgroup_size + 1;  // +1 accounts for the master lane processing one element
+                  // compute remaining work size (that is a leftover rec hit fraction size)
+                  pfrhf_size = iter_pfrhf_size - coop_subgroup_size;
+                }
+                // Continue scheduling while we have remaining iter lanes and enough free capacity
+                // to eventually place swap lanes
+                update_params = (iter_lane_idx < eff_w_extent) &&
+                                (static_cast<std::uint32_t>(alpaka::popcount(acc, free_lanes_mask)) > swap_lanes_num);
+              }
+
+              // Now we need to swap cached values to vacant lanes:
+              if (is_work_lane(free_lanes_mask | swap_lanes_mask, lane_idx)) {
+                const unsigned int src_log_lane_idx = is_work_lane(free_lanes_mask, lane_idx)
+                                                          ? get_logical_lane_idx(acc, free_lanes_mask, lane_idx)
+                                                          : w_extent;
+                const unsigned int src_phys_lane_idx =
+                    src_log_lane_idx < swap_lanes_num ? get_physical_lane_idx(acc, swap_lanes_mask, src_log_lane_idx)
+                                                      : lane_idx;
+
+                const unsigned int tmp_proc_lane_idx =
+                    warp::shfl_mask(acc, free_lanes_mask | swap_lanes_mask, swap_lane_idx, src_phys_lane_idx, w_extent);
+
+                if (is_work_lane(free_lanes_mask, lane_idx) && src_log_lane_idx < swap_lanes_num)
+                  proc_lane_idx = tmp_proc_lane_idx;
+              }
+
+              const warp::warp_mask_t nonvacant_lanes_mask =
+                  warp::ballot_mask(acc, active_lanes_mask, proc_lane_idx != w_extent);
+
+              if (is_work_lane(nonvacant_lanes_mask, lane_idx) == false)
+                continue;
+
+              const warp::warp_mask_t coop_group_mask = warp::match_any_mask(acc, nonvacant_lanes_mask, proc_lane_idx);
+
+              const reduce_t proc_eta_c = warp::shfl_mask(acc, coop_group_mask, eta_c, proc_lane_idx, w_extent);
+              const reduce_t proc_phi_c = warp::shfl_mask(acc, coop_group_mask, phi_c, proc_lane_idx, w_extent);
+              const reduce_t proc_pfc_energy =
+                  warp::shfl_mask(acc, coop_group_mask, pfc_energy, proc_lane_idx, w_extent);
+
+              const unsigned int coop_pfrhf_offset =
+                  warp::shfl_mask(acc, coop_group_mask, proc_pfrhf_offset, proc_lane_idx, w_extent);
+
+              const int pfrhfrac_idx = get_logical_lane_idx(acc, coop_group_mask, lane_idx) + coop_pfrhf_offset;
+
               const int pfrh_idx = pfRecHitFracs[pfrhfrac_idx].pfrhIdx();
-              const float fracXenergy = pfRecHitFracs[pfrhfrac_idx].frac() * pfRecHit[pfrh_idx].energy();
+              const reduce_t frac_energy = pfRecHitFracs[pfrhfrac_idx].frac() * pfRecHit[pfrh_idx].energy();
 
               const compute_t x_rh = pfRecHit[pfrh_idx].x();
               const compute_t y_rh = pfRecHit[pfrh_idx].y();
               const compute_t z_rh = pfRecHit[pfrh_idx].z();
 
-              const float eta_rh = static_cast<float>(cms::alpakamath::eta(acc, x_rh, y_rh, z_rh));
-              const float phi_rh = static_cast<float>(::cms::alpakatools::phi(acc, x_rh, y_rh));
+              const reduce_t eta_rh = static_cast<reduce_t>(cms::alpakamath::eta(acc, x_rh, y_rh, z_rh));
+              const reduce_t phi_rh = static_cast<reduce_t>(::cms::alpakatools::phi(acc, x_rh, y_rh));
 
-              auto etaSum_tmp = fracXenergy * alpaka::math::abs(acc, eta_rh - eta_c);
-              auto phiSum_tmp = fracXenergy * alpaka::math::abs(acc, ::cms::alpakatools::deltaPhi(acc, phi_rh, phi_c));
+              const reduce_t etaSum_ = frac_energy * alpaka::math::abs(acc, eta_rh - proc_eta_c);
+              const reduce_t phiSum_ =
+                  frac_energy * alpaka::math::abs(acc, ::cms::alpakatools::deltaPhi(acc, phi_rh, proc_phi_c));
+
+              iter_accum_etaSum += warp_sparse_reduce(acc, coop_group_mask, lane_idx, etaSum_, addFn);
+              iter_accum_phiSum += warp_sparse_reduce(acc, coop_group_mask, lane_idx, phiSum_, addFn);
+
+              if (cache_vals) {
+                accum_etaSum_div_en = static_cast<accum_t>(iter_accum_etaSum / proc_pfc_energy);
+                accum_phiSum_div_en = static_cast<accum_t>(iter_accum_phiSum / proc_pfc_energy);
+              }
+
+              if (keep_accum == false) {
+                iter_accum_etaSum = 0.;
+                iter_accum_phiSum = 0.;
+              } else {
+                keep_accum = false;
+              }
+            }  // end while
+          } else {  //non cooperative work
+            for (int pfrhfrac_idx = pfrhf_offset; pfrhfrac_idx < (pfrhf_offset + pfrhf_size); pfrhfrac_idx++) {
+              const int pfrh_idx = pfRecHitFracs[pfrhfrac_idx].pfrhIdx();
+              const reduce_t frac_energy = pfRecHitFracs[pfrhfrac_idx].frac() * pfRecHit[pfrh_idx].energy();
+
+              const compute_t x_rh = pfRecHit[pfrh_idx].x();
+              const compute_t y_rh = pfRecHit[pfrh_idx].y();
+              const compute_t z_rh = pfRecHit[pfrh_idx].z();
+
+              const reduce_t eta_rh = static_cast<reduce_t>(cms::alpakamath::eta(acc, x_rh, y_rh, z_rh));
+              const reduce_t phi_rh = static_cast<reduce_t>(::cms::alpakatools::phi(acc, x_rh, y_rh));
+
+              const reduce_t etaSum_tmp = (frac_energy)*alpaka::math::abs(acc, eta_rh - eta_c);
+              const reduce_t phiSum_tmp =
+                  (frac_energy)*alpaka::math::abs(acc, ::cms::alpakatools::deltaPhi(acc, phi_rh, phi_c));
 
               iter_accum_etaSum += etaSum_tmp;
               iter_accum_phiSum += phiSum_tmp;
             }
 
-            accum_etaSum_div_en = iter_accum_etaSum / pfc_energy;
-            accum_phiSum_div_en = iter_accum_phiSum / pfc_energy;
+            accum_etaSum_div_en = static_cast<accum_t>(iter_accum_etaSum / pfc_energy);
+            accum_phiSum_div_en = static_cast<accum_t>(iter_accum_phiSum / pfc_energy);
           }
-
-          if constexpr (!is_cooperative)  //uniform condition for all lanes
-            continue;
-
-          const unsigned int eff_w_extent = alpaka::popcount(acc, high_occup_lanes_mask);
-
-          auto addFn = [] ALPAKA_FN_ACC(reduce_t a, reduce_t b) -> reduce_t { return a + b; };
-
-          // Define iteration parameters:
-          unsigned int iter_lane_idx = 0;
-
-          float iter_eta_c{0};
-          float iter_phi_c{0};
-          float iter_pfc_energy{0};
-
-          bool update_iter_params = true;
-
-          while (iter_lane_idx < eff_w_extent) {
-            warp::syncWarpThreads_mask(acc, active_lanes_mask);
-
-            const unsigned int src_lane_idx = get_physical_lane_idx(acc, high_occup_lanes_mask, iter_lane_idx);
-
-            const unsigned int iter_pfrhf_size =
-                warp::shfl_mask(acc, active_lanes_mask, pfrhf_size, src_lane_idx, w_extent);  // exclude the source lane
-
-            const bool is_src_in_range = (src_lane_idx < iter_pfrhf_size);
-
-            const bool is_coop_lane = lane_idx == src_lane_idx || (is_src_in_range && lane_idx < iter_pfrhf_size) ||
-                                      (!is_src_in_range && lane_idx < (iter_pfrhf_size - 1));
-
-            const unsigned int coop_group_mask = warp::ballot_mask(acc, active_lanes_mask, is_coop_lane);
-
-            if (is_work_lane(coop_group_mask, lane_idx)) {
-              if (update_iter_params) {
-                iter_eta_c = warp::shfl_mask(acc, coop_group_mask, eta_c, src_lane_idx, w_extent);
-                iter_phi_c = warp::shfl_mask(acc, coop_group_mask, phi_c, src_lane_idx, w_extent);
-                iter_pfc_energy = warp::shfl_mask(acc, coop_group_mask, pfc_energy, src_lane_idx, w_extent);
-
-                iter_accum_etaSum = 0;
-                iter_accum_phiSum = 0;
-
-                update_iter_params = false;
-              }
-
-              const unsigned int iter_pfrhf_offset_stub =
-                  warp::shfl_mask(acc, coop_group_mask, pfrhf_offset, src_lane_idx, w_extent);
-
-              const unsigned int stride =
-                  (lane_idx != src_lane_idx || is_src_in_range) ? lane_idx : (iter_pfrhf_size - 1);
-
-              const unsigned int pfrhfrac_idx = iter_pfrhf_offset_stub + stride;
-
-              const int pfrh_idx = pfRecHitFracs[pfrhfrac_idx].pfrhIdx();
-              const float fracXenergy = pfRecHitFracs[pfrhfrac_idx].frac() * pfRecHit[pfrh_idx].energy();
-
-              const compute_t x_rh = pfRecHit[pfrh_idx].x();
-              const compute_t y_rh = pfRecHit[pfrh_idx].y();
-              const compute_t z_rh = pfRecHit[pfrh_idx].z();
-
-              const float eta_rh = static_cast<float>(cms::alpakamath::eta(acc, x_rh, y_rh, z_rh));
-              const float phi_rh = static_cast<float>(::cms::alpakatools::phi(acc, x_rh, y_rh));
-
-              const reduce_t etaSum_ = static_cast<reduce_t>(fracXenergy * alpaka::math::abs(acc, eta_rh - iter_eta_c));
-              const reduce_t phiSum_ = static_cast<reduce_t>(
-                  fracXenergy * alpaka::math::abs(acc, ::cms::alpakatools::deltaPhi(acc, phi_rh, iter_phi_c)));
-
-              iter_accum_etaSum += warp_sparse_reduce(acc, coop_group_mask, lane_idx, etaSum_, addFn);
-              iter_accum_phiSum += warp_sparse_reduce(acc, coop_group_mask, lane_idx, phiSum_, addFn);
-
-              const unsigned int coop_group_size = alpaka::popcount(acc, coop_group_mask);
-
-              if (iter_pfrhf_size == coop_group_size) {  //done for this iteration
-                if (src_lane_idx == lane_idx) {
-                  accum_etaSum_div_en = iter_accum_etaSum / iter_pfc_energy;
-                  accum_phiSum_div_en = iter_accum_phiSum / iter_pfc_energy;
-                }
-                iter_lane_idx += 1;
-                update_iter_params = true;
-              } else {
-                if (src_lane_idx == lane_idx) {
-                  pfrhf_size -= coop_group_size;
-                  pfrhf_offset += coop_group_size;
-                }
-              }
-            } else {
-              iter_lane_idx += 1;
-              update_iter_params = true;
-            }
-          }  //end of while
-        }  //end uniform_groups_elements
-
-        alpaka::syncBlockThreads(acc);
-
-        for (auto idx : ::cms::alpakatools::uniform_group_elements(acc, group, nClusters)) {
-          const reduce_t etaRMS2_ = alpaka::math::max(acc, accum_etaSum_div_en, rms2_threshold);
-          const reduce_t phiRMS2_ = alpaka::math::max(acc, accum_phiSum_div_en, rms2_threshold);
-
-          mdpfClusteringVars[idx.global].etaRMS2() = etaRMS2_ * etaRMS2_;
-          mdpfClusteringVars[idx.global].phiRMS2() = phiRMS2_ * phiRMS2_;
         }
+        warp::syncWarpThreads_mask(acc, active_lanes_mask);
+
+        const double etaRMS2_ = alpaka::math::max(acc, accum_etaSum_div_en, rms2_threshold);
+        const double phiRMS2_ = alpaka::math::max(acc, accum_phiSum_div_en, rms2_threshold);
+
+        mdpfClusteringVars[idx].etaRMS2() = etaRMS2_ * etaRMS2_;
+        mdpfClusteringVars[idx].phiRMS2() = phiRMS2_ * phiRMS2_;
       }
     }
   };


### PR DESCRIPTION
This bug-fix PR corrects the execution domain for the CPU backend of the Alpaka multi-depth PF clusterizer.

The previous implementation showed a high multiplicity discrepancy between the GPU and CPU paths in the extreme-eta regime. The discrepancy originates from an incorrect shower-shape computation in the Alpaka CPU backend, which explains why the GPU and CPU paths agree at moderate eta but diverge in the extreme-eta case.

Resolves https://github.com/cms-sw/framework-team/issues/2201
