### PR TITLE
Needed fixes to run with photos

### DIFF
--- a/GeneratorInterface/Core/src/EmbeddingHepMCFilter.cc
+++ b/GeneratorInterface/Core/src/EmbeddingHepMCFilter.cc
@@ -119,39 +119,39 @@ bool EmbeddingHepMCFilter::filter(const HepMC::GenEvent *evt) {
 
 void EmbeddingHepMCFilter::decay_and_sump4Vis(HepMC::GenParticle *particle, reco::Candidate::LorentzVector &p4Vis) {
   bool decaymode_known = false;
-  
-  if (particle->end_vertex() !=0 ) {
-  for (HepMC::GenVertex::particle_iterator daughter = particle->end_vertex()->particles_begin(HepMC::children);
-       daughter != particle->end_vertex()->particles_end(HepMC::children);
-       ++daughter) {
-    bool neutrino = (std::abs((*daughter)->pdg_id()) == tauon_neutrino_PDGID_) ||
-                    (std::abs((*daughter)->pdg_id()) == muon_neutrino_PDGID_) ||
-                    (std::abs((*daughter)->pdg_id()) == electron_neutrino_PDGID_);
 
-    // Determining DecayMode, if particle is tau lepton.
-    // Asuming, that there are only the two tauons from the Z-boson.
-    // This is the case for the simulated Z->tautau event constructed by EmbeddingLHEProducer.
-    if (std::abs(particle->pdg_id()) == tauonPDGID_ && !decaymode_known) {
-      // use these bools to protect againt taus that aren't the last copy (which "decay" to a tau and a gamma)
-      bool isGamma = std::abs((*daughter)->pdg_id()) == 22;
-      bool isTau = std::abs((*daughter)->pdg_id()) == 15;
-      if (std::abs((*daughter)->pdg_id()) == muonPDGID_) {
-        DecayChannel_.fill(TauDecayMode::Muon);
-        decaymode_known = true;
-      } else if (std::abs((*daughter)->pdg_id()) == electronPDGID_) {
-        DecayChannel_.fill(TauDecayMode::Electron);
-        decaymode_known = true;
-      } else if (!neutrino && !isGamma && !isTau) {
-        DecayChannel_.fill(TauDecayMode::Hadronic);
-        decaymode_known = true;
+  if (particle->end_vertex() != nullptr) {
+    for (HepMC::GenVertex::particle_iterator daughter = particle->end_vertex()->particles_begin(HepMC::children);
+         daughter != particle->end_vertex()->particles_end(HepMC::children);
+         ++daughter) {
+      bool neutrino = (std::abs((*daughter)->pdg_id()) == tauon_neutrino_PDGID_) ||
+                      (std::abs((*daughter)->pdg_id()) == muon_neutrino_PDGID_) ||
+                      (std::abs((*daughter)->pdg_id()) == electron_neutrino_PDGID_);
+
+      // Determining DecayMode, if particle is tau lepton.
+      // Asuming, that there are only the two tauons from the Z-boson.
+      // This is the case for the simulated Z->tautau event constructed by EmbeddingLHEProducer.
+      if (std::abs(particle->pdg_id()) == tauonPDGID_ && !decaymode_known) {
+        // use these bools to protect againt taus that aren't the last copy (which "decay" to a tau and a gamma)
+        bool isGamma = std::abs((*daughter)->pdg_id()) == 22;
+        bool isTau = std::abs((*daughter)->pdg_id()) == 15;
+        if (std::abs((*daughter)->pdg_id()) == muonPDGID_) {
+          DecayChannel_.fill(TauDecayMode::Muon);
+          decaymode_known = true;
+        } else if (std::abs((*daughter)->pdg_id()) == electronPDGID_) {
+          DecayChannel_.fill(TauDecayMode::Electron);
+          decaymode_known = true;
+        } else if (!neutrino && !isGamma && !isTau) {
+          DecayChannel_.fill(TauDecayMode::Hadronic);
+          decaymode_known = true;
+        }
       }
+      // Adding up all visible momentum in recursive way.
+      if ((*daughter)->status() == 1 && !neutrino)
+        p4Vis += (reco::Candidate::LorentzVector)(*daughter)->momentum();
+      else if (!neutrino)
+        decay_and_sump4Vis((*daughter), p4Vis);
     }
-    // Adding up all visible momentum in recursive way.
-    if ((*daughter)->status() == 1 && !neutrino)
-      p4Vis += (reco::Candidate::LorentzVector)(*daughter)->momentum();
-    else if (!neutrino)
-      decay_and_sump4Vis((*daughter), p4Vis);
-   }
   }
 }
 

--- a/GeneratorInterface/Core/src/EmbeddingHepMCFilter.cc
+++ b/GeneratorInterface/Core/src/EmbeddingHepMCFilter.cc
@@ -84,7 +84,7 @@ bool EmbeddingHepMCFilter::filter(const HepMC::GenEvent *evt) {
 
     if (!isHardProc) {
       continue;
-    } else if (pdg_id == tauonPDGID_) {
+    } else if (pdg_id == tauonPDGID_ && (*particle)->status() != 746) {
       reco::Candidate::LorentzVector p4Vis;
       decay_and_sump4Vis((*particle), p4Vis);  // recursive access to final states.
       p4VisPair_.push_back(p4Vis);
@@ -119,6 +119,8 @@ bool EmbeddingHepMCFilter::filter(const HepMC::GenEvent *evt) {
 
 void EmbeddingHepMCFilter::decay_and_sump4Vis(HepMC::GenParticle *particle, reco::Candidate::LorentzVector &p4Vis) {
   bool decaymode_known = false;
+  
+  if (particle->end_vertex() !=0 ) {
   for (HepMC::GenVertex::particle_iterator daughter = particle->end_vertex()->particles_begin(HepMC::children);
        daughter != particle->end_vertex()->particles_end(HepMC::children);
        ++daughter) {
@@ -149,6 +151,7 @@ void EmbeddingHepMCFilter::decay_and_sump4Vis(HepMC::GenParticle *particle, reco
       p4Vis += (reco::Candidate::LorentzVector)(*daughter)->momentum();
     else if (!neutrino)
       decay_and_sump4Vis((*daughter), p4Vis);
+   }
   }
 }
 


### PR DESCRIPTION
#### PR description:

Two protections added to avoid crashed when using photos ("null vertices of intermediate 746 particles")

#### PR validation:
Tested on 10k events with cmsDriver.py Configuration/GenProduction/python/SMP-RunIII2024Summer24wmLHEGS-00182-fragment.py --eventcontent RAWSIM,LHE --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM,LHE --conditions 140X_mcRun3_2024_realistic_v26 --beamspot DBrealistic...

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is made to the master branch to be backported to 140X releases to produce a 2024 sample for the dedicated DY production needed for tau polarisation studies

<!-- Please delete the text above after you verified all points of the checklist  -->
