### PR TITLE
UBSAN: avoid int overflow in GenHFHadronMatcher

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
@@ -979,7 +979,8 @@ int GenHFHadronMatcher::findInMothers(int idx,
     }
     int pdg_2 = hadMothers[idx2].pdgId();
     // Inverting the flavour if bb oscillation detected
-    if (isHadronPdgId(pdgId, pdg_1) && isHadronPdgId(pdgId, pdg_2) && pdg_1 * pdg_2 < 0) {
+    if (isHadronPdgId(pdgId, pdg_1) && isHadronPdgId(pdgId, pdg_2) &&
+        ((pdg_1 < 0 && pdg_2 > 0) || (pdg_1 > 0 && pdg_2 < 0))) {
       pdgId *= -1;
       if (verbose)
         printf("######### Inverting flavour of the hadron\n");

--- a/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
@@ -979,8 +979,7 @@ int GenHFHadronMatcher::findInMothers(int idx,
     }
     int pdg_2 = hadMothers[idx2].pdgId();
     // Inverting the flavour if bb oscillation detected
-    if (isHadronPdgId(pdgId, pdg_1) && isHadronPdgId(pdgId, pdg_2) &&
-        ((pdg_1 < 0 && pdg_2 > 0) || (pdg_1 > 0 && pdg_2 < 0))) {
+    if (isHadronPdgId(pdgId, pdg_1) && isHadronPdgId(pdgId, pdg_2) && ((pdg_1 < 0) != (pdg_2 < 0))) {
       pdgId *= -1;
       if (verbose)
         printf("######### Inverting flavour of the hadron\n");


### PR DESCRIPTION
UBSAN IBs show [runtime errors](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc13/CMSSW_17_0_UBSAN_X_2026-04-29-2300/pyRelValMatrixLogs/run/2500.3001_NANOmc150X/step2_NANOmc150X.log#/11887-11887) like
```
src/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc:982:77: runtime error: signed integer overflow: 100443 * 100443 cannot be represented in type 'int'
```

the code in question is https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc#L982 where ubsan complains about pdg_1 * pdg_2` overflowing int range. This PR proposes to change the logic and instead of multiplication just check the sign of these variables. 