### PR TITLE
remove invalid torch-interface dependency in `RecoML/AnomalyDetection` `BuildFile`

### DIFF
--- a/RecoML/AnomalyDetection/plugins/BuildFile.xml
+++ b/RecoML/AnomalyDetection/plugins/BuildFile.xml
@@ -11,7 +11,6 @@
 <use name="FWCore/Utilities"/>
 <use name="PhysicsTools/PyTorch"/>
 <use name="pytorch"/>
-<use name="torch-interface"/>
 <library file="*.cc" name="RecoMLAnomalyDetectionPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
#### PR description:

Title says it all.
Fixes the warning

```
****WARNING: Invalid tool torch-interface. Please fix src/RecoML/AnomalyDetection/plugins/BuildFile.xml file.
```

obtained when compiling this package.

#### PR validation:

`cmssw` compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A