### PR TITLE
Update the 2026 HI MC GT in autoCond with a new L1T menu

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -116,7 +116,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2026, Strip tracker in DECO mode
     'phase1_2026_cosmics'          :    '160X_mcRun3_2026cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2026 detector for Heavy Ion
-    'phase1_2026_realistic_hi'     :    '151X_mcRun3_2025_realistic_HI_v5',
+    'phase1_2026_realistic_hi'     :    '161X_mcRun3_2026_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '150X_mcRun4_realistic_v1'
 }


### PR DESCRIPTION
#### PR description:

A new GT was prepared in 161X for the 2026 HI MC campaign, as requested in https://cms-talk.web.cern.ch/t/gt-mc-hin-request-for-a-pbpb-run-mc-queue-in-161x/143262/15

The new 2026 HI MC GT is [161X_mcRun3_2026_realistic_HI_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/161X_mcRun3_2026_realistic_HI_v2) and the difference with the previous HI MC GT in autoCond is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/161X_mcRun3_2026_realistic_HI_v2/151X_mcRun3_2025_realistic_HI_v5) (only the L1T menu was updated with respect to the 2025 HI MC GT so far).

#### PR validation:

Rely on the PR tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It will be backported in CMSSW_16_1_X for the 2026 HI MC productions