### PR TITLE
Add reduced memory runtime toggle for LST

### DIFF
--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -32,6 +32,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           clustSizeCut_(static_cast<uint16_t>(config.getParameter<uint32_t>("clustSizeCut"))),
           nopLSDupClean_(config.getParameter<bool>("nopLSDupClean")),
           tcpLSTriplets_(config.getParameter<bool>("tcpLSTriplets")),
+          reduceMemByFullPrecompute_(config.getParameter<bool>("reduceMemByFullPrecompute")),
           lstOutputToken_{produces()} {}
 
     void produce(edm::StreamID sid, device::Event& iEvent, const device::EventSetup& iSetup) const override {
@@ -47,7 +48,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
               &lstESDeviceData,
               &lstInputDC,
               nopLSDupClean_,
-              tcpLSTriplets_);
+              tcpLSTriplets_,
+              reduceMemByFullPrecompute_);
 
       // Output
       auto lstTrackCandidates = lst.getTrackCandidates();
@@ -63,6 +65,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       desc.add<std::string>("ptCutLabel", "0.8");
       desc.add<bool>("nopLSDupClean", false);
       desc.add<bool>("tcpLSTriplets", false);
+      desc.add<bool>("reduceMemByFullPrecompute", false)
+          ->setComment(
+              "If true, run extra counting kernels that exactly size the MD/LS/T3/T5/T4 "
+              "buffers, reducing average per-event memory at a small CPU/GPU runtime cost. "
+              "If false (default), buffers use cheaper, looser occupancy estimates.");
       descriptions.addWithDefaultLabel(desc);
     }
 
@@ -74,6 +81,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const uint16_t clustSizeCut_;
     const bool nopLSDupClean_;
     const bool tcpLSTriplets_;
+    const bool reduceMemByFullPrecompute_;
     const device::EDPutToken<lst::TrackCandidatesBaseDeviceCollection> lstOutputToken_;
   };
 

--- a/RecoTracker/LSTCore/interface/alpaka/LST.h
+++ b/RecoTracker/LSTCore/interface/alpaka/LST.h
@@ -24,7 +24,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
              LSTESData<Device> const* deviceESData,
              LSTInputDeviceCollection const* lstInputDC,
              bool no_pls_dupclean,
-             bool tc_pls_triplets);
+             bool tc_pls_triplets,
+             bool reduce_mem_by_full_precompute);
     std::unique_ptr<TrackCandidatesBaseDeviceCollection> getTrackCandidates() {
       return std::move(trackCandidatesBaseDC_);
     }

--- a/RecoTracker/LSTCore/src/alpaka/LST.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LST.cc
@@ -17,8 +17,9 @@ void LST::run(Queue& queue,
               LSTESData<Device> const* deviceESData,
               LSTInputDeviceCollection const* lstInputDC,
               bool no_pls_dupclean,
-              bool tc_pls_triplets) {
-  auto event = LSTEvent(verbose, ptCut, clustSizeCut, queue, deviceESData);
+              bool tc_pls_triplets,
+              bool reduce_mem_by_full_precompute) {
+  auto event = LSTEvent(verbose, ptCut, clustSizeCut, queue, deviceESData, reduce_mem_by_full_precompute);
 
   event.addInputToEvent(lstInputDC);
   event.addHitToEvent();

--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
@@ -301,14 +301,20 @@ void LSTEvent::createSegmentsWithModuleMap() {
   if (!segmentsDC_) {
     auto const countMDConn_wd = cms::alpakatools::make_workdiv<Acc3D>({nLowerModules_, 1, 1}, {1, 8, 32});
 
-    alpaka::exec<Acc3D>(queue_,
-                        countMDConn_wd,
-                        CountMiniDoubletConnections{},
-                        modules_.const_view().modules(),
-                        miniDoubletsDC_->view().miniDoublets(),
-                        miniDoubletsDC_->const_view().miniDoubletsOccupancy(),
-                        rangesDC_->const_view(),
-                        ptCut_);
+    auto execCountMDConn = [&](auto kernel) {
+      alpaka::exec<Acc3D>(queue_,
+                          countMDConn_wd,
+                          kernel,
+                          modules_.const_view().modules(),
+                          miniDoubletsDC_->view().miniDoublets(),
+                          miniDoubletsDC_->const_view().miniDoubletsOccupancy(),
+                          rangesDC_->const_view(),
+                          ptCut_);
+    };
+    if (reduceMemByFullPrecompute_)
+      execCountMDConn(CountMiniDoubletConnectionsReduceMem{});
+    else
+      execCountMDConn(CountMiniDoubletConnections{});
 
     auto const createSegmentArrayRanges_workDiv = cms::alpakatools::make_workdiv<Acc1D>(1, 1024);
 
@@ -388,15 +394,21 @@ void LSTEvent::createTriplets() {
   if (!tripletsDC_) {
     auto const countSegConn_wd = cms::alpakatools::make_workdiv<Acc3D>({nLowerModules_, 1, 1}, {1, 16, 16});
 
-    alpaka::exec<Acc3D>(queue_,
-                        countSegConn_wd,
-                        CountSegmentConnections{},
-                        modules_.const_view().modules(),
-                        miniDoubletsDC_->const_view().miniDoublets(),
-                        segmentsDC_->view().segments(),
-                        segmentsDC_->const_view().segmentsOccupancy(),
-                        rangesDC_->const_view(),
-                        ptCut_);
+    auto execCountSegConn = [&](auto kernel) {
+      alpaka::exec<Acc3D>(queue_,
+                          countSegConn_wd,
+                          kernel,
+                          modules_.const_view().modules(),
+                          miniDoubletsDC_->const_view().miniDoublets(),
+                          segmentsDC_->view().segments(),
+                          segmentsDC_->const_view().segmentsOccupancy(),
+                          rangesDC_->const_view(),
+                          ptCut_);
+    };
+    if (reduceMemByFullPrecompute_)
+      execCountSegConn(CountSegmentConnectionsReduceMem{});
+    else
+      execCountSegConn(CountSegmentConnections{});
 
     auto const createTripletArrayRanges_workDiv = cms::alpakatools::make_workdiv<Acc1D>(1, 1024);
 
@@ -487,19 +499,25 @@ void LSTEvent::createTriplets() {
 
   auto const createTriplets_workDiv = cms::alpakatools::make_workdiv<Acc3D>({nonZeroModules, 1, 1}, {1, 16, 16});
 
-  alpaka::exec<Acc3D>(queue_,
-                      createTriplets_workDiv,
-                      CreateTriplets{},
-                      modules_.const_view().modules(),
-                      miniDoubletsDC_->const_view().miniDoublets(),
-                      segmentsDC_->const_view().segments(),
-                      segmentsDC_->const_view().segmentsOccupancy(),
-                      tripletsDC_->view().triplets(),
-                      tripletsDC_->view().tripletsOccupancy(),
-                      rangesDC_->const_view(),
-                      index_gpu_buf.data(),
-                      nonZeroModules,
-                      ptCut_);
+  auto execCreateTriplets = [&](auto kernel) {
+    alpaka::exec<Acc3D>(queue_,
+                        createTriplets_workDiv,
+                        kernel,
+                        modules_.const_view().modules(),
+                        miniDoubletsDC_->const_view().miniDoublets(),
+                        segmentsDC_->const_view().segments(),
+                        segmentsDC_->const_view().segmentsOccupancy(),
+                        tripletsDC_->view().triplets(),
+                        tripletsDC_->view().tripletsOccupancy(),
+                        rangesDC_->const_view(),
+                        index_gpu_buf.data(),
+                        nonZeroModules,
+                        ptCut_);
+  };
+  if (reduceMemByFullPrecompute_)
+    execCreateTriplets(CreateTripletsReduceMem{});
+  else
+    execCreateTriplets(CreateTriplets{});
 
   auto const addTripletRangesToEventExplicit_workDiv = cms::alpakatools::make_workdiv<Acc1D>(1, 1024);
 
@@ -922,16 +940,22 @@ void LSTEvent::createPixelTriplets() {
 void LSTEvent::createQuintuplets() {
   auto const countConn_workDiv = cms::alpakatools::make_workdiv<Acc3D>({nLowerModules_, 1, 1}, {1, 8, 32});
 
-  alpaka::exec<Acc3D>(queue_,
-                      countConn_workDiv,
-                      CountTripletConnections{},
-                      modules_.const_view().modules(),
-                      miniDoubletsDC_->const_view().miniDoublets(),
-                      segmentsDC_->const_view().segments(),
-                      tripletsDC_->view().triplets(),
-                      tripletsDC_->const_view().tripletsOccupancy(),
-                      rangesDC_->const_view(),
-                      ptCut_);
+  auto execCountTripletConn = [&](auto kernel) {
+    alpaka::exec<Acc3D>(queue_,
+                        countConn_workDiv,
+                        kernel,
+                        modules_.const_view().modules(),
+                        miniDoubletsDC_->const_view().miniDoublets(),
+                        segmentsDC_->const_view().segments(),
+                        tripletsDC_->view().triplets(),
+                        tripletsDC_->const_view().tripletsOccupancy(),
+                        rangesDC_->const_view(),
+                        ptCut_);
+  };
+  if (reduceMemByFullPrecompute_)
+    execCountTripletConn(CountTripletConnectionsReduceMem{});
+  else
+    execCountTripletConn(CountTripletConnections{});
 
   auto const createEligibleModulesListForQuintuplets_workDiv = cms::alpakatools::make_workdiv<Acc1D>(1, 1024);
 
@@ -980,19 +1004,25 @@ void LSTEvent::createQuintuplets() {
   auto const createQuintuplets_workDiv =
       cms::alpakatools::make_workdiv<Acc3D>({std::max((int)nEligibleT5Modules, 1), 1, 1}, {1, 8, 32});
 
-  alpaka::exec<Acc3D>(queue_,
-                      createQuintuplets_workDiv,
-                      CreateQuintuplets{},
-                      modules_.const_view().modules(),
-                      miniDoubletsDC_->const_view().miniDoublets(),
-                      segmentsDC_->const_view().segments(),
-                      tripletsDC_->view().triplets(),
-                      tripletsDC_->const_view().tripletsOccupancy(),
-                      quintupletsDC_->view().quintuplets(),
-                      quintupletsDC_->view().quintupletsOccupancy(),
-                      rangesDC_->const_view(),
-                      nEligibleT5Modules,
-                      ptCut_);
+  auto execCreateQuintuplets = [&](auto kernel) {
+    alpaka::exec<Acc3D>(queue_,
+                        createQuintuplets_workDiv,
+                        kernel,
+                        modules_.const_view().modules(),
+                        miniDoubletsDC_->const_view().miniDoublets(),
+                        segmentsDC_->const_view().segments(),
+                        tripletsDC_->view().triplets(),
+                        tripletsDC_->const_view().tripletsOccupancy(),
+                        quintupletsDC_->view().quintuplets(),
+                        quintupletsDC_->view().quintupletsOccupancy(),
+                        rangesDC_->const_view(),
+                        nEligibleT5Modules,
+                        ptCut_);
+  };
+  if (reduceMemByFullPrecompute_)
+    execCreateQuintuplets(CreateQuintupletsReduceMem{});
+  else
+    execCreateQuintuplets(CreateQuintuplets{});
 
   auto const removeDupQuintupletsAfterBuild_workDiv =
       cms::alpakatools::make_workdiv<Acc3D>({max_blocks, 1, 1}, {1, 16, 16});
@@ -1170,16 +1200,22 @@ void LSTEvent::createPixelQuintuplets() {
 void LSTEvent::createQuadruplets() {
   auto const countLSConn_workDiv = cms::alpakatools::make_workdiv<Acc3D>({nLowerModules_, 1, 1}, {1, 8, 32});
 
-  alpaka::exec<Acc3D>(queue_,
-                      countLSConn_workDiv,
-                      CountTripletLSConnections{},
-                      modules_.const_view().modules(),
-                      miniDoubletsDC_->const_view().miniDoublets(),
-                      segmentsDC_->const_view().segments(),
-                      tripletsDC_->view().triplets(),
-                      tripletsDC_->const_view().tripletsOccupancy(),
-                      rangesDC_->const_view(),
-                      ptCut_);
+  auto execCountTripletLSConn = [&](auto kernel) {
+    alpaka::exec<Acc3D>(queue_,
+                        countLSConn_workDiv,
+                        kernel,
+                        modules_.const_view().modules(),
+                        miniDoubletsDC_->const_view().miniDoublets(),
+                        segmentsDC_->const_view().segments(),
+                        tripletsDC_->view().triplets(),
+                        tripletsDC_->const_view().tripletsOccupancy(),
+                        rangesDC_->const_view(),
+                        ptCut_);
+  };
+  if (reduceMemByFullPrecompute_)
+    execCountTripletLSConn(CountTripletLSConnectionsReduceMem{});
+  else
+    execCountTripletLSConn(CountTripletLSConnections{});
 
   auto const createEligibleModulesListForQuadruplets_workDiv = cms::alpakatools::make_workdiv<Acc1D>(1, 1024);
 
@@ -1225,19 +1261,25 @@ void LSTEvent::createQuadruplets() {
   auto const createQuadruplets_workDiv =
       cms::alpakatools::make_workdiv<Acc3D>({std::max((int)nEligibleT4Modules, 1), 1, 1}, {1, 8, 32});
 
-  alpaka::exec<Acc3D>(queue_,
-                      createQuadruplets_workDiv,
-                      CreateQuadruplets{},
-                      modules_.const_view().modules(),
-                      miniDoubletsDC_->const_view().miniDoublets(),
-                      segmentsDC_->const_view().segments(),
-                      tripletsDC_->view().triplets(),
-                      tripletsDC_->const_view().tripletsOccupancy(),
-                      quadrupletsDC_->view().quadruplets(),
-                      quadrupletsDC_->view().quadrupletsOccupancy(),
-                      rangesDC_->const_view(),
-                      nEligibleT4Modules,
-                      ptCut_);
+  auto execCreateQuadruplets = [&](auto kernel) {
+    alpaka::exec<Acc3D>(queue_,
+                        createQuadruplets_workDiv,
+                        kernel,
+                        modules_.const_view().modules(),
+                        miniDoubletsDC_->const_view().miniDoublets(),
+                        segmentsDC_->const_view().segments(),
+                        tripletsDC_->view().triplets(),
+                        tripletsDC_->const_view().tripletsOccupancy(),
+                        quadrupletsDC_->view().quadruplets(),
+                        quadrupletsDC_->view().quadrupletsOccupancy(),
+                        rangesDC_->const_view(),
+                        nEligibleT4Modules,
+                        ptCut_);
+  };
+  if (reduceMemByFullPrecompute_)
+    execCreateQuadruplets(CreateQuadrupletsReduceMem{});
+  else
+    execCreateQuadruplets(CreateQuadruplets{});
 
   auto const removeDupQuadrupletsAfterBuild_workDiv =
       cms::alpakatools::make_workdiv<Acc3D>({max_blocks, 1, 1}, {1, 16, 16});

--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.h
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.h
@@ -43,6 +43,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     Queue& queue_;
     const float ptCut_;
     const uint16_t clustSizeCut_;
+    const bool reduceMemByFullPrecompute_;
 
     std::array<unsigned int, 6> n_minidoublets_by_layer_barrel_{};
     std::array<unsigned int, 5> n_minidoublets_by_layer_endcap_{};
@@ -101,11 +102,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
   public:
     // Constructor used for CMSSW integration. Uses an external queue.
-    LSTEvent(
-        bool verbose, const float ptCut, const uint16_t clustSizeCut, Queue& q, const LSTESData<Device>* deviceESData)
+    LSTEvent(bool verbose,
+             const float ptCut,
+             const uint16_t clustSizeCut,
+             Queue& q,
+             const LSTESData<Device>* deviceESData,
+             bool reduce_mem_by_full_precompute)
         : queue_(q),
           ptCut_(ptCut),
           clustSizeCut_(clustSizeCut),
+          reduceMemByFullPrecompute_(reduce_mem_by_full_precompute),
           nModules_(deviceESData->nModules),
           nLowerModules_(deviceESData->nLowerModules),
           nPixels_(deviceESData->nPixels),

--- a/RecoTracker/LSTCore/src/alpaka/Quadruplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quadruplet.h
@@ -513,7 +513,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return true;
   };
 
-  struct CreateQuadruplets {
+  template <bool ReduceMem>
+  struct CreateQuadrupletsT {
     ALPAKA_FN_ACC void operator()(Acc3D const& acc,
                                   ModulesConst modules,
                                   MiniDoubletsConst mds,
@@ -603,7 +604,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
               continue;
 
             // If densely connected, do not attempt parallel processing to avoid truncation
-            if (nInnerTriplets >= kNTripletThreshold || nOuterTriplets >= kNTripletThreshold) {
+            if (ReduceMem || nInnerTriplets >= kNTripletThreshold || nOuterTriplets >= kNTripletThreshold) {
               const uint16_t lowerModule3 = lmIdx[outerTripletIndex][1];
               const uint16_t lowerModule4 = lmIdx[outerTripletIndex][2];
 
@@ -717,6 +718,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           }
         }
 
+        if constexpr (ReduceMem)
+          continue;
+
         alpaka::syncBlockThreads(acc);
         if (matchCount == 0) {
           continue;
@@ -820,6 +824,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     }
   };
 
+  using CreateQuadruplets = CreateQuadrupletsT<false>;
+  using CreateQuadrupletsReduceMem = CreateQuadrupletsT<true>;
+
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool isValidQuadRegion(ModulesConst modules, uint16_t lowerModule) {
     const short layer = modules.layers()[lowerModule];
     const short subdet = modules.subdets()[lowerModule];
@@ -827,7 +834,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return (subdet == Barrel && layer > 2) || (subdet == Endcap);
   }
 
-  struct CountTripletLSConnections {
+  template <bool ReduceMem>
+  struct CountTripletLSConnectionsT {
     ALPAKA_FN_ACC void operator()(Acc3D const& acc,
                                   ModulesConst modules,
                                   MiniDoubletsConst mds,
@@ -872,7 +880,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
             if ((secondMDInner == thirdMDInner) && (secondMDOuter == thirdMDOuter)) {
               // Will only perform runQuadrupletDefaultAlgorithm() checks if densely connected
-              if (nInnerTriplets < kNTripletThreshold && nOuterTriplets < kNTripletThreshold) {
+              if (!ReduceMem && nInnerTriplets < kNTripletThreshold && nOuterTriplets < kNTripletThreshold) {
                 alpaka::atomicAdd(acc, &triplets.connectedLSMax()[innerTripletIndex], 1u, alpaka::hierarchy::Threads{});
               } else {
                 const uint16_t lowerModule3 = lmIdx[outerTripletIndex][1];
@@ -915,6 +923,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       }
     }
   };
+
+  using CountTripletLSConnections = CountTripletLSConnectionsT<false>;
+  using CountTripletLSConnectionsReduceMem = CountTripletLSConnectionsT<true>;
 
   struct CreateEligibleModulesListForQuadruplets {
     ALPAKA_FN_ACC void operator()(Acc1D const& acc,

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -1682,7 +1682,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return true;
   }
 
-  struct CreateQuintuplets {
+  template <bool ReduceMem>
+  struct CreateQuintupletsT {
     ALPAKA_FN_ACC void operator()(Acc3D const& acc,
                                   ModulesConst modules,
                                   MiniDoubletsConst mds,
@@ -1754,7 +1755,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
               continue;
 
             // If densely connected, do not attempt parallel processing to avoid truncation
-            if (nInnerTriplets >= kNTripletThreshold || nOuterTriplets >= kNTripletThreshold) {
+            if (ReduceMem || nInnerTriplets >= kNTripletThreshold || nOuterTriplets >= kNTripletThreshold) {
               uint16_t lowerModule2 = triplets.lowerModuleIndices()[innerTripletIndex][1];
               uint16_t lowerModule4 = triplets.lowerModuleIndices()[outerTripletIndex][1];
               uint16_t lowerModule5 = triplets.lowerModuleIndices()[outerTripletIndex][2];
@@ -1882,6 +1883,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           }
         }
 
+        if constexpr (ReduceMem)
+          continue;
+
         alpaka::syncBlockThreads(acc);
         if (matchCount == 0) {
           continue;
@@ -1998,6 +2002,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     }
   };
 
+  using CreateQuintuplets = CreateQuintupletsT<false>;
+  using CreateQuintupletsReduceMem = CreateQuintupletsT<true>;
+
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool isValidQuintRegion(ModulesConst modules, uint16_t lowerModule) {
     const short layer = modules.layers()[lowerModule];
     const short subdet = modules.subdets()[lowerModule];
@@ -2005,7 +2012,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return (subdet == Barrel && layer < 3) || (subdet == Endcap && layer <= 1);
   }
 
-  struct CountTripletConnections {
+  template <bool ReduceMem>
+  struct CountTripletConnectionsT {
     ALPAKA_FN_ACC void operator()(Acc3D const& acc,
                                   ModulesConst modules,
                                   MiniDoubletsConst mds,
@@ -2048,7 +2056,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
             if (secondMDOuter == thirdMDInner) {
               // Will only perform runQuintupletDefaultAlgorithm() checks if densely connected
-              if (nInnerTriplets < kNTripletThreshold && nOuterTriplets < kNTripletThreshold) {
+              if (!ReduceMem && nInnerTriplets < kNTripletThreshold && nOuterTriplets < kNTripletThreshold) {
                 alpaka::atomicAdd(acc, &triplets.connectedMax()[innerTripletIndex], 1u, alpaka::hierarchy::Threads{});
               } else {
                 const uint16_t lowerModule2 = lmIdx[innerTripletIndex][1];
@@ -2098,6 +2106,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       }
     }
   };
+
+  using CountTripletConnections = CountTripletConnectionsT<false>;
+  using CountTripletConnectionsReduceMem = CountTripletConnectionsT<true>;
 
   struct CreateEligibleModulesListForQuintuplets {
     ALPAKA_FN_ACC void operator()(Acc1D const& acc,

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -921,7 +921,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     }
   }
 
-  struct CountMiniDoubletConnections {
+  template <bool ReduceMem>
+  struct CountMiniDoubletConnectionsT {
     ALPAKA_FN_ACC void operator()(Acc3D const& acc,
                                   ModulesConst modules,
                                   MiniDoublets mds,
@@ -962,7 +963,38 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             const unsigned int outerMDIndex = mdRanges[outerLowerModuleIndex][0] + outerMDArrayIdx;
 
             // Increment the connected max if the LS passes the delta phi cuts.
-            if (passLooseSegmentCuts(acc, innerMod, outerMod, mds, innerMDIndex, outerMDIndex, ptCut)) {
+            bool pass;
+            if constexpr (ReduceMem) {
+              float dPhi, dPhiMin, dPhiMax, dPhiChange, dPhiChangeMin, dPhiChangeMax;
+#ifdef CUT_VALUE_DEBUG
+              float dAlphaInner, dAlphaOuter, dAlphaIO, zLo, zHi, rtLo, rtHi;
+#endif
+              pass = runSegmentDefaultAlgo(acc,
+                                           innerMod,
+                                           outerMod,
+                                           mds,
+                                           innerMDIndex,
+                                           outerMDIndex,
+                                           dPhi,
+                                           dPhiMin,
+                                           dPhiMax,
+                                           dPhiChange,
+                                           dPhiChangeMin,
+                                           dPhiChangeMax,
+#ifdef CUT_VALUE_DEBUG
+                                           dAlphaInner,
+                                           dAlphaOuter,
+                                           dAlphaIO,
+                                           zLo,
+                                           zHi,
+                                           rtLo,
+                                           rtHi,
+#endif
+                                           ptCut);
+            } else {
+              pass = passLooseSegmentCuts(acc, innerMod, outerMod, mds, innerMDIndex, outerMDIndex, ptCut);
+            }
+            if (pass) {
               alpaka::atomicAdd(acc, &mds.connectedMax()[innerMDIndex], 1u, alpaka::hierarchy::Threads{});
             }
           }
@@ -970,6 +1002,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       }
     }
   };
+
+  using CountMiniDoubletConnections = CountMiniDoubletConnectionsT<false>;
+  using CountMiniDoubletConnectionsReduceMem = CountMiniDoubletConnectionsT<true>;
 
   struct CreateSegmentArrayRanges {
     ALPAKA_FN_ACC void operator()(Acc1D const& acc,

--- a/RecoTracker/LSTCore/src/alpaka/Triplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Triplet.h
@@ -515,7 +515,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return true;
   }
 
-  struct CreateTriplets {
+  template <bool ReduceMem>
+  struct CreateTripletsT {
     ALPAKA_FN_ACC void operator()(Acc3D const& acc,
                                   ModulesConst modules,
                                   MiniDoubletsConst mds,
@@ -542,6 +543,69 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       const int blockSize = blockSizeX * blockSizeY;
       const int flatThreadIdxXY = threadIdY * blockSizeX + threadIdX;
       const int flatThreadExtent = blockSize;  // total threads per block
+
+      auto tryAddTriplet = [&](unsigned int innerSegmentIndex,
+                               unsigned int outerSegmentIndex,
+                               uint16_t innerInnerLowerModuleIndex,
+                               uint16_t middleLowerModuleIndex,
+                               uint16_t outerOuterLowerModuleIndex) {
+        float betaIn, betaInCut, circleRadius, circleCenterX, circleCenterY;
+        short charge;
+        float t3Scores[dnn::t3dnn::kOutputFeatures] = {0.f};
+
+        bool success = runTripletConstraintsAndAlgo(acc,
+                                                    modules,
+                                                    mds,
+                                                    segments,
+                                                    innerInnerLowerModuleIndex,
+                                                    middleLowerModuleIndex,
+                                                    outerOuterLowerModuleIndex,
+                                                    innerSegmentIndex,
+                                                    outerSegmentIndex,
+                                                    betaIn,
+                                                    betaInCut,
+                                                    circleRadius,
+                                                    circleCenterX,
+                                                    circleCenterY,
+                                                    ptCut,
+                                                    t3Scores,
+                                                    charge);
+        if (!success)
+          return;
+        unsigned int totOccupancyTriplets =
+            alpaka::atomicAdd(acc,
+                              &tripletsOccupancy.totOccupancyTriplets()[innerInnerLowerModuleIndex],
+                              1u,
+                              alpaka::hierarchy::Threads{});
+        if (static_cast<int>(totOccupancyTriplets) >= ranges.tripletModuleOccupancy()[innerInnerLowerModuleIndex]) {
+#ifdef WARNINGS
+          printf("Triplet excess alert! Module index = %d, Occupancy = %d\n",
+                 innerInnerLowerModuleIndex,
+                 totOccupancyTriplets);
+#endif
+          return;
+        }
+        unsigned int tripletModuleIndex = alpaka::atomicAdd(
+            acc, &tripletsOccupancy.nTriplets()[innerInnerLowerModuleIndex], 1u, alpaka::hierarchy::Threads{});
+        unsigned int tripletIndex = ranges.tripletModuleIndices()[innerInnerLowerModuleIndex] + tripletModuleIndex;
+        addTripletToMemory(modules,
+                           mds,
+                           segments,
+                           triplets,
+                           innerSegmentIndex,
+                           outerSegmentIndex,
+                           innerInnerLowerModuleIndex,
+                           middleLowerModuleIndex,
+                           outerOuterLowerModuleIndex,
+                           betaIn,
+                           betaInCut,
+                           circleRadius,
+                           circleCenterX,
+                           circleCenterY,
+                           tripletIndex,
+                           t3Scores,
+                           charge);
+      };
 
       for (uint16_t innerLowerModuleArrayIdx : cms::alpakatools::uniform_groups_z(acc, nonZeroModules)) {
         if (cms::alpakatools::once_per_block(acc)) {
@@ -591,6 +655,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             if (not passPointingConstraint(acc, innerSegData, x3, y3, outerSubdet, ptCut))
               continue;
 
+            if constexpr (ReduceMem) {
+              tryAddTriplet(innerSegmentIndex,
+                            outerSegmentIndex,
+                            innerInnerLowerModuleIndex,
+                            middleLowerModuleIndex,
+                            outerOuterLowerModuleIndex);
+              continue;
+            }
+
             // Match inner Sg and Outer Sg
             int mIdx = alpaka::atomicAdd(acc, &matchCount, 1, alpaka::hierarchy::Threads{});
 
@@ -614,6 +687,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           }
         }
 
+        if constexpr (ReduceMem)
+          continue;
+
         alpaka::syncBlockThreads(acc);
         if (matchCount == 0) {
           continue;
@@ -628,71 +704,21 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           uint16_t middleLowerModuleIndex = segments.outerLowerModuleIndices()[innerSegmentIndex];
           uint16_t outerOuterLowerModuleIndex = segments.outerLowerModuleIndices()[outerSegmentIndex];
 
-          float betaIn, betaInCut, circleRadius, circleCenterX, circleCenterY;
-          short charge;
-
-          float t3Scores[dnn::t3dnn::kOutputFeatures] = {0.f};
-
-          bool success = runTripletConstraintsAndAlgo(acc,
-                                                      modules,
-                                                      mds,
-                                                      segments,
-                                                      innerInnerLowerModuleIndex,
-                                                      middleLowerModuleIndex,
-                                                      outerOuterLowerModuleIndex,
-                                                      innerSegmentIndex,
-                                                      outerSegmentIndex,
-                                                      betaIn,
-                                                      betaInCut,
-                                                      circleRadius,
-                                                      circleCenterX,
-                                                      circleCenterY,
-                                                      ptCut,
-                                                      t3Scores,
-                                                      charge);
-          if (success) {
-            unsigned int totOccupancyTriplets =
-                alpaka::atomicAdd(acc,
-                                  &tripletsOccupancy.totOccupancyTriplets()[innerInnerLowerModuleIndex],
-                                  1u,
-                                  alpaka::hierarchy::Threads{});
-            if (static_cast<int>(totOccupancyTriplets) >= ranges.tripletModuleOccupancy()[innerInnerLowerModuleIndex]) {
-#ifdef WARNINGS
-              printf("Triplet excess alert! Module index = %d, Occupancy = %d\n",
-                     innerInnerLowerModuleIndex,
-                     totOccupancyTriplets);
-#endif
-            } else {
-              unsigned int tripletModuleIndex = alpaka::atomicAdd(
-                  acc, &tripletsOccupancy.nTriplets()[innerInnerLowerModuleIndex], 1u, alpaka::hierarchy::Threads{});
-              unsigned int tripletIndex =
-                  ranges.tripletModuleIndices()[innerInnerLowerModuleIndex] + tripletModuleIndex;
-
-              addTripletToMemory(modules,
-                                 mds,
-                                 segments,
-                                 triplets,
-                                 innerSegmentIndex,
-                                 outerSegmentIndex,
-                                 innerInnerLowerModuleIndex,
-                                 middleLowerModuleIndex,
-                                 outerOuterLowerModuleIndex,
-                                 betaIn,
-                                 betaInCut,
-                                 circleRadius,
-                                 circleCenterX,
-                                 circleCenterY,
-                                 tripletIndex,
-                                 t3Scores,
-                                 charge);
-            }
-          }
+          tryAddTriplet(innerSegmentIndex,
+                        outerSegmentIndex,
+                        innerInnerLowerModuleIndex,
+                        middleLowerModuleIndex,
+                        outerOuterLowerModuleIndex);
         }
       }
     }
   };
 
-  struct CountSegmentConnections {
+  using CreateTriplets = CreateTripletsT<false>;
+  using CreateTripletsReduceMem = CreateTripletsT<true>;
+
+  template <bool ReduceMem>
+  struct CountSegmentConnectionsT {
     ALPAKA_FN_ACC void operator()(Acc3D const& acc,
                                   ModulesConst modules,
                                   MiniDoubletsConst mds,
@@ -739,12 +765,40 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             if (not passPointingConstraint(acc, innerSegData, x3, y3, outerSubdet, ptCut))
               continue;
 
-            alpaka::atomicAdd(acc, &segments.connectedMax()[innerSegmentIndex], 1u, alpaka::hierarchy::Threads{});
+            bool counts = true;
+            if constexpr (ReduceMem) {
+              float betaIn, betaInCut, circleRadius, circleCenterX, circleCenterY;
+              short charge;
+              float t3Scores[dnn::t3dnn::kOutputFeatures] = {0.f};
+              counts = runTripletConstraintsAndAlgo(acc,
+                                                    modules,
+                                                    mds,
+                                                    segments,
+                                                    innerLowerModuleArrayIdx,
+                                                    middleLowerModuleIndex,
+                                                    outerOuterLowerModuleIndex,
+                                                    innerSegmentIndex,
+                                                    outerSegmentIndex,
+                                                    betaIn,
+                                                    betaInCut,
+                                                    circleRadius,
+                                                    circleCenterX,
+                                                    circleCenterY,
+                                                    ptCut,
+                                                    t3Scores,
+                                                    charge);
+            }
+            if (counts) {
+              alpaka::atomicAdd(acc, &segments.connectedMax()[innerSegmentIndex], 1u, alpaka::hierarchy::Threads{});
+            }
           }
         }
       }
     }
   };
+
+  using CountSegmentConnections = CountSegmentConnectionsT<false>;
+  using CountSegmentConnectionsReduceMem = CountSegmentConnectionsT<true>;
 
   struct CreateTripletArrayRanges {
     ALPAKA_FN_ACC void operator()(Acc1D const& acc,

--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -72,8 +72,10 @@ int main(int argc, char **argv) {
       "I,job_index",
       "job_index of split jobs (--nsplit_jobs must be set. index starts from 0. i.e. 0, 1, 2, 3, etc...)",
       cxxopts::value<int>())("3,tc_pls_triplets", "Allow triplet pLSs in TC collection")(
-      "2,no_pls_dupclean", "Disable pLS duplicate cleaning (both steps)")("h,help", "Print help")(
-      "md", "Write MD branches in output ntuple.")("ls", "Write LS branches in output ntuple.")(
+      "2,no_pls_dupclean", "Disable pLS duplicate cleaning (both steps)")(
+      "reduce_mem_by_full_precompute",
+      "Run extra counting kernels to exactly size MD/LS/T3/T5/T4 buffers (lower mem, small runtime cost)")(
+      "h,help", "Print help")("md", "Write MD branches in output ntuple.")("ls", "Write LS branches in output ntuple.")(
       "t3", "Write T3 branches in output ntuple.")("t5", "Write T5 branches in output ntuple.")(
       "pls", "Write pLS branches in output ntuple.")("pt3", "Write pT3 branches in output ntuple.")(
       "pt5", "Write pT5 branches in output ntuple.")("occ", "Write occupancy branches in output ntuple.")(
@@ -256,6 +258,10 @@ int main(int argc, char **argv) {
   ana.no_pls_dupclean = result["no_pls_dupclean"].as<bool>();
 
   //_______________________________________________________________________________
+  // --reduce_mem_by_full_precompute
+  ana.reduce_mem_by_full_precompute = result["reduce_mem_by_full_precompute"].as<bool>();
+
+  //_______________________________________________________________________________
   // --md
   ana.md_branches = result["md"].as<bool>() || result["allobj"].as<bool>();
 
@@ -331,6 +337,7 @@ int main(int argc, char **argv) {
   std::cout << " ana.nmatch_threshold: " << ana.nmatch_threshold << std::endl;
   std::cout << " ana.tc_pls_triplets: " << ana.tc_pls_triplets << std::endl;
   std::cout << " ana.no_pls_dupclean: " << ana.no_pls_dupclean << std::endl;
+  std::cout << " ana.reduce_mem_by_full_precompute: " << ana.reduce_mem_by_full_precompute << std::endl;
   std::cout << "=========================================================" << std::endl;
 
   // Create the TChain that holds the TTree's of the baby ntuples
@@ -439,7 +446,8 @@ void run_lst() {
   std::vector<LSTEvent *> events;
   std::vector<ALPAKA_ACCELERATOR_NAMESPACE::Queue *> event_queues;
   for (int s = 0; s < ana.streams; s++) {
-    LSTEvent *event = new LSTEvent(ana.verbose >= 2, ana.ptCut, ana.clustSizeCut, queues[s], &deviceESData);
+    LSTEvent *event = new LSTEvent(
+        ana.verbose >= 2, ana.ptCut, ana.clustSizeCut, queues[s], &deviceESData, ana.reduce_mem_by_full_precompute);
     events.push_back(event);
     event_queues.push_back(&queues[s]);
   }

--- a/RecoTracker/LSTCore/standalone/code/core/AnalysisConfig.h
+++ b/RecoTracker/LSTCore/standalone/code/core/AnalysisConfig.h
@@ -132,6 +132,9 @@ public:
   // Boolean to disable pLS duplicate cleaning
   bool no_pls_dupclean;
 
+  // Boolean to enable reduced-memory mode via exact precompute counting kernels
+  bool reduce_mem_by_full_precompute;
+
   // Boolean to enable MD branches
   bool md_branches;
 


### PR DESCRIPTION
This PR adds a `reduceMemByFullPrecompute` runtime flag that enables exact buffer sizing for all LST objects (LS, T3, T5, T4) in each counting kernel, reducing average memory usage from ~80 MB to ~33 MB per event. When the flag is off (default), behavior is identical to master with negligible timing overhead, as the new kernel launches are gated behind host-side `if (reduceMemByFullPrecompute_)` checks and use templated kernel variants. The flag is exposed as `--reduce_mem_by_full_precompute` in standalone and as a `reduceMemByFullPrecompute` config parameter in the CMSSW EDProducer. Increases LST time/event by roughly 10-20% on CPU and GPU (depending on stream count, lower when running multiple streams) for a 60-70% reduction in total memory. Table below shows average and max decreases in memory per event over 100 events.

<img width="892" height="515" alt="Screenshot 2026-05-08 at 11 54 48 AM" src="https://github.com/user-attachments/assets/7b18df6a-4816-4939-9000-64d4dccddd74" />

c.c @slava77