### PR TITLE
Properly Counting `maxDepth` as no. of Doublets in the CA

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/alpaka/CACell.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CACell.h
@@ -228,9 +228,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         if (last) {  // if long enough save...
           if ((unsigned int)(tmpNtuplet.size()) >= minHitsPerNtuplet - 1) {
             {
-              hindex_type hits[TrackerTraits::maxDepth + 2];
+              constexpr int maxFB = 2;  // for the time being let's limit this - fishbone extra hits limit
+              // maxDepth is the number of CACells. So +maxFB for the fishbone and +1 to properly count the number of hits
+              hindex_type hits
+                  [TrackerTraits::maxDepth + maxFB +
+                   1];  // maxDepth is the number of CACells. So +maxFB for the fishbone and +1 to properly count the number of hits
+
               auto nh = 0U;
-              constexpr int maxFB = 2;  // for the time being let's limit this
               int nfb = 0;
               for (auto c : tmpNtuplet) {
                 hits[nh++] = cells[c].theInnerHitId_;


### PR DESCRIPTION
#### PR description:

This PR proposes a small fix to the issue seen in https://github.com/cms-sw/cmssw/issues/49525. The problem was actually understood by @elusian, and it's due to the fact that `maxDepth` is the max number of `CACell`s that can compose an n-Tuplet. This means each track can have up to  `maxDepth + 1 ` hits. The container is sized to be `maxDepth + 2` to take into account the extra fishbone hits. But it should actually be `maxDepth + 1 + 2`.

#### PR validation:

```
cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:@relvalRun4 --conditions auto:phase2_realistic_T35 --datatier GEN-SIM-DIGI-RAW -n 10 --eventcontent FEVTDEBUGHLT --geometry ExtendedRun4D121 --era Phase2C22I13M9 --pileup AVE_200_BX_25ns --pileup_input das:/RelValMinBias_14TeV/CMSSW_16_0_0_pre2-150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D121_noPU-v1/GEN-SIM --filein /store/user/cmsbuild/store/relval/CMSSW_16_0_0_pre2/RelValTTbar_14TeV/GEN-SIM/150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D121_noPU-v1/2580000/2dbf40fb-f8dd-43d5-8ec9-f9e02cac4636.root --fileout file:step2.root --nThreads 4
```

runs in `CMSSW_17_0_ASAN_X_2026-05-06-2300`.