### PR TITLE
[EVOLUTION_X] Disable `TestCalibrationLumiAlCaRecoProducers` test because it reads a file with old data formats

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/test/BuildFile.xml
+++ b/Calibration/LumiAlCaRecoProducers/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="TestCalibrationLumiAlCaRecoProducers" command="test.sh"/>
+<!-- <test name="TestCalibrationLumiAlCaRecoProducers" command="test.sh"/> COMMENT: reads old format file -->


### PR DESCRIPTION
#### PR description:

Should fix (really hide) the failure of `TestCalibrationLumiAlCaRecoProducers` test in EVOLUTION_X IB
```
%MSG-w RootInputFileSequence:  file_open 09-May-2026 03:05:29 CEST pre-events
Input file root://eoscms.cern.ch//eos/cms/store/user/cmsbuild/store/data/Commissioning2018/AlCaLumiPixels0/ALCARECO/AlCaPCCRandom-02May2018-v1/70000/6CE65B93-D657-E811-BBB5-FA163E8006EF.root?scitag.flow=196664 could not be opened, and fallback was attempted.
Additional information:
  [a] Fatal Root Error: @SUB=TStreamerInfo::BuildCheck

   The StreamerInfo of class reco::PixelClusterCounts read from file root://eoscms.cern.ch//eos/cms/store/user/cmsbuild/store/data/Commissioning2018/AlCaLumiPixels0/ALCARECO/AlCaPCCRandom-02May2018-v1/70000/6CE65B93-D657-E811-BBB5-FA163E8006EF.root
   has the same version (=3) as the active class but a different checksum.
   You should update the version to ClassDef(reco::PixelClusterCounts,4).
   Do not try to write objects with the current class definition,
   the files will not be readable.
```
https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc13/CMSSW_17_0_EVOLUTION_X_2026-05-08-2300/unitTestLogs/Calibration/LumiAlCaRecoProducers#/

Resolves https://github.com/cms-sw/framework-team/issues/2214

#### PR validation:

None