### PR TITLE
Add source location to SoA out of range error messages

### DIFF
--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -222,26 +222,43 @@ The mutable and const views with the exact same set of columns and their paramet
 struct SoA1Layout::View;
 
 template<bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::enabled,
-         bool RANGE_CHECKING = cms::soa::RangeChecking::disabled>
+         bool RANGE_CHECKING = cms::soa::RangeChecking::enabled>
 struct SoA1Layout::ViewTemplate;
 
 template<size_t ALIGNMENT = cms::soa::CacheLineSize::defaultSize,
          bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::relaxed,
          bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::enabled,
-         bool RANGE_CHECKING = cms::soa::RangeChecking::disabled>
+         bool RANGE_CHECKING = cms::soa::RangeChecking::enabled>
 struct SoA1Layout::ViewTemplateFreeParams;
 
 struct SoA1Layout::ConstView;
 
 template<bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::enabled,
-         bool RANGE_CHECKING = cms::soa::RangeChecking::disabled>
+         bool RANGE_CHECKING = cms::soa::RangeChecking::enabled>
 struct SoA1Layout::ConstViewTemplate;
 
 template<size_t ALIGNMENT = cms::soa::CacheLineSize::defaultSize,
          bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::relaxed,
          bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::enabled,
-         bool RANGE_CHECKING = cms::soa::RangeChecking::disabled>
+         bool RANGE_CHECKING = cms::soa::RangeChecking::enabled>
 struct SoA1Layout::ConstViewTemplateFreeParams;
+```
+
+The trivial and const views derived from a layout use the `__restrict__` compiler hint where supported, and provide optional range checking.
+
+Range checking can also be enabled in an extended mode with `cms::soa::RangeChecking::extended` as the template parameter of a view. In this mode, `std::source_location` 
+is captured whenever an index is passed to a view, allowing out-of-bounds errors to report the originating file name and line number. 
+This additional context makes it easier to identify the exact access responsible for an out-of-bounds error, improving the debugging experience.
+Views with the extended range checking can be created like this: 
+
+```C++
+// default views with cms::soa::RestrictQualify::Default and cms::soa::RangeChecking::Default
+using SoAView = SoA::View;
+using SoAConstView = SoA::ConstView;
+
+// extended range checking to get more output when access out-of-bounds is encountered
+using SoAViewExtended = SoA::ViewTemplate<cms::soa::RestrictQualify::Default, cms::soa::RangeChecking::extended>;
+using SoAConstViewExtended = SoA::ConstViewTemplate<cms::soa::RestrictQualify::Default, cms::soa::RangeChecking::extended>;
 ```
 
 The SoA by blocks can be created in this way:

--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -320,8 +320,6 @@ blocksView.scalars().energy() = 100.0f;
   not compiled). Using `RangeChecking::extended` causes a capture of the source location using `std::source_location`,
   when an integer index is passed to access the data. When an out-of-bounds error is thrown, this leads to more information
   in the error message, including the file name and line number where the out-of-bounds index was passed to the SoA.
-  `RangeChecking::Default` is `RangeChecking::enabled` when build without `DEBUG` and `RangeChecking::extended` when build
-  with `DEBUG`.
 - Eigen columns are also suported, with both const and non-const flavors.
 - ROOT serialization and deserialization is supported. In CMSSW, it is planned to be used through the memory
   managing `PortableCollection` family of classes.

--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -320,6 +320,8 @@ blocksView.scalars().energy() = 100.0f;
   not compiled). Using `RangeChecking::extended` causes a capture of the source location using `std::source_location`,
   when an integer index is passed to access the data. When an out-of-bounds error is thrown, this leads to more information
   in the error message, including the file name and line number where the out-of-bounds index was passed to the SoA.
+  `RangeChecking::Default` is `RangeChecking::enabled` when build without `DEBUG` and `RangeChecking::extended` when build
+  with `DEBUG`.
 - Eigen columns are also suported, with both const and non-const flavors.
 - ROOT serialization and deserialization is supported. In CMSSW, it is planned to be used through the memory
   managing `PortableCollection` family of classes.

--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -317,7 +317,9 @@ blocksView.scalars().energy() = 100.0f;
   directly by the module developer, orthogonally from SoA.
 - Optional (compile time) range checking validates the index of every column access, throwing an exception on the
   CPU side and forcing a segmentation fault to halt kernels. When not enabled, it has no impact on performance (code
-  not compiled)
+  not compiled). Using `RangeChecking::extended` causes a capture of the source location using `std::source_location`,
+  when an integer index is passed to access the data. When an out-of-bounds error is thrown, this leads to more information
+  in the error message, including the file name and line number where the out-of-bounds index was passed to the SoA.
 - Eigen columns are also suported, with both const and non-const flavors.
 - ROOT serialization and deserialization is supported. In CMSSW, it is planned to be used through the memory
   managing `PortableCollection` family of classes.

--- a/DataFormats/SoATemplate/interface/SoABlocks.h
+++ b/DataFormats/SoATemplate/interface/SoABlocks.h
@@ -278,7 +278,7 @@
     template <CMS_SOA_BYTE_SIZE_TYPE VIEW_ALIGNMENT = cms::soa::CacheLineSize::defaultSize,                            \
             bool VIEW_ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::relaxed,                                 \
             bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,                                                \
-            bool RANGE_CHECKING = cms::soa::RangeChecking::Default>                                                    \
+            cms::soa::RangeChecking::Mode RANGE_CHECKING = cms::soa::RangeChecking::Default>                           \
     struct ViewTemplateFreeParams;                                                                                     \
                                                                                                                        \
     /* Helper function to compute the total number of blocks */                                                        \
@@ -328,7 +328,8 @@
                                                                                                                        \
     _ITERATE_ON_ALL(_DECLARE_LAYOUTS_ACCESSORS, ~, __VA_ARGS__)                                                        \
                                                                                                                        \
-    template <std::size_t VIEW_ALIGNMENT, bool VIEW_ALIGNMENT_ENFORCEMENT, bool RESTRICT_QUALIFY, bool RANGE_CHECKING> \
+    template <std::size_t VIEW_ALIGNMENT, bool VIEW_ALIGNMENT_ENFORCEMENT,                                             \
+              bool RESTRICT_QUALIFY, cms::soa::RangeChecking::Mode RANGE_CHECKING>                                     \
     struct ConstViewTemplateFreeParams {                                                                               \
       using BOOST_PP_CAT(CLASS, _parametrized) = CLASS<VIEW_ALIGNMENT, VIEW_ALIGNMENT_ENFORCEMENT>;                    \
                                                                                                                        \
@@ -339,10 +340,10 @@
       using byte_size_type = cms::soa::byte_size_type;                                                                 \
       using AlignmentEnforcement = cms::soa::AlignmentEnforcement;                                                     \
                                                                                                                        \
-      template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, bool>                                                              \
+      template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, cms::soa::RangeChecking::Mode>                                     \
       friend struct ViewTemplateFreeParams;                                                                            \
                                                                                                                        \
-      template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, bool>                                                              \
+      template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, cms::soa::RangeChecking::Mode>                                     \
       friend struct ConstViewTemplateFreeParams;                                                                       \
                                                                                                                        \
       constexpr static byte_size_type defaultAlignment = cms::soa::CacheLineSize::defaultSize;                         \
@@ -351,7 +352,7 @@
       constexpr static byte_size_type conditionalAlignment =                                                           \
           alignmentEnforcement == AlignmentEnforcement::enforced ? alignment : 0;                                      \
       constexpr static bool restrictQualify = RESTRICT_QUALIFY;                                                        \
-      constexpr static bool rangeChecking = RANGE_CHECKING;                                                            \
+      constexpr static cms::soa::RangeChecking::Mode rangeChecking = RANGE_CHECKING;                                   \
       /* Helper/friend class allowing SoA by blocks ConstView introspection. */                                        \
       struct Metadata {                                                                                                \
         friend ConstViewTemplateFreeParams;                                                                            \
@@ -404,7 +405,7 @@
         std::array<size_type, blocksNumber> sizes_;                                                                    \
     };                                                                                                                 \
                                                                                                                        \
-    template <bool RESTRICT_QUALIFY, bool RANGE_CHECKING>                                                              \
+    template <bool RESTRICT_QUALIFY, cms::soa::RangeChecking::Mode RANGE_CHECKING>                                     \
     using ConstViewTemplate = ConstViewTemplateFreeParams<ALIGNMENT, ALIGNMENT_ENFORCEMENT, RESTRICT_QUALIFY,          \
       RANGE_CHECKING>;                                                                                                 \
                                                                                                                        \
@@ -413,7 +414,7 @@
     template <CMS_SOA_BYTE_SIZE_TYPE VIEW_ALIGNMENT,                                                                   \
               bool VIEW_ALIGNMENT_ENFORCEMENT,                                                                         \
               bool RESTRICT_QUALIFY,                                                                                   \
-              bool RANGE_CHECKING>                                                                                     \
+              cms::soa::RangeChecking::Mode RANGE_CHECKING>                                                            \
       struct ViewTemplateFreeParams                                                                                    \
       : public ConstViewTemplateFreeParams<VIEW_ALIGNMENT, VIEW_ALIGNMENT_ENFORCEMENT,                                 \
                                            RESTRICT_QUALIFY, RANGE_CHECKING> {                                         \
@@ -432,9 +433,9 @@
       constexpr static byte_size_type conditionalAlignment =                                                           \
           alignmentEnforcement == AlignmentEnforcement::enforced ? alignment : 0;                                      \
       constexpr static bool restrictQualify = RESTRICT_QUALIFY;                                                        \
-      constexpr static bool rangeChecking = RANGE_CHECKING;                                                            \
+      constexpr static cms::soa::RangeChecking::Mode rangeChecking = RANGE_CHECKING;                                   \
                                                                                                                        \
-      template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, bool>                                                              \
+      template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, cms::soa::RangeChecking::Mode>                                     \
       friend struct ViewTemplateFreeParams;                                                                            \
       /* Helper/friend class allowing SoA by blocks View introspection. */                                             \
       struct Metadata {                                                                                                \
@@ -483,7 +484,7 @@
                                                                                                                        \
        /* Data members inherited from the ConstView */                                                                 \
     };                                                                                                                 \
-    template <bool RESTRICT_QUALIFY, bool RANGE_CHECKING>                                                              \
+    template <bool RESTRICT_QUALIFY, cms::soa::RangeChecking::Mode RANGE_CHECKING>                                     \
     using ViewTemplate = ViewTemplateFreeParams<ALIGNMENT, ALIGNMENT_ENFORCEMENT, RESTRICT_QUALIFY, RANGE_CHECKING>;   \
     using View = ViewTemplate<cms::soa::RestrictQualify::Default, cms::soa::RangeChecking::Default>;                   \
                                                                                                                        \

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -841,16 +841,16 @@ SOA_HOST_ONLY std::ostream& operator<<(std::ostream& os, const SOA& soa) {
 
 namespace cms::soa::detail {
 
-  struct SourceIndex {
-    SOA_HOST_DEVICE constexpr SourceIndex(const cms::soa::size_type value,
-                                          std::source_location location = std::source_location::current()) noexcept
+  struct IndexWithSourceLocation {
+    SOA_HOST_DEVICE constexpr IndexWithSourceLocation(
+        const cms::soa::size_type value, std::source_location location = std::source_location::current()) noexcept
         : value_{value}, location_{location} {}
 
     cms::soa::size_type value_;
     std::source_location location_;
   };
 
-  [[noreturn]] void throwOutOfRangeError(const char* message, SourceIndex index, cms::soa::size_type range);
+  [[noreturn]] void throwOutOfRangeError(const char* message, IndexWithSourceLocation index, cms::soa::size_type range);
   // Helper function to check alignment of a pointer. Returns true if the pointer is not aligned to the specified alignment.
   [[noreturn]] void throwRuntimeError(const char* message);
 

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -122,11 +122,8 @@ namespace cms::soa {
     constexpr Mode disabled = Mode::Disabled;
     constexpr Mode enabled = Mode::Enabled;
     constexpr Mode extended = Mode::Extended;
-#ifdef DEBUG
-    constexpr Mode Default = extended;
-#else
+
     constexpr Mode Default = enabled;
-#endif
 
   }  // namespace RangeChecking
 

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -35,27 +35,39 @@
 
 // Exception throwing (or willful crash in kernels)
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__)
-#define SOA_THROW_OUT_OF_RANGE(A, I, R)                         \
-  {                                                             \
-    printf("%s: index %d out of range %d at file %s line %d\n", \
-           (A),                                                 \
-           (I.value_),                                          \
-           (R),                                                 \
-           (I.location_.file_name()),                           \
-           (I.location_.line()));                               \
-    __trap();                                                   \
+
+#define SOA_THROW_OUT_OF_RANGE(A, I, R)                                     \
+  {                                                                         \
+    if constexpr (decltype(I)::mode == cms::soa::RangeChecking::extended) { \
+      printf("%s: index %d out of range %d at file %s line %d\n",           \
+             (A),                                                           \
+             (I.value_),                                                    \
+             (R),                                                           \
+             (I.location_.file_name()),                                     \
+             (I.location_.line()));                                         \
+    } else {                                                                \
+      printf("%s: index %d out of range %d\n", (A), (I.value_), (R));       \
+    }                                                                       \
+    __trap();                                                               \
   }
+
 #elif defined(__HIPCC__) && defined(__HIP_DEVICE_COMPILE__)
-#define SOA_THROW_OUT_OF_RANGE(A, I, R)                         \
-  {                                                             \
-    printf("%s: index %d out of range %d at file %s line %d\n", \
-           (A),                                                 \
-           (I.value_),                                          \
-           (R),                                                 \
-           (I.location_.file_name()),                           \
-           (I.location_.line()));                               \
-    abort();                                                    \
+
+#define SOA_THROW_OUT_OF_RANGE(A, I, R)                                     \
+  {                                                                         \
+    if constexpr (decltype(I)::mode == cms::soa::RangeChecking::extended) { \
+      printf("%s: index %d out of range %d at file %s line %d\n",           \
+             (A),                                                           \
+             (I.value_),                                                    \
+             (R),                                                           \
+             (I.location_.file_name()),                                     \
+             (I.location_.line()));                                         \
+    } else {                                                                \
+      printf("%s: index %d out of range %d\n", (A), (I.value_), (R));       \
+    }                                                                       \
+    abort();                                                                \
   }
+
 #else
 #define SOA_THROW_OUT_OF_RANGE(A, I, R)                    \
   {                                                        \
@@ -104,9 +116,15 @@ namespace cms::soa {
   }  // namespace RestrictQualify
 
   namespace RangeChecking {
-    constexpr bool enabled = true;
-    constexpr bool disabled = false;
-    constexpr bool Default = enabled;
+
+    enum class Mode { Disabled, Enabled, Extended };
+
+    constexpr Mode disabled = Mode::Disabled;
+    constexpr Mode enabled = Mode::Enabled;
+    constexpr Mode extended = Mode::Extended;
+
+    constexpr Mode Default = enabled;
+
   }  // namespace RangeChecking
 
   template <typename T, bool RESTRICT_QUALIFY>
@@ -841,16 +859,36 @@ SOA_HOST_ONLY std::ostream& operator<<(std::ostream& os, const SOA& soa) {
 
 namespace cms::soa::detail {
 
-  struct IndexWithSourceLocation {
+  template <RangeChecking::Mode M>
+  struct IndexWithSourceLocation;
+
+  template <RangeChecking::Mode M>
+    requires(M != RangeChecking::extended)
+  struct IndexWithSourceLocation<M> {
+    static constexpr auto mode = M;
+
+    SOA_HOST_DEVICE constexpr IndexWithSourceLocation(cms::soa::size_type value) noexcept : value_{value} {}
+
+    cms::soa::size_type value_;
+  };
+
+  template <>
+  struct IndexWithSourceLocation<RangeChecking::extended> {
+    static constexpr auto mode = RangeChecking::extended;
+
     SOA_HOST_DEVICE constexpr IndexWithSourceLocation(
-        const cms::soa::size_type value, std::source_location location = std::source_location::current()) noexcept
+        cms::soa::size_type value, std::source_location location = std::source_location::current()) noexcept
         : value_{value}, location_{location} {}
 
     cms::soa::size_type value_;
     std::source_location location_;
   };
 
-  [[noreturn]] void throwOutOfRangeError(const char* message, IndexWithSourceLocation index, cms::soa::size_type range);
+  template <RangeChecking::Mode M>
+  [[noreturn]] void throwOutOfRangeError(const char* message,
+                                         const IndexWithSourceLocation<M>& index,
+                                         cms::soa::size_type range);
+
   // Helper function to check alignment of a pointer. Returns true if the pointer is not aligned to the specified alignment.
   [[noreturn]] void throwRuntimeError(const char* message);
 

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -12,6 +12,7 @@
 #include <ostream>
 #include <sstream>
 #include <span>
+#include <source_location>
 #include <tuple>
 #include <type_traits>
 
@@ -34,16 +35,26 @@
 
 // Exception throwing (or willful crash in kernels)
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__)
-#define SOA_THROW_OUT_OF_RANGE(A, I, R)                      \
-  {                                                          \
-    printf("%s: index %d out of range %d\n", (A), (I), (R)); \
-    __trap();                                                \
+#define SOA_THROW_OUT_OF_RANGE(A, I, R)                         \
+  {                                                             \
+    printf("%s: index %d out of range %d at file %s line %d\n", \
+           (A),                                                 \
+           (I.value_),                                          \
+           (R),                                                 \
+           (I.location_.file_name()),                           \
+           (I.location_.line()));                               \
+    __trap();                                                   \
   }
 #elif defined(__HIPCC__) && defined(__HIP_DEVICE_COMPILE__)
-#define SOA_THROW_OUT_OF_RANGE(A, I, R)                      \
-  {                                                          \
-    printf("%s: index %d out of range %d\n", (A), (I), (R)); \
-    abort();                                                 \
+#define SOA_THROW_OUT_OF_RANGE(A, I, R)                         \
+  {                                                             \
+    printf("%s: index %d out of range %d at file %s line %d\n", \
+           (A),                                                 \
+           (I.value_),                                          \
+           (R),                                                 \
+           (I.location_.file_name()),                           \
+           (I.location_.line()));                               \
+    abort();                                                    \
   }
 #else
 #define SOA_THROW_OUT_OF_RANGE(A, I, R)                    \
@@ -829,7 +840,17 @@ SOA_HOST_ONLY std::ostream& operator<<(std::ostream& os, const SOA& soa) {
 }
 
 namespace cms::soa::detail {
-  [[noreturn]] void throwOutOfRangeError(const char* message, cms::soa::size_type index, cms::soa::size_type range);
+
+  struct SourceIndex {
+    SOA_HOST_DEVICE constexpr SourceIndex(const cms::soa::size_type value,
+                                          std::source_location location = std::source_location::current()) noexcept
+        : value_{value}, location_{location} {}
+
+    cms::soa::size_type value_;
+    std::source_location location_;
+  };
+
+  [[noreturn]] void throwOutOfRangeError(const char* message, SourceIndex index, cms::soa::size_type range);
   // Helper function to check alignment of a pointer. Returns true if the pointer is not aligned to the specified alignment.
   [[noreturn]] void throwRuntimeError(const char* message);
 

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -69,9 +69,9 @@
   }
 
 #else
-#define SOA_THROW_OUT_OF_RANGE(A, I, R)                    \
-  {                                                        \
-    cms::soa::detail::throwOutOfRangeError((A), (I), (R)); \
+#define SOA_THROW_OUT_OF_RANGE(A, I, R)                                       \
+  {                                                                           \
+    cms::soa::detail::throwOutOfRangeError<decltype(I)::mode>((A), (I), (R)); \
   }
 #endif
 
@@ -122,8 +122,11 @@ namespace cms::soa {
     constexpr Mode disabled = Mode::Disabled;
     constexpr Mode enabled = Mode::Enabled;
     constexpr Mode extended = Mode::Extended;
-
+#ifdef DEBUG
+    constexpr Mode Default = extended;
+#else
     constexpr Mode Default = enabled;
+#endif
 
   }  // namespace RangeChecking
 
@@ -860,11 +863,7 @@ SOA_HOST_ONLY std::ostream& operator<<(std::ostream& os, const SOA& soa) {
 namespace cms::soa::detail {
 
   template <RangeChecking::Mode M>
-  struct IndexWithSourceLocation;
-
-  template <RangeChecking::Mode M>
-    requires(M != RangeChecking::extended)
-  struct IndexWithSourceLocation<M> {
+  struct IndexWithSourceLocation {
     static constexpr auto mode = M;
 
     SOA_HOST_DEVICE constexpr IndexWithSourceLocation(cms::soa::size_type value) noexcept : value_{value} {}
@@ -872,9 +871,10 @@ namespace cms::soa::detail {
     cms::soa::size_type value_;
   };
 
-  template <>
-  struct IndexWithSourceLocation<RangeChecking::extended> {
-    static constexpr auto mode = RangeChecking::extended;
+  template <RangeChecking::Mode M>
+    requires(M == RangeChecking::extended)
+  struct IndexWithSourceLocation<M> {
+    static constexpr auto mode = M;
 
     SOA_HOST_DEVICE constexpr IndexWithSourceLocation(
         cms::soa::size_type value, std::source_location location = std::source_location::current()) noexcept

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -797,16 +797,16 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(size_type _soa_impl_index) const {                                                                            \
+  NAME(cms::soa::detail::SourceIndex _soa_impl_index) const {                                                        \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
-      if (_soa_impl_index >= elements_ or _soa_impl_index < 0)                                                       \
+      if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                         \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
           _soa_impl_index, elements_)                                                                                \
     }                                                                                                                \
     return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, NAME)>::                         \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
-                template RestrictQualifier<restrictQualify>(BOOST_PP_CAT(NAME, Parameters_))(_soa_impl_index);       \
+                template RestrictQualifier<restrictQualify>(BOOST_PP_CAT(NAME, Parameters_))(_soa_impl_index.value_);\
   }                                                                                                                  \
   ,                                                                                                                  \
   /* Column */                                                                                                       \
@@ -826,9 +826,9 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(size_type _soa_impl_index) const {                                                                            \
+  NAME(cms::soa::detail::SourceIndex _soa_impl_index) const {                                                        \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
-      if (_soa_impl_index >= elements_ or _soa_impl_index < 0)                                                       \
+      if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                         \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
           _soa_impl_index, elements_)                                                                                \
     }                                                                                                                \
@@ -836,7 +836,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
                 template RestrictQualifier<restrictQualify>(BOOST_PP_CAT(NAME, Parameters_),                         \
-                    elements_)(_soa_impl_index);                                                                     \
+                    elements_)(_soa_impl_index.value_);                                                              \
   }                                                                                                                  \
   ,                                                                                                                  \
   /* Eigen column */                                                                                                 \
@@ -859,9 +859,9 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(size_type _soa_impl_index) const {                                                                            \
+  NAME(cms::soa::detail::SourceIndex _soa_impl_index) const {                                                        \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
-      if (_soa_impl_index >= elements_ or _soa_impl_index < 0)                                                       \
+      if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                         \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
           _soa_impl_index, elements_)                                                                                \
     }                                                                                                                \
@@ -871,7 +871,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
                 template RestrictQualifier<restrictQualify>(BOOST_PP_CAT(NAME, Parameters_),                         \
                         cms::soa::alignSize(elements_ * sizeof(CPP_TYPE::Scalar), alignment) /                       \
                             sizeof(CPP_TYPE::Scalar) * CPP_TYPE::RowsAtCompileTime *                                 \
-                                CPP_TYPE::ColsAtCompileTime)(_soa_impl_index);                                       \
+                                CPP_TYPE::ColsAtCompileTime)(_soa_impl_index.value_);                                \
   }                                                                                                                  \
 )
 // clang-format on
@@ -1154,9 +1154,9 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(size_type _soa_impl_index) {                                                                                  \
+  NAME(cms::soa::detail::SourceIndex _soa_impl_index) {                                                              \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
-      if (_soa_impl_index >= base_type::elements_ or _soa_impl_index < 0)                                            \
+      if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                              \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
           _soa_impl_index, base_type::elements_)                                                                     \
     }                                                                                                                \
@@ -1164,7 +1164,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                 template RestrictQualifier<restrictQualify>(cms::soa::const_cast_SoAParametersImpl(                  \
-                    base_type:: BOOST_PP_CAT(NAME, Parameters_)))(_soa_impl_index);                                  \
+                    base_type:: BOOST_PP_CAT(NAME, Parameters_)))(_soa_impl_index.value_);                           \
   }                                                                                                                  \
   ,                                                                                                                  \
   /* Column */                                                                                                       \
@@ -1185,9 +1185,9 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(size_type _soa_impl_index) {                                                                                  \
+  NAME(cms::soa::detail::SourceIndex _soa_impl_index) {                                                              \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
-      if (_soa_impl_index >= base_type::elements_ or _soa_impl_index < 0)                                            \
+      if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                              \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
           _soa_impl_index, base_type::elements_)                                                                     \
     }                                                                                                                \
@@ -1195,7 +1195,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                 template RestrictQualifier<restrictQualify>(cms::soa::const_cast_SoAParametersImpl(                  \
-                    base_type:: BOOST_PP_CAT(NAME, Parameters_)), base_type::elements_)(_soa_impl_index);            \
+                    base_type:: BOOST_PP_CAT(NAME, Parameters_)), base_type::elements_)(_soa_impl_index.value_);     \
   }                                                                                                                  \
   ,                                                                                                                  \
   /* Eigen column */                                                                                                 \
@@ -1219,9 +1219,9 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(size_type _soa_impl_index) {                                                                                  \
+  NAME(cms::soa::detail::SourceIndex _soa_impl_index) {                                                              \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
-      if (_soa_impl_index >= base_type::elements_ or _soa_impl_index < 0)                                            \
+      if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                              \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
           _soa_impl_index, base_type::elements_)                                                                     \
     }                                                                                                                \
@@ -1232,7 +1232,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
                     base_type:: BOOST_PP_CAT(NAME, Parameters_)),                                                    \
                         cms::soa::alignSize(base_type::elements_ * sizeof(CPP_TYPE::Scalar), alignment) /            \
                             sizeof(CPP_TYPE::Scalar) * CPP_TYPE::RowsAtCompileTime *                                 \
-                                CPP_TYPE::ColsAtCompileTime)(_soa_impl_index);                                       \
+                                CPP_TYPE::ColsAtCompileTime)(_soa_impl_index.value_);                                \
   }                                                                                                                  \
 )
 // clang-format on
@@ -1489,14 +1489,14 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       };                                                                                                               \
                                                                                                                        \
         SOA_HOST_DEVICE SOA_INLINE                                                                                     \
-        const_element operator[](size_type _soa_impl_index) const {                                                    \
+        const_element operator[](cms::soa::detail::SourceIndex _soa_impl_index) const {                                \
           if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                           \
-            if (_soa_impl_index >= elements_ or _soa_impl_index < 0)                                                   \
+            if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                     \
               SOA_THROW_OUT_OF_RANGE("Out of range index in ConstViewTemplateFreeParams " #CLASS "::operator[]",       \
                 _soa_impl_index, elements_)                                                                            \
           }                                                                                                            \
           return const_element{                                                                                        \
-            _soa_impl_index, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONST_ELEMENT_CONSTR_CALL, ~, __VA_ARGS__)            \
+            _soa_impl_index.value_, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONST_ELEMENT_CONSTR_CALL, ~, __VA_ARGS__)     \
           };                                                                                                           \
         }                                                                                                              \
                                                                                                                        \
@@ -1676,13 +1676,15 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       };                                                                                                               \
                                                                                                                        \
       SOA_HOST_DEVICE SOA_INLINE                                                                                       \
-      element operator[](size_type _soa_impl_index) {                                                                  \
+      element operator[](cms::soa::detail::SourceIndex _soa_impl_index) {                                              \
         if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                             \
-          if (_soa_impl_index >= base_type::elements_ or _soa_impl_index < 0)                                          \
+          if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                            \
             SOA_THROW_OUT_OF_RANGE("Out of range index in ViewTemplateFreeParams" #CLASS "::operator[]",               \
               _soa_impl_index, base_type::elements_)                                                                   \
         }                                                                                                              \
-        return element{_soa_impl_index, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_ELEMENT_CONSTR_CALL, ~, __VA_ARGS__)};     \
+        return element{                                                                                                \
+          _soa_impl_index.value_, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_ELEMENT_CONSTR_CALL, ~, __VA_ARGS__)             \
+        };                                                                                                             \
       }                                                                                                                \
                                                                                                                        \
       /* inherit const accessors from ConstView */                                                                     \

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -798,7 +798,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
   NAME(cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) const {                             \
-    if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
+    if constexpr (rangeChecking != cms::soa::RangeChecking::disabled) {                                              \
       if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                         \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
           _soa_impl_index, elements_)                                                                                \
@@ -827,7 +827,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
   NAME(cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) const {                             \
-    if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
+    if constexpr (rangeChecking != cms::soa::RangeChecking::disabled) {                                              \
       if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                         \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
           _soa_impl_index, elements_)                                                                                \
@@ -860,7 +860,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
   NAME(cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) const {                             \
-    if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
+    if constexpr (rangeChecking != cms::soa::RangeChecking::disabled) {                                              \
       if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                         \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
           _soa_impl_index, elements_)                                                                                \
@@ -1155,7 +1155,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
   NAME(cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) {                                   \
-    if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
+    if constexpr (rangeChecking != cms::soa::RangeChecking::disabled) {                                              \
       if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                              \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
           _soa_impl_index, base_type::elements_)                                                                     \
@@ -1186,7 +1186,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
   NAME(cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) {                                   \
-    if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
+    if constexpr (rangeChecking != cms::soa::RangeChecking::disabled) {                                              \
       if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                              \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
           _soa_impl_index, base_type::elements_)                                                                     \
@@ -1220,7 +1220,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
   NAME(cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) {                                   \
-    if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
+    if constexpr (rangeChecking != cms::soa::RangeChecking::disabled) {                                              \
       if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                              \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
           _soa_impl_index, base_type::elements_)                                                                     \
@@ -1241,12 +1241,6 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
   BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, TYPE_NAME), _VALUE_LAST_COLUMN_TYPE), \
               BOOST_PP_EMPTY(),                                                             \
               BOOST_PP_EXPAND(_DECLARE_VIEW_SOA_ACCESSOR_IMPL TYPE_NAME))
-
-#ifdef DEBUG
-#define _DO_RANGECHECK true
-#else
-#define _DO_RANGECHECK false
-#endif
 
 /*
  * A macro defining a SoA layout (collection of scalars and columns of equal lengths)
@@ -1490,7 +1484,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
                                                                                                                        \
         SOA_HOST_DEVICE SOA_INLINE                                                                                     \
         const_element operator[](cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) const {     \
-          if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                           \
+          if constexpr (rangeChecking != cms::soa::RangeChecking::disabled) {                                          \
             if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                     \
               SOA_THROW_OUT_OF_RANGE("Out of range index in ConstViewTemplateFreeParams " #CLASS "::operator[]",       \
                 _soa_impl_index, elements_)                                                                            \
@@ -1677,7 +1671,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
                                                                                                                        \
       SOA_HOST_DEVICE SOA_INLINE                                                                                       \
       element operator[](cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) {                   \
-        if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                             \
+        if constexpr (rangeChecking != cms::soa::RangeChecking::disabled) {                                            \
           if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                            \
             SOA_THROW_OUT_OF_RANGE("Out of range index in ViewTemplateFreeParams" #CLASS "::operator[]",               \
               _soa_impl_index, base_type::elements_)                                                                   \

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -797,7 +797,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(cms::soa::detail::SourceIndex _soa_impl_index) const {                                                        \
+  NAME(cms::soa::detail::IndexWithSourceLocation _soa_impl_index) const {                                            \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
       if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                         \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
@@ -826,7 +826,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(cms::soa::detail::SourceIndex _soa_impl_index) const {                                                        \
+  NAME(cms::soa::detail::IndexWithSourceLocation _soa_impl_index) const {                                            \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
       if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                         \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
@@ -859,7 +859,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(cms::soa::detail::SourceIndex _soa_impl_index) const {                                                        \
+  NAME(cms::soa::detail::IndexWithSourceLocation _soa_impl_index) const {                                            \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
       if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                         \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
@@ -1154,7 +1154,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(cms::soa::detail::SourceIndex _soa_impl_index) {                                                              \
+  NAME(cms::soa::detail::IndexWithSourceLocation _soa_impl_index) {                                                  \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
       if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                              \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
@@ -1185,7 +1185,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(cms::soa::detail::SourceIndex _soa_impl_index) {                                                              \
+  NAME(cms::soa::detail::IndexWithSourceLocation _soa_impl_index) {                                                  \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
       if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                              \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
@@ -1219,7 +1219,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(cms::soa::detail::SourceIndex _soa_impl_index) {                                                              \
+  NAME(cms::soa::detail::IndexWithSourceLocation _soa_impl_index) {                                                  \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
       if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                              \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
@@ -1489,7 +1489,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       };                                                                                                               \
                                                                                                                        \
         SOA_HOST_DEVICE SOA_INLINE                                                                                     \
-        const_element operator[](cms::soa::detail::SourceIndex _soa_impl_index) const {                                \
+        const_element operator[](cms::soa::detail::IndexWithSourceLocation _soa_impl_index) const {                    \
           if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                           \
             if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                     \
               SOA_THROW_OUT_OF_RANGE("Out of range index in ConstViewTemplateFreeParams " #CLASS "::operator[]",       \
@@ -1676,7 +1676,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       };                                                                                                               \
                                                                                                                        \
       SOA_HOST_DEVICE SOA_INLINE                                                                                       \
-      element operator[](cms::soa::detail::SourceIndex _soa_impl_index) {                                              \
+      element operator[](cms::soa::detail::IndexWithSourceLocation _soa_impl_index) {                                  \
         if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                             \
           if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                            \
             SOA_THROW_OUT_OF_RANGE("Out of range index in ViewTemplateFreeParams" #CLASS "::operator[]",               \

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -797,7 +797,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(cms::soa::detail::IndexWithSourceLocation _soa_impl_index) const {                                            \
+  NAME(cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) const {                             \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
       if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                         \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
@@ -826,7 +826,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(cms::soa::detail::IndexWithSourceLocation _soa_impl_index) const {                                            \
+  NAME(cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) const {                             \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
       if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                         \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
@@ -859,7 +859,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(cms::soa::detail::IndexWithSourceLocation _soa_impl_index) const {                                            \
+  NAME(cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) const {                             \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
       if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                         \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
@@ -1154,7 +1154,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(cms::soa::detail::IndexWithSourceLocation _soa_impl_index) {                                                  \
+  NAME(cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) {                                   \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
       if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                              \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
@@ -1185,7 +1185,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(cms::soa::detail::IndexWithSourceLocation _soa_impl_index) {                                                  \
+  NAME(cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) {                                   \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
       if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                              \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
@@ -1219,7 +1219,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, NAME)>::template AccessType<                       \
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                      \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                        \
-  NAME(cms::soa::detail::IndexWithSourceLocation _soa_impl_index) {                                                  \
+  NAME(cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) {                                   \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
       if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                              \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #NAME "(size_type index)",                           \
@@ -1281,7 +1281,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
     template <CMS_SOA_BYTE_SIZE_TYPE VIEW_ALIGNMENT = cms::soa::CacheLineSize::defaultSize,                            \
             bool VIEW_ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::relaxed,                                 \
             bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,                                                \
-            bool RANGE_CHECKING = cms::soa::RangeChecking::Default>                                                    \
+            cms::soa::RangeChecking::Mode RANGE_CHECKING = cms::soa::RangeChecking::Default>                           \
     struct ViewTemplateFreeParams;                                                                                     \
                                                                                                                        \
     /* dump the SoA internal structure */                                                                              \
@@ -1355,7 +1355,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
     template <CMS_SOA_BYTE_SIZE_TYPE VIEW_ALIGNMENT,                                                                   \
               bool VIEW_ALIGNMENT_ENFORCEMENT,                                                                         \
               bool RESTRICT_QUALIFY,                                                                                   \
-              bool RANGE_CHECKING>                                                                                     \
+              cms::soa::RangeChecking::Mode RANGE_CHECKING>                                                            \
     struct ConstViewTemplateFreeParams {                                                                               \
       /* these could be moved to an external type trait to free up the symbol names */                                 \
       using self_type = ConstViewTemplateFreeParams;                                                                   \
@@ -1364,10 +1364,10 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       using byte_size_type = cms::soa::byte_size_type;                                                                 \
       using AlignmentEnforcement = cms::soa::AlignmentEnforcement;                                                     \
                                                                                                                        \
-      template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, bool>                                                              \
+      template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, cms::soa::RangeChecking::Mode>                                     \
       friend struct ViewTemplateFreeParams;                                                                            \
                                                                                                                        \
-      template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, bool>                                                              \
+      template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, cms::soa::RangeChecking::Mode>                                     \
       friend struct ConstViewTemplateFreeParams;                                                                       \
                                                                                                                        \
       /* For CUDA applications, we align to the 128 bytes of the cache lines.                                          \
@@ -1380,7 +1380,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       constexpr static byte_size_type conditionalAlignment =                                                           \
           alignmentEnforcement == AlignmentEnforcement::enforced ? alignment : 0;                                      \
       constexpr static bool restrictQualify = RESTRICT_QUALIFY;                                                        \
-      constexpr static bool rangeChecking = RANGE_CHECKING;                                                            \
+      constexpr static cms::soa::RangeChecking::Mode rangeChecking = RANGE_CHECKING;                                   \
                                                                                                                        \
       /**                                                                                                              \
        * Helper/friend class allowing SoA introspection.                                                               \
@@ -1446,7 +1446,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       template <CMS_SOA_BYTE_SIZE_TYPE OTHER_VIEW_ALIGNMENT,                                                           \
                 bool OTHER_VIEW_ALIGNMENT_ENFORCEMENT,                                                                 \
                 bool OTHER_RESTRICT_QUALIFY,                                                                           \
-                bool OTHER_RANGE_CHECKING>                                                                             \
+                cms::soa::RangeChecking::Mode OTHER_RANGE_CHECKING>                                                    \
       ConstViewTemplateFreeParams(ConstViewTemplateFreeParams<OTHER_VIEW_ALIGNMENT,                                    \
         OTHER_VIEW_ALIGNMENT_ENFORCEMENT, OTHER_RESTRICT_QUALIFY, OTHER_RANGE_CHECKING> const& other)                  \
         : ConstViewTemplateFreeParams{other.elements_,                                                                 \
@@ -1462,7 +1462,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       template <CMS_SOA_BYTE_SIZE_TYPE OTHER_VIEW_ALIGNMENT,                                                           \
           bool OTHER_VIEW_ALIGNMENT_ENFORCEMENT,                                                                       \
           bool OTHER_RESTRICT_QUALIFY,                                                                                 \
-          bool OTHER_RANGE_CHECKING>                                                                                   \
+          cms::soa::RangeChecking::Mode OTHER_RANGE_CHECKING>                                                          \
       ConstViewTemplateFreeParams& operator=(ConstViewTemplateFreeParams<OTHER_VIEW_ALIGNMENT,                         \
           OTHER_VIEW_ALIGNMENT_ENFORCEMENT, OTHER_RESTRICT_QUALIFY, OTHER_RANGE_CHECKING> const& other)                \
           { *this = other; }                                                                                           \
@@ -1489,7 +1489,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       };                                                                                                               \
                                                                                                                        \
         SOA_HOST_DEVICE SOA_INLINE                                                                                     \
-        const_element operator[](cms::soa::detail::IndexWithSourceLocation _soa_impl_index) const {                    \
+        const_element operator[](cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) const {     \
           if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                           \
             if (_soa_impl_index.value_ >= elements_ or _soa_impl_index.value_ < 0)                                     \
               SOA_THROW_OUT_OF_RANGE("Out of range index in ConstViewTemplateFreeParams " #CLASS "::operator[]",       \
@@ -1512,7 +1512,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
           _ITERATE_ON_ALL(_DECLARE_CONST_VIEW_SOA_MEMBER, ~, __VA_ARGS__)                                              \
       };                                                                                                               \
                                                                                                                        \
-    template <bool RESTRICT_QUALIFY, bool RANGE_CHECKING>                                                              \
+    template <bool RESTRICT_QUALIFY, cms::soa::RangeChecking::Mode RANGE_CHECKING>                                     \
     using ConstViewTemplate = ConstViewTemplateFreeParams<ALIGNMENT, ALIGNMENT_ENFORCEMENT, RESTRICT_QUALIFY,          \
       RANGE_CHECKING>;                                                                                                 \
                                                                                                                        \
@@ -1521,7 +1521,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
     template <CMS_SOA_BYTE_SIZE_TYPE VIEW_ALIGNMENT,                                                                   \
               bool VIEW_ALIGNMENT_ENFORCEMENT,                                                                         \
               bool RESTRICT_QUALIFY,                                                                                   \
-              bool RANGE_CHECKING>                                                                                     \
+              cms::soa::RangeChecking::Mode RANGE_CHECKING>                                                            \
       struct ViewTemplateFreeParams                                                                                    \
       : public ConstViewTemplateFreeParams<VIEW_ALIGNMENT, VIEW_ALIGNMENT_ENFORCEMENT,                                 \
                                            RESTRICT_QUALIFY, RANGE_CHECKING> {                                         \
@@ -1544,9 +1544,9 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       constexpr static byte_size_type conditionalAlignment =                                                           \
           alignmentEnforcement == AlignmentEnforcement::enforced ? alignment : 0;                                      \
       constexpr static bool restrictQualify = RESTRICT_QUALIFY;                                                        \
-      constexpr static bool rangeChecking = RANGE_CHECKING;                                                            \
+      constexpr static cms::soa::RangeChecking::Mode rangeChecking = RANGE_CHECKING;                                   \
                                                                                                                        \
-      template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, bool>                                                              \
+      template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, cms::soa::RangeChecking::Mode>                                     \
       friend struct ViewTemplateFreeParams;                                                                            \
                                                                                                                        \
       /**                                                                                                              \
@@ -1619,7 +1619,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       template <CMS_SOA_BYTE_SIZE_TYPE OTHER_VIEW_ALIGNMENT,                                                           \
                 bool OTHER_VIEW_ALIGNMENT_ENFORCEMENT,                                                                 \
                 bool OTHER_RESTRICT_QUALIFY,                                                                           \
-                bool OTHER_RANGE_CHECKING>                                                                             \
+                cms::soa::RangeChecking::Mode OTHER_RANGE_CHECKING>                                                    \
       ViewTemplateFreeParams(ViewTemplateFreeParams<OTHER_VIEW_ALIGNMENT, OTHER_VIEW_ALIGNMENT_ENFORCEMENT,            \
                                                     OTHER_RESTRICT_QUALIFY, OTHER_RANGE_CHECKING> const& other)        \
       : base_type{other.elements_,                                                                                     \
@@ -1629,7 +1629,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       template <CMS_SOA_BYTE_SIZE_TYPE OTHER_VIEW_ALIGNMENT,                                                           \
                 bool OTHER_VIEW_ALIGNMENT_ENFORCEMENT,                                                                 \
                 bool OTHER_RESTRICT_QUALIFY,                                                                           \
-                bool OTHER_RANGE_CHECKING>                                                                             \
+                cms::soa::RangeChecking::Mode OTHER_RANGE_CHECKING>                                                    \
       ViewTemplateFreeParams& operator=(ViewTemplateFreeParams<OTHER_VIEW_ALIGNMENT,                                   \
         OTHER_VIEW_ALIGNMENT_ENFORCEMENT, OTHER_RESTRICT_QUALIFY, OTHER_RANGE_CHECKING> const& other)                  \
           { static_cast<base_type>(*this) = static_cast<base_type>(other); }                                           \
@@ -1676,7 +1676,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       };                                                                                                               \
                                                                                                                        \
       SOA_HOST_DEVICE SOA_INLINE                                                                                       \
-      element operator[](cms::soa::detail::IndexWithSourceLocation _soa_impl_index) {                                  \
+      element operator[](cms::soa::detail::IndexWithSourceLocation<rangeChecking> _soa_impl_index) {                   \
         if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                             \
           if (_soa_impl_index.value_ >= base_type::elements_ or _soa_impl_index.value_ < 0)                            \
             SOA_THROW_OUT_OF_RANGE("Out of range index in ViewTemplateFreeParams" #CLASS "::operator[]",               \
@@ -1697,7 +1697,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
       SOA_HOST_ONLY friend void dump();                                                                                \
     };                                                                                                                 \
                                                                                                                        \
-    template <bool RESTRICT_QUALIFY, bool RANGE_CHECKING>                                                              \
+    template <bool RESTRICT_QUALIFY, cms::soa::RangeChecking::Mode RANGE_CHECKING>                                     \
     using ViewTemplate = ViewTemplateFreeParams<ALIGNMENT, ALIGNMENT_ENFORCEMENT, RESTRICT_QUALIFY, RANGE_CHECKING>;   \
                                                                                                                        \
     using View = ViewTemplate<cms::soa::RestrictQualify::Default, cms::soa::RangeChecking::Default>;                   \
@@ -1762,7 +1762,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
     }                                                                                                                  \
                                                                                                                        \
     /* Helper to implement View as derived from ConstView in SoABlocks implementation */                               \
-    template <bool RESTRICT_QUALIFY, bool RANGE_CHECKING>                                                              \
+    template <bool RESTRICT_QUALIFY, cms::soa::RangeChecking::Mode RANGE_CHECKING>                                     \
     SOA_HOST_DEVICE SOA_INLINE static ViewTemplate<RESTRICT_QUALIFY, RANGE_CHECKING> const_cast_View(                  \
       ConstViewTemplate<RESTRICT_QUALIFY, RANGE_CHECKING> const& view)  {                                              \
       return ViewTemplate<RESTRICT_QUALIFY, RANGE_CHECKING>{                                                           \

--- a/DataFormats/SoATemplate/src/SoACommon.cc
+++ b/DataFormats/SoATemplate/src/SoACommon.cc
@@ -6,7 +6,12 @@
 namespace cms::soa::detail {
   [[noreturn]] void throwRuntimeError(const char* message) { throw std::runtime_error(message); }
 
-  [[noreturn]] void throwOutOfRangeError(const char* message, cms::soa::size_type index, cms::soa::size_type range) {
-    throw std::out_of_range(std::format("{}: index {} out of range {}", message, index, range));
+  [[noreturn]] void throwOutOfRangeError(const char* message, SourceIndex index, cms::soa::size_type range) {
+    throw std::out_of_range(std::format("{}: index {} out of range {} at file {} at line {} \n",
+                                        message,
+                                        index.value_,
+                                        range,
+                                        index.location_.file_name(),
+                                        index.location_.line()));
   }
 }  // namespace cms::soa::detail

--- a/DataFormats/SoATemplate/src/SoACommon.cc
+++ b/DataFormats/SoATemplate/src/SoACommon.cc
@@ -6,7 +6,9 @@
 namespace cms::soa::detail {
   [[noreturn]] void throwRuntimeError(const char* message) { throw std::runtime_error(message); }
 
-  [[noreturn]] void throwOutOfRangeError(const char* message, SourceIndex index, cms::soa::size_type range) {
+  [[noreturn]] void throwOutOfRangeError(const char* message,
+                                         IndexWithSourceLocation index,
+                                         cms::soa::size_type range) {
     throw std::out_of_range(std::format("{}: index {} out of range {} at file {} at line {} \n",
                                         message,
                                         index.value_,

--- a/DataFormats/SoATemplate/src/SoACommon.cc
+++ b/DataFormats/SoATemplate/src/SoACommon.cc
@@ -6,14 +6,26 @@
 namespace cms::soa::detail {
   [[noreturn]] void throwRuntimeError(const char* message) { throw std::runtime_error(message); }
 
-  [[noreturn]] void throwOutOfRangeError(const char* message,
-                                         IndexWithSourceLocation index,
-                                         cms::soa::size_type range) {
-    throw std::out_of_range(std::format("{}: index {} out of range {} at file {} at line {} \n",
+  template <>
+  [[noreturn]] void throwOutOfRangeError<RangeChecking::extended>(
+      const char* message, const IndexWithSourceLocation<RangeChecking::extended>& index, cms::soa::size_type range) {
+    throw std::out_of_range(std::format("{}: index {} out of range {} at file {} at line {}\n",
                                         message,
                                         index.value_,
                                         range,
                                         index.location_.file_name(),
                                         index.location_.line()));
+  }
+
+  template <>
+  [[noreturn]] void throwOutOfRangeError<RangeChecking::enabled>(
+      const char* message, const IndexWithSourceLocation<RangeChecking::enabled>& index, cms::soa::size_type range) {
+    throw std::out_of_range(std::format("{}: index {} out of range {}\n", message, index.value_, range));
+  }
+
+  template <>
+  [[noreturn]] void throwOutOfRangeError<RangeChecking::disabled>(
+      const char* message, const IndexWithSourceLocation<RangeChecking::disabled>& index, cms::soa::size_type range) {
+    throw std::out_of_range(std::format("{}: index {} out of range {}\n", message, index.value_, range));
   }
 }  // namespace cms::soa::detail

--- a/DataFormats/SoATemplate/test/SoAUnitTests.cc
+++ b/DataFormats/SoATemplate/test/SoAUnitTests.cc
@@ -135,4 +135,35 @@ TEST_CASE("SoATemplate") {
     REQUIRE_THROWS_AS(slcv.x(underflow), std::out_of_range);
     REQUIRE_THROWS_AS(slcv.x(overflow), std::out_of_range);
   }
+
+  SECTION("Range checking View Extended") {
+    // Enable range checking
+    using View = SimpleLayout::ViewTemplate<cms::soa::RestrictQualify::Default, cms::soa::RangeChecking::extended>;
+    View slv{sl};
+    int underflow = -1;
+    int overflow = slv.metadata().size();
+
+    REQUIRE_THROWS_WITH(slv[underflow], Catch::Matchers::ContainsSubstring("at file"));
+    REQUIRE_THROWS_WITH(slv[overflow], Catch::Matchers::ContainsSubstring("at file"));
+
+    REQUIRE_THROWS_WITH(slv.x(underflow), Catch::Matchers::ContainsSubstring("at file"));
+    REQUIRE_THROWS_WITH(slv.x(overflow), Catch::Matchers::ContainsSubstring("at file"));
+  }
+
+  SECTION("Range checking ConstView Extended") {
+    // Enable range checking
+    using ConstView =
+        SimpleLayout::ConstViewTemplate<cms::soa::RestrictQualify::Default, cms::soa::RangeChecking::extended>;
+    ConstView slcv{sl};
+    int underflow = -1;
+    int overflow = slcv.metadata().size();
+
+    // Check for under- and overflow in the row accessor
+    REQUIRE_THROWS_WITH(slcv[underflow], Catch::Matchers::ContainsSubstring("at file"));
+    REQUIRE_THROWS_WITH(slcv[overflow], Catch::Matchers::ContainsSubstring("at file"));
+
+    // Check for under- and overflow in the element accessors
+    REQUIRE_THROWS_WITH(slcv.x(underflow), Catch::Matchers::ContainsSubstring("at file"));
+    REQUIRE_THROWS_WITH(slcv.x(overflow), Catch::Matchers::ContainsSubstring("at file"));
+  }
 }

--- a/RecoLocalCalo/HGCalRecAlgos/test/alpaka/HGCalRecHitESProducersTest.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/test/alpaka/HGCalRecHitESProducersTest.cc
@@ -80,7 +80,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     return stream.str();
   }
 
-  using CalibParamView = hgcalrechit::HGCalCalibParamSoALayout<>::ConstViewTemplateFreeParams<128, false, true, true>;
+  using CalibParamView = hgcalrechit::HGCalCalibParamSoALayout<>::
+      ConstViewTemplateFreeParams<128, false, true, cms::soa::RangeChecking::enabled>;
   static void printCalPars(const CalibParamView& calibView, const int idx) {
     const auto& calib = calibView[idx];
     std::cout << std::setw(6) << idx << std::setw(7) << int2hex(idx) << std::dec << std::setw(12) << calib.ADC_ped()


### PR DESCRIPTION
This PR extends the out-of-range error messages that are thrown in the SoA backend. The messages are extended by the file, in which the error is triggered, and the line number. This is done by using `std::source_location`. For example, an error message before this PR might look like this:

`Out of range index in ConstViewTemplateFreeParams TrackingHitsLayout::operator[]: index 7 out of range 2`

The same error message would now look like this, for example:

`Out of range index in ConstViewTemplateFreeParams TrackingHitsLayout::operator[]: index 3 out of range 2 at file src/RecoTracker/PixelSeeding/plugins/alpaka/CAPixelDoubletsAlgos.h line 247`

With this extension it is immediately clear where the problem is triggered, which helps for debugging faster.


@felicepantaleo fyi
