### PR TITLE
GEMDigiToRawModule Performance Optimization

### DIFF
--- a/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
@@ -124,14 +124,7 @@ void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
         else
           bx = 0;
       }
-      auto search = gemBxMap.find(bx);
-      if (search != gemBxMap.end()) {
-        search->second.insertDigi(gemId, *digi);
-      } else {
-        GEMDigiCollection newGDC;
-        newGDC.insertDigi(gemId, *digi);
-        gemBxMap.insert(std::pair<int, GEMDigiCollection>(bx, newGDC));
-      }
+      gemBxMap[bx].insertDigi(gemId, *digi);
     }
   }
 
@@ -167,7 +160,7 @@ void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
               uint64_t lsData = 0;  ///<channels from 1to64
               uint64_t msData = 0;  ///<channels from 65to128
 
-              GEMDigiCollection inBxGemDigis = gemBx.second;
+              const GEMDigiCollection& inBxGemDigis = gemBx.second;
               const GEMDigiCollection::Range& range = inBxGemDigis.get(gemId);
 
               for (GEMDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {


### PR DESCRIPTION
#### PR description:

This PR is a result of running Claude to find bottlenecks and easy optimizations in Phase 2 workflows. 

GEMDigiToRawModule is a CMSSW EDProducer that packs simulated GEM detector hits (digis) into the binary FED raw data format that mimics what real GEM front-end electronics would produce. It runs once per event as part of the DIGI2RAW step.
                                                                                                                                                         
  The packing algorithm works in two phases:                                                                                                             
  1. Build a BX map: group all input digis by bunch crossing (BX) number into a std::map<int, GEMDigiCollection>
  2. Encode to FED format: iterate over all FEDs × AMCs × GEBs × VFATs × eta partitions × BX entries to pack hit channel bits into the binary output     
                                                            
  ---                                                                                                                                                    
  1. Why the original implementation was sub-optimal        
                                                                                                                                                         
  There were two independent performance problems, both involving unnecessary copies of GEMDigiCollection objects.
                                                                                                                                                         
  Problem A — Inner loop copy (the dominant bottleneck)                                                                                                  
                                                                                                                                                         
  In the second phase, the code iterates over every combination of detector geometry element and BX entry. For each BX entry in the map, it did:         
                                                            
  // Inside a loop over: FEDs × AMCs × GEBs × VFATs × eta partitions                                                                                     
  for (auto const& gemBx : gemBxMap) {                                                                                                                   
      GEMDigiCollection inBxGemDigis = gemBx.second;  // BUG: copy by value                                                                              
      const GEMDigiCollection::Range& range = inBxGemDigis.get(gemId);                                                                                   
      // ... read-only access to range                                                                                                                   
  }                                                                                                                                                      
                                                                                                                                                         
  gemBx.second is a GEMDigiCollection — a container holding all the GEM hits for one bunch crossing, which at 200 pileup contains thousands of digis. The
   assignment GEMDigiCollection inBxGemDigis = gemBx.second performs a full deep copy of this collection every single iteration. Since inBxGemDigis is
  only ever read (the .get(gemId) call is a const lookup), the copy is entirely wasted work.                                                             
                                                            
  The geometry loop structure that surrounds this means the copy happens an enormous number of times per event:                                          
   
  12 FEDs × ~6 AMCs × ~24 GEBs × ~24 VFATs × ~8 eta partitions × ~7 BX entries                                                                           
  ≈ ~600,000 GEMDigiCollection copies per event                                                                                                          
                                                                                                                                                         
  At 200 pileup, each GEMDigiCollection holds O(10,000) digis. Copying it 600,000 times per event dominates the entire module's CPU time.                
                                                                                                                                                         
  Problem B — Map insertion with extra copy                                                                                                              
                                                            
  In the first phase, building the BX map:

  auto search = gemBxMap.find(bx);                                                                                                                       
  if (search != gemBxMap.end()) {
      search->second.insertDigi(gemId, *digi);                                                                                                           
  } else {                                                                                                                                               
      GEMDigiCollection newGDC;           // create temporary
      newGDC.insertDigi(gemId, *digi);    // insert into temporary                                                                                       
      gemBxMap.insert(std::pair<int, GEMDigiCollection>(bx, newGDC));  // copy into map
  }                                                                                                                                                      
                                                            
  When a new BX key is encountered, this creates a temporary GEMDigiCollection, inserts one digi into it, then copies it into the map via std::pair. This
   is two unnecessary operations — the temporary object and the copy — when a single in-place construction would suffice.
                                                                                                                                                         
  ---       
                                                
  2. Why the new implementation has better CPU performance
                                                                                                                                                         
  Fix A — Replace copy with const reference
                                                                                                                                                         
  const GEMDigiCollection& inBxGemDigis = gemBx.second;  // reference, zero cost
                                                                                                                                                         
  A reference binds to the existing object in the map with no allocation and no data movement. The .get(gemId) call is identical in behavior — it looks  
  up a range within the collection — but now it operates directly on the map's stored object. This eliminates ~600,000 GEMDigiCollection deep copies per 
  event.                                                                                                                                                 
                                                            
  Fix B — Use operator[] for map insertion                                                                                                               
   
  gemBxMap[bx].insertDigi(gemId, *digi);                                                                                                                 

  std::map::operator[] does exactly what is needed: if bx exists, it returns a reference to the existing value; if it doesn't exist, it
  default-constructs a new GEMDigiCollection in-place and returns a reference to it. Either way, insertDigi is called directly on the map-resident object
   with no temporaries and no copies.

  Measured speedup: benchmarked over 500 events, 6 threads, CPU-only (no GPU), using workflow 29834.21

  ┌──────────┬───────────────┬───────────┐
  │          │ gemPacker CPU │ per event │
  ├──────────┼───────────────┼───────────┤
  │ Original │ 3.012 s       │ 6.02 ms   │
  ├──────────┼───────────────┼───────────┤
  │ Fixed    │ 0.029 s       │ 0.06 ms   │
  ├──────────┼───────────────┼───────────┤
  │ Speedup  │               │ ~100×     │
  └──────────┴───────────────┴───────────┘

  At the whole-job level (step2 including all other DIGI, L1, HLT modules), this translates to a 14% reduction in total CPU time.

  ---
  3. Why the output is unchanged, and how it was verified

  Why the output should be identical (by construction)

  Both fixes are purely mechanical refactors of the data access pattern — they do not change the algorithm, the order of operations, or the data that
  ends up in the output.

  - Fix A: replacing a value copy with a const reference gives the same read result. const GEMDigiCollection& x = obj and GEMDigiCollection x = obj
  followed by read-only access to x are semantically equivalent — the only difference is that the copy wastes memory and CPU.
  - Fix B: std::map::operator[] with a default-constructed value, followed by insertDigi, produces exactly the same map contents as the
  find/construct-temporary/insert pattern. Both result in a map entry for key bx containing a GEMDigiCollection with the digi inserted. The
  GEMDigiCollection internal data structure (edm::RangeMap) is order-stable, so the in-place insertion and the copy-from-temporary insertion produce
  identical internal state.


#### PR validation:

  Two independent checks were performed:

  1. Bitwise comparison of FED raw output: step2.root (produced with the original code) and step2_fixed.root (produced with the fixed code) were compared
   event-by-event using a ROOT macro that reads the FEDRawDataCollection branch directly and calls memcmp on the raw byte buffer of each of the 12 GEM
  FED IDs (1467–1478) for all 10 events. Total data compared: ~2.1 MB of GEM FED raw bytes. Result: every byte identical across all FEDs and all events.
  2. End-to-end workflow check: the fixed step2.root was fed into the standard step3 (RAW2DIGI + RECO) workflow without errors or anomalous output,
  confirming that the downstream GEM unpacker (GEMRawToDigiModule) successfully decodes the packed data.\


The PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) running from CMSSW_16_1_0_pre4

