### PR TITLE
[EVOLUTION_X] Move more types to `io_v1` namespace

### DIFF
--- a/DataFormats/Candidate/interface/CompositePtrCandidate.h
+++ b/DataFormats/Candidate/interface/CompositePtrCandidate.h
@@ -13,75 +13,79 @@
  */
 
 namespace reco {
+  namespace io_v1 {
 
-  class CompositePtrCandidate : public LeafCandidate {
-  public:
-    /// collection of references to daughters
-    typedef std::vector<CandidatePtr> daughters;
-    /// collection of references to daughters
-    typedef std::vector<CandidatePtr> mothers;
-    /// default constructor
-    CompositePtrCandidate() : LeafCandidate() {}
-    /// constructor from values
-    CompositePtrCandidate(Charge q,
-                          const LorentzVector& p4,
-                          const Point& vtx = Point(0, 0, 0),
-                          int pdgId = 0,
-                          int status = 0,
-                          bool integerCharge = true)
-        : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge) {}
-    /// constructor from values
-    CompositePtrCandidate(Charge q,
-                          const PolarLorentzVector& p4,
-                          const Point& vtx = Point(0, 0, 0),
-                          int pdgId = 0,
-                          int status = 0,
-                          bool integerCharge = true)
-        : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge) {}
-    /// constructor from a Candidate
-    explicit CompositePtrCandidate(const Candidate& p) : LeafCandidate(p) {}
-    /// destructor
-    ~CompositePtrCandidate() override;
-    /// returns a clone of the candidate
-    CompositePtrCandidate* clone() const override;
-    /// number of daughters
-    size_t numberOfDaughters() const override;
-    /// number of mothers
-    size_t numberOfMothers() const override;
-    /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
-    const Candidate* daughter(size_type) const override;
-    using reco::LeafCandidate::daughter;  // avoid hiding the base
-    /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
-    Candidate* daughter(size_type) override;
-    /// add a daughter via a reference
-    void addDaughter(const CandidatePtr&);
-    /// clear daughter references
-    virtual void clearDaughters() { dau.clear(); }
-    /// reference to daughter at given position
-    virtual CandidatePtr daughterPtr(size_type i) const { return dau[i]; }
-    /// references to daughtes
-    virtual const daughters& daughterPtrVector() const { return dau; }
-    /// return pointer to mother
-    const Candidate* mother(size_t i = 0) const override;
-    /// number of source candidates
-    /// ( the candidates used to construct this Candidate).
-    /// for CompositeRefBaseCandidates, the source candidates
-    /// are the daughters.
-    size_type numberOfSourceCandidatePtrs() const override;
-    /// return a RefToBase to one of the source Candidates
-    /// ( the candidates used to construct this Candidate).
-    /// for CompositeRefBaseCandidates, the source candidates
-    /// are the daughters.
-    CandidatePtr sourceCandidatePtr(size_type i) const override;
+    class CompositePtrCandidate : public LeafCandidate {
+    public:
+      /// collection of references to daughters
+      typedef std::vector<CandidatePtr> daughters;
+      /// collection of references to daughters
+      typedef std::vector<CandidatePtr> mothers;
+      /// default constructor
+      CompositePtrCandidate() : LeafCandidate() {}
+      /// constructor from values
+      CompositePtrCandidate(Charge q,
+                            const LorentzVector& p4,
+                            const Point& vtx = Point(0, 0, 0),
+                            int pdgId = 0,
+                            int status = 0,
+                            bool integerCharge = true)
+          : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge) {}
+      /// constructor from values
+      CompositePtrCandidate(Charge q,
+                            const PolarLorentzVector& p4,
+                            const Point& vtx = Point(0, 0, 0),
+                            int pdgId = 0,
+                            int status = 0,
+                            bool integerCharge = true)
+          : LeafCandidate(q, p4, vtx, pdgId, status, integerCharge) {}
+      /// constructor from a Candidate
+      explicit CompositePtrCandidate(const Candidate& p) : LeafCandidate(p) {}
+      /// destructor
+      ~CompositePtrCandidate() override;
+      /// returns a clone of the candidate
+      CompositePtrCandidate* clone() const override;
+      /// number of daughters
+      size_t numberOfDaughters() const override;
+      /// number of mothers
+      size_t numberOfMothers() const override;
+      /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1 (read only mode)
+      const Candidate* daughter(size_type) const override;
+      using reco::LeafCandidate::daughter;  // avoid hiding the base
+      /// return daughter at a given position, i = 0, ... numberOfDaughters() - 1
+      Candidate* daughter(size_type) override;
+      /// add a daughter via a reference
+      void addDaughter(const CandidatePtr&);
+      /// clear daughter references
+      virtual void clearDaughters() { dau.clear(); }
+      /// reference to daughter at given position
+      virtual CandidatePtr daughterPtr(size_type i) const { return dau[i]; }
+      /// references to daughtes
+      virtual const daughters& daughterPtrVector() const { return dau; }
+      /// return pointer to mother
+      const Candidate* mother(size_t i = 0) const override;
+      /// number of source candidates
+      /// ( the candidates used to construct this Candidate).
+      /// for CompositeRefBaseCandidates, the source candidates
+      /// are the daughters.
+      size_type numberOfSourceCandidatePtrs() const override;
+      /// return a RefToBase to one of the source Candidates
+      /// ( the candidates used to construct this Candidate).
+      /// for CompositeRefBaseCandidates, the source candidates
+      /// are the daughters.
+      CandidatePtr sourceCandidatePtr(size_type i) const override;
 
-  private:
-    /// collection of references to daughters
-    daughters dau;
-    /// check overlap with another candidate
-    bool overlap(const Candidate&) const override;
-  };
+    private:
+      /// collection of references to daughters
+      daughters dau;
+      /// check overlap with another candidate
+      bool overlap(const Candidate&) const override;
+    };
 
-  inline void CompositePtrCandidate::addDaughter(const CandidatePtr& cand) { dau.push_back(cand); }
+    inline void CompositePtrCandidate::addDaughter(const CandidatePtr& cand) { dau.push_back(cand); }
+
+  }  // namespace io_v1
+  using CompositePtrCandidate = io_v1::CompositePtrCandidate;
 
 }  // namespace reco
 

--- a/DataFormats/Candidate/interface/LeafRefCandidateT.h
+++ b/DataFormats/Candidate/interface/LeafRefCandidateT.h
@@ -13,168 +13,169 @@
 #include "DataFormats/Common/interface/RefCoreWithIndex.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class LeafRefCandidateT : public LeafCandidate {
-  public:
-    /// collection of daughter candidates
-    typedef CandidateCollection daughters;
-    /// electric charge type
-    typedef int Charge;
-    /// Lorentz vector
-    typedef math::XYZTLorentzVector LorentzVector;
-    /// Lorentz vector
-    typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;
-    /// point in the space
-    typedef math::XYZPoint Point;
-    /// point in the space
-    typedef math::XYZVector Vector;
+    class LeafRefCandidateT : public LeafCandidate {
+    public:
+      /// collection of daughter candidates
+      typedef CandidateCollection daughters;
+      /// electric charge type
+      typedef int Charge;
+      /// Lorentz vector
+      typedef math::XYZTLorentzVector LorentzVector;
+      /// Lorentz vector
+      typedef math::PtEtaPhiMLorentzVector PolarLorentzVector;
+      /// point in the space
+      typedef math::XYZPoint Point;
+      /// point in the space
+      typedef math::XYZVector Vector;
 
-    typedef unsigned int index;
+      typedef unsigned int index;
 
-    /// default constructor
-    LeafRefCandidateT() {}
-    // constructor from T
-    template <class REF>
-    LeafRefCandidateT(const REF& c, float m)
-        : LeafCandidate(c->charge(), PolarLorentzVector(c->pt(), c->eta(), c->phi(), m), c->vertex()),
-          ref_(c.refCore(), c.key()) {}
-    /// destructor
-    ~LeafRefCandidateT() override {}
+      /// default constructor
+      LeafRefCandidateT() {}
+      // constructor from T
+      template <class REF>
+      LeafRefCandidateT(const REF& c, float m)
+          : LeafCandidate(c->charge(), PolarLorentzVector(c->pt(), c->eta(), c->phi(), m), c->vertex()),
+            ref_(c.refCore(), c.key()) {}
+      /// destructor
+      ~LeafRefCandidateT() override {}
 
-  protected:
-    // get the ref (better be the correct ref!)
-    template <typename REF>
-    REF getRef() const {
-      return REF(ref_.toRefCore(), ref_.index());
-    }
+    protected:
+      // get the ref (better be the correct ref!)
+      template <typename REF>
+      REF getRef() const {
+        return REF(ref_.toRefCore(), ref_.index());
+      }
 
-  public:
-    /// number of daughters
-    size_t numberOfDaughters() const final { return 0; }
-    /// return daughter at a given position (throws an exception)
-    const Candidate* daughter(size_type) const final { return nullptr; }
-    /// number of mothers
-    size_t numberOfMothers() const final { return 0; }
-    /// return mother at a given position (throws an exception)
-    const Candidate* mother(size_type) const final { return nullptr; }
-    /// return daughter at a given position (throws an exception)
-    Candidate* daughter(size_type) final { return nullptr; }
-    /// return daughter with a specified role name
-    Candidate* daughter(const std::string& s) final { return nullptr; }
-    /// return daughter with a specified role name
-    const Candidate* daughter(const std::string& s) const final { return nullptr; }
-    /// return the number of source Candidates
-    /// ( the candidates used to construct this Candidate)
-    size_t numberOfSourceCandidatePtrs() const final { return 0; }
-    /// return a Ptr to one of the source Candidates
-    /// ( the candidates used to construct this Candidate)
-    CandidatePtr sourceCandidatePtr(size_type i) const final {
-      static const CandidatePtr dummyPtr;
-      return dummyPtr;
-    }
+    public:
+      /// number of daughters
+      size_t numberOfDaughters() const final { return 0; }
+      /// return daughter at a given position (throws an exception)
+      const Candidate* daughter(size_type) const final { return nullptr; }
+      /// number of mothers
+      size_t numberOfMothers() const final { return 0; }
+      /// return mother at a given position (throws an exception)
+      const Candidate* mother(size_type) const final { return nullptr; }
+      /// return daughter at a given position (throws an exception)
+      Candidate* daughter(size_type) final { return nullptr; }
+      /// return daughter with a specified role name
+      Candidate* daughter(const std::string& s) final { return nullptr; }
+      /// return daughter with a specified role name
+      const Candidate* daughter(const std::string& s) const final { return nullptr; }
+      /// return the number of source Candidates
+      /// ( the candidates used to construct this Candidate)
+      size_t numberOfSourceCandidatePtrs() const final { return 0; }
+      /// return a Ptr to one of the source Candidates
+      /// ( the candidates used to construct this Candidate)
+      CandidatePtr sourceCandidatePtr(size_type i) const final {
+        static const CandidatePtr dummyPtr;
+        return dummyPtr;
+      }
 
-    /// This only happens if the concrete Candidate type is ShallowCloneCandidate
-    bool hasMasterClone() const final { return false; }
-    /// returns ptr to master clone, if existing.
-    /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate
-    const CandidateBaseRef& masterClone() const final {
-      static const CandidateBaseRef dummyRef;
-      return dummyRef;
-    }
-    /// returns true if this candidate has a ptr to a master clone.
-    /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate
-    bool hasMasterClonePtr() const final { return false; }
-    /// returns ptr to master clone, if existing.
-    /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate
-    const CandidatePtr& masterClonePtr() const final {
-      static const CandidatePtr dummyPtr;
-      return dummyPtr;
-    }
+      /// This only happens if the concrete Candidate type is ShallowCloneCandidate
+      bool hasMasterClone() const final { return false; }
+      /// returns ptr to master clone, if existing.
+      /// Throws an exception unless the concrete Candidate type is ShallowCloneCandidate
+      const CandidateBaseRef& masterClone() const final {
+        static const CandidateBaseRef dummyRef;
+        return dummyRef;
+      }
+      /// returns true if this candidate has a ptr to a master clone.
+      /// This only happens if the concrete Candidate type is ShallowClonePtrCandidate
+      bool hasMasterClonePtr() const final { return false; }
+      /// returns ptr to master clone, if existing.
+      /// Throws an exception unless the concrete Candidate type is ShallowClonePtrCandidate
+      const CandidatePtr& masterClonePtr() const final {
+        static const CandidatePtr dummyPtr;
+        return dummyPtr;
+      }
 
-    /// cast master clone reference to a concrete type
-    template <typename Ref>
-    Ref masterRef() const {
-      Ref dummyRef;
-      return dummyRef;
-    }
-    /// get a component
+      /// cast master clone reference to a concrete type
+      template <typename Ref>
+      Ref masterRef() const {
+        Ref dummyRef;
+        return dummyRef;
+      }
+      /// get a component
 
-    template <typename C>
-    C get() const {
-      if (hasMasterClone())
-        return masterClone()->template get<C>();
-      else
-        return reco::get<C>(*this);
-    }
-    /// get a component
-    template <typename C, typename Tag>
-    C get() const {
-      if (hasMasterClone())
-        return masterClone()->template get<C, Tag>();
-      else
-        return reco::get<C, Tag>(*this);
-    }
-    /// get a component
-    template <typename C>
-    C get(size_type i) const {
-      if (hasMasterClone())
-        return masterClone()->template get<C>(i);
-      else
-        return reco::get<C>(*this, i);
-    }
-    /// get a component
-    template <typename C, typename Tag>
-    C get(size_type i) const {
-      if (hasMasterClone())
-        return masterClone()->template get<C, Tag>(i);
-      else
-        return reco::get<C, Tag>(*this, i);
-    }
-    /// number of components
-    template <typename C>
-    size_type numberOf() const {
-      if (hasMasterClone())
-        return masterClone()->template numberOf<C>();
-      else
-        return reco::numberOf<C>(*this);
-    }
-    /// number of components
-    template <typename C, typename Tag>
-    size_type numberOf() const {
-      if (hasMasterClone())
-        return masterClone()->template numberOf<C, Tag>();
-      else
-        return reco::numberOf<C, Tag>(*this);
-    }
+      template <typename C>
+      C get() const {
+        if (hasMasterClone())
+          return masterClone()->template get<C>();
+        else
+          return reco::get<C>(*this);
+      }
+      /// get a component
+      template <typename C, typename Tag>
+      C get() const {
+        if (hasMasterClone())
+          return masterClone()->template get<C, Tag>();
+        else
+          return reco::get<C, Tag>(*this);
+      }
+      /// get a component
+      template <typename C>
+      C get(size_type i) const {
+        if (hasMasterClone())
+          return masterClone()->template get<C>(i);
+        else
+          return reco::get<C>(*this, i);
+      }
+      /// get a component
+      template <typename C, typename Tag>
+      C get(size_type i) const {
+        if (hasMasterClone())
+          return masterClone()->template get<C, Tag>(i);
+        else
+          return reco::get<C, Tag>(*this, i);
+      }
+      /// number of components
+      template <typename C>
+      size_type numberOf() const {
+        if (hasMasterClone())
+          return masterClone()->template numberOf<C>();
+        else
+          return reco::numberOf<C>(*this);
+      }
+      /// number of components
+      template <typename C, typename Tag>
+      size_type numberOf() const {
+        if (hasMasterClone())
+          return masterClone()->template numberOf<C, Tag>();
+        else
+          return reco::numberOf<C, Tag>(*this);
+      }
 
-    bool isElectron() const final { return false; }
-    bool isMuon() const final { return false; }
-    bool isStandAloneMuon() const final { return false; }
-    bool isGlobalMuon() const final { return false; }
-    bool isTrackerMuon() const final { return false; }
-    bool isCaloMuon() const final { return false; }
-    bool isPhoton() const final { return false; }
-    bool isConvertedPhoton() const final { return false; }
-    bool isJet() const final { return false; }
+      bool isElectron() const final { return false; }
+      bool isMuon() const final { return false; }
+      bool isStandAloneMuon() const final { return false; }
+      bool isGlobalMuon() const final { return false; }
+      bool isTrackerMuon() const final { return false; }
+      bool isCaloMuon() const final { return false; }
+      bool isPhoton() const final { return false; }
+      bool isConvertedPhoton() const final { return false; }
+      bool isJet() const final { return false; }
 
-  protected:
-    /// check overlap with another Candidate
-    bool overlap(const Candidate&) const override;
-    virtual bool overlap(const LeafRefCandidateT&) const;
-    template <typename, typename, typename>
-    friend struct component;
-    friend class ::OverlapChecker;
-    friend class ShallowCloneCandidate;
-    friend class ShallowClonePtrCandidate;
+    protected:
+      /// check overlap with another Candidate
+      bool overlap(const Candidate&) const override;
+      virtual bool overlap(const LeafRefCandidateT&) const;
+      template <typename, typename, typename>
+      friend struct component;
+      friend class ::OverlapChecker;
+      friend class ShallowCloneCandidate;
+      friend class ShallowClonePtrCandidate;
 
-  protected:
-    edm::RefCoreWithIndex ref_;
+    protected:
+      edm::RefCoreWithIndex ref_;
 
-  private:
-    ///
-    /// Hide these from all users:
-    ///
-    /*                                    
+    private:
+      ///
+      /// Hide these from all users:
+      ///
+      /*                                    
     virtual void setCharge( Charge q ) final  {}                                         
     virtual void setThreeCharge( Charge qx3 ) final  {}
     virtual void setP4( const LorentzVector & p4 ) final  {}
@@ -192,15 +193,18 @@ namespace reco {
     virtual double vertexCovariance(int i, int j) const final  { return 0.; }
     virtual void fillVertexCovariance(CovarianceMatrix & v) const final  {}
     */
-  };
+    };
 
-  inline bool LeafRefCandidateT::overlap(const Candidate& o) const {
-    return (p4() == o.p4()) && (vertex() == o.vertex()) && (charge() == o.charge());
-  }
+    inline bool LeafRefCandidateT::overlap(const Candidate& o) const {
+      return (p4() == o.p4()) && (vertex() == o.vertex()) && (charge() == o.charge());
+    }
 
-  inline bool LeafRefCandidateT::overlap(const LeafRefCandidateT& o) const {
-    return (ref_.id() == o.ref_.id()) && (ref_.index() == o.ref_.index());
-  }
+    inline bool LeafRefCandidateT::overlap(const LeafRefCandidateT& o) const {
+      return (ref_.id() == o.ref_.id()) && (ref_.index() == o.ref_.index());
+    }
+
+  }  // namespace io_v1
+  using LeafRefCandidateT = io_v1::LeafRefCandidateT;
 
 }  // namespace reco
 

--- a/DataFormats/Candidate/src/CompositePtrCandidate.cc
+++ b/DataFormats/Candidate/src/CompositePtrCandidate.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 using namespace reco;
+using namespace reco::io_v1;
 
 CompositePtrCandidate::~CompositePtrCandidate() {}
 

--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -31,12 +31,12 @@
   <class name="std::vector<std::pair<reco::io_v1::CompositeCandidate, std::vector<int> > >" />
   <class name="edm::Wrapper<std::vector<std::pair<reco::io_v1::CompositeCandidate, std::vector<int> > > >" />
 
-  <class name="reco::LeafRefCandidateT" ClassVersion="3">
-    <version ClassVersion="3" checksum="2164853592"/>
+  <class name="reco::io_v1::LeafRefCandidateT" ClassVersion="3">
+    <version ClassVersion="3" checksum="580483222"/>
    </class>
 
   <class name="reco::io_v1::VertexCompositePtrCandidate" ClassVersion="3">
-   <version ClassVersion="3" checksum="2009437832"/>
+   <version ClassVersion="3" checksum="3506942202"/>
   </class>  
 
   <class name="reco::io_v1::VertexCompositeCandidate" ClassVersion="3">
@@ -45,8 +45,8 @@
   <class name="reco::CompositeRefCandidate"  ClassVersion="3">
    <version ClassVersion="3" checksum="134608244"/>
   </class>
-  <class name="reco::CompositePtrCandidate"  ClassVersion="3">
-   <version ClassVersion="3" checksum="3593770037"/>
+  <class name="reco::io_v1::CompositePtrCandidate"  ClassVersion="3">
+   <version ClassVersion="3" checksum="357090655"/>
   </class>
   <class name="reco::CompositeRefBaseCandidate"  ClassVersion="3">
    <version ClassVersion="3" checksum="2593606352"/>

--- a/DataFormats/HLTReco/interface/TriggerRefsCollections.h
+++ b/DataFormats/HLTReco/interface/TriggerRefsCollections.h
@@ -106,1762 +106,1766 @@ namespace trigger {
 
   typedef l1t::P2GTCandidateVectorRef VRl1tp2gtcand;
 
-  class TriggerRefsCollections {
-    /// data members
-  private:
-    /// physics type ids and Refs
-    Vids photonIds_;
-    VRphoton photonRefs_;
-    Vids electronIds_;
-    VRelectron electronRefs_;
-    Vids muonIds_;
-    VRmuon muonRefs_;
-    Vids jetIds_;
-    VRjet jetRefs_;
-    Vids compositeIds_;
-    VRcomposite compositeRefs_;
-    Vids basemetIds_;
-    VRbasemet basemetRefs_;
-    Vids calometIds_;
-    VRcalomet calometRefs_;
-    Vids pixtrackIds_;
-    VRpixtrack pixtrackRefs_;
+  namespace io_v1 {
+    class TriggerRefsCollections {
+      /// data members
+    private:
+      /// physics type ids and Refs
+      Vids photonIds_;
+      VRphoton photonRefs_;
+      Vids electronIds_;
+      VRelectron electronRefs_;
+      Vids muonIds_;
+      VRmuon muonRefs_;
+      Vids jetIds_;
+      VRjet jetRefs_;
+      Vids compositeIds_;
+      VRcomposite compositeRefs_;
+      Vids basemetIds_;
+      VRbasemet basemetRefs_;
+      Vids calometIds_;
+      VRcalomet calometRefs_;
+      Vids pixtrackIds_;
+      VRpixtrack pixtrackRefs_;
 
-    Vids l1emIds_;
-    VRl1em l1emRefs_;
-    Vids l1muonIds_;
-    VRl1muon l1muonRefs_;
-    Vids l1jetIds_;
-    VRl1jet l1jetRefs_;
-    Vids l1etmissIds_;
-    VRl1etmiss l1etmissRefs_;
-    Vids l1hfringsIds_;
-    VRl1hfrings l1hfringsRefs_;
+      Vids l1emIds_;
+      VRl1em l1emRefs_;
+      Vids l1muonIds_;
+      VRl1muon l1muonRefs_;
+      Vids l1jetIds_;
+      VRl1jet l1jetRefs_;
+      Vids l1etmissIds_;
+      VRl1etmiss l1etmissRefs_;
+      Vids l1hfringsIds_;
+      VRl1hfrings l1hfringsRefs_;
 
-    Vids l1tmuonIds_;
-    VRl1tmuon l1tmuonRefs_;
-    Vids l1tmuonShowerIds_;
-    VRl1tmuonShower l1tmuonShowerRefs_;
-    Vids l1tegammaIds_;
-    VRl1tegamma l1tegammaRefs_;
-    Vids l1tjetIds_;
-    VRl1tjet l1tjetRefs_;
-    Vids l1ttauIds_;
-    VRl1ttau l1ttauRefs_;
-    Vids l1tetsumIds_;
-    VRl1tetsum l1tetsumRefs_;
-
-    /* Phase-2 */
-    Vids l1ttkmuonIds_;
-    VRl1ttkmuon l1ttkmuonRefs_;
-    Vids l1ttkeleIds_;
-    VRl1ttkele l1ttkeleRefs_;
-    Vids l1ttkemIds_;
-    VRl1ttkem l1ttkemRefs_;
-    Vids l1tpfjetIds_;
-    VRl1tpfjet l1tpfjetRefs_;
-    Vids l1tpftauIds_;
-    VRl1tpftau l1tpftauRefs_;
-    Vids l1thpspftauIds_;
-    VRl1thpspftau l1thpspftauRefs_;
-    Vids l1tpftrackIds_;
-    VRl1tpftrack l1tpftrackRefs_;
-    Vids l1tp2etsumIds_;
-    VRl1tp2etsum l1tp2etsumRefs_;
-
-    Vids pfjetIds_;
-    VRpfjet pfjetRefs_;
-    Vids pftauIds_;
-    VRpftau pftauRefs_;
-    Vids pfmetIds_;
-    VRpfmet pfmetRefs_;
-
-    Vids l1tp2gtcandIds_;
-    VRl1tp2gtcand l1tp2gtcandRefs_;
-
-    /// methods
-  public:
-    /// constructors
-    TriggerRefsCollections()
-        : photonIds_(),
-          photonRefs_(),
-          electronIds_(),
-          electronRefs_(),
-          muonIds_(),
-          muonRefs_(),
-          jetIds_(),
-          jetRefs_(),
-          compositeIds_(),
-          compositeRefs_(),
-          basemetIds_(),
-          basemetRefs_(),
-          calometIds_(),
-          calometRefs_(),
-          pixtrackIds_(),
-          pixtrackRefs_(),
-
-          l1emIds_(),
-          l1emRefs_(),
-          l1muonIds_(),
-          l1muonRefs_(),
-          l1jetIds_(),
-          l1jetRefs_(),
-          l1etmissIds_(),
-          l1etmissRefs_(),
-          l1hfringsIds_(),
-          l1hfringsRefs_(),
-
-          l1tmuonIds_(),
-          l1tmuonRefs_(),
-          l1tmuonShowerIds_(),
-          l1tmuonShowerRefs_(),
-          l1tegammaIds_(),
-          l1tegammaRefs_(),
-          l1tjetIds_(),
-          l1tjetRefs_(),
-          l1ttauIds_(),
-          l1ttauRefs_(),
-          l1tetsumIds_(),
-          l1tetsumRefs_(),
-
-          /* Phase-2 */
-          l1ttkmuonIds_(),
-          l1ttkmuonRefs_(),
-          l1ttkeleIds_(),
-          l1ttkeleRefs_(),
-          l1ttkemIds_(),
-          l1ttkemRefs_(),
-          l1tpfjetIds_(),
-          l1tpfjetRefs_(),
-          l1tpftauIds_(),
-          l1tpftauRefs_(),
-          l1thpspftauIds_(),
-          l1thpspftauRefs_(),
-          l1tpftrackIds_(),
-          l1tpftrackRefs_(),
-          l1tp2etsumIds_(),
-          l1tp2etsumRefs_(),
-
-          pfjetIds_(),
-          pfjetRefs_(),
-          pftauIds_(),
-          pftauRefs_(),
-          pfmetIds_(),
-          pfmetRefs_(),
-
-          l1tp2gtcandIds_(),
-          l1tp2gtcandRefs_() {}
-
-    /// utility
-    void swap(TriggerRefsCollections& other) {
-      std::swap(photonIds_, other.photonIds_);
-      std::swap(photonRefs_, other.photonRefs_);
-      std::swap(electronIds_, other.electronIds_);
-      std::swap(electronRefs_, other.electronRefs_);
-      std::swap(muonIds_, other.muonIds_);
-      std::swap(muonRefs_, other.muonRefs_);
-      std::swap(jetIds_, other.jetIds_);
-      std::swap(jetRefs_, other.jetRefs_);
-      std::swap(compositeIds_, other.compositeIds_);
-      std::swap(compositeRefs_, other.compositeRefs_);
-      std::swap(basemetIds_, other.basemetIds_);
-      std::swap(basemetRefs_, other.basemetRefs_);
-      std::swap(calometIds_, other.calometIds_);
-      std::swap(calometRefs_, other.calometRefs_);
-      std::swap(pixtrackIds_, other.pixtrackIds_);
-      std::swap(pixtrackRefs_, other.pixtrackRefs_);
-
-      std::swap(l1emIds_, other.l1emIds_);
-      std::swap(l1emRefs_, other.l1emRefs_);
-      std::swap(l1muonIds_, other.l1muonIds_);
-      std::swap(l1muonRefs_, other.l1muonRefs_);
-      std::swap(l1jetIds_, other.l1jetIds_);
-      std::swap(l1jetRefs_, other.l1jetRefs_);
-      std::swap(l1etmissIds_, other.l1etmissIds_);
-      std::swap(l1etmissRefs_, other.l1etmissRefs_);
-      std::swap(l1hfringsIds_, other.l1hfringsIds_);
-      std::swap(l1hfringsRefs_, other.l1hfringsRefs_);
-
-      std::swap(l1tmuonIds_, other.l1tmuonIds_);
-      std::swap(l1tmuonRefs_, other.l1tmuonRefs_);
-      std::swap(l1tmuonShowerIds_, other.l1tmuonShowerIds_);
-      std::swap(l1tmuonShowerRefs_, other.l1tmuonShowerRefs_);
-      std::swap(l1tegammaIds_, other.l1tegammaIds_);
-      std::swap(l1tegammaRefs_, other.l1tegammaRefs_);
-      std::swap(l1tjetIds_, other.l1tjetIds_);
-      std::swap(l1tjetRefs_, other.l1tjetRefs_);
-      std::swap(l1ttauIds_, other.l1ttauIds_);
-      std::swap(l1ttauRefs_, other.l1ttauRefs_);
-      std::swap(l1tetsumIds_, other.l1tetsumIds_);
-      std::swap(l1tetsumRefs_, other.l1tetsumRefs_);
+      Vids l1tmuonIds_;
+      VRl1tmuon l1tmuonRefs_;
+      Vids l1tmuonShowerIds_;
+      VRl1tmuonShower l1tmuonShowerRefs_;
+      Vids l1tegammaIds_;
+      VRl1tegamma l1tegammaRefs_;
+      Vids l1tjetIds_;
+      VRl1tjet l1tjetRefs_;
+      Vids l1ttauIds_;
+      VRl1ttau l1ttauRefs_;
+      Vids l1tetsumIds_;
+      VRl1tetsum l1tetsumRefs_;
 
       /* Phase-2 */
-      std::swap(l1ttkmuonIds_, other.l1ttkmuonIds_);
-      std::swap(l1ttkmuonRefs_, other.l1ttkmuonRefs_);
-      std::swap(l1ttkeleIds_, other.l1ttkeleIds_);
-      std::swap(l1ttkeleRefs_, other.l1ttkeleRefs_);
-      std::swap(l1ttkemIds_, other.l1ttkemIds_);
-      std::swap(l1ttkemRefs_, other.l1ttkemRefs_);
-      std::swap(l1tpfjetIds_, other.l1tpfjetIds_);
-      std::swap(l1tpfjetRefs_, other.l1tpfjetRefs_);
-      std::swap(l1tpftauIds_, other.l1tpftauIds_);
-      std::swap(l1tpftauRefs_, other.l1tpftauRefs_);
-      std::swap(l1thpspftauIds_, other.l1thpspftauIds_);
-      std::swap(l1thpspftauRefs_, other.l1thpspftauRefs_);
-      std::swap(l1tpftrackIds_, other.l1tpftrackIds_);
-      std::swap(l1tpftrackRefs_, other.l1tpftrackRefs_);
-      std::swap(l1tp2etsumIds_, other.l1tp2etsumIds_);
-      std::swap(l1tp2etsumRefs_, other.l1tp2etsumRefs_);
+      Vids l1ttkmuonIds_;
+      VRl1ttkmuon l1ttkmuonRefs_;
+      Vids l1ttkeleIds_;
+      VRl1ttkele l1ttkeleRefs_;
+      Vids l1ttkemIds_;
+      VRl1ttkem l1ttkemRefs_;
+      Vids l1tpfjetIds_;
+      VRl1tpfjet l1tpfjetRefs_;
+      Vids l1tpftauIds_;
+      VRl1tpftau l1tpftauRefs_;
+      Vids l1thpspftauIds_;
+      VRl1thpspftau l1thpspftauRefs_;
+      Vids l1tpftrackIds_;
+      VRl1tpftrack l1tpftrackRefs_;
+      Vids l1tp2etsumIds_;
+      VRl1tp2etsum l1tp2etsumRefs_;
 
-      std::swap(pfjetIds_, other.pfjetIds_);
-      std::swap(pfjetRefs_, other.pfjetRefs_);
-      std::swap(pftauIds_, other.pftauIds_);
-      std::swap(pftauRefs_, other.pftauRefs_);
-      std::swap(pfmetIds_, other.pfmetIds_);
-      std::swap(pfmetRefs_, other.pfmetRefs_);
+      Vids pfjetIds_;
+      VRpfjet pfjetRefs_;
+      Vids pftauIds_;
+      VRpftau pftauRefs_;
+      Vids pfmetIds_;
+      VRpfmet pfmetRefs_;
 
-      std::swap(l1tp2gtcandIds_, other.l1tp2gtcandIds_);
-      std::swap(l1tp2gtcandRefs_, other.l1tp2gtcandRefs_);
-    }
+      Vids l1tp2gtcandIds_;
+      VRl1tp2gtcand l1tp2gtcandRefs_;
 
-    /// setters for L3 collections: (id=physics type, and Ref<C>)
-    void addObject(int id, const reco::RecoEcalCandidateRef& ref) {
-      photonIds_.push_back(id);
-      photonRefs_.push_back(ref);
-    }
-    void addObject(int id, const reco::ElectronRef& ref) {
-      electronIds_.push_back(id);
-      electronRefs_.push_back(ref);
-    }
-    void addObject(int id, const reco::RecoChargedCandidateRef& ref) {
-      muonIds_.push_back(id);
-      muonRefs_.push_back(ref);
-    }
-    void addObject(int id, const reco::CaloJetRef& ref) {
-      jetIds_.push_back(id);
-      jetRefs_.push_back(ref);
-    }
-    void addObject(int id, const reco::CompositeCandidateRef& ref) {
-      compositeIds_.push_back(id);
-      compositeRefs_.push_back(ref);
-    }
-    void addObject(int id, const reco::METRef& ref) {
-      basemetIds_.push_back(id);
-      basemetRefs_.push_back(ref);
-    }
-    void addObject(int id, const reco::CaloMETRef& ref) {
-      calometIds_.push_back(id);
-      calometRefs_.push_back(ref);
-    }
-    void addObject(int id, const reco::IsolatedPixelTrackCandidateRef& ref) {
-      pixtrackIds_.push_back(id);
-      pixtrackRefs_.push_back(ref);
-    }
+      /// methods
+    public:
+      /// constructors
+      TriggerRefsCollections()
+          : photonIds_(),
+            photonRefs_(),
+            electronIds_(),
+            electronRefs_(),
+            muonIds_(),
+            muonRefs_(),
+            jetIds_(),
+            jetRefs_(),
+            compositeIds_(),
+            compositeRefs_(),
+            basemetIds_(),
+            basemetRefs_(),
+            calometIds_(),
+            calometRefs_(),
+            pixtrackIds_(),
+            pixtrackRefs_(),
 
-    void addObject(int id, const l1extra::L1EmParticleRef& ref) {
-      l1emIds_.push_back(id);
-      l1emRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1extra::L1MuonParticleRef& ref) {
-      l1muonIds_.push_back(id);
-      l1muonRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1extra::L1JetParticleRef& ref) {
-      l1jetIds_.push_back(id);
-      l1jetRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1extra::L1EtMissParticleRef& ref) {
-      l1etmissIds_.push_back(id);
-      l1etmissRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1extra::L1HFRingsRef& ref) {
-      l1hfringsIds_.push_back(id);
-      l1hfringsRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::MuonRef& ref) {
-      l1tmuonIds_.push_back(id);
-      l1tmuonRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::MuonShowerRef& ref) {
-      l1tmuonShowerIds_.push_back(id);
-      l1tmuonShowerRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::EGammaRef& ref) {
-      l1tegammaIds_.push_back(id);
-      l1tegammaRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::JetRef& ref) {
-      l1tjetIds_.push_back(id);
-      l1tjetRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::TauRef& ref) {
-      l1ttauIds_.push_back(id);
-      l1ttauRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::EtSumRef& ref) {
-      l1tetsumIds_.push_back(id);
-      l1tetsumRefs_.push_back(ref);
-    }
+            l1emIds_(),
+            l1emRefs_(),
+            l1muonIds_(),
+            l1muonRefs_(),
+            l1jetIds_(),
+            l1jetRefs_(),
+            l1etmissIds_(),
+            l1etmissRefs_(),
+            l1hfringsIds_(),
+            l1hfringsRefs_(),
 
-    /* Phase-2 */
-    void addObject(int id, const l1t::TrackerMuonRef& ref) {
-      l1ttkmuonIds_.push_back(id);
-      l1ttkmuonRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::TkElectronRef& ref) {
-      l1ttkeleIds_.push_back(id);
-      l1ttkeleRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::TkEmRef& ref) {
-      l1ttkemIds_.push_back(id);
-      l1ttkemRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::PFJetRef& ref) {
-      l1tpfjetIds_.push_back(id);
-      l1tpfjetRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::PFTauRef& ref) {
-      l1tpftauIds_.push_back(id);
-      l1tpftauRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::HPSPFTauRef& ref) {
-      l1thpspftauIds_.push_back(id);
-      l1thpspftauRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::PFTrackRef& ref) {
-      l1tpftrackIds_.push_back(id);
-      l1tpftrackRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::EtSumP2Ref& ref) {
-      l1tp2etsumIds_.push_back(id);
-      l1tp2etsumRefs_.push_back(ref);
-    }
-    void addObject(int id, const reco::PFJetRef& ref) {
-      pfjetIds_.push_back(id);
-      pfjetRefs_.push_back(ref);
-    }
-    void addObject(int id, const reco::PFTauRef& ref) {
-      pftauIds_.push_back(id);
-      pftauRefs_.push_back(ref);
-    }
-    void addObject(int id, const reco::PFMETRef& ref) {
-      pfmetIds_.push_back(id);
-      pfmetRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::P2GTCandidateRef& ref) {
-      l1tp2gtcandIds_.push_back(id);
-      l1tp2gtcandRefs_.push_back(ref);
-    }
+            l1tmuonIds_(),
+            l1tmuonRefs_(),
+            l1tmuonShowerIds_(),
+            l1tmuonShowerRefs_(),
+            l1tegammaIds_(),
+            l1tegammaRefs_(),
+            l1tjetIds_(),
+            l1tjetRefs_(),
+            l1ttauIds_(),
+            l1ttauRefs_(),
+            l1tetsumIds_(),
+            l1tetsumRefs_(),
 
-    ///
-    size_type addObjects(const Vids& ids, const VRphoton& refs) {
-      assert(ids.size() == refs.size());
-      photonIds_.insert(photonIds_.end(), ids.begin(), ids.end());
-      photonRefs_.insert(photonRefs_.end(), refs.begin(), refs.end());
-      return photonIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRelectron& refs) {
-      assert(ids.size() == refs.size());
-      electronIds_.insert(electronIds_.end(), ids.begin(), ids.end());
-      electronRefs_.insert(electronRefs_.end(), refs.begin(), refs.end());
-      return electronIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRmuon& refs) {
-      assert(ids.size() == refs.size());
-      muonIds_.insert(muonIds_.end(), ids.begin(), ids.end());
-      muonRefs_.insert(muonRefs_.end(), refs.begin(), refs.end());
-      return muonIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRjet& refs) {
-      assert(ids.size() == refs.size());
-      jetIds_.insert(jetIds_.end(), ids.begin(), ids.end());
-      jetRefs_.insert(jetRefs_.end(), refs.begin(), refs.end());
-      return jetIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRcomposite& refs) {
-      assert(ids.size() == refs.size());
-      compositeIds_.insert(compositeIds_.end(), ids.begin(), ids.end());
-      compositeRefs_.insert(compositeRefs_.end(), refs.begin(), refs.end());
-      return compositeIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRbasemet& refs) {
-      assert(ids.size() == refs.size());
-      basemetIds_.insert(basemetIds_.end(), ids.begin(), ids.end());
-      basemetRefs_.insert(basemetRefs_.end(), refs.begin(), refs.end());
-      return basemetIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRcalomet& refs) {
-      assert(ids.size() == refs.size());
-      calometIds_.insert(calometIds_.end(), ids.begin(), ids.end());
-      calometRefs_.insert(calometRefs_.end(), refs.begin(), refs.end());
-      return calometIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRpixtrack& refs) {
-      assert(ids.size() == refs.size());
-      pixtrackIds_.insert(pixtrackIds_.end(), ids.begin(), ids.end());
-      pixtrackRefs_.insert(pixtrackRefs_.end(), refs.begin(), refs.end());
-      return pixtrackIds_.size();
-    }
+            /* Phase-2 */
+            l1ttkmuonIds_(),
+            l1ttkmuonRefs_(),
+            l1ttkeleIds_(),
+            l1ttkeleRefs_(),
+            l1ttkemIds_(),
+            l1ttkemRefs_(),
+            l1tpfjetIds_(),
+            l1tpfjetRefs_(),
+            l1tpftauIds_(),
+            l1tpftauRefs_(),
+            l1thpspftauIds_(),
+            l1thpspftauRefs_(),
+            l1tpftrackIds_(),
+            l1tpftrackRefs_(),
+            l1tp2etsumIds_(),
+            l1tp2etsumRefs_(),
 
-    size_type addObjects(const Vids& ids, const VRl1em& refs) {
-      assert(ids.size() == refs.size());
-      l1emIds_.insert(l1emIds_.end(), ids.begin(), ids.end());
-      l1emRefs_.insert(l1emRefs_.end(), refs.begin(), refs.end());
-      return l1emIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1muon& refs) {
-      assert(ids.size() == refs.size());
-      l1muonIds_.insert(l1muonIds_.end(), ids.begin(), ids.end());
-      l1muonRefs_.insert(l1muonRefs_.end(), refs.begin(), refs.end());
-      return l1muonIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1jet& refs) {
-      assert(ids.size() == refs.size());
-      l1jetIds_.insert(l1jetIds_.end(), ids.begin(), ids.end());
-      l1jetRefs_.insert(l1jetRefs_.end(), refs.begin(), refs.end());
-      return l1jetIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1etmiss& refs) {
-      assert(ids.size() == refs.size());
-      l1etmissIds_.insert(l1etmissIds_.end(), ids.begin(), ids.end());
-      l1etmissRefs_.insert(l1etmissRefs_.end(), refs.begin(), refs.end());
-      return l1etmissIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1tmuon& refs) {
-      assert(ids.size() == refs.size());
-      l1tmuonIds_.insert(l1tmuonIds_.end(), ids.begin(), ids.end());
-      l1tmuonRefs_.insert(l1tmuonRefs_.end(), refs.begin(), refs.end());
-      return l1tmuonIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1tmuonShower& refs) {
-      assert(ids.size() == refs.size());
-      l1tmuonShowerIds_.insert(l1tmuonShowerIds_.end(), ids.begin(), ids.end());
-      l1tmuonShowerRefs_.insert(l1tmuonShowerRefs_.end(), refs.begin(), refs.end());
-      return l1tmuonShowerIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1tegamma& refs) {
-      assert(ids.size() == refs.size());
-      l1tegammaIds_.insert(l1tegammaIds_.end(), ids.begin(), ids.end());
-      l1tegammaRefs_.insert(l1tegammaRefs_.end(), refs.begin(), refs.end());
-      return l1tegammaIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1tjet& refs) {
-      assert(ids.size() == refs.size());
-      l1tjetIds_.insert(l1tjetIds_.end(), ids.begin(), ids.end());
-      l1tjetRefs_.insert(l1tjetRefs_.end(), refs.begin(), refs.end());
-      return l1tjetIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1ttau& refs) {
-      assert(ids.size() == refs.size());
-      l1ttauIds_.insert(l1ttauIds_.end(), ids.begin(), ids.end());
-      l1ttauRefs_.insert(l1ttauRefs_.end(), refs.begin(), refs.end());
-      return l1ttauIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1tetsum& refs) {
-      assert(ids.size() == refs.size());
-      l1tetsumIds_.insert(l1tetsumIds_.end(), ids.begin(), ids.end());
-      l1tetsumRefs_.insert(l1tetsumRefs_.end(), refs.begin(), refs.end());
-      return l1tetsumIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1hfrings& refs) {
-      assert(ids.size() == refs.size());
-      l1hfringsIds_.insert(l1hfringsIds_.end(), ids.begin(), ids.end());
-      l1hfringsRefs_.insert(l1hfringsRefs_.end(), refs.begin(), refs.end());
-      return l1hfringsIds_.size();
-    }
+            pfjetIds_(),
+            pfjetRefs_(),
+            pftauIds_(),
+            pftauRefs_(),
+            pfmetIds_(),
+            pfmetRefs_(),
 
-    /* Phase-2 */
-    size_type addObjects(const Vids& ids, const VRl1ttkmuon& refs) {
-      assert(ids.size() == refs.size());
-      l1ttkmuonIds_.insert(l1ttkmuonIds_.end(), ids.begin(), ids.end());
-      l1ttkmuonRefs_.insert(l1ttkmuonRefs_.end(), refs.begin(), refs.end());
-      return l1ttkmuonIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1ttkele& refs) {
-      assert(ids.size() == refs.size());
-      l1ttkeleIds_.insert(l1ttkeleIds_.end(), ids.begin(), ids.end());
-      l1ttkeleRefs_.insert(l1ttkeleRefs_.end(), refs.begin(), refs.end());
-      return l1ttkeleIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1ttkem& refs) {
-      assert(ids.size() == refs.size());
-      l1ttkemIds_.insert(l1ttkemIds_.end(), ids.begin(), ids.end());
-      l1ttkemRefs_.insert(l1ttkemRefs_.end(), refs.begin(), refs.end());
-      return l1ttkemIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1tpfjet& refs) {
-      assert(ids.size() == refs.size());
-      l1tpfjetIds_.insert(l1tpfjetIds_.end(), ids.begin(), ids.end());
-      l1tpfjetRefs_.insert(l1tpfjetRefs_.end(), refs.begin(), refs.end());
-      return l1tpfjetIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1tpftau& refs) {
-      assert(ids.size() == refs.size());
-      l1tpftauIds_.insert(l1tpftauIds_.end(), ids.begin(), ids.end());
-      l1tpftauRefs_.insert(l1tpftauRefs_.end(), refs.begin(), refs.end());
-      return l1tpftauIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1thpspftau& refs) {
-      assert(ids.size() == refs.size());
-      l1thpspftauIds_.insert(l1thpspftauIds_.end(), ids.begin(), ids.end());
-      l1thpspftauRefs_.insert(l1thpspftauRefs_.end(), refs.begin(), refs.end());
-      return l1thpspftauIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1tpftrack& refs) {
-      assert(ids.size() == refs.size());
-      l1tpftrackIds_.insert(l1tpftrackIds_.end(), ids.begin(), ids.end());
-      l1tpftrackRefs_.insert(l1tpftrackRefs_.end(), refs.begin(), refs.end());
-      return l1tpftrackIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1tp2etsum& refs) {
-      assert(ids.size() == refs.size());
-      l1tp2etsumIds_.insert(l1tp2etsumIds_.end(), ids.begin(), ids.end());
-      l1tp2etsumRefs_.insert(l1tp2etsumRefs_.end(), refs.begin(), refs.end());
-      return l1tp2etsumIds_.size();
-    }
+            l1tp2gtcandIds_(),
+            l1tp2gtcandRefs_() {}
 
-    size_type addObjects(const Vids& ids, const VRpfjet& refs) {
-      assert(ids.size() == refs.size());
-      pfjetIds_.insert(pfjetIds_.end(), ids.begin(), ids.end());
-      pfjetRefs_.insert(pfjetRefs_.end(), refs.begin(), refs.end());
-      return pfjetIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRpftau& refs) {
-      assert(ids.size() == refs.size());
-      pftauIds_.insert(pftauIds_.end(), ids.begin(), ids.end());
-      pftauRefs_.insert(pftauRefs_.end(), refs.begin(), refs.end());
-      return pftauIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRpfmet& refs) {
-      assert(ids.size() == refs.size());
-      pfmetIds_.insert(pfmetIds_.end(), ids.begin(), ids.end());
-      pfmetRefs_.insert(pfmetRefs_.end(), refs.begin(), refs.end());
-      return pfmetIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1tp2gtcand& refs) {
-      assert(ids.size() == refs.size());
-      l1tp2gtcandIds_.insert(l1tp2gtcandIds_.end(), ids.begin(), ids.end());
-      l1tp2gtcandRefs_.insert(l1tp2gtcandRefs_.end(), refs.begin(), refs.end());
-      return l1tp2gtcandIds_.size();
-    }
+      /// utility
+      void swap(TriggerRefsCollections& other) {
+        std::swap(photonIds_, other.photonIds_);
+        std::swap(photonRefs_, other.photonRefs_);
+        std::swap(electronIds_, other.electronIds_);
+        std::swap(electronRefs_, other.electronRefs_);
+        std::swap(muonIds_, other.muonIds_);
+        std::swap(muonRefs_, other.muonRefs_);
+        std::swap(jetIds_, other.jetIds_);
+        std::swap(jetRefs_, other.jetRefs_);
+        std::swap(compositeIds_, other.compositeIds_);
+        std::swap(compositeRefs_, other.compositeRefs_);
+        std::swap(basemetIds_, other.basemetIds_);
+        std::swap(basemetRefs_, other.basemetRefs_);
+        std::swap(calometIds_, other.calometIds_);
+        std::swap(calometRefs_, other.calometRefs_);
+        std::swap(pixtrackIds_, other.pixtrackIds_);
+        std::swap(pixtrackRefs_, other.pixtrackRefs_);
 
-    /// various physics-level getters:
-    void getObjects(Vids& ids, VRphoton& refs) const { getObjects(ids, refs, 0, photonIds_.size()); }
-    void getObjects(Vids& ids, VRphoton& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= photonIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = photonIds_[i];
-        refs[j] = photonRefs_[i];
-        ++j;
+        std::swap(l1emIds_, other.l1emIds_);
+        std::swap(l1emRefs_, other.l1emRefs_);
+        std::swap(l1muonIds_, other.l1muonIds_);
+        std::swap(l1muonRefs_, other.l1muonRefs_);
+        std::swap(l1jetIds_, other.l1jetIds_);
+        std::swap(l1jetRefs_, other.l1jetRefs_);
+        std::swap(l1etmissIds_, other.l1etmissIds_);
+        std::swap(l1etmissRefs_, other.l1etmissRefs_);
+        std::swap(l1hfringsIds_, other.l1hfringsIds_);
+        std::swap(l1hfringsRefs_, other.l1hfringsRefs_);
+
+        std::swap(l1tmuonIds_, other.l1tmuonIds_);
+        std::swap(l1tmuonRefs_, other.l1tmuonRefs_);
+        std::swap(l1tmuonShowerIds_, other.l1tmuonShowerIds_);
+        std::swap(l1tmuonShowerRefs_, other.l1tmuonShowerRefs_);
+        std::swap(l1tegammaIds_, other.l1tegammaIds_);
+        std::swap(l1tegammaRefs_, other.l1tegammaRefs_);
+        std::swap(l1tjetIds_, other.l1tjetIds_);
+        std::swap(l1tjetRefs_, other.l1tjetRefs_);
+        std::swap(l1ttauIds_, other.l1ttauIds_);
+        std::swap(l1ttauRefs_, other.l1ttauRefs_);
+        std::swap(l1tetsumIds_, other.l1tetsumIds_);
+        std::swap(l1tetsumRefs_, other.l1tetsumRefs_);
+
+        /* Phase-2 */
+        std::swap(l1ttkmuonIds_, other.l1ttkmuonIds_);
+        std::swap(l1ttkmuonRefs_, other.l1ttkmuonRefs_);
+        std::swap(l1ttkeleIds_, other.l1ttkeleIds_);
+        std::swap(l1ttkeleRefs_, other.l1ttkeleRefs_);
+        std::swap(l1ttkemIds_, other.l1ttkemIds_);
+        std::swap(l1ttkemRefs_, other.l1ttkemRefs_);
+        std::swap(l1tpfjetIds_, other.l1tpfjetIds_);
+        std::swap(l1tpfjetRefs_, other.l1tpfjetRefs_);
+        std::swap(l1tpftauIds_, other.l1tpftauIds_);
+        std::swap(l1tpftauRefs_, other.l1tpftauRefs_);
+        std::swap(l1thpspftauIds_, other.l1thpspftauIds_);
+        std::swap(l1thpspftauRefs_, other.l1thpspftauRefs_);
+        std::swap(l1tpftrackIds_, other.l1tpftrackIds_);
+        std::swap(l1tpftrackRefs_, other.l1tpftrackRefs_);
+        std::swap(l1tp2etsumIds_, other.l1tp2etsumIds_);
+        std::swap(l1tp2etsumRefs_, other.l1tp2etsumRefs_);
+
+        std::swap(pfjetIds_, other.pfjetIds_);
+        std::swap(pfjetRefs_, other.pfjetRefs_);
+        std::swap(pftauIds_, other.pftauIds_);
+        std::swap(pftauRefs_, other.pftauRefs_);
+        std::swap(pfmetIds_, other.pfmetIds_);
+        std::swap(pfmetRefs_, other.pfmetRefs_);
+
+        std::swap(l1tp2gtcandIds_, other.l1tp2gtcandIds_);
+        std::swap(l1tp2gtcandRefs_, other.l1tp2gtcandRefs_);
       }
-    }
-    void getObjects(int id, VRphoton& refs) const { getObjects(id, refs, 0, photonIds_.size()); }
-    void getObjects(int id, VRphoton& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= photonIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == photonIds_[i]) {
-          ++n;
-        }
+
+      /// setters for L3 collections: (id=physics type, and Ref<C>)
+      void addObject(int id, const reco::RecoEcalCandidateRef& ref) {
+        photonIds_.push_back(id);
+        photonRefs_.push_back(ref);
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == photonIds_[i]) {
+      void addObject(int id, const reco::ElectronRef& ref) {
+        electronIds_.push_back(id);
+        electronRefs_.push_back(ref);
+      }
+      void addObject(int id, const reco::RecoChargedCandidateRef& ref) {
+        muonIds_.push_back(id);
+        muonRefs_.push_back(ref);
+      }
+      void addObject(int id, const reco::CaloJetRef& ref) {
+        jetIds_.push_back(id);
+        jetRefs_.push_back(ref);
+      }
+      void addObject(int id, const reco::CompositeCandidateRef& ref) {
+        compositeIds_.push_back(id);
+        compositeRefs_.push_back(ref);
+      }
+      void addObject(int id, const reco::METRef& ref) {
+        basemetIds_.push_back(id);
+        basemetRefs_.push_back(ref);
+      }
+      void addObject(int id, const reco::CaloMETRef& ref) {
+        calometIds_.push_back(id);
+        calometRefs_.push_back(ref);
+      }
+      void addObject(int id, const reco::IsolatedPixelTrackCandidateRef& ref) {
+        pixtrackIds_.push_back(id);
+        pixtrackRefs_.push_back(ref);
+      }
+
+      void addObject(int id, const l1extra::L1EmParticleRef& ref) {
+        l1emIds_.push_back(id);
+        l1emRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1extra::L1MuonParticleRef& ref) {
+        l1muonIds_.push_back(id);
+        l1muonRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1extra::L1JetParticleRef& ref) {
+        l1jetIds_.push_back(id);
+        l1jetRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1extra::L1EtMissParticleRef& ref) {
+        l1etmissIds_.push_back(id);
+        l1etmissRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1extra::L1HFRingsRef& ref) {
+        l1hfringsIds_.push_back(id);
+        l1hfringsRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::MuonRef& ref) {
+        l1tmuonIds_.push_back(id);
+        l1tmuonRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::MuonShowerRef& ref) {
+        l1tmuonShowerIds_.push_back(id);
+        l1tmuonShowerRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::EGammaRef& ref) {
+        l1tegammaIds_.push_back(id);
+        l1tegammaRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::JetRef& ref) {
+        l1tjetIds_.push_back(id);
+        l1tjetRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::TauRef& ref) {
+        l1ttauIds_.push_back(id);
+        l1ttauRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::EtSumRef& ref) {
+        l1tetsumIds_.push_back(id);
+        l1tetsumRefs_.push_back(ref);
+      }
+
+      /* Phase-2 */
+      void addObject(int id, const l1t::TrackerMuonRef& ref) {
+        l1ttkmuonIds_.push_back(id);
+        l1ttkmuonRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::TkElectronRef& ref) {
+        l1ttkeleIds_.push_back(id);
+        l1ttkeleRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::TkEmRef& ref) {
+        l1ttkemIds_.push_back(id);
+        l1ttkemRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::PFJetRef& ref) {
+        l1tpfjetIds_.push_back(id);
+        l1tpfjetRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::PFTauRef& ref) {
+        l1tpftauIds_.push_back(id);
+        l1tpftauRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::HPSPFTauRef& ref) {
+        l1thpspftauIds_.push_back(id);
+        l1thpspftauRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::PFTrackRef& ref) {
+        l1tpftrackIds_.push_back(id);
+        l1tpftrackRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::EtSumP2Ref& ref) {
+        l1tp2etsumIds_.push_back(id);
+        l1tp2etsumRefs_.push_back(ref);
+      }
+      void addObject(int id, const reco::PFJetRef& ref) {
+        pfjetIds_.push_back(id);
+        pfjetRefs_.push_back(ref);
+      }
+      void addObject(int id, const reco::PFTauRef& ref) {
+        pftauIds_.push_back(id);
+        pftauRefs_.push_back(ref);
+      }
+      void addObject(int id, const reco::PFMETRef& ref) {
+        pfmetIds_.push_back(id);
+        pfmetRefs_.push_back(ref);
+      }
+      void addObject(int id, const l1t::P2GTCandidateRef& ref) {
+        l1tp2gtcandIds_.push_back(id);
+        l1tp2gtcandRefs_.push_back(ref);
+      }
+
+      ///
+      size_type addObjects(const Vids& ids, const VRphoton& refs) {
+        assert(ids.size() == refs.size());
+        photonIds_.insert(photonIds_.end(), ids.begin(), ids.end());
+        photonRefs_.insert(photonRefs_.end(), refs.begin(), refs.end());
+        return photonIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRelectron& refs) {
+        assert(ids.size() == refs.size());
+        electronIds_.insert(electronIds_.end(), ids.begin(), ids.end());
+        electronRefs_.insert(electronRefs_.end(), refs.begin(), refs.end());
+        return electronIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRmuon& refs) {
+        assert(ids.size() == refs.size());
+        muonIds_.insert(muonIds_.end(), ids.begin(), ids.end());
+        muonRefs_.insert(muonRefs_.end(), refs.begin(), refs.end());
+        return muonIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRjet& refs) {
+        assert(ids.size() == refs.size());
+        jetIds_.insert(jetIds_.end(), ids.begin(), ids.end());
+        jetRefs_.insert(jetRefs_.end(), refs.begin(), refs.end());
+        return jetIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRcomposite& refs) {
+        assert(ids.size() == refs.size());
+        compositeIds_.insert(compositeIds_.end(), ids.begin(), ids.end());
+        compositeRefs_.insert(compositeRefs_.end(), refs.begin(), refs.end());
+        return compositeIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRbasemet& refs) {
+        assert(ids.size() == refs.size());
+        basemetIds_.insert(basemetIds_.end(), ids.begin(), ids.end());
+        basemetRefs_.insert(basemetRefs_.end(), refs.begin(), refs.end());
+        return basemetIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRcalomet& refs) {
+        assert(ids.size() == refs.size());
+        calometIds_.insert(calometIds_.end(), ids.begin(), ids.end());
+        calometRefs_.insert(calometRefs_.end(), refs.begin(), refs.end());
+        return calometIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRpixtrack& refs) {
+        assert(ids.size() == refs.size());
+        pixtrackIds_.insert(pixtrackIds_.end(), ids.begin(), ids.end());
+        pixtrackRefs_.insert(pixtrackRefs_.end(), refs.begin(), refs.end());
+        return pixtrackIds_.size();
+      }
+
+      size_type addObjects(const Vids& ids, const VRl1em& refs) {
+        assert(ids.size() == refs.size());
+        l1emIds_.insert(l1emIds_.end(), ids.begin(), ids.end());
+        l1emRefs_.insert(l1emRefs_.end(), refs.begin(), refs.end());
+        return l1emIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1muon& refs) {
+        assert(ids.size() == refs.size());
+        l1muonIds_.insert(l1muonIds_.end(), ids.begin(), ids.end());
+        l1muonRefs_.insert(l1muonRefs_.end(), refs.begin(), refs.end());
+        return l1muonIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1jet& refs) {
+        assert(ids.size() == refs.size());
+        l1jetIds_.insert(l1jetIds_.end(), ids.begin(), ids.end());
+        l1jetRefs_.insert(l1jetRefs_.end(), refs.begin(), refs.end());
+        return l1jetIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1etmiss& refs) {
+        assert(ids.size() == refs.size());
+        l1etmissIds_.insert(l1etmissIds_.end(), ids.begin(), ids.end());
+        l1etmissRefs_.insert(l1etmissRefs_.end(), refs.begin(), refs.end());
+        return l1etmissIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1tmuon& refs) {
+        assert(ids.size() == refs.size());
+        l1tmuonIds_.insert(l1tmuonIds_.end(), ids.begin(), ids.end());
+        l1tmuonRefs_.insert(l1tmuonRefs_.end(), refs.begin(), refs.end());
+        return l1tmuonIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1tmuonShower& refs) {
+        assert(ids.size() == refs.size());
+        l1tmuonShowerIds_.insert(l1tmuonShowerIds_.end(), ids.begin(), ids.end());
+        l1tmuonShowerRefs_.insert(l1tmuonShowerRefs_.end(), refs.begin(), refs.end());
+        return l1tmuonShowerIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1tegamma& refs) {
+        assert(ids.size() == refs.size());
+        l1tegammaIds_.insert(l1tegammaIds_.end(), ids.begin(), ids.end());
+        l1tegammaRefs_.insert(l1tegammaRefs_.end(), refs.begin(), refs.end());
+        return l1tegammaIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1tjet& refs) {
+        assert(ids.size() == refs.size());
+        l1tjetIds_.insert(l1tjetIds_.end(), ids.begin(), ids.end());
+        l1tjetRefs_.insert(l1tjetRefs_.end(), refs.begin(), refs.end());
+        return l1tjetIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1ttau& refs) {
+        assert(ids.size() == refs.size());
+        l1ttauIds_.insert(l1ttauIds_.end(), ids.begin(), ids.end());
+        l1ttauRefs_.insert(l1ttauRefs_.end(), refs.begin(), refs.end());
+        return l1ttauIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1tetsum& refs) {
+        assert(ids.size() == refs.size());
+        l1tetsumIds_.insert(l1tetsumIds_.end(), ids.begin(), ids.end());
+        l1tetsumRefs_.insert(l1tetsumRefs_.end(), refs.begin(), refs.end());
+        return l1tetsumIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1hfrings& refs) {
+        assert(ids.size() == refs.size());
+        l1hfringsIds_.insert(l1hfringsIds_.end(), ids.begin(), ids.end());
+        l1hfringsRefs_.insert(l1hfringsRefs_.end(), refs.begin(), refs.end());
+        return l1hfringsIds_.size();
+      }
+
+      /* Phase-2 */
+      size_type addObjects(const Vids& ids, const VRl1ttkmuon& refs) {
+        assert(ids.size() == refs.size());
+        l1ttkmuonIds_.insert(l1ttkmuonIds_.end(), ids.begin(), ids.end());
+        l1ttkmuonRefs_.insert(l1ttkmuonRefs_.end(), refs.begin(), refs.end());
+        return l1ttkmuonIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1ttkele& refs) {
+        assert(ids.size() == refs.size());
+        l1ttkeleIds_.insert(l1ttkeleIds_.end(), ids.begin(), ids.end());
+        l1ttkeleRefs_.insert(l1ttkeleRefs_.end(), refs.begin(), refs.end());
+        return l1ttkeleIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1ttkem& refs) {
+        assert(ids.size() == refs.size());
+        l1ttkemIds_.insert(l1ttkemIds_.end(), ids.begin(), ids.end());
+        l1ttkemRefs_.insert(l1ttkemRefs_.end(), refs.begin(), refs.end());
+        return l1ttkemIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1tpfjet& refs) {
+        assert(ids.size() == refs.size());
+        l1tpfjetIds_.insert(l1tpfjetIds_.end(), ids.begin(), ids.end());
+        l1tpfjetRefs_.insert(l1tpfjetRefs_.end(), refs.begin(), refs.end());
+        return l1tpfjetIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1tpftau& refs) {
+        assert(ids.size() == refs.size());
+        l1tpftauIds_.insert(l1tpftauIds_.end(), ids.begin(), ids.end());
+        l1tpftauRefs_.insert(l1tpftauRefs_.end(), refs.begin(), refs.end());
+        return l1tpftauIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1thpspftau& refs) {
+        assert(ids.size() == refs.size());
+        l1thpspftauIds_.insert(l1thpspftauIds_.end(), ids.begin(), ids.end());
+        l1thpspftauRefs_.insert(l1thpspftauRefs_.end(), refs.begin(), refs.end());
+        return l1thpspftauIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1tpftrack& refs) {
+        assert(ids.size() == refs.size());
+        l1tpftrackIds_.insert(l1tpftrackIds_.end(), ids.begin(), ids.end());
+        l1tpftrackRefs_.insert(l1tpftrackRefs_.end(), refs.begin(), refs.end());
+        return l1tpftrackIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1tp2etsum& refs) {
+        assert(ids.size() == refs.size());
+        l1tp2etsumIds_.insert(l1tp2etsumIds_.end(), ids.begin(), ids.end());
+        l1tp2etsumRefs_.insert(l1tp2etsumRefs_.end(), refs.begin(), refs.end());
+        return l1tp2etsumIds_.size();
+      }
+
+      size_type addObjects(const Vids& ids, const VRpfjet& refs) {
+        assert(ids.size() == refs.size());
+        pfjetIds_.insert(pfjetIds_.end(), ids.begin(), ids.end());
+        pfjetRefs_.insert(pfjetRefs_.end(), refs.begin(), refs.end());
+        return pfjetIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRpftau& refs) {
+        assert(ids.size() == refs.size());
+        pftauIds_.insert(pftauIds_.end(), ids.begin(), ids.end());
+        pftauRefs_.insert(pftauRefs_.end(), refs.begin(), refs.end());
+        return pftauIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRpfmet& refs) {
+        assert(ids.size() == refs.size());
+        pfmetIds_.insert(pfmetIds_.end(), ids.begin(), ids.end());
+        pfmetRefs_.insert(pfmetRefs_.end(), refs.begin(), refs.end());
+        return pfmetIds_.size();
+      }
+      size_type addObjects(const Vids& ids, const VRl1tp2gtcand& refs) {
+        assert(ids.size() == refs.size());
+        l1tp2gtcandIds_.insert(l1tp2gtcandIds_.end(), ids.begin(), ids.end());
+        l1tp2gtcandRefs_.insert(l1tp2gtcandRefs_.end(), refs.begin(), refs.end());
+        return l1tp2gtcandIds_.size();
+      }
+
+      /// various physics-level getters:
+      void getObjects(Vids& ids, VRphoton& refs) const { getObjects(ids, refs, 0, photonIds_.size()); }
+      void getObjects(Vids& ids, VRphoton& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= photonIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = photonIds_[i];
           refs[j] = photonRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRelectron& refs) const { getObjects(ids, refs, 0, electronIds_.size()); }
-    void getObjects(Vids& ids, VRelectron& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= electronIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = electronIds_[i];
-        refs[j] = electronRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRelectron& refs) const { getObjects(id, refs, 0, electronIds_.size()); }
-    void getObjects(int id, VRelectron& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= electronIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == electronIds_[i]) {
-          ++n;
+      void getObjects(int id, VRphoton& refs) const { getObjects(id, refs, 0, photonIds_.size()); }
+      void getObjects(int id, VRphoton& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= photonIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == photonIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == photonIds_[i]) {
+            refs[j] = photonRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == electronIds_[i]) {
+
+      void getObjects(Vids& ids, VRelectron& refs) const { getObjects(ids, refs, 0, electronIds_.size()); }
+      void getObjects(Vids& ids, VRelectron& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= electronIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = electronIds_[i];
           refs[j] = electronRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRmuon& refs) const { getObjects(ids, refs, 0, muonIds_.size()); }
-    void getObjects(Vids& ids, VRmuon& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= muonIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = muonIds_[i];
-        refs[j] = muonRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRmuon& refs) const { getObjects(id, refs, 0, muonIds_.size()); }
-    void getObjects(int id, VRmuon& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= muonIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == muonIds_[i]) {
-          ++n;
+      void getObjects(int id, VRelectron& refs) const { getObjects(id, refs, 0, electronIds_.size()); }
+      void getObjects(int id, VRelectron& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= electronIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == electronIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == electronIds_[i]) {
+            refs[j] = electronRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == muonIds_[i]) {
+
+      void getObjects(Vids& ids, VRmuon& refs) const { getObjects(ids, refs, 0, muonIds_.size()); }
+      void getObjects(Vids& ids, VRmuon& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= muonIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = muonIds_[i];
           refs[j] = muonRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRjet& refs) const { getObjects(ids, refs, 0, jetIds_.size()); }
-    void getObjects(Vids& ids, VRjet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= jetIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = jetIds_[i];
-        refs[j] = jetRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRjet& refs) const { getObjects(id, refs, 0, jetIds_.size()); }
-    void getObjects(int id, VRjet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= jetIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == jetIds_[i]) {
-          ++n;
+      void getObjects(int id, VRmuon& refs) const { getObjects(id, refs, 0, muonIds_.size()); }
+      void getObjects(int id, VRmuon& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= muonIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == muonIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == muonIds_[i]) {
+            refs[j] = muonRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == jetIds_[i]) {
+
+      void getObjects(Vids& ids, VRjet& refs) const { getObjects(ids, refs, 0, jetIds_.size()); }
+      void getObjects(Vids& ids, VRjet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= jetIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = jetIds_[i];
           refs[j] = jetRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRcomposite& refs) const { getObjects(ids, refs, 0, compositeIds_.size()); }
-    void getObjects(Vids& ids, VRcomposite& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= compositeIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = compositeIds_[i];
-        refs[j] = compositeRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRcomposite& refs) const { getObjects(id, refs, 0, compositeIds_.size()); }
-    void getObjects(int id, VRcomposite& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= compositeIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == compositeIds_[i]) {
-          ++n;
+      void getObjects(int id, VRjet& refs) const { getObjects(id, refs, 0, jetIds_.size()); }
+      void getObjects(int id, VRjet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= jetIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == jetIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == jetIds_[i]) {
+            refs[j] = jetRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == compositeIds_[i]) {
+
+      void getObjects(Vids& ids, VRcomposite& refs) const { getObjects(ids, refs, 0, compositeIds_.size()); }
+      void getObjects(Vids& ids, VRcomposite& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= compositeIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = compositeIds_[i];
           refs[j] = compositeRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRbasemet& refs) const { getObjects(ids, refs, 0, basemetIds_.size()); }
-    void getObjects(Vids& ids, VRbasemet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= basemetIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = basemetIds_[i];
-        refs[j] = basemetRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRbasemet& refs) const { getObjects(id, refs, 0, basemetIds_.size()); }
-    void getObjects(int id, VRbasemet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= basemetIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == basemetIds_[i]) {
-          ++n;
+      void getObjects(int id, VRcomposite& refs) const { getObjects(id, refs, 0, compositeIds_.size()); }
+      void getObjects(int id, VRcomposite& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= compositeIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == compositeIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == compositeIds_[i]) {
+            refs[j] = compositeRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == basemetIds_[i]) {
+
+      void getObjects(Vids& ids, VRbasemet& refs) const { getObjects(ids, refs, 0, basemetIds_.size()); }
+      void getObjects(Vids& ids, VRbasemet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= basemetIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = basemetIds_[i];
           refs[j] = basemetRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRcalomet& refs) const { getObjects(ids, refs, 0, calometIds_.size()); }
-    void getObjects(Vids& ids, VRcalomet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= calometIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = calometIds_[i];
-        refs[j] = calometRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRcalomet& refs) const { getObjects(id, refs, 0, calometIds_.size()); }
-    void getObjects(int id, VRcalomet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= calometIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == calometIds_[i]) {
-          ++n;
+      void getObjects(int id, VRbasemet& refs) const { getObjects(id, refs, 0, basemetIds_.size()); }
+      void getObjects(int id, VRbasemet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= basemetIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == basemetIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == basemetIds_[i]) {
+            refs[j] = basemetRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == calometIds_[i]) {
+
+      void getObjects(Vids& ids, VRcalomet& refs) const { getObjects(ids, refs, 0, calometIds_.size()); }
+      void getObjects(Vids& ids, VRcalomet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= calometIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = calometIds_[i];
           refs[j] = calometRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRpixtrack& refs) const { getObjects(ids, refs, 0, pixtrackIds_.size()); }
-    void getObjects(Vids& ids, VRpixtrack& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= pixtrackIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = pixtrackIds_[i];
-        refs[j] = pixtrackRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRpixtrack& refs) const { getObjects(id, refs, 0, pixtrackIds_.size()); }
-    void getObjects(int id, VRpixtrack& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= pixtrackIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == pixtrackIds_[i]) {
-          ++n;
+      void getObjects(int id, VRcalomet& refs) const { getObjects(id, refs, 0, calometIds_.size()); }
+      void getObjects(int id, VRcalomet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= calometIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == calometIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == calometIds_[i]) {
+            refs[j] = calometRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == pixtrackIds_[i]) {
+
+      void getObjects(Vids& ids, VRpixtrack& refs) const { getObjects(ids, refs, 0, pixtrackIds_.size()); }
+      void getObjects(Vids& ids, VRpixtrack& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= pixtrackIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = pixtrackIds_[i];
           refs[j] = pixtrackRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1em& refs) const { getObjects(ids, refs, 0, l1emIds_.size()); }
-    void getObjects(Vids& ids, VRl1em& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1emIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1emIds_[i];
-        refs[j] = l1emRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1em& refs) const { getObjects(id, refs, 0, l1emIds_.size()); }
-    void getObjects(int id, VRl1em& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1emIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1emIds_[i]) {
-          ++n;
+      void getObjects(int id, VRpixtrack& refs) const { getObjects(id, refs, 0, pixtrackIds_.size()); }
+      void getObjects(int id, VRpixtrack& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= pixtrackIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == pixtrackIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == pixtrackIds_[i]) {
+            refs[j] = pixtrackRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1emIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1em& refs) const { getObjects(ids, refs, 0, l1emIds_.size()); }
+      void getObjects(Vids& ids, VRl1em& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1emIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1emIds_[i];
           refs[j] = l1emRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1muon& refs) const { getObjects(ids, refs, 0, l1muonIds_.size()); }
-    void getObjects(Vids& ids, VRl1muon& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1muonIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1muonIds_[i];
-        refs[j] = l1muonRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1muon& refs) const { getObjects(id, refs, 0, l1muonIds_.size()); }
-    void getObjects(int id, VRl1muon& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1muonIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1muonIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1em& refs) const { getObjects(id, refs, 0, l1emIds_.size()); }
+      void getObjects(int id, VRl1em& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1emIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1emIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1emIds_[i]) {
+            refs[j] = l1emRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1muonIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1muon& refs) const { getObjects(ids, refs, 0, l1muonIds_.size()); }
+      void getObjects(Vids& ids, VRl1muon& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1muonIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1muonIds_[i];
           refs[j] = l1muonRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1jet& refs) const { getObjects(ids, refs, 0, l1jetIds_.size()); }
-    void getObjects(Vids& ids, VRl1jet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1jetIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1jetIds_[i];
-        refs[j] = l1jetRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1jet& refs) const { getObjects(id, refs, 0, l1jetIds_.size()); }
-    void getObjects(int id, VRl1jet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1jetIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1jetIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1muon& refs) const { getObjects(id, refs, 0, l1muonIds_.size()); }
+      void getObjects(int id, VRl1muon& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1muonIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1muonIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1muonIds_[i]) {
+            refs[j] = l1muonRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1jetIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1jet& refs) const { getObjects(ids, refs, 0, l1jetIds_.size()); }
+      void getObjects(Vids& ids, VRl1jet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1jetIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1jetIds_[i];
           refs[j] = l1jetRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1etmiss& refs) const { getObjects(ids, refs, 0, l1etmissIds_.size()); }
-    void getObjects(Vids& ids, VRl1etmiss& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1etmissIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1etmissIds_[i];
-        refs[j] = l1etmissRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1etmiss& refs) const { getObjects(id, refs, 0, l1etmissIds_.size()); }
-    void getObjects(int id, VRl1etmiss& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1etmissIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1etmissIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1jet& refs) const { getObjects(id, refs, 0, l1jetIds_.size()); }
+      void getObjects(int id, VRl1jet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1jetIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1jetIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1jetIds_[i]) {
+            refs[j] = l1jetRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1etmissIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1etmiss& refs) const { getObjects(ids, refs, 0, l1etmissIds_.size()); }
+      void getObjects(Vids& ids, VRl1etmiss& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1etmissIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1etmissIds_[i];
           refs[j] = l1etmissRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1hfrings& refs) const { getObjects(ids, refs, 0, l1hfringsIds_.size()); }
-    void getObjects(Vids& ids, VRl1hfrings& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1hfringsIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1hfringsIds_[i];
-        refs[j] = l1hfringsRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1hfrings& refs) const { getObjects(id, refs, 0, l1hfringsIds_.size()); }
-    void getObjects(int id, VRl1hfrings& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1hfringsIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1hfringsIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1etmiss& refs) const { getObjects(id, refs, 0, l1etmissIds_.size()); }
+      void getObjects(int id, VRl1etmiss& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1etmissIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1etmissIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1etmissIds_[i]) {
+            refs[j] = l1etmissRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1hfringsIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1hfrings& refs) const { getObjects(ids, refs, 0, l1hfringsIds_.size()); }
+      void getObjects(Vids& ids, VRl1hfrings& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1hfringsIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1hfringsIds_[i];
           refs[j] = l1hfringsRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1tmuon& refs) const { getObjects(ids, refs, 0, l1tmuonIds_.size()); }
-    void getObjects(Vids& ids, VRl1tmuon& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tmuonIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tmuonIds_[i];
-        refs[j] = l1tmuonRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tmuon& refs) const { getObjects(id, refs, 0, l1tmuonIds_.size()); }
-    void getObjects(int id, VRl1tmuon& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tmuonIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tmuonIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1hfrings& refs) const { getObjects(id, refs, 0, l1hfringsIds_.size()); }
+      void getObjects(int id, VRl1hfrings& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1hfringsIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1hfringsIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1hfringsIds_[i]) {
+            refs[j] = l1hfringsRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tmuonIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1tmuon& refs) const { getObjects(ids, refs, 0, l1tmuonIds_.size()); }
+      void getObjects(Vids& ids, VRl1tmuon& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tmuonIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1tmuonIds_[i];
           refs[j] = l1tmuonRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1tmuonShower& refs) const { getObjects(ids, refs, 0, l1tmuonShowerIds_.size()); }
-    void getObjects(Vids& ids, VRl1tmuonShower& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tmuonShowerIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tmuonShowerIds_[i];
-        refs[j] = l1tmuonShowerRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tmuonShower& refs) const { getObjects(id, refs, 0, l1tmuonShowerIds_.size()); }
-    void getObjects(int id, VRl1tmuonShower& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tmuonShowerIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tmuonShowerIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1tmuon& refs) const { getObjects(id, refs, 0, l1tmuonIds_.size()); }
+      void getObjects(int id, VRl1tmuon& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tmuonIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tmuonIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tmuonIds_[i]) {
+            refs[j] = l1tmuonRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tmuonShowerIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1tmuonShower& refs) const { getObjects(ids, refs, 0, l1tmuonShowerIds_.size()); }
+      void getObjects(Vids& ids, VRl1tmuonShower& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tmuonShowerIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1tmuonShowerIds_[i];
           refs[j] = l1tmuonShowerRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1tegamma& refs) const { getObjects(ids, refs, 0, l1tegammaIds_.size()); }
-    void getObjects(Vids& ids, VRl1tegamma& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tegammaIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tegammaIds_[i];
-        refs[j] = l1tegammaRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tegamma& refs) const { getObjects(id, refs, 0, l1tegammaIds_.size()); }
-    void getObjects(int id, VRl1tegamma& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tegammaIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tegammaIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1tmuonShower& refs) const { getObjects(id, refs, 0, l1tmuonShowerIds_.size()); }
+      void getObjects(int id, VRl1tmuonShower& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tmuonShowerIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tmuonShowerIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tmuonShowerIds_[i]) {
+            refs[j] = l1tmuonShowerRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tegammaIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1tegamma& refs) const { getObjects(ids, refs, 0, l1tegammaIds_.size()); }
+      void getObjects(Vids& ids, VRl1tegamma& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tegammaIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1tegammaIds_[i];
           refs[j] = l1tegammaRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1tjet& refs) const { getObjects(ids, refs, 0, l1tjetIds_.size()); }
-    void getObjects(Vids& ids, VRl1tjet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tjetIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tjetIds_[i];
-        refs[j] = l1tjetRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tjet& refs) const { getObjects(id, refs, 0, l1tjetIds_.size()); }
-    void getObjects(int id, VRl1tjet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tjetIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tjetIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1tegamma& refs) const { getObjects(id, refs, 0, l1tegammaIds_.size()); }
+      void getObjects(int id, VRl1tegamma& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tegammaIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tegammaIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tegammaIds_[i]) {
+            refs[j] = l1tegammaRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tjetIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1tjet& refs) const { getObjects(ids, refs, 0, l1tjetIds_.size()); }
+      void getObjects(Vids& ids, VRl1tjet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tjetIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1tjetIds_[i];
           refs[j] = l1tjetRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1ttau& refs) const { getObjects(ids, refs, 0, l1ttauIds_.size()); }
-    void getObjects(Vids& ids, VRl1ttau& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1ttauIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1ttauIds_[i];
-        refs[j] = l1ttauRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1ttau& refs) const { getObjects(id, refs, 0, l1ttauIds_.size()); }
-    void getObjects(int id, VRl1ttau& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1ttauIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1ttauIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1tjet& refs) const { getObjects(id, refs, 0, l1tjetIds_.size()); }
+      void getObjects(int id, VRl1tjet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tjetIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tjetIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tjetIds_[i]) {
+            refs[j] = l1tjetRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1ttauIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1ttau& refs) const { getObjects(ids, refs, 0, l1ttauIds_.size()); }
+      void getObjects(Vids& ids, VRl1ttau& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1ttauIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1ttauIds_[i];
           refs[j] = l1ttauRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1tetsum& refs) const { getObjects(ids, refs, 0, l1tetsumIds_.size()); }
-    void getObjects(Vids& ids, VRl1tetsum& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tetsumIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tetsumIds_[i];
-        refs[j] = l1tetsumRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tetsum& refs) const { getObjects(id, refs, 0, l1tetsumIds_.size()); }
-    void getObjects(int id, VRl1tetsum& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tetsumIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tetsumIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1ttau& refs) const { getObjects(id, refs, 0, l1ttauIds_.size()); }
+      void getObjects(int id, VRl1ttau& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1ttauIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1ttauIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1ttauIds_[i]) {
+            refs[j] = l1ttauRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tetsumIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1tetsum& refs) const { getObjects(ids, refs, 0, l1tetsumIds_.size()); }
+      void getObjects(Vids& ids, VRl1tetsum& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tetsumIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1tetsumIds_[i];
           refs[j] = l1tetsumRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    /* Phase-2 */
-    void getObjects(Vids& ids, VRl1ttkmuon& refs) const { getObjects(ids, refs, 0, l1ttkmuonIds_.size()); }
-    void getObjects(Vids& ids, VRl1ttkmuon& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1ttkmuonIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1ttkmuonIds_[i];
-        refs[j] = l1ttkmuonRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1ttkmuon& refs) const { getObjects(id, refs, 0, l1ttkmuonIds_.size()); }
-    void getObjects(int id, VRl1ttkmuon& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1ttkmuonIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1ttkmuonIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1tetsum& refs) const { getObjects(id, refs, 0, l1tetsumIds_.size()); }
+      void getObjects(int id, VRl1tetsum& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tetsumIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tetsumIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tetsumIds_[i]) {
+            refs[j] = l1tetsumRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1ttkmuonIds_[i]) {
+
+      /* Phase-2 */
+      void getObjects(Vids& ids, VRl1ttkmuon& refs) const { getObjects(ids, refs, 0, l1ttkmuonIds_.size()); }
+      void getObjects(Vids& ids, VRl1ttkmuon& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1ttkmuonIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1ttkmuonIds_[i];
           refs[j] = l1ttkmuonRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1ttkele& refs) const { getObjects(ids, refs, 0, l1ttkeleIds_.size()); }
-    void getObjects(Vids& ids, VRl1ttkele& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1ttkeleIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1ttkeleIds_[i];
-        refs[j] = l1ttkeleRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1ttkele& refs) const { getObjects(id, refs, 0, l1ttkeleIds_.size()); }
-    void getObjects(int id, VRl1ttkele& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1ttkeleIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1ttkeleIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1ttkmuon& refs) const { getObjects(id, refs, 0, l1ttkmuonIds_.size()); }
+      void getObjects(int id, VRl1ttkmuon& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1ttkmuonIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1ttkmuonIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1ttkmuonIds_[i]) {
+            refs[j] = l1ttkmuonRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1ttkeleIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1ttkele& refs) const { getObjects(ids, refs, 0, l1ttkeleIds_.size()); }
+      void getObjects(Vids& ids, VRl1ttkele& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1ttkeleIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1ttkeleIds_[i];
           refs[j] = l1ttkeleRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1ttkem& refs) const { getObjects(ids, refs, 0, l1ttkemIds_.size()); }
-    void getObjects(Vids& ids, VRl1ttkem& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1ttkemIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1ttkemIds_[i];
-        refs[j] = l1ttkemRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1ttkem& refs) const { getObjects(id, refs, 0, l1ttkemIds_.size()); }
-    void getObjects(int id, VRl1ttkem& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1ttkemIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1ttkemIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1ttkele& refs) const { getObjects(id, refs, 0, l1ttkeleIds_.size()); }
+      void getObjects(int id, VRl1ttkele& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1ttkeleIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1ttkeleIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1ttkeleIds_[i]) {
+            refs[j] = l1ttkeleRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1ttkemIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1ttkem& refs) const { getObjects(ids, refs, 0, l1ttkemIds_.size()); }
+      void getObjects(Vids& ids, VRl1ttkem& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1ttkemIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1ttkemIds_[i];
           refs[j] = l1ttkemRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1tpfjet& refs) const { getObjects(ids, refs, 0, l1tpfjetIds_.size()); }
-    void getObjects(Vids& ids, VRl1tpfjet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tpfjetIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tpfjetIds_[i];
-        refs[j] = l1tpfjetRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tpfjet& refs) const { getObjects(id, refs, 0, l1tpfjetIds_.size()); }
-    void getObjects(int id, VRl1tpfjet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tpfjetIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tpfjetIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1ttkem& refs) const { getObjects(id, refs, 0, l1ttkemIds_.size()); }
+      void getObjects(int id, VRl1ttkem& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1ttkemIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1ttkemIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1ttkemIds_[i]) {
+            refs[j] = l1ttkemRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tpfjetIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1tpfjet& refs) const { getObjects(ids, refs, 0, l1tpfjetIds_.size()); }
+      void getObjects(Vids& ids, VRl1tpfjet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tpfjetIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1tpfjetIds_[i];
           refs[j] = l1tpfjetRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1tpftau& refs) const { getObjects(ids, refs, 0, l1tpftauIds_.size()); }
-    void getObjects(Vids& ids, VRl1tpftau& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tpftauIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tpftauIds_[i];
-        refs[j] = l1tpftauRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tpftau& refs) const { getObjects(id, refs, 0, l1tpftauIds_.size()); }
-    void getObjects(int id, VRl1tpftau& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tpftauIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tpftauIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1tpfjet& refs) const { getObjects(id, refs, 0, l1tpfjetIds_.size()); }
+      void getObjects(int id, VRl1tpfjet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tpfjetIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tpfjetIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tpfjetIds_[i]) {
+            refs[j] = l1tpfjetRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tpftauIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1tpftau& refs) const { getObjects(ids, refs, 0, l1tpftauIds_.size()); }
+      void getObjects(Vids& ids, VRl1tpftau& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tpftauIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1tpftauIds_[i];
           refs[j] = l1tpftauRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1thpspftau& refs) const { getObjects(ids, refs, 0, l1thpspftauIds_.size()); }
-    void getObjects(Vids& ids, VRl1thpspftau& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1thpspftauIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1thpspftauIds_[i];
-        refs[j] = l1thpspftauRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1thpspftau& refs) const { getObjects(id, refs, 0, l1thpspftauIds_.size()); }
-    void getObjects(int id, VRl1thpspftau& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1thpspftauIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1thpspftauIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1tpftau& refs) const { getObjects(id, refs, 0, l1tpftauIds_.size()); }
+      void getObjects(int id, VRl1tpftau& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tpftauIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tpftauIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tpftauIds_[i]) {
+            refs[j] = l1tpftauRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1thpspftauIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1thpspftau& refs) const { getObjects(ids, refs, 0, l1thpspftauIds_.size()); }
+      void getObjects(Vids& ids, VRl1thpspftau& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1thpspftauIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1thpspftauIds_[i];
           refs[j] = l1thpspftauRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1tpftrack& refs) const { getObjects(ids, refs, 0, l1tpftrackIds_.size()); }
-    void getObjects(Vids& ids, VRl1tpftrack& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tpftrackIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tpftrackIds_[i];
-        refs[j] = l1tpftrackRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tpftrack& refs) const { getObjects(id, refs, 0, l1tpftrackIds_.size()); }
-    void getObjects(int id, VRl1tpftrack& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tpftrackIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tpftrackIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1thpspftau& refs) const { getObjects(id, refs, 0, l1thpspftauIds_.size()); }
+      void getObjects(int id, VRl1thpspftau& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1thpspftauIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1thpspftauIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1thpspftauIds_[i]) {
+            refs[j] = l1thpspftauRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tpftrackIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1tpftrack& refs) const { getObjects(ids, refs, 0, l1tpftrackIds_.size()); }
+      void getObjects(Vids& ids, VRl1tpftrack& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tpftrackIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1tpftrackIds_[i];
           refs[j] = l1tpftrackRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1tp2etsum& refs) const { getObjects(ids, refs, 0, l1tp2etsumIds_.size()); }
-    void getObjects(Vids& ids, VRl1tp2etsum& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tp2etsumIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tp2etsumIds_[i];
-        refs[j] = l1tp2etsumRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tp2etsum& refs) const { getObjects(id, refs, 0, l1tp2etsumIds_.size()); }
-    void getObjects(int id, VRl1tp2etsum& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tp2etsumIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tp2etsumIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1tpftrack& refs) const { getObjects(id, refs, 0, l1tpftrackIds_.size()); }
+      void getObjects(int id, VRl1tpftrack& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tpftrackIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tpftrackIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tpftrackIds_[i]) {
+            refs[j] = l1tpftrackRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tp2etsumIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1tp2etsum& refs) const { getObjects(ids, refs, 0, l1tp2etsumIds_.size()); }
+      void getObjects(Vids& ids, VRl1tp2etsum& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tp2etsumIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1tp2etsumIds_[i];
           refs[j] = l1tp2etsumRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRpfjet& refs) const { getObjects(ids, refs, 0, pfjetIds_.size()); }
-    void getObjects(Vids& ids, VRpfjet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= pfjetIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = pfjetIds_[i];
-        refs[j] = pfjetRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRpfjet& refs) const { getObjects(id, refs, 0, pfjetIds_.size()); }
-    void getObjects(int id, VRpfjet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= pfjetIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == pfjetIds_[i]) {
-          ++n;
+      void getObjects(int id, VRl1tp2etsum& refs) const { getObjects(id, refs, 0, l1tp2etsumIds_.size()); }
+      void getObjects(int id, VRl1tp2etsum& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tp2etsumIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tp2etsumIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tp2etsumIds_[i]) {
+            refs[j] = l1tp2etsumRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == pfjetIds_[i]) {
+
+      void getObjects(Vids& ids, VRpfjet& refs) const { getObjects(ids, refs, 0, pfjetIds_.size()); }
+      void getObjects(Vids& ids, VRpfjet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= pfjetIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = pfjetIds_[i];
           refs[j] = pfjetRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRpftau& refs) const { getObjects(ids, refs, 0, pftauIds_.size()); }
-    void getObjects(Vids& ids, VRpftau& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= pftauIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = pftauIds_[i];
-        refs[j] = pftauRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRpftau& refs) const { getObjects(id, refs, 0, pftauIds_.size()); }
-    void getObjects(int id, VRpftau& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= pftauIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == pftauIds_[i]) {
-          ++n;
+      void getObjects(int id, VRpfjet& refs) const { getObjects(id, refs, 0, pfjetIds_.size()); }
+      void getObjects(int id, VRpfjet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= pfjetIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == pfjetIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == pfjetIds_[i]) {
+            refs[j] = pfjetRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == pftauIds_[i]) {
+
+      void getObjects(Vids& ids, VRpftau& refs) const { getObjects(ids, refs, 0, pftauIds_.size()); }
+      void getObjects(Vids& ids, VRpftau& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= pftauIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = pftauIds_[i];
           refs[j] = pftauRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRpfmet& refs) const { getObjects(ids, refs, 0, pfmetIds_.size()); }
-    void getObjects(Vids& ids, VRpfmet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= pfmetIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = pfmetIds_[i];
-        refs[j] = pfmetRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRpfmet& refs) const { getObjects(id, refs, 0, pfmetIds_.size()); }
-    void getObjects(int id, VRpfmet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= pfmetIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == pfmetIds_[i]) {
-          ++n;
+      void getObjects(int id, VRpftau& refs) const { getObjects(id, refs, 0, pftauIds_.size()); }
+      void getObjects(int id, VRpftau& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= pftauIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == pftauIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == pftauIds_[i]) {
+            refs[j] = pftauRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == pfmetIds_[i]) {
+
+      void getObjects(Vids& ids, VRpfmet& refs) const { getObjects(ids, refs, 0, pfmetIds_.size()); }
+      void getObjects(Vids& ids, VRpfmet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= pfmetIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = pfmetIds_[i];
           refs[j] = pfmetRefs_[i];
           ++j;
         }
       }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1tp2gtcand& refs) const { getObjects(ids, refs, 0, l1tp2gtcandIds_.size()); }
-    void getObjects(Vids& ids, VRl1tp2gtcand& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tp2gtcandIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tp2gtcandIds_[i];
-        refs[j] = l1tp2gtcandRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tp2gtcand& refs) const { getObjects(id, refs, 0, l1tp2gtcandIds_.size()); }
-    void getObjects(int id, VRl1tp2gtcand& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tp2gtcandIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tp2gtcandIds_[i]) {
-          ++n;
+      void getObjects(int id, VRpfmet& refs) const { getObjects(id, refs, 0, pfmetIds_.size()); }
+      void getObjects(int id, VRpfmet& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= pfmetIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == pfmetIds_[i]) {
+            ++n;
+          }
         }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == pfmetIds_[i]) {
+            refs[j] = pfmetRefs_[i];
+            ++j;
+          }
+        }
+        return;
       }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tp2gtcandIds_[i]) {
+
+      void getObjects(Vids& ids, VRl1tp2gtcand& refs) const { getObjects(ids, refs, 0, l1tp2gtcandIds_.size()); }
+      void getObjects(Vids& ids, VRl1tp2gtcand& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tp2gtcandIds_.size());
+        const size_type n(end - begin);
+        ids.resize(n);
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          ids[j] = l1tp2gtcandIds_[i];
           refs[j] = l1tp2gtcandRefs_[i];
           ++j;
         }
       }
-      return;
-    }
+      void getObjects(int id, VRl1tp2gtcand& refs) const { getObjects(id, refs, 0, l1tp2gtcandIds_.size()); }
+      void getObjects(int id, VRl1tp2gtcand& refs, size_type begin, size_type end) const {
+        assert(begin <= end);
+        assert(end <= l1tp2gtcandIds_.size());
+        size_type n(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tp2gtcandIds_[i]) {
+            ++n;
+          }
+        }
+        refs.resize(n);
+        size_type j(0);
+        for (size_type i = begin; i != end; ++i) {
+          if (id == l1tp2gtcandIds_[i]) {
+            refs[j] = l1tp2gtcandRefs_[i];
+            ++j;
+          }
+        }
+        return;
+      }
 
-    /// low-level getters for data members
-    size_type photonSize() const { return photonIds_.size(); }
-    const Vids& photonIds() const { return photonIds_; }
-    const VRphoton& photonRefs() const { return photonRefs_; }
+      /// low-level getters for data members
+      size_type photonSize() const { return photonIds_.size(); }
+      const Vids& photonIds() const { return photonIds_; }
+      const VRphoton& photonRefs() const { return photonRefs_; }
 
-    size_type electronSize() const { return electronIds_.size(); }
-    const Vids& electronIds() const { return electronIds_; }
-    const VRelectron& electronRefs() const { return electronRefs_; }
+      size_type electronSize() const { return electronIds_.size(); }
+      const Vids& electronIds() const { return electronIds_; }
+      const VRelectron& electronRefs() const { return electronRefs_; }
 
-    size_type muonSize() const { return muonIds_.size(); }
-    const Vids& muonIds() const { return muonIds_; }
-    const VRmuon& muonRefs() const { return muonRefs_; }
+      size_type muonSize() const { return muonIds_.size(); }
+      const Vids& muonIds() const { return muonIds_; }
+      const VRmuon& muonRefs() const { return muonRefs_; }
 
-    size_type jetSize() const { return jetIds_.size(); }
-    const Vids& jetIds() const { return jetIds_; }
-    const VRjet& jetRefs() const { return jetRefs_; }
+      size_type jetSize() const { return jetIds_.size(); }
+      const Vids& jetIds() const { return jetIds_; }
+      const VRjet& jetRefs() const { return jetRefs_; }
 
-    size_type compositeSize() const { return compositeIds_.size(); }
-    const Vids& compositeIds() const { return compositeIds_; }
-    const VRcomposite& compositeRefs() const { return compositeRefs_; }
+      size_type compositeSize() const { return compositeIds_.size(); }
+      const Vids& compositeIds() const { return compositeIds_; }
+      const VRcomposite& compositeRefs() const { return compositeRefs_; }
 
-    size_type basemetSize() const { return basemetIds_.size(); }
-    const Vids& basemetIds() const { return basemetIds_; }
-    const VRbasemet& basemetRefs() const { return basemetRefs_; }
+      size_type basemetSize() const { return basemetIds_.size(); }
+      const Vids& basemetIds() const { return basemetIds_; }
+      const VRbasemet& basemetRefs() const { return basemetRefs_; }
 
-    size_type calometSize() const { return calometIds_.size(); }
-    const Vids& calometIds() const { return calometIds_; }
-    const VRcalomet& calometRefs() const { return calometRefs_; }
+      size_type calometSize() const { return calometIds_.size(); }
+      const Vids& calometIds() const { return calometIds_; }
+      const VRcalomet& calometRefs() const { return calometRefs_; }
 
-    size_type pixtrackSize() const { return pixtrackIds_.size(); }
-    const Vids& pixtrackIds() const { return pixtrackIds_; }
-    const VRpixtrack& pixtrackRefs() const { return pixtrackRefs_; }
+      size_type pixtrackSize() const { return pixtrackIds_.size(); }
+      const Vids& pixtrackIds() const { return pixtrackIds_; }
+      const VRpixtrack& pixtrackRefs() const { return pixtrackRefs_; }
 
-    size_type l1emSize() const { return l1emIds_.size(); }
-    const Vids& l1emIds() const { return l1emIds_; }
-    const VRl1em& l1emRefs() const { return l1emRefs_; }
+      size_type l1emSize() const { return l1emIds_.size(); }
+      const Vids& l1emIds() const { return l1emIds_; }
+      const VRl1em& l1emRefs() const { return l1emRefs_; }
 
-    size_type l1muonSize() const { return l1muonIds_.size(); }
-    const Vids& l1muonIds() const { return l1muonIds_; }
-    const VRl1muon& l1muonRefs() const { return l1muonRefs_; }
+      size_type l1muonSize() const { return l1muonIds_.size(); }
+      const Vids& l1muonIds() const { return l1muonIds_; }
+      const VRl1muon& l1muonRefs() const { return l1muonRefs_; }
 
-    size_type l1jetSize() const { return l1jetIds_.size(); }
-    const Vids& l1jetIds() const { return l1jetIds_; }
-    const VRl1jet& l1jetRefs() const { return l1jetRefs_; }
+      size_type l1jetSize() const { return l1jetIds_.size(); }
+      const Vids& l1jetIds() const { return l1jetIds_; }
+      const VRl1jet& l1jetRefs() const { return l1jetRefs_; }
 
-    size_type l1etmissSize() const { return l1etmissIds_.size(); }
-    const Vids& l1etmissIds() const { return l1etmissIds_; }
-    const VRl1etmiss& l1etmissRefs() const { return l1etmissRefs_; }
+      size_type l1etmissSize() const { return l1etmissIds_.size(); }
+      const Vids& l1etmissIds() const { return l1etmissIds_; }
+      const VRl1etmiss& l1etmissRefs() const { return l1etmissRefs_; }
 
-    size_type l1hfringsSize() const { return l1hfringsIds_.size(); }
-    const Vids& l1hfringsIds() const { return l1hfringsIds_; }
-    const VRl1hfrings& l1hfringsRefs() const { return l1hfringsRefs_; }
+      size_type l1hfringsSize() const { return l1hfringsIds_.size(); }
+      const Vids& l1hfringsIds() const { return l1hfringsIds_; }
+      const VRl1hfrings& l1hfringsRefs() const { return l1hfringsRefs_; }
 
-    size_type pfjetSize() const { return pfjetIds_.size(); }
-    const Vids& pfjetIds() const { return pfjetIds_; }
-    const VRpfjet& pfjetRefs() const { return pfjetRefs_; }
+      size_type pfjetSize() const { return pfjetIds_.size(); }
+      const Vids& pfjetIds() const { return pfjetIds_; }
+      const VRpfjet& pfjetRefs() const { return pfjetRefs_; }
 
-    size_type pftauSize() const { return pftauIds_.size(); }
-    const Vids& pftauIds() const { return pftauIds_; }
-    const VRpftau& pftauRefs() const { return pftauRefs_; }
+      size_type pftauSize() const { return pftauIds_.size(); }
+      const Vids& pftauIds() const { return pftauIds_; }
+      const VRpftau& pftauRefs() const { return pftauRefs_; }
 
-    size_type pfmetSize() const { return pfmetIds_.size(); }
-    const Vids& pfmetIds() const { return pfmetIds_; }
-    const VRpfmet& pfmetRefs() const { return pfmetRefs_; }
+      size_type pfmetSize() const { return pfmetIds_.size(); }
+      const Vids& pfmetIds() const { return pfmetIds_; }
+      const VRpfmet& pfmetRefs() const { return pfmetRefs_; }
 
-    size_type l1tmuonSize() const { return l1tmuonIds_.size(); }
-    const Vids& l1tmuonIds() const { return l1tmuonIds_; }
-    const VRl1tmuon& l1tmuonRefs() const { return l1tmuonRefs_; }
+      size_type l1tmuonSize() const { return l1tmuonIds_.size(); }
+      const Vids& l1tmuonIds() const { return l1tmuonIds_; }
+      const VRl1tmuon& l1tmuonRefs() const { return l1tmuonRefs_; }
 
-    size_type l1tmuonShowerSize() const { return l1tmuonShowerIds_.size(); }
-    const Vids& l1tmuonShowerIds() const { return l1tmuonShowerIds_; }
-    const VRl1tmuonShower& l1tmuonShowerRefs() const { return l1tmuonShowerRefs_; }
+      size_type l1tmuonShowerSize() const { return l1tmuonShowerIds_.size(); }
+      const Vids& l1tmuonShowerIds() const { return l1tmuonShowerIds_; }
+      const VRl1tmuonShower& l1tmuonShowerRefs() const { return l1tmuonShowerRefs_; }
 
-    size_type l1tegammaSize() const { return l1tegammaIds_.size(); }
-    const Vids& l1tegammaIds() const { return l1tegammaIds_; }
-    const VRl1tegamma& l1tegammaRefs() const { return l1tegammaRefs_; }
+      size_type l1tegammaSize() const { return l1tegammaIds_.size(); }
+      const Vids& l1tegammaIds() const { return l1tegammaIds_; }
+      const VRl1tegamma& l1tegammaRefs() const { return l1tegammaRefs_; }
 
-    size_type l1tjetSize() const { return l1tjetIds_.size(); }
-    const Vids& l1tjetIds() const { return l1tjetIds_; }
-    const VRl1tjet& l1tjetRefs() const { return l1tjetRefs_; }
+      size_type l1tjetSize() const { return l1tjetIds_.size(); }
+      const Vids& l1tjetIds() const { return l1tjetIds_; }
+      const VRl1tjet& l1tjetRefs() const { return l1tjetRefs_; }
 
-    /* Phase-2 */
+      /* Phase-2 */
 
-    size_type l1ttkmuonSize() const { return l1ttkmuonIds_.size(); }
-    const Vids& l1ttkmuonIds() const { return l1ttkmuonIds_; }
-    const VRl1ttkmuon& l1ttkmuonRefs() const { return l1ttkmuonRefs_; }
+      size_type l1ttkmuonSize() const { return l1ttkmuonIds_.size(); }
+      const Vids& l1ttkmuonIds() const { return l1ttkmuonIds_; }
+      const VRl1ttkmuon& l1ttkmuonRefs() const { return l1ttkmuonRefs_; }
 
-    size_type l1ttkeleSize() const { return l1ttkeleIds_.size(); }
-    const Vids& l1ttkeleIds() const { return l1ttkeleIds_; }
-    const VRl1ttkele& l1ttkeleRefs() const { return l1ttkeleRefs_; }
+      size_type l1ttkeleSize() const { return l1ttkeleIds_.size(); }
+      const Vids& l1ttkeleIds() const { return l1ttkeleIds_; }
+      const VRl1ttkele& l1ttkeleRefs() const { return l1ttkeleRefs_; }
 
-    size_type l1ttkemSize() const { return l1ttkemIds_.size(); }
-    const Vids& l1ttkemIds() const { return l1ttkemIds_; }
-    const VRl1ttkem& l1ttkemRefs() const { return l1ttkemRefs_; }
+      size_type l1ttkemSize() const { return l1ttkemIds_.size(); }
+      const Vids& l1ttkemIds() const { return l1ttkemIds_; }
+      const VRl1ttkem& l1ttkemRefs() const { return l1ttkemRefs_; }
 
-    size_type l1tpfjetSize() const { return l1tpfjetIds_.size(); }
-    const Vids& l1tpfjetIds() const { return l1tpfjetIds_; }
-    const VRl1tpfjet& l1tpfjetRefs() const { return l1tpfjetRefs_; }
+      size_type l1tpfjetSize() const { return l1tpfjetIds_.size(); }
+      const Vids& l1tpfjetIds() const { return l1tpfjetIds_; }
+      const VRl1tpfjet& l1tpfjetRefs() const { return l1tpfjetRefs_; }
 
-    size_type l1tpftauSize() const { return l1tpftauIds_.size(); }
-    const Vids& l1tpftauIds() const { return l1tpftauIds_; }
-    const VRl1tpftau& l1tpftauRefs() const { return l1tpftauRefs_; }
+      size_type l1tpftauSize() const { return l1tpftauIds_.size(); }
+      const Vids& l1tpftauIds() const { return l1tpftauIds_; }
+      const VRl1tpftau& l1tpftauRefs() const { return l1tpftauRefs_; }
 
-    size_type l1thpspftauSize() const { return l1thpspftauIds_.size(); }
-    const Vids& l1thpspftauIds() const { return l1thpspftauIds_; }
-    const VRl1thpspftau& l1thpspftauRefs() const { return l1thpspftauRefs_; }
+      size_type l1thpspftauSize() const { return l1thpspftauIds_.size(); }
+      const Vids& l1thpspftauIds() const { return l1thpspftauIds_; }
+      const VRl1thpspftau& l1thpspftauRefs() const { return l1thpspftauRefs_; }
 
-    size_type l1tpftrackSize() const { return l1tpftrackIds_.size(); }
-    const Vids& l1tpftrackIds() const { return l1tpftrackIds_; }
-    const VRl1tpftrack& l1tpftrackRefs() const { return l1tpftrackRefs_; }
+      size_type l1tpftrackSize() const { return l1tpftrackIds_.size(); }
+      const Vids& l1tpftrackIds() const { return l1tpftrackIds_; }
+      const VRl1tpftrack& l1tpftrackRefs() const { return l1tpftrackRefs_; }
 
-    size_type l1tp2etsumSize() const { return l1tp2etsumIds_.size(); }
-    const Vids& l1tp2etsumIds() const { return l1tp2etsumIds_; }
-    const VRl1tp2etsum& l1tp2etsumRefs() const { return l1tp2etsumRefs_; }
+      size_type l1tp2etsumSize() const { return l1tp2etsumIds_.size(); }
+      const Vids& l1tp2etsumIds() const { return l1tp2etsumIds_; }
+      const VRl1tp2etsum& l1tp2etsumRefs() const { return l1tp2etsumRefs_; }
 
-    size_type l1ttauSize() const { return l1ttauIds_.size(); }
-    const Vids& l1ttauIds() const { return l1ttauIds_; }
-    const VRl1ttau& l1ttauRefs() const { return l1ttauRefs_; }
+      size_type l1ttauSize() const { return l1ttauIds_.size(); }
+      const Vids& l1ttauIds() const { return l1ttauIds_; }
+      const VRl1ttau& l1ttauRefs() const { return l1ttauRefs_; }
 
-    size_type l1tetsumSize() const { return l1tetsumIds_.size(); }
-    const Vids& l1tetsumIds() const { return l1tetsumIds_; }
-    const VRl1tetsum& l1tetsumRefs() const { return l1tetsumRefs_; }
+      size_type l1tetsumSize() const { return l1tetsumIds_.size(); }
+      const Vids& l1tetsumIds() const { return l1tetsumIds_; }
+      const VRl1tetsum& l1tetsumRefs() const { return l1tetsumRefs_; }
 
-    size_type l1tp2gtcandSize() const { return l1tp2gtcandIds_.size(); }
-    const Vids& l1tp2gtcandIds() const { return l1tp2gtcandIds_; }
-    const VRl1tp2gtcand& l1tp2gtcandRefs() const { return l1tp2gtcandRefs_; }
-  };
+      size_type l1tp2gtcandSize() const { return l1tp2gtcandIds_.size(); }
+      const Vids& l1tp2gtcandIds() const { return l1tp2gtcandIds_; }
+      const VRl1tp2gtcand& l1tp2gtcandRefs() const { return l1tp2gtcandRefs_; }
+    };
 
-  // picked up via argument dependent lookup, e-g- by boost::swap()
-  inline void swap(TriggerRefsCollections& first, TriggerRefsCollections& second) { first.swap(second); }
+    // picked up via argument dependent lookup, e-g- by boost::swap()
+    inline void swap(TriggerRefsCollections& first, TriggerRefsCollections& second) { first.swap(second); }
+
+  }  // namespace io_v1
+  using TriggerRefsCollections = io_v1::TriggerRefsCollections;
 
 }  // namespace trigger
 

--- a/DataFormats/HLTReco/src/classes_def.xml
+++ b/DataFormats/HLTReco/src/classes_def.xml
@@ -35,11 +35,11 @@
   </class>
 
   <class name="trigger::TriggerObjectCollection"/>
-  <class name="trigger::TriggerRefsCollections" ClassVersion="3">
-   <version ClassVersion="3" checksum="1210037489"/>
+  <class name="trigger::io_v1::TriggerRefsCollections" ClassVersion="3">
+   <version ClassVersion="3" checksum="2276235489"/>
   </class>
   <class name="trigger::io_v1::TriggerFilterObjectWithRefs" ClassVersion="3">
-   <version ClassVersion="3" checksum="1456673002"/>
+   <version ClassVersion="3" checksum="2242334848"/>
   </class>
 
   <class name="trigger::TriggerEvent::TriggerFilterObject" ClassVersion="10">
@@ -56,7 +56,7 @@
   </class>
   <class name="std::vector<trigger::io_v1::TriggerEventWithRefs::TriggerFilterObject>"/>
   <class name="trigger::io_v1::TriggerEventWithRefs" ClassVersion="3">
-   <version ClassVersion="3" checksum="2861334506"/>
+   <version ClassVersion="3" checksum="2719392386"/>
   </class>
 
   <class name="edm::Wrapper<trigger::TriggerObjectCollection>" splitLevel="0"/>

--- a/DataFormats/JetMatching/interface/JetFlavourInfo.h
+++ b/DataFormats/JetMatching/interface/JetFlavourInfo.h
@@ -6,7 +6,8 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
 
 namespace reco {
-  /**\class JetFlavourInfo JetFlavourInfo.h DataFormats/JetMatching/interface/JetFlavourInfo.h
+  namespace io_v1 {
+    /**\class JetFlavourInfo JetFlavourInfo.h DataFormats/JetMatching/interface/JetFlavourInfo.h
  * \brief Class storing the jet flavour information
  *
  * JetFlavourInfo class stores the jet flavour information based on hadrons
@@ -15,50 +16,52 @@ namespace reco {
  * flavours are defined in the JetFlavourClustering producer.
  */
 
-  class JetFlavourInfo {
-  public:
-    JetFlavourInfo(void) : m_hadronFlavour(0), m_partonFlavour(0) {}
-    JetFlavourInfo(const int hadronFlavour, const int partonFlavour)
-        : m_hadronFlavour(hadronFlavour), m_partonFlavour(partonFlavour) {}
-    JetFlavourInfo(const GenParticleRefVector& bHadrons,
-                   const GenParticleRefVector& cHadrons,
-                   const GenParticleRefVector& partons,
-                   const GenParticleRefVector& leptons,
-                   const int hadronFlavour,
-                   const int partonFlavour)
-        : m_bHadrons(bHadrons),
-          m_cHadrons(cHadrons),
-          m_partons(partons),
-          m_leptons(leptons),
-          m_hadronFlavour(hadronFlavour),
-          m_partonFlavour(partonFlavour) {}
+    class JetFlavourInfo {
+    public:
+      JetFlavourInfo(void) : m_hadronFlavour(0), m_partonFlavour(0) {}
+      JetFlavourInfo(const int hadronFlavour, const int partonFlavour)
+          : m_hadronFlavour(hadronFlavour), m_partonFlavour(partonFlavour) {}
+      JetFlavourInfo(const GenParticleRefVector& bHadrons,
+                     const GenParticleRefVector& cHadrons,
+                     const GenParticleRefVector& partons,
+                     const GenParticleRefVector& leptons,
+                     const int hadronFlavour,
+                     const int partonFlavour)
+          : m_bHadrons(bHadrons),
+            m_cHadrons(cHadrons),
+            m_partons(partons),
+            m_leptons(leptons),
+            m_hadronFlavour(hadronFlavour),
+            m_partonFlavour(partonFlavour) {}
 
-    /// Return a vector of GenParticleRef's to b hadrons clustered inside the jet
-    const GenParticleRefVector& getbHadrons() const { return m_bHadrons; }
-    /// Return a vector of GenParticleRef's to c hadrons clustered inside the jet
-    const GenParticleRefVector& getcHadrons() const { return m_cHadrons; }
-    /// Return a vector of GenParticleRef's to partons clustered inside the jet
-    const GenParticleRefVector& getPartons() const { return m_partons; }
-    /// Return a vector of GenParticleRef's to leptons clustered inside the jet
-    const GenParticleRefVector& getLeptons() const { return m_leptons; }
-    /// Return the hadron-based flavour
-    const int getHadronFlavour() const { return m_hadronFlavour; }
-    /// Return the parton-based flavour
-    const int getPartonFlavour() const { return m_partonFlavour; }
+      /// Return a vector of GenParticleRef's to b hadrons clustered inside the jet
+      const GenParticleRefVector& getbHadrons() const { return m_bHadrons; }
+      /// Return a vector of GenParticleRef's to c hadrons clustered inside the jet
+      const GenParticleRefVector& getcHadrons() const { return m_cHadrons; }
+      /// Return a vector of GenParticleRef's to partons clustered inside the jet
+      const GenParticleRefVector& getPartons() const { return m_partons; }
+      /// Return a vector of GenParticleRef's to leptons clustered inside the jet
+      const GenParticleRefVector& getLeptons() const { return m_leptons; }
+      /// Return the hadron-based flavour
+      const int getHadronFlavour() const { return m_hadronFlavour; }
+      /// Return the parton-based flavour
+      const int getPartonFlavour() const { return m_partonFlavour; }
 
-    /// Set the hadron-based flavour
-    void setHadronFlavour(const int hadronFlavour) { m_hadronFlavour = hadronFlavour; }
-    /// Set the parton-based flavour
-    void setPartonFlavour(const int partonFlavour) { m_partonFlavour = partonFlavour; }
+      /// Set the hadron-based flavour
+      void setHadronFlavour(const int hadronFlavour) { m_hadronFlavour = hadronFlavour; }
+      /// Set the parton-based flavour
+      void setPartonFlavour(const int partonFlavour) { m_partonFlavour = partonFlavour; }
 
-  private:
-    GenParticleRefVector m_bHadrons;
-    GenParticleRefVector m_cHadrons;
-    GenParticleRefVector m_partons;
-    GenParticleRefVector m_leptons;
-    int m_hadronFlavour;
-    int m_partonFlavour;
-  };
+    private:
+      GenParticleRefVector m_bHadrons;
+      GenParticleRefVector m_cHadrons;
+      GenParticleRefVector m_partons;
+      GenParticleRefVector m_leptons;
+      int m_hadronFlavour;
+      int m_partonFlavour;
+    };
 
+  }  // namespace io_v1
+  using JetFlavourInfo = io_v1::JetFlavourInfo;
 }  // namespace reco
 #endif

--- a/DataFormats/JetMatching/src/classes_def.xml
+++ b/DataFormats/JetMatching/src/classes_def.xml
@@ -1,6 +1,6 @@
 <lcgdict>
-  <class name="reco::JetFlavourInfo" ClassVersion="3">
-   <version ClassVersion="3" checksum="2786652764"/>
+  <class name="reco::io_v1::JetFlavourInfo" ClassVersion="3">
+   <version ClassVersion="3" checksum="2503167498"/>
   </class>
   <class name="std::vector<reco::JetFlavourInfo>"/>
   <class name="std::pair<edm::RefToBase<reco::io_v1::Jet>, reco::JetFlavourInfo>"/>
@@ -9,7 +9,7 @@
     <field name="transientVector_" transient="true"/>
   </class>
   <class name="reco::io_v1::JetFlavourInfoMatchingCollection" ClassVersion="3">
-   <version ClassVersion="3" checksum="3071743479"/>
+   <version ClassVersion="3" checksum="3573636419"/>
     <!-- <field name="transientVector_" transient="true"/> -->
     <!-- <field name="fixed_" transient="true"/> -->
   </class>

--- a/DataFormats/JetReco/src/classes_def_1.xml
+++ b/DataFormats/JetReco/src/classes_def_1.xml
@@ -1,13 +1,13 @@
 <lcgdict>
   <class name="reco::io_v1::Jet" ClassVersion="3">
-   <version ClassVersion="3" checksum="718784871"/>
+   <version ClassVersion="3" checksum="545468239"/>
   </class>
   <class name="reco::io_v1::Jet::EtaPhiMoments" ClassVersion="3">
    <version ClassVersion="3" checksum="3852241398"/>
   </class>
 
   <class name="reco::io_v1::CaloJet" ClassVersion="3">
-   <version ClassVersion="3" checksum="1484483325"/>
+   <version ClassVersion="3" checksum="3607481829"/>
   </class>
   <class name="reco::io_v1::CaloJet::Specific" ClassVersion="3">
    <version ClassVersion="3" checksum="1704847273"/>
@@ -37,7 +37,7 @@
   <class name="edm::Wrapper<std::vector<reco::CaloJetRefVector> >"/>
 
   <class name="reco::io_v1::JPTJet" ClassVersion="3">
-   <version ClassVersion="3" checksum="2313687382"/>
+   <version ClassVersion="3" checksum="3981231870"/>
   </class>
   <class name="reco::io_v1::JPTJet::Specific" ClassVersion="3">
    <version ClassVersion="3" checksum="1084724008"/>
@@ -56,7 +56,7 @@
   <class name="edm::helpers::KeyVal<edm::RefProd<reco::JPTJetCollection>,edm::RefProd<std::vector<reco::Track> > >"/>
 
   <class name="reco::io_v1::PFJet" ClassVersion="3">
-   <version ClassVersion="3" checksum="988205209"/>
+   <version ClassVersion="3" checksum="2655749697"/>
   </class>
   <class name="reco::io_v1::PFJet::Specific" ClassVersion="3">
    <version ClassVersion="3" checksum="1839745193"/>
@@ -81,7 +81,7 @@
   <class name="edm::reftobase::RefVectorHolder<reco::PFJetRefVector>"/>
 
   <class name="reco::io_v1::GenJet" ClassVersion="3">
-   <version ClassVersion="3" checksum="2544745155"/>
+   <version ClassVersion="3" checksum="3252411323"/>
   </class>
   <class name="reco::io_v1::GenJet::Specific" ClassVersion="3">
    <version ClassVersion="3" checksum="477291414"/>
@@ -103,7 +103,7 @@
   <class name="edm::Wrapper<reco::GenJetFwdPtrVector>"/>
 
   <class name="reco::io_v1::BasicJet" ClassVersion="3">
-   <version ClassVersion="3" checksum="526930831"/>
+   <version ClassVersion="3" checksum="353614199"/>
   </class>
   <class name="std::vector<reco::io_v1::BasicJet>"/>
   <class name="edm::RefVector<std::vector<reco::io_v1::BasicJet>,reco::io_v1::BasicJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::BasicJet>,reco::io_v1::BasicJet> >"/>

--- a/DataFormats/JetReco/src/classes_def_3.xml
+++ b/DataFormats/JetReco/src/classes_def_3.xml
@@ -1,6 +1,6 @@
 <lcgdict>
   <class name="reco::io_v1::TrackJet" ClassVersion="3">
-   <version ClassVersion="3" checksum="87636228"/>
+   <version ClassVersion="3" checksum="2313715948"/>
   </class>
   <class name="std::vector<reco::io_v1::TrackJet>"/>
   <class name="edm::RefVector<std::vector<reco::io_v1::TrackJet>,reco::io_v1::TrackJet,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::TrackJet>,reco::io_v1::TrackJet> >"/>
@@ -18,7 +18,7 @@
   <class name="edm::Wrapper<reco::TrackJetFwdPtrVector>"/>
 
   <class name="reco::PFClusterJet" ClassVersion="3">
-   <version ClassVersion="3" checksum="2428041643"/>
+   <version ClassVersion="3" checksum="2254725011"/>
   </class>
   <class name="std::vector<reco::PFClusterJet>"/>
   <class name="edm::RefVector<std::vector<reco::PFClusterJet>,reco::PFClusterJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFClusterJet>,reco::PFClusterJet> >"/>

--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -12,53 +12,59 @@
 
 namespace l1ct {
 
-  // all possible tag categories (can be extended for new / separate taggers)
-  class JetTagClass {
-  public:
-    enum JetTagClassValue : uint8_t { b, c, uds, g, tau_p, tau_n, mu, e };
-    JetTagClass() = default;
-    JetTagClass(JetTagClassValue aJetTagClassValue) : value_(aJetTagClassValue) {}
-    JetTagClass(std::string aJetTagClassValueString) {
-      auto it = labels_.find(aJetTagClassValueString);
-      if (it != labels_.end()) {
-        value_ = it->second;
-      } else {
-        // TODO throw an error
-        value_ = JetTagClass::JetTagClassValue::uds;
+  namespace io_v1 {
+
+    // all possible tag categories (can be extended for new / separate taggers)
+    class JetTagClass {
+    public:
+      enum JetTagClassValue : uint8_t { b, c, uds, g, tau_p, tau_n, mu, e };
+      JetTagClass() = default;
+      JetTagClass(JetTagClassValue aJetTagClassValue) : value_(aJetTagClassValue) {}
+      JetTagClass(std::string aJetTagClassValueString) {
+        auto it = labels_.find(aJetTagClassValueString);
+        if (it != labels_.end()) {
+          value_ = it->second;
+        } else {
+          // TODO throw an error
+          value_ = JetTagClass::JetTagClassValue::uds;
+        }
       }
-    }
 
-    inline bool operator==(const JetTagClass &other) const { return value_ == other.value_; }
+      inline bool operator==(const JetTagClass &other) const { return value_ == other.value_; }
 
-  private:
-    JetTagClassValue value_;
-    static const std::unordered_map<std::string, JetTagClassValue> labels_;
+    private:
+      JetTagClassValue value_;
+      static const std::unordered_map<std::string, JetTagClassValue> labels_;
 
-    friend std::ostream &operator<<(std::ostream &ost, const l1ct::JetTagClass &jtc) {
-      auto it = std::find_if(
-          std::begin(jtc.labels_), std::end(jtc.labels_), [&jtc](auto &&p) { return p.second == jtc.value_; });
-      if (it != std::end(jtc.labels_)) {
-        ost << it->first;
+      friend std::ostream &operator<<(std::ostream &ost, const l1ct::io_v1::JetTagClass &jtc) {
+        auto it = std::find_if(
+            std::begin(jtc.labels_), std::end(jtc.labels_), [&jtc](auto &&p) { return p.second == jtc.value_; });
+        if (it != std::end(jtc.labels_)) {
+          ost << it->first;
+        }
+        return ost;
       }
-      return ost;
-    }
 
-  };  // JetTagClass
+    };  // JetTagClass
 
-  // Define a separate class/struct for jet tag handling
-  struct JetTagClassHandler {
-    static const unsigned NTagFields = 8;
-    static const JetTagClass tagClassesDefault_[NTagFields];
+    // Define a separate class/struct for jet tag handling
+    struct JetTagClassHandler {
+      static const unsigned NTagFields = 8;
+      static const JetTagClass tagClassesDefault_[NTagFields];
 
-    JetTagClass tagClassesArray[NTagFields];
+      JetTagClass tagClassesArray[NTagFields];
 
-    JetTagClassHandler() {
-      // Copy the default values to the array
-      for (unsigned i = 0; i < NTagFields; i++) {
-        tagClassesArray[i] = tagClassesDefault_[i];
+      JetTagClassHandler() {
+        // Copy the default values to the array
+        for (unsigned i = 0; i < NTagFields; i++) {
+          tagClassesArray[i] = tagClassesDefault_[i];
+        }
       }
-    }
-  };
+    };
+
+  }  // namespace io_v1
+  using JetTagClass = io_v1::JetTagClass;
+  using JetTagClassHandler = io_v1::JetTagClassHandler;
 
   struct Jet {
     pt_t hwPt;

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -30,7 +30,7 @@
   <class name="edm::Wrapper<l1t::RegionalOutput<l1t::PFCandidateCollection>>" />
 
   <class name="l1t::io_v1::PFJet"  ClassVersion="3">
-        <version ClassVersion="3" checksum="3811042396"/>
+        <version ClassVersion="3" checksum="1164493406"/>
   </class>
   <class name="l1t::PFJetCollection" />
   <class name="edm::Wrapper<l1t::PFJetCollection>" />

--- a/DataFormats/L1TParticleFlow/src/jets.cpp
+++ b/DataFormats/L1TParticleFlow/src/jets.cpp
@@ -1,20 +1,21 @@
 #include "DataFormats/L1TParticleFlow/interface/jets.h"
 
-const std::unordered_map<std::string, l1ct::JetTagClass::JetTagClassValue> l1ct::JetTagClass::labels_ = {
-    {"b", l1ct::JetTagClass::JetTagClassValue::b},
-    {"c", l1ct::JetTagClass::JetTagClassValue::c},
-    {"uds", l1ct::JetTagClass::JetTagClassValue::uds},
-    {"g", l1ct::JetTagClass::JetTagClassValue::g},
-    {"tau_p", l1ct::JetTagClass::JetTagClassValue::tau_p},
-    {"tau_n", l1ct::JetTagClass::JetTagClassValue::tau_n},
-    {"mu", l1ct::JetTagClass::JetTagClassValue::mu},
-    {"e", l1ct::JetTagClass::JetTagClassValue::e}};
+const std::unordered_map<std::string, l1ct::io_v1::JetTagClass::JetTagClassValue> l1ct::io_v1::JetTagClass::labels_ = {
+    {"b", l1ct::io_v1::JetTagClass::JetTagClassValue::b},
+    {"c", l1ct::io_v1::JetTagClass::JetTagClassValue::c},
+    {"uds", l1ct::io_v1::JetTagClass::JetTagClassValue::uds},
+    {"g", l1ct::io_v1::JetTagClass::JetTagClassValue::g},
+    {"tau_p", l1ct::io_v1::JetTagClass::JetTagClassValue::tau_p},
+    {"tau_n", l1ct::io_v1::JetTagClass::JetTagClassValue::tau_n},
+    {"mu", l1ct::io_v1::JetTagClass::JetTagClassValue::mu},
+    {"e", l1ct::io_v1::JetTagClass::JetTagClassValue::e}};
 
-const l1ct::JetTagClass l1ct::JetTagClassHandler::tagClassesDefault_[NTagFields] = {l1ct::JetTagClass("b"),
-                                                                                    l1ct::JetTagClass("c"),
-                                                                                    l1ct::JetTagClass("uds"),
-                                                                                    l1ct::JetTagClass("g"),
-                                                                                    l1ct::JetTagClass("tau_p"),
-                                                                                    l1ct::JetTagClass("tau_n"),
-                                                                                    l1ct::JetTagClass("mu"),
-                                                                                    l1ct::JetTagClass("e")};
+const l1ct::io_v1::JetTagClass l1ct::io_v1::JetTagClassHandler::tagClassesDefault_[NTagFields] = {
+    l1ct::io_v1::JetTagClass("b"),
+    l1ct::io_v1::JetTagClass("c"),
+    l1ct::io_v1::JetTagClass("uds"),
+    l1ct::io_v1::JetTagClass("g"),
+    l1ct::io_v1::JetTagClass("tau_p"),
+    l1ct::io_v1::JetTagClass("tau_n"),
+    l1ct::io_v1::JetTagClass("mu"),
+    l1ct::io_v1::JetTagClass("e")};

--- a/DataFormats/METReco/interface/HaloClusterCandidateECAL.h
+++ b/DataFormats/METReco/interface/HaloClusterCandidateECAL.h
@@ -18,72 +18,75 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 namespace reco {
-  class HaloClusterCandidateECAL {
-  public:
-    HaloClusterCandidateECAL();
-    ~HaloClusterCandidateECAL() {}
+  namespace io_v1 {
+    class HaloClusterCandidateECAL {
+    public:
+      HaloClusterCandidateECAL();
+      ~HaloClusterCandidateECAL() {}
 
-    double getClusterEt() const { return et; }
-    double getSeedEt() const { return seed_et; }
-    double getSeedEta() const { return seed_eta; }
-    double getSeedPhi() const { return seed_phi; }
-    double getSeedZ() const { return seed_Z; }
-    double getSeedR() const { return seed_R; }
-    double getSeedTime() const { return seed_time; }
-    double getTimeDiscriminator() const { return timediscriminator; }
-    bool getIsHaloFromPattern() const { return ishalofrompattern; }
-    bool getIsHaloFromPattern_HLT() const { return ishalofrompattern_hlt; }
-    const edm::RefVector<EcalRecHitCollection>& getBeamHaloRecHitsCandidates() const { return bhrhcandidates; }
+      double getClusterEt() const { return et; }
+      double getSeedEt() const { return seed_et; }
+      double getSeedEta() const { return seed_eta; }
+      double getSeedPhi() const { return seed_phi; }
+      double getSeedZ() const { return seed_Z; }
+      double getSeedR() const { return seed_R; }
+      double getSeedTime() const { return seed_time; }
+      double getTimeDiscriminator() const { return timediscriminator; }
+      bool getIsHaloFromPattern() const { return ishalofrompattern; }
+      bool getIsHaloFromPattern_HLT() const { return ishalofrompattern_hlt; }
+      const edm::RefVector<EcalRecHitCollection>& getBeamHaloRecHitsCandidates() const { return bhrhcandidates; }
 
-    //Specific to EB:
-    double getEtStripIPhiSeedPlus1() const { return etstrip_iphiseedplus1; }
-    double getEtStripIPhiSeedMinus1() const { return etstrip_iphiseedminus1; }
-    double getHoverE() const { return hovere; }
-    int getNbofCrystalsInEta() const { return numberofcrystalsineta; }
-    //Specific to EE:
-    double getH2overE() const { return h2overe; }
-    int getNbEarlyCrystals() const { return nbearlycrystals; }
-    int getNbLateCrystals() const { return nblatecrystals; }
-    int getClusterSize() const { return clustersize; }
+      //Specific to EB:
+      double getEtStripIPhiSeedPlus1() const { return etstrip_iphiseedplus1; }
+      double getEtStripIPhiSeedMinus1() const { return etstrip_iphiseedminus1; }
+      double getHoverE() const { return hovere; }
+      int getNbofCrystalsInEta() const { return numberofcrystalsineta; }
+      //Specific to EE:
+      double getH2overE() const { return h2overe; }
+      int getNbEarlyCrystals() const { return nbearlycrystals; }
+      int getNbLateCrystals() const { return nblatecrystals; }
+      int getClusterSize() const { return clustersize; }
 
-    void setClusterEt(double x) { et = x; }
-    void setSeedEt(double x) { seed_et = x; }
-    void setSeedEta(double x) { seed_eta = x; }
-    void setSeedPhi(double x) { seed_phi = x; }
-    void setSeedZ(double x) { seed_Z = x; }
-    void setSeedR(double x) { seed_R = x; }
-    void setSeedTime(double x) { seed_time = x; }
-    void setTimeDiscriminator(double x) { timediscriminator = x; }
-    void setIsHaloFromPattern(bool x) { ishalofrompattern = x; }
-    void setIsHaloFromPattern_HLT(bool x) { ishalofrompattern_hlt = x; }
-    void setBeamHaloRecHitsCandidates(edm::RefVector<EcalRecHitCollection> x) { bhrhcandidates = x; }
-    //Specific to EB:
-    void setEtStripIPhiSeedPlus1(double x) { etstrip_iphiseedplus1 = x; }
-    void setEtStripIPhiSeedMinus1(double x) { etstrip_iphiseedminus1 = x; }
-    void setHoverE(double x) { hovere = x; }
-    void setNbofCrystalsInEta(double x) { numberofcrystalsineta = x; }
-    //Specific to EE:
-    void setH2overE(double x) { h2overe = x; }
-    void setNbEarlyCrystals(int x) { nbearlycrystals = x; }
-    void setNbLateCrystals(int x) { nblatecrystals = x; }
-    void setClusterSize(int x) { clustersize = x; }
+      void setClusterEt(double x) { et = x; }
+      void setSeedEt(double x) { seed_et = x; }
+      void setSeedEta(double x) { seed_eta = x; }
+      void setSeedPhi(double x) { seed_phi = x; }
+      void setSeedZ(double x) { seed_Z = x; }
+      void setSeedR(double x) { seed_R = x; }
+      void setSeedTime(double x) { seed_time = x; }
+      void setTimeDiscriminator(double x) { timediscriminator = x; }
+      void setIsHaloFromPattern(bool x) { ishalofrompattern = x; }
+      void setIsHaloFromPattern_HLT(bool x) { ishalofrompattern_hlt = x; }
+      void setBeamHaloRecHitsCandidates(edm::RefVector<EcalRecHitCollection> x) { bhrhcandidates = x; }
+      //Specific to EB:
+      void setEtStripIPhiSeedPlus1(double x) { etstrip_iphiseedplus1 = x; }
+      void setEtStripIPhiSeedMinus1(double x) { etstrip_iphiseedminus1 = x; }
+      void setHoverE(double x) { hovere = x; }
+      void setNbofCrystalsInEta(double x) { numberofcrystalsineta = x; }
+      //Specific to EE:
+      void setH2overE(double x) { h2overe = x; }
+      void setNbEarlyCrystals(int x) { nbearlycrystals = x; }
+      void setNbLateCrystals(int x) { nblatecrystals = x; }
+      void setClusterSize(int x) { clustersize = x; }
 
-  private:
-    double et;
-    double seed_et, seed_eta, seed_phi, seed_Z, seed_R, seed_time;
-    double timediscriminator;
-    bool ishalofrompattern;
-    bool ishalofrompattern_hlt;
-    //Specific to EB:
-    double hovere;
-    int numberofcrystalsineta;
-    double etstrip_iphiseedplus1, etstrip_iphiseedminus1;
-    //Specific to EE:
-    double h2overe;
-    int nbearlycrystals, nblatecrystals, clustersize;
+    private:
+      double et;
+      double seed_et, seed_eta, seed_phi, seed_Z, seed_R, seed_time;
+      double timediscriminator;
+      bool ishalofrompattern;
+      bool ishalofrompattern_hlt;
+      //Specific to EB:
+      double hovere;
+      int numberofcrystalsineta;
+      double etstrip_iphiseedplus1, etstrip_iphiseedminus1;
+      //Specific to EE:
+      double h2overe;
+      int nbearlycrystals, nblatecrystals, clustersize;
 
-    edm::RefVector<EcalRecHitCollection> bhrhcandidates;
-  };
+      edm::RefVector<EcalRecHitCollection> bhrhcandidates;
+    };
+  }  // namespace io_v1
+  using HaloClusterCandidateECAL = io_v1::HaloClusterCandidateECAL;
   typedef std::vector<HaloClusterCandidateECAL> HaloClusterCandidateECALCollection;
 }  // namespace reco
 #endif

--- a/DataFormats/METReco/interface/HaloClusterCandidateHCAL.h
+++ b/DataFormats/METReco/interface/HaloClusterCandidateHCAL.h
@@ -18,72 +18,75 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 namespace reco {
-  class HaloClusterCandidateHCAL {
-  public:
-    HaloClusterCandidateHCAL();
-    ~HaloClusterCandidateHCAL() {}
+  namespace io_v1 {
+    class HaloClusterCandidateHCAL {
+    public:
+      HaloClusterCandidateHCAL();
+      ~HaloClusterCandidateHCAL() {}
 
-    double getClusterEt() const { return et; }
-    double getSeedEt() const { return seed_et; }
-    double getSeedEta() const { return seed_eta; }
-    double getSeedPhi() const { return seed_phi; }
-    double getSeedZ() const { return seed_Z; }
-    double getSeedR() const { return seed_R; }
-    double getSeedTime() const { return seed_time; }
-    bool getIsHaloFromPattern() const { return ishalofrompattern; }
-    bool getIsHaloFromPattern_HLT() const { return ishalofrompattern_hlt; }
-    double getEoverH() const { return eoverh; }
-    double getEtStripPhiSeedPlus1() const { return etstrip_phiseedplus1; }
-    double getEtStripPhiSeedMinus1() const { return etstrip_phiseedminus1; }
-    edm::RefVector<HBHERecHitCollection> getBeamHaloRecHitsCandidates() const { return bhrhcandidates; }
-    //Specific to HB:
-    int getNbTowersInEta() const { return nbtowersineta; }
-    double getTimeDiscriminatorITBH() const { return timediscriminatoritbh; }
-    double getTimeDiscriminatorOTBH() const { return timediscriminatorotbh; }
-    //Specific to HE:
-    double getH1overH123() const { return h1overh123; }
-    int getClusterSize() const { return clustersize; }
-    double getTimeDiscriminator() const { return timediscriminator; }
+      double getClusterEt() const { return et; }
+      double getSeedEt() const { return seed_et; }
+      double getSeedEta() const { return seed_eta; }
+      double getSeedPhi() const { return seed_phi; }
+      double getSeedZ() const { return seed_Z; }
+      double getSeedR() const { return seed_R; }
+      double getSeedTime() const { return seed_time; }
+      bool getIsHaloFromPattern() const { return ishalofrompattern; }
+      bool getIsHaloFromPattern_HLT() const { return ishalofrompattern_hlt; }
+      double getEoverH() const { return eoverh; }
+      double getEtStripPhiSeedPlus1() const { return etstrip_phiseedplus1; }
+      double getEtStripPhiSeedMinus1() const { return etstrip_phiseedminus1; }
+      edm::RefVector<HBHERecHitCollection> getBeamHaloRecHitsCandidates() const { return bhrhcandidates; }
+      //Specific to HB:
+      int getNbTowersInEta() const { return nbtowersineta; }
+      double getTimeDiscriminatorITBH() const { return timediscriminatoritbh; }
+      double getTimeDiscriminatorOTBH() const { return timediscriminatorotbh; }
+      //Specific to HE:
+      double getH1overH123() const { return h1overh123; }
+      int getClusterSize() const { return clustersize; }
+      double getTimeDiscriminator() const { return timediscriminator; }
 
-    void setClusterEt(double x) { et = x; }
-    void setSeedEt(double x) { seed_et = x; }
-    void setSeedEta(double x) { seed_eta = x; }
-    void setSeedPhi(double x) { seed_phi = x; }
-    void setSeedZ(double x) { seed_Z = x; }
-    void setSeedR(double x) { seed_R = x; }
-    void setSeedTime(double x) { seed_time = x; }
-    void setIsHaloFromPattern(bool x) { ishalofrompattern = x; }
-    void setIsHaloFromPattern_HLT(bool x) { ishalofrompattern_hlt = x; }
-    void setEoverH(double x) { eoverh = x; }
-    void setEtStripPhiSeedPlus1(double x) { etstrip_phiseedplus1 = x; }
-    void setEtStripPhiSeedMinus1(double x) { etstrip_phiseedminus1 = x; }
-    void setBeamHaloRecHitsCandidates(edm::RefVector<HBHERecHitCollection> x) { bhrhcandidates = x; }
-    //Specific to HB:
-    void setNbTowersInEta(double x) { nbtowersineta = x; }
-    void setTimeDiscriminatorITBH(double x) { timediscriminatoritbh = x; }
-    void setTimeDiscriminatorOTBH(double x) { timediscriminatorotbh = x; }
-    //Specific to HE:
-    void setH1overH123(double x) { h1overh123 = x; }
-    void setClusterSize(int x) { clustersize = x; }
-    void setTimeDiscriminator(double x) { timediscriminator = x; }
+      void setClusterEt(double x) { et = x; }
+      void setSeedEt(double x) { seed_et = x; }
+      void setSeedEta(double x) { seed_eta = x; }
+      void setSeedPhi(double x) { seed_phi = x; }
+      void setSeedZ(double x) { seed_Z = x; }
+      void setSeedR(double x) { seed_R = x; }
+      void setSeedTime(double x) { seed_time = x; }
+      void setIsHaloFromPattern(bool x) { ishalofrompattern = x; }
+      void setIsHaloFromPattern_HLT(bool x) { ishalofrompattern_hlt = x; }
+      void setEoverH(double x) { eoverh = x; }
+      void setEtStripPhiSeedPlus1(double x) { etstrip_phiseedplus1 = x; }
+      void setEtStripPhiSeedMinus1(double x) { etstrip_phiseedminus1 = x; }
+      void setBeamHaloRecHitsCandidates(edm::RefVector<HBHERecHitCollection> x) { bhrhcandidates = x; }
+      //Specific to HB:
+      void setNbTowersInEta(double x) { nbtowersineta = x; }
+      void setTimeDiscriminatorITBH(double x) { timediscriminatoritbh = x; }
+      void setTimeDiscriminatorOTBH(double x) { timediscriminatorotbh = x; }
+      //Specific to HE:
+      void setH1overH123(double x) { h1overh123 = x; }
+      void setClusterSize(int x) { clustersize = x; }
+      void setTimeDiscriminator(double x) { timediscriminator = x; }
 
-  private:
-    double et;
-    double seed_et, seed_eta, seed_phi, seed_Z, seed_R, seed_time;
-    bool ishalofrompattern;
-    bool ishalofrompattern_hlt;
-    double eoverh;
-    double etstrip_phiseedplus1, etstrip_phiseedminus1;
-    //Specific to HB:
-    int nbtowersineta;
-    double timediscriminatoritbh, timediscriminatorotbh;
-    //Specific to HE:
-    double h1overh123;
-    int clustersize;
-    double timediscriminator;
+    private:
+      double et;
+      double seed_et, seed_eta, seed_phi, seed_Z, seed_R, seed_time;
+      bool ishalofrompattern;
+      bool ishalofrompattern_hlt;
+      double eoverh;
+      double etstrip_phiseedplus1, etstrip_phiseedminus1;
+      //Specific to HB:
+      int nbtowersineta;
+      double timediscriminatoritbh, timediscriminatorotbh;
+      //Specific to HE:
+      double h1overh123;
+      int clustersize;
+      double timediscriminator;
 
-    edm::RefVector<HBHERecHitCollection> bhrhcandidates;
-  };
+      edm::RefVector<HBHERecHitCollection> bhrhcandidates;
+    };
+  }  // namespace io_v1
+  using HaloClusterCandidateHCAL = io_v1::HaloClusterCandidateHCAL;
   typedef std::vector<HaloClusterCandidateHCAL> HaloClusterCandidateHCALCollection;
 }  // namespace reco
 #endif

--- a/DataFormats/METReco/src/HaloClusterCandidateECAL.cc
+++ b/DataFormats/METReco/src/HaloClusterCandidateECAL.cc
@@ -1,6 +1,7 @@
 #include "DataFormats/METReco/interface/HaloClusterCandidateECAL.h"
 
 using namespace reco;
+using namespace reco::io_v1;
 HaloClusterCandidateECAL::HaloClusterCandidateECAL()
     : et(0),
       seed_et(0),

--- a/DataFormats/METReco/src/HaloClusterCandidateHCAL.cc
+++ b/DataFormats/METReco/src/HaloClusterCandidateHCAL.cc
@@ -1,6 +1,7 @@
 #include "DataFormats/METReco/interface/HaloClusterCandidateHCAL.h"
 
 using namespace reco;
+using namespace reco::io_v1;
 HaloClusterCandidateHCAL::HaloClusterCandidateHCAL()
     : et(0),
       seed_et(0),

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -141,12 +141,12 @@
   <class name="std::vector<reco::PhiWedge>::iterator"/>
 
   <class name="reco::io_v1::EcalHaloData" ClassVersion="3">
-   <version ClassVersion="3" checksum="2280589981"/>
+   <version ClassVersion="3" checksum="4136869207"/>
   </class>
   <class name="edm::Wrapper<reco::io_v1::EcalHaloData>"/>
 
   <class name="reco::io_v1::HcalHaloData" ClassVersion="3">
-   <version ClassVersion="3" checksum="3753607864"/>
+   <version ClassVersion="3" checksum="60239034"/>
   </class>
   <class name="edm::Wrapper<reco::io_v1::HcalHaloData>"/>
 
@@ -185,14 +185,14 @@
   <class name="std::vector<BoundaryInformation>"/>
   <class name="edm::Wrapper<std::vector<BoundaryInformation> >"/>
   
-  <class name="reco::HaloClusterCandidateECAL" ClassVersion="3">
-    <version ClassVersion="3" checksum="2487939807"/>
+  <class name="reco::io_v1::HaloClusterCandidateECAL" ClassVersion="3">
+    <version ClassVersion="3" checksum="509322413"/>
   </class>
   <class name="std::vector<reco::HaloClusterCandidateECAL>"/>
   <class name="edm::Wrapper<std::vector<reco::HaloClusterCandidateECAL> >"/>
     
-  <class name="reco::HaloClusterCandidateHCAL" ClassVersion="3">
-    <version ClassVersion="3" checksum="4228642932"/>
+  <class name="reco::io_v1::HaloClusterCandidateHCAL" ClassVersion="3">
+    <version ClassVersion="3" checksum="1190401378"/>
   </class> 
   <class name="std::vector<reco::HaloClusterCandidateHCAL>"/>
   <class name="edm::Wrapper<std::vector<reco::HaloClusterCandidateHCAL> >"/>

--- a/DataFormats/MuonReco/interface/MuonChamberMatch.h
+++ b/DataFormats/MuonReco/interface/MuonChamberMatch.h
@@ -8,37 +8,42 @@
 #include <vector>
 
 namespace reco {
-  class MuonChamberMatch {
-  public:
-    std::vector<reco::MuonSegmentMatch> segmentMatches;  // segments matching propagated track trajectory
-    std::vector<reco::MuonSegmentMatch> gemMatches;      // segments matching propagated track trajectory
-    std::vector<reco::MuonGEMHitMatch> gemHitMatches;    // segments matching propagated track trajectory
-    std::vector<reco::MuonSegmentMatch> me0Matches;      // segments matching propagated track trajectory
-    std::vector<reco::MuonSegmentMatch> truthMatches;    // SimHit projection matching propagated track trajectory
-    std::vector<reco::MuonRPCHitMatch> rpcMatches;       // rpc hits matching propagated track trajectory
-    float edgeX;    // distance to closest edge in X (negative - inside, positive - outside)
-    float edgeY;    // distance to closest edge in Y (negative - inside, positive - outside)
-    float x;        // X position of the track
-    float y;        // Y position of the track
-    float xErr;     // propagation uncertainty in X
-    float yErr;     // propagation uncertainty in Y
-    float dXdZ;     // dX/dZ of the track
-    float dYdZ;     // dY/dZ of the track
-    float dXdZErr;  // propagation uncertainty in dX/dZ
-    float dYdZErr;  // propagation uncertainty in dY/dZ
-    DetId id;       // chamber ID
+  namespace io_v1 {
+    class MuonChamberMatch {
+    public:
+      std::vector<reco::MuonSegmentMatch> segmentMatches;  // segments matching propagated track trajectory
+      std::vector<reco::MuonSegmentMatch> gemMatches;      // segments matching propagated track trajectory
+      std::vector<reco::MuonGEMHitMatch> gemHitMatches;    // segments matching propagated track trajectory
+      std::vector<reco::MuonSegmentMatch> me0Matches;      // segments matching propagated track trajectory
+      std::vector<reco::MuonSegmentMatch> truthMatches;    // SimHit projection matching propagated track trajectory
+      std::vector<reco::MuonRPCHitMatch> rpcMatches;       // rpc hits matching propagated track trajectory
+      float edgeX;    // distance to closest edge in X (negative - inside, positive - outside)
+      float edgeY;    // distance to closest edge in Y (negative - inside, positive - outside)
+      float x;        // X position of the track
+      float y;        // Y position of the track
+      float xErr;     // propagation uncertainty in X
+      float yErr;     // propagation uncertainty in Y
+      float dXdZ;     // dX/dZ of the track
+      float dYdZ;     // dY/dZ of the track
+      float dXdZErr;  // propagation uncertainty in dX/dZ
+      float dYdZErr;  // propagation uncertainty in dY/dZ
+      DetId id;       // chamber ID
 
-    int nDigisInRange;  // # of DT/CSC digis in the chamber close-by to the propagated track
+      int nDigisInRange;  // # of DT/CSC digis in the chamber close-by to the propagated track
 
-    int detector() const { return id.subdetId(); }
-    int station() const;
+      int detector() const { return id.subdetId(); }
+      int station() const;
 
-    std::pair<float, float> getDistancePair(float edgeX, float edgeY, float xErr, float yErr) const;
-    float dist() const { return getDistancePair(edgeX, edgeY, xErr, yErr).first; }  // distance to absolute closest edge
-    float distErr() const {
-      return getDistancePair(edgeX, edgeY, xErr, yErr).second;
-    }  // propagation uncertainty in above distance
-  };
+      std::pair<float, float> getDistancePair(float edgeX, float edgeY, float xErr, float yErr) const;
+      float dist() const {
+        return getDistancePair(edgeX, edgeY, xErr, yErr).first;
+      }  // distance to absolute closest edge
+      float distErr() const {
+        return getDistancePair(edgeX, edgeY, xErr, yErr).second;
+      }  // propagation uncertainty in above distance
+    };
+  }  // namespace io_v1
+  using MuonChamberMatch = io_v1::MuonChamberMatch;
 }  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonSegmentMatch.h
+++ b/DataFormats/MuonReco/interface/MuonSegmentMatch.h
@@ -9,53 +9,56 @@
 #include "DataFormats/GEMRecHit/interface/ME0SegmentCollection.h"
 
 namespace reco {
-  class MuonSegmentMatch {
-  public:
-    /// segment mask flags
-    static const unsigned int Arbitrated = 1 << 8;                  // is arbitrated (multiple muons)
-    static const unsigned int BestInChamberByDX = 1 << 9;           // best delta x in single muon chamber
-    static const unsigned int BestInChamberByDR = 1 << 10;          // best delta r in single muon chamber
-    static const unsigned int BestInChamberByDXSlope = 1 << 11;     // best delta dx/dz in single muon chamber
-    static const unsigned int BestInChamberByDRSlope = 1 << 12;     // best delta dy/dz in single muon chamber
-    static const unsigned int BestInStationByDX = 1 << 13;          // best delta x in single muon station
-    static const unsigned int BestInStationByDR = 1 << 14;          // best delta r in single muon station
-    static const unsigned int BestInStationByDXSlope = 1 << 15;     // best delta dx/dz in single muon station
-    static const unsigned int BestInStationByDRSlope = 1 << 16;     // best delta dy/dz in single muon station
-    static const unsigned int BelongsToTrackByDX = 1 << 17;         // best delta x of multiple muons
-    static const unsigned int BelongsToTrackByDR = 1 << 18;         // best delta r of multiple muons
-    static const unsigned int BelongsToTrackByDXSlope = 1 << 19;    // best delta dx/dz of multiple muons
-    static const unsigned int BelongsToTrackByDRSlope = 1 << 20;    // best delta dy/dz of multiple muons
-    static const unsigned int BelongsToTrackByME1aClean = 1 << 21;  // won ME1a segment sharing cleaning
-    static const unsigned int BelongsToTrackByOvlClean = 1 << 22;   // won chamber overlap segment sharing cleaning
-    static const unsigned int BelongsToTrackByClusClean = 1 << 23;  // won cluster sharing cleaning
-    // won any arbitration cleaning type, including defaults
-    static const unsigned int BelongsToTrackByCleaning = 1 << 24;
+  namespace io_v1 {
+    class MuonSegmentMatch {
+    public:
+      /// segment mask flags
+      static const unsigned int Arbitrated = 1 << 8;                  // is arbitrated (multiple muons)
+      static const unsigned int BestInChamberByDX = 1 << 9;           // best delta x in single muon chamber
+      static const unsigned int BestInChamberByDR = 1 << 10;          // best delta r in single muon chamber
+      static const unsigned int BestInChamberByDXSlope = 1 << 11;     // best delta dx/dz in single muon chamber
+      static const unsigned int BestInChamberByDRSlope = 1 << 12;     // best delta dy/dz in single muon chamber
+      static const unsigned int BestInStationByDX = 1 << 13;          // best delta x in single muon station
+      static const unsigned int BestInStationByDR = 1 << 14;          // best delta r in single muon station
+      static const unsigned int BestInStationByDXSlope = 1 << 15;     // best delta dx/dz in single muon station
+      static const unsigned int BestInStationByDRSlope = 1 << 16;     // best delta dy/dz in single muon station
+      static const unsigned int BelongsToTrackByDX = 1 << 17;         // best delta x of multiple muons
+      static const unsigned int BelongsToTrackByDR = 1 << 18;         // best delta r of multiple muons
+      static const unsigned int BelongsToTrackByDXSlope = 1 << 19;    // best delta dx/dz of multiple muons
+      static const unsigned int BelongsToTrackByDRSlope = 1 << 20;    // best delta dy/dz of multiple muons
+      static const unsigned int BelongsToTrackByME1aClean = 1 << 21;  // won ME1a segment sharing cleaning
+      static const unsigned int BelongsToTrackByOvlClean = 1 << 22;   // won chamber overlap segment sharing cleaning
+      static const unsigned int BelongsToTrackByClusClean = 1 << 23;  // won cluster sharing cleaning
+      // won any arbitration cleaning type, including defaults
+      static const unsigned int BelongsToTrackByCleaning = 1 << 24;
 
-    float x;            // X position of the matched segment
-    float y;            // Y position of the matched segment
-    float xErr;         // uncertainty in X
-    float yErr;         // uncertainty in Y
-    float dXdZ;         // dX/dZ of the matched segment
-    float dYdZ;         // dY/dZ of the matched segment
-    float dXdZErr;      // uncertainty in dX/dZ
-    float dYdZErr;      // uncertainty in dY/dZ
-    unsigned int mask;  // arbitration mask
-    bool hasZed_;       // contains local y information (only relevant for segments in DT)
-    bool hasPhi_;       // contains local x information (only relevant for segments in DT)
+      float x;            // X position of the matched segment
+      float y;            // Y position of the matched segment
+      float xErr;         // uncertainty in X
+      float yErr;         // uncertainty in Y
+      float dXdZ;         // dX/dZ of the matched segment
+      float dYdZ;         // dY/dZ of the matched segment
+      float dXdZErr;      // uncertainty in dX/dZ
+      float dYdZErr;      // uncertainty in dY/dZ
+      unsigned int mask;  // arbitration mask
+      bool hasZed_;       // contains local y information (only relevant for segments in DT)
+      bool hasPhi_;       // contains local x information (only relevant for segments in DT)
 
-    bool isMask(unsigned int flag = Arbitrated) const { return (mask & flag) == flag; }
-    void setMask(unsigned int flag) { mask |= flag; }
-    float t0;
+      bool isMask(unsigned int flag = Arbitrated) const { return (mask & flag) == flag; }
+      void setMask(unsigned int flag) { mask |= flag; }
+      float t0;
 
-    DTRecSegment4DRef dtSegmentRef;
-    CSCSegmentRef cscSegmentRef;
-    GEMSegmentRef gemSegmentRef;
-    ME0SegmentRef me0SegmentRef;
-    MuonSegmentMatch() : x(0), y(0), xErr(0), yErr(0), dXdZ(0), dYdZ(0), dXdZErr(0), dYdZErr(0) {}
+      DTRecSegment4DRef dtSegmentRef;
+      CSCSegmentRef cscSegmentRef;
+      GEMSegmentRef gemSegmentRef;
+      ME0SegmentRef me0SegmentRef;
+      MuonSegmentMatch() : x(0), y(0), xErr(0), yErr(0), dXdZ(0), dYdZ(0), dXdZErr(0), dYdZErr(0) {}
 
-    bool hasZed() const { return hasZed_; }
-    bool hasPhi() const { return hasPhi_; }
-  };
+      bool hasZed() const { return hasZed_; }
+      bool hasPhi() const { return hasPhi_; }
+    };
+  }  // namespace io_v1
+  using MuonSegmentMatch = io_v1::MuonSegmentMatch;
 }  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/src/MuonChamberMatch.cc
+++ b/DataFormats/MuonReco/src/MuonChamberMatch.cc
@@ -7,6 +7,7 @@
 #include "DataFormats/MuonReco/interface/MuonChamberMatch.h"
 #include <cmath>
 using namespace reco;
+using namespace reco::io_v1;
 
 int MuonChamberMatch::station() const {
   if (detector() == MuonSubdetId::DT) {  // DT

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -9,7 +9,7 @@ initial version number of a class which has never been stored before.
 -->
 <lcgdict>
   <class name="reco::io_v1::Muon" ClassVersion="3">
-   <version ClassVersion="3" checksum="1255314174"/>
+   <version ClassVersion="3" checksum="2806403532"/>
   </class>
   <class name="std::vector<reco::io_v1::Muon>"/>
   <class name="edm::Wrapper<std::vector<reco::io_v1::Muon> >"/>
@@ -48,11 +48,11 @@ initial version number of a class which has never been stored before.
    <version ClassVersion="3" checksum="2031556424"/>
   </class>
   <class name="std::vector<reco::HcalMuonRecHit>"/>
-  <class name="reco::MuonChamberMatch" ClassVersion="3">
-   <version ClassVersion="3" checksum="3579435038"/>
+  <class name="reco::io_v1::MuonChamberMatch" ClassVersion="3">
+   <version ClassVersion="3" checksum="2011871712"/>
   </class>
-  <class name="reco::MuonSegmentMatch" ClassVersion="3">
-    <version ClassVersion="3" checksum="351152846"/>
+  <class name="reco::io_v1::MuonSegmentMatch" ClassVersion="3">
+    <version ClassVersion="3" checksum="2116957468"/>
   </class>
   <class name="reco::MuonRPCHitMatch" ClassVersion="3">
    <version ClassVersion="3" checksum="4193465224"/>

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElement.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElement.h
@@ -16,159 +16,166 @@
 #include <iostream>
 
 namespace reco {
-  class PFBlockElementCluster;
-  class PFBlockElementTrack;
+  namespace io_v1 {
 
-  /// \brief Abstract base class for a PFBlock element (track, cluster...)
-  ///
-  /// this class contains a PFRecTrackRef of a
-  /// PFClusterRef, depending on the type of the element
-  class PFBlockElement {
-  public:
-    /// possible types for the element
-    /// do not modify this enum if you don't know what you're doing!!!
-    enum Type {
-      NONE = 0,
-      TRACK = 1,
-      PS1 = 2,
-      PS2 = 3,
-      ECAL = 4,
-      HCAL = 5,
-      GSF = 6,
-      BREM = 7,
-      HFEM = 8,
-      HFHAD = 9,
-      SC = 10,
-      HO = 11,
-      HGCAL = 12,
-      kNBETypes = 13
+    class PFBlockElementCluster;
+    class PFBlockElementTrack;
+
+    /// \brief Abstract base class for a PFBlock element (track, cluster...)
+    ///
+    /// this class contains a PFRecTrackRef of a
+    /// PFClusterRef, depending on the type of the element
+    class PFBlockElement {
+    public:
+      /// possible types for the element
+      /// do not modify this enum if you don't know what you're doing!!!
+      enum Type {
+        NONE = 0,
+        TRACK = 1,
+        PS1 = 2,
+        PS2 = 3,
+        ECAL = 4,
+        HCAL = 5,
+        GSF = 6,
+        BREM = 7,
+        HFEM = 8,
+        HFHAD = 9,
+        SC = 10,
+        HO = 11,
+        HGCAL = 12,
+        kNBETypes = 13
+      };
+
+      enum TrackType { DEFAULT = 0, T_FROM_DISP, T_TO_DISP, T_FROM_GAMMACONV, MUON, T_FROM_V0 };
+
+      /// standard constructor
+      PFBlockElement(Type type = NONE)
+          : type_(type), locked_(false), index_(static_cast<unsigned>(-1)), time_(0.f), timeError_(-1.f) {}
+
+      /// destructor
+      virtual ~PFBlockElement() {}
+
+      /// print the object inside the element
+      virtual void Dump(std::ostream& out = std::cout, const char* tab = " ") const;
+
+      /// necessary to have the edm::OwnVector<PFBlockElement> working
+      virtual PFBlockElement* clone() const = 0;
+
+      /// lock element
+      void lock() { locked_ = true; }
+
+      /// unlock element
+      void unLock() { locked_ = false; }
+
+      /// \return type
+      Type type() const { return type_; }
+
+      /// \return tracktype
+      virtual bool trackType(TrackType trType) const { return false; }
+
+      /// \set the trackType
+      virtual void setTrackType(TrackType trType, bool value) {
+        std::cout << "Error in PFBlockElement::setTrackType : this base class method is not implemented" << std::endl;
+      }
+
+      /// locked ?
+      bool locked() const { return locked_; }
+
+      /// set index
+      void setIndex(unsigned index) { index_ = index; }
+
+      /// \return index
+      unsigned index() const { return index_; }
+
+      virtual const reco::TrackRef& trackRef() const { return nullTrack_; }
+      virtual const PFRecTrackRef& trackRefPF() const { return nullPFRecTrack_; }
+      virtual const PFClusterRef& clusterRef() const { return nullPFCluster_; }
+      virtual const PFDisplacedTrackerVertexRef& displacedVertexRef(TrackType trType) const {
+        return nullPFDispVertex_;
+      }
+      virtual const ConversionRefVector& convRefs() const { return nullConv_; }
+      virtual const MuonRef& muonRef() const { return nullMuon_; }
+      virtual const VertexCompositeCandidateRef& V0Ref() const { return nullVertex_; }
+      virtual void setDisplacedVertexRef(const PFDisplacedTrackerVertexRef& niref, TrackType trType) {
+        std::cout << "Error in PFBlockElement::setDisplacedVertexRef : this base class method is not implemented"
+                  << std::endl;
+      }
+      virtual void setConversionRef(const ConversionRef& convRef, TrackType trType) {
+        std::cout << "Error in PFBlockElement::setConversionRef : this base class method is not implemented"
+                  << std::endl;
+      }
+      virtual void setMuonRef(const MuonRef& muref) {
+        std::cout << "Error in PFBlockElement::setMuonRef : this base class method is not implemented" << std::endl;
+      }
+      virtual void setV0Ref(const VertexCompositeCandidateRef& v0ref, TrackType trType) {
+        std::cout << "Error in PFBlockElement::setV0Ref : this base class method is not implemented" << std::endl;
+      }
+
+      virtual bool isSecondary() const { return false; }
+      virtual bool isPrimary() const { return false; }
+      virtual bool isLinkedToDisplacedVertex() const { return false; }
+
+      // Glowinski & Gouzevitch
+      void setMultilinks(const PFMultiLinksTC& ml, Type type) { multilinks_[type] = ml; }
+      void setIsValidMultilinks(bool isVal, Type type) { multilinks_[type].isValid = isVal; }
+
+      bool isMultilinksValide(Type type) const {
+        const auto& it = multilinks_.find(type);
+        if (it != multilinks_.end())
+          return it->second.isValid;
+        else
+          return false;  // no multilinks_ for the specified type
+      }
+      const PFMultilinksType& getMultilinks(Type type) const { return multilinks_.at(type).linkedPFObjects; }
+      // ! Glowinski & Gouzevitch
+
+      /// do we have a valid time information
+      bool isTimeValid() const { return timeError_ >= 0.f; }
+      /// \return the timing
+      float time() const { return time_; }
+      /// \return the timing uncertainty
+      float timeError() const { return timeError_; }
+      /// \set the timing information
+      void setTime(float time, float timeError = 0.f) {
+        time_ = time;
+        timeError_ = timeError;
+      }
+
+    protected:
+      /// type, see PFBlockElementType
+      /// \todo replace by a char ?
+      Type type_;
+
+      /// locked flag.
+      /// \todo can probably be transient. Could be replaced by a
+      /// "remaining energy". IS THIS STILL USED ?
+      bool locked_;
+
+      /// index in block vector
+      unsigned index_;
+
+      // Glowinski & Gouzevitch
+      // PFMultiLinks for each different link target type
+      std::map<PFBlockElement::Type, PFMultiLinksTC> multilinks_;
+      // ! Glowinski & Gouzevitch
+
+      /// timing information (valid if timeError_ >= 0)
+      float time_;
+      /// timing information uncertainty (<0 if timing not available)
+      float timeError_;
+
+      const static reco::TrackRef nullTrack_;
+      const static PFRecTrackRef nullPFRecTrack_;
+      const static PFClusterRef nullPFCluster_;
+      const static PFDisplacedTrackerVertexRef nullPFDispVertex_;
+      const static ConversionRefVector nullConv_;
+      const static MuonRef nullMuon_;
+      const static VertexCompositeCandidateRef nullVertex_;
     };
 
-    enum TrackType { DEFAULT = 0, T_FROM_DISP, T_TO_DISP, T_FROM_GAMMACONV, MUON, T_FROM_V0 };
+    std::ostream& operator<<(std::ostream& out, const PFBlockElement& element);
 
-    /// standard constructor
-    PFBlockElement(Type type = NONE)
-        : type_(type), locked_(false), index_(static_cast<unsigned>(-1)), time_(0.f), timeError_(-1.f) {}
-
-    /// destructor
-    virtual ~PFBlockElement() {}
-
-    /// print the object inside the element
-    virtual void Dump(std::ostream& out = std::cout, const char* tab = " ") const;
-
-    /// necessary to have the edm::OwnVector<PFBlockElement> working
-    virtual PFBlockElement* clone() const = 0;
-
-    /// lock element
-    void lock() { locked_ = true; }
-
-    /// unlock element
-    void unLock() { locked_ = false; }
-
-    /// \return type
-    Type type() const { return type_; }
-
-    /// \return tracktype
-    virtual bool trackType(TrackType trType) const { return false; }
-
-    /// \set the trackType
-    virtual void setTrackType(TrackType trType, bool value) {
-      std::cout << "Error in PFBlockElement::setTrackType : this base class method is not implemented" << std::endl;
-    }
-
-    /// locked ?
-    bool locked() const { return locked_; }
-
-    /// set index
-    void setIndex(unsigned index) { index_ = index; }
-
-    /// \return index
-    unsigned index() const { return index_; }
-
-    virtual const reco::TrackRef& trackRef() const { return nullTrack_; }
-    virtual const PFRecTrackRef& trackRefPF() const { return nullPFRecTrack_; }
-    virtual const PFClusterRef& clusterRef() const { return nullPFCluster_; }
-    virtual const PFDisplacedTrackerVertexRef& displacedVertexRef(TrackType trType) const { return nullPFDispVertex_; }
-    virtual const ConversionRefVector& convRefs() const { return nullConv_; }
-    virtual const MuonRef& muonRef() const { return nullMuon_; }
-    virtual const VertexCompositeCandidateRef& V0Ref() const { return nullVertex_; }
-    virtual void setDisplacedVertexRef(const PFDisplacedTrackerVertexRef& niref, TrackType trType) {
-      std::cout << "Error in PFBlockElement::setDisplacedVertexRef : this base class method is not implemented"
-                << std::endl;
-    }
-    virtual void setConversionRef(const ConversionRef& convRef, TrackType trType) {
-      std::cout << "Error in PFBlockElement::setConversionRef : this base class method is not implemented" << std::endl;
-    }
-    virtual void setMuonRef(const MuonRef& muref) {
-      std::cout << "Error in PFBlockElement::setMuonRef : this base class method is not implemented" << std::endl;
-    }
-    virtual void setV0Ref(const VertexCompositeCandidateRef& v0ref, TrackType trType) {
-      std::cout << "Error in PFBlockElement::setV0Ref : this base class method is not implemented" << std::endl;
-    }
-
-    virtual bool isSecondary() const { return false; }
-    virtual bool isPrimary() const { return false; }
-    virtual bool isLinkedToDisplacedVertex() const { return false; }
-
-    // Glowinski & Gouzevitch
-    void setMultilinks(const PFMultiLinksTC& ml, Type type) { multilinks_[type] = ml; }
-    void setIsValidMultilinks(bool isVal, Type type) { multilinks_[type].isValid = isVal; }
-
-    bool isMultilinksValide(Type type) const {
-      const auto& it = multilinks_.find(type);
-      if (it != multilinks_.end())
-        return it->second.isValid;
-      else
-        return false;  // no multilinks_ for the specified type
-    }
-    const PFMultilinksType& getMultilinks(Type type) const { return multilinks_.at(type).linkedPFObjects; }
-    // ! Glowinski & Gouzevitch
-
-    /// do we have a valid time information
-    bool isTimeValid() const { return timeError_ >= 0.f; }
-    /// \return the timing
-    float time() const { return time_; }
-    /// \return the timing uncertainty
-    float timeError() const { return timeError_; }
-    /// \set the timing information
-    void setTime(float time, float timeError = 0.f) {
-      time_ = time;
-      timeError_ = timeError;
-    }
-
-  protected:
-    /// type, see PFBlockElementType
-    /// \todo replace by a char ?
-    Type type_;
-
-    /// locked flag.
-    /// \todo can probably be transient. Could be replaced by a
-    /// "remaining energy". IS THIS STILL USED ?
-    bool locked_;
-
-    /// index in block vector
-    unsigned index_;
-
-    // Glowinski & Gouzevitch
-    // PFMultiLinks for each different link target type
-    std::map<reco::PFBlockElement::Type, PFMultiLinksTC> multilinks_;
-    // ! Glowinski & Gouzevitch
-
-    /// timing information (valid if timeError_ >= 0)
-    float time_;
-    /// timing information uncertainty (<0 if timing not available)
-    float timeError_;
-
-    const static reco::TrackRef nullTrack_;
-    const static PFRecTrackRef nullPFRecTrack_;
-    const static PFClusterRef nullPFCluster_;
-    const static PFDisplacedTrackerVertexRef nullPFDispVertex_;
-    const static ConversionRefVector nullConv_;
-    const static MuonRef nullMuon_;
-    const static VertexCompositeCandidateRef nullVertex_;
-  };
-
-  std::ostream& operator<<(std::ostream& out, const PFBlockElement& element);
-
+  }  // namespace io_v1
+  using PFBlockElement = io_v1::PFBlockElement;
 }  // namespace reco
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h
@@ -7,38 +7,41 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  /**\class PFRecHitFraction
+    /**\class PFRecHitFraction
      \brief Fraction of a PFRecHit 
      (rechits can be shared between several PFCluster's)
           
      \author Colin Bernet
      \date   July 2006
   */
-  class PFRecHitFraction {
-  public:
-    /// default constructor
-    PFRecHitFraction() : fraction_(-1) {}
+    class PFRecHitFraction {
+    public:
+      /// default constructor
+      PFRecHitFraction() : fraction_(-1) {}
 
-    /// constructor
-    PFRecHitFraction(const PFRecHitRef& recHitRef, double fraction) : recHitRef_(recHitRef), fraction_(fraction) {}
+      /// constructor
+      PFRecHitFraction(const PFRecHitRef& recHitRef, double fraction) : recHitRef_(recHitRef), fraction_(fraction) {}
 
-    /// \return index to rechit
-    const PFRecHitRef& recHitRef() const { return recHitRef_; }
+      /// \return index to rechit
+      const PFRecHitRef& recHitRef() const { return recHitRef_; }
 
-    /// \return energy fraction
-    double fraction() const { return fraction_; }
+      /// \return energy fraction
+      double fraction() const { return fraction_; }
 
-  private:
-    /// corresponding rechit
-    PFRecHitRef recHitRef_;
+    private:
+      /// corresponding rechit
+      PFRecHitRef recHitRef_;
 
-    /// fraction of the rechit energy owned by the cluster
-    double fraction_;
-  };
+      /// fraction of the rechit energy owned by the cluster
+      double fraction_;
+    };
 
-  std::ostream& operator<<(std::ostream& out, const PFRecHitFraction& hit);
+    std::ostream& operator<<(std::ostream& out, const PFRecHitFraction& hit);
 
+  }  // namespace io_v1
+  using PFRecHitFraction = io_v1::PFRecHitFraction;
 }  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/src/PFBlockElement.cc
+++ b/DataFormats/ParticleFlowReco/src/PFBlockElement.cc
@@ -5,15 +5,17 @@
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h"
 
-const reco::TrackRef reco::PFBlockElement::nullTrack_ = reco::TrackRef();
-const reco::PFRecTrackRef reco::PFBlockElement::nullPFRecTrack_ = reco::PFRecTrackRef();
-const reco::PFClusterRef reco::PFBlockElement::nullPFCluster_ = reco::PFClusterRef();
-const reco::PFDisplacedTrackerVertexRef reco::PFBlockElement::nullPFDispVertex_ = reco::PFDisplacedTrackerVertexRef();
-const reco::ConversionRefVector reco::PFBlockElement::nullConv_ = reco::ConversionRefVector();
-const reco::MuonRef reco::PFBlockElement::nullMuon_ = reco::MuonRef();
-const reco::VertexCompositeCandidateRef reco::PFBlockElement::nullVertex_ = reco::VertexCompositeCandidateRef();
+const reco::TrackRef reco::io_v1::PFBlockElement::nullTrack_ = reco::TrackRef();
+const reco::PFRecTrackRef reco::io_v1::PFBlockElement::nullPFRecTrack_ = reco::PFRecTrackRef();
+const reco::PFClusterRef reco::io_v1::PFBlockElement::nullPFCluster_ = reco::PFClusterRef();
+const reco::PFDisplacedTrackerVertexRef reco::io_v1::PFBlockElement::nullPFDispVertex_ =
+    reco::PFDisplacedTrackerVertexRef();
+const reco::ConversionRefVector reco::io_v1::PFBlockElement::nullConv_ = reco::ConversionRefVector();
+const reco::MuonRef reco::io_v1::PFBlockElement::nullMuon_ = reco::MuonRef();
+const reco::VertexCompositeCandidateRef reco::io_v1::PFBlockElement::nullVertex_ = reco::VertexCompositeCandidateRef();
 
 using namespace reco;
+using namespace reco::io_v1;
 
 // int PFBlockElement::instanceCounter_ = 0;
 
@@ -27,7 +29,7 @@ void PFBlockElement::Dump(std::ostream& out, const char* pad) const {
   out << pad << "base element";
 }
 
-std::ostream& reco::operator<<(std::ostream& out, const PFBlockElement& element) {
+std::ostream& reco::io_v1::operator<<(std::ostream& out, const PFBlockElement& element) {
   if (!out)
     return out;
 

--- a/DataFormats/ParticleFlowReco/src/PFRecHitFraction.cc
+++ b/DataFormats/ParticleFlowReco/src/PFRecHitFraction.cc
@@ -5,8 +5,9 @@
 
 using namespace std;
 using namespace reco;
+using namespace reco::io_v1;
 
-ostream& reco::operator<<(std::ostream& out, const PFRecHitFraction& hit) {
+ostream& reco::io_v1::operator<<(std::ostream& out, const PFRecHitFraction& hit) {
   if (!out)
     return out;
 

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -2,7 +2,7 @@
 <selection>
 
   <class name="reco::io_v1::PFCluster" ClassVersion="3">
-   <version ClassVersion="3" checksum="3548902471"/>
+   <version ClassVersion="3" checksum="1417779317"/>
     <field name="posrep_" transient="true"/>
     <field name="layer_" transient="true"/> 
   </class>
@@ -10,7 +10,7 @@
   <class name="edm::Wrapper<std::vector<reco::io_v1::PFCluster> >"/>
 
   <class name="reco::io_v1::HGCalMultiCluster" ClassVersion="3">
-    <version ClassVersion="3" checksum="121905775"/>
+    <version ClassVersion="3" checksum="3088110733"/>
   </class>
   <class name="std::vector<reco::io_v1::HGCalMultiCluster>"/>
   <class name="edm::RefProd<vector<reco::io_v1::HGCalMultiCluster> >" />
@@ -24,13 +24,13 @@
    <version ClassVersion="3" checksum="85611"/>
   </class>
   <enum name="PFLayer::Layer"/> 
-  <class name="reco::PFRecHitFraction" ClassVersion="3">
-   <version ClassVersion="3" checksum="1054932742"/>
+  <class name="reco::io_v1::PFRecHitFraction" ClassVersion="3">
+   <version ClassVersion="3" checksum="4008159088"/>
   </class>
   <class name="std::vector<reco::PFRecHitFraction>"/>
 
   <class name="reco::RecoPFClusterRefCandidate"  ClassVersion="3">
-   <version ClassVersion="3" checksum="3961848295"/>
+   <version ClassVersion="3" checksum="2445767687"/>
   </class>
 
 
@@ -93,8 +93,8 @@
   <class name="std::vector<reco::PFSimParticle>"/>
   <class name="edm::Wrapper<std::vector<reco::PFSimParticle> >"/>
 
-  <class name="reco::PFBlockElement" ClassVersion="3">
-   <version ClassVersion="3" checksum="684943224"/>
+  <class name="reco::io_v1::PFBlockElement" ClassVersion="3">
+   <version ClassVersion="3" checksum="311100232"/>
    <field name="multilinks_" transient="true"/>
    <field name="nullTrack_" transient="true"/>
    <field name="nullPFRecTrack_" transient="true"/>
@@ -104,17 +104,17 @@
    <field name="nullMuon_" transient="true"/>
    <field name="nullVertex_" transient="true"/>
   </class>
-  <class name="std::map<reco::PFBlockElement::Type,reco::PFMultiLinksTC>" />
+  <class name="std::map<reco::io_v1::PFBlockElement::Type,reco::PFMultiLinksTC>" />
   <class name="std::vector<reco::PFBlockElement *>" />
   <class name="edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> >" rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> > >" />
 
   <class name="reco::PFBlockElementTrack" ClassVersion="3">
-   <version ClassVersion="3" checksum="972442600"/>
+   <version ClassVersion="3" checksum="803168084"/>
   </class>
 
   <class name="reco::PFBlockElementGsfTrack" ClassVersion="3">
-   <version ClassVersion="3" checksum="874706272"/>
+   <version ClassVersion="3" checksum="3790540192"/>
 <!-- removed by Florian. It useful to have this Ref (especially for a reprocessing)
    Florian
     <field name="GsftrackRefPF_" transient="true"/> // Daniele
@@ -122,7 +122,7 @@
   </class>
 
   <class name="reco::PFBlockElementBrem" ClassVersion="3">
-   <version ClassVersion="3" checksum="4159933843"/>
+   <version ClassVersion="3" checksum="2375295821"/>
 <!-- removed by Florian. It useful to have this Ref (especially for a reprocessing)
    Florian
     <field name="BremtrackRefPF_" transient="true"/> // Daniele
@@ -131,7 +131,7 @@
 
 
   <class name="reco::PFBlockElementCluster" ClassVersion="3">
-   <version ClassVersion="3" checksum="1113199285"/>
+   <version ClassVersion="3" checksum="920628063"/>
   </class>
 
   <class name="std::map<unsigned int,reco::io_v1::PFBlock::Link>"/>
@@ -139,7 +139,7 @@
    <version ClassVersion="3" checksum="3388044151"/>
   </class>
   <class name="reco::io_v1::PFBlock" ClassVersion="3">
-   <version ClassVersion="3" checksum="2904310273"/>
+   <version ClassVersion="3" checksum="4019864691"/>
   </class>
 
   <class name="std::vector<reco::io_v1::PFBlock>"/>
@@ -205,7 +205,7 @@
   <class name="edm::Ref<std::vector<reco::io_v1::PreId>,reco::io_v1::PreId,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PreId>,reco::io_v1::PreId> >" />
 
   <class name="reco::PFBlockElementSuperCluster" ClassVersion="3">
-   <version ClassVersion="3" checksum="322190993"/>
+   <version ClassVersion="3" checksum="67957541"/>
   </class>
   <class name="std::vector<reco::PFBlockElementSuperCluster>"/>
   <class name="edm::Wrapper<std::vector<reco::PFBlockElementSuperCluster> >"/>
@@ -231,7 +231,7 @@
 
 </selection>
 <exclusion>
-  <class name="edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> >">
+  <class name="edm::OwnVector<reco::io_v1::PFBlockElement, edm::ClonePolicy<reco::io_v1::PFBlockElement> >">
     <method name="sort"/>
   </class>
 </exclusion>

--- a/DataFormats/PatCandidates/interface/TauPFEssential.h
+++ b/DataFormats/PatCandidates/interface/TauPFEssential.h
@@ -18,50 +18,54 @@
 
 namespace pat {
   namespace tau {
+    namespace io_v1 {
 
-    struct TauPFEssential {
-      // define a float-precision version of the typedefs in reco::PFTauTransverseImpactParameter class
-      typedef math::PtEtaPhiMLorentzVectorF LorentzVector;
-      typedef math::XYZPointF Point;
-      typedef math::XYZVectorF Vector;
-      typedef math::ErrorF<3>::type CovMatrix;
+      struct TauPFEssential {
+        // define a float-precision version of the typedefs in reco::PFTauTransverseImpactParameter class
+        typedef math::PtEtaPhiMLorentzVectorF LorentzVector;
+        typedef math::XYZPointF Point;
+        typedef math::XYZVectorF Vector;
+        typedef math::ErrorF<3>::type CovMatrix;
 
-      // dummy constructor for ROOT I/O
-      TauPFEssential() {}
-      // constructor from PFTau
-      TauPFEssential(const reco::PFTau& tau);
-      // datamembers
-      LorentzVector p4Jet_;
-      LorentzVector p4CorrJet_;
+        // dummy constructor for ROOT I/O
+        TauPFEssential() {}
+        // constructor from PFTau
+        TauPFEssential(const reco::PFTau& tau);
+        // datamembers
+        LorentzVector p4Jet_;
+        LorentzVector p4CorrJet_;
 
-      int decayMode_;
+        int decayMode_;
 
-      Point dxy_PCA_;
-      float dxy_;
-      float dxy_error_;
-      float dxy_Sig_;
-      reco::VertexRef pv_;
-      Point pvPos_;
-      CovMatrix pvCov_;
-      bool hasSV_;
-      Vector flightLength_;
-      float flightLengthSig_;
-      reco::VertexRef sv_;
-      Point svPos_;
-      CovMatrix svCov_;
-      float ip3d_;
-      float ip3d_error_;
-      float ecalEnergy_;
-      float hcalEnergy_;
-      float leadingTrackNormChi2_;
-      float phiAtEcalEntrance_;
-      float etaAtEcalEntrance_;
-      float ecalEnergyLeadChargedHadrCand_;
-      float hcalEnergyLeadChargedHadrCand_;
-      float etaAtEcalEntranceLeadChargedCand_;
-      float ptLeadChargedCand_;
-      float emFraction_;
-    };
+        Point dxy_PCA_;
+        float dxy_;
+        float dxy_error_;
+        float dxy_Sig_;
+        reco::VertexRef pv_;
+        Point pvPos_;
+        CovMatrix pvCov_;
+        bool hasSV_;
+        Vector flightLength_;
+        float flightLengthSig_;
+        reco::VertexRef sv_;
+        Point svPos_;
+        CovMatrix svCov_;
+        float ip3d_;
+        float ip3d_error_;
+        float ecalEnergy_;
+        float hcalEnergy_;
+        float leadingTrackNormChi2_;
+        float phiAtEcalEntrance_;
+        float etaAtEcalEntrance_;
+        float ecalEnergyLeadChargedHadrCand_;
+        float hcalEnergyLeadChargedHadrCand_;
+        float etaAtEcalEntranceLeadChargedCand_;
+        float ptLeadChargedCand_;
+        float emFraction_;
+      };
+
+    }  // namespace io_v1
+    using TauPFEssential = io_v1::TauPFEssential;
 
   }  // namespace tau
 }  // namespace pat

--- a/DataFormats/PatCandidates/interface/TauPFSpecific.h
+++ b/DataFormats/PatCandidates/interface/TauPFSpecific.h
@@ -18,55 +18,59 @@
 
 namespace pat {
   namespace tau {
+    namespace io_v1 {
 
-    struct TauPFSpecific {
-      // dummy constructor for ROOT I/O
-      TauPFSpecific() {}
-      // constructor from PFTau
-      TauPFSpecific(const reco::PFTau& tau);
-      // datamembers
-      reco::JetBaseRef pfJetRef_;
-      reco::CandidatePtr leadPFChargedHadrCand_;
-      float leadPFChargedHadrCandsignedSipt_;
-      reco::PFCandidatePtr leadPFNeutralCand_;
-      reco::PFCandidatePtr leadPFCand_;
-      std::vector<reco::PFCandidatePtr> selectedSignalPFCands_;
-      std::vector<reco::PFCandidatePtr> selectedSignalPFChargedHadrCands_;
-      std::vector<reco::PFCandidatePtr> selectedSignalPFNeutrHadrCands_;
-      std::vector<reco::PFCandidatePtr> selectedSignalPFGammaCands_;
-      std::vector<reco::PFRecoTauChargedHadron> signalTauChargedHadronCandidates_;
-      std::vector<reco::RecoTauPiZero> signalPiZeroCandidates_;
-      std::vector<reco::PFCandidatePtr> selectedIsolationPFCands_;
-      std::vector<reco::PFCandidatePtr> selectedIsolationPFChargedHadrCands_;
-      std::vector<reco::PFCandidatePtr> selectedIsolationPFNeutrHadrCands_;
-      std::vector<reco::PFCandidatePtr> selectedIsolationPFGammaCands_;
-      std::vector<reco::PFRecoTauChargedHadron> isolationTauChargedHadronCandidates_;
-      std::vector<reco::RecoTauPiZero> isolationPiZeroCandidates_;
-      float isolationPFChargedHadrCandsPtSum_;
-      float isolationPFGammaCandsEtSum_;
-      float maximumHCALPFClusterEt_;
+      struct TauPFSpecific {
+        // dummy constructor for ROOT I/O
+        TauPFSpecific() {}
+        // constructor from PFTau
+        TauPFSpecific(const reco::PFTau& tau);
+        // datamembers
+        reco::JetBaseRef pfJetRef_;
+        reco::CandidatePtr leadPFChargedHadrCand_;
+        float leadPFChargedHadrCandsignedSipt_;
+        reco::PFCandidatePtr leadPFNeutralCand_;
+        reco::PFCandidatePtr leadPFCand_;
+        std::vector<reco::PFCandidatePtr> selectedSignalPFCands_;
+        std::vector<reco::PFCandidatePtr> selectedSignalPFChargedHadrCands_;
+        std::vector<reco::PFCandidatePtr> selectedSignalPFNeutrHadrCands_;
+        std::vector<reco::PFCandidatePtr> selectedSignalPFGammaCands_;
+        std::vector<reco::PFRecoTauChargedHadron> signalTauChargedHadronCandidates_;
+        std::vector<reco::RecoTauPiZero> signalPiZeroCandidates_;
+        std::vector<reco::PFCandidatePtr> selectedIsolationPFCands_;
+        std::vector<reco::PFCandidatePtr> selectedIsolationPFChargedHadrCands_;
+        std::vector<reco::PFCandidatePtr> selectedIsolationPFNeutrHadrCands_;
+        std::vector<reco::PFCandidatePtr> selectedIsolationPFGammaCands_;
+        std::vector<reco::PFRecoTauChargedHadron> isolationTauChargedHadronCandidates_;
+        std::vector<reco::RecoTauPiZero> isolationPiZeroCandidates_;
+        float isolationPFChargedHadrCandsPtSum_;
+        float isolationPFGammaCandsEtSum_;
+        float maximumHCALPFClusterEt_;
 
-      float emFraction_;
-      float hcalTotOverPLead_;
-      float hcalMaxOverPLead_;
-      float hcal3x3OverPLead_;
-      float ecalStripSumEOverPLead_;
-      float bremsRecoveryEOverPLead_;
-      reco::TrackRef electronPreIDTrack_;
-      float electronPreIDOutput_;
-      bool electronPreIDDecision_;
+        float emFraction_;
+        float hcalTotOverPLead_;
+        float hcalMaxOverPLead_;
+        float hcal3x3OverPLead_;
+        float ecalStripSumEOverPLead_;
+        float bremsRecoveryEOverPLead_;
+        reco::TrackRef electronPreIDTrack_;
+        float electronPreIDOutput_;
+        bool electronPreIDDecision_;
 
-      float caloComp_;
-      float segComp_;
-      bool muonDecision_;
+        float caloComp_;
+        float segComp_;
+        bool muonDecision_;
 
-      float etaetaMoment_;
-      float phiphiMoment_;
-      float etaphiMoment_;
+        float etaetaMoment_;
+        float phiphiMoment_;
+        float etaphiMoment_;
 
-      float bendCorrMass_;
-      float signalConeSize_;
-    };
+        float bendCorrMass_;
+        float signalConeSize_;
+      };
+
+    }  // namespace io_v1
+    using TauPFSpecific = io_v1::TauPFSpecific;
 
   }  // namespace tau
 }  // namespace pat

--- a/DataFormats/PatCandidates/src/TauPFEssential.cc
+++ b/DataFormats/PatCandidates/src/TauPFEssential.cc
@@ -2,7 +2,7 @@
 
 #include "DataFormats/JetReco/interface/Jet.h"
 
-pat::tau::TauPFEssential::TauPFEssential(const reco::PFTau& tau)
+pat::tau::io_v1::TauPFEssential::TauPFEssential(const reco::PFTau& tau)
     : p4Jet_(reco::Candidate::LorentzVector()),
       p4CorrJet_(reco::Candidate::LorentzVector()),
       decayMode_(tau.decayMode()),

--- a/DataFormats/PatCandidates/src/TauPFSpecific.cc
+++ b/DataFormats/PatCandidates/src/TauPFSpecific.cc
@@ -2,7 +2,7 @@
 
 #include "DataFormats/JetReco/interface/Jet.h"
 
-pat::tau::TauPFSpecific::TauPFSpecific(const reco::PFTau& tau)
+pat::tau::io_v1::TauPFSpecific::TauPFSpecific(const reco::PFTau& tau)
     :  // reference to PFJet from which PFTau was made
       pfJetRef_(tau.jetRef()),
       // Leading track/charged candidate

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -24,11 +24,11 @@
     <![CDATA[superClusterRelinked_.reset();]]>
   </ioread>
   <class name="pat::io_v1::Muon"  ClassVersion="3">
-   <version ClassVersion="3" checksum="3912957737"/>
+   <version ClassVersion="3" checksum="2866733603"/>
   </class>
 
   <class name="pat::io_v1::Tau"  ClassVersion="3">
-   <version ClassVersion="3" checksum="3191587699"/>
+   <version ClassVersion="3" checksum="13491307"/>
    <field name="isolationTracksTransientRefVector_" transient="true"/>
    <field name="signalTracksTransientRefVector_" transient="true"/>
    <field name="signalPFCandsTransientPtrs_" transient="true"/>
@@ -79,13 +79,13 @@
   <ioread sourceClass="pat::io_v1::Tau" targetClass="pat::io_v1::Tau" version="[1-]" source="" target="isolationPFGammaCandsTransientPtrs_">
   <![CDATA[isolationPFGammaCandsTransientPtrs_.reset();]]>
   </ioread>
-  <class name="pat::tau::TauPFSpecific"  ClassVersion="3">
-   <version ClassVersion="3" checksum="4003299421"/>
+  <class name="pat::tau::io_v1::TauPFSpecific"  ClassVersion="3">
+   <version ClassVersion="3" checksum="3288745861"/>
   </class>
   <class name="std::vector<pat::tau::TauPFSpecific>" />
 
-  <class name="pat::tau::TauPFEssential" ClassVersion="3">
-    <version ClassVersion="3" checksum="904488891" /> 
+  <class name="pat::tau::io_v1::TauPFEssential" ClassVersion="3">
+    <version ClassVersion="3" checksum="833004921"/>
   </class>
 
   <class name="std::vector<pat::tau::TauPFEssential>" />
@@ -98,7 +98,7 @@
   </ioread>
 
   <class name="pat::io_v1::Jet"  ClassVersion="3">
-   <version ClassVersion="3" checksum="2400232157"/>
+   <version ClassVersion="3" checksum="2304093505"/>
    <field name="daughtersTemp_" transient="true"/>
    <field name="caloTowersTemp_" transient="true"/>
    <field name="pfCandidatesTemp_" transient="true"/>
@@ -138,7 +138,7 @@
    <version ClassVersion="3" checksum="3105008866"/>
   </class>
   <class name="pat::Hemisphere"  ClassVersion="3">
-   <version ClassVersion="3" checksum="3728411613"/>
+   <version ClassVersion="3" checksum="2205145303"/>
   </class>
   <class name="pat::Conversion"  ClassVersion="3">
    <version ClassVersion="3" checksum="1239840459"/>

--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -7,7 +7,7 @@
    <version ClassVersion="3" checksum="2583659187"/>
   </class>
   <class name="reco::io_v1::RecoChargedRefCandidate"  ClassVersion="3">
-   <version ClassVersion="3" checksum="2706310913"/>
+   <version ClassVersion="3" checksum="1069615397"/>
   </class>
   <class name="reco::io_v1::RecoEcalCandidate"  ClassVersion="3">
    <version ClassVersion="3" checksum="2351437140"/>

--- a/DataFormats/TauReco/interface/BaseTau.h
+++ b/DataFormats/TauReco/interface/BaseTau.h
@@ -15,35 +15,38 @@
 #include <limits>
 
 namespace reco {
-  class BaseTau : public RecoCandidate {
-  public:
-    BaseTau();
-    BaseTau(Charge q, const LorentzVector&, const Point& = Point(0, 0, 0));
-    ~BaseTau() override {}
-    BaseTau* clone() const override;
+  namespace io_v1 {
+    class BaseTau : public RecoCandidate {
+    public:
+      BaseTau();
+      BaseTau(Charge q, const LorentzVector&, const Point& = Point(0, 0, 0));
+      ~BaseTau() override {}
+      BaseTau* clone() const override;
 
-    // rec. jet Lorentz-vector combining (Tracks and neutral ECAL Island BasicClusters) or (charged hadr. PFCandidates and gamma PFCandidates)
-    math::XYZTLorentzVector alternatLorentzVect() const;
-    void setalternatLorentzVect(const math::XYZTLorentzVector&);
+      // rec. jet Lorentz-vector combining (Tracks and neutral ECAL Island BasicClusters) or (charged hadr. PFCandidates and gamma PFCandidates)
+      math::XYZTLorentzVector alternatLorentzVect() const;
+      void setalternatLorentzVect(const math::XYZTLorentzVector&);
 
-    // leading Track
-    virtual reco::TrackRef leadTrack() const;
-    void setleadTrack(const TrackRef&);
+      // leading Track
+      virtual reco::TrackRef leadTrack() const;
+      void setleadTrack(const TrackRef&);
 
-    // Tracks which passed quality cuts and are inside a tracker signal cone around leading Track
-    virtual const reco::TrackRefVector& signalTracks() const;
-    void setsignalTracks(const TrackRefVector&);
+      // Tracks which passed quality cuts and are inside a tracker signal cone around leading Track
+      virtual const reco::TrackRefVector& signalTracks() const;
+      void setsignalTracks(const TrackRefVector&);
 
-    // Tracks which passed quality cuts and are inside a tracker isolation annulus around leading Track
-    virtual const reco::TrackRefVector& isolationTracks() const;
-    void setisolationTracks(const TrackRefVector&);
+      // Tracks which passed quality cuts and are inside a tracker isolation annulus around leading Track
+      virtual const reco::TrackRefVector& isolationTracks() const;
+      void setisolationTracks(const TrackRefVector&);
 
-  private:
-    // check overlap with another candidate
-    bool overlap(const Candidate&) const override;
-    math::XYZTLorentzVector alternatLorentzVect_;
-    reco::TrackRef leadTrack_;
-    reco::TrackRefVector signalTracks_, isolationTracks_;
-  };
+    private:
+      // check overlap with another candidate
+      bool overlap(const Candidate&) const override;
+      math::XYZTLorentzVector alternatLorentzVect_;
+      reco::TrackRef leadTrack_;
+      reco::TrackRefVector signalTracks_, isolationTracks_;
+    };
+  }  // namespace io_v1
+  using BaseTau = io_v1::BaseTau;
 }  // namespace reco
 #endif

--- a/DataFormats/TauReco/interface/BaseTauFwd.h
+++ b/DataFormats/TauReco/interface/BaseTauFwd.h
@@ -6,7 +6,10 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 namespace reco {
-  class BaseTau;
+  namespace io_v1 {
+    class BaseTau;
+  }
+  using BaseTau = io_v1::BaseTau;
   /// collection of BaseTau objects
   typedef std::vector<BaseTau> BaseTauCollection;
   /// presistent reference to a BaseTau

--- a/DataFormats/TauReco/interface/PFRecoTauChargedHadron.h
+++ b/DataFormats/TauReco/interface/PFRecoTauChargedHadron.h
@@ -19,78 +19,82 @@ namespace reco {
 class PFRecoTauChargedHadronProducer;
 
 namespace reco {
+  namespace io_v1 {
 
-  class PFRecoTauChargedHadron : public CompositePtrCandidate {
-  public:
-    typedef edm::Ptr<Track> TrackPtr;
+    class PFRecoTauChargedHadron : public CompositePtrCandidate {
+    public:
+      typedef edm::Ptr<Track> TrackPtr;
 
-    enum PFRecoTauChargedHadronAlgorithm {
-      // Algorithm where each photon becomes a pi zero
-      kUndefined = 0,
-      kChargedPFCandidate = 1,
-      kTrack = 2,
-      kPFNeutralHadron = 3
+      enum PFRecoTauChargedHadronAlgorithm {
+        // Algorithm where each photon becomes a pi zero
+        kUndefined = 0,
+        kChargedPFCandidate = 1,
+        kTrack = 2,
+        kPFNeutralHadron = 3
+      };
+
+      PFRecoTauChargedHadron();
+      PFRecoTauChargedHadron(PFRecoTauChargedHadronAlgorithm algo, Charge q);
+
+      /// constructor from a Candidate
+      PFRecoTauChargedHadron(const Candidate& c, PFRecoTauChargedHadronAlgorithm algo = kUndefined);
+
+      /// constructor from values
+      PFRecoTauChargedHadron(Charge q,
+                             const LorentzVector& p4,
+                             const Point& vtx = Point(0, 0, 0),
+                             int status = 0,
+                             bool integerCharge = true,
+                             PFRecoTauChargedHadronAlgorithm algo = kUndefined);
+
+      /// destructor
+      ~PFRecoTauChargedHadron() override;
+
+      /// reference to "charged" PFCandidate (either charged PFCandidate or PFNeutralHadron)
+      const CandidatePtr& getChargedPFCandidate() const;
+
+      /// reference to reco::Track
+      const TrackPtr& getTrack() const;
+
+      /// reference to "lostTrack Candidate" when chadron built with tracks stored as pat::PackedCandidates
+      const CandidatePtr& getLostTrackCandidate() const;
+
+      /// references to additional neutral PFCandidates
+      const std::vector<CandidatePtr>& getNeutralPFCandidates() const;
+
+      /// position at ECAL entrance
+      const math::XYZPointF& positionAtECALEntrance() const;
+
+      /// Algorithm that built this charged hadron
+      PFRecoTauChargedHadronAlgorithm algo() const;
+
+      /// Check whether a given algo produced this charged hadron
+      bool algoIs(PFRecoTauChargedHadronAlgorithm algo) const;
+
+      void print(std::ostream& stream = std::cout) const;
+
+    private:
+      friend class tau::PFRecoTauChargedHadronFromPFCandidatePlugin;
+      template <class TrackClass>
+      friend class tau::PFRecoTauChargedHadronFromGenericTrackPlugin;
+      friend class tau::RecoTauConstructor;
+      friend class tau::PFRecoTauEnergyAlgorithmPlugin;
+      friend class ::PFRecoTauChargedHadronProducer;
+
+      PFRecoTauChargedHadronAlgorithm algo_;
+
+      CandidatePtr chargedPFCandidate_;
+      CandidatePtr lostTrackCandidate_;
+      TrackPtr track_;
+      std::vector<CandidatePtr> neutralPFCandidates_;
+
+      math::XYZPointF positionAtECALEntrance_;
     };
 
-    PFRecoTauChargedHadron();
-    PFRecoTauChargedHadron(PFRecoTauChargedHadronAlgorithm algo, Charge q);
+    std::ostream& operator<<(std::ostream& stream, const PFRecoTauChargedHadron& c);
 
-    /// constructor from a Candidate
-    PFRecoTauChargedHadron(const Candidate& c, PFRecoTauChargedHadronAlgorithm algo = kUndefined);
-
-    /// constructor from values
-    PFRecoTauChargedHadron(Charge q,
-                           const LorentzVector& p4,
-                           const Point& vtx = Point(0, 0, 0),
-                           int status = 0,
-                           bool integerCharge = true,
-                           PFRecoTauChargedHadronAlgorithm algo = kUndefined);
-
-    /// destructor
-    ~PFRecoTauChargedHadron() override;
-
-    /// reference to "charged" PFCandidate (either charged PFCandidate or PFNeutralHadron)
-    const CandidatePtr& getChargedPFCandidate() const;
-
-    /// reference to reco::Track
-    const TrackPtr& getTrack() const;
-
-    /// reference to "lostTrack Candidate" when chadron built with tracks stored as pat::PackedCandidates
-    const CandidatePtr& getLostTrackCandidate() const;
-
-    /// references to additional neutral PFCandidates
-    const std::vector<CandidatePtr>& getNeutralPFCandidates() const;
-
-    /// position at ECAL entrance
-    const math::XYZPointF& positionAtECALEntrance() const;
-
-    /// Algorithm that built this charged hadron
-    PFRecoTauChargedHadronAlgorithm algo() const;
-
-    /// Check whether a given algo produced this charged hadron
-    bool algoIs(PFRecoTauChargedHadronAlgorithm algo) const;
-
-    void print(std::ostream& stream = std::cout) const;
-
-  private:
-    friend class tau::PFRecoTauChargedHadronFromPFCandidatePlugin;
-    template <class TrackClass>
-    friend class tau::PFRecoTauChargedHadronFromGenericTrackPlugin;
-    friend class tau::RecoTauConstructor;
-    friend class tau::PFRecoTauEnergyAlgorithmPlugin;
-    friend class ::PFRecoTauChargedHadronProducer;
-
-    PFRecoTauChargedHadronAlgorithm algo_;
-
-    CandidatePtr chargedPFCandidate_;
-    CandidatePtr lostTrackCandidate_;
-    TrackPtr track_;
-    std::vector<CandidatePtr> neutralPFCandidates_;
-
-    math::XYZPointF positionAtECALEntrance_;
-  };
-
-  std::ostream& operator<<(std::ostream& stream, const PFRecoTauChargedHadron& c);
+  }  // namespace io_v1
+  using PFRecoTauChargedHadron = io_v1::PFRecoTauChargedHadron;
 
 }  // end namespace reco
 

--- a/DataFormats/TauReco/interface/PFRecoTauChargedHadronFwd.h
+++ b/DataFormats/TauReco/interface/PFRecoTauChargedHadronFwd.h
@@ -9,7 +9,10 @@
 #include <vector>
 
 namespace reco {
-  class PFRecoTauChargedHadron;
+  namespace io_v1 {
+    class PFRecoTauChargedHadron;
+  }
+  using PFRecoTauChargedHadron = io_v1::PFRecoTauChargedHadron;
   /// collection of PFRecoTauChargedHadron objects
   typedef std::vector<PFRecoTauChargedHadron> PFRecoTauChargedHadronCollection;
   /// presistent reference to a PFRecoTauChargedHadron

--- a/DataFormats/TauReco/src/BaseTau.cc
+++ b/DataFormats/TauReco/src/BaseTau.cc
@@ -1,6 +1,7 @@
 #include "DataFormats/TauReco/interface/BaseTau.h"
 
 using namespace reco;
+using namespace reco::io_v1;
 
 BaseTau::BaseTau() {
   alternatLorentzVect_.SetPx(NAN);

--- a/DataFormats/TauReco/src/PFRecoTauChargedHadron.cc
+++ b/DataFormats/TauReco/src/PFRecoTauChargedHadron.cc
@@ -3,115 +3,117 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  PFRecoTauChargedHadron::PFRecoTauChargedHadron() : CompositePtrCandidate(), algo_(kUndefined) {}
+    PFRecoTauChargedHadron::PFRecoTauChargedHadron() : CompositePtrCandidate(), algo_(kUndefined) {}
 
-  PFRecoTauChargedHadron::PFRecoTauChargedHadron(PFRecoTauChargedHadronAlgorithm algo, Charge q)
-      : CompositePtrCandidate(), algo_(algo) {
-    if (q > 0.)
-      this->setPdgId(+211);
-    else if (q < 0.)
-      this->setPdgId(-211);
-  }
-
-  PFRecoTauChargedHadron::PFRecoTauChargedHadron(Charge q,
-                                                 const LorentzVector& p4,
-                                                 const Point& vtx,
-                                                 int status,
-                                                 bool integerCharge,
-                                                 PFRecoTauChargedHadronAlgorithm algo)
-      : CompositePtrCandidate(q, p4, vtx, 211, status, integerCharge), algo_(algo) {
-    if (q > 0.)
-      this->setPdgId(+211);
-    else if (q < 0.)
-      this->setPdgId(-211);
-  }
-
-  PFRecoTauChargedHadron::PFRecoTauChargedHadron(const Candidate& c, PFRecoTauChargedHadronAlgorithm algo)
-      : CompositePtrCandidate(c), algo_(algo) {
-    if (c.charge() > 0.)
-      this->setPdgId(+211);
-    else if (c.charge() < 0.)
-      this->setPdgId(-211);
-  }
-
-  PFRecoTauChargedHadron::~PFRecoTauChargedHadron() {}
-
-  const CandidatePtr& PFRecoTauChargedHadron::getChargedPFCandidate() const { return chargedPFCandidate_; }
-
-  const PFRecoTauChargedHadron::TrackPtr& PFRecoTauChargedHadron::getTrack() const { return track_; }
-
-  const CandidatePtr& PFRecoTauChargedHadron::getLostTrackCandidate() const { return lostTrackCandidate_; }
-
-  const std::vector<CandidatePtr>& PFRecoTauChargedHadron::getNeutralPFCandidates() const {
-    return neutralPFCandidates_;
-  }
-
-  const math::XYZPointF& PFRecoTauChargedHadron::positionAtECALEntrance() const { return positionAtECALEntrance_; }
-
-  PFRecoTauChargedHadron::PFRecoTauChargedHadronAlgorithm PFRecoTauChargedHadron::algo() const { return algo_; }
-
-  bool PFRecoTauChargedHadron::algoIs(PFRecoTauChargedHadron::PFRecoTauChargedHadronAlgorithm algo) const {
-    return (algo_ == algo);
-  }
-
-  void PFRecoTauChargedHadron::print(std::ostream& stream) const {
-    stream << " Pt = " << this->pt() << ", eta = " << this->eta() << ", phi = " << this->phi()
-           << " (mass = " << this->mass() << ")" << std::endl;
-    stream << " charge = " << this->charge() << " (pdgId = " << this->pdgId() << ")" << std::endl;
-    stream << "charged PFCandidate";
-    if (chargedPFCandidate_.isNonnull()) {
-      stream << " (" << chargedPFCandidate_.id() << ":" << chargedPFCandidate_.key() << "):"
-             << " Pt = " << chargedPFCandidate_->pt() << ", eta = " << chargedPFCandidate_->eta()
-             << ", phi = " << chargedPFCandidate_->phi() << " (pdgId = " << chargedPFCandidate_->pdgId() << ")"
-             << std::endl;
-    } else {
-      stream << ": N/A" << std::endl;
+    PFRecoTauChargedHadron::PFRecoTauChargedHadron(PFRecoTauChargedHadronAlgorithm algo, Charge q)
+        : CompositePtrCandidate(), algo_(algo) {
+      if (q > 0.)
+        this->setPdgId(+211);
+      else if (q < 0.)
+        this->setPdgId(-211);
     }
-    stream << "reco::Track: ";
-    if (track_.isNonnull()) {
-      stream << "Pt = " << track_->pt() << " +/- " << track_->ptError() << ", eta = " << track_->eta()
-             << ", phi = " << track_->phi() << std::endl;
-    } else if (lostTrackCandidate_.isNonnull()) {
-      stream << "(lostTrackCandidate: " << lostTrackCandidate_.id() << ":" << lostTrackCandidate_.key() << "):"
-             << " Pt = " << lostTrackCandidate_->pt() << ", eta = " << lostTrackCandidate_->eta()
-             << ", phi = " << lostTrackCandidate_->phi() << std::endl;
-    } else {
-      stream << "N/A" << std::endl;
+
+    PFRecoTauChargedHadron::PFRecoTauChargedHadron(Charge q,
+                                                   const LorentzVector& p4,
+                                                   const Point& vtx,
+                                                   int status,
+                                                   bool integerCharge,
+                                                   PFRecoTauChargedHadronAlgorithm algo)
+        : CompositePtrCandidate(q, p4, vtx, 211, status, integerCharge), algo_(algo) {
+      if (q > 0.)
+        this->setPdgId(+211);
+      else if (q < 0.)
+        this->setPdgId(-211);
     }
-    stream << "neutral PFCandidates:";
-    if (!neutralPFCandidates_.empty()) {
-      stream << std::endl;
-      int idx = 0;
-      for (std::vector<CandidatePtr>::const_iterator neutralPFCandidate = neutralPFCandidates_.begin();
-           neutralPFCandidate != neutralPFCandidates_.end();
-           ++neutralPFCandidate) {
-        stream << " #" << idx << " (" << neutralPFCandidate->id() << ":" << neutralPFCandidate->key() << "):"
-               << " Pt = " << (*neutralPFCandidate)->pt() << ", eta = " << (*neutralPFCandidate)->eta()
-               << ", phi = " << (*neutralPFCandidate)->phi() << " (pdgId = " << (*neutralPFCandidate)->pdgId() << ")"
+
+    PFRecoTauChargedHadron::PFRecoTauChargedHadron(const Candidate& c, PFRecoTauChargedHadronAlgorithm algo)
+        : CompositePtrCandidate(c), algo_(algo) {
+      if (c.charge() > 0.)
+        this->setPdgId(+211);
+      else if (c.charge() < 0.)
+        this->setPdgId(-211);
+    }
+
+    PFRecoTauChargedHadron::~PFRecoTauChargedHadron() {}
+
+    const CandidatePtr& PFRecoTauChargedHadron::getChargedPFCandidate() const { return chargedPFCandidate_; }
+
+    const PFRecoTauChargedHadron::TrackPtr& PFRecoTauChargedHadron::getTrack() const { return track_; }
+
+    const CandidatePtr& PFRecoTauChargedHadron::getLostTrackCandidate() const { return lostTrackCandidate_; }
+
+    const std::vector<CandidatePtr>& PFRecoTauChargedHadron::getNeutralPFCandidates() const {
+      return neutralPFCandidates_;
+    }
+
+    const math::XYZPointF& PFRecoTauChargedHadron::positionAtECALEntrance() const { return positionAtECALEntrance_; }
+
+    PFRecoTauChargedHadron::PFRecoTauChargedHadronAlgorithm PFRecoTauChargedHadron::algo() const { return algo_; }
+
+    bool PFRecoTauChargedHadron::algoIs(PFRecoTauChargedHadron::PFRecoTauChargedHadronAlgorithm algo) const {
+      return (algo_ == algo);
+    }
+
+    void PFRecoTauChargedHadron::print(std::ostream& stream) const {
+      stream << " Pt = " << this->pt() << ", eta = " << this->eta() << ", phi = " << this->phi()
+             << " (mass = " << this->mass() << ")" << std::endl;
+      stream << " charge = " << this->charge() << " (pdgId = " << this->pdgId() << ")" << std::endl;
+      stream << "charged PFCandidate";
+      if (chargedPFCandidate_.isNonnull()) {
+        stream << " (" << chargedPFCandidate_.id() << ":" << chargedPFCandidate_.key() << "):"
+               << " Pt = " << chargedPFCandidate_->pt() << ", eta = " << chargedPFCandidate_->eta()
+               << ", phi = " << chargedPFCandidate_->phi() << " (pdgId = " << chargedPFCandidate_->pdgId() << ")"
                << std::endl;
-        ++idx;
+      } else {
+        stream << ": N/A" << std::endl;
       }
-    } else {
-      stream << " ";
-      stream << "N/A" << std::endl;
+      stream << "reco::Track: ";
+      if (track_.isNonnull()) {
+        stream << "Pt = " << track_->pt() << " +/- " << track_->ptError() << ", eta = " << track_->eta()
+               << ", phi = " << track_->phi() << std::endl;
+      } else if (lostTrackCandidate_.isNonnull()) {
+        stream << "(lostTrackCandidate: " << lostTrackCandidate_.id() << ":" << lostTrackCandidate_.key() << "):"
+               << " Pt = " << lostTrackCandidate_->pt() << ", eta = " << lostTrackCandidate_->eta()
+               << ", phi = " << lostTrackCandidate_->phi() << std::endl;
+      } else {
+        stream << "N/A" << std::endl;
+      }
+      stream << "neutral PFCandidates:";
+      if (!neutralPFCandidates_.empty()) {
+        stream << std::endl;
+        int idx = 0;
+        for (std::vector<CandidatePtr>::const_iterator neutralPFCandidate = neutralPFCandidates_.begin();
+             neutralPFCandidate != neutralPFCandidates_.end();
+             ++neutralPFCandidate) {
+          stream << " #" << idx << " (" << neutralPFCandidate->id() << ":" << neutralPFCandidate->key() << "):"
+                 << " Pt = " << (*neutralPFCandidate)->pt() << ", eta = " << (*neutralPFCandidate)->eta()
+                 << ", phi = " << (*neutralPFCandidate)->phi() << " (pdgId = " << (*neutralPFCandidate)->pdgId() << ")"
+                 << std::endl;
+          ++idx;
+        }
+      } else {
+        stream << " ";
+        stream << "N/A" << std::endl;
+      }
+      stream << "position@ECAL entrance: x = " << this->positionAtECALEntrance().x()
+             << ", y = " << this->positionAtECALEntrance().y() << ", z = " << this->positionAtECALEntrance().z()
+             << " (eta = " << this->positionAtECALEntrance().eta() << ", phi = " << this->positionAtECALEntrance().phi()
+             << ")" << std::endl;
+      std::string algo_string = "undefined";
+      if (algo_ == kChargedPFCandidate)
+        algo_string = "chargedPFCandidate";
+      else if (algo_ == kTrack)
+        algo_string = "Track";
+      else if (algo_ == kPFNeutralHadron)
+        algo_string = "PFNeutralHadron";
+      stream << "algo = " << algo_string << std::endl;
     }
-    stream << "position@ECAL entrance: x = " << this->positionAtECALEntrance().x()
-           << ", y = " << this->positionAtECALEntrance().y() << ", z = " << this->positionAtECALEntrance().z()
-           << " (eta = " << this->positionAtECALEntrance().eta() << ", phi = " << this->positionAtECALEntrance().phi()
-           << ")" << std::endl;
-    std::string algo_string = "undefined";
-    if (algo_ == kChargedPFCandidate)
-      algo_string = "chargedPFCandidate";
-    else if (algo_ == kTrack)
-      algo_string = "Track";
-    else if (algo_ == kPFNeutralHadron)
-      algo_string = "PFNeutralHadron";
-    stream << "algo = " << algo_string << std::endl;
-  }
 
-  std::ostream& operator<<(std::ostream& stream, const reco::PFRecoTauChargedHadron& c) {
-    c.print(stream);
-    return stream;
-  }
+    std::ostream& operator<<(std::ostream& stream, const reco::PFRecoTauChargedHadron& c) {
+      c.print(stream);
+      return stream;
+    }
+  }  // namespace io_v1
 }  // namespace reco

--- a/DataFormats/TauReco/src/classes_def_1.xml
+++ b/DataFormats/TauReco/src/classes_def_1.xml
@@ -28,8 +28,8 @@
   <class name="edm::RefProd<std::vector<reco::PFTauTagInfo> >"/>
   <class name="edm::RefVector<std::vector<reco::PFTauTagInfo>,reco::PFTauTagInfo,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTagInfo>,reco::PFTauTagInfo> >"/>
   
-  <class name="reco::BaseTau" ClassVersion="3">
-   <version ClassVersion="3" checksum="2297856736"/>
+  <class name="reco::io_v1::BaseTau" ClassVersion="3">
+   <version ClassVersion="3" checksum="2253510714"/>
   </class>
   <class name="std::vector<reco::BaseTau>"/>
   <class name="edm::Wrapper<std::vector<reco::BaseTau> >"/>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -1,7 +1,7 @@
 <lcgdict>
   
   <class name="reco::io_v1::PFTau" ClassVersion="3">
-   <version ClassVersion="3" checksum="3700826437"/>
+   <version ClassVersion="3" checksum="4187542055"/>
      <field name="leadPFChargedHadrCand_" transient="true"/>
      <field name="leadPFNeutralCand_" transient="true"/>
      <field name="leadPFCand_" transient="true"/>
@@ -114,7 +114,7 @@ isolationTauChargedHadronCandidates_.reset();
   <class name="edm::Wrapper<edm::Association<std::vector<reco::io_v1::PFTau> > >"/>
 
   <class name="reco::io_v1::RecoTauPiZero" ClassVersion="3">
-   <version ClassVersion="3" checksum="444545959"/>
+   <version ClassVersion="3" checksum="113324653"/>
   </class>
   <class name="std::vector<reco::io_v1::RecoTauPiZero>"/>
   <class name="edm::AtomicPtrCache<std::vector<reco::io_v1::RecoTauPiZero> >"/>
@@ -124,9 +124,9 @@ isolationTauChargedHadronCandidates_.reset();
   <class name="edm::Ref<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero> >"/>
   <class name="edm::RefProd<std::vector<reco::io_v1::RecoTauPiZero> >"/>
   <class name="edm::RefVector<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero> >"/>
-  <class name="edm::reftobase::Holder<reco::CompositePtrCandidate, edm::Ref<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero> > >" />
-  <class name="reco::PFRecoTauChargedHadron" ClassVersion="3">
-   <version ClassVersion="3" checksum="98882705"/>
+  <class name="edm::reftobase::Holder<reco::io_v1::CompositePtrCandidate, edm::Ref<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoTauPiZero>,reco::io_v1::RecoTauPiZero> > >" />
+  <class name="reco::io_v1::PFRecoTauChargedHadron" ClassVersion="3">
+   <version ClassVersion="3" checksum="3337236259"/>
   </class>
   <class name="std::vector<reco::PFRecoTauChargedHadron>"/>
   <class name="edm::AtomicPtrCache<std::vector<reco::PFRecoTauChargedHadron> >"/>
@@ -136,7 +136,7 @@ isolationTauChargedHadronCandidates_.reset();
   <class name="edm::Ref<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron> >"/>
   <class name="edm::RefProd<std::vector<reco::PFRecoTauChargedHadron> >"/>
   <class name="edm::RefVector<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron> >"/>
-  <class name="edm::reftobase::Holder<reco::CompositePtrCandidate, edm::Ref<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron> > >" />
+  <class name="edm::reftobase::Holder<reco::io_v1::CompositePtrCandidate, edm::Ref<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron,edm::refhelper::FindUsingAdvance<std::vector<reco::PFRecoTauChargedHadron>,reco::PFRecoTauChargedHadron> > >" />
 
 
 

--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -62,7 +62,7 @@
   </class>
 
   <class name="reco::PFJetChargedHadronAssociation" ClassVersion="3">
-   <version ClassVersion="3" checksum="2811520304"/>
+   <version ClassVersion="3" checksum="3666343972"/>
     <field name="transientVector_" transient="true"/>
   </class>
   <class name="reco::PFJetChargedHadronAssociationRef"/>

--- a/DataFormats/TrackReco/interface/TrackExtraBase.h
+++ b/DataFormats/TrackReco/interface/TrackExtraBase.h
@@ -18,75 +18,78 @@
 #include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
 
 namespace reco {
+  namespace io_v1 {
 
-  class TrackExtraBase {
-  public:
-    using TrajParams = std::vector<LocalTrajectoryParameters>;
-    using Chi2sFive = std::vector<unsigned char>;
+    class TrackExtraBase {
+    public:
+      using TrajParams = std::vector<LocalTrajectoryParameters>;
+      using Chi2sFive = std::vector<unsigned char>;
 
-    /// default constructor
-    TrackExtraBase() : m_firstHit((unsigned int)-1), m_nHits(0) {}
+      /// default constructor
+      TrackExtraBase() : m_firstHit((unsigned int)-1), m_nHits(0) {}
 
-    void setHits(TrackingRecHitRefProd const& prod, unsigned firstH, unsigned int nH) {
-      m_hitCollection.pushBackItem(prod.refCore(), true);
-      m_firstHit = firstH;
-      m_nHits = nH;
-    }
-
-    void setTrajParams(TrajParams tmps, Chi2sFive chi2s) {
-      m_trajParams = std::move(tmps);
-      m_chi2sX5 = std::move(chi2s);
-    }
-
-    unsigned int firstRecHit() const { return m_firstHit; }
-
-    /// number of RecHits
-    unsigned int recHitsSize() const { return m_nHits; }
-
-    /// accessor to RecHits
-    auto recHits() const { return TrackingRecHitRange(recHitsBegin(), recHitsEnd()); }
-
-    /// first iterator over RecHits
-    trackingRecHit_iterator recHitsBegin() const { return recHitsProduct().data().begin() + firstRecHit(); }
-
-    /// last iterator over RecHits
-    trackingRecHit_iterator recHitsEnd() const { return recHitsBegin() + recHitsSize(); }
-
-    /// get a ref to i-th recHit
-    TrackingRecHitRef recHitRef(unsigned int i) const {
-      //Another thread might change the RefCore at the same time.
-      // By using a copy we will be safe.
-      edm::RefCore hitCollection(m_hitCollection);
-      if (hitCollection.productPtr()) {
-        TrackingRecHitRef::finder_type finder;
-        TrackingRecHitRef::value_type const* item =
-            finder(*(static_cast<TrackingRecHitRef::product_type const*>(hitCollection.productPtr())), m_firstHit + i);
-        return TrackingRecHitRef(hitCollection.id(), item, m_firstHit + i);
+      void setHits(TrackingRecHitRefProd const& prod, unsigned firstH, unsigned int nH) {
+        m_hitCollection.pushBackItem(prod.refCore(), true);
+        m_firstHit = firstH;
+        m_nHits = nH;
       }
-      return TrackingRecHitRef(hitCollection, m_firstHit + i);
-    }
 
-    /// get i-th recHit
-    TrackingRecHitRef recHit(unsigned int i) const { return recHitRef(i); }
+      void setTrajParams(TrajParams tmps, Chi2sFive chi2s) {
+        m_trajParams = std::move(tmps);
+        m_chi2sX5 = std::move(chi2s);
+      }
 
-    TrackingRecHitCollection const& recHitsProduct() const {
-      return *edm::getProduct<TrackingRecHitCollection>(m_hitCollection);
-    }
+      unsigned int firstRecHit() const { return m_firstHit; }
 
-    TrajParams const& trajParams() const { return m_trajParams; }
-    Chi2sFive const& chi2sX5() const { return m_chi2sX5; }
+      /// number of RecHits
+      unsigned int recHitsSize() const { return m_nHits; }
 
-    // Check validity of track rechits
-    bool recHitsOk() const { return m_hitCollection.isNonnull() && m_hitCollection.isAvailable(); }
+      /// accessor to RecHits
+      auto recHits() const { return TrackingRecHitRange(recHitsBegin(), recHitsEnd()); }
 
-  private:
-    edm::RefCore m_hitCollection;
-    unsigned int m_firstHit;
-    unsigned int m_nHits;
-    TrajParams m_trajParams;
-    Chi2sFive m_chi2sX5;  // chi2 * 5  chopped at 255  (max chi2 is 51)
-  };
+      /// first iterator over RecHits
+      trackingRecHit_iterator recHitsBegin() const { return recHitsProduct().data().begin() + firstRecHit(); }
 
+      /// last iterator over RecHits
+      trackingRecHit_iterator recHitsEnd() const { return recHitsBegin() + recHitsSize(); }
+
+      /// get a ref to i-th recHit
+      TrackingRecHitRef recHitRef(unsigned int i) const {
+        //Another thread might change the RefCore at the same time.
+        // By using a copy we will be safe.
+        edm::RefCore hitCollection(m_hitCollection);
+        if (hitCollection.productPtr()) {
+          TrackingRecHitRef::finder_type finder;
+          TrackingRecHitRef::value_type const* item = finder(
+              *(static_cast<TrackingRecHitRef::product_type const*>(hitCollection.productPtr())), m_firstHit + i);
+          return TrackingRecHitRef(hitCollection.id(), item, m_firstHit + i);
+        }
+        return TrackingRecHitRef(hitCollection, m_firstHit + i);
+      }
+
+      /// get i-th recHit
+      TrackingRecHitRef recHit(unsigned int i) const { return recHitRef(i); }
+
+      TrackingRecHitCollection const& recHitsProduct() const {
+        return *edm::getProduct<TrackingRecHitCollection>(m_hitCollection);
+      }
+
+      TrajParams const& trajParams() const { return m_trajParams; }
+      Chi2sFive const& chi2sX5() const { return m_chi2sX5; }
+
+      // Check validity of track rechits
+      bool recHitsOk() const { return m_hitCollection.isNonnull() && m_hitCollection.isAvailable(); }
+
+    private:
+      edm::RefCore m_hitCollection;
+      unsigned int m_firstHit;
+      unsigned int m_nHits;
+      TrajParams m_trajParams;
+      Chi2sFive m_chi2sX5;  // chi2 * 5  chopped at 255  (max chi2 is 51)
+    };
+
+  }  // namespace io_v1
+  using TrackExtraBase = io_v1::TrackExtraBase;
 }  // namespace reco
 
 #endif  // DataFormats_TrackReco_TrackExtraBase_h

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -13,13 +13,12 @@
     <field name="momentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
   </class>
 
-  <class name="reco::TrackExtraBase" ClassVersion="3">
-   <version ClassVersion="3" checksum="1846152141"/>
+  <class name="reco::io_v1::TrackExtraBase" ClassVersion="3">
+   <version ClassVersion="3" checksum="1521832759"/>
   </class>
 
-
   <class name="reco::io_v1::TrackExtra" ClassVersion="3">
-   <version ClassVersion="3" checksum="592326124"/>
+   <version ClassVersion="3" checksum="3555884644"/>
     <field name="outerPosition_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="outerMomentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="innerPosition_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 

--- a/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
@@ -10,7 +10,7 @@
 //#define DO_INTERNAL_CHECKS_BTR
 //#define VI_DEBUG
 
-class OmniClusterRef;
+#include "DataFormats/TrackerRecHit2D/interface/OmniClusterRefFwd.h"
 
 namespace io_v1 {
   class BaseTrackerRecHit : public TrackingRecHit {

--- a/DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h
+++ b/DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h
@@ -9,102 +9,108 @@
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/FTLRecHit/interface/FTLClusterCollections.h"
 
-class OmniClusterRef {
-  static const unsigned int kInvalid = 0x80000000;  // bit 31 on
-  static const unsigned int kIsStrip = 0x20000000;  // bit 29 on
-  // FIXME:: need to check when introducing phase2 pixel
-  static const unsigned int kIsPhase2 = 0x40000000;    // bit 30 on
-  static const unsigned int kIsTiming = 0x10000000;    // bit 28 on
-  static const unsigned int kIsRegional = 0x60000000;  // bit 30 and 29 on  (will become fastsim???)
+namespace io_v1 {
 
-  static const unsigned int indexMask = 0xFFFFFF;
-  static const unsigned int subClusMask = 0xF000000;
-  static const unsigned int subClusShift = 24;
+  class OmniClusterRef {
+    static const unsigned int kInvalid = 0x80000000;  // bit 31 on
+    static const unsigned int kIsStrip = 0x20000000;  // bit 29 on
+    // FIXME:: need to check when introducing phase2 pixel
+    static const unsigned int kIsPhase2 = 0x40000000;    // bit 30 on
+    static const unsigned int kIsTiming = 0x10000000;    // bit 28 on
+    static const unsigned int kIsRegional = 0x60000000;  // bit 30 and 29 on  (will become fastsim???)
 
-public:
-  typedef edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> ClusterPixelRef;
-  typedef edm::Ref<edmNew::DetSetVector<SiStripCluster>, SiStripCluster> ClusterStripRef;
-  typedef edm::Ref<edmNew::DetSetVector<Phase2TrackerCluster1D>, Phase2TrackerCluster1D> Phase2Cluster1DRef;
-  typedef edm::Ref<FTLClusterCollection, FTLCluster> ClusterMTDRef;
+    static const unsigned int indexMask = 0xFFFFFF;
+    static const unsigned int subClusMask = 0xF000000;
+    static const unsigned int subClusShift = 24;
 
-  OmniClusterRef() : me(edm::RefCore(), kInvalid) {}
-  OmniClusterRef(edm::ProductID const& id, SiStripCluster const* clu, unsigned int key) : me(id, clu, key | kIsStrip) {}
-  explicit OmniClusterRef(ClusterPixelRef const& ref, unsigned int subClus = 0)
-      : me(ref.refCore(), (ref.isNonnull() ? ref.key() | (subClus << subClusShift) : kInvalid)) {}
-  explicit OmniClusterRef(ClusterStripRef const& ref, unsigned int subClus = 0)
-      : me(ref.refCore(), (ref.isNonnull() ? (ref.key() | kIsStrip) | (subClus << subClusShift) : kInvalid)) {}
-  explicit OmniClusterRef(Phase2Cluster1DRef const& ref, unsigned int subClus = 0)
-      : me(ref.refCore(), (ref.isNonnull() ? (ref.key() | kIsPhase2) | (subClus << subClusShift) : kInvalid)) {}
-  explicit OmniClusterRef(ClusterMTDRef const& ref)
-      : me(ref.refCore(), (ref.isNonnull() ? (ref.key() | kIsTiming) : kInvalid)) {}
+  public:
+    typedef edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> ClusterPixelRef;
+    typedef edm::Ref<edmNew::DetSetVector<SiStripCluster>, SiStripCluster> ClusterStripRef;
+    typedef edm::Ref<edmNew::DetSetVector<Phase2TrackerCluster1D>, Phase2TrackerCluster1D> Phase2Cluster1DRef;
+    typedef edm::Ref<FTLClusterCollection, FTLCluster> ClusterMTDRef;
 
-  ClusterPixelRef cluster_pixel() const {
-    return (isPixel() && isValid()) ? ClusterPixelRef(me.toRefCore(), index()) : ClusterPixelRef();
-  }
+    OmniClusterRef() : me(edm::RefCore(), kInvalid) {}
+    OmniClusterRef(edm::ProductID const& id, SiStripCluster const* clu, unsigned int key)
+        : me(id, clu, key | kIsStrip) {}
+    explicit OmniClusterRef(ClusterPixelRef const& ref, unsigned int subClus = 0)
+        : me(ref.refCore(), (ref.isNonnull() ? ref.key() | (subClus << subClusShift) : kInvalid)) {}
+    explicit OmniClusterRef(ClusterStripRef const& ref, unsigned int subClus = 0)
+        : me(ref.refCore(), (ref.isNonnull() ? (ref.key() | kIsStrip) | (subClus << subClusShift) : kInvalid)) {}
+    explicit OmniClusterRef(Phase2Cluster1DRef const& ref, unsigned int subClus = 0)
+        : me(ref.refCore(), (ref.isNonnull() ? (ref.key() | kIsPhase2) | (subClus << subClusShift) : kInvalid)) {}
+    explicit OmniClusterRef(ClusterMTDRef const& ref)
+        : me(ref.refCore(), (ref.isNonnull() ? (ref.key() | kIsTiming) : kInvalid)) {}
 
-  ClusterStripRef cluster_strip() const {
-    return isStrip() ? ClusterStripRef(me.toRefCore(), index()) : ClusterStripRef();
-  }
+    ClusterPixelRef cluster_pixel() const {
+      return (isPixel() && isValid()) ? ClusterPixelRef(me.toRefCore(), index()) : ClusterPixelRef();
+    }
 
-  Phase2Cluster1DRef cluster_phase2OT() const {
-    return isPhase2() ? Phase2Cluster1DRef(me.toRefCore(), index()) : Phase2Cluster1DRef();
-  }
+    ClusterStripRef cluster_strip() const {
+      return isStrip() ? ClusterStripRef(me.toRefCore(), index()) : ClusterStripRef();
+    }
 
-  ClusterMTDRef cluster_mtd() const { return isTiming() ? ClusterMTDRef(me.toRefCore(), index()) : ClusterMTDRef(); }
+    Phase2Cluster1DRef cluster_phase2OT() const {
+      return isPhase2() ? Phase2Cluster1DRef(me.toRefCore(), index()) : Phase2Cluster1DRef();
+    }
 
-  SiPixelCluster const& pixelCluster() const { return *ClusterPixelRef(me.toRefCore(), index()); }
-  SiStripCluster const& stripCluster() const { return *ClusterStripRef(me.toRefCore(), index()); }
-  Phase2TrackerCluster1D const& phase2OTCluster() const { return *Phase2Cluster1DRef(me.toRefCore(), index()); }
-  FTLCluster const& mtdCluster() const { return *ClusterMTDRef(me.toRefCore(), index()); }
+    ClusterMTDRef cluster_mtd() const { return isTiming() ? ClusterMTDRef(me.toRefCore(), index()) : ClusterMTDRef(); }
 
-  bool operator==(OmniClusterRef const& lh) const {
-    return rawIndex() == lh.rawIndex();  // in principle this is enough!
-  }
+    SiPixelCluster const& pixelCluster() const { return *ClusterPixelRef(me.toRefCore(), index()); }
+    SiStripCluster const& stripCluster() const { return *ClusterStripRef(me.toRefCore(), index()); }
+    Phase2TrackerCluster1D const& phase2OTCluster() const { return *Phase2Cluster1DRef(me.toRefCore(), index()); }
+    FTLCluster const& mtdCluster() const { return *ClusterMTDRef(me.toRefCore(), index()); }
 
-  bool operator<(OmniClusterRef const& lh) const {
-    return rawIndex() < lh.rawIndex();  // in principle this is enough!
-  }
+    bool operator==(OmniClusterRef const& lh) const {
+      return rawIndex() == lh.rawIndex();  // in principle this is enough!
+    }
 
-  bool const stripOverlap(OmniClusterRef const& lh, bool includeEdges = true) const {
-    if (!isStrip())
-      return false;
-    const auto& tc = stripCluster();
-    const uint16_t tf = tc.firstStrip();
-    const uint16_t tl = tf + tc.amplitudes().size() - 1;
-    const auto& oc = lh.stripCluster();
-    const uint16_t of = oc.firstStrip();
-    const uint16_t ol = of + oc.amplitudes().size() - 1;
-    // By default, include edge overlaps
-    // For single-strip clusters with non-matching edges, edge overlaps are excluded
-    if (((tl - tf) <= 1 || (ol - of) <= 1) && (tf != of || tl != ol))
-      includeEdges = false;
-    const auto e = includeEdges ? 1 : 0;
-    // Check that last strip of "other" cluster is within first and last strip of "this", or viceversa
-    // Edge strips are considered for determining overlap (e=1) if includeEdges = true (default)
-    return (((ol + e) > tf && ol < (tl + e)) || ((tl + e) > of && tl < (ol + e)));
-  }
+    bool operator<(OmniClusterRef const& lh) const {
+      return rawIndex() < lh.rawIndex();  // in principle this is enough!
+    }
 
-public:
-  // edm Ref interface
-  /* auto */ edm::ProductID id() const { return me.id(); }
-  unsigned int key() const { return index(); }
+    bool const stripOverlap(OmniClusterRef const& lh, bool includeEdges = true) const {
+      if (!isStrip())
+        return false;
+      const auto& tc = stripCluster();
+      const uint16_t tf = tc.firstStrip();
+      const uint16_t tl = tf + tc.amplitudes().size() - 1;
+      const auto& oc = lh.stripCluster();
+      const uint16_t of = oc.firstStrip();
+      const uint16_t ol = of + oc.amplitudes().size() - 1;
+      // By default, include edge overlaps
+      // For single-strip clusters with non-matching edges, edge overlaps are excluded
+      if (((tl - tf) <= 1 || (ol - of) <= 1) && (tf != of || tl != ol))
+        includeEdges = false;
+      const auto e = includeEdges ? 1 : 0;
+      // Check that last strip of "other" cluster is within first and last strip of "this", or viceversa
+      // Edge strips are considered for determining overlap (e=1) if includeEdges = true (default)
+      return (((ol + e) > tf && ol < (tl + e)) || ((tl + e) > of && tl < (ol + e)));
+    }
 
-  unsigned int rawIndex() const { return me.index(); }
+  public:
+    // edm Ref interface
+    /* auto */ edm::ProductID id() const { return me.id(); }
+    unsigned int key() const { return index(); }
 
-  unsigned int index() const { return rawIndex() & indexMask; }
+    unsigned int rawIndex() const { return me.index(); }
 
-  unsigned int subCluster() const { return (rawIndex() & subClusMask) >> subClusShift; }
+    unsigned int index() const { return rawIndex() & indexMask; }
 
-  bool isValid() const { return !(rawIndex() & kInvalid); }
-  bool isPixel() const { return !isStrip() && !isPhase2(); }  //NOTE: non-valid will also show up as a pixel
-  bool isStrip() const { return rawIndex() & kIsStrip; }
-  bool isPhase2() const { return rawIndex() & kIsPhase2; }
-  bool isTiming() const { return rawIndex() & kIsTiming; }
-  // bool isRegional() const { return (rawIndex() & kIsRegional)==kIsRegional; }
-  // bool isNonRegionalStrip() const {return (rawIndex() & kIsRegional)==kIsStrip;}
+    unsigned int subCluster() const { return (rawIndex() & subClusMask) >> subClusShift; }
 
-private:
-  edm::RefCoreWithIndex me;
-};
+    bool isValid() const { return !(rawIndex() & kInvalid); }
+    bool isPixel() const { return !isStrip() && !isPhase2(); }  //NOTE: non-valid will also show up as a pixel
+    bool isStrip() const { return rawIndex() & kIsStrip; }
+    bool isPhase2() const { return rawIndex() & kIsPhase2; }
+    bool isTiming() const { return rawIndex() & kIsTiming; }
+    // bool isRegional() const { return (rawIndex() & kIsRegional)==kIsRegional; }
+    // bool isNonRegionalStrip() const {return (rawIndex() & kIsRegional)==kIsStrip;}
+
+  private:
+    edm::RefCoreWithIndex me;
+  };
+
+}  // namespace io_v1
+using OmniClusterRef = io_v1::OmniClusterRef;
 
 #endif  // TrackerRecHit2D_OmniClusterRef_H

--- a/DataFormats/TrackerRecHit2D/interface/OmniClusterRefFwd.h
+++ b/DataFormats/TrackerRecHit2D/interface/OmniClusterRefFwd.h
@@ -1,0 +1,9 @@
+#ifndef TrackerRecHit2D_OmniClusterRefFwd_H
+#define TrackerRecHit2D_OmniClusterRefFwd_H
+
+namespace io_v1 {
+  class OmniClusterRef;
+}
+using OmniClusterRef = io_v1::OmniClusterRef;
+
+#endif  // TrackerRecHit2D_OmniClusterRefFwd_H

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -6,37 +6,37 @@
      <field name="err_" transient="true" />	 
    </class>	 
   <class name="io_v1::TrackerSingleRecHit" ClassVersion="3">
-   <version ClassVersion="3" checksum="2233339069"/>
+   <version ClassVersion="3" checksum="2049188155"/>
   </class>	 
 
-  <class name="OmniClusterRef"  ClassVersion="3">
-   <version ClassVersion="3" checksum="735211426"/>
+  <class name="io_v1::OmniClusterRef"  ClassVersion="3">
+   <version ClassVersion="3" checksum="2409258018"/>
   </class>
 
   <class name="SiStripRecHit1D"  ClassVersion="3">
-   <version ClassVersion="3" checksum="457821070"/>
+   <version ClassVersion="3" checksum="273670156"/>
     <field name="sigmaPitch_" transient="true"/>
   </class> 
 
   <class name="SiStripRecHit2D"  ClassVersion="3">
-   <version ClassVersion="3" checksum="2254457535"/>
+   <version ClassVersion="3" checksum="2070306621"/>
     <field name="sigmaPitch_" transient="true"/>
   </class>
 
 
   <class name="ProjectedSiStripRecHit2D" ClassVersion="3">
-   <version ClassVersion="3" checksum="2774452855"/>
+   <version ClassVersion="3" checksum="2590301941"/>
    <field name="theOriginalDet" transient="true" />
   </class>
   <class name="SiStripMatchedRecHit2D" ClassVersion="3">
-   <version ClassVersion="3" checksum="3009556865"/>
+   <version ClassVersion="3" checksum="335746927"/>
   </class>
   <class name="SiTrackerMultiRecHit" ClassVersion="3">
    <version ClassVersion="3" checksum="1899254770"/>
   </class>
 
   <class name="SiPixelRecHit" ClassVersion="3">
-   <version ClassVersion="3" checksum="3719400935"/>
+   <version ClassVersion="3" checksum="3535250021"/>
   </class>
 
   <class name="std::vector<std::unique_ptr<io_v1::BaseTrackerRecHit>>" persistent="false"/>
@@ -105,7 +105,7 @@
   // phase2 containers
 
   <class name="Phase2TrackerRecHit1D" ClassVersion="3">
-      <version ClassVersion="3" checksum="2054321903"/>
+      <version ClassVersion="3" checksum="1870170989"/>
   </class>
   <class name="std::vector< Phase2TrackerRecHit1D >"/>
   <class name="std::vector< edmNew::DetSet< Phase2TrackerRecHit1D > >"/>
@@ -117,14 +117,14 @@
   <class name="edm::Wrapper< Phase2TrackerRecHit1DCollectionNew >"/>
 
   <class name="io_v1::MTDTrackingRecHit" ClassVersion="3">
-    <version ClassVersion="3" checksum="3389713887"/>
+    <version ClassVersion="3" checksum="3205562973"/>
   </class>
 
   <class name="std::vector<io_v1::MTDTrackingRecHit>"/>
   <class name="MTDTrackingDetSetVector"/>
   <class name="edm::Wrapper< MTDTrackingDetSetVector >"/>
   <class name="VectorHit" ClassVersion="3">
-   <version ClassVersion="3" checksum="3550784686"/>
+   <version ClassVersion="3" checksum="1962500276"/>
   </class>
   <class name="VectorHit2D" ClassVersion="3">
    <version ClassVersion="3" checksum="86550371"/>

--- a/Fireworks/Calo/interface/FWTauProxyBuilderBase.h
+++ b/Fireworks/Calo/interface/FWTauProxyBuilderBase.h
@@ -28,9 +28,7 @@
 class TEveScalableStraightLineSet;
 class FWViewContext;
 
-namespace reco {
-  class BaseTau;
-}  // namespace reco
+#include "DataFormats/TauReco/interface/BaseTauFwd.h"
 
 namespace fireworks {
   class Context;

--- a/RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h
+++ b/RecoTauTag/RecoTau/interface/PFRecoTauChargedHadronPlugins.h
@@ -24,10 +24,9 @@
 
 #include <vector>
 
-namespace reco {
+#include "DataFormats/TauReco/interface/PFRecoTauChargedHadronFwd.h"
 
-  // Forward declarations
-  class PFRecoTauChargedHadron;
+namespace reco {
 
   namespace tau {
 


### PR DESCRIPTION
#### PR description:

This batch includes types that are stored in the files produced in workflow 34434.0 as member data of other data products, and hold edm::RefCore, edm::RefCoreWithIndex, std::map, or std::unordered_map as member data.

Resolves https://github.com/cms-sw/framework-team/issues/2208

#### PR validation:

Code compiles