### PR TITLE
Fix for testModelJit unit test

### DIFF
--- a/PhysicsTools/PyTorch/interface/Model.h
+++ b/PhysicsTools/PyTorch/interface/Model.h
@@ -28,7 +28,7 @@ namespace cms::torch {
       if (dev == device_)
         return;
 
-      assert(!is_frozen_ && "Model is frozen, cannot be moved to another device!");
+      TORCH_CHECK(!is_frozen_ && "Model is frozen, cannot be moved to another device!");
       model_.to(dev, non_blocking);
       device_ = dev;
       if (auto_freeze_) {

--- a/PhysicsTools/PyTorch/test/testModelJit.cc
+++ b/PhysicsTools/PyTorch/test/testModelJit.cc
@@ -78,13 +78,21 @@ namespace torchtest {
 
     auto m_path = edm::FileInPath(modelPath).fullPath();
     forEachCudaDevice([&](auto dev) {
-      auto m = cms::torch::Model(m_path);
+      auto m = cms::torch::Model(m_path, false);
       m.to(dev);
 
       CPPUNIT_ASSERT_EQUAL(dev, m.device());
 
       m.to(::torch::kCPU);
       CPPUNIT_ASSERT_EQUAL(::torch::kCPU, m.device().type());
+    });
+
+    forEachCudaDevice([&](auto dev) {
+      auto m = cms::torch::Model(m_path);
+      m.to(dev);
+
+      CPPUNIT_ASSERT_EQUAL(dev, m.device());
+      CPPUNIT_ASSERT_THROW(m.to(::torch::kCPU), c10::Error);
     });
   }
 


### PR DESCRIPTION
This PR should fix the failing ` testModelJit ` unit test. The code in `TestModelJIT::testToDevice_UpdatesUnderlyingState` was creating a `torch::Model` with default `auto_freeze=true`.  First call to `Model.to()` then sets  `is_forzen_=true` and 2nd call `m.to(::torch::kCPU);` should have asserted.

```
      auto m = cms::torch::Model(m_path);
      m.to(dev);
      CPPUNIT_ASSERT_EQUAL(dev, m.device());
      m.to(::torch::kCPU);
      CPPUNIT_ASSERT_EQUAL(::torch::kCPU, m.device().type());
```

This PR propose to test both auto_freeze ON and OFF. 
`auto_freeze=false`: Multiple calls to `Model.to(dev)` should not assert
`auto_freeze=true`:  First call to `Model.to(dev)` should work but next call to `Model.to(dev2)` should throw.

@lukaszmichalskii , I think for `cms::torch::Model` constructor , we should call the freeze() if auto_freeze is true. Currently model become frozen only after calling first `Model.to(dev)` . If the intend is that if a model is created with auto_freeze then it should not be allowed to move to different device then may be we should call `freeze()` in the constructor
