### PR TITLE
Removing default/invalid (-999 ns) HCAL rechit timings from HCAL PF cluster time calculation

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -59,6 +59,7 @@ public:
       logWeightDenom.push_back(conf.getParameter<double>("logWeightDenominator"));
     }
 
+    logWeightDenomInv.reserve(depths.size());
     for (unsigned int i = 0; i < depths.size(); ++i) {
       logWeightDenomInv.push_back(1. / logWeightDenom[i]);
     }

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -180,14 +180,14 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
       res2 = isBarrel(cell_layer) ? 1. / _timeResolutionCalcBarrel->timeResolution2(rh_rawenergy)
                                   : 1. / _timeResolutionCalcEndcap->timeResolution2(rh_rawenergy);
       if (refhit.time() != -999) {
-	cl_time += rh_fraction * refhit.time() * res2;
-	cl_timeweight += rh_fraction * res2;
+        cl_time += rh_fraction * refhit.time() * res2;
+        cl_timeweight += rh_fraction * res2;
       }
     } else {  // assume resolution = 1/E**2
       const double rh_rawenergy2 = rh_rawenergy * rh_rawenergy;
       if (refhit.time() != -999) {
-	cl_timeweight += rh_rawenergy2 * rh_fraction;
-	cl_time += rh_rawenergy2 * rh_fraction * refhit.time();
+        cl_timeweight += rh_rawenergy2 * rh_fraction;
+        cl_time += rh_rawenergy2 * rh_fraction * refhit.time();
       }
     }
 
@@ -198,8 +198,10 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
   }
 
   cluster.setEnergy(cl_energy);
-  if (cl_timeweight == 0) cluster.setTime(-999); // means no cells with valid timing in the cluster -- thus, report default time
-  else cluster.setTime(cl_time / cl_timeweight);
+  if (cl_timeweight == 0)
+    cluster.setTime(-999);  // means no cells with valid timing in the cluster -- thus, report default time
+  else
+    cluster.setTime(cl_time / cl_timeweight);
   if (resGiven) {
     cluster.setTimeError(std::sqrt(1.0f / float(cl_timeweight)));
   }

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -59,7 +59,6 @@ public:
       logWeightDenom.push_back(conf.getParameter<double>("logWeightDenominator"));
     }
 
-    logWeightDenomInv.reserve(depths.size());
     for (unsigned int i = 0; i < depths.size(); ++i) {
       logWeightDenomInv.push_back(1. / logWeightDenom[i]);
     }
@@ -179,12 +178,16 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
       int cell_layer = (int)refhit.layer();
       res2 = isBarrel(cell_layer) ? 1. / _timeResolutionCalcBarrel->timeResolution2(rh_rawenergy)
                                   : 1. / _timeResolutionCalcEndcap->timeResolution2(rh_rawenergy);
-      cl_time += rh_fraction * refhit.time() * res2;
-      cl_timeweight += rh_fraction * res2;
+      if (refhit.time() != -999) {
+	cl_time += rh_fraction * refhit.time() * res2;
+	cl_timeweight += rh_fraction * res2;
+      }
     } else {  // assume resolution = 1/E**2
       const double rh_rawenergy2 = rh_rawenergy * rh_rawenergy;
-      cl_timeweight += rh_rawenergy2 * rh_fraction;
-      cl_time += rh_rawenergy2 * rh_fraction * refhit.time();
+      if (refhit.time() != -999) {
+	cl_timeweight += rh_rawenergy2 * rh_fraction;
+	cl_time += rh_rawenergy2 * rh_fraction * refhit.time();
+      }
     }
 
     if (rh_energy > max_e) {
@@ -194,7 +197,8 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
   }
 
   cluster.setEnergy(cl_energy);
-  cluster.setTime(cl_time / cl_timeweight);
+  if (cl_timeweight == 0) cluster.setTime(-999); // means no cells with valid timing in the cluster -- thus, report default time
+  else cluster.setTime(cl_time / cl_timeweight);
   if (resGiven) {
     cluster.setTimeError(std::sqrt(1.0f / float(cl_timeweight)));
   }


### PR DESCRIPTION
#### PR description:

All HCAL PF rechits are currently considered in the computation of the HCAL PF cluster time, even when those rechits have an "invalid" time (from the MAHI fit) of -999 reported. The PF cluster time is computed as an energy weighted time average of all associated rechits, and ends up reporting non-physical values such as -300ns due to averaging in the default -999ns hit times. This PR excludes those rechits with reported times of -999, such that the cluster time is only computed with valid rechit times. If no rechits associated to the cluster have a valid time, then the cluster time is also reported as -999ns.

This removes the long tail of cluster times between -999ns and about -20ns. This doesn't change anything about the PF algorithm, just reports the HCAL PF cluster time as a more meaningful quantity instead of a smeared / contaminated average value. 

#### PR validation:

- Ran a re-reco on single pion gun MC sample and produced validation plots (in CMSSW_15_0_6). The HCAL cluster time now agrees with the energy weighted mean of valid rechit time, and the tail of negative times above -999 is removed. The total number of PF rechits per cluster and fraction of rechits with timing = -999 is the same before and after the change (the PF algorithm is not impacted). See plots in slides: [PF_timing_validation.pdf](https://github.com/user-attachments/files/27414831/PF_timing_validation.pdf)
- Ran `runTheMatrix.py -l limited -i all --ibeos` (some failed to execute due to missing "lumi_ranges.txt")
- Code checks and format checks run

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.

cc: @ahinzmann 