### PR TITLE
BuildFile dependency cleaning, 1st round

### DIFF
--- a/AnalysisDataFormats/SUSYBSMObjects/BuildFile.xml
+++ b/AnalysisDataFormats/SUSYBSMObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/CSCRecHit"/>

--- a/AnalysisDataFormats/TrackInfo/BuildFile.xml
+++ b/AnalysisDataFormats/TrackInfo/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/VertexReco"/>

--- a/CalibCalorimetry/EBPhase2TPGTools/plugins/BuildFile.xml
+++ b/CalibCalorimetry/EBPhase2TPGTools/plugins/BuildFile.xml
@@ -1,10 +1,10 @@
 <use name="CondCore/DBOutputService"/>
 <use name="FWCore/Framework"/>
 <use name="Geometry/EcalMapping"/>
-<use name="OnlineDB/EcalCondDB"/>
 <use name="Geometry/CaloTopology"/>
 <use name="CalibCalorimetry/EBPhase2TPGTools"/>
 <use name="SimCalorimetry/EcalSimAlgos"/>
+<use name="rootrio"/>
 <library file="*.cc" name="CalibCalorimetryEBPhase2TPGToolsPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/CalibCalorimetry/EcalLaserCorrection/BuildFile.xml
+++ b/CalibCalorimetry/EcalLaserCorrection/BuildFile.xml
@@ -3,9 +3,8 @@
 <use name="CalibCalorimetry/EcalLaserAnalyzer"/>
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/EcalDetId"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/MessageLogger"/>
-<use name="boost"/>
 <use name="tbb"/>
 <export>
   <lib name="1"/>

--- a/CalibCalorimetry/EcalLaserCorrection/test/BuildFile.xml
+++ b/CalibCalorimetry/EcalLaserCorrection/test/BuildFile.xml
@@ -1,9 +1,8 @@
 <use name="CondFormats/EcalObjects"/>
 <use name="DataFormats/EcalDetId"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Framework"/>
 <use name="CalibCalorimetry/EcalLaserCorrection"/>
-<use name="boost"/>
 <flags EDM_PLUGIN="1"/>
 <library file="EcalLaserTestAnalyzer.cc" name="EcalLaserTestAnalyzer">
 </library>

--- a/CalibCalorimetry/EcalTrivialCondModules/BuildFile.xml
+++ b/CalibCalorimetry/EcalTrivialCondModules/BuildFile.xml
@@ -1,7 +1,6 @@
 <flags EDM_PLUGIN="1"/>
 <use name="rootcore"/>
 <use name="root"/>
-<use name="boost"/>
 <use name="hdf5"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>

--- a/CalibCalorimetry/HcalAlgos/BuildFile.xml
+++ b/CalibCalorimetry/HcalAlgos/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="boost"/>
 <use name="root"/>
 <use name="clhep"/>
 <use name="gsl"/>

--- a/CalibFormats/CaloObjects/BuildFile.xml
+++ b/CalibFormats/CaloObjects/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/MessageLogger"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/CalibPPS/ESProducers/plugins/BuildFile.xml
+++ b/CalibPPS/ESProducers/plugins/BuildFile.xml
@@ -15,6 +15,7 @@
   <use name="CondFormats/RunInfo"/>
 
   <use name="DataFormats/CTPPSDetId"/>
+  <use name="DataFormats/Provenance"/>
 
   <use name="Geometry/Records"/>
   <use name="Geometry/VeryForwardGeometryBuilder"/>

--- a/CalibTracker/SiPixelQuality/BuildFile.xml
+++ b/CalibTracker/SiPixelQuality/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/FEDRawData"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/SiPixelCluster"/>
 <use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/SiPixelDigi"/>
@@ -16,8 +16,6 @@
 <use name="Geometry/CommonTopologies"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="rootcling"/>
-<use name="rootrflx"/>
 <export>
   <lib name="1"/>
 </export>
-

--- a/Calibration/EcalTBTools/BuildFile.xml
+++ b/Calibration/EcalTBTools/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="root"/>
-<use name="clhep"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CommonTools/UtilAlgos/BuildFile.xml
+++ b/CommonTools/UtilAlgos/BuildFile.xml
@@ -3,9 +3,9 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/DetId"/>
-<use name="roothistmatrix"/>
+<use name="rootrio"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
+++ b/CommonTools/UtilAlgos/interface/StoreManagerTrait.h
@@ -13,7 +13,6 @@
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include <memory>
-#include "boost/type_traits.hpp"
 
 namespace helper {
 

--- a/CommonTools/UtilAlgos/test/BuildFile.xml
+++ b/CommonTools/UtilAlgos/test/BuildFile.xml
@@ -3,4 +3,5 @@
   <flags EDM_PLUGIN="1"/>
   <use name="CommonTools/UtilAlgos"/>
   <use name="FWCore/ServiceRegistry"/>
+  <use name="roothistmatrix"/>
 </library>

--- a/CondCore/CondDB/BuildFile.xml
+++ b/CondCore/CondDB/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="CondFormats/Serialization"/>
 <use name="CondFormats/Common"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/Framework"/>
 <use name="Utilities/OpenSSL"/>
 <use name="boost"/>

--- a/CondCore/DBOutputService/BuildFile.xml
+++ b/CondCore/DBOutputService/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="DataFormats/Provenance"/>
 <use name="CondCore/CondDB"/>
 <use name="curl"/>
 <use name="boost"/>

--- a/CondCore/Utilities/bin/BuildFile.xml
+++ b/CondCore/Utilities/bin/BuildFile.xml
@@ -5,11 +5,11 @@
 </bin>
 
 <bin file="cmscond_to_lumiid.cpp" name="cmscond_to_lumiid">
-  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Provenance" source_only="1"/>
 </bin>
 
 <bin file="cmscond_from_lumiid.cpp" name="cmscond_from_lumiid">
-  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Provenance" source_only="1"/>
 </bin>
 
 <bin file="cmscond_authentication_manager.cpp" name="cmscond_authentication_manager">

--- a/CondFormats/Alignment/BuildFile.xml
+++ b/CondFormats/Alignment/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="CondFormats/Serialization"/>
 <use name="DataFormats/CLHEP"/>
 <use name="DataFormats/Math"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <use name="clhep"/>
 <use name="DataFormats/DetId"/>

--- a/CondFormats/BTauObjects/BuildFile.xml
+++ b/CondFormats/BTauObjects/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="CondFormats/Serialization"/>
 <use name="FWCore/Utilities"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <use name="CondFormats/PhysicsToolsObjects"/>
 <export>

--- a/CondFormats/BeamSpotObjects/BuildFile.xml
+++ b/CondFormats/BeamSpotObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="CondFormats/Serialization"/>
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Common"/>

--- a/CondFormats/CSCObjects/BuildFile.xml
+++ b/CondFormats/CSCObjects/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/MuonDetId"/>
 <use name="FWCore/MessageLogger"/>
 <use name="CondFormats/Serialization"/>
+<use name="rootcling"/>
 <use name="boost_serialization"/>
 <export>
   <lib name="1"/>

--- a/CondFormats/Calibration/BuildFile.xml
+++ b/CondFormats/Calibration/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="CondFormats/Common"/>
 <use name="CondFormats/Serialization"/>
 <use name="FWCore/Utilities"/>

--- a/CondFormats/CastorObjects/BuildFile.xml
+++ b/CondFormats/CastorObjects/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="DataFormats/HcalDetId"/>
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Serialization"/>
+<use name="rootcling"/>
 <use name="boost_serialization"/>
 <export>
   <lib name="1"/>

--- a/CondFormats/Common/BuildFile.xml
+++ b/CondFormats/Common/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="DataFormats/Common"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <use name="boost_serialization"/>
 <export>

--- a/CondFormats/DQMObjects/BuildFile.xml
+++ b/CondFormats/DQMObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Serialization"/>

--- a/CondFormats/EcalCorrections/BuildFile.xml
+++ b/CondFormats/EcalCorrections/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="CondFormats/Serialization"/>
 <use name="DataFormats/EcalDetId"/>
 <use name="FWCore/Utilities"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <use name="boost_serialization"/>
 <export>

--- a/CondFormats/EgammaObjects/BuildFile.xml
+++ b/CondFormats/EgammaObjects/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Serialization"/>
 <use name="CondFormats/PhysicsToolsObjects"/>
+<use name="rootcling"/>
 <use name="boost_serialization"/>
 <export>
   <lib name="1"/>

--- a/CondFormats/External/BuildFile.xml
+++ b/CondFormats/External/BuildFile.xml
@@ -3,6 +3,6 @@
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/EcalDetId"/>
 <use name="DataFormats/L1GlobalTrigger"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="clhep"/>
-<use name="rootmath"/>
+<use name="rootmathcore"/>

--- a/CondFormats/GEMObjects/BuildFile.xml
+++ b/CondFormats/GEMObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Serialization"/>

--- a/CondFormats/GeometryObjects/BuildFile.xml
+++ b/CondFormats/GeometryObjects/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="DataFormats/DetId"/>
 <use name="CondFormats/Serialization"/>
+<use name="rootcling"/>
 <use name="boost_serialization"/>
 <export>
   <lib name="1"/>

--- a/CondFormats/HGCalObjects/BuildFile.xml
+++ b/CondFormats/HGCalObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="boost_serialization"/>
 <use name="CondFormats/Serialization"/>
 <use name="DataFormats/HGCalDigi"/>

--- a/CondFormats/HLTObjects/BuildFile.xml
+++ b/CondFormats/HLTObjects/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Serialization"/>
 <use name="CondFormats/External"/>
+<use name="rootcling"/>
 <use name="boost_serialization"/>
 <export>
   <lib name="1"/>

--- a/CondFormats/HcalObjects/BuildFile.xml
+++ b/CondFormats/HcalObjects/BuildFile.xml
@@ -1,6 +1,7 @@
 <ifrelease name="UBSAN">
   <flags REM_CXXFLAGS="-fno-omit-frame-pointer -fsanitize=undefined"/>
 </ifrelease>
+<use name="rootcling"/>
 <use name="boost_serialization"/>
 <use name="CondFormats/Serialization"/>
 <use name="DataFormats/Portable"/>

--- a/CondFormats/L1TObjects/BuildFile.xml
+++ b/CondFormats/L1TObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="boost"/>
 <use name="CondFormats/Serialization"/>
 <use name="boost_serialization"/>

--- a/CondFormats/MFObjects/BuildFile.xml
+++ b/CondFormats/MFObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="CondFormats/Serialization"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>

--- a/CondFormats/OptAlignObjects/BuildFile.xml
+++ b/CondFormats/OptAlignObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="CondFormats/Serialization"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/Utilities"/>

--- a/CondFormats/PCLConfig/BuildFile.xml
+++ b/CondFormats/PCLConfig/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Serialization"/>
+<use name="rootcling"/>
 <use name="boost_serialization"/>
 <export>
   <lib name="1"/>

--- a/CondFormats/RPCObjects/BuildFile.xml
+++ b/CondFormats/RPCObjects/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="DataFormats/MuonDetId"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <use name="CondFormats/L1TObjects"/>
 <use name="CondFormats/Serialization"/>

--- a/CondFormats/RecoMuonObjects/BuildFile.xml
+++ b/CondFormats/RecoMuonObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/Serialization"/>

--- a/CondFormats/RunInfo/BuildFile.xml
+++ b/CondFormats/RunInfo/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="CoralBase"/>
+<use name="rootcling"/>
 <use name="boost_serialization"/>
 <export>
   <lib name="1"/>

--- a/CondFormats/SiPixelObjects/BuildFile.xml
+++ b/CondFormats/SiPixelObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="alpaka"/>
 <use name="CalibFormats/SiPixelObjects"/>
 <use name="CondCore/DBOutputService"/>

--- a/CondFormats/SiStripObjects/BuildFile.xml
+++ b/CondFormats/SiStripObjects/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/DetId"/>
+<use name="rootcling"/>
 <use name="clhep"/>
 <use name="boost"/>
 <use name="boost_serialization"/>

--- a/CondTools/BTau/BuildFile.xml
+++ b/CondTools/BTau/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="FWCore/Utilities"/>
 <use name="CondFormats/BTauObjects"/>
 <export>

--- a/CondTools/DT/BuildFile.xml
+++ b/CondTools/DT/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="CondCore/CondDB"/>
 <use name="CondFormats/DTObjects"/>
 <use name="CoralBase"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="CondCore/DBOutputService"/>

--- a/CondTools/Ecal/BuildFile.xml
+++ b/CondTools/Ecal/BuildFile.xml
@@ -6,7 +6,7 @@
 <use name="CondFormats/ESObjects"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/EcalDetId"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
@@ -17,10 +17,8 @@
 <use name="SimCalorimetry/EcalSelectiveReadoutProducers"/>
 <use name="Geometry/EcalMapping"/>
 <use name="CalibCalorimetry/EcalLaserCorrection"/>
-<use name="root"/>
 <use name="rootcore"/>
-<use name="rootphysics"/>
-<use name="rootgraphics"/>
+<use name="rootrio"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CondTools/Ecal/plugins/BuildFile.xml
+++ b/CondTools/Ecal/plugins/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="DataFormats/EcalDetId"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>
+<use name="roothistmatrix"/>
 <library file="*.cc" name="CondToolsEcalPlugin">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/DPGAnalysis/SiStripTools/BuildFile.xml
+++ b/DPGAnalysis/SiStripTools/BuildFile.xml
@@ -6,7 +6,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="DataFormats/Luminosity"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/SiStripDigi"/>
 <use name="DataFormats/SiStripCluster"/>
 <use name="DataFormats/Scalers"/>

--- a/DPGAnalysis/Skims/BuildFile.xml
+++ b/DPGAnalysis/Skims/BuildFile.xml
@@ -31,6 +31,6 @@
 <use name="DataFormats/HcalRecHit"/>
 <use name="DataFormats/EgammaReco"/>
 <use name="PhysicsTools/SelectorUtils"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/OnlineMetaData"/>
 <flags EDM_PLUGIN="1"/>

--- a/DQM/SiStripMonitorHardware/BuildFile.xml
+++ b/DQM/SiStripMonitorHardware/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="DataFormats/SiStripCommon"/>
 <use name="DataFormats/SiStripDigi"/>
 <use name="DataFormats/Common"/>
+<use name="DataFormats/Provenance"/>
 <use name="DataFormats/FEDRawData"/>
 <use name="CondFormats/SiStripObjects"/>
 <use name="CommonTools/UtilAlgos"/>

--- a/DQMServices/Components/plugins/BuildFile.xml
+++ b/DQMServices/Components/plugins/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="DQMServices/Components"/>
 <use name="DataFormats/Histograms"/>
 <use name="DataFormats/OnlineMetaData"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>

--- a/DQMServices/Core/BuildFile.xml
+++ b/DQMServices/Core/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="roothistmatrix"/>
 <use name="tbb"/>
 <use name="fmt"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>

--- a/DQMServices/FwkIO/plugins/BuildFile.xml
+++ b/DQMServices/FwkIO/plugins/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="tbb"/>
 <use name="DQMServices/Core"/>
 <use name="DataFormats/Histograms"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>

--- a/DQMServices/StreamerIO/plugins/BuildFile.xml
+++ b/DQMServices/StreamerIO/plugins/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="DQMServices/Core"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Histograms"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/DataFormats/Alignment/BuildFile.xml
+++ b/DataFormats/Alignment/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrackingRecHit"/>
 <use name="DataFormats/SiStripDetId"/>

--- a/DataFormats/AlpakaCommon/BuildFile.xml
+++ b/DataFormats/AlpakaCommon/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/Utilities"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>

--- a/DataFormats/AlpakaCommon/BuildFile.xml
+++ b/DataFormats/AlpakaCommon/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/Utilities"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>

--- a/DataFormats/BTauReco/BuildFile.xml
+++ b/DataFormats/BTauReco/BuildFile.xml
@@ -11,7 +11,7 @@
 <use name="DataFormats/GeometryVector"/>
 <use name="boost"/>
 <use name="clhep"/>
-<use name="rootmath"/>
+<use name="rootmathcore"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/BeamSpot/BuildFile.xml
+++ b/DataFormats/BeamSpot/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="clhep"/>
-<use name="rootcore"/>
 <use name="rootsmatrix"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/CLHEP"/>

--- a/DataFormats/CLHEP/BuildFile.xml
+++ b/DataFormats/CLHEP/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="clhep"/>
-<use name="rootmath"/>
+<use name="rootmathcore"/>
 <use name="DataFormats/Math"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/CSCDigi/BuildFile.xml
+++ b/DataFormats/CSCDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/GEMDigi"/>

--- a/DataFormats/CSCRecHit/BuildFile.xml
+++ b/DataFormats/CSCRecHit/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/TrackingRecHit"/>

--- a/DataFormats/CTPPSDetId/BuildFile.xml
+++ b/DataFormats/CTPPSDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/DetId"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/DataFormats/CTPPSDigi/BuildFile.xml
+++ b/DataFormats/CTPPSDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/DataFormats/CTPPSReco/BuildFile.xml
+++ b/DataFormats/CTPPSReco/BuildFile.xml
@@ -5,7 +5,7 @@
 <use name="DataFormats/CTPPSDetId"/>
 <use name="DataFormats/GeometryVector"/>
 <use name="rootsmatrix"/>
-<use name="rootmath"/>
+<use name="rootmathcore"/>
 <use name="rootphysics"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/CaloRecHit/BuildFile.xml
+++ b/DataFormats/CaloRecHit/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="DataFormats/Math"/>
 <use name="DataFormats/DetId"/>
 <use name="FWCore/Utilities"/>
-<use name="rootmath"/>
+<use name="rootmathcore"/>
 <use name="eigen"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/CaloTowers/BuildFile.xml
+++ b/DataFormats/CaloTowers/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/Math"/>

--- a/DataFormats/Candidate/BuildFile.xml
+++ b/DataFormats/Candidate/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="DataFormats/GeometryVector"/>
 <use name="DataFormats/Math"/>
 <use name="FWCore/Utilities"/>
-<use name="rootmath"/>
+<use name="rootmathcore"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/Candidate/test/BuildFile.xml
+++ b/DataFormats/Candidate/test/BuildFile.xml
@@ -1,4 +1,5 @@
 <bin name="testDataFormatsCandidate" file="testCompositeCandidate.cc,testCandidate.cc,testParticle.cc,testRunner.cpp">
   <use name="DataFormats/Candidate"/>
   <use name="cppunit"/>
+  <use name="rootrio"/>
 </bin>

--- a/DataFormats/CastorReco/BuildFile.xml
+++ b/DataFormats/CastorReco/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/HcalRecHit"/>

--- a/DataFormats/Common/BuildFile.xml
+++ b/DataFormats/Common/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="rootcling"/>
 <use name="boost"/>
 <use name="tbb"/>
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/DataFormats/Common/BuildFile.xml
+++ b/DataFormats/Common/BuildFile.xml
@@ -1,6 +1,7 @@
+<use name="rootcling"/>
 <use name="boost"/>
 <use name="tbb"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/DataFormats/DTDigi/BuildFile.xml
+++ b/DataFormats/DTDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/FEDRawData"/>

--- a/DataFormats/DTRecHit/BuildFile.xml
+++ b/DataFormats/DTRecHit/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/DTDigi"/>
 <use name="DataFormats/GeometrySurface"/>

--- a/DataFormats/DetId/BuildFile.xml
+++ b/DataFormats/DetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/EcalDetId/BuildFile.xml
+++ b/DataFormats/EcalDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/DetId"/>
 <use name="FWCore/Utilities"/>

--- a/DataFormats/EcalDigi/BuildFile.xml
+++ b/DataFormats/EcalDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/EcalDetId"/>

--- a/DataFormats/EcalRawData/BuildFile.xml
+++ b/DataFormats/EcalRawData/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/EcalRecHit/BuildFile.xml
+++ b/DataFormats/EcalRecHit/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/CaloRecHit"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/EcalDetId"/>

--- a/DataFormats/EgammaCandidates/BuildFile.xml
+++ b/DataFormats/EgammaCandidates/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/CLHEP"/>
 <use name="DataFormats/Common"/>

--- a/DataFormats/EgammaReco/BuildFile.xml
+++ b/DataFormats/EgammaReco/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/EcalRecHit"/>
 <use name="clhepheader"/>

--- a/DataFormats/EgammaTrackReco/BuildFile.xml
+++ b/DataFormats/EgammaTrackReco/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/EgammaReco"/>

--- a/DataFormats/EgammaTrackReco/BuildFile.xml
+++ b/DataFormats/EgammaTrackReco/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/EgammaReco"/>

--- a/DataFormats/FEDRawData/BuildFile.xml
+++ b/DataFormats/FEDRawData/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/DataFormats/FTLDigi/BuildFile.xml
+++ b/DataFormats/FTLDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/ForwardDetId"/>
 <use name="DataFormats/DetId"/>

--- a/DataFormats/FTLRecHit/BuildFile.xml
+++ b/DataFormats/FTLRecHit/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/CaloRecHit"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/ForwardDetId"/>

--- a/DataFormats/FWLite/BuildFile.xml
+++ b/DataFormats/FWLite/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/Common"/>
 <use name="FWCore/FWLite"/>
 <use name="FWCore/ParameterSet"/>

--- a/DataFormats/FWLite/BuildFile.xml
+++ b/DataFormats/FWLite/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Common"/>
 <use name="FWCore/FWLite"/>
 <use name="FWCore/ParameterSet"/>

--- a/DataFormats/ForwardDetId/BuildFile.xml
+++ b/DataFormats/ForwardDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/DetId"/>
 <export>

--- a/DataFormats/GEMDigi/BuildFile.xml
+++ b/DataFormats/GEMDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/GEMRecHit"/>

--- a/DataFormats/GeometryCommonDetAlgo/BuildFile.xml
+++ b/DataFormats/GeometryCommonDetAlgo/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/CLHEP"/>
 <use name="DataFormats/GeometrySurface"/>

--- a/DataFormats/GeometrySurface/BuildFile.xml
+++ b/DataFormats/GeometrySurface/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="DataFormats/Math"/>
 <use name="FWCore/Utilities"/>
 <use name="boost"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/GeometryVector/BuildFile.xml
+++ b/DataFormats/GeometryVector/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="rootmath"/>
+<use name="rootmathcore"/>
 <use name="DataFormats/Math"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/GsfTrackReco/BuildFile.xml
+++ b/DataFormats/GsfTrackReco/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/GeometryCommonDetAlgo"/>

--- a/DataFormats/HGCDigi/BuildFile.xml
+++ b/DataFormats/HGCDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/ForwardDetId"/>
 <use name="DataFormats/DetId"/>

--- a/DataFormats/HGCRecHit/BuildFile.xml
+++ b/DataFormats/HGCRecHit/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/CaloRecHit"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/ForwardDetId"/>

--- a/DataFormats/HGCalDigi/BuildFile.xml
+++ b/DataFormats/HGCalDigi/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="rootcore"/>
 <use name="DataFormats/Portable"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/ForwardDetId"/>
@@ -6,6 +5,7 @@
 <use name="DataFormats/SoATemplate"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
 <use name="eigen"/>
+<use name="rootcling"/>
 <flags ALPAKA_BACKENDS="!serial"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/HGCalReco/BuildFile.xml
+++ b/DataFormats/HGCalReco/BuildFile.xml
@@ -1,10 +1,11 @@
+<use name="rootcling"/>
 <use name="eigen"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/GeometryVector"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/Portable"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/SoATemplate"/>
 <use name="DataFormats/TrackReco"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>

--- a/DataFormats/HLTReco/BuildFile.xml
+++ b/DataFormats/HLTReco/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Candidate"/>

--- a/DataFormats/HcalCalibObjects/BuildFile.xml
+++ b/DataFormats/HcalCalibObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/HcalDetId/BuildFile.xml
+++ b/DataFormats/HcalDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/DetId"/>
 <use name="FWCore/Utilities"/>
 <use name="FWCore/MessageLogger"/>

--- a/DataFormats/HcalDigi/BuildFile.xml
+++ b/DataFormats/HcalDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/HcalDetId"/>
 <use name="DataFormats/DetId"/>

--- a/DataFormats/HcalIsolatedTrack/BuildFile.xml
+++ b/DataFormats/HcalIsolatedTrack/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Math"/>

--- a/DataFormats/HcalRecHit/BuildFile.xml
+++ b/DataFormats/HcalRecHit/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/CaloRecHit"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/HcalDetId"/>

--- a/DataFormats/HeavyIonEvent/BuildFile.xml
+++ b/DataFormats/HeavyIonEvent/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="root"/>
+<use name="rootrio"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Candidate"/>
 <export>

--- a/DataFormats/Histograms/BuildFile.xml
+++ b/DataFormats/Histograms/BuildFile.xml
@@ -1,6 +1,6 @@
 <use name="roothistmatrix"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Utilities"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/JetMatching/BuildFile.xml
+++ b/DataFormats/JetMatching/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/HepMCCandidate"/>
 <use name="DataFormats/JetReco"/>

--- a/DataFormats/JetReco/BuildFile.xml
+++ b/DataFormats/JetReco/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/CaloTowers"/>
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="DataFormats/Candidate"/>

--- a/DataFormats/L1CSCTrackFinder/BuildFile.xml
+++ b/DataFormats/L1CSCTrackFinder/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/CSCDigi"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/DetId"/>

--- a/DataFormats/L1CaloTrigger/BuildFile.xml
+++ b/DataFormats/L1CaloTrigger/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/DetId"/>
 <export>

--- a/DataFormats/L1DTTrackFinder/BuildFile.xml
+++ b/DataFormats/L1DTTrackFinder/BuildFile.xml
@@ -1,6 +1,6 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/L1GlobalMuonTrigger"/>
 <export>
   <lib name="1"/>
-  <lib name="DataFormatsL1DTTrackFinder"/>
 </export>

--- a/DataFormats/L1GlobalCaloTrigger/BuildFile.xml
+++ b/DataFormats/L1GlobalCaloTrigger/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/L1CaloTrigger"/>
 <use name="boost"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/L1GlobalMuonTrigger/BuildFile.xml
+++ b/DataFormats/L1GlobalMuonTrigger/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="tbb"/>
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/MessageLogger"/>
 <export>

--- a/DataFormats/L1GlobalTrigger/BuildFile.xml
+++ b/DataFormats/L1GlobalTrigger/BuildFile.xml
@@ -1,9 +1,10 @@
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/L1GlobalMuonTrigger"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="boost"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/L1GlobalTrigger/test/BuildFile.xml
+++ b/DataFormats/L1GlobalTrigger/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="DataFormats/L1GlobalTrigger"/>
 <use name="FWCore/ParameterSet"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <bin file="L1GlobalTriggerObjectMaps_t.cc">
 </bin>

--- a/DataFormats/L1Scouting/BuildFile.xml
+++ b/DataFormats/L1Scouting/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/Common"/>
 <export>

--- a/DataFormats/L1ScoutingRawData/BuildFile.xml
+++ b/DataFormats/L1ScoutingRawData/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/FEDRawData"/>

--- a/DataFormats/L1TCalorimeter/BuildFile.xml
+++ b/DataFormats/L1TCalorimeter/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/L1Trigger"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/L1TGlobal/BuildFile.xml
+++ b/DataFormats/L1TGlobal/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="FWCore/MessageLogger"/>

--- a/DataFormats/L1TrackTrigger/BuildFile.xml
+++ b/DataFormats/L1TrackTrigger/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="hls"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/L1Trigger/BuildFile.xml
+++ b/DataFormats/L1Trigger/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="DataFormats/HcalDetId"/>
 <use name="FWCore/Concurrency"/>
 <use name="FWCore/MessageLogger"/>
+<use name="rootcling"/>
 <use name="hls"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/LTCDigi/BuildFile.xml
+++ b/DataFormats/LTCDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/DataFormats/Luminosity/BuildFile.xml
+++ b/DataFormats/Luminosity/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/Utilities"/>

--- a/DataFormats/METReco/BuildFile.xml
+++ b/DataFormats/METReco/BuildFile.xml
@@ -14,7 +14,7 @@
 <use name="DataFormats/HcalDigi"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/TrackReco"/>
-<use name="root"/>
+<use name="rootmathcore"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/MuonDetId/BuildFile.xml
+++ b/DataFormats/MuonDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/DetId"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/DataFormats/MuonReco/BuildFile.xml
+++ b/DataFormats/MuonReco/BuildFile.xml
@@ -9,7 +9,7 @@
 <use name="DataFormats/HcalDetId"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/MuonDetId"/>
-<use name="rootmath"/>
+<use name="rootmathcore"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/MuonSeed/BuildFile.xml
+++ b/DataFormats/MuonSeed/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="clhepheader"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/L1Trigger"/>

--- a/DataFormats/NanoAOD/BuildFile.xml
+++ b/DataFormats/NanoAOD/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Math"/>
 <use name="boost"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/OnlineMetaData/BuildFile.xml
+++ b/DataFormats/OnlineMetaData/BuildFile.xml
@@ -1,5 +1,6 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/ParticleFlowCandidate/BuildFile.xml
+++ b/DataFormats/ParticleFlowCandidate/BuildFile.xml
@@ -9,8 +9,7 @@
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/EgammaReco"/>
 <use name="DataFormats/VertexReco"/>
-<use name="rootcore"/>
-<use name="rootmath"/>
+<use name="rootmathcore"/>
 <use name="clhepheader"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/ParticleFlowReco/BuildFile.xml
+++ b/DataFormats/ParticleFlowReco/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="eigen"/>
-<use name="rootcore"/>
-<use name="rootmath"/>
+<use name="rootmathcore"/>
 <use name="DataFormats/CaloRecHit"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>

--- a/DataFormats/PatCandidates/BuildFile.xml
+++ b/DataFormats/PatCandidates/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="boost"/>
 <use name="boost_regex"/>
 <use name="tbb"/>
+<use name="rootcling"/>
 <use name="DataFormats/BTauReco"/>
 <use name="DataFormats/CLHEP"/>
 <use name="DataFormats/CaloTowers"/>
@@ -21,7 +22,7 @@
 <use name="DataFormats/Math"/>
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/ParticleFlowCandidate"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/Scouting"/>
 <use name="DataFormats/SiPixelDetId"/>

--- a/DataFormats/PatCandidates/BuildFile.xml
+++ b/DataFormats/PatCandidates/BuildFile.xml
@@ -22,7 +22,7 @@
 <use name="DataFormats/Math"/>
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/ParticleFlowCandidate"/>
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/Scouting"/>
 <use name="DataFormats/SiPixelDetId"/>

--- a/DataFormats/Phase2TrackerDigi/BuildFile.xml
+++ b/DataFormats/Phase2TrackerDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/Portable/BuildFile.xml
+++ b/DataFormats/Portable/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="alpaka"/>
-<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrivialSerialisation"/>
 <use name="FWCore/Utilities" source_only="1"/>

--- a/DataFormats/PortableTestObjects/BuildFile.xml
+++ b/DataFormats/PortableTestObjects/BuildFile.xml
@@ -1,5 +1,5 @@
-<use name="rootcore"/>
 <use name="eigen"/>
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Portable"/>
 <use name="DataFormats/SoATemplate"/>

--- a/DataFormats/ProtonReco/BuildFile.xml
+++ b/DataFormats/ProtonReco/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/CTPPSReco"/>
 <use name="DataFormats/Math"/>

--- a/DataFormats/Provenance/BuildFile.xml
+++ b/DataFormats/Provenance/BuildFile.xml
@@ -1,8 +1,8 @@
 <use name="FWCore/Utilities"/>
 <use name="FWCore/Reflection"/>
 <use name="boost_header"/>
-<use name="rootcore"/>
 <use name="tbb"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/RPCDigi/BuildFile.xml
+++ b/DataFormats/RPCDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="CondFormats/RPCObjects"/>

--- a/DataFormats/RPCRecHit/BuildFile.xml
+++ b/DataFormats/RPCRecHit/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/TrackingRecHit"/>

--- a/DataFormats/RecoCandidate/BuildFile.xml
+++ b/DataFormats/RecoCandidate/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="DataFormats/EgammaReco"/>
 <use name="DataFormats/GsfTrackReco"/>
 <use name="clhep"/>
+<use name="rootcling"/>
 <use name="DataFormats/Math"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>

--- a/DataFormats/Scalers/BuildFile.xml
+++ b/DataFormats/Scalers/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/Scouting/BuildFile.xml
+++ b/DataFormats/Scouting/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/SiPixelCluster/BuildFile.xml
+++ b/DataFormats/SiPixelCluster/BuildFile.xml
@@ -1,5 +1,6 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Utilities"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/SiPixelClusterSoA/BuildFile.xml
+++ b/DataFormats/SiPixelClusterSoA/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="alpaka"/>
-<use name="rootcore"/>
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Portable"/>
 <use name="DataFormats/SoATemplate"/>

--- a/DataFormats/SiPixelDetId/BuildFile.xml
+++ b/DataFormats/SiPixelDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/DetId"/>
 <use name="FWCore/Utilities"/>
 <use name="FWCore/MessageLogger"/>

--- a/DataFormats/SiPixelDigi/BuildFile.xml
+++ b/DataFormats/SiPixelDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/SiPixelDetId"/>
 <export>

--- a/DataFormats/SiPixelDigiSoA/BuildFile.xml
+++ b/DataFormats/SiPixelDigiSoA/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="alpaka"/>
-<use name="rootcore"/>
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Portable"/>
 <use name="DataFormats/SiPixelRawData"/>

--- a/DataFormats/SiPixelRawData/BuildFile.xml
+++ b/DataFormats/SiPixelRawData/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/DataFormats/SiStripCluster/BuildFile.xml
+++ b/DataFormats/SiStripCluster/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrajectoryState"/>
 <use name="DataFormats/SiStripDigi"/>

--- a/DataFormats/SiStripClusterSoA/BuildFile.xml
+++ b/DataFormats/SiStripClusterSoA/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Portable"/>
 <use name="DataFormats/SoATemplate"/>

--- a/DataFormats/SiStripCommon/BuildFile.xml
+++ b/DataFormats/SiStripCommon/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="FWCore/MessageLogger"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/SiStripDetId"/>

--- a/DataFormats/SiStripDetId/BuildFile.xml
+++ b/DataFormats/SiStripDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/DetId"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/SiStripDigi/BuildFile.xml
+++ b/DataFormats/SiStripDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/SiStripDigiSoA/BuildFile.xml
+++ b/DataFormats/SiStripDigiSoA/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Portable"/>
 <use name="DataFormats/SoATemplate"/>

--- a/DataFormats/SoATemplate/BuildFile.xml
+++ b/DataFormats/SoATemplate/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="boost_header"/>
+<use name="rootcling"/>
 <use name="FWCore/Reflection" source_only="1"/>
 <use name="FWCore/Utilities" source_only="1"/>
 <export>

--- a/DataFormats/SoATemplate/BuildFile.xml
+++ b/DataFormats/SoATemplate/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="boost_header"/>
-<use name="rootcling"/>
 <use name="FWCore/Reflection" source_only="1"/>
 <use name="FWCore/Utilities" source_only="1"/>
 <export>

--- a/DataFormats/StdDictionaries/BuildFile.xml
+++ b/DataFormats/StdDictionaries/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="rootcore"/>
+<use name="rootcling"/>
 <flags LCG_DICT_HEADER="classes_map.h classes_others.h classes_pair.h classes_vector.h"/>
 <flags LCG_DICT_XML="classes_def_map.xml classes_def_others.xml classes_def_pair.xml classes_def_vector.xml"/>
 <export>

--- a/DataFormats/Streamer/BuildFile.xml
+++ b/DataFormats/Streamer/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="rootcling"/>
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/DataFormats/Streamer/BuildFile.xml
+++ b/DataFormats/Streamer/BuildFile.xml
@@ -1,4 +1,5 @@
-<use name="DataFormats/Provenance"/>
+<use name="rootcling"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/DataFormats/TCDS/BuildFile.xml
+++ b/DataFormats/TCDS/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/FEDRawData"/>
 <export>

--- a/DataFormats/TauReco/BuildFile.xml
+++ b/DataFormats/TauReco/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/Candidate"/>

--- a/DataFormats/TestObjects/BuildFile.xml
+++ b/DataFormats/TestObjects/BuildFile.xml
@@ -1,5 +1,6 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/SOA" source_only="1"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/DataFormats/TotemReco/BuildFile.xml
+++ b/DataFormats/TotemReco/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/TrackCandidate/BuildFile.xml
+++ b/DataFormats/TrackCandidate/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="DataFormats/TrajectorySeed"/>
 <use name="FWCore/Utilities"/>
 <use name="clhepheader"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/TrackReco/BuildFile.xml
+++ b/DataFormats/TrackReco/BuildFile.xml
@@ -18,9 +18,7 @@
 <use name="DataFormats/TrajectoryState"/>
 <use name="FWCore/Utilities"/>
 <use name="clhepheader"/>
-<use name="rootmath"/>
+<use name="rootmathcore"/>
 <export>
   <lib name="1"/>
 </export>
-
-

--- a/DataFormats/TrackSoA/BuildFile.xml
+++ b/DataFormats/TrackSoA/BuildFile.xml
@@ -1,6 +1,6 @@
 <use name="alpaka"/>
-<use name="rootcore"/>
 <use name="eigen"/>
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Portable"/>
 <use name="DataFormats/SoATemplate"/>

--- a/DataFormats/TrackerCommon/BuildFile.xml
+++ b/DataFormats/TrackerCommon/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/SiStripCluster"/>
 <use name="DataFormats/SiPixelDetId"/>

--- a/DataFormats/TrackerRecHit2D/BuildFile.xml
+++ b/DataFormats/TrackerRecHit2D/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/CLHEP"/>
 <use name="DataFormats/FTLRecHit"/>

--- a/DataFormats/TrackingRecHit/BuildFile.xml
+++ b/DataFormats/TrackingRecHit/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="DataFormats/GeometryVector"/>
 <use name="DataFormats/Math"/>
 <use name="clhep"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/TrackingRecHitSoA/BuildFile.xml
+++ b/DataFormats/TrackingRecHitSoA/BuildFile.xml
@@ -1,6 +1,6 @@
 <use name="alpaka"/>
-<use name="rootcore"/>
 <use name="eigen"/>
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/SiPixelClusterSoA"/>
 <use name="DataFormats/SoATemplate"/>

--- a/DataFormats/TrajectorySeed/BuildFile.xml
+++ b/DataFormats/TrajectorySeed/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="DataFormats/TrackingRecHit"/>
 <use name="FWCore/Utilities"/>
 <use name="clhepheader"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/TrajectoryState/BuildFile.xml
+++ b/DataFormats/TrajectoryState/BuildFile.xml
@@ -1,6 +1,6 @@
+<use name="rootcling"/>
 <use name="DataFormats/GeometryVector"/>
 <use name="DataFormats/Math"/>
-<use name="rootcore"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/V0Candidate/BuildFile.xml
+++ b/DataFormats/V0Candidate/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/VertexReco"/>
 <export>

--- a/DataFormats/VertexReco/BuildFile.xml
+++ b/DataFormats/VertexReco/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/CLHEP"/>
 <use name="DataFormats/Math"/>

--- a/DataFormats/VertexSoA/BuildFile.xml
+++ b/DataFormats/VertexSoA/BuildFile.xml
@@ -1,6 +1,6 @@
 <use name="alpaka"/>
-<use name="rootcore"/>
 <use name="eigen"/>
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Portable"/>
 <use name="DataFormats/SoATemplate"/>

--- a/DataFormats/WrappedStdDictionaries/BuildFile.xml
+++ b/DataFormats/WrappedStdDictionaries/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <export>
   <lib name="1"/>

--- a/EventFilter/Utilities/BuildFile.xml
+++ b/EventFilter/Utilities/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="DataFormats/L1ScoutingRawData"/>
 <use name="DataFormats/TCDS"/>
 <use name="DataFormats/L1Trigger"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ServiceRegistry"/>

--- a/FWCore/AbstractServices/BuildFile.xml
+++ b/FWCore/AbstractServices/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Utilities"/>
 <export>
   <lib name="1"/>

--- a/FWCore/Common/BuildFile.xml
+++ b/FWCore/Common/BuildFile.xml
@@ -1,6 +1,7 @@
+<use name="rootcling"/>
 <use name="tbb"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/FWCore/Common/BuildFile.xml
+++ b/FWCore/Common/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="rootcling"/>
 <use name="tbb"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <export>

--- a/FWCore/FWLite/BuildFile.xml
+++ b/FWCore/FWLite/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>
 <use name="FWCore/Reflection"/>

--- a/FWCore/FWLite/BuildFile.xml
+++ b/FWCore/FWLite/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>
 <use name="FWCore/Reflection"/>

--- a/FWCore/MessageService/plugins/BuildFile.xml
+++ b/FWCore/MessageService/plugins/BuildFile.xml
@@ -2,5 +2,5 @@
   <flags EDM_PLUGIN="1"/>
   <use name="FWCore/MessageService"/>
   <use name="FWCore/ServiceRegistry"/>
-  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Provenance" source_only="1"/>
 </library>

--- a/FWCore/Modules/plugins/BuildFile.xml
+++ b/FWCore/Modules/plugins/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/FWCore/Modules/plugins/BuildFile.xml
+++ b/FWCore/Modules/plugins/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/FWCore/ParameterSet/BuildFile.xml
+++ b/FWCore/ParameterSet/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>

--- a/FWCore/ParameterSet/BuildFile.xml
+++ b/FWCore/ParameterSet/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>

--- a/FWCore/PrescaleService/BuildFile.xml
+++ b/FWCore/PrescaleService/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="FWCore/ServiceRegistry"/>

--- a/FWCore/PrescaleService/BuildFile.xml
+++ b/FWCore/PrescaleService/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="FWCore/ServiceRegistry"/>

--- a/FWCore/PythonParameterSet/BuildFile.xml
+++ b/FWCore/PythonParameterSet/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="py3-pybind11"/>

--- a/FWCore/PythonParameterSet/BuildFile.xml
+++ b/FWCore/PythonParameterSet/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="py3-pybind11"/>

--- a/FWCore/ServiceRegistry/BuildFile.xml
+++ b/FWCore/ServiceRegistry/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/AbstractServices"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>

--- a/FWCore/ServiceRegistry/BuildFile.xml
+++ b/FWCore/ServiceRegistry/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/AbstractServices"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>

--- a/FWCore/Services/plugins/BuildFile.xml
+++ b/FWCore/Services/plugins/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="gcc-atomic"/>
 <use name="tbb"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/Concurrency"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>

--- a/FWCore/Services/plugins/BuildFile.xml
+++ b/FWCore/Services/plugins/BuildFile.xml
@@ -3,7 +3,7 @@
 <use name="gcc-atomic"/>
 <use name="tbb"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Concurrency"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>

--- a/FWCore/Sources/BuildFile.xml
+++ b/FWCore/Sources/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>

--- a/FWCore/Sources/BuildFile.xml
+++ b/FWCore/Sources/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>

--- a/FWStorage/Services/plugins/BuildFile.xml
+++ b/FWStorage/Services/plugins/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/AbstractServices"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/FWStorage/Services/plugins/BuildFile.xml
+++ b/FWStorage/Services/plugins/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/AbstractServices"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/FastSimDataFormats/External/BuildFile.xml
+++ b/FastSimDataFormats/External/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/GeometrySurface"/>
 <use name="DataFormats/DetId"/>

--- a/FastSimDataFormats/PileUpEvents/BuildFile.xml
+++ b/FastSimDataFormats/PileUpEvents/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="rootcore"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/FastSimulation/Event/BuildFile.xml
+++ b/FastSimulation/Event/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="DataFormats/HepMCCandidate"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/Math"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/ParameterSet"/>
 <use name="CommonTools/BaseParticlePropagator"/>
 <use name="FastSimulation/Particle"/>

--- a/GeneratorInterface/Core/BuildFile.xml
+++ b/GeneratorInterface/Core/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/Concurrency"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>

--- a/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/plugins/BuildFile.xml
@@ -13,6 +13,7 @@
 </library>
 
 <library name="GeneratorInterfaceLHEIO" file="LH5Source.cc LHESource.cc LHEProvenanceHelper.cc LHEWriter.cc">
+  <use name="DataFormats/Provenance"/>
   <use name="FWCore/AbstractServices"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/Sources"/>

--- a/Geometry/CaloGeometry/BuildFile.xml
+++ b/Geometry/CaloGeometry/BuildFile.xml
@@ -1,12 +1,13 @@
 <use name="DataFormats/EcalDetId"/>
 <use name="DataFormats/HcalDetId"/>
-<use name="DataFormats/CaloTowers"/>
+<use name="DataFormats/CaloTowers" source_only="1"/>
 <use name="DataFormats/GeometryVector"/>
-<use name="DataFormats/DetId"/>
+<use name="DataFormats/DetId" source_only="1"/>
 <use name="DataFormats/Math"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="clhep"/>
+<use name="rootmath"/>
 <export>
   <lib name="1"/>
 </export>

--- a/HLTrigger/HLTcore/BuildFile.xml
+++ b/HLTrigger/HLTcore/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="tbb"/>
 <use name="boost"/>
 <use name="DataFormats/Common"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PrescaleService"/>

--- a/HLTrigger/HLTcore/plugins/BuildFile.xml
+++ b/HLTrigger/HLTcore/plugins/BuildFile.xml
@@ -6,7 +6,7 @@
   <use name="DataFormats/JetReco"/>
   <use name="DataFormats/L1Trigger"/>
   <use name="DataFormats/METReco"/>
-  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Provenance" source_only="1"/>
   <use name="DataFormats/RecoCandidate"/>
   <use name="DataFormats/TauReco"/>
   <use name="DataFormats/L1TMuonPhase2"/>

--- a/HLTrigger/Timer/BuildFile.xml
+++ b/HLTrigger/Timer/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="boost_chrono"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/HLTrigger/Timer/BuildFile.xml
+++ b/HLTrigger/Timer/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="boost_chrono"/>
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/HLTrigger/Timer/plugins/BuildFile.xml
+++ b/HLTrigger/Timer/plugins/BuildFile.xml
@@ -5,7 +5,7 @@
   <use name="rootminuit"/>
   <use name="tbb"/>
   <use name="DQMServices/Core"/>
-  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Provenance" source_only="1"/>
   <use name="DataFormats/Scalers"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>

--- a/HeavyFlavorAnalysis/Onia2MuMu/BuildFile.xml
+++ b/HeavyFlavorAnalysis/Onia2MuMu/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="DataFormats/HepMCCandidate"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/MuonReco"/>
+<use name="DataFormats/Provenance"/>
 <use name="DataFormats/VertexReco"/>
 <use name="DataFormats/TrackReco"/>
 <use name="TrackingTools/PatternTools"/>

--- a/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
@@ -3,7 +3,7 @@
   <use name="tbb"/>
   <use name="fmt"/>
   <use name="DataFormats/Common"/>
-  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Provenance" source_only="1"/>
   <use name="FWCore/AbstractServices"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>

--- a/HeterogeneousCore/MPICore/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="fmt"/>
 <use name="mpi"/>
 <use name="DataFormats/Common"/>

--- a/HeterogeneousCore/MPICore/plugins/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/plugins/BuildFile.xml
@@ -1,7 +1,7 @@
 <library file="*.cc" name="HeterogeneousCoreMPICorePlugins">
   <use name="json"/>
   <use name="DataFormats/Common"/>
-  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Provenance" source_only="1"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>

--- a/HeterogeneousCore/MPICore/plugins/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/plugins/BuildFile.xml
@@ -1,7 +1,7 @@
 <library file="*.cc" name="HeterogeneousCoreMPICorePlugins">
   <use name="json"/>
   <use name="DataFormats/Common"/>
-  <use name="DataFormats/Provenance" source_only="1"/>
+  <use name="DataFormats/Provenance"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>

--- a/HeterogeneousCore/ROCmServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/ROCmServices/plugins/BuildFile.xml
@@ -1,6 +1,6 @@
 <iftool name="rocm">
   <use name="rocm"/>
-  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Provenance" source_only="1"/>
   <use name="FWCore/AbstractServices"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>

--- a/HeterogeneousCore/SonicTriton/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/HeterogeneousCore/TrivialSerialisation/plugins/BuildFile.xml
+++ b/HeterogeneousCore/TrivialSerialisation/plugins/BuildFile.xml
@@ -1,6 +1,6 @@
 <library file="*.cc" name="HeterogeneousCoreTrivialSerialisationPlugins">
   <use name="DataFormats/Portable"/>
-  <use name="DataFormats/Provenance" source_only="1"/>
+  <use name="DataFormats/Provenance"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/PluginManager"/>

--- a/HeterogeneousCore/TrivialSerialisation/plugins/BuildFile.xml
+++ b/HeterogeneousCore/TrivialSerialisation/plugins/BuildFile.xml
@@ -1,6 +1,6 @@
 <library file="*.cc" name="HeterogeneousCoreTrivialSerialisationPlugins">
   <use name="DataFormats/Portable"/>
-  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Provenance" source_only="1"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/PluginManager"/>

--- a/IOMC/RandomEngine/test/BuildFile.xml
+++ b/IOMC/RandomEngine/test/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/AbstractServices"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ServiceRegistry"/>

--- a/IORawData/CSCCommissioning/BuildFile.xml
+++ b/IORawData/CSCCommissioning/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/FEDRawData"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <flags   EDM_PLUGIN="1"/>

--- a/IORawData/DTCommissioning/plugins/BuildFile.xml
+++ b/IORawData/DTCommissioning/plugins/BuildFile.xml
@@ -2,7 +2,7 @@
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="DataFormats/FEDRawData"/>
-  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Provenance" source_only="1"/>
   <flags EDM_PLUGIN="1"/>
   <use name="xrootd"/>
   <flags cppflags="-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64"/>

--- a/JetMETCorrections/JetCorrector/BuildFile.xml
+++ b/JetMETCorrections/JetCorrector/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/JetReco"/>
 <export>

--- a/JetMETCorrections/Modules/BuildFile.xml
+++ b/JetMETCorrections/Modules/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="JetMETCorrections/JetCorrector"/>
 <use name="FWCore/Utilities"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/L1Trigger/GlobalTriggerAnalyzer/BuildFile.xml
+++ b/L1Trigger/GlobalTriggerAnalyzer/BuildFile.xml
@@ -5,7 +5,7 @@
 <use name="DataFormats/L1GlobalTrigger"/>
 <use name="DataFormats/L1GlobalMuonTrigger"/>
 <use name="DataFormats/L1GlobalCaloTrigger"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="CondFormats/L1TObjects"/>
 <use name="CondFormats/DataRecord"/>

--- a/L1Trigger/L1TGlobal/BuildFile.xml
+++ b/L1Trigger/L1TGlobal/BuildFile.xml
@@ -5,13 +5,14 @@
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/Serialization"/>
 <use name="DataFormats/L1Trigger"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="xerces-c"/>
 <use name="hls"/>
 <use name="hls4mlEmulatorExtras"/>
 <use name="AXOL1TL"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/L1Trigger/L1THGCalUtilities/BuildFile.xml
+++ b/L1Trigger/L1THGCalUtilities/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="FWCore/Framework"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/L1THGCal"/>

--- a/L1Trigger/L1TNtuples/plugins/BuildFile.xml
+++ b/L1Trigger/L1TNtuples/plugins/BuildFile.xml
@@ -40,7 +40,7 @@
 <use name="DataFormats/HepMCCandidate"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/MuonDetId"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/TauReco"/>
 <use name="FWCore/Common"/>
 <use name="FWCore/MessageLogger"/>

--- a/L1Trigger/Phase2L1GT/BuildFile.xml
+++ b/L1Trigger/Phase2L1GT/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="DataFormats/Common"/>
 <use name="FWCore/ParameterSet"/>
+<use name="rootcling"/>
 <use name="py3-pybind11"/>
 <use name="python3"/>
 <export>

--- a/L1Trigger/Phase2L1GT/plugins/BuildFile.xml
+++ b/L1Trigger/Phase2L1GT/plugins/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/L1Trigger"/>
+<use name="DataFormats/Provenance"/>
 <use name="L1Trigger/DemonstratorTools"/>
 <use name="L1Trigger/Phase2L1GT"/>
 <use name="DataFormats/L1TMuonPhase2"/>

--- a/L1TriggerScouting/Utilities/plugins/BuildFile.xml
+++ b/L1TriggerScouting/Utilities/plugins/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="DataFormats/L1Scouting"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/NanoAOD"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/L1TriggerScouting/Utilities/plugins/BuildFile.xml
+++ b/L1TriggerScouting/Utilities/plugins/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="DataFormats/L1Scouting"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/NanoAOD"/>
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/Mixing/Base/BuildFile.xml
+++ b/Mixing/Base/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/RunInfo"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="FWCore/AbstractServices"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>

--- a/Mixing/Base/BuildFile.xml
+++ b/Mixing/Base/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/RunInfo"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/AbstractServices"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>

--- a/OnlineDB/EcalCondDB/BuildFile.xml
+++ b/OnlineDB/EcalCondDB/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="OnlineDB/Oracle"/>
 <use name="DataFormats/EcalDetId"/>
 <export>

--- a/PhysicsTools/BPHNano/plugins/BuildFile.xml
+++ b/PhysicsTools/BPHNano/plugins/BuildFile.xml
@@ -15,7 +15,7 @@
 <use   name="HLTrigger/HLTcore"/>
 <use   name="DataFormats/HLTReco"/>
 <use   name="CondFormats/DataRecord"/>
-<use   name="DataFormats/Provenance"/>
+<use   name="DataFormats/Provenance" source_only="1"/>
 <use   name="roothistmatrix"/>
 <use   name="RecoVertex/VertexTools"/>
 <use   name="RecoVertex/VertexPrimitives"/>

--- a/PhysicsTools/CondLiteIO/BuildFile.xml
+++ b/PhysicsTools/CondLiteIO/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance" source_only="1"/>
+<use name="DataFormats/Provenance"/>
 <use name="DataFormats/FWLite"/>
 <use name="rootcore"/>
 <export>

--- a/PhysicsTools/CondLiteIO/BuildFile.xml
+++ b/PhysicsTools/CondLiteIO/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/FWLite"/>
 <use name="rootcore"/>
 <export>

--- a/PhysicsTools/CondLiteIO/plugins/BuildFile.xml
+++ b/PhysicsTools/CondLiteIO/plugins/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="FWCore/Utilities"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/FWLite"/>
+<use name="DataFormats/Provenance"/>
 <use name="PhysicsTools/CondLiteIO"/>
 <library file="*.cc" name="PhysicsToolsCondLiteIOPlugins">
   <flags EDM_PLUGIN="1"/>

--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -18,6 +18,7 @@
 <use name="DataFormats/OnlineMetaData"/>
 <use name="DataFormats/PatCandidates"/>
 <use name="DataFormats/ProtonReco"/>
+<use name="DataFormats/Provenance"/>
 <use name="DataFormats/TrackReco"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>

--- a/PhysicsTools/PatAlgos/plugins/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/plugins/BuildFile.xml
@@ -18,6 +18,7 @@
   <use name="DataFormats/HeavyIonEvent"/>
   <use name="DataFormats/HepMCCandidate"/>
   <use name="PhysicsTools/PatUtils"/>
+  <use name="DataFormats/Provenance"/>
   <use name="PhysicsTools/XGBoost"/>
   <use name="CondFormats/JetMETObjects"/>
   <use name="CondFormats/HcalObjects"/>

--- a/PhysicsTools/SelectorUtils/BuildFile.xml
+++ b/PhysicsTools/SelectorUtils/BuildFile.xml
@@ -8,7 +8,7 @@
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/BeamSpot"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/VertexReco"/>
 <use name="FWCore/Common"/>
 <use name="FWCore/Framework"/>

--- a/PhysicsTools/UtilAlgos/BuildFile.xml
+++ b/PhysicsTools/UtilAlgos/BuildFile.xml
@@ -5,7 +5,7 @@
 <use name="FWCore/Utilities"/>
 <use name="FWCore/Common"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/PatCandidates"/>

--- a/PhysicsTools/Utilities/BuildFile.xml
+++ b/PhysicsTools/Utilities/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Utilities"/>
 <use name="FWCore/Common"/>
 <use name="SimDataFormats/PileupSummaryInfo"/>

--- a/RecoEgamma/EgammaElectronAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaElectronAlgos/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="TrackingTools/MaterialEffects"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
-<use name="clhep"/>
 <use name="MagneticField/Engine"/>
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/TrackingRecHit"/>

--- a/RecoEgamma/EgammaPhotonProducers/BuildFile.xml
+++ b/RecoEgamma/EgammaPhotonProducers/BuildFile.xml
@@ -21,6 +21,5 @@
 <use name="RecoTracker/TrackProducer"/>
 <use name="DataFormats/HcalRecHit"/>
 <use name="RecoCaloTools/Selectors" source_only="1"/>
-<use name="clhep"/>
 <use name="PhysicsTools/ONNXRuntime" />
 <flags EDM_PLUGIN="1"/>

--- a/RecoLuminosity/LumiProducer/BuildFile.xml
+++ b/RecoLuminosity/LumiProducer/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
+<use name="rootcling"/>
 <use name="CoralBase"/>
 <use name="RelationalAccess"/>
 <use name="FWCore/Utilities"/>

--- a/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
+++ b/RecoLuminosity/LumiProducer/plugins/BuildFile.xml
@@ -71,7 +71,7 @@
 
 <library file="LumiProducer.cc" name="LumiProducer">
   <use name="RecoLuminosity/LumiProducer"/>
-  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Provenance" source_only="1"/>
   <use name="DataFormats/Luminosity"/>
   <use name="Utilities/Xerces"/>
   <use name="xerces-c"/>
@@ -79,13 +79,13 @@
 </library>
 
 <library file="BunchSpacingProducer.cc" name="BunchSpacingProducer">
-  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Provenance" source_only="1"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 
 <library file="ExpressLumiProducer.cc" name="ExpressLumiProducer">
   <use name="RecoLuminosity/LumiProducer"/>
-  <use name="DataFormats/Provenance"/>
+  <use name="DataFormats/Provenance" source_only="1"/>
   <use name="DataFormats/Luminosity"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoParticleFlow/Benchmark/BuildFile.xml
+++ b/RecoParticleFlow/Benchmark/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DQMServices/Core"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
@@ -95,8 +95,6 @@ bool HLTDeDxFilter::hltFilter(edm::Event& iEvent,
 
   auto chargedCandidates = std::make_unique<std::vector<RecoChargedCandidate>>();
 
-  ModuleDescription moduleDesc_;
-
   if (saveTags()) {
     filterproduct.addCollectionTag(thisModuleTag_);
     filterproduct.addCollectionTag(inputTracksTag_);

--- a/RecoTracker/MeasurementDet/BuildFile.xml
+++ b/RecoTracker/MeasurementDet/BuildFile.xml
@@ -23,3 +23,4 @@
 <use name="RecoLocalTracker/Phase2TrackerRecHits"/>
 <use name="TrackingTools/DetLayers"/>
 <use name="TrackingTools/MeasurementDet"/>
+<use name="rootcling"/>

--- a/RecoTracker/MkFit/BuildFile.xml
+++ b/RecoTracker/MkFit/BuildFile.xml
@@ -1,11 +1,11 @@
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/TrackerCommon"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="RecoTracker/TkDetLayers"/>
 <use name="RecoTracker/MkFitCore"/>
 <use name="RecoTracker/MkFitCMS"/>
-<use name="rootcore"/>
+<use name="rootmathcore"/>
 <export>
   <lib name="RecoTrackerMkFit"/>
 </export>

--- a/SimDataFormats/Associations/BuildFile.xml
+++ b/SimDataFormats/Associations/BuildFile.xml
@@ -18,6 +18,7 @@
 <use name="SimDataFormats/TrackingHit"/>
 <use name="SimDataFormats/Vertex"/>
 <use name="DataFormats/ParticleFlowReco"/>
+<use name="rootcling"/>
 <use name="clhep"/>
 <export>
   <lib name="1"/>

--- a/SimDataFormats/CaloAnalysis/BuildFile.xml
+++ b/SimDataFormats/CaloAnalysis/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="SimDataFormats/CaloHit"/>
 <use name="SimDataFormats/TrackingHit"/>
 <use name="FWCore/MessageLogger"/>
+<use name="rootcling"/>
 <use name="clhepheader"/>
 <export>
   <lib name="1"/>

--- a/SimDataFormats/CaloHit/BuildFile.xml
+++ b/SimDataFormats/CaloHit/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Math"/>
 <use name="SimDataFormats/EncodedEventId"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/SimDataFormats/CaloTest/BuildFile.xml
+++ b/SimDataFormats/CaloTest/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="SimDataFormats/CaloHit"/>
 <use name="DataFormats/HcalDetId"/>
 <use name="DataFormats/Math"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/SimDataFormats/CrossingFrame/BuildFile.xml
+++ b/SimDataFormats/CrossingFrame/BuildFile.xml
@@ -1,5 +1,6 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Utilities"/>
 <use name="SimDataFormats/CaloHit"/>
 <use name="SimDataFormats/EncodedEventId"/>

--- a/SimDataFormats/DigiSimLinks/BuildFile.xml
+++ b/SimDataFormats/DigiSimLinks/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="SimDataFormats/EncodedEventId"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/MuonData" source_only="1"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/SimDataFormats/EcalTestBeam/BuildFile.xml
+++ b/SimDataFormats/EcalTestBeam/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/EcalDetId"/>
 <use name="FWCore/Utilities"/>
+<use name="rootcling"/>
 <export>
   <lib name="1"/>
 </export>

--- a/SimDataFormats/Forward/BuildFile.xml
+++ b/SimDataFormats/Forward/BuildFile.xml
@@ -3,3 +3,4 @@
 </export>
 <use name="DataFormats/Common"/>
 <use name="FWCore/MessageLogger"/>
+<use name="rootcling"/>

--- a/SimDataFormats/GEMDigiSimLink/BuildFile.xml
+++ b/SimDataFormats/GEMDigiSimLink/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/GeometryVector"/>
 <use name="SimDataFormats/EncodedEventId"/>

--- a/SimDataFormats/HTXS/BuildFile.xml
+++ b/SimDataFormats/HTXS/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Math"/>
 <export>

--- a/SimDataFormats/HcalTestBeam/BuildFile.xml
+++ b/SimDataFormats/HcalTestBeam/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/MessageLogger"/>
 <export>

--- a/SimDataFormats/HiGenData/BuildFile.xml
+++ b/SimDataFormats/HiGenData/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/HepMCCandidate"/>
 <use name="DataFormats/Common"/>
 <export>

--- a/SimDataFormats/PileupSummaryInfo/BuildFile.xml
+++ b/SimDataFormats/PileupSummaryInfo/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/Math"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
+<use name="rootcling"/>
 <use name="hepmc"/>
 <export>
   <lib name="1"/>

--- a/SimDataFormats/RPCDigiSimLink/BuildFile.xml
+++ b/SimDataFormats/RPCDigiSimLink/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="SimDataFormats/EncodedEventId"/>
 <use name="DataFormats/GeometryVector"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/SimDataFormats/RandomEngine/BuildFile.xml
+++ b/SimDataFormats/RandomEngine/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="DataFormats/Common"/>
 <use name="FWCore/Utilities"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/SimDataFormats/Track/BuildFile.xml
+++ b/SimDataFormats/Track/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Math"/>
 <use name="SimDataFormats/EncodedEventId"/>

--- a/SimDataFormats/TrackerDigiSimLink/BuildFile.xml
+++ b/SimDataFormats/TrackerDigiSimLink/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="DataFormats/Common"/>
 <use name="SimDataFormats/EncodedEventId"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <use name="DataFormats/GeometryVector"/>
 <export>

--- a/SimDataFormats/TrackingAnalysis/BuildFile.xml
+++ b/SimDataFormats/TrackingAnalysis/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="SimDataFormats/Track"/>
 <use name="SimDataFormats/Vertex"/>
 <use name="FWCore/MessageLogger"/>
+<use name="rootcling"/>
 <use name="clhepheader"/>
 <export>
   <lib name="1"/>

--- a/SimDataFormats/TrackingHit/BuildFile.xml
+++ b/SimDataFormats/TrackingHit/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/GeometryVector"/>
 <use name="SimDataFormats/EncodedEventId"/>

--- a/SimDataFormats/ValidationFormats/BuildFile.xml
+++ b/SimDataFormats/ValidationFormats/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/GeometryVector"/>
 <use name="DataFormats/Math"/>
+<use name="rootcling"/>
 <use name="clhep"/>
 <use name="expat"/>
 <export>

--- a/SimDataFormats/Vertex/BuildFile.xml
+++ b/SimDataFormats/Vertex/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Math"/>
 <use name="SimDataFormats/EncodedEventId"/>

--- a/SimGeneral/DataMixingModule/plugins/BuildFile.xml
+++ b/SimGeneral/DataMixingModule/plugins/BuildFile.xml
@@ -7,7 +7,7 @@
 <use name="DataFormats/EcalRecHit"/>
 <use name="DataFormats/HcalDigi"/>
 <use name="DataFormats/HcalRecHit"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/RPCDigi"/>
 <use name="DataFormats/SiPixelDigi"/>
 <use name="DataFormats/SiStripDigi"/>

--- a/SimGeneral/MixingModule/plugins/BuildFile.xml
+++ b/SimGeneral/MixingModule/plugins/BuildFile.xml
@@ -1,6 +1,6 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/HepMCCandidate"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/SimTracker/TrackerHitAssociation/BuildFile.xml
+++ b/SimTracker/TrackerHitAssociation/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/Common"/>
@@ -8,16 +9,13 @@
 <use name="TrackingTools/TransientTrackingRecHit"/>
 <use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/DetId"/>
-<use name="DataFormats/Provenance"/>
+<use name="DataFormats/Provenance" source_only="1"/>
 <use name="DataFormats/SiPixelDigi"/>
 <use name="DataFormats/SiStripDetId"/>
 <use name="DataFormats/TrackingRecHit"/>
 <use name="FWCore/MessageLogger"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimDataFormats/TrackingAnalysis"/>
-<use name="clhep"/>
-<use name="boost"/>
-<use name="root"/>
 <export>
   <lib name="1"/>
 </export>

--- a/TBDataFormats/EcalTBObjects/BuildFile.xml
+++ b/TBDataFormats/EcalTBObjects/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/EcalDetId"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/TBDataFormats/HcalTBObjects/BuildFile.xml
+++ b/TBDataFormats/HcalTBObjects/BuildFile.xml
@@ -1,5 +1,6 @@
 <flags CXXFLAGS="-Wno-error=array-bounds" />
 <use name="DataFormats/Common"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/TrackingTools/GsfTracking/BuildFile.xml
+++ b/TrackingTools/GsfTracking/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="ofast-flag"/>
+<use name="rootcling"/>
 <use name="boost"/>
 <use name="CLHEP"/>
 <export>

--- a/TrackingTools/PatternTools/BuildFile.xml
+++ b/TrackingTools/PatternTools/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/BeamSpot"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/GeometrySurface"/>

--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="TrackingTools/AnalyticalJacobians"/>
 <use name="TrackingTools/TrajectoryParametrization"/>
 <use name="MagneticField/Engine"/>
+<use name="rootcling"/>
 <use name="vdt_headers"/>
 <export>
   <lib name="1"/>

--- a/TrackingTools/TransientTrack/BuildFile.xml
+++ b/TrackingTools/TransientTrack/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="rootcling"/>
 <use name="DataFormats/BeamSpot"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/GsfTrackReco"/>

--- a/TrackingTools/TransientTrackingRecHit/BuildFile.xml
+++ b/TrackingTools/TransientTrackingRecHit/BuildFile.xml
@@ -1,4 +1,4 @@
-
+<use name="rootcling"/>
 <use name="clhep"/>
 <use name="FWCore/Utilities"/>
 <use name="FWCore/MessageLogger"/>

--- a/Validation/HGCalValidation/BuildFile.xml
+++ b/Validation/HGCalValidation/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="SimDataFormats/CaloAnalysis"/>
 <use name="RecoLocalCalo/HGCalRecAlgos"/>
 <use name="RecoLocalCalo/HGCalRecProducers"/>
+<use name="rootcling"/>
 <use name="clhep"/>
 <use name="hepmc"/>
 <export>


### PR DESCRIPTION
#### PR description:

This PR is the first pass of some dependency cleanups.

General changes:

- Make sure that every package that declares dictionaries has a dependency on `rootcling`.  See #50692 for motivation.
- Change many uses of `DataFormats/Provenance` to `source_only="1"`.  Outside of IO modules and FWCore, most uses of `DataFormats/Provenance` are for one of a few elementary types like `edm::EventID` or `edm::Timestamp`.  These uses do not need the dependency on `FWCore/Reflection` that `DataFormats/Provenance` brings in.  A future PR may move the core types into a separate package.
- Narrow ROOT dependencies where possible, especially narrowing `rootmath` to `rootmathcore`.
- Remove unnecessary dependencies on `boost` and `clhep`

Specific changes:

- Remove a dependency from `CalibCalorimetry/EBPhase2TPGTools` to `OnlineDB/EcalCondDB`.  The `OnlineDB` pulls in the Oracle client libraries, which is undesirable.  See #50279.
- Remove an unused member data of type `ModuleDescription` in `RecoTracker/DeDx/plugins/HLTDeDxFilter.cc`

Resolves https://github.com/cms-sw/framework-team/issues/1972?issue=cms-sw%7Cframework-team%7C1973 

#### PR validation:

Compiles.  No changes that should affect physics or computational performance.