### PR TITLE
[16_1_X][L1T] EMTF DQM Plot Changes to Address CSC Timing Issues for Backport

### DIFF
--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -1098,6 +1098,22 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
       }
     }
 
+    int numHitsInTrackBX0 = 0;
+    int numHitsRPC = 0;
+    if (numHits == 3 || numHits == 4) {
+      for (const auto& jTrkHit : Track->Hits()) {
+        if (jTrkHit.BX() == 0)
+          numHitsInTrackBX0++;
+      }
+      if (numHitsInTrackBX0 >= numHits - 1) {
+        for (const auto& iTrkHit : Track->Hits()) {
+          if (iTrkHit.Is_RPC()) {
+            numHitsRPC++;
+          }
+        }
+      }
+    }
+
     ////////////////////////////////////////////////////
     ///  Begin block for CSC LCT and RPC hit timing  ///
     ////////////////////////////////////////////////////
@@ -1158,18 +1174,24 @@ void L1TStage2EMTF::analyze(const edm::Event& e, const edm::EventSetup& c) {
           if (endcap > 0)
             hist_index = 19 - hist_index;
           if (neighbor == false) {
-            cscLCTTiming[histIndexBX.at(trackHitBX)]->Fill(chamber_bin(station, ring, chamber), hist_index, evt_wgt);
-            cscTimingTot->Fill(chamber_bin(station, ring, chamber), hist_index, evt_wgt);
+            if (numHitsRPC < 2) {
+              cscLCTTiming[histIndexBX.at(trackHitBX)]->Fill(chamber_bin(station, ring, chamber), hist_index, evt_wgt);
+              cscTimingTot->Fill(chamber_bin(station, ring, chamber), hist_index, evt_wgt);
+            }
             if (station > 1 && (ring % 2) == 1) {
-              cscLCTTiming[histIndexBX.at(trackHitBX)]->Fill(
-                  chamber_bin(station, ring, chamber) - 1, hist_index, evt_wgt);
-              cscTimingTot->Fill(chamber_bin(station, ring, chamber) - 1, hist_index, evt_wgt);
+              if (numHitsRPC < 2) {
+                cscLCTTiming[histIndexBX.at(trackHitBX)]->Fill(
+                    chamber_bin(station, ring, chamber) - 1, hist_index, evt_wgt);
+                cscTimingTot->Fill(chamber_bin(station, ring, chamber) - 1, hist_index, evt_wgt);
+              }
             }
           } else {
             // Map neighbor chambers to "fake" CSC IDs: 1/3 --> 1, 1/6 --> 2, 1/9 --> 3, 2/3 --> 4, 2/9 --> 5, etc.
             //int cscid_n = (station == 1 ? (cscid / 3) : (station * 2) + ((cscid - 3) / 6) );
-            cscLCTTiming[histIndexBX.at(trackHitBX)]->Fill((sector % 6 + 1) * 7 - 4, hist_index, evt_wgt);
-            cscTimingTot->Fill((sector % 6 + 1) * 7 - 4, hist_index, evt_wgt);
+            if (numHitsRPC < 2) {
+              cscLCTTiming[histIndexBX.at(trackHitBX)]->Fill((sector % 6 + 1) * 7 - 4, hist_index, evt_wgt);
+              cscTimingTot->Fill((sector % 6 + 1) * 7 - 4, hist_index, evt_wgt);
+            }
           }
 
           // Fill RPC timing with matched CSC LCTs


### PR DESCRIPTION
#### PR description:

The proposed changes effect the cscLCTTiming Plots in the EMTF DQM and work to address poor resolution seen in the CSC chambers in the negative endcap, documented [here](https://indico.cern.ch/event/1590013/contributions/6700433/attachments/3137704/5567899/CSC%20trigger%20timing%20Aug%202025.pdf).

An EMTF investigation revealed that EMTF tracks built with more than or equal to 2 RPC hits contributed significantly to the csc chamber occupancy in BX -1 for the negative endcap region which is not mirrored in the positive endcap region. The source of this problem is a known retriggering issue in RPC chambers in negative endcap. The fix implemented in the PR is to remove tracks with more than or equal to 2 RPC hits from the cscLCTTiming monitoring plots which are used to extract CSC Timing shifts

#### PR validation:

n order to validate this reason, the BX-1 csc chamber occupancy was plotted for tracks with more than or equal to 2 RPC hits and showed that the occupancy only existed in the negative endcap for a total of 100,000 events (See image below).

<img width="702" height="482" alt="Screenshot 2026-05-04 at 4 34 50 PM" src="https://github.com/user-attachments/assets/0e15bd68-f60b-49e9-b6b0-2f8d31a0fc99" />

To further validate the fix, the DQM was run over 153,000 events and included cscLCTTiming plots with and without the 2 RPC hit tracks. Through this it is shown that there is an improvement in the csc chamber occupancy in BX-1 and thus the timing resolution (See below).

Before Fix
<img width="764" height="662" alt="Screenshot 2026-05-04 at 4 36 53 PM" src="https://github.com/user-attachments/assets/f461a8f6-d4ba-46e1-9306-f63f382c47d2" />

After Fix
<img width="817" height="662" alt="588977808-86c56d42-8904-4d0b-aaf1-b2c06266ac27" src="https://github.com/user-attachments/assets/41d68a56-3097-4cd5-8511-cd44dcb63ea7" />

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

The original PR can be found https://github.com/cms-sw/cmssw/pull/50903. This is a backport request for CMSSW_16_1_X as this affects online DQM.
