### PR TITLE
[L1T] DT Trigger Phase-2  Shower Tagging v1.2

### DIFF
--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTShower.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTShower.h
@@ -32,47 +32,54 @@ namespace io_v1 {
 
     L1Phase2MuDTShower();
 
-    L1Phase2MuDTShower(int wh,                               // Wheel
-                       int sc,                               // Sector
-                       int st,                               // Station
-                       int sl,                               // Superlayer
-                       int ndigis,                           // Number of digis within shower
-                       int bx,                               // BX estimation
-                       int min_wire,                         // Minimum wire
-                       int max_wire,                         // Maximum wire
-                       float avg_pos,                        // Averaged position of the shower
-                       float avg_time,                       // Averaged time of the shower
-                       const std::vector<int> wires_profile  // Wires profile
-    );
+  L1Phase2MuDTShower(int wh,                                           // Wheel
+                     int sc,                                           // Sector
+                     int st,                                           // Station
+                     int sl,                                           // Superlayer
+                     int ndigis,                                       // Number of digis within shower
+                     int bx,                                           // BX estimation
+                     int min_wire,                                     // Minimum wire
+                     int max_wire,                                     // Maximum wire
+                     float avg_pos,                                    // Averaged position of the shower
+                     float avg_time,                                   // Averaged time of the shower
+                     const std::vector<int> wires_profile,             // Wires profile
+                     const std::vector<int> wires_constituents,        // Wires constituents
+                     const std::vector<int> wires_layer_constituents,  // Wires layer constituents
+                     const std::vector<int> wires_tdc_constituents     // Wires tdc constituents
+  );
 
     // Operations
 
-    int whNum() const;
-    int scNum() const;
-    int stNum() const;
-    int slNum() const;
-    int ndigis() const;
-    int bxNum() const;
-    int minWire() const;
-    int maxWire() const;
-    float avg_time() const;
-    float avg_pos() const;
-    std::vector<int> wiresProfile() const;
+  int whNum() const;
+  int scNum() const;
+  int stNum() const;
+  int slNum() const;
+  int ndigis() const;
+  int bxNum() const;
+  int minWire() const;
+  int maxWire() const;
+  float avg_time() const;
+  float avg_pos() const;
+  std::vector<int> wiresProfile() const;
+  std::vector<int> wiresConstituents() const;
+  std::vector<int> wiresLayerConstituents() const;
+  std::vector<int> wiresTdcConstituents() const;
 
-  private:
-    int m_wheel;
-    int m_sector;
-    int m_station;
-    int m_superlayer;
-    int m_ndigis;
-    int m_bx;
-    int m_min_wire;
-    int m_max_wire;
-    float m_avg_pos;
-    float m_avg_time;
-    std::vector<int> m_wires_profile;
-  };
-}  // namespace io_v1
-using L1Phase2MuDTShower = io_v1::L1Phase2MuDTShower;
+private:
+  int m_wheel;
+  int m_sector;
+  int m_station;
+  int m_superlayer;
+  int m_ndigis;
+  int m_bx;
+  int m_min_wire;
+  int m_max_wire;
+  float m_avg_pos;
+  float m_avg_time;
+  std::vector<int> m_wires_profile;
+  std::vector<int> m_wires_constituents;
+  std::vector<int> m_wires_layer_constituents;
+  std::vector<int> m_wires_tdc_constituents;
+};
 
 #endif

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTShower.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTShower.h
@@ -32,54 +32,56 @@ namespace io_v1 {
 
     L1Phase2MuDTShower();
 
-  L1Phase2MuDTShower(int wh,                                           // Wheel
-                     int sc,                                           // Sector
-                     int st,                                           // Station
-                     int sl,                                           // Superlayer
-                     int ndigis,                                       // Number of digis within shower
-                     int bx,                                           // BX estimation
-                     int min_wire,                                     // Minimum wire
-                     int max_wire,                                     // Maximum wire
-                     float avg_pos,                                    // Averaged position of the shower
-                     float avg_time,                                   // Averaged time of the shower
-                     const std::vector<int> wires_profile,             // Wires profile
-                     const std::vector<int> wires_constituents,        // Wires constituents
-                     const std::vector<int> wires_layer_constituents,  // Wires layer constituents
-                     const std::vector<int> wires_tdc_constituents     // Wires tdc constituents
-  );
+    L1Phase2MuDTShower(int wh,                                           // Wheel
+                       int sc,                                           // Sector
+                       int st,                                           // Station
+                       int sl,                                           // Superlayer
+                       int ndigis,                                       // Number of digis within shower
+                       int bx,                                           // BX estimation
+                       int min_wire,                                     // Minimum wire
+                       int max_wire,                                     // Maximum wire
+                       float avg_pos,                                    // Averaged position of the shower
+                       float avg_time,                                   // Averaged time of the shower
+                       const std::vector<int> wires_profile,             // Wires profile
+                       const std::vector<int> wires_constituents,        // Wires constituents
+                       const std::vector<int> wires_layer_constituents,  // Wires layer constituents
+                       const std::vector<int> wires_tdc_constituents     // Wires tdc constituents
+    );
 
     // Operations
 
-  int whNum() const;
-  int scNum() const;
-  int stNum() const;
-  int slNum() const;
-  int ndigis() const;
-  int bxNum() const;
-  int minWire() const;
-  int maxWire() const;
-  float avg_time() const;
-  float avg_pos() const;
-  std::vector<int> wiresProfile() const;
-  std::vector<int> wiresConstituents() const;
-  std::vector<int> wiresLayerConstituents() const;
-  std::vector<int> wiresTdcConstituents() const;
+    int whNum() const;
+    int scNum() const;
+    int stNum() const;
+    int slNum() const;
+    int ndigis() const;
+    int bxNum() const;
+    int minWire() const;
+    int maxWire() const;
+    float avg_time() const;
+    float avg_pos() const;
+    std::vector<int> wiresProfile() const;
+    std::vector<int> wiresConstituents() const;
+    std::vector<int> wiresLayerConstituents() const;
+    std::vector<int> wiresTdcConstituents() const;
 
-private:
-  int m_wheel;
-  int m_sector;
-  int m_station;
-  int m_superlayer;
-  int m_ndigis;
-  int m_bx;
-  int m_min_wire;
-  int m_max_wire;
-  float m_avg_pos;
-  float m_avg_time;
-  std::vector<int> m_wires_profile;
-  std::vector<int> m_wires_constituents;
-  std::vector<int> m_wires_layer_constituents;
-  std::vector<int> m_wires_tdc_constituents;
-};
+  private:
+    int m_wheel;
+    int m_sector;
+    int m_station;
+    int m_superlayer;
+    int m_ndigis;
+    int m_bx;
+    int m_min_wire;
+    int m_max_wire;
+    float m_avg_pos;
+    float m_avg_time;
+    std::vector<int> m_wires_profile;
+    std::vector<int> m_wires_constituents;
+    std::vector<int> m_wires_layer_constituents;
+    std::vector<int> m_wires_tdc_constituents;
+  };
+}  // namespace io_v1
+using L1Phase2MuDTShower = io_v1::L1Phase2MuDTShower;
 
 #endif

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTShower.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTShower.h
@@ -32,16 +32,16 @@ namespace io_v1 {
 
     L1Phase2MuDTShower();
 
-    L1Phase2MuDTShower(int wh,                                           // Wheel
-                       int sc,                                           // Sector
-                       int st,                                           // Station
-                       int sl,                                           // Superlayer
-                       int ndigis,                                       // Number of digis within shower
-                       int bx,                                           // BX estimation
-                       int min_wire,                                     // Minimum wire
-                       int max_wire,                                     // Maximum wire
-                       float avg_pos,                                    // Averaged position of the shower
-                       float avg_time,                                   // Averaged time of the shower
+    L1Phase2MuDTShower(int wh,                                            // Wheel
+                       int sc,                                            // Sector
+                       int st,                                            // Station
+                       int sl,                                            // Superlayer
+                       int ndigis,                                        // Number of digis within shower
+                       int bx,                                            // BX estimation
+                       int min_wire,                                      // Minimum wire
+                       int max_wire,                                      // Maximum wire
+                       float avg_pos,                                     // Averaged position of the shower
+                       float avg_time,                                    // Averaged time of the shower
                        const std::vector<int>& wires_profile,             // Wires profile
                        const std::vector<int>& wires_constituents,        // Wires constituents
                        const std::vector<int>& wires_layer_constituents,  // Wires layer constituents

--- a/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTShower.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTShower.h
@@ -42,10 +42,10 @@ namespace io_v1 {
                        int max_wire,                                     // Maximum wire
                        float avg_pos,                                    // Averaged position of the shower
                        float avg_time,                                   // Averaged time of the shower
-                       const std::vector<int> wires_profile,             // Wires profile
-                       const std::vector<int> wires_constituents,        // Wires constituents
-                       const std::vector<int> wires_layer_constituents,  // Wires layer constituents
-                       const std::vector<int> wires_tdc_constituents     // Wires tdc constituents
+                       const std::vector<int>& wires_profile,             // Wires profile
+                       const std::vector<int>& wires_constituents,        // Wires constituents
+                       const std::vector<int>& wires_layer_constituents,  // Wires layer constituents
+                       const std::vector<int>& wires_tdc_constituents     // Wires tdc constituents
     );
 
     // Operations

--- a/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTShower.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTShower.cc
@@ -21,51 +21,52 @@
 //----------------
 // Constructors --
 //----------------
-L1Phase2MuDTShower::L1Phase2MuDTShower()
-    : m_wheel(0),
-      m_sector(0),
-      m_station(0),
-      m_superlayer(0),
-      m_ndigis(0),
-      m_bx(-100),
-      m_min_wire(0),
-      m_max_wire(0),
-      m_avg_pos(0),
-      m_avg_time(0) {
-  m_wires_profile.resize(96, 0);
-  m_wires_constituents.resize(50, 0);
-  m_wires_layer_constituents.resize(50, 0);
-  m_wires_tdc_constituents.resize(50, 0);
-}
+namespace io_v1 {
+  L1Phase2MuDTShower::L1Phase2MuDTShower()
+      : m_wheel(0),
+        m_sector(0),
+        m_station(0),
+        m_superlayer(0),
+        m_ndigis(0),
+        m_bx(-100),
+        m_min_wire(0),
+        m_max_wire(0),
+        m_avg_pos(0),
+        m_avg_time(0) {
+    m_wires_profile.resize(96, 0);
+    m_wires_constituents.resize(50, 0);
+    m_wires_layer_constituents.resize(50, 0);
+    m_wires_tdc_constituents.resize(50, 0);
+  }
 
-L1Phase2MuDTShower::L1Phase2MuDTShower(int wh,
-                                       int sc,
-                                       int st,
-                                       int sl,
-                                       int ndigis,
-                                       int bx,
-                                       int min_wire,
-                                       int max_wire,
-                                       float avg_pos,
-                                       float avg_time,
-                                       const std::vector<int> wires_profile,
-                                       const std::vector<int> wires_constituents,
-                                       const std::vector<int> wires_layer_constituents,
-                                       const std::vector<int> wires_tdc_constituents)
-    : m_wheel(wh),
-      m_sector(sc),
-      m_station(st),
-      m_superlayer(sl),
-      m_ndigis(ndigis),
-      m_bx(bx),
-      m_min_wire(min_wire),
-      m_max_wire(max_wire),
-      m_avg_pos(avg_pos),
-      m_avg_time(avg_time),
-      m_wires_profile(wires_profile),
-      m_wires_constituents(wires_constituents),
-      m_wires_layer_constituents(wires_layer_constituents),
-      m_wires_tdc_constituents(wires_tdc_constituents) {}
+  L1Phase2MuDTShower::L1Phase2MuDTShower(int wh,
+                                         int sc,
+                                         int st,
+                                         int sl,
+                                         int ndigis,
+                                         int bx,
+                                         int min_wire,
+                                         int max_wire,
+                                         float avg_pos,
+                                         float avg_time,
+                                         const std::vector<int> wires_profile,
+                                         const std::vector<int> wires_constituents,
+                                         const std::vector<int> wires_layer_constituents,
+                                         const std::vector<int> wires_tdc_constituents)
+      : m_wheel(wh),
+        m_sector(sc),
+        m_station(st),
+        m_superlayer(sl),
+        m_ndigis(ndigis),
+        m_bx(bx),
+        m_min_wire(min_wire),
+        m_max_wire(max_wire),
+        m_avg_pos(avg_pos),
+        m_avg_time(avg_time),
+        m_wires_profile(wires_profile),
+        m_wires_constituents(wires_constituents),
+        m_wires_layer_constituents(wires_layer_constituents),
+        m_wires_tdc_constituents(wires_tdc_constituents) {}
 
   //--------------
   // Operations --
@@ -91,7 +92,9 @@ L1Phase2MuDTShower::L1Phase2MuDTShower(int wh,
 
   float L1Phase2MuDTShower::avg_pos() const { return m_avg_pos; }
 
-std::vector<int> L1Phase2MuDTShower::wiresProfile() const { return m_wires_profile; }
-std::vector<int> L1Phase2MuDTShower::wiresConstituents() const { return m_wires_constituents; }
-std::vector<int> L1Phase2MuDTShower::wiresLayerConstituents() const { return m_wires_layer_constituents; }
-std::vector<int> L1Phase2MuDTShower::wiresTdcConstituents() const { return m_wires_tdc_constituents; }
+  std::vector<int> L1Phase2MuDTShower::wiresProfile() const { return m_wires_profile; }
+  std::vector<int> L1Phase2MuDTShower::wiresConstituents() const { return m_wires_constituents; }
+  std::vector<int> L1Phase2MuDTShower::wiresLayerConstituents() const { return m_wires_layer_constituents; }
+  std::vector<int> L1Phase2MuDTShower::wiresTdcConstituents() const { return m_wires_tdc_constituents; }
+
+}  // namespace io_v1

--- a/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTShower.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTShower.cc
@@ -21,44 +21,51 @@
 //----------------
 // Constructors --
 //----------------
-namespace io_v1 {
+L1Phase2MuDTShower::L1Phase2MuDTShower()
+    : m_wheel(0),
+      m_sector(0),
+      m_station(0),
+      m_superlayer(0),
+      m_ndigis(0),
+      m_bx(-100),
+      m_min_wire(0),
+      m_max_wire(0),
+      m_avg_pos(0),
+      m_avg_time(0) {
+  m_wires_profile.resize(96, 0);
+  m_wires_constituents.resize(50, 0);
+  m_wires_layer_constituents.resize(50, 0);
+  m_wires_tdc_constituents.resize(50, 0);
+}
 
-  L1Phase2MuDTShower::L1Phase2MuDTShower()
-      : m_wheel(0),
-        m_sector(0),
-        m_station(0),
-        m_superlayer(0),
-        m_ndigis(0),
-        m_bx(-100),
-        m_min_wire(0),
-        m_max_wire(0),
-        m_avg_pos(0),
-        m_avg_time(0) {
-    m_wires_profile.resize(96, 0);
-  }
-
-  L1Phase2MuDTShower::L1Phase2MuDTShower(int wh,
-                                         int sc,
-                                         int st,
-                                         int sl,
-                                         int ndigis,
-                                         int bx,
-                                         int min_wire,
-                                         int max_wire,
-                                         float avg_pos,
-                                         float avg_time,
-                                         const std::vector<int> wires_profile)
-      : m_wheel(wh),
-        m_sector(sc),
-        m_station(st),
-        m_superlayer(sl),
-        m_ndigis(ndigis),
-        m_bx(bx),
-        m_min_wire(min_wire),
-        m_max_wire(max_wire),
-        m_avg_pos(avg_pos),
-        m_avg_time(avg_time),
-        m_wires_profile(wires_profile) {}
+L1Phase2MuDTShower::L1Phase2MuDTShower(int wh,
+                                       int sc,
+                                       int st,
+                                       int sl,
+                                       int ndigis,
+                                       int bx,
+                                       int min_wire,
+                                       int max_wire,
+                                       float avg_pos,
+                                       float avg_time,
+                                       const std::vector<int> wires_profile,
+                                       const std::vector<int> wires_constituents,
+                                       const std::vector<int> wires_layer_constituents,
+                                       const std::vector<int> wires_tdc_constituents)
+    : m_wheel(wh),
+      m_sector(sc),
+      m_station(st),
+      m_superlayer(sl),
+      m_ndigis(ndigis),
+      m_bx(bx),
+      m_min_wire(min_wire),
+      m_max_wire(max_wire),
+      m_avg_pos(avg_pos),
+      m_avg_time(avg_time),
+      m_wires_profile(wires_profile),
+      m_wires_constituents(wires_constituents),
+      m_wires_layer_constituents(wires_layer_constituents),
+      m_wires_tdc_constituents(wires_tdc_constituents) {}
 
   //--------------
   // Operations --
@@ -84,6 +91,7 @@ namespace io_v1 {
 
   float L1Phase2MuDTShower::avg_pos() const { return m_avg_pos; }
 
-  std::vector<int> L1Phase2MuDTShower::wiresProfile() const { return m_wires_profile; }
-
-}  // namespace io_v1
+std::vector<int> L1Phase2MuDTShower::wiresProfile() const { return m_wires_profile; }
+std::vector<int> L1Phase2MuDTShower::wiresConstituents() const { return m_wires_constituents; }
+std::vector<int> L1Phase2MuDTShower::wiresLayerConstituents() const { return m_wires_layer_constituents; }
+std::vector<int> L1Phase2MuDTShower::wiresTdcConstituents() const { return m_wires_tdc_constituents; }

--- a/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTShower.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1Phase2MuDTShower.cc
@@ -32,12 +32,7 @@ namespace io_v1 {
         m_min_wire(0),
         m_max_wire(0),
         m_avg_pos(0),
-        m_avg_time(0) {
-    m_wires_profile.resize(96, 0);
-    m_wires_constituents.resize(50, 0);
-    m_wires_layer_constituents.resize(50, 0);
-    m_wires_tdc_constituents.resize(50, 0);
-  }
+        m_avg_time(0) {}
 
   L1Phase2MuDTShower::L1Phase2MuDTShower(int wh,
                                          int sc,
@@ -49,10 +44,10 @@ namespace io_v1 {
                                          int max_wire,
                                          float avg_pos,
                                          float avg_time,
-                                         const std::vector<int> wires_profile,
-                                         const std::vector<int> wires_constituents,
-                                         const std::vector<int> wires_layer_constituents,
-                                         const std::vector<int> wires_tdc_constituents)
+                                         const std::vector<int>& wires_profile,
+                                         const std::vector<int>& wires_constituents,
+                                         const std::vector<int>& wires_layer_constituents,
+                                         const std::vector<int>& wires_tdc_constituents)
       : m_wheel(wh),
         m_sector(sc),
         m_station(st),

--- a/DataFormats/L1DTTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1DTTrackFinder/src/classes_def.xml
@@ -15,7 +15,7 @@
   <version ClassVersion="3" checksum="178259425"/>
  </class>
 
-<class name="L1Phase2MuDTShower" ClassVersion="4">
+<class name="io_v1::L1Phase2MuDTShower" ClassVersion="4">
  <version ClassVersion="4" checksum="436071814"/>
  <version ClassVersion="3" checksum="2419604126"/>
  </class>

--- a/DataFormats/L1DTTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1DTTrackFinder/src/classes_def.xml
@@ -16,7 +16,7 @@
  </class>
 
 <class name="L1Phase2MuDTShower" ClassVersion="4">
- <version ClassVersion="4" checksum="2808103942"/>
+ <version ClassVersion="4" checksum="436071814"/>
  <version ClassVersion="3" checksum="448482846"/>
  </class>
 

--- a/DataFormats/L1DTTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1DTTrackFinder/src/classes_def.xml
@@ -15,8 +15,9 @@
   <version ClassVersion="3" checksum="178259425"/>
  </class>
 
- <class name="io_v1::L1Phase2MuDTShower" ClassVersion="3">
-  <version ClassVersion="3" checksum="2419604126"/>
+<class name="L1Phase2MuDTShower" ClassVersion="4">
+ <version ClassVersion="4" checksum="2808103942"/>
+ <version ClassVersion="3" checksum="448482846"/>
  </class>
 
  <class name="io_v1::L1Phase2MuDTExtPhDigi" ClassVersion="3">

--- a/DataFormats/L1DTTrackFinder/src/classes_def.xml
+++ b/DataFormats/L1DTTrackFinder/src/classes_def.xml
@@ -17,7 +17,7 @@
 
 <class name="L1Phase2MuDTShower" ClassVersion="4">
  <version ClassVersion="4" checksum="436071814"/>
- <version ClassVersion="3" checksum="448482846"/>
+ <version ClassVersion="3" checksum="2419604126"/>
  </class>
 
  <class name="io_v1::L1Phase2MuDTExtPhDigi" ClassVersion="3">

--- a/L1Trigger/DTTriggerPhase2/interface/DTprimitive.h
+++ b/L1Trigger/DTTriggerPhase2/interface/DTprimitive.h
@@ -19,6 +19,7 @@ public:
   void setTimeCorrection(int time) { timeCorrection_ = time; };
   void setTDCTimeStamp(int tstamp) { tdcTimeStamp_ = tstamp; };
   void setOrbit(int orb) { orbit_ = orb; }
+  void setOrbitCorrection(int orbc) { orbitCorrection_ = orbc; }
   void setPayload(double hitTag, int idx) { this->payLoad_[idx] = hitTag; };
   void setChannelId(int channel) { channelId_ = channel; };
   void setLayerId(int layer) { layerId_ = layer; };
@@ -29,7 +30,9 @@ public:
   const int timeCorrection() const { return timeCorrection_; };
   const int tdcTimeStamp() const { return tdcTimeStamp_; };
   const int orbit() const { return orbit_; };
+  const int orbitCorrection() const { return orbitCorrection_; };
   const int tdcTimeStampNoOffset() const { return tdcTimeStamp_ - timeCorrection_; };
+  const int orbitNoOffset() const { return orbit_ - orbitCorrection_; };
   const double payLoad(int idx) const { return payLoad_[idx]; };
   const int channelId() const { return channelId_; };
   const int layerId() const { return layerId_; };
@@ -50,6 +53,7 @@ private:
   cmsdt::LATERAL_CASES laterality_;  // LEFT, RIGHT, NONE
 
   int timeCorrection_;
+  int orbitCorrection_;
   int tdcTimeStamp_;
   int orbit_;
   double payLoad_[cmsdt::PAYLOAD_ENTRIES];

--- a/L1Trigger/DTTriggerPhase2/interface/ShowerBuilder.h
+++ b/L1Trigger/DTTriggerPhase2/interface/ShowerBuilder.h
@@ -18,6 +18,8 @@
 #include <iostream>
 #include <fstream>
 
+#include "TTree.h"
+
 // ===============================================================================
 // Previous definitions and declarations
 // ===============================================================================
@@ -89,16 +91,26 @@ namespace showerb {
     return aux_avgTime_ / nhits_;
   }
 
-  inline void set_wires_profile(std::vector<int>& wires_profile, DTPrimitives& hits) {
+  inline void set_wire_properties(ShowerCandidatePtr& shower_cand, DTPrimitives& hits) {
+    auto& wires_profile = shower_cand->getWiresProfile();
+    auto& wires_constituents = shower_cand->getWiresConstituents();
+    auto& wires_layer_constituents = shower_cand->getWiresLayerConstituents();
+    auto& wires_tdc_constituents = shower_cand->getWiresTdcConstituents();
+
     for (auto& hit : hits) {
       wires_profile[hit.channelId() - 1]++;
+      wires_constituents.push_back(hit.channelId());
+      wires_layer_constituents.push_back(hit.layerId());
+      wires_tdc_constituents.push_back(hit.tdcTimeStamp());
     }
   }
 
   inline bool buffer_contains(const ShowerBuffer& buffer, const DTPrimitive& hit) {
     for (const auto& item : buffer) {
-      if (item.second.channelId() == hit.channelId())
+      if (item.second.channelId() == hit.channelId() && item.second.layerId() == hit.layerId() &&
+          item.second.superLayerId() == hit.superLayerId()) {
         return true;
+      }
     }
     return false;
   }
@@ -116,6 +128,52 @@ namespace showerb {
   }
 
   inline void buffer_reset(ShowerBuffer& buffer) { buffer.clear(); }
+
+  inline std::string buffer_to_string(const ShowerBuffer& buffer) {
+    // Create a string representation of the buffer contents
+    // Format: [BX:SL:Layer:Wire, BX:SL:Layer:Wire, ...]
+    std::string contents = "[";
+    for (const auto& hit : buffer) {
+      if (contents.length() > 1)
+        contents += ", ";
+      contents += std::to_string(hit.first) + ":" + std::to_string(hit.second.superLayerId()) + ":" +
+                  std::to_string(hit.second.layerId()) + ":" + std::to_string(hit.second.channelId());
+    }
+    contents += "]";
+    return contents;
+  }
+
+  // Stream-like debug logger class
+  class DebugLogger {
+  public:
+    DebugLogger(const std::string& category) : category_(category) {}
+
+    // Template to accept any type with << operator
+    template <typename T>
+    DebugLogger& operator<<(const T& value) {
+      stream_ << value;
+      return *this;
+    }
+
+    // Handle std::endl and other manipulators
+    DebugLogger& operator<<(std::ostream& (*manip)(std::ostream&)) {
+      stream_ << manip;
+      return *this;
+    }
+
+    // Destructor - actually performs the logging
+    ~DebugLogger() {
+      LogDebug(category_) << stream_.str();
+      std::cout << stream_.str() << std::endl;
+    }
+
+  private:
+    std::string category_;
+    std::ostringstream stream_;
+  };
+
+  // Helper function to create the logger
+  inline DebugLogger log_debug(const std::string& category) { return DebugLogger(category); }
 }  // namespace showerb
 
 // ===============================================================================
@@ -125,54 +183,92 @@ namespace showerb {
 class ShowerBuilder {
 public:
   // Constructors and destructor
-  ShowerBuilder(const edm::ParameterSet& pset, edm::ConsumesCollector& iC);
+  ShowerBuilder(const edm::ParameterSet& pset,
+                edm::ConsumesCollector& iC,
+                TTree* tree);  // Changed from std::shared_ptr<TTree> to TTree*
 
   // Main methods
   void initialise(const edm::EventSetup& iEventSetup);
   void run(edm::Event& iEvent,
            const edm::EventSetup& iEventSetup,
            const DTDigiCollection& digis,
-           ShowerCandidatePtr& showerCandidate_SL1,
-           ShowerCandidatePtr& showerCandidate_SL3);
+           ShowerCandidatesMap& dtshowers_out,
+           const DTChamber* chamber);
 
 private:
   // Private auxiliary methods
   void clear();
   void setInChannels(const DTDigiCollection* digi);
-  void processHits_standAlone(std::map<int, ShowerCandidatePtr>& showerCands);
-  void processHitsFirmwareEmulation(std::map<int, ShowerCandidatePtr>& showerCands);
+  void processHits_standAlone();
+  void processHitsFirmwareEmulation();
 
   bool triggerShower(const showerb::ShowerBuffer& buffer);
   void set_shower_properties(ShowerCandidatePtr& showerCand,
                              showerb::ShowerBuffer& buffer,
                              int nhits = -1,
-                             int bx = -1,
                              int min_wire = -1,
                              int max_wire = -1,
                              float avg_pos = -1.,
                              float avg_time = -1.);
   void groupHits_byBx();
   void fill_obdt(const int bx);
-  void fill_bmtl1_buffers();
+  void fill_bmtl1_buffers(const int bx);
   void bxStep(const int _current_bx);
+  void dump_digi_to_tree(showerb::DTPrimPlusBx& hitpbx);
 
   // Private attributes
   const int showerTaggingAlgo_;
   const int threshold_for_shower_;
-  const int nHits_per_bx_;
-  const int obdt_hits_bxpersistence_;
+  const int nHits_per_bx_phi_;
+  const int nHits_per_bx_z_;
+  const int obdt_hits_bxpersistence_phi_;
+  const int obdt_hits_bxpersistence_z_;
   const int obdt_wire_relaxing_time_;
   const int bmtl1_hits_bxpersistence_;
   const bool debug_;
+  const bool dump_digis_;
   const int scenario_;
+  int bx_shift_back_;
+  int time_shift_back_;
 
   // auxiliary variables
   DTPrimitives all_hits;
   std::map<int, DTPrimitives, std::less<int>> all_hits_perBx;
-  showerb::ShowerBuffer obdt_buffer;       // Buffer to emulate the OBDT behavior
-  showerb::ShowerBuffer hot_wires_buffer;  // Buffer to emulate the hot wires behavior
-  showerb::ShowerBuffer bmtl1_sl1_buffer;  // Buffer to emulate the BMTL1 shower buffer for SL1
-  showerb::ShowerBuffer bmtl1_sl3_buffer;  // Buffer to emulate the BMTL1 shower buffer for SL3
+
+  std::map<int, ShowerCandidatePtrs> showerCands;  // defined as a map to easy acces with SL number
+
+  // initialize buffers
+  showerb::ShowerBuffer obdt_buffer_phi_;       // Buffer to emulate the OBDT behavior
+  showerb::ShowerBuffer obdt_buffer_z_;         // Buffer to emulate the OBDT behavior
+  showerb::ShowerBuffer hot_wires_buffer_phi_;  // Buffer to emulate the hot wires behavior in OBDT-phi
+  showerb::ShowerBuffer hot_wires_buffer_z_;    // Buffer to emulate the hot wires behavior in OBDT-z
+
+  std::map<int, std::pair<showerb::ShowerBuffer*, showerb::ShowerBuffer*>> obdt_buffers = {
+      {1, {&obdt_buffer_phi_, &hot_wires_buffer_phi_}},
+      {2, {&obdt_buffer_z_, &hot_wires_buffer_z_}},
+      {3, {&obdt_buffer_phi_, &hot_wires_buffer_phi_}}  // 1 and 3 point to the same buffers
+  };
+  showerb::ShowerBuffer bmtl1_sl1_buffer_;  // Buffer to emulate the BMTL1 behavior for SL1
+  showerb::ShowerBuffer bmtl1_sl3_buffer_;  // Buffer to emulate the BMTL1 behavior for SL3
+  showerb::ShowerBuffer bmtl1_sl2_buffer_;  // Buffer to emulate the BMTL1 behavior for SL2
+
+  std::map<int, showerb::ShowerBuffer*> bmtl1_buffers = {  // Buffers to emulate the BMTL1 shower buffer SL1, SL2, SL3
+      {1, &bmtl1_sl1_buffer_},
+      {3, &bmtl1_sl3_buffer_},
+      {2, &bmtl1_sl2_buffer_}};
+
+  // To dump digis in case requested
+  TTree* m_tree;
+
+  int m_event_number;
+  std::vector<short> m_hit_wheel;
+  std::vector<short> m_hit_sector;
+  std::vector<short> m_hit_station;
+  std::vector<short> m_hit_superlayer;
+  std::vector<short> m_hit_layer;
+  std::vector<int> m_hit_wire;
+  std::vector<float> m_hit_tdc;
+  std::vector<int> m_hit_bx;
 };
 
 #endif

--- a/L1Trigger/DTTriggerPhase2/interface/ShowerBuilder.h
+++ b/L1Trigger/DTTriggerPhase2/interface/ShowerBuilder.h
@@ -142,38 +142,6 @@ namespace showerb {
     contents += "]";
     return contents;
   }
-
-  // Stream-like debug logger class
-  class DebugLogger {
-  public:
-    DebugLogger(const std::string& category) : category_(category) {}
-
-    // Template to accept any type with << operator
-    template <typename T>
-    DebugLogger& operator<<(const T& value) {
-      stream_ << value;
-      return *this;
-    }
-
-    // Handle std::endl and other manipulators
-    DebugLogger& operator<<(std::ostream& (*manip)(std::ostream&)) {
-      stream_ << manip;
-      return *this;
-    }
-
-    // Destructor - actually performs the logging
-    ~DebugLogger() {
-      LogDebug(category_) << stream_.str();
-      std::cout << stream_.str() << std::endl;
-    }
-
-  private:
-    std::string category_;
-    std::ostringstream stream_;
-  };
-
-  // Helper function to create the logger
-  inline DebugLogger log_debug(const std::string& category) { return DebugLogger(category); }
 }  // namespace showerb
 
 // ===============================================================================
@@ -228,8 +196,8 @@ private:
   const bool debug_;
   const bool dump_digis_;
   const int scenario_;
-  int bx_shift_back_;
-  int time_shift_back_;
+  const int bx_shift_back_;
+  const int time_shift_back_;
 
   // auxiliary variables
   DTPrimitives all_hits;

--- a/L1Trigger/DTTriggerPhase2/interface/ShowerCandidate.h
+++ b/L1Trigger/DTTriggerPhase2/interface/ShowerCandidate.h
@@ -2,9 +2,10 @@
 #define L1Trigger_DTTriggerPhase2_ShowerCandidate_h
 #include <iostream>
 #include <memory>
+#include <map>
 
+#include "DataFormats/MuonDetId/interface/DTSuperLayerId.h"
 #include "L1Trigger/DTTriggerPhase2/interface/DTprimitive.h"
-#include "DataFormats/DTDigi/interface/DTDigiCollection.h"
 
 class ShowerCandidate {
 public:
@@ -30,6 +31,9 @@ public:
   float getAvgPos() { return avgPos_; }
   float getAvgTime() { return avgTime_; }
   std::vector<int>& getWiresProfile() { return wires_profile_; }
+  std::vector<int>& getWiresConstituents() { return wires_constituents_; }
+  std::vector<int>& getWiresLayerConstituents() { return wires_layer_constituents_; }
+  std::vector<int>& getWiresTdcConstituents() { return wires_tdc_constituents_; }
   bool isFlagged() { return shower_flag_; }
 
   // Other methods
@@ -48,10 +52,14 @@ private:
   float avgPos_;
   float avgTime_;
   std::vector<int> wires_profile_;
+  std::vector<int> wires_constituents_;
+  std::vector<int> wires_layer_constituents_;
+  std::vector<int> wires_tdc_constituents_;
 };
 
 typedef std::vector<ShowerCandidate> ShowerCandidates;
 typedef std::shared_ptr<ShowerCandidate> ShowerCandidatePtr;
 typedef std::vector<ShowerCandidatePtr> ShowerCandidatePtrs;
-
+typedef std::map<DTSuperLayerId, ShowerCandidatePtr> ShowerCandidateMap;
+typedef std::map<DTSuperLayerId, ShowerCandidatePtrs> ShowerCandidatesMap;
 #endif

--- a/L1Trigger/DTTriggerPhase2/interface/ShowerCandidate.h
+++ b/L1Trigger/DTTriggerPhase2/interface/ShowerCandidate.h
@@ -40,6 +40,7 @@ public:
   void clear();
 
 private:
+  int const WIRES_PROFILE_SIZE = 96;  // Expected buffer size for this variable in firmware
   //------------------------------------------------------------------
   //---  ShowerCandidate's data
   //------------------------------------------------------------------

--- a/L1Trigger/DTTriggerPhase2/plugins/BuildFile.xml
+++ b/L1Trigger/DTTriggerPhase2/plugins/BuildFile.xml
@@ -13,5 +13,6 @@
  <use name="Geometry/RPCGeometry"/>
  <use name="Geometry/Records"/>
  <use name="L1Trigger/DTTriggerPhase2"/>
+ <use name="CommonTools/UtilAlgos"/>
  <flags EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2ShowerProd.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2ShowerProd.cc
@@ -200,8 +200,7 @@ void DTTrigPhase2ShowerProd::produce(edm::Event& iEvent, const edm::EventSetup& 
   }
 
   if (debug_)
-    LogDebug("DTTrigPhase2ShowerProd")
-        << "    Hits preprocessed: " << digiMap.size() << " DT chambers to analyze";
+    LogDebug("DTTrigPhase2ShowerProd") << "    Hits preprocessed: " << digiMap.size() << " DT chambers to analyze";
 
   // 2. Look for showers in each chamber
   if (debug_)
@@ -227,8 +226,7 @@ void DTTrigPhase2ShowerProd::produce(edm::Event& iEvent, const edm::EventSetup& 
 
   // 3. Check shower candidates and store them if flagged
   if (debug_)
-    LogDebug("DTTrigPhase2ShowerProd")
-        << "    Selecting shower candidates (to check: " << showersMap.size() << " )";
+    LogDebug("DTTrigPhase2ShowerProd") << "    Selecting shower candidates (to check: " << showersMap.size() << " )";
 
   std::vector<L1Phase2MuDTShower> outShower;
   for (auto& sl_showerCandIt : showersMap) {

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2ShowerProd.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2ShowerProd.cc
@@ -141,14 +141,14 @@ DTTrigPhase2ShowerProd::DTTrigPhase2ShowerProd(const ParameterSet& pset)
   dtGeomH = esConsumes<DTGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
 
   if (debug_) {
-    showerb::log_debug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: constructor";
+    LogDebug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: constructor";
 
     if (showerTaggingAlgo_ == 0)
-      showerb::log_debug("DTTrigPhase2ShowerProd") << "Using standalone mode";
+      LogDebug("DTTrigPhase2ShowerProd") << "Using standalone mode";
     else if (showerTaggingAlgo_ == 1)
-      showerb::log_debug("DTTrigPhase2ShowerProd") << "Using firmware emulation mode";
+      LogDebug("DTTrigPhase2ShowerProd") << "Using firmware emulation mode";
     else
-      showerb::log_debug("DTTrigPhase2ShowerProd") << "Unrecognized shower tagging algorithm";
+      LogDebug("DTTrigPhase2ShowerProd") << "Unrecognized shower tagging algorithm";
   }
 }
 
@@ -164,12 +164,12 @@ DTTrigPhase2ShowerProd::~DTTrigPhase2ShowerProd() {
   }
 
   if (debug_)
-    showerb::log_debug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: destructor";
+    LogDebug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: destructor";
 }
 
 void DTTrigPhase2ShowerProd::beginRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) {
   if (debug_)
-    showerb::log_debug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: beginRun started";
+    LogDebug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: beginRun started";
 
   if (auto geom = iEventSetup.getHandle(dtGeomH)) {
     dtGeo_ = &(*geom);
@@ -180,7 +180,7 @@ void DTTrigPhase2ShowerProd::produce(edm::Event& iEvent, const edm::EventSetup& 
   showerBuilder->initialise(iEventSetup);
 
   if (debug_)
-    showerb::log_debug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: produce Processing event";
+    LogDebug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: produce Processing event";
 
   // Fetch the handle for hits
   edm::Handle<DTDigiCollection> dtdigis;
@@ -190,7 +190,7 @@ void DTTrigPhase2ShowerProd::produce(edm::Event& iEvent, const edm::EventSetup& 
   DTDigiMap digiMap;
   DTDigiCollection::DigiRangeIterator detUnitIt;
   if (debug_)
-    showerb::log_debug("DTTrigPhase2ShowerProd") << "    Preprocessing hits for event " << iEvent.id().event();
+    LogDebug("DTTrigPhase2ShowerProd") << "    Preprocessing hits for event " << iEvent.id().event();
 
   for (const auto& detUnitIt : *dtdigis) {
     const DTLayerId& layId = detUnitIt.first;
@@ -200,12 +200,12 @@ void DTTrigPhase2ShowerProd::produce(edm::Event& iEvent, const edm::EventSetup& 
   }
 
   if (debug_)
-    showerb::log_debug("DTTrigPhase2ShowerProd")
+    LogDebug("DTTrigPhase2ShowerProd")
         << "    Hits preprocessed: " << digiMap.size() << " DT chambers to analyze";
 
   // 2. Look for showers in each chamber
   if (debug_)
-    showerb::log_debug("DTTrigPhase2ShowerProd") << "    Building shower candidates for:";
+    LogDebug("DTTrigPhase2ShowerProd") << "    Building shower candidates for:";
 
   ShowerCandidatesMap showersMap;
   for (const auto& ich : dtGeo_->chambers()) {
@@ -217,7 +217,7 @@ void DTTrigPhase2ShowerProd::produce(edm::Event& iEvent, const edm::EventSetup& 
       continue;
 
     if (debug_)
-      showerb::log_debug("DTTrigPhase2ShowerProd") << "      " << chid;
+      LogDebug("DTTrigPhase2ShowerProd") << "      " << chid;
 
     showerBuilder->run(iEvent, iEventSetup, (*dmit).second, showersMap, chamb);
   }
@@ -227,7 +227,7 @@ void DTTrigPhase2ShowerProd::produce(edm::Event& iEvent, const edm::EventSetup& 
 
   // 3. Check shower candidates and store them if flagged
   if (debug_)
-    showerb::log_debug("DTTrigPhase2ShowerProd")
+    LogDebug("DTTrigPhase2ShowerProd")
         << "    Selecting shower candidates (to check: " << showersMap.size() << " )";
 
   std::vector<L1Phase2MuDTShower> outShower;
@@ -238,7 +238,7 @@ void DTTrigPhase2ShowerProd::produce(edm::Event& iEvent, const edm::EventSetup& 
         DTSuperLayerId slId(sl_showerCandIt.first.rawId());
 
         if (debug_)
-          showerb::log_debug("DTTrigPhase2ShowerProd")
+          LogDebug("DTTrigPhase2ShowerProd")
               << "      Shower candidate tagged in chamber" << slId.chamberId() << ", SL" << slId.superlayer();
 
         // 4. Storing results
@@ -262,7 +262,7 @@ void DTTrigPhase2ShowerProd::produce(edm::Event& iEvent, const edm::EventSetup& 
     }
   }
   if (debug_)
-    showerb::log_debug("DTTrigPhase2ShowerProd") << "    Storing results...";
+    LogDebug("DTTrigPhase2ShowerProd") << "    Storing results...";
 
   // 4.1 Storing results
   std::unique_ptr<L1Phase2MuDTShowerContainer> resultShower(new L1Phase2MuDTShowerContainer);
@@ -272,7 +272,7 @@ void DTTrigPhase2ShowerProd::produce(edm::Event& iEvent, const edm::EventSetup& 
 
 void DTTrigPhase2ShowerProd::endRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) {
   if (debug_)
-    showerb::log_debug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: endRun";
+    LogDebug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: endRun";
 }
 
 void DTTrigPhase2ShowerProd::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2ShowerProd.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2ShowerProd.cc
@@ -21,6 +21,10 @@
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "TFile.h"
+#include "TTree.h"
 
 // Include Geometry plugins
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
@@ -88,63 +92,95 @@ public:
 private:
   // Private methods/attributes
   bool debug_;                                       // Debug flag
-  int showerTaggingAlgo_;                            // Shower tagging algorithm
+  bool dump_digis_;                                  // Dump digis flag
   edm::InputTag digiTag_;                            // Digi collection label
+  int showerTaggingAlgo_;                            // Shower tagging algorithm
   edm::EDGetTokenT<DTDigiCollection> dtDigisToken_;  // Digi container
   std::unique_ptr<ShowerBuilder> showerBuilder;      // Shower builder instance
+
+  // TTree to dump digis
+  std::unique_ptr<TFile> shower_digis_file_;  // Only used if TFileService is not available
+  TTree* m_dumped_digis_tree;
+  bool using_tfileservice_;
 };
 
 /* Implementation of the plugin */
-DTTrigPhase2ShowerProd::DTTrigPhase2ShowerProd(const ParameterSet& pset) {
-  // Constructor implementation
+DTTrigPhase2ShowerProd::DTTrigPhase2ShowerProd(const ParameterSet& pset)
+    : debug_(pset.getUntrackedParameter<bool>("debug")),
+      dump_digis_(pset.getUntrackedParameter<bool>("dump_digis")),
+      digiTag_(pset.getParameter<edm::InputTag>("digiTag")),
+      showerTaggingAlgo_(pset.getParameter<int>("showerTaggingAlgo")),
+      using_tfileservice_(false) {
   produces<L1Phase2MuDTShowerContainer>();
-  // Unpack information from pset
-  debug_ = pset.getUntrackedParameter<bool>("debug");
-  digiTag_ = pset.getParameter<edm::InputTag>("digiTag");
-  showerTaggingAlgo_ = pset.getParameter<int>("showerTaggingAlgo");
+
+  if (dump_digis_) {
+    // Try to get TFileService
+    edm::Service<TFileService> fs;
+
+    if (fs.isAvailable()) {
+      // TFileService is available - use it
+      m_dumped_digis_tree = fs->make<TTree>("DTShowerDigisTree", "DT Shower Digis Tree");
+      using_tfileservice_ = true;
+    } else {
+      // TFileService not available - create a standalone TFile
+      shower_digis_file_ = std::make_unique<TFile>("shower_digis.root", "RECREATE");
+      m_dumped_digis_tree = new TTree("DTShowerDigisTree", "DT Shower Digis Tree");
+      using_tfileservice_ = false;
+    }
+  }
 
   // Fetch consumes
   dtDigisToken_ = consumes<DTDigiCollection>(digiTag_);
 
   // Algorithm functionalities
   edm::ConsumesCollector consumesColl(consumesCollector());
-  showerBuilder = std::make_unique<ShowerBuilder>(pset, consumesColl);
+  // Pass raw pointer directly - no shared_ptr wrapper needed
+  showerBuilder = std::make_unique<ShowerBuilder>(pset, consumesColl, dump_digis_ ? m_dumped_digis_tree : nullptr);
 
   // Load geometry
   dtGeomH = esConsumes<DTGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
 
   if (debug_) {
-    LogDebug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: constructor" << std::endl;
-    if (showerTaggingAlgo_ == 0) {
-      LogDebug("DTTrigPhase2ShowerProd") << "Using standalone mode" << std::endl;
-    } else if (showerTaggingAlgo_ == 1) {
-      LogDebug("DTTrigPhase2ShowerProd") << "Using firmware emulation mode" << std::endl;
-    } else
-      LogError("DTTrigPhase2ShowerProd") << "Unrecognized shower tagging algorithm" << std::endl;
+    showerb::log_debug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: constructor";
+
+    if (showerTaggingAlgo_ == 0)
+      showerb::log_debug("DTTrigPhase2ShowerProd") << "Using standalone mode";
+    else if (showerTaggingAlgo_ == 1)
+      showerb::log_debug("DTTrigPhase2ShowerProd") << "Using firmware emulation mode";
+    else
+      showerb::log_debug("DTTrigPhase2ShowerProd") << "Unrecognized shower tagging algorithm";
   }
 }
 
 DTTrigPhase2ShowerProd::~DTTrigPhase2ShowerProd() {
-  // Destructor implementation
+  if (dump_digis_ && !using_tfileservice_) {
+    // Only manage file ourselves if it was created. Not necessary if TFileService was used.
+    if (shower_digis_file_) {
+      shower_digis_file_->cd();
+      m_dumped_digis_tree->Write();
+      shower_digis_file_->Close();
+      delete m_dumped_digis_tree;  // Clean up our TTree
+    }
+  }
+
   if (debug_)
-    LogDebug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: destructor" << std::endl;
+    showerb::log_debug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: destructor";
 }
 
 void DTTrigPhase2ShowerProd::beginRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) {
-  // beginRun implementation
   if (debug_)
-    LogDebug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: beginRun started" << std::endl;
+    showerb::log_debug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: beginRun started";
 
-  showerBuilder->initialise(iEventSetup);
   if (auto geom = iEventSetup.getHandle(dtGeomH)) {
     dtGeo_ = &(*geom);
   }
 }
 
 void DTTrigPhase2ShowerProd::produce(edm::Event& iEvent, const edm::EventSetup& iEventSetup) {
-  // produce implementation
+  showerBuilder->initialise(iEventSetup);
+
   if (debug_)
-    LogDebug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: produce Processing event" << std::endl;
+    showerb::log_debug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: produce Processing event";
 
   // Fetch the handle for hits
   edm::Handle<DTDigiCollection> dtdigis;
@@ -154,77 +190,79 @@ void DTTrigPhase2ShowerProd::produce(edm::Event& iEvent, const edm::EventSetup& 
   DTDigiMap digiMap;
   DTDigiCollection::DigiRangeIterator detUnitIt;
   if (debug_)
-    LogDebug("DTTrigPhase2ShowerProd") << "    Preprocessing hits..." << std::endl;
+    showerb::log_debug("DTTrigPhase2ShowerProd") << "    Preprocessing hits for event " << iEvent.id().event();
 
   for (const auto& detUnitIt : *dtdigis) {
     const DTLayerId& layId = detUnitIt.first;
     const DTChamberId chambId = layId.superlayerId().chamberId();
-    const DTDigiCollection::Range& digi_range = detUnitIt.second;  // This is the digi collection
+    const DTDigiCollection::Range& digi_range = detUnitIt.second;
     digiMap[chambId].put(digi_range, layId);
   }
 
   if (debug_)
-    LogDebug("DTTrigPhase2ShowerProd") << "    Hits preprocessed: " << digiMap.size() << " DT chambers to analyze"
-                                       << std::endl;
+    showerb::log_debug("DTTrigPhase2ShowerProd")
+        << "    Hits preprocessed: " << digiMap.size() << " DT chambers to analyze";
 
   // 2. Look for showers in each chamber
   if (debug_)
-    LogDebug("DTTrigPhase2ShowerProd") << "    Building shower candidates for:" << std::endl;
+    showerb::log_debug("DTTrigPhase2ShowerProd") << "    Building shower candidates for:";
 
-  std::map<DTSuperLayerId, ShowerCandidatePtr> ShowerCandidates;
+  ShowerCandidatesMap showersMap;
   for (const auto& ich : dtGeo_->chambers()) {
     const DTChamber* chamb = ich;
     DTChamberId chid = chamb->id();
     DTDigiMap_iterator dmit = digiMap.find(chid);
 
-    DTSuperLayerId sl1id = chamb->superLayer(1)->id();
-    DTSuperLayerId sl3id = chamb->superLayer(3)->id();
-
     if (dmit == digiMap.end())
       continue;
 
     if (debug_)
-      LogDebug("DTTrigPhase2ShowerProd") << "      " << chid << std::endl;
+      showerb::log_debug("DTTrigPhase2ShowerProd") << "      " << chid;
 
-    showerBuilder->run(iEvent, iEventSetup, (*dmit).second, ShowerCandidates[sl1id], ShowerCandidates[sl3id]);
-
-    // Save the rawId of these shower candidates
-    ShowerCandidates[sl1id]->rawId(sl1id.rawId());
-    ShowerCandidates[sl3id]->rawId(sl3id.rawId());
+    showerBuilder->run(iEvent, iEventSetup, (*dmit).second, showersMap, chamb);
   }
+
+  if (dump_digis_)
+    m_dumped_digis_tree->Fill();
 
   // 3. Check shower candidates and store them if flagged
   if (debug_)
-    LogDebug("DTTrigPhase2ShowerProd") << "    Selecting shower candidates" << std::endl;
+    showerb::log_debug("DTTrigPhase2ShowerProd")
+        << "    Selecting shower candidates (to check: " << showersMap.size() << " )";
 
-  std::vector<L1Phase2MuDTShower> outShower;  // prepare output container
-  for (auto& sl_showerCand : ShowerCandidates) {
-    auto showerCandIt = sl_showerCand.second;
+  std::vector<L1Phase2MuDTShower> outShower;
+  for (auto& sl_showerCandIt : showersMap) {
+    auto& showerCandPtrs = sl_showerCandIt.second;
+    for (auto& showerCandPtr : showerCandPtrs) {
+      if (showerCandPtr->isFlagged()) {
+        DTSuperLayerId slId(sl_showerCandIt.first.rawId());
 
-    if (showerCandIt->isFlagged()) {
-      DTSuperLayerId slId(showerCandIt->getRawId());
+        if (debug_)
+          showerb::log_debug("DTTrigPhase2ShowerProd")
+              << "      Shower candidate tagged in chamber" << slId.chamberId() << ", SL" << slId.superlayer();
 
-      if (debug_) {
-        LogDebug("DTTrigPhase2ShowerProd")
-            << "      Shower candidate tagged in chamber" << slId.chamberId() << ", SL" << slId.superlayer();
+        // 4. Storing results
+        outShower.emplace_back(L1Phase2MuDTShower(
+            slId.wheel(),                                // Wheel
+            slId.sector(),                               // Sector
+            slId.station(),                              // Station
+            slId.superlayer(),                           // SuperLayer
+            showerCandPtr->getNhits(),                   // number of digis
+            showerCandPtr->getBX(),                      // BX
+            showerCandPtr->getMinWire(),                 // Min wire
+            showerCandPtr->getMaxWire(),                 // Max wire
+            showerCandPtr->getAvgPos(),                  // Average position
+            showerCandPtr->getAvgTime(),                 // Average time
+            showerCandPtr->getWiresProfile(),            // Wires profile
+            showerCandPtr->getWiresConstituents(),       // Wires constituents
+            showerCandPtr->getWiresLayerConstituents(),  // Wires layer constituents
+            showerCandPtr->getWiresTdcConstituents()     // Wires tdc constituents
+            ));
       }
-      // 4. Storing results
-      outShower.emplace_back(L1Phase2MuDTShower(slId.wheel(),                    // Wheel
-                                                slId.sector(),                   // Sector
-                                                slId.station(),                  // Station
-                                                slId.superlayer(),               // SuperLayer
-                                                showerCandIt->getNhits(),        // number of digis
-                                                showerCandIt->getBX(),           // BX
-                                                showerCandIt->getMinWire(),      // Min wire
-                                                showerCandIt->getMaxWire(),      // Max wire
-                                                showerCandIt->getAvgPos(),       // Average position
-                                                showerCandIt->getAvgTime(),      // Average time
-                                                showerCandIt->getWiresProfile()  // Wires profile
-                                                ));
     }
   }
   if (debug_)
-    LogDebug("DTTrigPhase2ShowerProd") << "    Storing results..." << std::endl;
+    showerb::log_debug("DTTrigPhase2ShowerProd") << "    Storing results...";
 
   // 4.1 Storing results
   std::unique_ptr<L1Phase2MuDTShowerContainer> resultShower(new L1Phase2MuDTShowerContainer);
@@ -233,9 +271,8 @@ void DTTrigPhase2ShowerProd::produce(edm::Event& iEvent, const edm::EventSetup& 
 }
 
 void DTTrigPhase2ShowerProd::endRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) {
-  // endRun implementation
   if (debug_)
-    LogDebug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: endRun" << std::endl;
+    showerb::log_debug("DTTrigPhase2ShowerProd") << "DTTrigPhase2ShowerProd: endRun";
 }
 
 void DTTrigPhase2ShowerProd::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -244,13 +281,15 @@ void DTTrigPhase2ShowerProd::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<edm::InputTag>("digiTag", edm::InputTag("CalibratedDigis"));
   desc.add<int>("showerTaggingAlgo", 1);
   desc.add<int>("threshold_for_shower", 6);
-  desc.add<int>("nHits_per_bx", 8);
-  desc.add<int>("obdt_hits_bxpersistence", 4);
+  desc.add<int>("nHits_per_bx_phi", 8);
+  desc.add<int>("nHits_per_bx_z", 8);
+  desc.add<int>("obdt_hits_bxpersistence_phi", 4);
+  desc.add<int>("obdt_hits_bxpersistence_z", 4);
   desc.add<int>("obdt_wire_relaxing_time", 2);
   desc.add<int>("bmtl1_hits_bxpersistence", 16);
   desc.add<int>("scenario", 0);
   desc.addUntracked<bool>("debug", false);
-
+  desc.addUntracked<bool>("dump_digis", false);
   descriptions.add("dtTriggerPhase2Shower", desc);
 }
 

--- a/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2Showers_cfi.py
+++ b/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2Showers_cfi.py
@@ -7,10 +7,12 @@ dtTriggerPhase2Shower = cms.EDProducer("DTTrigPhase2ShowerProd",
                                         digiTag = cms.InputTag("CalibratedDigis"),
                                         showerTaggingAlgo = cms.int32(1),
                                         threshold_for_shower = cms.int32(6),
-                                        nHits_per_bx = cms.int32(8),
-                                        obdt_hits_bxpersistence = cms.int32(4),
+                                        nHits_per_bx_phi = cms.int32(8),
+                                        nHits_per_bx_z = cms.int32(8),
+                                        obdt_hits_bxpersistence_phi = cms.int32(4),
+                                        obdt_hits_bxpersistence_z = cms.int32(4),
                                         obdt_wire_relaxing_time = cms.int32(2),
                                         bmtl1_hits_bxpersistence = cms.int32(16),
                                         debug = cms.untracked.bool(True),
-                                        scenario = cms.int32(0))
-
+                                        scenario = cms.int32(0),
+                                        dump_digis = cms.untracked.bool(False))

--- a/L1Trigger/DTTriggerPhase2/src/DTprimitive.cc
+++ b/L1Trigger/DTTriggerPhase2/src/DTprimitive.cc
@@ -15,6 +15,7 @@ DTPrimitive::DTPrimitive() {
   tdcTimeStamp_ = -1;
   orbit_ = -1;
   timeCorrection_ = 0;
+  orbitCorrection_ = 0;
   laterality_ = NONE;
 
   for (int i = 0; i < PAYLOAD_ENTRIES; i++)
@@ -24,6 +25,7 @@ DTPrimitive::DTPrimitive() {
 DTPrimitive::DTPrimitive(DTPrimitivePtr& ptr) {
   setTimeCorrection(ptr->timeCorrection());
   setTDCTimeStamp(ptr->tdcTimeStamp());
+  setOrbitCorrection(ptr->orbitCorrection());
   setOrbit(ptr->orbit());
   setChannelId(ptr->channelId());
   setLayerId(ptr->layerId());
@@ -38,6 +40,7 @@ DTPrimitive::DTPrimitive(DTPrimitivePtr& ptr) {
 DTPrimitive::DTPrimitive(DTPrimitive* ptr) {
   setTimeCorrection(ptr->timeCorrection());
   setTDCTimeStamp(ptr->tdcTimeStamp());
+  setOrbitCorrection(ptr->orbitCorrection());
   setOrbit(ptr->orbit());
   setChannelId(ptr->channelId());
   setLayerId(ptr->layerId());

--- a/L1Trigger/DTTriggerPhase2/src/ShowerBuilder.cc
+++ b/L1Trigger/DTTriggerPhase2/src/ShowerBuilder.cc
@@ -7,55 +7,101 @@ using namespace cmsdt;
 // ============================================================================
 // Constructors and destructor
 // ============================================================================
-ShowerBuilder::ShowerBuilder(const edm::ParameterSet &pset, edm::ConsumesCollector &iC)
+ShowerBuilder::ShowerBuilder(const edm::ParameterSet &pset, edm::ConsumesCollector &iC, TTree *tree)
     :  // Unpack information from pset
       showerTaggingAlgo_(pset.getParameter<int>("showerTaggingAlgo")),
       threshold_for_shower_(pset.getParameter<int>("threshold_for_shower")),
-      nHits_per_bx_(pset.getParameter<int>("nHits_per_bx")),
-      obdt_hits_bxpersistence_(pset.getParameter<int>("obdt_hits_bxpersistence")),
+      nHits_per_bx_phi_(pset.getParameter<int>("nHits_per_bx_phi")),
+      nHits_per_bx_z_(pset.getParameter<int>("nHits_per_bx_z")),
+      obdt_hits_bxpersistence_phi_(pset.getParameter<int>("obdt_hits_bxpersistence_phi")),
+      obdt_hits_bxpersistence_z_(pset.getParameter<int>("obdt_hits_bxpersistence_z")),
       obdt_wire_relaxing_time_(pset.getParameter<int>("obdt_wire_relaxing_time")),
       bmtl1_hits_bxpersistence_(pset.getParameter<int>("bmtl1_hits_bxpersistence")),
       debug_(pset.getUntrackedParameter<bool>("debug")),
-      scenario_(pset.getParameter<int>("scenario")) {}
+      dump_digis_(pset.getUntrackedParameter<bool>("dump_digis")),
+      scenario_(pset.getParameter<int>("scenario")),
+      m_tree(tree) {
+  int bx_shift = 0;
+  if (scenario_ == MC)         //scope for MC
+    bx_shift = 400;            // value used in standard CMSSW simulation
+  else if (scenario_ == DATA)  //scope for data
+    bx_shift = 0;
+  else if (scenario_ == SLICE_TEST)  //scope for slice test
+    bx_shift = 400;                  // slice test to mimic simulation
+
+  bx_shift_back_ = bx_shift;
+  time_shift_back_ = bx_shift_back_ * 25;
+  if (dump_digis_) {
+    // Book tree branches
+    m_tree->Branch("event_eventNumber", &m_event_number);
+    m_tree->Branch("wheel", &m_hit_wheel);
+    m_tree->Branch("sector", &m_hit_sector);
+    m_tree->Branch("station", &m_hit_station);
+    m_tree->Branch("superlayer", &m_hit_superlayer);
+    m_tree->Branch("layer", &m_hit_layer);
+    m_tree->Branch("wire", &m_hit_wire);
+    m_tree->Branch("tdc", &m_hit_tdc);
+    m_tree->Branch("bx", &m_hit_bx);
+  }
+}
 
 // ============================================================================
 // Main methods (initialise, run, finish)
 // ============================================================================
-void ShowerBuilder::initialise(const edm::EventSetup &iEventSetup) {}
+void ShowerBuilder::initialise(const edm::EventSetup &iEventSetup) {
+  // clear branch vectors - once per event
+  if (dump_digis_) {
+    m_hit_wheel.clear();
+    m_hit_sector.clear();
+    m_hit_station.clear();
+    m_hit_superlayer.clear();
+    m_hit_layer.clear();
+    m_hit_wire.clear();
+    m_hit_tdc.clear();
+    m_hit_bx.clear();
+  }
+}
 
 void ShowerBuilder::run(edm::Event &iEvent,
                         const edm::EventSetup &iEventSetup,
                         const DTDigiCollection &digis,
-                        ShowerCandidatePtr &showerCandidate_SL1,
-                        ShowerCandidatePtr &showerCandidate_SL3) {
+                        ShowerCandidatesMap &dtshowers_out,
+                        const DTChamber *chamber) {
+  m_event_number = iEvent.id().event();
   // Clear auxiliars
   clear();
   // Set the incoming hits in the channels
   setInChannels(&digis);
 
-  std::map<int, ShowerCandidatePtr> aux_showerCands{// defined as a map to easy acces with SL number
-                                                    {1, std::make_shared<ShowerCandidate>()},
-                                                    {3, std::make_shared<ShowerCandidate>()}};
-
   int nHits = all_hits.size();
   if (nHits != 0) {
-    if (debug_)
-      LogDebug("ShowerBuilder") << "        - Going to study " << nHits << " hits";
+    if (debug_) {
+      showerb::log_debug("ShowerBuilder") << "        - Going to study " << nHits << " hits";
+      for (auto &cand : showerCands) {
+        showerb::log_debug("ShowerBuilder")
+            << "        - Candidate vector for SL" << cand.first << " initialized with size " << cand.second.size();
+      }
+    }
     if (showerTaggingAlgo_ == 0) {
       // Standalone mode: just save hits and flag if the number of hits is above the threshold
-      processHits_standAlone(aux_showerCands);
+      processHits_standAlone();
     } else if (showerTaggingAlgo_ == 1) {
       // Firmware emulation:
       // mimics the behavior of sending and receiving hits from the OBDT to the shower algorithm in the BMTL1.
-      processHitsFirmwareEmulation(aux_showerCands);
+      processHitsFirmwareEmulation();
     }
   } else {
     if (debug_)
-      LogDebug("ShowerBuilder") << "        - No hits to study.";
+      showerb::log_debug("ShowerBuilder") << "        - No hits to study.";
   }
 
-  showerCandidate_SL1 = std::move(aux_showerCands[1]);
-  showerCandidate_SL3 = std::move(aux_showerCands[3]);
+  for (int sl : {1, 2, 3}) {
+    // MB4 stations does not have SL2, so check it first
+    if (chamber->superLayer(sl) && !showerCands[sl].empty()) {
+      DTSuperLayerId sl1id = chamber->superLayer(sl)->id();
+      dtshowers_out[sl1id] = std::move(showerCands[sl]);
+    }
+  }
 }
 
 // ============================================================================
@@ -64,26 +110,36 @@ void ShowerBuilder::run(edm::Event &iEvent,
 void ShowerBuilder::clear() {
   all_hits.clear();
   all_hits_perBx.clear();
-  showerb::buffer_reset(obdt_buffer);
-  showerb::buffer_reset(hot_wires_buffer);
-  showerb::buffer_reset(bmtl1_sl1_buffer);
-  showerb::buffer_reset(bmtl1_sl3_buffer);
+  // clear buffers
+  for (auto &pair : obdt_buffers) {
+    showerb::buffer_reset(*pair.second.first);
+    showerb::buffer_reset(*pair.second.second);
+  }
+  for (auto &pair : bmtl1_buffers) {
+    showerb::buffer_reset(*pair.second);
+  }
+  // recreated candidates each time since the results are moved out each run execution
+  showerCands = {{1, ShowerCandidatePtrs{}}, {3, ShowerCandidatePtrs{}}, {2, ShowerCandidatePtrs{}}};
 }
 
 void ShowerBuilder::setInChannels(const DTDigiCollection *digis) {
   for (const auto &dtLayerId_It : *digis) {
     const DTLayerId id = dtLayerId_It.first;
-    if (id.superlayer() == 2)
-      continue;  // Skip SL2 digis
-    // Now iterate over the digis
+    // iterate over the digis
     for (DTDigiCollection::const_iterator digiIt = (dtLayerId_It.second).first; digiIt != (dtLayerId_It.second).second;
          ++digiIt) {
       auto dtpAux = DTPrimitive();
+
       dtpAux.setTDCTimeStamp((*digiIt).time());
+      dtpAux.setTimeCorrection(time_shift_back_);
+      dtpAux.setOrbit((*digiIt).countsTDC() / (*digiIt).tdcBase());
+      dtpAux.setOrbitCorrection(bx_shift_back_);
       dtpAux.setChannelId((*digiIt).wire());
+
       dtpAux.setLayerId(id.layer());
       dtpAux.setSuperLayerId(id.superlayer());
       dtpAux.setCameraId(id.rawId());
+
       all_hits.push_back(dtpAux);
     }
   }
@@ -91,98 +147,105 @@ void ShowerBuilder::setInChannels(const DTDigiCollection *digis) {
   std::stable_sort(all_hits.begin(), all_hits.end(), showerb::hitTimeSort_shower);
 }
 
-void ShowerBuilder::processHits_standAlone(std::map<int, ShowerCandidatePtr> &showerCands) {
-  // For each superlayer, fill the buffer and check if nHits >= threshold
-  for (auto &hit : all_hits) {
-    showerb::DTPrimPlusBx _hitpbx(-1, hit);
-    if (hit.superLayerId() == 1)
-      bmtl1_sl1_buffer.push_back(_hitpbx);
-    else if (hit.superLayerId() == 3)
-      bmtl1_sl3_buffer.push_back(_hitpbx);
-  }
+void ShowerBuilder::processHits_standAlone() {
+  // Standalone mode: for each superlayer, fill the buffer and check if nHits >= threshold
+  std::map<int, ShowerCandidatePtr> candidates = {// only three  Candidates are possible in this case
+                                                  {1, std::make_shared<ShowerCandidate>()},
+                                                  {2, std::make_shared<ShowerCandidate>()},
+                                                  {3, std::make_shared<ShowerCandidate>()}};
 
-  if (triggerShower(bmtl1_sl1_buffer)) {
-    if (debug_) {
-      int nHits_sl1 = bmtl1_sl1_buffer.size();
-      LogDebug("ShowerBuilder") << "        o Shower found in SL1 with " << nHits_sl1 << " hits";
-    }
-    showerCands[1]->flag();
-    set_shower_properties(showerCands[1], bmtl1_sl1_buffer);
+  // Fill buffers
+  for (auto &hit : all_hits) {
+    int sl = hit.superLayerId();
+    bmtl1_buffers[sl]->push_back(showerb::DTPrimPlusBx(-1, hit));
   }
-  if (triggerShower(bmtl1_sl3_buffer)) {
-    if (debug_) {
-      int nHits_sl3 = bmtl1_sl3_buffer.size();
-      LogDebug("ShowerBuilder") << "        o Shower found in SL3 with " << nHits_sl3 << " hits";
+  // Process each superlayer
+  for (int sl : {1, 2, 3}) {
+    if (triggerShower(*bmtl1_buffers[sl])) {
+      if (debug_)
+        showerb::log_debug("ShowerBuilder")
+            << "        o Shower found in SL" << sl << " with " << bmtl1_buffers[sl]->size() << " hits";
+      candidates[sl]->flag();
+      set_shower_properties(candidates[sl], *bmtl1_buffers[sl]);
     }
-    showerCands[3]->flag();
-    set_shower_properties(showerCands[3], bmtl1_sl3_buffer);
+    showerCands[sl].push_back(candidates[sl]);
   }
 }
 
-void ShowerBuilder::processHitsFirmwareEmulation(std::map<int, ShowerCandidatePtr> &showerCands) {
+void ShowerBuilder::processHitsFirmwareEmulation() {
   // Use a for over BXs to emulate the behavior of the OBDT and BMTL1, this means considering:
-  // 1. OBDT can only store recived hits during 4 BXs (adjustable with obdt_hits_bxpersistence_)
-  // 2. OBDT can recive hits from the same wire during 2 BXs (adjustable with obdt_wire_relaxing_time_)
-  // 3. OBDT can only sends 8 hits per BX to the BMTL1 (adjustable with obdt_hits_per_bx_)
+  // 1. OBDT can only store recived hits during 4 BXs (adjustable with obdt_hits_bxpersistence_phi/z_)
+  // 2. OBDT can not recive hits from the same wire during 2 BXs (adjustable with obdt_wire_relaxing_time_)
+  // 3. OBDT can only sends 8 hits (less if OBDT-z) per BX to the BMTL1 (adjustable with obdt_hits_per_bx_phi/z)
   // 4. Shower algorithm in the BMTL1 mantains the hits along 16 BXs and triggers if nHits >= threshold (adjustable with bmtl1_hits_bxpersistence_)
   groupHits_byBx();
 
   // auxiliary variables
-  int prev_nHits_sl1 = 0;
-  int nHits_sl1 = 0;
-  bool shower_sl1_already_set = false;
-  int prev_nHits_sl3 = 0;
-  int nHits_sl3 = 0;
-  bool shower_sl3_already_set = false;
+  std::map<int, int> prev_nHits = {{1, 0}, {2, 0}, {3, 0}};
+  std::map<int, int> nHits = {{1, 0}, {2, 0}, {3, 0}};
+  std::map<int, bool> shower_already_set = {{1, false}, {2, false}, {3, false}};
+  // prepare the candidates with at least one entry for each superlayer
+  for (int sl : {1, 2, 3}) {
+    showerCands[sl].push_back(std::make_shared<ShowerCandidate>());
+  }
+
+  // necessary to don't lose the first hits in BMTL1 buffers
+  std::map<int, showerb::ShowerBuffer> prev_bmtl1_buffers_state_;
+
   // -------------------
 
   int min_bx = all_hits_perBx.begin()->first;
   int max_bx = all_hits_perBx.rbegin()->first;
 
   if (debug_)
-    LogDebug("ShowerBuilder") << "        - bx range: " << min_bx << " - " << max_bx << ", size: " << (max_bx - min_bx);
+    showerb::log_debug("ShowerBuilder") << "        - bx range: " << min_bx << " - " << max_bx
+                                        << ", size: " << (max_bx - min_bx);
 
   for (int bx = min_bx; bx <= max_bx + 17; bx++) {
+    // Clear old hits from buffers
+    bxStep(bx);
+
     fill_obdt(bx);
 
-    if (debug_)
-      LogDebug("ShowerBuilder") << "          ^ " << obdt_buffer.size() << " hits in obdt_buffer at BX " << bx;
-    fill_bmtl1_buffers();
-
-    nHits_sl1 = bmtl1_sl1_buffer.size();
-    if (debug_)
-      LogDebug("ShowerBuilder") << "          ^ " << nHits_sl1 << " hits in bmtl1_sl1_buffer at BX " << bx;
-    nHits_sl3 = bmtl1_sl3_buffer.size();
-    if (debug_)
-      LogDebug("ShowerBuilder") << "          ^ " << nHits_sl3 << " hits in bmtl1_sl3_buffer at BX " << bx;
-    if (triggerShower(bmtl1_sl1_buffer)) {
-      if (debug_ && !showerCands[1]->isFlagged()) {
-        LogDebug("ShowerBuilder") << "        o Shower found in SL1 with " << nHits_sl1 << " hits";
+    if (debug_) {
+      for (int sl : {1, 2}) {
+        showerb::log_debug("ShowerBuilder") << "          ^ OBDT buffer for SL" << sl << " at BX " << bx << ": "
+                                            << showerb::buffer_to_string(*obdt_buffers[sl].first);
+        showerb::log_debug("ShowerBuilder") << "          ^ Hot wires buffer for SL" << sl << " at BX " << bx << ": "
+                                            << showerb::buffer_to_string(*obdt_buffers[sl].second);
       }
-      showerCands[1]->flag();
     }
-    if (triggerShower(bmtl1_sl3_buffer)) {
-      if (debug_ && !showerCands[3]->isFlagged()) {
-        LogDebug("ShowerBuilder") << "        o Shower found in SL3 with " << nHits_sl3 << " hits";
+    fill_bmtl1_buffers(bx);
+
+    // For each superlayer, update nHits, print debug, check trigger, and set shower properties
+    for (int sl : {1, 2, 3}) {
+      nHits[sl] = bmtl1_buffers[sl]->size();
+
+      if (debug_)
+        showerb::log_debug("ShowerBuilder") << "          ^ bmtl1 buffer for SL" << sl << " at BX " << bx << ": "
+                                            << showerb::buffer_to_string(*bmtl1_buffers[sl]);
+
+      // Operate on last candidate in vector
+      ShowerCandidatePtr &cand = showerCands[sl].back();
+      // Trigger shower and flag
+      if (triggerShower(*bmtl1_buffers[sl]) && !cand->isFlagged()) {
+        if (debug_)
+          showerb::log_debug("ShowerBuilder")
+              << "        o Shower found in SL" << sl << " with " << nHits[sl] << " hits";
+        cand->flag();
       }
-      showerCands[3]->flag();
+      // Set shower properties if needed
+      if (nHits[sl] < prev_nHits[sl] && cand->isFlagged() && !shower_already_set[sl]) {
+        shower_already_set[sl] = true;
+        set_shower_properties(cand, prev_bmtl1_buffers_state_[sl], prev_nHits[sl]);
+      } else {
+        prev_nHits[sl] = nHits[sl];
+      }
+      if (cand->isFlagged() && !shower_already_set[sl]) {
+        // Save current buffer state for next iteration, ONLY for flagged showers that haven't been set yet
+        prev_bmtl1_buffers_state_[sl] = *bmtl1_buffers[sl];
+      }
     }
-
-    if (nHits_sl1 < prev_nHits_sl1 && showerCands[1]->isFlagged() && !shower_sl1_already_set) {
-      shower_sl1_already_set = true;
-      set_shower_properties(showerCands[1], bmtl1_sl1_buffer, nHits_sl1, bx);
-    } else {
-      prev_nHits_sl1 = nHits_sl1;
-    }
-
-    if (nHits_sl3 < prev_nHits_sl3 && showerCands[3]->isFlagged() && !shower_sl3_already_set) {
-      shower_sl3_already_set = true;
-      set_shower_properties(showerCands[3], bmtl1_sl3_buffer, nHits_sl3, bx);
-    } else {
-      prev_nHits_sl3 = nHits_sl3;
-    }
-
-    bxStep(bx);
   }
 }
 
@@ -197,11 +260,12 @@ bool ShowerBuilder::triggerShower(const showerb::ShowerBuffer &buffer) {
 void ShowerBuilder::set_shower_properties(ShowerCandidatePtr &showerCand,
                                           showerb::ShowerBuffer &buffer,
                                           int nhits,
-                                          int bx,
                                           int min_wire,
                                           int max_wire,
                                           float avg_pos,
                                           float avg_time) {
+  showerCand->setBX(buffer.front().first);
+
   DTPrimitives _hits;
 
   showerb::buffer_get_hits(buffer, _hits);
@@ -215,75 +279,128 @@ void ShowerBuilder::set_shower_properties(ShowerCandidatePtr &showerCand,
   avg_time = (avg_time == -1) ? showerb::compute_avg_time(_hits) : avg_time;
 
   showerCand->setNhits(nhits);
-  showerCand->setBX(bx);
   showerCand->setMinWire(min_wire);
   showerCand->setMaxWire(max_wire);
   showerCand->setAvgPos(avg_pos);
   showerCand->setAvgTime(avg_time);
-  showerb::set_wires_profile(showerCand->getWiresProfile(), _hits);
+
+  showerb::set_wire_properties(showerCand, _hits);
+
+  if (debug_) {
+    showerb::log_debug("ShowerBuilder") << "        o Setting shower properties with buffer: "
+                                        << showerb::buffer_to_string(buffer);
+    showerb::log_debug("ShowerBuilder") << "          - Setting BX: " << buffer.front().first;
+    showerb::log_debug("ShowerBuilder") << "          - Setting nhits: " << nhits;
+    showerb::log_debug("ShowerBuilder") << "          - Setting min_wire: " << min_wire;
+    showerb::log_debug("ShowerBuilder") << "          - Setting max_wire: " << max_wire;
+    showerb::log_debug("ShowerBuilder") << "          - Setting avg_pos: " << avg_pos;
+    showerb::log_debug("ShowerBuilder") << "          - Setting avg_time: " << avg_time;
+    showerb::log_debug("ShowerBuilder") << "          - Wire properties set successfully";
+  }
 }
 
 void ShowerBuilder::groupHits_byBx() {
-  double temp_shift = 0;
-  if (scenario_ == MC)         //scope for MC
-    temp_shift = 400;          // value used in standard CMSSW simulation
-  else if (scenario_ == DATA)  //scope for data
-    temp_shift = 0;
-  else if (scenario_ == SLICE_TEST)  //scope for slice test
-    temp_shift = 400;                // slice test to mimic simulation
-
-  static const double shift_back = temp_shift;
-
   all_hits_perBx.clear();
   // Group hits by BX
   for (auto &hit : all_hits) {
     // Compute the BX from the TDC time
-    int bx = hit.tdcTimeStamp() / 25 - shift_back;
+    int bx = hit.orbitNoOffset();
     all_hits_perBx[bx].push_back(hit);
   }
 }
 
 void ShowerBuilder::fill_obdt(const int bx) {
-  // Fill the OBDT buffer with the hits in the current BX this function ensure that hot wires are not added
-  if (all_hits_perBx.find(bx) != all_hits_perBx.end()) {
-    for (auto &hit : all_hits_perBx[bx]) {
+  // Fill the OBDT buffer with the hits in the current BX
+
+  if (all_hits_perBx.find(bx) == all_hits_perBx.end()) {
+    return;
+  }  // if there are not hits in this BX nothing to do
+
+  for (auto &hit : all_hits_perBx[bx]) {
+    int sl = hit.superLayerId();
+    auto &obdt_buffer = *obdt_buffers[sl].first;
+    auto &hot_wires_buffer = *obdt_buffers[sl].second;
+    if (debug_)
+      showerb::log_debug("ShowerBuilder") << "          ^ Trying to add hit with wire " << hit.layerId() << ":"
+                                          << hit.channelId() << " in OBDT sl:" << sl << " at BX " << bx;
+
+    if (!showerb::buffer_contains(hot_wires_buffer, hit)) {
       if (debug_)
-        LogDebug("ShowerBuilder") << "          ^ Trying to add hit with wire " << hit.channelId() << " in OBDT at BX "
-                                  << bx;
-      if (!showerb::buffer_contains(hot_wires_buffer, hit)) {
-        if (debug_)
-          LogDebug("ShowerBuilder") << "          ^ added";
-        showerb::DTPrimPlusBx _hit(bx, hit);
-        obdt_buffer.push_back(_hit);
-        hot_wires_buffer.push_back(_hit);
-      }
+        showerb::log_debug("ShowerBuilder") << "          ^ added";
+
+      showerb::DTPrimPlusBx _hit(bx, hit);
+      obdt_buffer.push_back(_hit);
+      hot_wires_buffer.push_back(_hit);
     }
   }
 }
 
-void ShowerBuilder::fill_bmtl1_buffers() {
-  // Fill the BMTL1 buffer with the hits in the OBDT buffer only nHits_per_bx_ hits are added
-  if (obdt_buffer.empty())
-    return;
-  if (debug_)
-    LogDebug("ShowerBuilder") << "          ^ Getting hits from OBDT";
-  for (int i = 0; i < nHits_per_bx_; i++) {
-    if (obdt_buffer.empty())
+void ShowerBuilder::fill_bmtl1_buffers(const int bx) {
+  // Fill the BMTL1 buffer with the hits in the OBDT buffer only nHits_per_bx_phi/z_ hits are added
+
+  // if all OBDT buffers are empty, nothing to do
+  bool all_empty = true;
+  for (int sl : {1, 2}) {
+    if (!obdt_buffers[sl].first->empty()) {
+      all_empty = false;
       break;
-    auto _hitpbx = obdt_buffer.front();
-    if (_hitpbx.second.superLayerId() == 1) {
-      bmtl1_sl1_buffer.push_back(_hitpbx);
-    } else if (_hitpbx.second.superLayerId() == 3) {
-      bmtl1_sl3_buffer.push_back(_hitpbx);
     }
-    obdt_buffer.pop_front();
+  }
+  if (all_empty)
+    return;
+
+  if (debug_)
+    showerb::log_debug("ShowerBuilder") << "          ^ Getting hits from OBDT";
+
+  std::map<int, int> hits_per_bx = {{1, nHits_per_bx_phi_}, {2, nHits_per_bx_z_}, {3, nHits_per_bx_phi_}};
+  int hits_count_phi_ = 0;
+  int hits_count_z_ = 0;
+  std::map<int, int *> hits_count = {{1, &hits_count_phi_}, {2, &hits_count_z_}, {3, &hits_count_phi_}};
+
+  for (const auto &pair : obdt_buffers) {
+    auto &obdt_buffer = *pair.second.first;
+    while (!obdt_buffer.empty()) {  // if empty, nothing to do
+      auto _hitpbx = obdt_buffer.front();
+      int sl = _hitpbx.second.superLayerId();
+      if (*hits_count[sl] >= hits_per_bx[sl])  // don't add more hits if the max per bx is reached
+        break;
+      _hitpbx.first = bx;  // set the correct BX in the hit in the context of the BMTL1 (BXsend)
+      bmtl1_buffers[sl]->push_back(_hitpbx);
+      (*hits_count[sl])++;
+      if (dump_digis_)
+        dump_digi_to_tree(_hitpbx);
+      obdt_buffer.pop_front();
+    }
   }
 }
 
 void ShowerBuilder::bxStep(const int _current_bx) {
   // Remove old elements from the buffers
-  showerb::buffer_clear_olds(obdt_buffer, _current_bx, obdt_hits_bxpersistence_);
-  showerb::buffer_clear_olds(hot_wires_buffer, _current_bx, obdt_hits_bxpersistence_);
-  showerb::buffer_clear_olds(bmtl1_sl1_buffer, _current_bx, bmtl1_hits_bxpersistence_);
-  showerb::buffer_clear_olds(bmtl1_sl3_buffer, _current_bx, bmtl1_hits_bxpersistence_);
+  std::map<int, int> obdt_hits_bxpersistences = {
+      {1, obdt_hits_bxpersistence_phi_}, {3, obdt_hits_bxpersistence_phi_}, {2, obdt_hits_bxpersistence_z_}};
+  for (auto &pair : obdt_buffers) {
+    int sl = pair.first;
+    showerb::buffer_clear_olds(*pair.second.first, _current_bx, obdt_hits_bxpersistences[sl]);
+    showerb::buffer_clear_olds(*pair.second.second, _current_bx, obdt_wire_relaxing_time_);
+  }
+
+  for (auto &pair : bmtl1_buffers) {
+    showerb::buffer_clear_olds(*pair.second, _current_bx, bmtl1_hits_bxpersistence_);
+  }
+}
+
+void ShowerBuilder::dump_digi_to_tree(showerb::DTPrimPlusBx &hitpbx) {
+  DTPrimitive &hit = hitpbx.second;
+
+  DTChamberId chId(hit.cameraId());
+
+  m_hit_wheel.push_back(chId.wheel());
+  m_hit_sector.push_back(chId.sector());
+  m_hit_station.push_back(chId.station());
+  m_hit_superlayer.push_back(hit.superLayerId());
+  m_hit_layer.push_back(hit.layerId());
+  m_hit_wire.push_back(hit.channelId());
+  m_hit_tdc.push_back(hit.tdcTimeStampNoOffset());
+  int bxsend = hitpbx.first;
+  m_hit_bx.push_back(bxsend);
 }

--- a/L1Trigger/DTTriggerPhase2/src/ShowerBuilder.cc
+++ b/L1Trigger/DTTriggerPhase2/src/ShowerBuilder.cc
@@ -20,17 +20,9 @@ ShowerBuilder::ShowerBuilder(const edm::ParameterSet &pset, edm::ConsumesCollect
       debug_(pset.getUntrackedParameter<bool>("debug")),
       dump_digis_(pset.getUntrackedParameter<bool>("dump_digis")),
       scenario_(pset.getParameter<int>("scenario")),
+      bx_shift_back_(scenario_ == MC || scenario_ == SLICE_TEST ? 400 : 0), // standard value used for MC and slice test, 0 for data
+      time_shift_back_(bx_shift_back_ * 25),
       m_tree(tree) {
-  int bx_shift = 0;
-  if (scenario_ == MC)         //scope for MC
-    bx_shift = 400;            // value used in standard CMSSW simulation
-  else if (scenario_ == DATA)  //scope for data
-    bx_shift = 0;
-  else if (scenario_ == SLICE_TEST)  //scope for slice test
-    bx_shift = 400;                  // slice test to mimic simulation
-
-  bx_shift_back_ = bx_shift;
-  time_shift_back_ = bx_shift_back_ * 25;
   if (dump_digis_) {
     // Book tree branches
     m_tree->Branch("event_eventNumber", &m_event_number);
@@ -76,9 +68,9 @@ void ShowerBuilder::run(edm::Event &iEvent,
   int nHits = all_hits.size();
   if (nHits != 0) {
     if (debug_) {
-      showerb::log_debug("ShowerBuilder") << "        - Going to study " << nHits << " hits";
+      LogDebug("ShowerBuilder") << "        - Going to study " << nHits << " hits";
       for (auto &cand : showerCands) {
-        showerb::log_debug("ShowerBuilder")
+        LogDebug("ShowerBuilder")
             << "        - Candidate vector for SL" << cand.first << " initialized with size " << cand.second.size();
       }
     }
@@ -92,7 +84,7 @@ void ShowerBuilder::run(edm::Event &iEvent,
     }
   } else {
     if (debug_)
-      showerb::log_debug("ShowerBuilder") << "        - No hits to study.";
+      LogDebug("ShowerBuilder") << "        - No hits to study.";
   }
 
   for (int sl : {1, 2, 3}) {
@@ -163,7 +155,7 @@ void ShowerBuilder::processHits_standAlone() {
   for (int sl : {1, 2, 3}) {
     if (triggerShower(*bmtl1_buffers[sl])) {
       if (debug_)
-        showerb::log_debug("ShowerBuilder")
+        LogDebug("ShowerBuilder")
             << "        o Shower found in SL" << sl << " with " << bmtl1_buffers[sl]->size() << " hits";
       candidates[sl]->flag();
       set_shower_properties(candidates[sl], *bmtl1_buffers[sl]);
@@ -198,7 +190,7 @@ void ShowerBuilder::processHitsFirmwareEmulation() {
   int max_bx = all_hits_perBx.rbegin()->first;
 
   if (debug_)
-    showerb::log_debug("ShowerBuilder") << "        - bx range: " << min_bx << " - " << max_bx
+    LogDebug("ShowerBuilder") << "        - bx range: " << min_bx << " - " << max_bx
                                         << ", size: " << (max_bx - min_bx);
 
   for (int bx = min_bx; bx <= max_bx + 17; bx++) {
@@ -209,9 +201,9 @@ void ShowerBuilder::processHitsFirmwareEmulation() {
 
     if (debug_) {
       for (int sl : {1, 2}) {
-        showerb::log_debug("ShowerBuilder") << "          ^ OBDT buffer for SL" << sl << " at BX " << bx << ": "
+        LogDebug("ShowerBuilder") << "          ^ OBDT buffer for SL" << sl << " at BX " << bx << ": "
                                             << showerb::buffer_to_string(*obdt_buffers[sl].first);
-        showerb::log_debug("ShowerBuilder") << "          ^ Hot wires buffer for SL" << sl << " at BX " << bx << ": "
+        LogDebug("ShowerBuilder") << "          ^ Hot wires buffer for SL" << sl << " at BX " << bx << ": "
                                             << showerb::buffer_to_string(*obdt_buffers[sl].second);
       }
     }
@@ -222,7 +214,7 @@ void ShowerBuilder::processHitsFirmwareEmulation() {
       nHits[sl] = bmtl1_buffers[sl]->size();
 
       if (debug_)
-        showerb::log_debug("ShowerBuilder") << "          ^ bmtl1 buffer for SL" << sl << " at BX " << bx << ": "
+        LogDebug("ShowerBuilder") << "          ^ bmtl1 buffer for SL" << sl << " at BX " << bx << ": "
                                             << showerb::buffer_to_string(*bmtl1_buffers[sl]);
 
       // Operate on last candidate in vector
@@ -230,7 +222,7 @@ void ShowerBuilder::processHitsFirmwareEmulation() {
       // Trigger shower and flag
       if (triggerShower(*bmtl1_buffers[sl]) && !cand->isFlagged()) {
         if (debug_)
-          showerb::log_debug("ShowerBuilder")
+          LogDebug("ShowerBuilder")
               << "        o Shower found in SL" << sl << " with " << nHits[sl] << " hits";
         cand->flag();
       }
@@ -287,15 +279,15 @@ void ShowerBuilder::set_shower_properties(ShowerCandidatePtr &showerCand,
   showerb::set_wire_properties(showerCand, _hits);
 
   if (debug_) {
-    showerb::log_debug("ShowerBuilder") << "        o Setting shower properties with buffer: "
+    LogDebug("ShowerBuilder") << "        o Setting shower properties with buffer: "
                                         << showerb::buffer_to_string(buffer);
-    showerb::log_debug("ShowerBuilder") << "          - Setting BX: " << buffer.front().first;
-    showerb::log_debug("ShowerBuilder") << "          - Setting nhits: " << nhits;
-    showerb::log_debug("ShowerBuilder") << "          - Setting min_wire: " << min_wire;
-    showerb::log_debug("ShowerBuilder") << "          - Setting max_wire: " << max_wire;
-    showerb::log_debug("ShowerBuilder") << "          - Setting avg_pos: " << avg_pos;
-    showerb::log_debug("ShowerBuilder") << "          - Setting avg_time: " << avg_time;
-    showerb::log_debug("ShowerBuilder") << "          - Wire properties set successfully";
+    LogDebug("ShowerBuilder") << "          - Setting BX: " << buffer.front().first;
+    LogDebug("ShowerBuilder") << "          - Setting nhits: " << nhits;
+    LogDebug("ShowerBuilder") << "          - Setting min_wire: " << min_wire;
+    LogDebug("ShowerBuilder") << "          - Setting max_wire: " << max_wire;
+    LogDebug("ShowerBuilder") << "          - Setting avg_pos: " << avg_pos;
+    LogDebug("ShowerBuilder") << "          - Setting avg_time: " << avg_time;
+    LogDebug("ShowerBuilder") << "          - Wire properties set successfully";
   }
 }
 
@@ -321,12 +313,12 @@ void ShowerBuilder::fill_obdt(const int bx) {
     auto &obdt_buffer = *obdt_buffers[sl].first;
     auto &hot_wires_buffer = *obdt_buffers[sl].second;
     if (debug_)
-      showerb::log_debug("ShowerBuilder") << "          ^ Trying to add hit with wire " << hit.layerId() << ":"
+      LogDebug("ShowerBuilder") << "          ^ Trying to add hit with wire " << hit.layerId() << ":"
                                           << hit.channelId() << " in OBDT sl:" << sl << " at BX " << bx;
 
     if (!showerb::buffer_contains(hot_wires_buffer, hit)) {
       if (debug_)
-        showerb::log_debug("ShowerBuilder") << "          ^ added";
+        LogDebug("ShowerBuilder") << "          ^ added";
 
       showerb::DTPrimPlusBx _hit(bx, hit);
       obdt_buffer.push_back(_hit);
@@ -350,7 +342,7 @@ void ShowerBuilder::fill_bmtl1_buffers(const int bx) {
     return;
 
   if (debug_)
-    showerb::log_debug("ShowerBuilder") << "          ^ Getting hits from OBDT";
+    LogDebug("ShowerBuilder") << "          ^ Getting hits from OBDT";
 
   std::map<int, int> hits_per_bx = {{1, nHits_per_bx_phi_}, {2, nHits_per_bx_z_}, {3, nHits_per_bx_phi_}};
   int hits_count_phi_ = 0;

--- a/L1Trigger/DTTriggerPhase2/src/ShowerBuilder.cc
+++ b/L1Trigger/DTTriggerPhase2/src/ShowerBuilder.cc
@@ -20,7 +20,9 @@ ShowerBuilder::ShowerBuilder(const edm::ParameterSet &pset, edm::ConsumesCollect
       debug_(pset.getUntrackedParameter<bool>("debug")),
       dump_digis_(pset.getUntrackedParameter<bool>("dump_digis")),
       scenario_(pset.getParameter<int>("scenario")),
-      bx_shift_back_(scenario_ == MC || scenario_ == SLICE_TEST ? 400 : 0), // standard value used for MC and slice test, 0 for data
+      bx_shift_back_(scenario_ == MC || scenario_ == SLICE_TEST
+                         ? 400
+                         : 0),  // standard value used for MC and slice test, 0 for data
       time_shift_back_(bx_shift_back_ * 25),
       m_tree(tree) {
   if (dump_digis_) {
@@ -70,8 +72,8 @@ void ShowerBuilder::run(edm::Event &iEvent,
     if (debug_) {
       LogDebug("ShowerBuilder") << "        - Going to study " << nHits << " hits";
       for (auto &cand : showerCands) {
-        LogDebug("ShowerBuilder")
-            << "        - Candidate vector for SL" << cand.first << " initialized with size " << cand.second.size();
+        LogDebug("ShowerBuilder") << "        - Candidate vector for SL" << cand.first << " initialized with size "
+                                  << cand.second.size();
       }
     }
     if (showerTaggingAlgo_ == 0) {
@@ -155,8 +157,8 @@ void ShowerBuilder::processHits_standAlone() {
   for (int sl : {1, 2, 3}) {
     if (triggerShower(*bmtl1_buffers[sl])) {
       if (debug_)
-        LogDebug("ShowerBuilder")
-            << "        o Shower found in SL" << sl << " with " << bmtl1_buffers[sl]->size() << " hits";
+        LogDebug("ShowerBuilder") << "        o Shower found in SL" << sl << " with " << bmtl1_buffers[sl]->size()
+                                  << " hits";
       candidates[sl]->flag();
       set_shower_properties(candidates[sl], *bmtl1_buffers[sl]);
     }
@@ -190,8 +192,7 @@ void ShowerBuilder::processHitsFirmwareEmulation() {
   int max_bx = all_hits_perBx.rbegin()->first;
 
   if (debug_)
-    LogDebug("ShowerBuilder") << "        - bx range: " << min_bx << " - " << max_bx
-                                        << ", size: " << (max_bx - min_bx);
+    LogDebug("ShowerBuilder") << "        - bx range: " << min_bx << " - " << max_bx << ", size: " << (max_bx - min_bx);
 
   for (int bx = min_bx; bx <= max_bx + 17; bx++) {
     // Clear old hits from buffers
@@ -202,9 +203,9 @@ void ShowerBuilder::processHitsFirmwareEmulation() {
     if (debug_) {
       for (int sl : {1, 2}) {
         LogDebug("ShowerBuilder") << "          ^ OBDT buffer for SL" << sl << " at BX " << bx << ": "
-                                            << showerb::buffer_to_string(*obdt_buffers[sl].first);
+                                  << showerb::buffer_to_string(*obdt_buffers[sl].first);
         LogDebug("ShowerBuilder") << "          ^ Hot wires buffer for SL" << sl << " at BX " << bx << ": "
-                                            << showerb::buffer_to_string(*obdt_buffers[sl].second);
+                                  << showerb::buffer_to_string(*obdt_buffers[sl].second);
       }
     }
     fill_bmtl1_buffers(bx);
@@ -215,15 +216,14 @@ void ShowerBuilder::processHitsFirmwareEmulation() {
 
       if (debug_)
         LogDebug("ShowerBuilder") << "          ^ bmtl1 buffer for SL" << sl << " at BX " << bx << ": "
-                                            << showerb::buffer_to_string(*bmtl1_buffers[sl]);
+                                  << showerb::buffer_to_string(*bmtl1_buffers[sl]);
 
       // Operate on last candidate in vector
       ShowerCandidatePtr &cand = showerCands[sl].back();
       // Trigger shower and flag
       if (triggerShower(*bmtl1_buffers[sl]) && !cand->isFlagged()) {
         if (debug_)
-          LogDebug("ShowerBuilder")
-              << "        o Shower found in SL" << sl << " with " << nHits[sl] << " hits";
+          LogDebug("ShowerBuilder") << "        o Shower found in SL" << sl << " with " << nHits[sl] << " hits";
         cand->flag();
       }
       // Set shower properties if needed
@@ -280,7 +280,7 @@ void ShowerBuilder::set_shower_properties(ShowerCandidatePtr &showerCand,
 
   if (debug_) {
     LogDebug("ShowerBuilder") << "        o Setting shower properties with buffer: "
-                                        << showerb::buffer_to_string(buffer);
+                              << showerb::buffer_to_string(buffer);
     LogDebug("ShowerBuilder") << "          - Setting BX: " << buffer.front().first;
     LogDebug("ShowerBuilder") << "          - Setting nhits: " << nhits;
     LogDebug("ShowerBuilder") << "          - Setting min_wire: " << min_wire;
@@ -313,8 +313,8 @@ void ShowerBuilder::fill_obdt(const int bx) {
     auto &obdt_buffer = *obdt_buffers[sl].first;
     auto &hot_wires_buffer = *obdt_buffers[sl].second;
     if (debug_)
-      LogDebug("ShowerBuilder") << "          ^ Trying to add hit with wire " << hit.layerId() << ":"
-                                          << hit.channelId() << " in OBDT sl:" << sl << " at BX " << bx;
+      LogDebug("ShowerBuilder") << "          ^ Trying to add hit with wire " << hit.layerId() << ":" << hit.channelId()
+                                << " in OBDT sl:" << sl << " at BX " << bx;
 
     if (!showerb::buffer_contains(hot_wires_buffer, hit)) {
       if (debug_)

--- a/L1Trigger/DTTriggerPhase2/src/ShowerCandidate.cc
+++ b/L1Trigger/DTTriggerPhase2/src/ShowerCandidate.cc
@@ -31,4 +31,7 @@ void ShowerCandidate::clear() {
   avgTime_ = 0;
   shower_flag_ = false;
   wires_profile_.resize(96, 0);
+  wires_constituents_.clear();
+  wires_layer_constituents_.clear();
+  wires_tdc_constituents_.clear();
 }

--- a/L1Trigger/DTTriggerPhase2/src/ShowerCandidate.cc
+++ b/L1Trigger/DTTriggerPhase2/src/ShowerCandidate.cc
@@ -30,7 +30,7 @@ void ShowerCandidate::clear() {
   avgPos_ = 0;
   avgTime_ = 0;
   shower_flag_ = false;
-  wires_profile_.resize(96, 0);
+  wires_profile_.resize(ShowerCandidate::WIRES_PROFILE_SIZE, 0);
   wires_constituents_.clear();
   wires_layer_constituents_.clear();
   wires_tdc_constituents_.clear();


### PR DESCRIPTION
This PR implements SL2 support, enriches shower metadata, and refactors the buffer model to align with firmware-like behavior.

### Key Changes
*   **Support SL2:** Integrate Super Layer 2 shower primitives.
*   **Fix Buffer Logic:** Identify hits by both wire and layer in `buffer_contains` to prevent data loss.
*   **Improve Timing:** Assign shower BX based on the first received hit.
*   **Refactor Buffering:** Overhaul buffer handling and candidate containers to capture missing early hits.
*   **Enhance Metadata:** Track wire, layer, and TDC for all digis used in shower construction.
*   **Future-Proof Containers:** Use vectors for shower candidates to support future multi-candidate output.

### Other changes
*   **ROOT Output:** Enable saving shower-associated hits in ROOT format for offline debugging.
*   **Logging:** Add a stream-like helper for standardized log messaging.
*   **Orbit Support:** Extend `DTPrimitive` with orbit-correction capabilities.

### Impact
* The resulting logic more closely emulates expected firmware behavior.
* These updates increase the shower production / rate.

More details in this [presentation](https://indico.cern.ch/event/1695073/contributions/7127869/attachments/3288534/5879344/presentacion-cmsl1trigger-meeting-040626.pdf)
