### PR TITLE
[NGT] Fix content of `SiPixelClusterSoA` for empty Pixel Detector

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelPhase2DigiToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelPhase2DigiToCluster.cc
@@ -141,8 +141,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
     digis_d_ = SiPixelDigisSoACollection(iEvent.queue(), nDigis_);
 
-    if (nDigis_ == 0)
+    if (nDigis_ == 0) {
+      algo_.zeroInitializePhase2Clusters(iEvent.queue());
       return;
+    }
 
     SiPixelDigisHost digis_h(iEvent.queue(), nDigis_);
 
@@ -170,14 +172,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   }
 
   void SiPixelPhase2DigiToCluster::produce(device::Event& iEvent, device::EventSetup const& iSetup) {
-    if (nDigis_ == 0) {
-      iEvent.emplace(digiPutToken_, std::move(*digis_d_));
-      iEvent.emplace(clusterPutToken_, iEvent.queue(), pixelTopology::Phase2::numberOfModules);
-    } else {
+    if (nDigis_ != 0)
       digis_d_->setNModules(algo_.nModules());
-      iEvent.emplace(digiPutToken_, std::move(*digis_d_));
-      iEvent.emplace(clusterPutToken_, algo_.getClusters());
-    }
+
+    iEvent.emplace(digiPutToken_, std::move(*digis_d_));
+    iEvent.emplace(clusterPutToken_, algo_.getClusters());
     digis_d_.reset();
   }
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -777,6 +777,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       constexpr int numberOfModules = pixelTopology::Phase2::numberOfModules;
       clusters_d = SiPixelClustersSoACollection(queue, numberOfModules);
       clusters_d->zeroInitialise(queue);
+      // set moduleStartFirstElement, moduleStartLastElement and bpix2ClusterStart on the host to zero
+      // these changes are later propagated to the device portable collection during getDigis() and getClusters()
+      nModules_Clusters_h[0] = 0;
+      nModules_Clusters_h[1] = 0;
+      nModules_Clusters_h[2] = 0;
     }
 
     template class SiPixelRawToClusterKernel<pixelTopology::Phase1>;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -771,6 +771,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #endif
     }  //
 
+    // Function to zero-initialize the clusters
+    template <typename TrackerTraits>
+    void SiPixelRawToClusterKernel<TrackerTraits>::zeroInitializePhase2Clusters(Queue &queue) {
+      constexpr int numberOfModules = pixelTopology::Phase2::numberOfModules;
+      clusters_d = SiPixelClustersSoACollection(queue, numberOfModules);
+      clusters_d->zeroInitialise(queue);
+    }
+
     template class SiPixelRawToClusterKernel<pixelTopology::Phase1>;
     template class SiPixelRawToClusterKernel<pixelTopology::Phase2>;
     template class SiPixelRawToClusterKernel<pixelTopology::HIonPhase1>;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
@@ -177,6 +177,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                    const uint32_t numDigis,
                                    const uint32_t offsetBPIX2);
 
+      void zeroInitializePhase2Clusters(Queue& queue);
+
       SiPixelDigisSoACollection getDigis() {
         digis_d->setNModules(nModules_Clusters_h[0]);
         return std::move(*digis_d);


### PR DESCRIPTION
#### PR description:

This PR is introducing the zero-initialization of the `SiPixelClusterSoA` for events with zero digis in the pixel detector. It fixes an issue that is arising later in the CA pixel tracking when the (previously wrong) values of the SoA are used, leading to crashes. This is described in detail in #50881 .

#### PR validation:

It is a minor change that only affects empty events in the pixel tracker. I tested on the previously crashing workflow `34090.203`, which runs after these changes. For any further validation the bot-tests should be sufficient.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.
