### PR TITLE
DQM/SiTrackerPhase2: Streamline and clean up DQM code

### DIFF
--- a/DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h
+++ b/DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h
@@ -23,14 +23,24 @@ namespace phase2tkutil {
   MonitorElement* bookProfile1DFromPSet(const edm::ParameterSet& hpars, DQMStore::IBooker& ibooker);
 
   void add1DDesc(edm::ParameterSetDescription& desc,
-                 const std::string& psetKey, const std::string& histName,
-                 const std::string& xlabel, const std::string& ylabel,
-                 int nbins, double xmin, double xmax);
+                 const std::string& psetKey,
+                 const std::string& histName,
+                 const std::string& xlabel,
+                 const std::string& ylabel,
+                 int nbins,
+                 double xmin,
+                 double xmax);
 
   void add2DDesc(edm::ParameterSetDescription& desc,
-                 const std::string& psetKey, const std::string& histName,
-                 const std::string& xlabel, const std::string& ylabel,
-                 int nbx, double xmin, double xmax,
-                 int nby, double ymin, double ymax);
+                 const std::string& psetKey,
+                 const std::string& histName,
+                 const std::string& xlabel,
+                 const std::string& ylabel,
+                 int nbx,
+                 double xmin,
+                 double xmax,
+                 int nby,
+                 double ymin,
+                 double ymax);
 }  // namespace phase2tkutil
 #endif

--- a/DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h
+++ b/DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h
@@ -2,6 +2,7 @@
 #define _DQM_SiTrackerPhase2_Phase2TrackerValidationUtil_h
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <string>
@@ -20,5 +21,16 @@ namespace phase2tkutil {
   MonitorElement* book2DFromPSet(const edm::ParameterSet& hpars, DQMStore::IBooker& ibooker);
 
   MonitorElement* bookProfile1DFromPSet(const edm::ParameterSet& hpars, DQMStore::IBooker& ibooker);
+
+  void add1DDesc(edm::ParameterSetDescription& desc,
+                 const std::string& psetKey, const std::string& histName,
+                 const std::string& xlabel, const std::string& ylabel,
+                 int nbins, double xmin, double xmax);
+
+  void add2DDesc(edm::ParameterSetDescription& desc,
+                 const std::string& psetKey, const std::string& histName,
+                 const std::string& xlabel, const std::string& ylabel,
+                 int nbx, double xmin, double xmax,
+                 int nby, double ymin, double ymax);
 }  // namespace phase2tkutil
 #endif

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTCluster.cc
@@ -45,6 +45,8 @@
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h"
+#include "L1Trigger/TrackFindingTracklet/interface/Settings.h"
 
 class Phase2OTMonitorTTCluster : public DQMEDAnalyzer {
 public:
@@ -58,13 +60,13 @@ public:
   MonitorElement *Cluster_IMem_Barrel = nullptr;
   MonitorElement *Cluster_IMem_Endcap_Disc = nullptr;
   MonitorElement *Cluster_IMem_Endcap_Ring = nullptr;
-  MonitorElement *Cluster_IMem_Endcap_Ring_Fw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
-  MonitorElement *Cluster_IMem_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
+  MonitorElement *Cluster_IMem_Endcap_Ring_Fw[trklet::N_DISK] = {};
+  MonitorElement *Cluster_IMem_Endcap_Ring_Bw[trklet::N_DISK] = {};
   MonitorElement *Cluster_OMem_Barrel = nullptr;
   MonitorElement *Cluster_OMem_Endcap_Disc = nullptr;
   MonitorElement *Cluster_OMem_Endcap_Ring = nullptr;
-  MonitorElement *Cluster_OMem_Endcap_Ring_Fw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
-  MonitorElement *Cluster_OMem_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
+  MonitorElement *Cluster_OMem_Endcap_Ring_Fw[trklet::N_DISK] = {};
+  MonitorElement *Cluster_OMem_Endcap_Ring_Bw[trklet::N_DISK] = {};
   MonitorElement *Cluster_W = nullptr;
   MonitorElement *Cluster_Phi = nullptr;
   MonitorElement *Cluster_R = nullptr;
@@ -192,298 +194,70 @@ void Phase2OTMonitorTTCluster::analyze(const edm::Event &iEvent, const edm::Even
 void Phase2OTMonitorTTCluster::bookHistograms(DQMStore::IBooker &iBooker,
                                               edm::Run const &run,
                                               edm::EventSetup const &es) {
-  std::string HistoName;
-  const int numDiscs = 5;
+  using namespace phase2tkutil;
 
   iBooker.setCurrentFolder(topFolderName_ + "/Clusters/NClusters");
+  Cluster_IMem_Barrel      = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Barrel"),      iBooker);
+  Cluster_OMem_Barrel      = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Barrel"),      iBooker);
+  Cluster_IMem_Endcap_Disc = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Endcap_Disc"), iBooker);
+  Cluster_OMem_Endcap_Disc = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Endcap_Disc"), iBooker);
+  Cluster_IMem_Endcap_Ring = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Endcap_Ring"), iBooker);
+  Cluster_OMem_Endcap_Ring = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Endcap_Ring"), iBooker);
 
-  // NClusters
-  edm::ParameterSet psTTCluster_Barrel = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Barrel");
-  HistoName = "NClusters_IMem_Barrel";
-  Cluster_IMem_Barrel = iBooker.book1D(HistoName,
-                                       HistoName,
-                                       psTTCluster_Barrel.getParameter<int32_t>("Nbinsx"),
-                                       psTTCluster_Barrel.getParameter<double>("xmin"),
-                                       psTTCluster_Barrel.getParameter<double>("xmax"));
-  Cluster_IMem_Barrel->setAxisTitle("Barrel Layer", 1);
-  Cluster_IMem_Barrel->setAxisTitle("# L1 Clusters", 2);
-
-  HistoName = "NClusters_OMem_Barrel";
-  Cluster_OMem_Barrel = iBooker.book1D(HistoName,
-                                       HistoName,
-                                       psTTCluster_Barrel.getParameter<int32_t>("Nbinsx"),
-                                       psTTCluster_Barrel.getParameter<double>("xmin"),
-                                       psTTCluster_Barrel.getParameter<double>("xmax"));
-  Cluster_OMem_Barrel->setAxisTitle("Barrel Layer", 1);
-  Cluster_OMem_Barrel->setAxisTitle("# L1 Clusters", 2);
-
-  edm::ParameterSet psTTCluster_ECDisc = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_ECDiscs");
-  HistoName = "NClusters_IMem_Endcap_Disc";
-  Cluster_IMem_Endcap_Disc = iBooker.book1D(HistoName,
-                                            HistoName,
-                                            psTTCluster_ECDisc.getParameter<int32_t>("Nbinsx"),
-                                            psTTCluster_ECDisc.getParameter<double>("xmin"),
-                                            psTTCluster_ECDisc.getParameter<double>("xmax"));
-  Cluster_IMem_Endcap_Disc->setAxisTitle("Endcap Disc", 1);
-  Cluster_IMem_Endcap_Disc->setAxisTitle("# L1 Clusters", 2);
-
-  HistoName = "NClusters_OMem_Endcap_Disc";
-  Cluster_OMem_Endcap_Disc = iBooker.book1D(HistoName,
-                                            HistoName,
-                                            psTTCluster_ECDisc.getParameter<int32_t>("Nbinsx"),
-                                            psTTCluster_ECDisc.getParameter<double>("xmin"),
-                                            psTTCluster_ECDisc.getParameter<double>("xmax"));
-  Cluster_OMem_Endcap_Disc->setAxisTitle("Endcap Disc", 1);
-  Cluster_OMem_Endcap_Disc->setAxisTitle("# L1 Clusters", 2);
-
-  edm::ParameterSet psTTCluster_ECRing = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_ECRings");
-  HistoName = "NClusters_IMem_Endcap_Ring";
-  Cluster_IMem_Endcap_Ring = iBooker.book1D(HistoName,
-                                            HistoName,
-                                            psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
-                                            psTTCluster_ECRing.getParameter<double>("xmin"),
-                                            psTTCluster_ECRing.getParameter<double>("xmax"));
-  Cluster_IMem_Endcap_Ring->setAxisTitle("Endcap Ring", 1);
-  Cluster_IMem_Endcap_Ring->setAxisTitle("# L1 Clusters", 2);
-
-  HistoName = "NClusters_OMem_Endcap_Ring";
-  Cluster_OMem_Endcap_Ring = iBooker.book1D(HistoName,
-                                            HistoName,
-                                            psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
-                                            psTTCluster_ECRing.getParameter<double>("xmin"),
-                                            psTTCluster_ECRing.getParameter<double>("xmax"));
-  Cluster_OMem_Endcap_Ring->setAxisTitle("Endcap Ring", 1);
-  Cluster_OMem_Endcap_Ring->setAxisTitle("# L1 Clusters", 2);
-
-  for (int i = 0; i < numDiscs; i++) {
-    HistoName = "NClusters_IMem_Disc+" + std::to_string(i + 1);
-    Cluster_IMem_Endcap_Ring_Fw[i] = iBooker.book1D(HistoName,
-                                                    HistoName,
-                                                    psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
-                                                    psTTCluster_ECRing.getParameter<double>("xmin"),
-                                                    psTTCluster_ECRing.getParameter<double>("xmax"));
-    Cluster_IMem_Endcap_Ring_Fw[i]->setAxisTitle("Endcap Ring", 1);
-    Cluster_IMem_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Clusters ", 2);
-  }
-
-  for (int i = 0; i < numDiscs; i++) {
-    HistoName = "NClusters_IMem_Disc-" + std::to_string(i + 1);
-    Cluster_IMem_Endcap_Ring_Bw[i] = iBooker.book1D(HistoName,
-                                                    HistoName,
-                                                    psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
-                                                    psTTCluster_ECRing.getParameter<double>("xmin"),
-                                                    psTTCluster_ECRing.getParameter<double>("xmax"));
-    Cluster_IMem_Endcap_Ring_Bw[i]->setAxisTitle("Endcap Ring", 1);
-    Cluster_IMem_Endcap_Ring_Bw[i]->setAxisTitle("# L1 Clusters ", 2);
-  }
-
-  for (int i = 0; i < numDiscs; i++) {
-    HistoName = "NClusters_OMem_Disc+" + std::to_string(i + 1);
-    Cluster_OMem_Endcap_Ring_Fw[i] = iBooker.book1D(HistoName,
-                                                    HistoName,
-                                                    psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
-                                                    psTTCluster_ECRing.getParameter<double>("xmin"),
-                                                    psTTCluster_ECRing.getParameter<double>("xmax"));
-    Cluster_OMem_Endcap_Ring_Fw[i]->setAxisTitle("Endcap Ring", 1);
-    Cluster_OMem_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Clusters ", 2);
-  }
-
-  for (int i = 0; i < numDiscs; i++) {
-    HistoName = "NClusters_OMem_Disc-" + std::to_string(i + 1);
-    Cluster_OMem_Endcap_Ring_Bw[i] = iBooker.book1D(HistoName,
-                                                    HistoName,
-                                                    psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
-                                                    psTTCluster_ECRing.getParameter<double>("xmin"),
-                                                    psTTCluster_ECRing.getParameter<double>("xmax"));
-    Cluster_OMem_Endcap_Ring_Bw[i]->setAxisTitle("Endcap Ring", 1);
-    Cluster_OMem_Endcap_Ring_Bw[i]->setAxisTitle("# L1 Clusters ", 2);
+  for (int i = 0; i < static_cast<int>(trklet::N_DISK); i++) {
+    const std::string si = std::to_string(i + 1);
+    Cluster_IMem_Endcap_Ring_Fw[i] = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Disc_Fw_" + si), iBooker);
+    Cluster_IMem_Endcap_Ring_Bw[i] = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Disc_Bw_" + si), iBooker);
+    Cluster_OMem_Endcap_Ring_Fw[i] = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Disc_Fw_" + si), iBooker);
+    Cluster_OMem_Endcap_Ring_Bw[i] = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Disc_Bw_" + si), iBooker);
   }
 
   iBooker.setCurrentFolder(topFolderName_ + "/Clusters");
-
-  // Cluster Width
-  edm::ParameterSet psTTClusterWidth = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Width");
-  HistoName = "Cluster_W";
-  Cluster_W = iBooker.book2D(HistoName,
-                             HistoName,
-                             psTTClusterWidth.getParameter<int32_t>("Nbinsx"),
-                             psTTClusterWidth.getParameter<double>("xmin"),
-                             psTTClusterWidth.getParameter<double>("xmax"),
-                             psTTClusterWidth.getParameter<int32_t>("Nbinsy"),
-                             psTTClusterWidth.getParameter<double>("ymin"),
-                             psTTClusterWidth.getParameter<double>("ymax"));
-  Cluster_W->setAxisTitle("L1 Cluster Width", 1);
-  Cluster_W->setAxisTitle("Stack Member", 2);
-
-  // Cluster eta distribution
-  edm::ParameterSet psTTClusterEta = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Eta");
-  HistoName = "Cluster_Eta";
-  Cluster_Eta = iBooker.book1D(HistoName,
-                               HistoName,
-                               psTTClusterEta.getParameter<int32_t>("Nbinsx"),
-                               psTTClusterEta.getParameter<double>("xmin"),
-                               psTTClusterEta.getParameter<double>("xmax"));
-  Cluster_Eta->setAxisTitle("#eta", 1);
-  Cluster_Eta->setAxisTitle("# L1 Clusters ", 2);
-
-  // Cluster phi distribution
-  edm::ParameterSet psTTClusterPhi = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Phi");
-  HistoName = "Cluster_Phi";
-  Cluster_Phi = iBooker.book1D(HistoName,
-                               HistoName,
-                               psTTClusterPhi.getParameter<int32_t>("Nbinsx"),
-                               psTTClusterPhi.getParameter<double>("xmin"),
-                               psTTClusterPhi.getParameter<double>("xmax"));
-  Cluster_Phi->setAxisTitle("#phi", 1);
-  Cluster_Phi->setAxisTitle("# L1 Clusters", 2);
-
-  // Cluster R distribution
-  edm::ParameterSet psTTClusterR = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_R");
-  HistoName = "Cluster_R";
-  Cluster_R = iBooker.book1D(HistoName,
-                             HistoName,
-                             psTTClusterR.getParameter<int32_t>("Nbinsx"),
-                             psTTClusterR.getParameter<double>("xmin"),
-                             psTTClusterR.getParameter<double>("xmax"));
-  Cluster_R->setAxisTitle("R [cm]", 1);
-  Cluster_R->setAxisTitle("# L1 Clusters", 2);
+  Cluster_W   = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_W"),   iBooker);
+  Cluster_Eta = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_Eta"), iBooker);
+  Cluster_Phi = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_Phi"), iBooker);
+  Cluster_R   = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_R"),   iBooker);
 
   iBooker.setCurrentFolder(topFolderName_ + "/Clusters/Position");
+  Cluster_Barrel_XY    = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_Barrel_XY"),    iBooker);
+  Cluster_Endcap_Fw_XY = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_Endcap_Fw_XY"), iBooker);
+  Cluster_Endcap_Bw_XY = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_Endcap_Bw_XY"), iBooker);
+  Cluster_RZ           = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_RZ"),           iBooker);
+}
 
-  // Position plots
-  edm::ParameterSet psTTCluster_Barrel_XY = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
-  HistoName = "Cluster_Barrel_XY";
-  Cluster_Barrel_XY = iBooker.book2D(HistoName,
-                                     HistoName,
-                                     psTTCluster_Barrel_XY.getParameter<int32_t>("Nbinsx"),
-                                     psTTCluster_Barrel_XY.getParameter<double>("xmin"),
-                                     psTTCluster_Barrel_XY.getParameter<double>("xmax"),
-                                     psTTCluster_Barrel_XY.getParameter<int32_t>("Nbinsy"),
-                                     psTTCluster_Barrel_XY.getParameter<double>("ymin"),
-                                     psTTCluster_Barrel_XY.getParameter<double>("ymax"));
-  Cluster_Barrel_XY->setAxisTitle("L1 Cluster Barrel position x [cm]", 1);
-  Cluster_Barrel_XY->setAxisTitle("L1 Cluster Barrel position y [cm]", 2);
-
-  edm::ParameterSet psTTCluster_Endcap_Fw_XY = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
-  HistoName = "Cluster_Endcap_Fw_XY";
-  Cluster_Endcap_Fw_XY = iBooker.book2D(HistoName,
-                                        HistoName,
-                                        psTTCluster_Endcap_Fw_XY.getParameter<int32_t>("Nbinsx"),
-                                        psTTCluster_Endcap_Fw_XY.getParameter<double>("xmin"),
-                                        psTTCluster_Endcap_Fw_XY.getParameter<double>("xmax"),
-                                        psTTCluster_Endcap_Fw_XY.getParameter<int32_t>("Nbinsy"),
-                                        psTTCluster_Endcap_Fw_XY.getParameter<double>("ymin"),
-                                        psTTCluster_Endcap_Fw_XY.getParameter<double>("ymax"));
-  Cluster_Endcap_Fw_XY->setAxisTitle("L1 Cluster Forward Endcap position x [cm]", 1);
-  Cluster_Endcap_Fw_XY->setAxisTitle("L1 Cluster Forward Endcap position y [cm]", 2);
-
-  edm::ParameterSet psTTCluster_Endcap_Bw_XY = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
-  HistoName = "Cluster_Endcap_Bw_XY";
-  Cluster_Endcap_Bw_XY = iBooker.book2D(HistoName,
-                                        HistoName,
-                                        psTTCluster_Endcap_Bw_XY.getParameter<int32_t>("Nbinsx"),
-                                        psTTCluster_Endcap_Bw_XY.getParameter<double>("xmin"),
-                                        psTTCluster_Endcap_Bw_XY.getParameter<double>("xmax"),
-                                        psTTCluster_Endcap_Bw_XY.getParameter<int32_t>("Nbinsy"),
-                                        psTTCluster_Endcap_Bw_XY.getParameter<double>("ymin"),
-                                        psTTCluster_Endcap_Bw_XY.getParameter<double>("ymax"));
-  Cluster_Endcap_Bw_XY->setAxisTitle("L1 Cluster Backward Endcap position x [cm]", 1);
-  Cluster_Endcap_Bw_XY->setAxisTitle("L1 Cluster Backward Endcap position y [cm]", 2);
-
-  // TTCluster #rho vs. z
-  edm::ParameterSet psTTCluster_RZ = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_RZ");
-  HistoName = "Cluster_RZ";
-  Cluster_RZ = iBooker.book2D(HistoName,
-                              HistoName,
-                              psTTCluster_RZ.getParameter<int32_t>("Nbinsx"),
-                              psTTCluster_RZ.getParameter<double>("xmin"),
-                              psTTCluster_RZ.getParameter<double>("xmax"),
-                              psTTCluster_RZ.getParameter<int32_t>("Nbinsy"),
-                              psTTCluster_RZ.getParameter<double>("ymin"),
-                              psTTCluster_RZ.getParameter<double>("ymax"));
-  Cluster_RZ->setAxisTitle("L1 Cluster position z [cm]", 1);
-  Cluster_RZ->setAxisTitle("L1 Cluster position #rho [cm]", 2);
-
-}  // end of method
 void Phase2OTMonitorTTCluster::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
-  // OuterTrackerMonitorTTCluster
   edm::ParameterSetDescription desc;
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 7);
-    psd0.add<double>("xmax", 7.5);
-    psd0.add<double>("xmin", 0.5);
-    desc.add<edm::ParameterSetDescription>("TH1TTCluster_Barrel", psd0);
+
+  // NClusters
+  phase2tkutil::add1DDesc(desc, "NClusters_IMem_Barrel",      "NClusters_IMem_Barrel",      "Barrel Layer", "# L1 Clusters",  7, 0.5,  7.5);
+  phase2tkutil::add1DDesc(desc, "NClusters_OMem_Barrel",      "NClusters_OMem_Barrel",      "Barrel Layer", "# L1 Clusters",  7, 0.5,  7.5);
+  phase2tkutil::add1DDesc(desc, "NClusters_IMem_Endcap_Disc", "NClusters_IMem_Endcap_Disc", "Endcap Disc",  "# L1 Clusters",  6, 0.5,  6.5);
+  phase2tkutil::add1DDesc(desc, "NClusters_OMem_Endcap_Disc", "NClusters_OMem_Endcap_Disc", "Endcap Disc",  "# L1 Clusters",  6, 0.5,  6.5);
+  phase2tkutil::add1DDesc(desc, "NClusters_IMem_Endcap_Ring", "NClusters_IMem_Endcap_Ring", "Endcap Ring",  "# L1 Clusters", 16, 0.5, 16.5);
+  phase2tkutil::add1DDesc(desc, "NClusters_OMem_Endcap_Ring", "NClusters_OMem_Endcap_Ring", "Endcap Ring",  "# L1 Clusters", 16, 0.5, 16.5);
+
+  for (int i = 1; i <= static_cast<int>(trklet::N_DISK); i++) {
+    const std::string si = std::to_string(i);
+    phase2tkutil::add1DDesc(desc, "NClusters_IMem_Disc_Fw_" + si, "NClusters_IMem_Disc+" + si, "Endcap Ring", "# L1 Clusters", 16, 0.5, 16.5);
+    phase2tkutil::add1DDesc(desc, "NClusters_IMem_Disc_Bw_" + si, "NClusters_IMem_Disc-" + si, "Endcap Ring", "# L1 Clusters", 16, 0.5, 16.5);
+    phase2tkutil::add1DDesc(desc, "NClusters_OMem_Disc_Fw_" + si, "NClusters_OMem_Disc+" + si, "Endcap Ring", "# L1 Clusters", 16, 0.5, 16.5);
+    phase2tkutil::add1DDesc(desc, "NClusters_OMem_Disc_Bw_" + si, "NClusters_OMem_Disc-" + si, "Endcap Ring", "# L1 Clusters", 16, 0.5, 16.5);
   }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 6);
-    psd0.add<double>("xmax", 6.5);
-    psd0.add<double>("xmin", 0.5);
-    desc.add<edm::ParameterSetDescription>("TH1TTCluster_ECDiscs", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 16);
-    psd0.add<double>("xmin", 0.5);
-    psd0.add<double>("xmax", 16.5);
-    desc.add<edm::ParameterSetDescription>("TH1TTCluster_ECRings", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 45);
-    psd0.add<double>("xmax", 5.0);
-    psd0.add<double>("xmin", -5.0);
-    desc.add<edm::ParameterSetDescription>("TH1TTCluster_Eta", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 60);
-    psd0.add<double>("xmax", 3.5);
-    psd0.add<double>("xmin", -3.5);
-    desc.add<edm::ParameterSetDescription>("TH1TTCluster_Phi", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 45);
-    psd0.add<double>("xmax", 120);
-    psd0.add<double>("xmin", 0);
-    desc.add<edm::ParameterSetDescription>("TH1TTCluster_R", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 7);
-    psd0.add<double>("xmax", 6.5);
-    psd0.add<double>("xmin", -0.5);
-    psd0.add<int>("Nbinsy", 2);
-    psd0.add<double>("ymax", 1.5);
-    psd0.add<double>("ymin", -0.5);
-    desc.add<edm::ParameterSetDescription>("TH2TTCluster_Width", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 960);
-    psd0.add<double>("xmax", 120);
-    psd0.add<double>("xmin", -120);
-    psd0.add<int>("Nbinsy", 960);
-    psd0.add<double>("ymax", 120);
-    psd0.add<double>("ymin", -120);
-    desc.add<edm::ParameterSetDescription>("TH2TTCluster_Position", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 900);
-    psd0.add<double>("xmax", 300);
-    psd0.add<double>("xmin", -300);
-    psd0.add<int>("Nbinsy", 900);
-    psd0.add<double>("ymax", 120);
-    psd0.add<double>("ymin", 0);
-    desc.add<edm::ParameterSetDescription>("TH2TTCluster_RZ", psd0);
-  }
+
+  // Cluster properties
+  phase2tkutil::add2DDesc(desc, "Cluster_W",   "Cluster_W",   "L1 Cluster Width", "Stack Member",   7, -0.5,   6.5,  2,  -0.5,   1.5);
+  phase2tkutil::add1DDesc(desc, "Cluster_Eta", "Cluster_Eta", "#eta",             "# L1 Clusters", 45,  -5.0,  5.0);
+  phase2tkutil::add1DDesc(desc, "Cluster_Phi", "Cluster_Phi", "#phi",             "# L1 Clusters", 60,  -3.5,  3.5);
+  phase2tkutil::add1DDesc(desc, "Cluster_R",   "Cluster_R",   "R [cm]",           "# L1 Clusters", 45,   0,   120);
+
+  // Position
+  phase2tkutil::add2DDesc(desc, "Cluster_Barrel_XY",    "Cluster_Barrel_XY",    "L1 Cluster Barrel position x [cm]",          "L1 Cluster Barrel position y [cm]",          960, -120, 120, 960, -120, 120);
+  phase2tkutil::add2DDesc(desc, "Cluster_Endcap_Fw_XY", "Cluster_Endcap_Fw_XY", "L1 Cluster Forward Endcap position x [cm]",  "L1 Cluster Forward Endcap position y [cm]",  960, -120, 120, 960, -120, 120);
+  phase2tkutil::add2DDesc(desc, "Cluster_Endcap_Bw_XY", "Cluster_Endcap_Bw_XY", "L1 Cluster Backward Endcap position x [cm]", "L1 Cluster Backward Endcap position y [cm]", 960, -120, 120, 960, -120, 120);
+  phase2tkutil::add2DDesc(desc, "Cluster_RZ",            "Cluster_RZ",            "L1 Cluster position z [cm]",                 "L1 Cluster position #rho [cm]",              900, -300, 300, 900,    0, 120);
+
   desc.add<std::string>("TopFolderName", "TrackerPhase2TTCluster");
   desc.add<edm::InputTag>("TTClusters", edm::InputTag("TTClustersFromPhase2TrackerDigis", "ClusterInclusive"));
   descriptions.add("Phase2OTMonitorTTCluster", desc);
-  // or use the following to generate the label from the module's C++ type
-  //descriptions.addWithDefaultLabel(desc);
 }
 DEFINE_FWK_MODULE(Phase2OTMonitorTTCluster);

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTCluster.cc
@@ -197,64 +197,147 @@ void Phase2OTMonitorTTCluster::bookHistograms(DQMStore::IBooker &iBooker,
   using namespace phase2tkutil;
 
   iBooker.setCurrentFolder(topFolderName_ + "/Clusters/NClusters");
-  Cluster_IMem_Barrel      = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Barrel"),      iBooker);
-  Cluster_OMem_Barrel      = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Barrel"),      iBooker);
-  Cluster_IMem_Endcap_Disc = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Endcap_Disc"), iBooker);
-  Cluster_OMem_Endcap_Disc = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Endcap_Disc"), iBooker);
-  Cluster_IMem_Endcap_Ring = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Endcap_Ring"), iBooker);
-  Cluster_OMem_Endcap_Ring = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Endcap_Ring"), iBooker);
+  Cluster_IMem_Barrel = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Barrel"), iBooker);
+  Cluster_OMem_Barrel = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Barrel"), iBooker);
+  Cluster_IMem_Endcap_Disc =
+      book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Endcap_Disc"), iBooker);
+  Cluster_OMem_Endcap_Disc =
+      book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Endcap_Disc"), iBooker);
+  Cluster_IMem_Endcap_Ring =
+      book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Endcap_Ring"), iBooker);
+  Cluster_OMem_Endcap_Ring =
+      book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Endcap_Ring"), iBooker);
 
   for (int i = 0; i < static_cast<int>(trklet::N_DISK); i++) {
     const std::string si = std::to_string(i + 1);
-    Cluster_IMem_Endcap_Ring_Fw[i] = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Disc_Fw_" + si), iBooker);
-    Cluster_IMem_Endcap_Ring_Bw[i] = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Disc_Bw_" + si), iBooker);
-    Cluster_OMem_Endcap_Ring_Fw[i] = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Disc_Fw_" + si), iBooker);
-    Cluster_OMem_Endcap_Ring_Bw[i] = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Disc_Bw_" + si), iBooker);
+    Cluster_IMem_Endcap_Ring_Fw[i] =
+        book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Disc_Fw_" + si), iBooker);
+    Cluster_IMem_Endcap_Ring_Bw[i] =
+        book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_IMem_Disc_Bw_" + si), iBooker);
+    Cluster_OMem_Endcap_Ring_Fw[i] =
+        book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Disc_Fw_" + si), iBooker);
+    Cluster_OMem_Endcap_Ring_Bw[i] =
+        book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NClusters_OMem_Disc_Bw_" + si), iBooker);
   }
 
   iBooker.setCurrentFolder(topFolderName_ + "/Clusters");
-  Cluster_W   = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_W"),   iBooker);
+  Cluster_W = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_W"), iBooker);
   Cluster_Eta = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_Eta"), iBooker);
   Cluster_Phi = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_Phi"), iBooker);
-  Cluster_R   = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_R"),   iBooker);
+  Cluster_R = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_R"), iBooker);
 
   iBooker.setCurrentFolder(topFolderName_ + "/Clusters/Position");
-  Cluster_Barrel_XY    = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_Barrel_XY"),    iBooker);
+  Cluster_Barrel_XY = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_Barrel_XY"), iBooker);
   Cluster_Endcap_Fw_XY = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_Endcap_Fw_XY"), iBooker);
   Cluster_Endcap_Bw_XY = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_Endcap_Bw_XY"), iBooker);
-  Cluster_RZ           = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_RZ"),           iBooker);
+  Cluster_RZ = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Cluster_RZ"), iBooker);
 }
 
 void Phase2OTMonitorTTCluster::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
 
   // NClusters
-  phase2tkutil::add1DDesc(desc, "NClusters_IMem_Barrel",      "NClusters_IMem_Barrel",      "Barrel Layer", "# L1 Clusters",  7, 0.5,  7.5);
-  phase2tkutil::add1DDesc(desc, "NClusters_OMem_Barrel",      "NClusters_OMem_Barrel",      "Barrel Layer", "# L1 Clusters",  7, 0.5,  7.5);
-  phase2tkutil::add1DDesc(desc, "NClusters_IMem_Endcap_Disc", "NClusters_IMem_Endcap_Disc", "Endcap Disc",  "# L1 Clusters",  6, 0.5,  6.5);
-  phase2tkutil::add1DDesc(desc, "NClusters_OMem_Endcap_Disc", "NClusters_OMem_Endcap_Disc", "Endcap Disc",  "# L1 Clusters",  6, 0.5,  6.5);
-  phase2tkutil::add1DDesc(desc, "NClusters_IMem_Endcap_Ring", "NClusters_IMem_Endcap_Ring", "Endcap Ring",  "# L1 Clusters", 16, 0.5, 16.5);
-  phase2tkutil::add1DDesc(desc, "NClusters_OMem_Endcap_Ring", "NClusters_OMem_Endcap_Ring", "Endcap Ring",  "# L1 Clusters", 16, 0.5, 16.5);
+  phase2tkutil::add1DDesc(
+      desc, "NClusters_IMem_Barrel", "NClusters_IMem_Barrel", "Barrel Layer", "# L1 Clusters", 7, 0.5, 7.5);
+  phase2tkutil::add1DDesc(
+      desc, "NClusters_OMem_Barrel", "NClusters_OMem_Barrel", "Barrel Layer", "# L1 Clusters", 7, 0.5, 7.5);
+  phase2tkutil::add1DDesc(
+      desc, "NClusters_IMem_Endcap_Disc", "NClusters_IMem_Endcap_Disc", "Endcap Disc", "# L1 Clusters", 6, 0.5, 6.5);
+  phase2tkutil::add1DDesc(
+      desc, "NClusters_OMem_Endcap_Disc", "NClusters_OMem_Endcap_Disc", "Endcap Disc", "# L1 Clusters", 6, 0.5, 6.5);
+  phase2tkutil::add1DDesc(
+      desc, "NClusters_IMem_Endcap_Ring", "NClusters_IMem_Endcap_Ring", "Endcap Ring", "# L1 Clusters", 16, 0.5, 16.5);
+  phase2tkutil::add1DDesc(
+      desc, "NClusters_OMem_Endcap_Ring", "NClusters_OMem_Endcap_Ring", "Endcap Ring", "# L1 Clusters", 16, 0.5, 16.5);
 
   for (int i = 1; i <= static_cast<int>(trklet::N_DISK); i++) {
     const std::string si = std::to_string(i);
-    phase2tkutil::add1DDesc(desc, "NClusters_IMem_Disc_Fw_" + si, "NClusters_IMem_Disc+" + si, "Endcap Ring", "# L1 Clusters", 16, 0.5, 16.5);
-    phase2tkutil::add1DDesc(desc, "NClusters_IMem_Disc_Bw_" + si, "NClusters_IMem_Disc-" + si, "Endcap Ring", "# L1 Clusters", 16, 0.5, 16.5);
-    phase2tkutil::add1DDesc(desc, "NClusters_OMem_Disc_Fw_" + si, "NClusters_OMem_Disc+" + si, "Endcap Ring", "# L1 Clusters", 16, 0.5, 16.5);
-    phase2tkutil::add1DDesc(desc, "NClusters_OMem_Disc_Bw_" + si, "NClusters_OMem_Disc-" + si, "Endcap Ring", "# L1 Clusters", 16, 0.5, 16.5);
+    phase2tkutil::add1DDesc(desc,
+                            "NClusters_IMem_Disc_Fw_" + si,
+                            "NClusters_IMem_Disc+" + si,
+                            "Endcap Ring",
+                            "# L1 Clusters",
+                            16,
+                            0.5,
+                            16.5);
+    phase2tkutil::add1DDesc(desc,
+                            "NClusters_IMem_Disc_Bw_" + si,
+                            "NClusters_IMem_Disc-" + si,
+                            "Endcap Ring",
+                            "# L1 Clusters",
+                            16,
+                            0.5,
+                            16.5);
+    phase2tkutil::add1DDesc(desc,
+                            "NClusters_OMem_Disc_Fw_" + si,
+                            "NClusters_OMem_Disc+" + si,
+                            "Endcap Ring",
+                            "# L1 Clusters",
+                            16,
+                            0.5,
+                            16.5);
+    phase2tkutil::add1DDesc(desc,
+                            "NClusters_OMem_Disc_Bw_" + si,
+                            "NClusters_OMem_Disc-" + si,
+                            "Endcap Ring",
+                            "# L1 Clusters",
+                            16,
+                            0.5,
+                            16.5);
   }
 
   // Cluster properties
-  phase2tkutil::add2DDesc(desc, "Cluster_W",   "Cluster_W",   "L1 Cluster Width", "Stack Member",   7, -0.5,   6.5,  2,  -0.5,   1.5);
-  phase2tkutil::add1DDesc(desc, "Cluster_Eta", "Cluster_Eta", "#eta",             "# L1 Clusters", 45,  -5.0,  5.0);
-  phase2tkutil::add1DDesc(desc, "Cluster_Phi", "Cluster_Phi", "#phi",             "# L1 Clusters", 60,  -3.5,  3.5);
-  phase2tkutil::add1DDesc(desc, "Cluster_R",   "Cluster_R",   "R [cm]",           "# L1 Clusters", 45,   0,   120);
+  phase2tkutil::add2DDesc(
+      desc, "Cluster_W", "Cluster_W", "L1 Cluster Width", "Stack Member", 7, -0.5, 6.5, 2, -0.5, 1.5);
+  phase2tkutil::add1DDesc(desc, "Cluster_Eta", "Cluster_Eta", "#eta", "# L1 Clusters", 45, -5.0, 5.0);
+  phase2tkutil::add1DDesc(desc, "Cluster_Phi", "Cluster_Phi", "#phi", "# L1 Clusters", 60, -3.5, 3.5);
+  phase2tkutil::add1DDesc(desc, "Cluster_R", "Cluster_R", "R [cm]", "# L1 Clusters", 45, 0, 120);
 
   // Position
-  phase2tkutil::add2DDesc(desc, "Cluster_Barrel_XY",    "Cluster_Barrel_XY",    "L1 Cluster Barrel position x [cm]",          "L1 Cluster Barrel position y [cm]",          960, -120, 120, 960, -120, 120);
-  phase2tkutil::add2DDesc(desc, "Cluster_Endcap_Fw_XY", "Cluster_Endcap_Fw_XY", "L1 Cluster Forward Endcap position x [cm]",  "L1 Cluster Forward Endcap position y [cm]",  960, -120, 120, 960, -120, 120);
-  phase2tkutil::add2DDesc(desc, "Cluster_Endcap_Bw_XY", "Cluster_Endcap_Bw_XY", "L1 Cluster Backward Endcap position x [cm]", "L1 Cluster Backward Endcap position y [cm]", 960, -120, 120, 960, -120, 120);
-  phase2tkutil::add2DDesc(desc, "Cluster_RZ",            "Cluster_RZ",            "L1 Cluster position z [cm]",                 "L1 Cluster position #rho [cm]",              900, -300, 300, 900,    0, 120);
+  phase2tkutil::add2DDesc(desc,
+                          "Cluster_Barrel_XY",
+                          "Cluster_Barrel_XY",
+                          "L1 Cluster Barrel position x [cm]",
+                          "L1 Cluster Barrel position y [cm]",
+                          960,
+                          -120,
+                          120,
+                          960,
+                          -120,
+                          120);
+  phase2tkutil::add2DDesc(desc,
+                          "Cluster_Endcap_Fw_XY",
+                          "Cluster_Endcap_Fw_XY",
+                          "L1 Cluster Forward Endcap position x [cm]",
+                          "L1 Cluster Forward Endcap position y [cm]",
+                          960,
+                          -120,
+                          120,
+                          960,
+                          -120,
+                          120);
+  phase2tkutil::add2DDesc(desc,
+                          "Cluster_Endcap_Bw_XY",
+                          "Cluster_Endcap_Bw_XY",
+                          "L1 Cluster Backward Endcap position x [cm]",
+                          "L1 Cluster Backward Endcap position y [cm]",
+                          960,
+                          -120,
+                          120,
+                          960,
+                          -120,
+                          120);
+  phase2tkutil::add2DDesc(desc,
+                          "Cluster_RZ",
+                          "Cluster_RZ",
+                          "L1 Cluster position z [cm]",
+                          "L1 Cluster position #rho [cm]",
+                          900,
+                          -300,
+                          300,
+                          900,
+                          0,
+                          120);
 
   desc.add<std::string>("TopFolderName", "TrackerPhase2TTCluster");
   desc.add<edm::InputTag>("TTClusters", edm::InputTag("TTClustersFromPhase2TrackerDigis", "ClusterInclusive"));

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
@@ -66,11 +66,11 @@ public:
   MonitorElement *CrackOverview = nullptr;      // Cosmic rack: TTStub layer vs module
 
   // Number of stubs
-  MonitorElement *Stub_Barrel = nullptr;                                                   // TTStub per layer
-  MonitorElement *Stub_Endcap_Disc = nullptr;                                              // TTStubs per disc
-  MonitorElement *Stub_Endcap_Disc_Fw = nullptr;                                           // TTStub per disc
-  MonitorElement *Stub_Endcap_Disc_Bw = nullptr;                                           // TTStub per disc
-  MonitorElement *Stub_Endcap_Ring = nullptr;                                              // TTStubs per ring
+  MonitorElement *Stub_Barrel = nullptr;                     // TTStub per layer
+  MonitorElement *Stub_Endcap_Disc = nullptr;                // TTStubs per disc
+  MonitorElement *Stub_Endcap_Disc_Fw = nullptr;             // TTStub per disc
+  MonitorElement *Stub_Endcap_Disc_Bw = nullptr;             // TTStub per disc
+  MonitorElement *Stub_Endcap_Ring = nullptr;                // TTStubs per ring
   MonitorElement *Stub_Endcap_Ring_Fw[trklet::N_DISK] = {};  // TTStubs per EC ring
   MonitorElement *Stub_Endcap_Ring_Bw[trklet::N_DISK] = {};  // TTStub per EC ring
 
@@ -83,12 +83,12 @@ public:
   MonitorElement *Stub_isPS = nullptr;    // is this stub a PS module?
 
   // STUB Displacement - offset
-  MonitorElement *Stub_Barrel_W = nullptr;       // TTstub Pos-Corr Displacement (layer)
-  MonitorElement *Stub_Barrel_O = nullptr;       // TTStub Offset (layer)
-  MonitorElement *Stub_Endcap_Disc_W = nullptr;  // TTstub Pos-Corr Displacement (disc)
-  MonitorElement *Stub_Endcap_Disc_O = nullptr;  // TTStub Offset (disc)
-  MonitorElement *Stub_Endcap_Ring_W = nullptr;  // TTstub Pos-Corr Displacement (EC ring)
-  MonitorElement *Stub_Endcap_Ring_O = nullptr;  // TTStub Offset (EC ring)
+  MonitorElement *Stub_Barrel_W = nullptr;                     // TTstub Pos-Corr Displacement (layer)
+  MonitorElement *Stub_Barrel_O = nullptr;                     // TTStub Offset (layer)
+  MonitorElement *Stub_Endcap_Disc_W = nullptr;                // TTstub Pos-Corr Displacement (disc)
+  MonitorElement *Stub_Endcap_Disc_O = nullptr;                // TTStub Offset (disc)
+  MonitorElement *Stub_Endcap_Ring_W = nullptr;                // TTstub Pos-Corr Displacement (EC ring)
+  MonitorElement *Stub_Endcap_Ring_O = nullptr;                // TTStub Offset (EC ring)
   MonitorElement *Stub_Endcap_Ring_W_Fw[trklet::N_DISK] = {};  // TTstub Pos-Corr Displacement (EC ring)
   MonitorElement *Stub_Endcap_Ring_O_Fw[trklet::N_DISK] = {};  // TTStub Offset (EC ring)
   MonitorElement *Stub_Endcap_Ring_W_Bw[trklet::N_DISK] = {};  // TTstub Pos-Corr Displacement (EC ring)
@@ -211,10 +211,10 @@ void Phase2OTMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker, edm::Run 
   using namespace phase2tkutil;
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/Position");
-  Stub_Barrel_XY    = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Barrel_XY"),    iBooker);
+  Stub_Barrel_XY = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Barrel_XY"), iBooker);
   Stub_Endcap_Fw_XY = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Endcap_Fw_XY"), iBooker);
   Stub_Endcap_Bw_XY = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Endcap_Bw_XY"), iBooker);
-  Stub_RZ           = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_RZ"),            iBooker);
+  Stub_RZ = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_RZ"), iBooker);
 
   // CRACK ONLY: module vs layer
   edm::ParameterSet Parameters = conf_.getParameter<edm::ParameterSet>("CrackOverview");
@@ -244,41 +244,47 @@ void Phase2OTMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker, edm::Run 
     CrackOverview = nullptr;
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs");
-  Stub_Eta    = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Eta"),    iBooker);
-  Stub_Phi    = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Phi"),    iBooker);
-  Stub_R      = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_R"),      iBooker);
+  Stub_Eta = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Eta"), iBooker);
+  Stub_Phi = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Phi"), iBooker);
+  Stub_R = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_R"), iBooker);
   Stub_bendFE = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_bendFE"), iBooker);
   Stub_bendBE = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_bendBE"), iBooker);
-  Stub_isPS   = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_isPS"),   iBooker);
+  Stub_isPS = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_isPS"), iBooker);
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/NStubs");
-  Stub_Barrel         = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Barrel"),         iBooker);
-  Stub_Endcap_Disc    = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Endcap_Disc"),    iBooker);
+  Stub_Barrel = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Barrel"), iBooker);
+  Stub_Endcap_Disc = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Endcap_Disc"), iBooker);
   Stub_Endcap_Disc_Fw = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Endcap_Disc_Fw"), iBooker);
   Stub_Endcap_Disc_Bw = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Endcap_Disc_Bw"), iBooker);
-  Stub_Endcap_Ring    = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Endcap_Ring"),    iBooker);
+  Stub_Endcap_Ring = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Endcap_Ring"), iBooker);
 
   for (int i = 0; i < static_cast<int>(trklet::N_DISK); i++) {
-    Stub_Endcap_Ring_Fw[i] = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Disc_Fw_" + std::to_string(i + 1)), iBooker);
-    Stub_Endcap_Ring_Bw[i] = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Disc_Bw_" + std::to_string(i + 1)), iBooker);
+    Stub_Endcap_Ring_Fw[i] =
+        book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Disc_Fw_" + std::to_string(i + 1)), iBooker);
+    Stub_Endcap_Ring_Bw[i] =
+        book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Disc_Bw_" + std::to_string(i + 1)), iBooker);
   }
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/Width");
-  Stub_Barrel_W      = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Width_Barrel"),      iBooker);
+  Stub_Barrel_W = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Width_Barrel"), iBooker);
   Stub_Endcap_Disc_W = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Width_Endcap_Disc"), iBooker);
   Stub_Endcap_Ring_W = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Width_Endcap_Ring"), iBooker);
   for (int i = 0; i < static_cast<int>(trklet::N_DISK); i++) {
-    Stub_Endcap_Ring_W_Fw[i] = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Width_Disc_Fw_"  + std::to_string(i + 1)), iBooker);
-    Stub_Endcap_Ring_W_Bw[i] = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Width_Disc_Bw_"  + std::to_string(i + 1)), iBooker);
+    Stub_Endcap_Ring_W_Fw[i] =
+        book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Width_Disc_Fw_" + std::to_string(i + 1)), iBooker);
+    Stub_Endcap_Ring_W_Bw[i] =
+        book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Width_Disc_Bw_" + std::to_string(i + 1)), iBooker);
   }
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/Offset");
-  Stub_Barrel_O      = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Offset_Barrel"),      iBooker);
+  Stub_Barrel_O = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Offset_Barrel"), iBooker);
   Stub_Endcap_Disc_O = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Offset_Endcap_Disc"), iBooker);
   Stub_Endcap_Ring_O = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Offset_Endcap_Ring"), iBooker);
   for (int i = 0; i < static_cast<int>(trklet::N_DISK); i++) {
-    Stub_Endcap_Ring_O_Fw[i] = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Offset_Disc_Fw_" + std::to_string(i + 1)), iBooker);
-    Stub_Endcap_Ring_O_Bw[i] = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Offset_Disc_Bw_" + std::to_string(i + 1)), iBooker);
+    Stub_Endcap_Ring_O_Fw[i] =
+        book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Offset_Disc_Fw_" + std::to_string(i + 1)), iBooker);
+    Stub_Endcap_Ring_O_Bw[i] =
+        book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Offset_Disc_Bw_" + std::to_string(i + 1)), iBooker);
   }
 }
 
@@ -286,10 +292,41 @@ void Phase2OTMonitorTTStub::fillDescriptions(edm::ConfigurationDescriptions &des
   edm::ParameterSetDescription desc;
 
   // Position
-  phase2tkutil::add2DDesc(desc, "Stub_Barrel_XY",    "Stub_Barrel_XY",    "L1 Stub Barrel position x [cm]", "L1 Stub Barrel position y [cm]", 960, -120, 120, 960, -120, 120);
-  phase2tkutil::add2DDesc(desc, "Stub_Endcap_Fw_XY", "Stub_Endcap_Fw_XY", "L1 Stub Endcap position x [cm]", "L1 Stub Endcap position y [cm]", 960, -120, 120, 960, -120, 120);
-  phase2tkutil::add2DDesc(desc, "Stub_Endcap_Bw_XY", "Stub_Endcap_Bw_XY", "L1 Stub Endcap position x [cm]", "L1 Stub Endcap position y [cm]", 960, -120, 120, 960, -120, 120);
-  phase2tkutil::add2DDesc(desc, "Stub_RZ",            "Stub_RZ",            "L1 Stub position z [cm]",        "L1 Stub position #rho [cm]",    900, -300, 300, 900, 0, 120);
+  phase2tkutil::add2DDesc(desc,
+                          "Stub_Barrel_XY",
+                          "Stub_Barrel_XY",
+                          "L1 Stub Barrel position x [cm]",
+                          "L1 Stub Barrel position y [cm]",
+                          960,
+                          -120,
+                          120,
+                          960,
+                          -120,
+                          120);
+  phase2tkutil::add2DDesc(desc,
+                          "Stub_Endcap_Fw_XY",
+                          "Stub_Endcap_Fw_XY",
+                          "L1 Stub Endcap position x [cm]",
+                          "L1 Stub Endcap position y [cm]",
+                          960,
+                          -120,
+                          120,
+                          960,
+                          -120,
+                          120);
+  phase2tkutil::add2DDesc(desc,
+                          "Stub_Endcap_Bw_XY",
+                          "Stub_Endcap_Bw_XY",
+                          "L1 Stub Endcap position x [cm]",
+                          "L1 Stub Endcap position y [cm]",
+                          960,
+                          -120,
+                          120,
+                          960,
+                          -120,
+                          120);
+  phase2tkutil::add2DDesc(
+      desc, "Stub_RZ", "Stub_RZ", "L1 Stub position z [cm]", "L1 Stub position #rho [cm]", 900, -300, 300, 900, 0, 120);
 
   {
     edm::ParameterSetDescription psd0;
@@ -304,39 +341,134 @@ void Phase2OTMonitorTTStub::fillDescriptions(edm::ConfigurationDescriptions &des
   }
 
   // Stub distributions
-  phase2tkutil::add1DDesc(desc, "Stub_Eta",    "Stub_Eta",    "#eta",          "# L1 Stubs", 45, -5,     5);
-  phase2tkutil::add1DDesc(desc, "Stub_Phi",    "Stub_Phi",    "#phi",          "# L1 Stubs", 60, -3.5,   3.5);
-  phase2tkutil::add1DDesc(desc, "Stub_R",      "Stub_R",      "R",             "# L1 Stubs", 45,  0,     120);
-  phase2tkutil::add1DDesc(desc, "Stub_bendFE", "Stub_bendFE", "Trigger bend",  "# L1 Stubs", 69, -8.625, 8.625);
+  phase2tkutil::add1DDesc(desc, "Stub_Eta", "Stub_Eta", "#eta", "# L1 Stubs", 45, -5, 5);
+  phase2tkutil::add1DDesc(desc, "Stub_Phi", "Stub_Phi", "#phi", "# L1 Stubs", 60, -3.5, 3.5);
+  phase2tkutil::add1DDesc(desc, "Stub_R", "Stub_R", "R", "# L1 Stubs", 45, 0, 120);
+  phase2tkutil::add1DDesc(desc, "Stub_bendFE", "Stub_bendFE", "Trigger bend", "# L1 Stubs", 69, -8.625, 8.625);
   phase2tkutil::add1DDesc(desc, "Stub_bendBE", "Stub_bendBE", "Hardware bend", "# L1 Stubs", 69, -8.625, 8.625);
-  phase2tkutil::add1DDesc(desc, "Stub_isPS",   "Stub_isPS",   "Is PS?",        "# L1 Stubs",  2,  0,     2);
+  phase2tkutil::add1DDesc(desc, "Stub_isPS", "Stub_isPS", "Is PS?", "# L1 Stubs", 2, 0, 2);
 
   // NStubs
-  phase2tkutil::add1DDesc(desc, "NStubs_Barrel",         "NStubs_Barrel",         "Barrel Layer",         "# L1 Stubs",  7, 0.5, 7.5);
-  phase2tkutil::add1DDesc(desc, "NStubs_Endcap_Disc",    "NStubs_Endcap_Disc",    "Endcap Disc",          "# L1 Stubs",  6, 0.5, 6.5);
-  phase2tkutil::add1DDesc(desc, "NStubs_Endcap_Disc_Fw", "NStubs_Endcap_Disc_Fw", "Forward Endcap Disc",  "# L1 Stubs",  6, 0.5, 6.5);
-  phase2tkutil::add1DDesc(desc, "NStubs_Endcap_Disc_Bw", "NStubs_Endcap_Disc_Bw", "Backward Endcap Disc", "# L1 Stubs",  6, 0.5, 6.5);
-  phase2tkutil::add1DDesc(desc, "NStubs_Endcap_Ring",    "NStubs_Endcap_Ring",    "Endcap Ring",          "# L1 Stubs", 16, 0.5, 16.5);
+  phase2tkutil::add1DDesc(desc, "NStubs_Barrel", "NStubs_Barrel", "Barrel Layer", "# L1 Stubs", 7, 0.5, 7.5);
+  phase2tkutil::add1DDesc(desc, "NStubs_Endcap_Disc", "NStubs_Endcap_Disc", "Endcap Disc", "# L1 Stubs", 6, 0.5, 6.5);
+  phase2tkutil::add1DDesc(
+      desc, "NStubs_Endcap_Disc_Fw", "NStubs_Endcap_Disc_Fw", "Forward Endcap Disc", "# L1 Stubs", 6, 0.5, 6.5);
+  phase2tkutil::add1DDesc(
+      desc, "NStubs_Endcap_Disc_Bw", "NStubs_Endcap_Disc_Bw", "Backward Endcap Disc", "# L1 Stubs", 6, 0.5, 6.5);
+  phase2tkutil::add1DDesc(desc, "NStubs_Endcap_Ring", "NStubs_Endcap_Ring", "Endcap Ring", "# L1 Stubs", 16, 0.5, 16.5);
 
   // Width
-  phase2tkutil::add2DDesc(desc, "Stub_Width_Barrel",      "Stub_Width_Barrel",      "Barrel Layer", "Displacement - Offset",  6, 0.5,  6.5, 43, -10.75, 10.75);
-  phase2tkutil::add2DDesc(desc, "Stub_Width_Endcap_Disc", "Stub_Width_Endcap_Disc", "Endcap Disc",  "Displacement - Offset",  5, 0.5,  5.5, 43, -10.75, 10.75);
-  phase2tkutil::add2DDesc(desc, "Stub_Width_Endcap_Ring", "Stub_Width_Endcap_Ring", "Endcap Ring",  "Displacement - Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+  phase2tkutil::add2DDesc(desc,
+                          "Stub_Width_Barrel",
+                          "Stub_Width_Barrel",
+                          "Barrel Layer",
+                          "Displacement - Offset",
+                          6,
+                          0.5,
+                          6.5,
+                          43,
+                          -10.75,
+                          10.75);
+  phase2tkutil::add2DDesc(desc,
+                          "Stub_Width_Endcap_Disc",
+                          "Stub_Width_Endcap_Disc",
+                          "Endcap Disc",
+                          "Displacement - Offset",
+                          5,
+                          0.5,
+                          5.5,
+                          43,
+                          -10.75,
+                          10.75);
+  phase2tkutil::add2DDesc(desc,
+                          "Stub_Width_Endcap_Ring",
+                          "Stub_Width_Endcap_Ring",
+                          "Endcap Ring",
+                          "Displacement - Offset",
+                          16,
+                          0.5,
+                          16.5,
+                          43,
+                          -10.75,
+                          10.75);
 
   // Offset
-  phase2tkutil::add2DDesc(desc, "Stub_Offset_Barrel",      "Stub_Offset_Barrel",      "Barrel Layer", "Trigger Offset",  6, 0.5,  6.5, 43, -10.75, 10.75);
-  phase2tkutil::add2DDesc(desc, "Stub_Offset_Endcap_Disc", "Stub_Offset_Endcap_Disc", "Endcap Disc",  "Trigger Offset",  5, 0.5,  5.5, 43, -10.75, 10.75);
-  phase2tkutil::add2DDesc(desc, "Stub_Offset_Endcap_Ring", "Stub_Offset_Endcap_Ring", "Endcap Ring",  "Trigger Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+  phase2tkutil::add2DDesc(
+      desc, "Stub_Offset_Barrel", "Stub_Offset_Barrel", "Barrel Layer", "Trigger Offset", 6, 0.5, 6.5, 43, -10.75, 10.75);
+  phase2tkutil::add2DDesc(desc,
+                          "Stub_Offset_Endcap_Disc",
+                          "Stub_Offset_Endcap_Disc",
+                          "Endcap Disc",
+                          "Trigger Offset",
+                          5,
+                          0.5,
+                          5.5,
+                          43,
+                          -10.75,
+                          10.75);
+  phase2tkutil::add2DDesc(desc,
+                          "Stub_Offset_Endcap_Ring",
+                          "Stub_Offset_Endcap_Ring",
+                          "Endcap Ring",
+                          "Trigger Offset",
+                          16,
+                          0.5,
+                          16.5,
+                          43,
+                          -10.75,
+                          10.75);
 
   // Disc-specific ring histograms
   for (int i = 1; i <= static_cast<int>(trklet::N_DISK); i++) {
     const std::string si = std::to_string(i);
-    phase2tkutil::add1DDesc(desc, "NStubs_Disc_Fw_" + si, "NStubs_Disc+" + si, "Endcap Ring", "# L1 Stubs", 16, 0.5, 16.5);
-    phase2tkutil::add1DDesc(desc, "NStubs_Disc_Bw_" + si, "NStubs_Disc-" + si, "Endcap Ring", "# L1 Stubs", 16, 0.5, 16.5);
-    phase2tkutil::add2DDesc(desc, "Stub_Width_Disc_Fw_"  + si, "Stub_Width_Disc+"  + si, "Endcap Ring", "Displacement - Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
-    phase2tkutil::add2DDesc(desc, "Stub_Width_Disc_Bw_"  + si, "Stub_Width_Disc-"  + si, "Endcap Ring", "Displacement - Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
-    phase2tkutil::add2DDesc(desc, "Stub_Offset_Disc_Fw_" + si, "Stub_Offset_Disc+" + si, "Endcap Ring", "Trigger Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
-    phase2tkutil::add2DDesc(desc, "Stub_Offset_Disc_Bw_" + si, "Stub_Offset_Disc-" + si, "Endcap Ring", "Trigger Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+    phase2tkutil::add1DDesc(
+        desc, "NStubs_Disc_Fw_" + si, "NStubs_Disc+" + si, "Endcap Ring", "# L1 Stubs", 16, 0.5, 16.5);
+    phase2tkutil::add1DDesc(
+        desc, "NStubs_Disc_Bw_" + si, "NStubs_Disc-" + si, "Endcap Ring", "# L1 Stubs", 16, 0.5, 16.5);
+    phase2tkutil::add2DDesc(desc,
+                            "Stub_Width_Disc_Fw_" + si,
+                            "Stub_Width_Disc+" + si,
+                            "Endcap Ring",
+                            "Displacement - Offset",
+                            16,
+                            0.5,
+                            16.5,
+                            43,
+                            -10.75,
+                            10.75);
+    phase2tkutil::add2DDesc(desc,
+                            "Stub_Width_Disc_Bw_" + si,
+                            "Stub_Width_Disc-" + si,
+                            "Endcap Ring",
+                            "Displacement - Offset",
+                            16,
+                            0.5,
+                            16.5,
+                            43,
+                            -10.75,
+                            10.75);
+    phase2tkutil::add2DDesc(desc,
+                            "Stub_Offset_Disc_Fw_" + si,
+                            "Stub_Offset_Disc+" + si,
+                            "Endcap Ring",
+                            "Trigger Offset",
+                            16,
+                            0.5,
+                            16.5,
+                            43,
+                            -10.75,
+                            10.75);
+    phase2tkutil::add2DDesc(desc,
+                            "Stub_Offset_Disc_Bw_" + si,
+                            "Stub_Offset_Disc-" + si,
+                            "Endcap Ring",
+                            "Trigger Offset",
+                            16,
+                            0.5,
+                            16.5,
+                            43,
+                            -10.75,
+                            10.75);
   }
 
   desc.add<std::string>("TopFolderName", "TrackerPhase2OTStub");

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
@@ -46,6 +46,8 @@
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h"
+#include "L1Trigger/TrackFindingTracklet/interface/Settings.h"
 
 class Phase2OTMonitorTTStub : public DQMEDAnalyzer {
 public:
@@ -69,8 +71,8 @@ public:
   MonitorElement *Stub_Endcap_Disc_Fw = nullptr;                                           // TTStub per disc
   MonitorElement *Stub_Endcap_Disc_Bw = nullptr;                                           // TTStub per disc
   MonitorElement *Stub_Endcap_Ring = nullptr;                                              // TTStubs per ring
-  MonitorElement *Stub_Endcap_Ring_Fw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStubs per EC ring
-  MonitorElement *Stub_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStub per EC ring
+  MonitorElement *Stub_Endcap_Ring_Fw[trklet::N_DISK] = {};  // TTStubs per EC ring
+  MonitorElement *Stub_Endcap_Ring_Bw[trklet::N_DISK] = {};  // TTStub per EC ring
 
   // Stub distribution
   MonitorElement *Stub_Eta = nullptr;     // TTstub eta distribution
@@ -87,12 +89,10 @@ public:
   MonitorElement *Stub_Endcap_Disc_O = nullptr;  // TTStub Offset (disc)
   MonitorElement *Stub_Endcap_Ring_W = nullptr;  // TTstub Pos-Corr Displacement (EC ring)
   MonitorElement *Stub_Endcap_Ring_O = nullptr;  // TTStub Offset (EC ring)
-  MonitorElement *Stub_Endcap_Ring_W_Fw[5] = {
-      nullptr, nullptr, nullptr, nullptr, nullptr};  // TTstub Pos-Corr Displacement (EC ring)
-  MonitorElement *Stub_Endcap_Ring_O_Fw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStub Offset (EC ring)
-  MonitorElement *Stub_Endcap_Ring_W_Bw[5] = {
-      nullptr, nullptr, nullptr, nullptr, nullptr};  // TTstub Pos-Corr Displacement (EC ring)
-  MonitorElement *Stub_Endcap_Ring_O_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStub Offset (EC ring)
+  MonitorElement *Stub_Endcap_Ring_W_Fw[trklet::N_DISK] = {};  // TTstub Pos-Corr Displacement (EC ring)
+  MonitorElement *Stub_Endcap_Ring_O_Fw[trklet::N_DISK] = {};  // TTStub Offset (EC ring)
+  MonitorElement *Stub_Endcap_Ring_W_Bw[trklet::N_DISK] = {};  // TTstub Pos-Corr Displacement (EC ring)
+  MonitorElement *Stub_Endcap_Ring_O_Bw[trklet::N_DISK] = {};  // TTStub Offset (EC ring)
 
 private:
   edm::ParameterSet conf_;
@@ -207,64 +207,14 @@ void Phase2OTMonitorTTStub::analyze(const edm::Event &iEvent, const edm::EventSe
   }
 }  // end of method
 
-// ------------ method called when starting to processes a run  ------------
 void Phase2OTMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &run, edm::EventSetup const &es) {
-  std::string HistoName;
-  const int numDiscs = 5;
+  using namespace phase2tkutil;
+
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/Position");
-
-  edm::ParameterSet psTTStub_Barrel_XY = conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
-  HistoName = "Stub_Barrel_XY";
-  Stub_Barrel_XY = iBooker.book2D(HistoName,
-                                  HistoName,
-                                  psTTStub_Barrel_XY.getParameter<int32_t>("Nbinsx"),
-                                  psTTStub_Barrel_XY.getParameter<double>("xmin"),
-                                  psTTStub_Barrel_XY.getParameter<double>("xmax"),
-                                  psTTStub_Barrel_XY.getParameter<int32_t>("Nbinsy"),
-                                  psTTStub_Barrel_XY.getParameter<double>("ymin"),
-                                  psTTStub_Barrel_XY.getParameter<double>("ymax"));
-  Stub_Barrel_XY->setAxisTitle("L1 Stub Barrel position x [cm]", 1);
-  Stub_Barrel_XY->setAxisTitle("L1 Stub Barrel position y [cm]", 2);
-
-  edm::ParameterSet psTTStub_Endcap_Fw_XY = conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
-  HistoName = "Stub_Endcap_Fw_XY";
-  Stub_Endcap_Fw_XY = iBooker.book2D(HistoName,
-                                     HistoName,
-                                     psTTStub_Endcap_Fw_XY.getParameter<int32_t>("Nbinsx"),
-                                     psTTStub_Endcap_Fw_XY.getParameter<double>("xmin"),
-                                     psTTStub_Endcap_Fw_XY.getParameter<double>("xmax"),
-                                     psTTStub_Endcap_Fw_XY.getParameter<int32_t>("Nbinsy"),
-                                     psTTStub_Endcap_Fw_XY.getParameter<double>("ymin"),
-                                     psTTStub_Endcap_Fw_XY.getParameter<double>("ymax"));
-  Stub_Endcap_Fw_XY->setAxisTitle("L1 Stub Endcap position x [cm]", 1);
-  Stub_Endcap_Fw_XY->setAxisTitle("L1 Stub Endcap position y [cm]", 2);
-
-  edm::ParameterSet psTTStub_Endcap_Bw_XY = conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
-  HistoName = "Stub_Endcap_Bw_XY";
-  Stub_Endcap_Bw_XY = iBooker.book2D(HistoName,
-                                     HistoName,
-                                     psTTStub_Endcap_Bw_XY.getParameter<int32_t>("Nbinsx"),
-                                     psTTStub_Endcap_Bw_XY.getParameter<double>("xmin"),
-                                     psTTStub_Endcap_Bw_XY.getParameter<double>("xmax"),
-                                     psTTStub_Endcap_Bw_XY.getParameter<int32_t>("Nbinsy"),
-                                     psTTStub_Endcap_Bw_XY.getParameter<double>("ymin"),
-                                     psTTStub_Endcap_Bw_XY.getParameter<double>("ymax"));
-  Stub_Endcap_Bw_XY->setAxisTitle("L1 Stub Endcap position x [cm]", 1);
-  Stub_Endcap_Bw_XY->setAxisTitle("L1 Stub Endcap position y [cm]", 2);
-
-  // TTStub #rho vs. z
-  edm::ParameterSet psTTStub_RZ = conf_.getParameter<edm::ParameterSet>("TH2TTStub_RZ");
-  HistoName = "Stub_RZ";
-  Stub_RZ = iBooker.book2D(HistoName,
-                           HistoName,
-                           psTTStub_RZ.getParameter<int32_t>("Nbinsx"),
-                           psTTStub_RZ.getParameter<double>("xmin"),
-                           psTTStub_RZ.getParameter<double>("xmax"),
-                           psTTStub_RZ.getParameter<int32_t>("Nbinsy"),
-                           psTTStub_RZ.getParameter<double>("ymin"),
-                           psTTStub_RZ.getParameter<double>("ymax"));
-  Stub_RZ->setAxisTitle("L1 Stub position z [cm]", 1);
-  Stub_RZ->setAxisTitle("L1 Stub position #rho [cm]", 2);
+  Stub_Barrel_XY    = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Barrel_XY"),    iBooker);
+  Stub_Endcap_Fw_XY = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Endcap_Fw_XY"), iBooker);
+  Stub_Endcap_Bw_XY = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Endcap_Bw_XY"), iBooker);
+  Stub_RZ           = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_RZ"),            iBooker);
 
   // CRACK ONLY: module vs layer
   edm::ParameterSet Parameters = conf_.getParameter<edm::ParameterSet>("CrackOverview");
@@ -294,306 +244,82 @@ void Phase2OTMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker, edm::Run 
     CrackOverview = nullptr;
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs");
-  // TTStub eta
-  edm::ParameterSet psTTStub_Eta = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Eta");
-  HistoName = "Stub_Eta";
-  Stub_Eta = iBooker.book1D(HistoName,
-                            HistoName,
-                            psTTStub_Eta.getParameter<int32_t>("Nbinsx"),
-                            psTTStub_Eta.getParameter<double>("xmin"),
-                            psTTStub_Eta.getParameter<double>("xmax"));
-  Stub_Eta->setAxisTitle("#eta", 1);
-  Stub_Eta->setAxisTitle("# L1 Stubs ", 2);
-
-  // TTStub phi
-  edm::ParameterSet psTTStub_Phi = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Phi");
-  HistoName = "Stub_Phi";
-  Stub_Phi = iBooker.book1D(HistoName,
-                            HistoName,
-                            psTTStub_Phi.getParameter<int32_t>("Nbinsx"),
-                            psTTStub_Phi.getParameter<double>("xmin"),
-                            psTTStub_Phi.getParameter<double>("xmax"));
-  Stub_Phi->setAxisTitle("#phi", 1);
-  Stub_Phi->setAxisTitle("# L1 Stubs ", 2);
-
-  // TTStub R
-  edm::ParameterSet psTTStub_R = conf_.getParameter<edm::ParameterSet>("TH1TTStub_R");
-  HistoName = "Stub_R";
-  Stub_R = iBooker.book1D(HistoName,
-                          HistoName,
-                          psTTStub_R.getParameter<int32_t>("Nbinsx"),
-                          psTTStub_R.getParameter<double>("xmin"),
-                          psTTStub_R.getParameter<double>("xmax"));
-  Stub_R->setAxisTitle("R", 1);
-  Stub_R->setAxisTitle("# L1 Stubs ", 2);
-
-  // TTStub trigger bend
-  edm::ParameterSet psTTStub_bend = conf_.getParameter<edm::ParameterSet>("TH1TTStub_bend");
-  HistoName = "Stub_bendFE";
-  Stub_bendFE = iBooker.book1D(HistoName,
-                               HistoName,
-                               psTTStub_bend.getParameter<int32_t>("Nbinsx"),
-                               psTTStub_bend.getParameter<double>("xmin"),
-                               psTTStub_bend.getParameter<double>("xmax"));
-  Stub_bendFE->setAxisTitle("Trigger bend", 1);
-  Stub_bendFE->setAxisTitle("# L1 Stubs ", 2);
-
-  // TTStub hardware bend
-  HistoName = "Stub_bendBE";
-  Stub_bendBE = iBooker.book1D(HistoName,
-                               HistoName,
-                               psTTStub_bend.getParameter<int32_t>("Nbinsx"),
-                               psTTStub_bend.getParameter<double>("xmin"),
-                               psTTStub_bend.getParameter<double>("xmax"));
-  Stub_bendBE->setAxisTitle("Hardware bend", 1);
-  Stub_bendBE->setAxisTitle("# L1 Stubs ", 2);
-
-  // TTStub, is PS?
-  edm::ParameterSet psTTStub_isPS = conf_.getParameter<edm::ParameterSet>("TH1TTStub_isPS");
-  HistoName = "Stub_isPS";
-  Stub_isPS = iBooker.book1D(HistoName,
-                             HistoName,
-                             psTTStub_isPS.getParameter<int32_t>("Nbinsx"),
-                             psTTStub_isPS.getParameter<double>("xmin"),
-                             psTTStub_isPS.getParameter<double>("xmax"));
-  Stub_isPS->setAxisTitle("Is PS?", 1);
-  Stub_isPS->setAxisTitle("# L1 Stubs ", 2);
+  Stub_Eta    = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Eta"),    iBooker);
+  Stub_Phi    = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Phi"),    iBooker);
+  Stub_R      = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_R"),      iBooker);
+  Stub_bendFE = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_bendFE"), iBooker);
+  Stub_bendBE = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_bendBE"), iBooker);
+  Stub_isPS   = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_isPS"),   iBooker);
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/NStubs");
-  // TTStub barrel stack
-  edm::ParameterSet psTTStub_Barrel = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Layers");
-  HistoName = "NStubs_Barrel";
-  Stub_Barrel = iBooker.book1D(HistoName,
-                               HistoName,
-                               psTTStub_Barrel.getParameter<int32_t>("Nbinsx"),
-                               psTTStub_Barrel.getParameter<double>("xmin"),
-                               psTTStub_Barrel.getParameter<double>("xmax"));
-  Stub_Barrel->setAxisTitle("Barrel Layer", 1);
-  Stub_Barrel->setAxisTitle("# L1 Stubs ", 2);
+  Stub_Barrel         = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Barrel"),         iBooker);
+  Stub_Endcap_Disc    = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Endcap_Disc"),    iBooker);
+  Stub_Endcap_Disc_Fw = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Endcap_Disc_Fw"), iBooker);
+  Stub_Endcap_Disc_Bw = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Endcap_Disc_Bw"), iBooker);
+  Stub_Endcap_Ring    = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Endcap_Ring"),    iBooker);
 
-  // TTStub Endcap stack
-  edm::ParameterSet psTTStub_ECDisc = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Discs");
-  HistoName = "NStubs_Endcap_Disc";
-  Stub_Endcap_Disc = iBooker.book1D(HistoName,
-                                    HistoName,
-                                    psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"),
-                                    psTTStub_ECDisc.getParameter<double>("xmin"),
-                                    psTTStub_ECDisc.getParameter<double>("xmax"));
-  Stub_Endcap_Disc->setAxisTitle("Endcap Disc", 1);
-  Stub_Endcap_Disc->setAxisTitle("# L1 Stubs ", 2);
-
-  // TTStub Endcap stack
-  HistoName = "NStubs_Endcap_Disc_Fw";
-  Stub_Endcap_Disc_Fw = iBooker.book1D(HistoName,
-                                       HistoName,
-                                       psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"),
-                                       psTTStub_ECDisc.getParameter<double>("xmin"),
-                                       psTTStub_ECDisc.getParameter<double>("xmax"));
-  Stub_Endcap_Disc_Fw->setAxisTitle("Forward Endcap Disc", 1);
-  Stub_Endcap_Disc_Fw->setAxisTitle("# L1 Stubs ", 2);
-
-  // TTStub Endcap stack
-  HistoName = "NStubs_Endcap_Disc_Bw";
-  Stub_Endcap_Disc_Bw = iBooker.book1D(HistoName,
-                                       HistoName,
-                                       psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"),
-                                       psTTStub_ECDisc.getParameter<double>("xmin"),
-                                       psTTStub_ECDisc.getParameter<double>("xmax"));
-  Stub_Endcap_Disc_Bw->setAxisTitle("Backward Endcap Disc", 1);
-  Stub_Endcap_Disc_Bw->setAxisTitle("# L1 Stubs ", 2);
-
-  edm::ParameterSet psTTStub_ECRing = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Rings");
-  HistoName = "NStubs_Endcap_Ring";
-  Stub_Endcap_Ring = iBooker.book1D(HistoName,
-                                    HistoName,
-                                    psTTStub_ECRing.getParameter<int32_t>("Nbinsx"),
-                                    psTTStub_ECRing.getParameter<double>("xmin"),
-                                    psTTStub_ECRing.getParameter<double>("xmax"));
-  Stub_Endcap_Ring->setAxisTitle("Endcap Ring", 1);
-  Stub_Endcap_Ring->setAxisTitle("# L1 Stubs ", 2);
-
-  for (int i = 0; i < numDiscs; i++) {
-    HistoName = "NStubs_Disc+" + std::to_string(i + 1);
-    // TTStub Endcap stack
-    Stub_Endcap_Ring_Fw[i] = iBooker.book1D(HistoName,
-                                            HistoName,
-                                            psTTStub_ECRing.getParameter<int32_t>("Nbinsx"),
-                                            psTTStub_ECRing.getParameter<double>("xmin"),
-                                            psTTStub_ECRing.getParameter<double>("xmax"));
-    Stub_Endcap_Ring_Fw[i]->setAxisTitle("Endcap Ring", 1);
-    Stub_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Stubs ", 2);
+  for (int i = 0; i < static_cast<int>(trklet::N_DISK); i++) {
+    Stub_Endcap_Ring_Fw[i] = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Disc_Fw_" + std::to_string(i + 1)), iBooker);
+    Stub_Endcap_Ring_Bw[i] = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("NStubs_Disc_Bw_" + std::to_string(i + 1)), iBooker);
   }
-
-  for (int i = 0; i < numDiscs; i++) {
-    HistoName = "NStubs_Disc-" + std::to_string(i + 1);
-    // TTStub Endcap stack
-    Stub_Endcap_Ring_Bw[i] = iBooker.book1D(HistoName,
-                                            HistoName,
-                                            psTTStub_ECRing.getParameter<int32_t>("Nbinsx"),
-                                            psTTStub_ECRing.getParameter<double>("xmin"),
-                                            psTTStub_ECRing.getParameter<double>("xmax"));
-    Stub_Endcap_Ring_Bw[i]->setAxisTitle("Endcap Ring", 1);
-    Stub_Endcap_Ring_Bw[i]->setAxisTitle("# L1 Stubs ", 2);
-  }
-
-  // TTStub displ/offset
-  edm::ParameterSet psTTStub_Barrel_2D = conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Layer");
-  edm::ParameterSet psTTStub_ECDisc_2D = conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Disc");
-  edm::ParameterSet psTTStub_ECRing_2D = conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Ring");
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/Width");
-  HistoName = "Stub_Width_Barrel";
-  Stub_Barrel_W = iBooker.book2D(HistoName,
-                                 HistoName,
-                                 psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsx"),
-                                 psTTStub_Barrel_2D.getParameter<double>("xmin"),
-                                 psTTStub_Barrel_2D.getParameter<double>("xmax"),
-                                 psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsy"),
-                                 psTTStub_Barrel_2D.getParameter<double>("ymin"),
-                                 psTTStub_Barrel_2D.getParameter<double>("ymax"));
-  Stub_Barrel_W->setAxisTitle("Barrel Layer", 1);
-  Stub_Barrel_W->setAxisTitle("Displacement - Offset", 2);
-
-  HistoName = "Stub_Width_Endcap_Disc";
-  Stub_Endcap_Disc_W = iBooker.book2D(HistoName,
-                                      HistoName,
-                                      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsx"),
-                                      psTTStub_ECDisc_2D.getParameter<double>("xmin"),
-                                      psTTStub_ECDisc_2D.getParameter<double>("xmax"),
-                                      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsy"),
-                                      psTTStub_ECDisc_2D.getParameter<double>("ymin"),
-                                      psTTStub_ECDisc_2D.getParameter<double>("ymax"));
-  Stub_Endcap_Disc_W->setAxisTitle("Endcap Disc", 1);
-  Stub_Endcap_Disc_W->setAxisTitle("Displacement - Offset", 2);
-
-  HistoName = "Stub_Width_Endcap_Ring";
-  Stub_Endcap_Ring_W = iBooker.book2D(HistoName,
-                                      HistoName,
-                                      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
-                                      psTTStub_ECRing_2D.getParameter<double>("xmin"),
-                                      psTTStub_ECRing_2D.getParameter<double>("xmax"),
-                                      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
-                                      psTTStub_ECRing_2D.getParameter<double>("ymin"),
-                                      psTTStub_ECRing_2D.getParameter<double>("ymax"));
-  Stub_Endcap_Ring_W->setAxisTitle("Endcap Ring", 1);
-  Stub_Endcap_Ring_W->setAxisTitle("Trigger Offset", 2);
-
-  for (int i = 0; i < numDiscs; i++) {
-    HistoName = "Stub_Width_Disc+" + std::to_string(i + 1);
-    Stub_Endcap_Ring_W_Fw[i] = iBooker.book2D(HistoName,
-                                              HistoName,
-                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
-                                              psTTStub_ECRing_2D.getParameter<double>("xmin"),
-                                              psTTStub_ECRing_2D.getParameter<double>("xmax"),
-                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
-                                              psTTStub_ECRing_2D.getParameter<double>("ymin"),
-                                              psTTStub_ECRing_2D.getParameter<double>("ymax"));
-    Stub_Endcap_Ring_W_Fw[i]->setAxisTitle("Endcap Ring", 1);
-    Stub_Endcap_Ring_W_Fw[i]->setAxisTitle("Displacement - Offset", 2);
-  }
-
-  for (int i = 0; i < numDiscs; i++) {
-    HistoName = "Stub_Width_Disc-" + std::to_string(i + 1);
-    Stub_Endcap_Ring_W_Bw[i] = iBooker.book2D(HistoName,
-                                              HistoName,
-                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
-                                              psTTStub_ECRing_2D.getParameter<double>("xmin"),
-                                              psTTStub_ECRing_2D.getParameter<double>("xmax"),
-                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
-                                              psTTStub_ECRing_2D.getParameter<double>("ymin"),
-                                              psTTStub_ECRing_2D.getParameter<double>("ymax"));
-    Stub_Endcap_Ring_W_Bw[i]->setAxisTitle("Endcap Ring", 1);
-    Stub_Endcap_Ring_W_Bw[i]->setAxisTitle("Displacement - Offset", 2);
+  Stub_Barrel_W      = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Width_Barrel"),      iBooker);
+  Stub_Endcap_Disc_W = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Width_Endcap_Disc"), iBooker);
+  Stub_Endcap_Ring_W = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Width_Endcap_Ring"), iBooker);
+  for (int i = 0; i < static_cast<int>(trklet::N_DISK); i++) {
+    Stub_Endcap_Ring_W_Fw[i] = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Width_Disc_Fw_"  + std::to_string(i + 1)), iBooker);
+    Stub_Endcap_Ring_W_Bw[i] = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Width_Disc_Bw_"  + std::to_string(i + 1)), iBooker);
   }
 
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/Offset");
-  HistoName = "Stub_Offset_Barrel";
-  Stub_Barrel_O = iBooker.book2D(HistoName,
-                                 HistoName,
-                                 psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsx"),
-                                 psTTStub_Barrel_2D.getParameter<double>("xmin"),
-                                 psTTStub_Barrel_2D.getParameter<double>("xmax"),
-                                 psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsy"),
-                                 psTTStub_Barrel_2D.getParameter<double>("ymin"),
-                                 psTTStub_Barrel_2D.getParameter<double>("ymax"));
-  Stub_Barrel_O->setAxisTitle("Barrel Layer", 1);
-  Stub_Barrel_O->setAxisTitle("Trigger Offset", 2);
-
-  HistoName = "Stub_Offset_Endcap_Disc";
-  Stub_Endcap_Disc_O = iBooker.book2D(HistoName,
-                                      HistoName,
-                                      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsx"),
-                                      psTTStub_ECDisc_2D.getParameter<double>("xmin"),
-                                      psTTStub_ECDisc_2D.getParameter<double>("xmax"),
-                                      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsy"),
-                                      psTTStub_ECDisc_2D.getParameter<double>("ymin"),
-                                      psTTStub_ECDisc_2D.getParameter<double>("ymax"));
-  Stub_Endcap_Disc_O->setAxisTitle("Endcap Disc", 1);
-  Stub_Endcap_Disc_O->setAxisTitle("Trigger Offset", 2);
-
-  HistoName = "Stub_Offset_Endcap_Ring";
-  Stub_Endcap_Ring_O = iBooker.book2D(HistoName,
-                                      HistoName,
-                                      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
-                                      psTTStub_ECRing_2D.getParameter<double>("xmin"),
-                                      psTTStub_ECRing_2D.getParameter<double>("xmax"),
-                                      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
-                                      psTTStub_ECRing_2D.getParameter<double>("ymin"),
-                                      psTTStub_ECRing_2D.getParameter<double>("ymax"));
-  Stub_Endcap_Ring_O->setAxisTitle("Endcap Ring", 1);
-  Stub_Endcap_Ring_O->setAxisTitle("Trigger Offset", 2);
-
-  for (int i = 0; i < numDiscs; i++) {
-    HistoName = "Stub_Offset_Disc+" + std::to_string(i + 1);
-    Stub_Endcap_Ring_O_Fw[i] = iBooker.book2D(HistoName,
-                                              HistoName,
-                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
-                                              psTTStub_ECRing_2D.getParameter<double>("xmin"),
-                                              psTTStub_ECRing_2D.getParameter<double>("xmax"),
-                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
-                                              psTTStub_ECRing_2D.getParameter<double>("ymin"),
-                                              psTTStub_ECRing_2D.getParameter<double>("ymax"));
-    Stub_Endcap_Ring_O_Fw[i]->setAxisTitle("Endcap Ring", 1);
-    Stub_Endcap_Ring_O_Fw[i]->setAxisTitle("Trigger Offset", 2);
-  }
-
-  for (int i = 0; i < numDiscs; i++) {
-    HistoName = "Stub_Offset_Disc-" + std::to_string(i + 1);
-    Stub_Endcap_Ring_O_Bw[i] = iBooker.book2D(HistoName,
-                                              HistoName,
-                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
-                                              psTTStub_ECRing_2D.getParameter<double>("xmin"),
-                                              psTTStub_ECRing_2D.getParameter<double>("xmax"),
-                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
-                                              psTTStub_ECRing_2D.getParameter<double>("ymin"),
-                                              psTTStub_ECRing_2D.getParameter<double>("ymax"));
-    Stub_Endcap_Ring_O_Bw[i]->setAxisTitle("Endcap Ring", 1);
-    Stub_Endcap_Ring_O_Bw[i]->setAxisTitle("Trigger Offset", 2);
+  Stub_Barrel_O      = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Offset_Barrel"),      iBooker);
+  Stub_Endcap_Disc_O = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Offset_Endcap_Disc"), iBooker);
+  Stub_Endcap_Ring_O = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Offset_Endcap_Ring"), iBooker);
+  for (int i = 0; i < static_cast<int>(trklet::N_DISK); i++) {
+    Stub_Endcap_Ring_O_Fw[i] = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Offset_Disc_Fw_" + std::to_string(i + 1)), iBooker);
+    Stub_Endcap_Ring_O_Bw[i] = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Stub_Offset_Disc_Bw_" + std::to_string(i + 1)), iBooker);
   }
 }
+
 void Phase2OTMonitorTTStub::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
-  // Phase2OTMonitorTTStub
   edm::ParameterSetDescription desc;
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 960);
-    psd0.add<double>("xmax", 120);
-    psd0.add<double>("xmin", -120);
-    psd0.add<int>("Nbinsy", 960);
-    psd0.add<double>("ymax", 120);
-    psd0.add<double>("ymin", -120);
-    desc.add<edm::ParameterSetDescription>("TH2TTStub_Position", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 900);
-    psd0.add<double>("xmax", 300);
-    psd0.add<double>("xmin", -300);
-    psd0.add<int>("Nbinsy", 900);
-    psd0.add<double>("ymax", 120);
-    psd0.add<double>("ymin", 0);
-    desc.add<edm::ParameterSetDescription>("TH2TTStub_RZ", psd0);
-  }
+
+  auto add1D = [&](const std::string& psetKey, const std::string& histName,
+                   const std::string& xlabel, const std::string& ylabel,
+                   int nbins, double xmin, double xmax) {
+    edm::ParameterSetDescription ps;
+    ps.add<bool>("switch", true);
+    ps.add<std::string>("name", histName);
+    ps.add<std::string>("title", histName + ";" + xlabel + ";" + ylabel);
+    ps.add<int>("NxBins", nbins);
+    ps.add<double>("xmin", xmin);
+    ps.add<double>("xmax", xmax);
+    desc.add<edm::ParameterSetDescription>(psetKey, ps);
+  };
+
+  auto add2D = [&](const std::string& psetKey, const std::string& histName,
+                   const std::string& xlabel, const std::string& ylabel,
+                   int nbx, double xmin, double xmax, int nby, double ymin, double ymax) {
+    edm::ParameterSetDescription ps;
+    ps.add<bool>("switch", true);
+    ps.add<std::string>("name", histName);
+    ps.add<std::string>("title", histName + ";" + xlabel + ";" + ylabel);
+    ps.add<int>("NxBins", nbx);
+    ps.add<double>("xmin", xmin);
+    ps.add<double>("xmax", xmax);
+    ps.add<int>("NyBins", nby);
+    ps.add<double>("ymin", ymin);
+    ps.add<double>("ymax", ymax);
+    desc.add<edm::ParameterSetDescription>(psetKey, ps);
+  };
+
+  // Position (psetKey == histId for all fixed histograms)
+  add2D("Stub_Barrel_XY",    "Stub_Barrel_XY",    "L1 Stub Barrel position x [cm]", "L1 Stub Barrel position y [cm]", 960, -120, 120, 960, -120, 120);
+  add2D("Stub_Endcap_Fw_XY", "Stub_Endcap_Fw_XY", "L1 Stub Endcap position x [cm]", "L1 Stub Endcap position y [cm]", 960, -120, 120, 960, -120, 120);
+  add2D("Stub_Endcap_Bw_XY", "Stub_Endcap_Bw_XY", "L1 Stub Endcap position x [cm]", "L1 Stub Endcap position y [cm]", 960, -120, 120, 960, -120, 120);
+  add2D("Stub_RZ",            "Stub_RZ",            "L1 Stub position z [cm]",        "L1 Stub position #rho [cm]",    900, -300, 300, 900, 0, 120);
+
   {
     edm::ParameterSetDescription psd0;
     psd0.add<std::string>("name", "Crack_Overview_Stubs");
@@ -605,96 +331,46 @@ void Phase2OTMonitorTTStub::fillDescriptions(edm::ConfigurationDescriptions &des
     psd0.add<double>("ymax", 7.5);
     desc.add<edm::ParameterSetDescription>("CrackOverview", psd0);
   }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 45);
-    psd0.add<double>("xmin", -5);
-    psd0.add<double>("xmax", 5);
-    desc.add<edm::ParameterSetDescription>("TH1TTStub_Eta", psd0);
+
+  // Stub distributions
+  add1D("Stub_Eta",    "Stub_Eta",    "#eta",          "# L1 Stubs", 45, -5,     5);
+  add1D("Stub_Phi",    "Stub_Phi",    "#phi",          "# L1 Stubs", 60, -3.5,   3.5);
+  add1D("Stub_R",      "Stub_R",      "R",             "# L1 Stubs", 45,  0,     120);
+  add1D("Stub_bendFE", "Stub_bendFE", "Trigger bend",  "# L1 Stubs", 69, -8.625, 8.625);
+  add1D("Stub_bendBE", "Stub_bendBE", "Hardware bend", "# L1 Stubs", 69, -8.625, 8.625);
+  add1D("Stub_isPS",   "Stub_isPS",   "Is PS?",        "# L1 Stubs",  2,  0,     2);
+
+  // NStubs
+  add1D("NStubs_Barrel",         "NStubs_Barrel",         "Barrel Layer",         "# L1 Stubs",  7, 0.5, 7.5);
+  add1D("NStubs_Endcap_Disc",    "NStubs_Endcap_Disc",    "Endcap Disc",          "# L1 Stubs",  6, 0.5, 6.5);
+  add1D("NStubs_Endcap_Disc_Fw", "NStubs_Endcap_Disc_Fw", "Forward Endcap Disc",  "# L1 Stubs",  6, 0.5, 6.5);
+  add1D("NStubs_Endcap_Disc_Bw", "NStubs_Endcap_Disc_Bw", "Backward Endcap Disc", "# L1 Stubs",  6, 0.5, 6.5);
+  add1D("NStubs_Endcap_Ring",    "NStubs_Endcap_Ring",    "Endcap Ring",          "# L1 Stubs", 16, 0.5, 16.5);
+
+  // Width
+  add2D("Stub_Width_Barrel",      "Stub_Width_Barrel",      "Barrel Layer", "Displacement - Offset",  6, 0.5,  6.5, 43, -10.75, 10.75);
+  add2D("Stub_Width_Endcap_Disc", "Stub_Width_Endcap_Disc", "Endcap Disc",  "Displacement - Offset",  5, 0.5,  5.5, 43, -10.75, 10.75);
+  add2D("Stub_Width_Endcap_Ring", "Stub_Width_Endcap_Ring", "Endcap Ring",  "Displacement - Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+
+  // Offset
+  add2D("Stub_Offset_Barrel",      "Stub_Offset_Barrel",      "Barrel Layer", "Trigger Offset",  6, 0.5,  6.5, 43, -10.75, 10.75);
+  add2D("Stub_Offset_Endcap_Disc", "Stub_Offset_Endcap_Disc", "Endcap Disc",  "Trigger Offset",  5, 0.5,  5.5, 43, -10.75, 10.75);
+  add2D("Stub_Offset_Endcap_Ring", "Stub_Offset_Endcap_Ring", "Endcap Ring",  "Trigger Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+
+  // Disc-specific ring histograms: pset key uses _Fw_/_Bw_ (Python-safe), histId preserves +/-
+  for (int i = 1; i <= static_cast<int>(trklet::N_DISK); i++) {
+    const std::string si = std::to_string(i);
+    add1D("NStubs_Disc_Fw_" + si, "NStubs_Disc+" + si, "Endcap Ring", "# L1 Stubs", 16, 0.5, 16.5);
+    add1D("NStubs_Disc_Bw_" + si, "NStubs_Disc-" + si, "Endcap Ring", "# L1 Stubs", 16, 0.5, 16.5);
+    add2D("Stub_Width_Disc_Fw_"  + si, "Stub_Width_Disc+"  + si, "Endcap Ring", "Displacement - Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+    add2D("Stub_Width_Disc_Bw_"  + si, "Stub_Width_Disc-"  + si, "Endcap Ring", "Displacement - Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+    add2D("Stub_Offset_Disc_Fw_" + si, "Stub_Offset_Disc+" + si, "Endcap Ring", "Trigger Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+    add2D("Stub_Offset_Disc_Bw_" + si, "Stub_Offset_Disc-" + si, "Endcap Ring", "Trigger Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
   }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 60);
-    psd0.add<double>("xmin", -3.5);
-    psd0.add<double>("xmax", 3.5);
-    desc.add<edm::ParameterSetDescription>("TH1TTStub_Phi", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 45);
-    psd0.add<double>("xmin", 0);
-    psd0.add<double>("xmax", 120);
-    desc.add<edm::ParameterSetDescription>("TH1TTStub_R", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 69);
-    psd0.add<double>("xmin", -8.625);
-    psd0.add<double>("xmax", 8.625);
-    desc.add<edm::ParameterSetDescription>("TH1TTStub_bend", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 2);
-    psd0.add<double>("xmin", 0.0);
-    psd0.add<double>("xmax", 2.0);
-    desc.add<edm::ParameterSetDescription>("TH1TTStub_isPS", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 7);
-    psd0.add<double>("xmin", 0.5);
-    psd0.add<double>("xmax", 7.5);
-    desc.add<edm::ParameterSetDescription>("TH1TTStub_Layers", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 6);
-    psd0.add<double>("xmin", 0.5);
-    psd0.add<double>("xmax", 6.5);
-    desc.add<edm::ParameterSetDescription>("TH1TTStub_Discs", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 16);
-    psd0.add<double>("xmin", 0.5);
-    psd0.add<double>("xmax", 16.5);
-    desc.add<edm::ParameterSetDescription>("TH1TTStub_Rings", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 6);
-    psd0.add<double>("xmax", 6.5);
-    psd0.add<double>("xmin", 0.5);
-    psd0.add<int>("Nbinsy", 43);
-    psd0.add<double>("ymax", 10.75);
-    psd0.add<double>("ymin", -10.75);
-    desc.add<edm::ParameterSetDescription>("TH2TTStub_DisOf_Layer", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 5);
-    psd0.add<double>("xmax", 5.5);
-    psd0.add<double>("xmin", 0.5);
-    psd0.add<int>("Nbinsy", 43);
-    psd0.add<double>("ymax", 10.75);
-    psd0.add<double>("ymin", -10.75);
-    desc.add<edm::ParameterSetDescription>("TH2TTStub_DisOf_Disc", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 16);
-    psd0.add<double>("xmax", 16.5);
-    psd0.add<double>("xmin", 0.5);
-    psd0.add<int>("Nbinsy", 43);
-    psd0.add<double>("ymax", 10.75);
-    psd0.add<double>("ymin", -10.75);
-    desc.add<edm::ParameterSetDescription>("TH2TTStub_DisOf_Ring", psd0);
-  }
+
   desc.add<std::string>("TopFolderName", "TrackerPhase2OTStub");
   desc.add<edm::InputTag>("TTStubs", edm::InputTag("TTStubsFromPhase2TrackerDigis", "StubAccepted"));
   descriptions.add("Phase2OTMonitorTTStub", desc);
-  // or use the following to generate the label from the module's C++ type
   //descriptions.addWithDefaultLabel(desc);
 }
 

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
@@ -285,40 +285,11 @@ void Phase2OTMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker, edm::Run 
 void Phase2OTMonitorTTStub::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
 
-  auto add1D = [&](const std::string& psetKey, const std::string& histName,
-                   const std::string& xlabel, const std::string& ylabel,
-                   int nbins, double xmin, double xmax) {
-    edm::ParameterSetDescription ps;
-    ps.add<bool>("switch", true);
-    ps.add<std::string>("name", histName);
-    ps.add<std::string>("title", histName + ";" + xlabel + ";" + ylabel);
-    ps.add<int>("NxBins", nbins);
-    ps.add<double>("xmin", xmin);
-    ps.add<double>("xmax", xmax);
-    desc.add<edm::ParameterSetDescription>(psetKey, ps);
-  };
-
-  auto add2D = [&](const std::string& psetKey, const std::string& histName,
-                   const std::string& xlabel, const std::string& ylabel,
-                   int nbx, double xmin, double xmax, int nby, double ymin, double ymax) {
-    edm::ParameterSetDescription ps;
-    ps.add<bool>("switch", true);
-    ps.add<std::string>("name", histName);
-    ps.add<std::string>("title", histName + ";" + xlabel + ";" + ylabel);
-    ps.add<int>("NxBins", nbx);
-    ps.add<double>("xmin", xmin);
-    ps.add<double>("xmax", xmax);
-    ps.add<int>("NyBins", nby);
-    ps.add<double>("ymin", ymin);
-    ps.add<double>("ymax", ymax);
-    desc.add<edm::ParameterSetDescription>(psetKey, ps);
-  };
-
-  // Position (psetKey == histId for all fixed histograms)
-  add2D("Stub_Barrel_XY",    "Stub_Barrel_XY",    "L1 Stub Barrel position x [cm]", "L1 Stub Barrel position y [cm]", 960, -120, 120, 960, -120, 120);
-  add2D("Stub_Endcap_Fw_XY", "Stub_Endcap_Fw_XY", "L1 Stub Endcap position x [cm]", "L1 Stub Endcap position y [cm]", 960, -120, 120, 960, -120, 120);
-  add2D("Stub_Endcap_Bw_XY", "Stub_Endcap_Bw_XY", "L1 Stub Endcap position x [cm]", "L1 Stub Endcap position y [cm]", 960, -120, 120, 960, -120, 120);
-  add2D("Stub_RZ",            "Stub_RZ",            "L1 Stub position z [cm]",        "L1 Stub position #rho [cm]",    900, -300, 300, 900, 0, 120);
+  // Position
+  phase2tkutil::add2DDesc(desc, "Stub_Barrel_XY",    "Stub_Barrel_XY",    "L1 Stub Barrel position x [cm]", "L1 Stub Barrel position y [cm]", 960, -120, 120, 960, -120, 120);
+  phase2tkutil::add2DDesc(desc, "Stub_Endcap_Fw_XY", "Stub_Endcap_Fw_XY", "L1 Stub Endcap position x [cm]", "L1 Stub Endcap position y [cm]", 960, -120, 120, 960, -120, 120);
+  phase2tkutil::add2DDesc(desc, "Stub_Endcap_Bw_XY", "Stub_Endcap_Bw_XY", "L1 Stub Endcap position x [cm]", "L1 Stub Endcap position y [cm]", 960, -120, 120, 960, -120, 120);
+  phase2tkutil::add2DDesc(desc, "Stub_RZ",            "Stub_RZ",            "L1 Stub position z [cm]",        "L1 Stub position #rho [cm]",    900, -300, 300, 900, 0, 120);
 
   {
     edm::ParameterSetDescription psd0;
@@ -333,45 +304,44 @@ void Phase2OTMonitorTTStub::fillDescriptions(edm::ConfigurationDescriptions &des
   }
 
   // Stub distributions
-  add1D("Stub_Eta",    "Stub_Eta",    "#eta",          "# L1 Stubs", 45, -5,     5);
-  add1D("Stub_Phi",    "Stub_Phi",    "#phi",          "# L1 Stubs", 60, -3.5,   3.5);
-  add1D("Stub_R",      "Stub_R",      "R",             "# L1 Stubs", 45,  0,     120);
-  add1D("Stub_bendFE", "Stub_bendFE", "Trigger bend",  "# L1 Stubs", 69, -8.625, 8.625);
-  add1D("Stub_bendBE", "Stub_bendBE", "Hardware bend", "# L1 Stubs", 69, -8.625, 8.625);
-  add1D("Stub_isPS",   "Stub_isPS",   "Is PS?",        "# L1 Stubs",  2,  0,     2);
+  phase2tkutil::add1DDesc(desc, "Stub_Eta",    "Stub_Eta",    "#eta",          "# L1 Stubs", 45, -5,     5);
+  phase2tkutil::add1DDesc(desc, "Stub_Phi",    "Stub_Phi",    "#phi",          "# L1 Stubs", 60, -3.5,   3.5);
+  phase2tkutil::add1DDesc(desc, "Stub_R",      "Stub_R",      "R",             "# L1 Stubs", 45,  0,     120);
+  phase2tkutil::add1DDesc(desc, "Stub_bendFE", "Stub_bendFE", "Trigger bend",  "# L1 Stubs", 69, -8.625, 8.625);
+  phase2tkutil::add1DDesc(desc, "Stub_bendBE", "Stub_bendBE", "Hardware bend", "# L1 Stubs", 69, -8.625, 8.625);
+  phase2tkutil::add1DDesc(desc, "Stub_isPS",   "Stub_isPS",   "Is PS?",        "# L1 Stubs",  2,  0,     2);
 
   // NStubs
-  add1D("NStubs_Barrel",         "NStubs_Barrel",         "Barrel Layer",         "# L1 Stubs",  7, 0.5, 7.5);
-  add1D("NStubs_Endcap_Disc",    "NStubs_Endcap_Disc",    "Endcap Disc",          "# L1 Stubs",  6, 0.5, 6.5);
-  add1D("NStubs_Endcap_Disc_Fw", "NStubs_Endcap_Disc_Fw", "Forward Endcap Disc",  "# L1 Stubs",  6, 0.5, 6.5);
-  add1D("NStubs_Endcap_Disc_Bw", "NStubs_Endcap_Disc_Bw", "Backward Endcap Disc", "# L1 Stubs",  6, 0.5, 6.5);
-  add1D("NStubs_Endcap_Ring",    "NStubs_Endcap_Ring",    "Endcap Ring",          "# L1 Stubs", 16, 0.5, 16.5);
+  phase2tkutil::add1DDesc(desc, "NStubs_Barrel",         "NStubs_Barrel",         "Barrel Layer",         "# L1 Stubs",  7, 0.5, 7.5);
+  phase2tkutil::add1DDesc(desc, "NStubs_Endcap_Disc",    "NStubs_Endcap_Disc",    "Endcap Disc",          "# L1 Stubs",  6, 0.5, 6.5);
+  phase2tkutil::add1DDesc(desc, "NStubs_Endcap_Disc_Fw", "NStubs_Endcap_Disc_Fw", "Forward Endcap Disc",  "# L1 Stubs",  6, 0.5, 6.5);
+  phase2tkutil::add1DDesc(desc, "NStubs_Endcap_Disc_Bw", "NStubs_Endcap_Disc_Bw", "Backward Endcap Disc", "# L1 Stubs",  6, 0.5, 6.5);
+  phase2tkutil::add1DDesc(desc, "NStubs_Endcap_Ring",    "NStubs_Endcap_Ring",    "Endcap Ring",          "# L1 Stubs", 16, 0.5, 16.5);
 
   // Width
-  add2D("Stub_Width_Barrel",      "Stub_Width_Barrel",      "Barrel Layer", "Displacement - Offset",  6, 0.5,  6.5, 43, -10.75, 10.75);
-  add2D("Stub_Width_Endcap_Disc", "Stub_Width_Endcap_Disc", "Endcap Disc",  "Displacement - Offset",  5, 0.5,  5.5, 43, -10.75, 10.75);
-  add2D("Stub_Width_Endcap_Ring", "Stub_Width_Endcap_Ring", "Endcap Ring",  "Displacement - Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+  phase2tkutil::add2DDesc(desc, "Stub_Width_Barrel",      "Stub_Width_Barrel",      "Barrel Layer", "Displacement - Offset",  6, 0.5,  6.5, 43, -10.75, 10.75);
+  phase2tkutil::add2DDesc(desc, "Stub_Width_Endcap_Disc", "Stub_Width_Endcap_Disc", "Endcap Disc",  "Displacement - Offset",  5, 0.5,  5.5, 43, -10.75, 10.75);
+  phase2tkutil::add2DDesc(desc, "Stub_Width_Endcap_Ring", "Stub_Width_Endcap_Ring", "Endcap Ring",  "Displacement - Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
 
   // Offset
-  add2D("Stub_Offset_Barrel",      "Stub_Offset_Barrel",      "Barrel Layer", "Trigger Offset",  6, 0.5,  6.5, 43, -10.75, 10.75);
-  add2D("Stub_Offset_Endcap_Disc", "Stub_Offset_Endcap_Disc", "Endcap Disc",  "Trigger Offset",  5, 0.5,  5.5, 43, -10.75, 10.75);
-  add2D("Stub_Offset_Endcap_Ring", "Stub_Offset_Endcap_Ring", "Endcap Ring",  "Trigger Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+  phase2tkutil::add2DDesc(desc, "Stub_Offset_Barrel",      "Stub_Offset_Barrel",      "Barrel Layer", "Trigger Offset",  6, 0.5,  6.5, 43, -10.75, 10.75);
+  phase2tkutil::add2DDesc(desc, "Stub_Offset_Endcap_Disc", "Stub_Offset_Endcap_Disc", "Endcap Disc",  "Trigger Offset",  5, 0.5,  5.5, 43, -10.75, 10.75);
+  phase2tkutil::add2DDesc(desc, "Stub_Offset_Endcap_Ring", "Stub_Offset_Endcap_Ring", "Endcap Ring",  "Trigger Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
 
-  // Disc-specific ring histograms: pset key uses _Fw_/_Bw_ (Python-safe), histId preserves +/-
+  // Disc-specific ring histograms
   for (int i = 1; i <= static_cast<int>(trklet::N_DISK); i++) {
     const std::string si = std::to_string(i);
-    add1D("NStubs_Disc_Fw_" + si, "NStubs_Disc+" + si, "Endcap Ring", "# L1 Stubs", 16, 0.5, 16.5);
-    add1D("NStubs_Disc_Bw_" + si, "NStubs_Disc-" + si, "Endcap Ring", "# L1 Stubs", 16, 0.5, 16.5);
-    add2D("Stub_Width_Disc_Fw_"  + si, "Stub_Width_Disc+"  + si, "Endcap Ring", "Displacement - Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
-    add2D("Stub_Width_Disc_Bw_"  + si, "Stub_Width_Disc-"  + si, "Endcap Ring", "Displacement - Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
-    add2D("Stub_Offset_Disc_Fw_" + si, "Stub_Offset_Disc+" + si, "Endcap Ring", "Trigger Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
-    add2D("Stub_Offset_Disc_Bw_" + si, "Stub_Offset_Disc-" + si, "Endcap Ring", "Trigger Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+    phase2tkutil::add1DDesc(desc, "NStubs_Disc_Fw_" + si, "NStubs_Disc+" + si, "Endcap Ring", "# L1 Stubs", 16, 0.5, 16.5);
+    phase2tkutil::add1DDesc(desc, "NStubs_Disc_Bw_" + si, "NStubs_Disc-" + si, "Endcap Ring", "# L1 Stubs", 16, 0.5, 16.5);
+    phase2tkutil::add2DDesc(desc, "Stub_Width_Disc_Fw_"  + si, "Stub_Width_Disc+"  + si, "Endcap Ring", "Displacement - Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+    phase2tkutil::add2DDesc(desc, "Stub_Width_Disc_Bw_"  + si, "Stub_Width_Disc-"  + si, "Endcap Ring", "Displacement - Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+    phase2tkutil::add2DDesc(desc, "Stub_Offset_Disc_Fw_" + si, "Stub_Offset_Disc+" + si, "Endcap Ring", "Trigger Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
+    phase2tkutil::add2DDesc(desc, "Stub_Offset_Disc_Bw_" + si, "Stub_Offset_Disc-" + si, "Endcap Ring", "Trigger Offset", 16, 0.5, 16.5, 43, -10.75, 10.75);
   }
 
   desc.add<std::string>("TopFolderName", "TrackerPhase2OTStub");
   desc.add<edm::InputTag>("TTStubs", edm::InputTag("TTStubsFromPhase2TrackerDigis", "StubAccepted"));
   descriptions.add("Phase2OTMonitorTTStub", desc);
-  //descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_MODULE(Phase2OTMonitorTTStub);

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc
@@ -238,96 +238,158 @@ void Phase2OTMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   using namespace phase2tkutil;
 
   iBooker.setCurrentFolder(topFolderName_ + "/Tracks/All");
-  Track_All_N                = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_N"),                iBooker);
-  Track_All_NStubs           = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_NStubs"),           iBooker);
-  Track_All_NLayersMissed    = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_NLayersMissed"),    iBooker);
-  Track_All_Eta_NStubs       = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Eta_NStubs"),       iBooker);
-  Track_All_Pt               = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Pt"),               iBooker);
-  Track_All_Phi              = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Phi"),              iBooker);
-  Track_All_D0               = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_D0"),               iBooker);
-  Track_All_Eta              = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Eta"),              iBooker);
-  Track_All_VtxZ             = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_VtxZ"),             iBooker);
-  Track_All_Chi2             = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2"),             iBooker);
-  Track_All_Chi2RZ           = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2RZ"),           iBooker);
-  Track_All_Chi2RPhi         = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2RPhi"),         iBooker);
-  Track_All_BendChi2         = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_BendChi2"),         iBooker);
-  Track_All_Chi2Red          = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2Red"),          iBooker);
-  Track_All_Chi2_Probability = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2_Probability"), iBooker);
-  Track_All_MVA1             = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_MVA1"),             iBooker);
-  Track_All_Chi2Red_NStubs   = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2Red_NStubs"),   iBooker);
-  Track_All_Chi2Red_Eta      = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2Red_Eta"),      iBooker);
-  Track_All_Eta_BarrelStubs  = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Eta_BarrelStubs"),  iBooker);
-  Track_All_Eta_ECStubs      = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Eta_ECStubs"),      iBooker);
+  Track_All_N = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_N"), iBooker);
+  Track_All_NStubs = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_NStubs"), iBooker);
+  Track_All_NLayersMissed = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_NLayersMissed"), iBooker);
+  Track_All_Eta_NStubs = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Eta_NStubs"), iBooker);
+  Track_All_Pt = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Pt"), iBooker);
+  Track_All_Phi = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Phi"), iBooker);
+  Track_All_D0 = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_D0"), iBooker);
+  Track_All_Eta = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Eta"), iBooker);
+  Track_All_VtxZ = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_VtxZ"), iBooker);
+  Track_All_Chi2 = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2"), iBooker);
+  Track_All_Chi2RZ = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2RZ"), iBooker);
+  Track_All_Chi2RPhi = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2RPhi"), iBooker);
+  Track_All_BendChi2 = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_BendChi2"), iBooker);
+  Track_All_Chi2Red = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2Red"), iBooker);
+  Track_All_Chi2_Probability =
+      book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2_Probability"), iBooker);
+  Track_All_MVA1 = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_MVA1"), iBooker);
+  Track_All_Chi2Red_NStubs = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2Red_NStubs"), iBooker);
+  Track_All_Chi2Red_Eta = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2Red_Eta"), iBooker);
+  Track_All_Eta_BarrelStubs =
+      book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Eta_BarrelStubs"), iBooker);
+  Track_All_Eta_ECStubs = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Eta_ECStubs"), iBooker);
 
   iBooker.setCurrentFolder(topFolderName_ + "/Tracks/HQ");
-  Track_HQ_N                = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_N"),                iBooker);
-  Track_HQ_NStubs           = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_NStubs"),           iBooker);
-  Track_HQ_NLayersMissed    = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_NLayersMissed"),    iBooker);
-  Track_HQ_Eta_NStubs       = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Eta_NStubs"),       iBooker);
-  Track_HQ_Pt               = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Pt"),               iBooker);
-  Track_HQ_Phi              = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Phi"),              iBooker);
-  Track_HQ_D0               = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_D0"),               iBooker);
-  Track_HQ_Eta              = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Eta"),              iBooker);
-  Track_HQ_VtxZ             = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_VtxZ"),             iBooker);
-  Track_HQ_Chi2             = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2"),             iBooker);
-  Track_HQ_BendChi2         = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_BendChi2"),         iBooker);
-  Track_HQ_Chi2RZ           = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2RZ"),           iBooker);
-  Track_HQ_Chi2RPhi         = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2RPhi"),         iBooker);
-  Track_HQ_Chi2Red          = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2Red"),          iBooker);
-  Track_HQ_Chi2_Probability = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2_Probability"), iBooker);
-  Track_HQ_MVA1             = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_MVA1"),             iBooker);
-  Track_HQ_Chi2Red_NStubs   = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2Red_NStubs"),   iBooker);
-  Track_HQ_Chi2Red_Eta      = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2Red_Eta"),      iBooker);
-  Track_HQ_Eta_BarrelStubs  = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Eta_BarrelStubs"),  iBooker);
-  Track_HQ_Eta_ECStubs      = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Eta_ECStubs"),      iBooker);
+  Track_HQ_N = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_N"), iBooker);
+  Track_HQ_NStubs = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_NStubs"), iBooker);
+  Track_HQ_NLayersMissed = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_NLayersMissed"), iBooker);
+  Track_HQ_Eta_NStubs = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Eta_NStubs"), iBooker);
+  Track_HQ_Pt = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Pt"), iBooker);
+  Track_HQ_Phi = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Phi"), iBooker);
+  Track_HQ_D0 = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_D0"), iBooker);
+  Track_HQ_Eta = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Eta"), iBooker);
+  Track_HQ_VtxZ = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_VtxZ"), iBooker);
+  Track_HQ_Chi2 = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2"), iBooker);
+  Track_HQ_BendChi2 = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_BendChi2"), iBooker);
+  Track_HQ_Chi2RZ = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2RZ"), iBooker);
+  Track_HQ_Chi2RPhi = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2RPhi"), iBooker);
+  Track_HQ_Chi2Red = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2Red"), iBooker);
+  Track_HQ_Chi2_Probability =
+      book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2_Probability"), iBooker);
+  Track_HQ_MVA1 = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_MVA1"), iBooker);
+  Track_HQ_Chi2Red_NStubs = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2Red_NStubs"), iBooker);
+  Track_HQ_Chi2Red_Eta = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2Red_Eta"), iBooker);
+  Track_HQ_Eta_BarrelStubs = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Eta_BarrelStubs"), iBooker);
+  Track_HQ_Eta_ECStubs = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Eta_ECStubs"), iBooker);
 }
 
 void Phase2OTMonitorTTTrack::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
 
   // All tracks
-  phase2tkutil::add1DDesc(desc, "Track_All_N",                "Track_All_N",                "# L1 Tracks",                    "# Events",            100,   0,   399);
-  phase2tkutil::add1DDesc(desc, "Track_All_NStubs",           "Track_All_NStubs",           "# L1 Stubs per L1 Track",        "# L1 Tracks",           8,   0,     8);
-  phase2tkutil::add1DDesc(desc, "Track_All_NLayersMissed",    "Track_All_NLayersMissed",    "# Layers missed",                "# L1 Tracks",           8,   0,     8);
-  phase2tkutil::add2DDesc(desc, "Track_All_Eta_NStubs",       "Track_All_Eta_NStubs",       "#eta",                           "# L1 Stubs",           15,  -3.0,  3.0,  5,  3,   8);
-  phase2tkutil::add1DDesc(desc, "Track_All_Pt",               "Track_All_Pt",               "p_{T} [GeV]",                    "# L1 Tracks",          50,   0,   100);
-  phase2tkutil::add1DDesc(desc, "Track_All_Phi",              "Track_All_Phi",              "#phi",                           "# L1 Tracks",          60,  -3.5,  3.5);
-  phase2tkutil::add1DDesc(desc, "Track_All_D0",               "Track_All_D0",               "Track D0",                       "# L1 Tracks",         101,  -0.15, 0.15);
-  phase2tkutil::add1DDesc(desc, "Track_All_Eta",              "Track_All_Eta",              "#eta",                           "# L1 Tracks",          45,  -3.0,  3.0);
-  phase2tkutil::add1DDesc(desc, "Track_All_VtxZ",             "Track_All_VtxZ",             "L1 Track vertex position z [cm]","# L1 Tracks",          41, -20,    20);
-  phase2tkutil::add1DDesc(desc, "Track_All_Chi2",             "Track_All_Chi2",             "L1 Track #chi^{2}",              "# L1 Tracks",         100,   0,    50);
-  phase2tkutil::add1DDesc(desc, "Track_All_Chi2RZ",           "Track_All_Chi2RZ",           "L1 Track #chi^{2} r-z",          "# L1 Tracks",         100,   0,    50);
-  phase2tkutil::add1DDesc(desc, "Track_All_Chi2RPhi",         "Track_All_Chi2RPhi",         "L1 Track #chi^{2}",              "# L1 Tracks",         100,   0,    50);
-  phase2tkutil::add1DDesc(desc, "Track_All_BendChi2",         "Track_All_BendChi2",         "L1 Track Bend #chi^{2}",         "# L1 Tracks",         100,   0,    10);
-  phase2tkutil::add1DDesc(desc, "Track_All_Chi2Red",          "Track_All_Chi2Red",          "L1 Track #chi^{2}/ndf",          "# L1 Tracks",         100,   0,    10);
-  phase2tkutil::add1DDesc(desc, "Track_All_Chi2_Probability", "Track_All_Chi2_Probability", "#chi^{2} probability",           "# L1 Tracks",         100,   0,     1);
-  phase2tkutil::add1DDesc(desc, "Track_All_MVA1",             "Track_All_MVA1",             "MVA1",                           "# L1 Tracks",         100,   0,     1);
-  phase2tkutil::add2DDesc(desc, "Track_All_Chi2Red_NStubs",   "Track_All_Chi2Red_NStubs",   "# L1 Stubs",                     "L1 Track #chi^{2}/ndf",  5,  3,    8,  15,  0,  10);
-  phase2tkutil::add2DDesc(desc, "Track_All_Chi2Red_Eta",      "Track_All_Chi2Red_Eta",      "#eta",                           "L1 Track #chi^{2}/ndf", 15, -3.0,  3.0, 15,  0,  10);
-  phase2tkutil::add2DDesc(desc, "Track_All_Eta_BarrelStubs",  "Track_All_Eta_BarrelStubs",  "#eta",                           "# L1 Barrel Stubs",    15,  -3.0,  3.0,  5,  3,   8);
-  phase2tkutil::add2DDesc(desc, "Track_All_Eta_ECStubs",      "Track_All_Eta_ECStubs",       "#eta",                           "# L1 EC Stubs",        15,  -3.0,  3.0,  5,  3,   8);
+  phase2tkutil::add1DDesc(desc, "Track_All_N", "Track_All_N", "# L1 Tracks", "# Events", 100, 0, 399);
+  phase2tkutil::add1DDesc(
+      desc, "Track_All_NStubs", "Track_All_NStubs", "# L1 Stubs per L1 Track", "# L1 Tracks", 8, 0, 8);
+  phase2tkutil::add1DDesc(
+      desc, "Track_All_NLayersMissed", "Track_All_NLayersMissed", "# Layers missed", "# L1 Tracks", 8, 0, 8);
+  phase2tkutil::add2DDesc(
+      desc, "Track_All_Eta_NStubs", "Track_All_Eta_NStubs", "#eta", "# L1 Stubs", 15, -3.0, 3.0, 5, 3, 8);
+  phase2tkutil::add1DDesc(desc, "Track_All_Pt", "Track_All_Pt", "p_{T} [GeV]", "# L1 Tracks", 50, 0, 100);
+  phase2tkutil::add1DDesc(desc, "Track_All_Phi", "Track_All_Phi", "#phi", "# L1 Tracks", 60, -3.5, 3.5);
+  phase2tkutil::add1DDesc(desc, "Track_All_D0", "Track_All_D0", "Track D0", "# L1 Tracks", 101, -0.15, 0.15);
+  phase2tkutil::add1DDesc(desc, "Track_All_Eta", "Track_All_Eta", "#eta", "# L1 Tracks", 45, -3.0, 3.0);
+  phase2tkutil::add1DDesc(
+      desc, "Track_All_VtxZ", "Track_All_VtxZ", "L1 Track vertex position z [cm]", "# L1 Tracks", 41, -20, 20);
+  phase2tkutil::add1DDesc(desc, "Track_All_Chi2", "Track_All_Chi2", "L1 Track #chi^{2}", "# L1 Tracks", 100, 0, 50);
+  phase2tkutil::add1DDesc(
+      desc, "Track_All_Chi2RZ", "Track_All_Chi2RZ", "L1 Track #chi^{2} r-z", "# L1 Tracks", 100, 0, 50);
+  phase2tkutil::add1DDesc(
+      desc, "Track_All_Chi2RPhi", "Track_All_Chi2RPhi", "L1 Track #chi^{2}", "# L1 Tracks", 100, 0, 50);
+  phase2tkutil::add1DDesc(
+      desc, "Track_All_BendChi2", "Track_All_BendChi2", "L1 Track Bend #chi^{2}", "# L1 Tracks", 100, 0, 10);
+  phase2tkutil::add1DDesc(
+      desc, "Track_All_Chi2Red", "Track_All_Chi2Red", "L1 Track #chi^{2}/ndf", "# L1 Tracks", 100, 0, 10);
+  phase2tkutil::add1DDesc(desc,
+                          "Track_All_Chi2_Probability",
+                          "Track_All_Chi2_Probability",
+                          "#chi^{2} probability",
+                          "# L1 Tracks",
+                          100,
+                          0,
+                          1);
+  phase2tkutil::add1DDesc(desc, "Track_All_MVA1", "Track_All_MVA1", "MVA1", "# L1 Tracks", 100, 0, 1);
+  phase2tkutil::add2DDesc(desc,
+                          "Track_All_Chi2Red_NStubs",
+                          "Track_All_Chi2Red_NStubs",
+                          "# L1 Stubs",
+                          "L1 Track #chi^{2}/ndf",
+                          5,
+                          3,
+                          8,
+                          15,
+                          0,
+                          10);
+  phase2tkutil::add2DDesc(
+      desc, "Track_All_Chi2Red_Eta", "Track_All_Chi2Red_Eta", "#eta", "L1 Track #chi^{2}/ndf", 15, -3.0, 3.0, 15, 0, 10);
+  phase2tkutil::add2DDesc(desc,
+                          "Track_All_Eta_BarrelStubs",
+                          "Track_All_Eta_BarrelStubs",
+                          "#eta",
+                          "# L1 Barrel Stubs",
+                          15,
+                          -3.0,
+                          3.0,
+                          5,
+                          3,
+                          8);
+  phase2tkutil::add2DDesc(
+      desc, "Track_All_Eta_ECStubs", "Track_All_Eta_ECStubs", "#eta", "# L1 EC Stubs", 15, -3.0, 3.0, 5, 3, 8);
 
   // HQ tracks
-  phase2tkutil::add1DDesc(desc, "Track_HQ_N",                "Track_HQ_N",                "# L1 Tracks",                    "# Events",            100,   0,   399);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_NStubs",           "Track_HQ_NStubs",           "# L1 Stubs per L1 Track",        "# L1 Tracks",           8,   0,     8);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_NLayersMissed",    "Track_HQ_NLayersMissed",    "# Layers missed",                "# L1 Tracks",           8,   0,     8);
-  phase2tkutil::add2DDesc(desc, "Track_HQ_Eta_NStubs",       "Track_HQ_Eta_NStubs",       "#eta",                           "# L1 Stubs",           15,  -3.0,  3.0,  5,  3,   8);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_Pt",               "Track_HQ_Pt",               "p_{T} [GeV]",                    "# L1 Tracks",          50,   0,   100);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_Phi",              "Track_HQ_Phi",              "#phi",                           "# L1 Tracks",          60,  -3.5,  3.5);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_D0",               "Track_HQ_D0",               "Track D0",                       "# L1 Tracks",         101,  -0.15, 0.15);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_Eta",              "Track_HQ_Eta",              "#eta",                           "# L1 Tracks",          45,  -3.0,  3.0);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_VtxZ",             "Track_HQ_VtxZ",             "L1 Track vertex position z [cm]","# L1 Tracks",          41, -20,    20);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_Chi2",             "Track_HQ_Chi2",             "L1 Track #chi^{2}",              "# L1 Tracks",         100,   0,    50);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_BendChi2",         "Track_HQ_BendChi2",         "L1 Track Bend #chi^{2}",         "# L1 Tracks",         100,   0,    10);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_Chi2RZ",           "Track_HQ_Chi2RZ",           "L1 Track #chi^{2} r-z",          "# L1 Tracks",         100,   0,    50);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_Chi2RPhi",         "Track_HQ_Chi2RPhi",         "L1 Track #chi^{2} r-phi",        "# L1 Tracks",         100,   0,    50);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_Chi2Red",          "Track_HQ_Chi2Red",          "L1 Track #chi^{2}/ndf",          "# L1 Tracks",         100,   0,    10);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_Chi2_Probability", "Track_HQ_Chi2_Probability", "#chi^{2} probability",           "# L1 Tracks",         100,   0,     1);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_MVA1",             "Track_HQ_MVA1",             "MVA1",                           "# L1 Tracks",         100,   0,     1);
-  phase2tkutil::add2DDesc(desc, "Track_HQ_Chi2Red_NStubs",   "Track_HQ_Chi2Red_NStubs",   "# L1 Stubs",                     "L1 Track #chi^{2}/ndf",  5,  3,    8,  15,  0,  10);
-  phase2tkutil::add2DDesc(desc, "Track_HQ_Chi2Red_Eta",      "Track_HQ_Chi2Red_Eta",      "#eta",                           "L1 Track #chi^{2}/ndf", 15, -3.0,  3.0, 15,  0,  10);
-  phase2tkutil::add2DDesc(desc, "Track_HQ_Eta_BarrelStubs",  "Track_HQ_Eta_BarrelStubs",  "#eta",                           "# L1 Barrel Stubs",    15,  -3.0,  3.0,  5,  3,   8);
-  phase2tkutil::add2DDesc(desc, "Track_HQ_Eta_ECStubs",      "Track_HQ_Eta_ECStubs",      "#eta",                           "# L1 EC Stubs",        15,  -3.0,  3.0,  5,  3,   8);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_N", "Track_HQ_N", "# L1 Tracks", "# Events", 100, 0, 399);
+  phase2tkutil::add1DDesc(
+      desc, "Track_HQ_NStubs", "Track_HQ_NStubs", "# L1 Stubs per L1 Track", "# L1 Tracks", 8, 0, 8);
+  phase2tkutil::add1DDesc(
+      desc, "Track_HQ_NLayersMissed", "Track_HQ_NLayersMissed", "# Layers missed", "# L1 Tracks", 8, 0, 8);
+  phase2tkutil::add2DDesc(
+      desc, "Track_HQ_Eta_NStubs", "Track_HQ_Eta_NStubs", "#eta", "# L1 Stubs", 15, -3.0, 3.0, 5, 3, 8);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_Pt", "Track_HQ_Pt", "p_{T} [GeV]", "# L1 Tracks", 50, 0, 100);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_Phi", "Track_HQ_Phi", "#phi", "# L1 Tracks", 60, -3.5, 3.5);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_D0", "Track_HQ_D0", "Track D0", "# L1 Tracks", 101, -0.15, 0.15);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_Eta", "Track_HQ_Eta", "#eta", "# L1 Tracks", 45, -3.0, 3.0);
+  phase2tkutil::add1DDesc(
+      desc, "Track_HQ_VtxZ", "Track_HQ_VtxZ", "L1 Track vertex position z [cm]", "# L1 Tracks", 41, -20, 20);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_Chi2", "Track_HQ_Chi2", "L1 Track #chi^{2}", "# L1 Tracks", 100, 0, 50);
+  phase2tkutil::add1DDesc(
+      desc, "Track_HQ_BendChi2", "Track_HQ_BendChi2", "L1 Track Bend #chi^{2}", "# L1 Tracks", 100, 0, 10);
+  phase2tkutil::add1DDesc(
+      desc, "Track_HQ_Chi2RZ", "Track_HQ_Chi2RZ", "L1 Track #chi^{2} r-z", "# L1 Tracks", 100, 0, 50);
+  phase2tkutil::add1DDesc(
+      desc, "Track_HQ_Chi2RPhi", "Track_HQ_Chi2RPhi", "L1 Track #chi^{2} r-phi", "# L1 Tracks", 100, 0, 50);
+  phase2tkutil::add1DDesc(
+      desc, "Track_HQ_Chi2Red", "Track_HQ_Chi2Red", "L1 Track #chi^{2}/ndf", "# L1 Tracks", 100, 0, 10);
+  phase2tkutil::add1DDesc(
+      desc, "Track_HQ_Chi2_Probability", "Track_HQ_Chi2_Probability", "#chi^{2} probability", "# L1 Tracks", 100, 0, 1);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_MVA1", "Track_HQ_MVA1", "MVA1", "# L1 Tracks", 100, 0, 1);
+  phase2tkutil::add2DDesc(desc,
+                          "Track_HQ_Chi2Red_NStubs",
+                          "Track_HQ_Chi2Red_NStubs",
+                          "# L1 Stubs",
+                          "L1 Track #chi^{2}/ndf",
+                          5,
+                          3,
+                          8,
+                          15,
+                          0,
+                          10);
+  phase2tkutil::add2DDesc(
+      desc, "Track_HQ_Chi2Red_Eta", "Track_HQ_Chi2Red_Eta", "#eta", "L1 Track #chi^{2}/ndf", 15, -3.0, 3.0, 15, 0, 10);
+  phase2tkutil::add2DDesc(
+      desc, "Track_HQ_Eta_BarrelStubs", "Track_HQ_Eta_BarrelStubs", "#eta", "# L1 Barrel Stubs", 15, -3.0, 3.0, 5, 3, 8);
+  phase2tkutil::add2DDesc(
+      desc, "Track_HQ_Eta_ECStubs", "Track_HQ_Eta_ECStubs", "#eta", "# L1 EC Stubs", 15, -3.0, 3.0, 5, 3, 8);
 
   desc.add<std::string>("TopFolderName", "TrackerPhase2OTL1Track");
   desc.add<edm::InputTag>("TTTracksTag", edm::InputTag("l1tTTTracksFromTrackletEmulation", "Level1TTTracks"));

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc
@@ -36,6 +36,7 @@
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h"
 
 class Phase2OTMonitorTTTrack : public DQMEDAnalyzer {
 public:
@@ -234,574 +235,105 @@ void Phase2OTMonitorTTTrack::analyze(const edm::Event &iEvent, const edm::EventS
 void Phase2OTMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
                                             edm::Run const &run,
                                             edm::EventSetup const &es) {
-  std::string HistoName;
+  using namespace phase2tkutil;
 
-  /// Low-quality tracks (All tracks, including HQ tracks)
   iBooker.setCurrentFolder(topFolderName_ + "/Tracks/All");
-  // Nb of L1Tracks
-  HistoName = "Track_All_N";
-  edm::ParameterSet psTrack_N = conf_.getParameter<edm::ParameterSet>("TH1_NTracks");
-  Track_All_N = iBooker.book1D(HistoName,
-                               HistoName,
-                               psTrack_N.getParameter<int32_t>("Nbinsx"),
-                               psTrack_N.getParameter<double>("xmin"),
-                               psTrack_N.getParameter<double>("xmax"));
-  Track_All_N->setAxisTitle("# L1 Tracks", 1);
-  Track_All_N->setAxisTitle("# Events", 2);
+  Track_All_N                = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_N"),                iBooker);
+  Track_All_NStubs           = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_NStubs"),           iBooker);
+  Track_All_NLayersMissed    = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_NLayersMissed"),    iBooker);
+  Track_All_Eta_NStubs       = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Eta_NStubs"),       iBooker);
+  Track_All_Pt               = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Pt"),               iBooker);
+  Track_All_Phi              = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Phi"),              iBooker);
+  Track_All_D0               = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_D0"),               iBooker);
+  Track_All_Eta              = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Eta"),              iBooker);
+  Track_All_VtxZ             = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_VtxZ"),             iBooker);
+  Track_All_Chi2             = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2"),             iBooker);
+  Track_All_Chi2RZ           = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2RZ"),           iBooker);
+  Track_All_Chi2RPhi         = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2RPhi"),         iBooker);
+  Track_All_BendChi2         = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_BendChi2"),         iBooker);
+  Track_All_Chi2Red          = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2Red"),          iBooker);
+  Track_All_Chi2_Probability = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2_Probability"), iBooker);
+  Track_All_MVA1             = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_MVA1"),             iBooker);
+  Track_All_Chi2Red_NStubs   = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2Red_NStubs"),   iBooker);
+  Track_All_Chi2Red_Eta      = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Chi2Red_Eta"),      iBooker);
+  Track_All_Eta_BarrelStubs  = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Eta_BarrelStubs"),  iBooker);
+  Track_All_Eta_ECStubs      = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_All_Eta_ECStubs"),      iBooker);
 
-  // Number of stubs
-  edm::ParameterSet psTrack_NStubs = conf_.getParameter<edm::ParameterSet>("TH1_NStubs");
-  HistoName = "Track_All_NStubs";
-  Track_All_NStubs = iBooker.book1D(HistoName,
-                                    HistoName,
-                                    psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
-                                    psTrack_NStubs.getParameter<double>("xmin"),
-                                    psTrack_NStubs.getParameter<double>("xmax"));
-  Track_All_NStubs->setAxisTitle("# L1 Stubs per L1 Track", 1);
-  Track_All_NStubs->setAxisTitle("# L1 Tracks", 2);
-
-  // Number of layers missed
-  HistoName = "Track_All_NLayersMissed";
-  Track_All_NLayersMissed = iBooker.book1D(HistoName,
-                                           HistoName,
-                                           psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
-                                           psTrack_NStubs.getParameter<double>("xmin"),
-                                           psTrack_NStubs.getParameter<double>("xmax"));
-  Track_All_NLayersMissed->setAxisTitle("# Layers missed", 1);
-  Track_All_NLayersMissed->setAxisTitle("# L1 Tracks", 2);
-
-  edm::ParameterSet psTrack_Eta_NStubs = conf_.getParameter<edm::ParameterSet>("TH2_Track_Eta_NStubs");
-  HistoName = "Track_All_Eta_NStubs";
-  Track_All_Eta_NStubs = iBooker.book2D(HistoName,
-                                        HistoName,
-                                        psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
-                                        psTrack_Eta_NStubs.getParameter<double>("xmin"),
-                                        psTrack_Eta_NStubs.getParameter<double>("xmax"),
-                                        psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
-                                        psTrack_Eta_NStubs.getParameter<double>("ymin"),
-                                        psTrack_Eta_NStubs.getParameter<double>("ymax"));
-  Track_All_Eta_NStubs->setAxisTitle("#eta", 1);
-  Track_All_Eta_NStubs->setAxisTitle("# L1 Stubs", 2);
-
-  // Pt of the tracks
-  edm::ParameterSet psTrack_Pt = conf_.getParameter<edm::ParameterSet>("TH1_Track_Pt");
-  HistoName = "Track_All_Pt";
-  Track_All_Pt = iBooker.book1D(HistoName,
-                                HistoName,
-                                psTrack_Pt.getParameter<int32_t>("Nbinsx"),
-                                psTrack_Pt.getParameter<double>("xmin"),
-                                psTrack_Pt.getParameter<double>("xmax"));
-  Track_All_Pt->setAxisTitle("p_{T} [GeV]", 1);
-  Track_All_Pt->setAxisTitle("# L1 Tracks", 2);
-
-  // Phi
-  edm::ParameterSet psTrack_Phi = conf_.getParameter<edm::ParameterSet>("TH1_Track_Phi");
-  HistoName = "Track_All_Phi";
-  Track_All_Phi = iBooker.book1D(HistoName,
-                                 HistoName,
-                                 psTrack_Phi.getParameter<int32_t>("Nbinsx"),
-                                 psTrack_Phi.getParameter<double>("xmin"),
-                                 psTrack_Phi.getParameter<double>("xmax"));
-  Track_All_Phi->setAxisTitle("#phi", 1);
-  Track_All_Phi->setAxisTitle("# L1 Tracks", 2);
-
-  // D0
-  edm::ParameterSet psTrack_D0 = conf_.getParameter<edm::ParameterSet>("TH1_Track_D0");
-  HistoName = "Track_All_D0";
-  Track_All_D0 = iBooker.book1D(HistoName,
-                                HistoName,
-                                psTrack_D0.getParameter<int32_t>("Nbinsx"),
-                                psTrack_D0.getParameter<double>("xmin"),
-                                psTrack_D0.getParameter<double>("xmax"));
-  Track_All_D0->setAxisTitle("Track D0", 1);
-  Track_All_D0->setAxisTitle("# L1 Tracks", 2);
-
-  // Eta
-  edm::ParameterSet psTrack_Eta = conf_.getParameter<edm::ParameterSet>("TH1_Track_Eta");
-  HistoName = "Track_All_Eta";
-  Track_All_Eta = iBooker.book1D(HistoName,
-                                 HistoName,
-                                 psTrack_Eta.getParameter<int32_t>("Nbinsx"),
-                                 psTrack_Eta.getParameter<double>("xmin"),
-                                 psTrack_Eta.getParameter<double>("xmax"));
-  Track_All_Eta->setAxisTitle("#eta", 1);
-  Track_All_Eta->setAxisTitle("# L1 Tracks", 2);
-
-  // VtxZ
-  edm::ParameterSet psTrack_VtxZ = conf_.getParameter<edm::ParameterSet>("TH1_Track_VtxZ");
-  HistoName = "Track_All_VtxZ";
-  Track_All_VtxZ = iBooker.book1D(HistoName,
-                                  HistoName,
-                                  psTrack_VtxZ.getParameter<int32_t>("Nbinsx"),
-                                  psTrack_VtxZ.getParameter<double>("xmin"),
-                                  psTrack_VtxZ.getParameter<double>("xmax"));
-  Track_All_VtxZ->setAxisTitle("L1 Track vertex position z [cm]", 1);
-  Track_All_VtxZ->setAxisTitle("# L1 Tracks", 2);
-
-  // chi2
-  edm::ParameterSet psTrack_Chi2 = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2");
-  HistoName = "Track_All_Chi2";
-  Track_All_Chi2 = iBooker.book1D(HistoName,
-                                  HistoName,
-                                  psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
-                                  psTrack_Chi2.getParameter<double>("xmin"),
-                                  psTrack_Chi2.getParameter<double>("xmax"));
-  Track_All_Chi2->setAxisTitle("L1 Track #chi^{2}", 1);
-  Track_All_Chi2->setAxisTitle("# L1 Tracks", 2);
-
-  // chi2 r-z
-  HistoName = "Track_All_Chi2RZ";
-  Track_All_Chi2RZ = iBooker.book1D(HistoName,
-                                    HistoName,
-                                    psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
-                                    psTrack_Chi2.getParameter<double>("xmin"),
-                                    psTrack_Chi2.getParameter<double>("xmax"));
-  Track_All_Chi2RZ->setAxisTitle("L1 Track #chi^{2} r-z", 1);
-  Track_All_Chi2RZ->setAxisTitle("# L1 Tracks", 2);
-
-  // chi2 r-phi
-  HistoName = "Track_All_Chi2RPhi";
-  Track_All_Chi2RPhi = iBooker.book1D(HistoName,
-                                      HistoName,
-                                      psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
-                                      psTrack_Chi2.getParameter<double>("xmin"),
-                                      psTrack_Chi2.getParameter<double>("xmax"));
-  Track_All_Chi2RPhi->setAxisTitle("L1 Track #chi^{2}", 1);
-  Track_All_Chi2RPhi->setAxisTitle("# L1 Tracks", 2);
-
-  // Bendchi2
-  edm::ParameterSet psTrack_Chi2R = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2R");
-  HistoName = "Track_All_BendChi2";
-  Track_All_BendChi2 = iBooker.book1D(HistoName,
-                                      HistoName,
-                                      psTrack_Chi2R.getParameter<int32_t>("Nbinsx"),
-                                      psTrack_Chi2R.getParameter<double>("xmin"),
-                                      psTrack_Chi2R.getParameter<double>("xmax"));
-  Track_All_BendChi2->setAxisTitle("L1 Track Bend #chi^{2}", 1);
-  Track_All_BendChi2->setAxisTitle("# L1 Tracks", 2);
-
-  // chi2Red
-  edm::ParameterSet psTrack_Chi2Red = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2R");
-  HistoName = "Track_All_Chi2Red";
-  Track_All_Chi2Red = iBooker.book1D(HistoName,
-                                     HistoName,
-                                     psTrack_Chi2R.getParameter<int32_t>("Nbinsx"),
-                                     psTrack_Chi2R.getParameter<double>("xmin"),
-                                     psTrack_Chi2R.getParameter<double>("xmax"));
-  Track_All_Chi2Red->setAxisTitle("L1 Track #chi^{2}/ndf", 1);
-  Track_All_Chi2Red->setAxisTitle("# L1 Tracks", 2);
-
-  // Chi2 prob
-  edm::ParameterSet psTrack_Chi2_Probability = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2_Probability");
-  HistoName = "Track_All_Chi2_Probability";
-  Track_All_Chi2_Probability = iBooker.book1D(HistoName,
-                                              HistoName,
-                                              psTrack_Chi2_Probability.getParameter<int32_t>("Nbinsx"),
-                                              psTrack_Chi2_Probability.getParameter<double>("xmin"),
-                                              psTrack_Chi2_Probability.getParameter<double>("xmax"));
-  Track_All_Chi2_Probability->setAxisTitle("#chi^{2} probability", 1);
-  Track_All_Chi2_Probability->setAxisTitle("# L1 Tracks", 2);
-
-  // MVA1 (prompt quality)
-  edm::ParameterSet psTrack_MVA1 = conf_.getParameter<edm::ParameterSet>("TH1_Track_MVA1");
-  HistoName = "Track_All_MVA1";
-  Track_All_MVA1 = iBooker.book1D(HistoName,
-                                  HistoName,
-                                  psTrack_MVA1.getParameter<int32_t>("Nbinsx"),
-                                  psTrack_MVA1.getParameter<double>("xmin"),
-                                  psTrack_MVA1.getParameter<double>("xmax"));
-  Track_All_MVA1->setAxisTitle("MVA1", 1);
-  Track_All_MVA1->setAxisTitle("# L1 Tracks", 2);
-
-  // Reduced chi2 vs #stubs
-  edm::ParameterSet psTrack_Chi2R_NStubs = conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_NStubs");
-  HistoName = "Track_All_Chi2Red_NStubs";
-  Track_All_Chi2Red_NStubs = iBooker.book2D(HistoName,
-                                            HistoName,
-                                            psTrack_Chi2R_NStubs.getParameter<int32_t>("Nbinsx"),
-                                            psTrack_Chi2R_NStubs.getParameter<double>("xmin"),
-                                            psTrack_Chi2R_NStubs.getParameter<double>("xmax"),
-                                            psTrack_Chi2R_NStubs.getParameter<int32_t>("Nbinsy"),
-                                            psTrack_Chi2R_NStubs.getParameter<double>("ymin"),
-                                            psTrack_Chi2R_NStubs.getParameter<double>("ymax"));
-  Track_All_Chi2Red_NStubs->setAxisTitle("# L1 Stubs", 1);
-  Track_All_Chi2Red_NStubs->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
-
-  // chi2/dof vs eta
-  edm::ParameterSet psTrack_Chi2R_Eta = conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_Eta");
-  HistoName = "Track_All_Chi2Red_Eta";
-  Track_All_Chi2Red_Eta = iBooker.book2D(HistoName,
-                                         HistoName,
-                                         psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsx"),
-                                         psTrack_Chi2R_Eta.getParameter<double>("xmin"),
-                                         psTrack_Chi2R_Eta.getParameter<double>("xmax"),
-                                         psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsy"),
-                                         psTrack_Chi2R_Eta.getParameter<double>("ymin"),
-                                         psTrack_Chi2R_Eta.getParameter<double>("ymax"));
-  Track_All_Chi2Red_Eta->setAxisTitle("#eta", 1);
-  Track_All_Chi2Red_Eta->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
-
-  // Eta vs #stubs in barrel
-  HistoName = "Track_All_Eta_BarrelStubs";
-  Track_All_Eta_BarrelStubs = iBooker.book2D(HistoName,
-                                             HistoName,
-                                             psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
-                                             psTrack_Eta_NStubs.getParameter<double>("xmin"),
-                                             psTrack_Eta_NStubs.getParameter<double>("xmax"),
-                                             psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
-                                             psTrack_Eta_NStubs.getParameter<double>("ymin"),
-                                             psTrack_Eta_NStubs.getParameter<double>("ymax"));
-  Track_All_Eta_BarrelStubs->setAxisTitle("#eta", 1);
-  Track_All_Eta_BarrelStubs->setAxisTitle("# L1 Barrel Stubs", 2);
-
-  // Eta vs #stubs in EC
-  HistoName = "Track_LQ_Eta_ECStubs";
-  Track_All_Eta_ECStubs = iBooker.book2D(HistoName,
-                                         HistoName,
-                                         psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
-                                         psTrack_Eta_NStubs.getParameter<double>("xmin"),
-                                         psTrack_Eta_NStubs.getParameter<double>("xmax"),
-                                         psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
-                                         psTrack_Eta_NStubs.getParameter<double>("ymin"),
-                                         psTrack_Eta_NStubs.getParameter<double>("ymax"));
-  Track_All_Eta_ECStubs->setAxisTitle("#eta", 1);
-  Track_All_Eta_ECStubs->setAxisTitle("# L1 EC Stubs", 2);
-
-  /// High-quality tracks (Bendchi2 < 2.2 and chi2/dof < 10)
   iBooker.setCurrentFolder(topFolderName_ + "/Tracks/HQ");
-  // Nb of L1Tracks
-  HistoName = "Track_HQ_N";
-  Track_HQ_N = iBooker.book1D(HistoName,
-                              HistoName,
-                              psTrack_N.getParameter<int32_t>("Nbinsx"),
-                              psTrack_N.getParameter<double>("xmin"),
-                              psTrack_N.getParameter<double>("xmax"));
-  Track_HQ_N->setAxisTitle("# L1 Tracks", 1);
-  Track_HQ_N->setAxisTitle("# Events", 2);
-
-  // Number of stubs
-  HistoName = "Track_HQ_NStubs";
-  Track_HQ_NStubs = iBooker.book1D(HistoName,
-                                   HistoName,
-                                   psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
-                                   psTrack_NStubs.getParameter<double>("xmin"),
-                                   psTrack_NStubs.getParameter<double>("xmax"));
-  Track_HQ_NStubs->setAxisTitle("# L1 Stubs per L1 Track", 1);
-  Track_HQ_NStubs->setAxisTitle("# L1 Tracks", 2);
-
-  // Number of layers missed
-  HistoName = "Track_HQ_NLayersMissed";
-  Track_HQ_NLayersMissed = iBooker.book1D(HistoName,
-                                          HistoName,
-                                          psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
-                                          psTrack_NStubs.getParameter<double>("xmin"),
-                                          psTrack_NStubs.getParameter<double>("xmax"));
-  Track_HQ_NLayersMissed->setAxisTitle("# Layers missed", 1);
-  Track_HQ_NLayersMissed->setAxisTitle("# L1 Tracks", 2);
-
-  // Track eta vs #stubs
-  HistoName = "Track_HQ_Eta_NStubs";
-  Track_HQ_Eta_NStubs = iBooker.book2D(HistoName,
-                                       HistoName,
-                                       psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
-                                       psTrack_Eta_NStubs.getParameter<double>("xmin"),
-                                       psTrack_Eta_NStubs.getParameter<double>("xmax"),
-                                       psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
-                                       psTrack_Eta_NStubs.getParameter<double>("ymin"),
-                                       psTrack_Eta_NStubs.getParameter<double>("ymax"));
-  Track_HQ_Eta_NStubs->setAxisTitle("#eta", 1);
-  Track_HQ_Eta_NStubs->setAxisTitle("# L1 Stubs", 2);
-
-  // Pt of the tracks
-  HistoName = "Track_HQ_Pt";
-  Track_HQ_Pt = iBooker.book1D(HistoName,
-                               HistoName,
-                               psTrack_Pt.getParameter<int32_t>("Nbinsx"),
-                               psTrack_Pt.getParameter<double>("xmin"),
-                               psTrack_Pt.getParameter<double>("xmax"));
-  Track_HQ_Pt->setAxisTitle("p_{T} [GeV]", 1);
-  Track_HQ_Pt->setAxisTitle("# L1 Tracks", 2);
-
-  // Phi
-  HistoName = "Track_HQ_Phi";
-  Track_HQ_Phi = iBooker.book1D(HistoName,
-                                HistoName,
-                                psTrack_Phi.getParameter<int32_t>("Nbinsx"),
-                                psTrack_Phi.getParameter<double>("xmin"),
-                                psTrack_Phi.getParameter<double>("xmax"));
-  Track_HQ_Phi->setAxisTitle("#phi", 1);
-  Track_HQ_Phi->setAxisTitle("# L1 Tracks", 2);
-
-  // D0
-  HistoName = "Track_HQ_D0";
-  Track_HQ_D0 = iBooker.book1D(HistoName,
-                               HistoName,
-                               psTrack_D0.getParameter<int32_t>("Nbinsx"),
-                               psTrack_D0.getParameter<double>("xmin"),
-                               psTrack_D0.getParameter<double>("xmax"));
-  Track_HQ_D0->setAxisTitle("Track D0", 1);
-  Track_HQ_D0->setAxisTitle("# L1 Tracks", 2);
-
-  // Eta
-  HistoName = "Track_HQ_Eta";
-  Track_HQ_Eta = iBooker.book1D(HistoName,
-                                HistoName,
-                                psTrack_Eta.getParameter<int32_t>("Nbinsx"),
-                                psTrack_Eta.getParameter<double>("xmin"),
-                                psTrack_Eta.getParameter<double>("xmax"));
-  Track_HQ_Eta->setAxisTitle("#eta", 1);
-  Track_HQ_Eta->setAxisTitle("# L1 Tracks", 2);
-
-  // VtxZ
-  HistoName = "Track_HQ_VtxZ";
-  Track_HQ_VtxZ = iBooker.book1D(HistoName,
-                                 HistoName,
-                                 psTrack_VtxZ.getParameter<int32_t>("Nbinsx"),
-                                 psTrack_VtxZ.getParameter<double>("xmin"),
-                                 psTrack_VtxZ.getParameter<double>("xmax"));
-  Track_HQ_VtxZ->setAxisTitle("L1 Track vertex position z [cm]", 1);
-  Track_HQ_VtxZ->setAxisTitle("# L1 Tracks", 2);
-
-  // chi2
-  HistoName = "Track_HQ_Chi2";
-  Track_HQ_Chi2 = iBooker.book1D(HistoName,
-                                 HistoName,
-                                 psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
-                                 psTrack_Chi2.getParameter<double>("xmin"),
-                                 psTrack_Chi2.getParameter<double>("xmax"));
-  Track_HQ_Chi2->setAxisTitle("L1 Track #chi^{2}", 1);
-  Track_HQ_Chi2->setAxisTitle("# L1 Tracks", 2);
-
-  // Bendchi2
-  HistoName = "Track_HQ_BendChi2";
-  Track_HQ_BendChi2 = iBooker.book1D(HistoName,
-                                     HistoName,
-                                     psTrack_Chi2R.getParameter<int32_t>("Nbinsx"),
-                                     psTrack_Chi2R.getParameter<double>("xmin"),
-                                     psTrack_Chi2R.getParameter<double>("xmax"));
-  Track_HQ_BendChi2->setAxisTitle("L1 Track Bend #chi^{2}", 1);
-  Track_HQ_BendChi2->setAxisTitle("# L1 Tracks", 2);
-
-  // chi2 r-z
-  HistoName = "Track_HQ_Chi2RZ";
-  Track_HQ_Chi2RZ = iBooker.book1D(HistoName,
-                                   HistoName,
-                                   psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
-                                   psTrack_Chi2.getParameter<double>("xmin"),
-                                   psTrack_Chi2.getParameter<double>("xmax"));
-  Track_HQ_Chi2RZ->setAxisTitle("L1 Track #chi^{2} r-z", 1);
-  Track_HQ_Chi2RZ->setAxisTitle("# L1 Tracks", 2);
-
-  HistoName = "Track_HQ_Chi2RPhi";
-  Track_HQ_Chi2RPhi = iBooker.book1D(HistoName,
-                                     HistoName,
-                                     psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
-                                     psTrack_Chi2.getParameter<double>("xmin"),
-                                     psTrack_Chi2.getParameter<double>("xmax"));
-  Track_HQ_Chi2RPhi->setAxisTitle("L1 Track #chi^{2} r-phi", 1);
-  Track_HQ_Chi2RPhi->setAxisTitle("# L1 Tracks", 2);
-
-  // chi2Red
-  HistoName = "Track_HQ_Chi2Red";
-  Track_HQ_Chi2Red = iBooker.book1D(HistoName,
-                                    HistoName,
-                                    psTrack_Chi2R.getParameter<int32_t>("Nbinsx"),
-                                    psTrack_Chi2R.getParameter<double>("xmin"),
-                                    psTrack_Chi2R.getParameter<double>("xmax"));
-  Track_HQ_Chi2Red->setAxisTitle("L1 Track #chi^{2}/ndf", 1);
-  Track_HQ_Chi2Red->setAxisTitle("# L1 Tracks", 2);
-
-  // Chi2 prob
-  HistoName = "Track_HQ_Chi2_Probability";
-  Track_HQ_Chi2_Probability = iBooker.book1D(HistoName,
-                                             HistoName,
-                                             psTrack_Chi2_Probability.getParameter<int32_t>("Nbinsx"),
-                                             psTrack_Chi2_Probability.getParameter<double>("xmin"),
-                                             psTrack_Chi2_Probability.getParameter<double>("xmax"));
-  Track_HQ_Chi2_Probability->setAxisTitle("#chi^{2} probability", 1);
-  Track_HQ_Chi2_Probability->setAxisTitle("# L1 Tracks", 2);
-
-  // MVA1 (prompt quality)
-  HistoName = "Track_HQ_MVA1";
-  Track_HQ_MVA1 = iBooker.book1D(HistoName,
-                                 HistoName,
-                                 psTrack_MVA1.getParameter<int32_t>("Nbinsx"),
-                                 psTrack_MVA1.getParameter<double>("xmin"),
-                                 psTrack_MVA1.getParameter<double>("xmax"));
-  Track_HQ_MVA1->setAxisTitle("MVA1", 1);
-  Track_HQ_MVA1->setAxisTitle("# L1 Tracks", 2);
-
-  // Reduced chi2 vs #stubs
-  HistoName = "Track_HQ_Chi2Red_NStubs";
-  Track_HQ_Chi2Red_NStubs = iBooker.book2D(HistoName,
-                                           HistoName,
-                                           psTrack_Chi2R_NStubs.getParameter<int32_t>("Nbinsx"),
-                                           psTrack_Chi2R_NStubs.getParameter<double>("xmin"),
-                                           psTrack_Chi2R_NStubs.getParameter<double>("xmax"),
-                                           psTrack_Chi2R_NStubs.getParameter<int32_t>("Nbinsy"),
-                                           psTrack_Chi2R_NStubs.getParameter<double>("ymin"),
-                                           psTrack_Chi2R_NStubs.getParameter<double>("ymax"));
-  Track_HQ_Chi2Red_NStubs->setAxisTitle("# L1 Stubs", 1);
-  Track_HQ_Chi2Red_NStubs->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
-
-  // chi2/dof vs eta
-  HistoName = "Track_HQ_Chi2Red_Eta";
-  Track_HQ_Chi2Red_Eta = iBooker.book2D(HistoName,
-                                        HistoName,
-                                        psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsx"),
-                                        psTrack_Chi2R_Eta.getParameter<double>("xmin"),
-                                        psTrack_Chi2R_Eta.getParameter<double>("xmax"),
-                                        psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsy"),
-                                        psTrack_Chi2R_Eta.getParameter<double>("ymin"),
-                                        psTrack_Chi2R_Eta.getParameter<double>("ymax"));
-  Track_HQ_Chi2Red_Eta->setAxisTitle("#eta", 1);
-  Track_HQ_Chi2Red_Eta->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
-
-  // eta vs #stubs in barrel
-  HistoName = "Track_HQ_Eta_BarrelStubs";
-  Track_HQ_Eta_BarrelStubs = iBooker.book2D(HistoName,
-                                            HistoName,
-                                            psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
-                                            psTrack_Eta_NStubs.getParameter<double>("xmin"),
-                                            psTrack_Eta_NStubs.getParameter<double>("xmax"),
-                                            psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
-                                            psTrack_Eta_NStubs.getParameter<double>("ymin"),
-                                            psTrack_Eta_NStubs.getParameter<double>("ymax"));
-  Track_HQ_Eta_BarrelStubs->setAxisTitle("#eta", 1);
-  Track_HQ_Eta_BarrelStubs->setAxisTitle("# L1 Barrel Stubs", 2);
-
-  // eta vs #stubs in EC
-  HistoName = "Track_HQ_Eta_ECStubs";
-  Track_HQ_Eta_ECStubs = iBooker.book2D(HistoName,
-                                        HistoName,
-                                        psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
-                                        psTrack_Eta_NStubs.getParameter<double>("xmin"),
-                                        psTrack_Eta_NStubs.getParameter<double>("xmax"),
-                                        psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
-                                        psTrack_Eta_NStubs.getParameter<double>("ymin"),
-                                        psTrack_Eta_NStubs.getParameter<double>("ymax"));
-  Track_HQ_Eta_ECStubs->setAxisTitle("#eta", 1);
-  Track_HQ_Eta_ECStubs->setAxisTitle("# L1 EC Stubs", 2);
-
-}  // end of method
+  Track_HQ_N                = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_N"),                iBooker);
+  Track_HQ_NStubs           = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_NStubs"),           iBooker);
+  Track_HQ_NLayersMissed    = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_NLayersMissed"),    iBooker);
+  Track_HQ_Eta_NStubs       = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Eta_NStubs"),       iBooker);
+  Track_HQ_Pt               = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Pt"),               iBooker);
+  Track_HQ_Phi              = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Phi"),              iBooker);
+  Track_HQ_D0               = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_D0"),               iBooker);
+  Track_HQ_Eta              = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Eta"),              iBooker);
+  Track_HQ_VtxZ             = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_VtxZ"),             iBooker);
+  Track_HQ_Chi2             = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2"),             iBooker);
+  Track_HQ_BendChi2         = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_BendChi2"),         iBooker);
+  Track_HQ_Chi2RZ           = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2RZ"),           iBooker);
+  Track_HQ_Chi2RPhi         = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2RPhi"),         iBooker);
+  Track_HQ_Chi2Red          = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2Red"),          iBooker);
+  Track_HQ_Chi2_Probability = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2_Probability"), iBooker);
+  Track_HQ_MVA1             = book1DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_MVA1"),             iBooker);
+  Track_HQ_Chi2Red_NStubs   = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2Red_NStubs"),   iBooker);
+  Track_HQ_Chi2Red_Eta      = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Chi2Red_Eta"),      iBooker);
+  Track_HQ_Eta_BarrelStubs  = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Eta_BarrelStubs"),  iBooker);
+  Track_HQ_Eta_ECStubs      = book2DFromPSet(conf_.getParameter<edm::ParameterSet>("Track_HQ_Eta_ECStubs"),      iBooker);
+}
 
 void Phase2OTMonitorTTTrack::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
-  // Phase2OTMonitorTTTrack
   edm::ParameterSetDescription desc;
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 8);
-    psd0.add<double>("xmax", 8);
-    psd0.add<double>("xmin", 0);
-    desc.add<edm::ParameterSetDescription>("TH1_NStubs", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 100);
-    psd0.add<double>("xmax", 399);
-    psd0.add<double>("xmin", 0);
-    desc.add<edm::ParameterSetDescription>("TH1_NTracks", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 50);
-    psd0.add<double>("xmax", 100);
-    psd0.add<double>("xmin", 0);
-    desc.add<edm::ParameterSetDescription>("TH1_Track_Pt", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 60);
-    psd0.add<double>("xmax", 3.5);
-    psd0.add<double>("xmin", -3.5);
-    desc.add<edm::ParameterSetDescription>("TH1_Track_Phi", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 50);
-    psd0.add<double>("xmax", 5.0);
-    psd0.add<double>("xmin", -5.0);
-    desc.add<edm::ParameterSetDescription>("TH1_Track_D0", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 45);
-    psd0.add<double>("xmax", 3.0);
-    psd0.add<double>("xmin", -3.0);
-    desc.add<edm::ParameterSetDescription>("TH1_Track_Eta", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 41);
-    psd0.add<double>("xmax", 20);
-    psd0.add<double>("xmin", -20);
-    desc.add<edm::ParameterSetDescription>("TH1_Track_VtxZ", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 100);
-    psd0.add<double>("xmax", 50);
-    psd0.add<double>("xmin", 0);
-    desc.add<edm::ParameterSetDescription>("TH1_Track_Chi2", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 100);
-    psd0.add<double>("xmax", 10);
-    psd0.add<double>("xmin", 0);
-    desc.add<edm::ParameterSetDescription>("TH1_Track_Chi2R", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 100);
-    psd0.add<double>("xmax", 1);
-    psd0.add<double>("xmin", 0);
-    desc.add<edm::ParameterSetDescription>("TH1_Track_Chi2_Probability", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 100);
-    psd0.add<double>("xmax", 1);
-    psd0.add<double>("xmin", 0);
-    desc.add<edm::ParameterSetDescription>("TH1_Track_MVA1", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 5);
-    psd0.add<double>("xmax", 8);
-    psd0.add<double>("xmin", 3);
-    psd0.add<int>("Nbinsy", 15);
-    psd0.add<double>("ymax", 10);
-    psd0.add<double>("ymin", 0);
-    desc.add<edm::ParameterSetDescription>("TH2_Track_Chi2R_NStubs", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 15);
-    psd0.add<double>("xmax", 3.0);
-    psd0.add<double>("xmin", -3.0);
-    psd0.add<int>("Nbinsy", 15);
-    psd0.add<double>("ymax", 10);
-    psd0.add<double>("ymin", 0);
-    desc.add<edm::ParameterSetDescription>("TH2_Track_Chi2R_Eta", psd0);
-  }
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<int>("Nbinsx", 15);
-    psd0.add<double>("xmax", 3.0);
-    psd0.add<double>("xmin", -3.0);
-    psd0.add<int>("Nbinsy", 5);
-    psd0.add<double>("ymax", 8);
-    psd0.add<double>("ymin", 3);
-    desc.add<edm::ParameterSetDescription>("TH2_Track_Eta_NStubs", psd0);
-  }
+
+  // All tracks
+  phase2tkutil::add1DDesc(desc, "Track_All_N",                "Track_All_N",                "# L1 Tracks",                    "# Events",            100,   0,   399);
+  phase2tkutil::add1DDesc(desc, "Track_All_NStubs",           "Track_All_NStubs",           "# L1 Stubs per L1 Track",        "# L1 Tracks",           8,   0,     8);
+  phase2tkutil::add1DDesc(desc, "Track_All_NLayersMissed",    "Track_All_NLayersMissed",    "# Layers missed",                "# L1 Tracks",           8,   0,     8);
+  phase2tkutil::add2DDesc(desc, "Track_All_Eta_NStubs",       "Track_All_Eta_NStubs",       "#eta",                           "# L1 Stubs",           15,  -3.0,  3.0,  5,  3,   8);
+  phase2tkutil::add1DDesc(desc, "Track_All_Pt",               "Track_All_Pt",               "p_{T} [GeV]",                    "# L1 Tracks",          50,   0,   100);
+  phase2tkutil::add1DDesc(desc, "Track_All_Phi",              "Track_All_Phi",              "#phi",                           "# L1 Tracks",          60,  -3.5,  3.5);
+  phase2tkutil::add1DDesc(desc, "Track_All_D0",               "Track_All_D0",               "Track D0",                       "# L1 Tracks",          50,   0,  0.002);
+  phase2tkutil::add1DDesc(desc, "Track_All_Eta",              "Track_All_Eta",              "#eta",                           "# L1 Tracks",          45,  -3.0,  3.0);
+  phase2tkutil::add1DDesc(desc, "Track_All_VtxZ",             "Track_All_VtxZ",             "L1 Track vertex position z [cm]","# L1 Tracks",          41, -20,    20);
+  phase2tkutil::add1DDesc(desc, "Track_All_Chi2",             "Track_All_Chi2",             "L1 Track #chi^{2}",              "# L1 Tracks",         100,   0,    50);
+  phase2tkutil::add1DDesc(desc, "Track_All_Chi2RZ",           "Track_All_Chi2RZ",           "L1 Track #chi^{2} r-z",          "# L1 Tracks",         100,   0,    50);
+  phase2tkutil::add1DDesc(desc, "Track_All_Chi2RPhi",         "Track_All_Chi2RPhi",         "L1 Track #chi^{2}",              "# L1 Tracks",         100,   0,    50);
+  phase2tkutil::add1DDesc(desc, "Track_All_BendChi2",         "Track_All_BendChi2",         "L1 Track Bend #chi^{2}",         "# L1 Tracks",         100,   0,    10);
+  phase2tkutil::add1DDesc(desc, "Track_All_Chi2Red",          "Track_All_Chi2Red",          "L1 Track #chi^{2}/ndf",          "# L1 Tracks",         100,   0,    10);
+  phase2tkutil::add1DDesc(desc, "Track_All_Chi2_Probability", "Track_All_Chi2_Probability", "#chi^{2} probability",           "# L1 Tracks",         100,   0,     1);
+  phase2tkutil::add1DDesc(desc, "Track_All_MVA1",             "Track_All_MVA1",             "MVA1",                           "# L1 Tracks",         100,   0,     1);
+  phase2tkutil::add2DDesc(desc, "Track_All_Chi2Red_NStubs",   "Track_All_Chi2Red_NStubs",   "# L1 Stubs",                     "L1 Track #chi^{2}/ndf",  5,  3,    8,  15,  0,  10);
+  phase2tkutil::add2DDesc(desc, "Track_All_Chi2Red_Eta",      "Track_All_Chi2Red_Eta",      "#eta",                           "L1 Track #chi^{2}/ndf", 15, -3.0,  3.0, 15,  0,  10);
+  phase2tkutil::add2DDesc(desc, "Track_All_Eta_BarrelStubs",  "Track_All_Eta_BarrelStubs",  "#eta",                           "# L1 Barrel Stubs",    15,  -3.0,  3.0,  5,  3,   8);
+  phase2tkutil::add2DDesc(desc, "Track_All_Eta_ECStubs",      "Track_All_Eta_ECStubs",       "#eta",                           "# L1 EC Stubs",        15,  -3.0,  3.0,  5,  3,   8);
+
+  // HQ tracks
+  phase2tkutil::add1DDesc(desc, "Track_HQ_N",                "Track_HQ_N",                "# L1 Tracks",                    "# Events",            100,   0,   399);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_NStubs",           "Track_HQ_NStubs",           "# L1 Stubs per L1 Track",        "# L1 Tracks",           8,   0,     8);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_NLayersMissed",    "Track_HQ_NLayersMissed",    "# Layers missed",                "# L1 Tracks",           8,   0,     8);
+  phase2tkutil::add2DDesc(desc, "Track_HQ_Eta_NStubs",       "Track_HQ_Eta_NStubs",       "#eta",                           "# L1 Stubs",           15,  -3.0,  3.0,  5,  3,   8);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_Pt",               "Track_HQ_Pt",               "p_{T} [GeV]",                    "# L1 Tracks",          50,   0,   100);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_Phi",              "Track_HQ_Phi",              "#phi",                           "# L1 Tracks",          60,  -3.5,  3.5);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_D0",               "Track_HQ_D0",               "Track D0",                       "# L1 Tracks",          50,   0,  0.002);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_Eta",              "Track_HQ_Eta",              "#eta",                           "# L1 Tracks",          45,  -3.0,  3.0);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_VtxZ",             "Track_HQ_VtxZ",             "L1 Track vertex position z [cm]","# L1 Tracks",          41, -20,    20);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_Chi2",             "Track_HQ_Chi2",             "L1 Track #chi^{2}",              "# L1 Tracks",         100,   0,    50);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_BendChi2",         "Track_HQ_BendChi2",         "L1 Track Bend #chi^{2}",         "# L1 Tracks",         100,   0,    10);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_Chi2RZ",           "Track_HQ_Chi2RZ",           "L1 Track #chi^{2} r-z",          "# L1 Tracks",         100,   0,    50);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_Chi2RPhi",         "Track_HQ_Chi2RPhi",         "L1 Track #chi^{2} r-phi",        "# L1 Tracks",         100,   0,    50);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_Chi2Red",          "Track_HQ_Chi2Red",          "L1 Track #chi^{2}/ndf",          "# L1 Tracks",         100,   0,    10);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_Chi2_Probability", "Track_HQ_Chi2_Probability", "#chi^{2} probability",           "# L1 Tracks",         100,   0,     1);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_MVA1",             "Track_HQ_MVA1",             "MVA1",                           "# L1 Tracks",         100,   0,     1);
+  phase2tkutil::add2DDesc(desc, "Track_HQ_Chi2Red_NStubs",   "Track_HQ_Chi2Red_NStubs",   "# L1 Stubs",                     "L1 Track #chi^{2}/ndf",  5,  3,    8,  15,  0,  10);
+  phase2tkutil::add2DDesc(desc, "Track_HQ_Chi2Red_Eta",      "Track_HQ_Chi2Red_Eta",      "#eta",                           "L1 Track #chi^{2}/ndf", 15, -3.0,  3.0, 15,  0,  10);
+  phase2tkutil::add2DDesc(desc, "Track_HQ_Eta_BarrelStubs",  "Track_HQ_Eta_BarrelStubs",  "#eta",                           "# L1 Barrel Stubs",    15,  -3.0,  3.0,  5,  3,   8);
+  phase2tkutil::add2DDesc(desc, "Track_HQ_Eta_ECStubs",      "Track_HQ_Eta_ECStubs",      "#eta",                           "# L1 EC Stubs",        15,  -3.0,  3.0,  5,  3,   8);
+
   desc.add<std::string>("TopFolderName", "TrackerPhase2OTL1Track");
   desc.add<edm::InputTag>("TTTracksTag", edm::InputTag("l1tTTTracksFromTrackletEmulation", "Level1TTTracks"));
   desc.add<int>("HQNStubs", 4);
   desc.add<double>("HQChi2dof", 10.0);
   desc.add<double>("HQBendChi2", 2.2);
   descriptions.add("Phase2OTMonitorTTTrack", desc);
-  // or use the following to generate the label from the module's C++ type
-  //descriptions.addWithDefaultLabel(desc);
 }
 DEFINE_FWK_MODULE(Phase2OTMonitorTTTrack);

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc
@@ -292,7 +292,7 @@ void Phase2OTMonitorTTTrack::fillDescriptions(edm::ConfigurationDescriptions &de
   phase2tkutil::add2DDesc(desc, "Track_All_Eta_NStubs",       "Track_All_Eta_NStubs",       "#eta",                           "# L1 Stubs",           15,  -3.0,  3.0,  5,  3,   8);
   phase2tkutil::add1DDesc(desc, "Track_All_Pt",               "Track_All_Pt",               "p_{T} [GeV]",                    "# L1 Tracks",          50,   0,   100);
   phase2tkutil::add1DDesc(desc, "Track_All_Phi",              "Track_All_Phi",              "#phi",                           "# L1 Tracks",          60,  -3.5,  3.5);
-  phase2tkutil::add1DDesc(desc, "Track_All_D0",               "Track_All_D0",               "Track D0",                       "# L1 Tracks",          50,   0,  0.002);
+  phase2tkutil::add1DDesc(desc, "Track_All_D0",               "Track_All_D0",               "Track D0",                       "# L1 Tracks",         101,  -0.15, 0.15);
   phase2tkutil::add1DDesc(desc, "Track_All_Eta",              "Track_All_Eta",              "#eta",                           "# L1 Tracks",          45,  -3.0,  3.0);
   phase2tkutil::add1DDesc(desc, "Track_All_VtxZ",             "Track_All_VtxZ",             "L1 Track vertex position z [cm]","# L1 Tracks",          41, -20,    20);
   phase2tkutil::add1DDesc(desc, "Track_All_Chi2",             "Track_All_Chi2",             "L1 Track #chi^{2}",              "# L1 Tracks",         100,   0,    50);
@@ -314,7 +314,7 @@ void Phase2OTMonitorTTTrack::fillDescriptions(edm::ConfigurationDescriptions &de
   phase2tkutil::add2DDesc(desc, "Track_HQ_Eta_NStubs",       "Track_HQ_Eta_NStubs",       "#eta",                           "# L1 Stubs",           15,  -3.0,  3.0,  5,  3,   8);
   phase2tkutil::add1DDesc(desc, "Track_HQ_Pt",               "Track_HQ_Pt",               "p_{T} [GeV]",                    "# L1 Tracks",          50,   0,   100);
   phase2tkutil::add1DDesc(desc, "Track_HQ_Phi",              "Track_HQ_Phi",              "#phi",                           "# L1 Tracks",          60,  -3.5,  3.5);
-  phase2tkutil::add1DDesc(desc, "Track_HQ_D0",               "Track_HQ_D0",               "Track D0",                       "# L1 Tracks",          50,   0,  0.002);
+  phase2tkutil::add1DDesc(desc, "Track_HQ_D0",               "Track_HQ_D0",               "Track D0",                       "# L1 Tracks",         101,  -0.15, 0.15);
   phase2tkutil::add1DDesc(desc, "Track_HQ_Eta",              "Track_HQ_Eta",              "#eta",                           "# L1 Tracks",          45,  -3.0,  3.0);
   phase2tkutil::add1DDesc(desc, "Track_HQ_VtxZ",             "Track_HQ_VtxZ",             "L1 Track vertex position z [cm]","# L1 Tracks",          41, -20,    20);
   phase2tkutil::add1DDesc(desc, "Track_HQ_Chi2",             "Track_HQ_Chi2",             "L1 Track #chi^{2}",              "# L1 Tracks",         100,   0,    50);

--- a/DQM/SiTrackerPhase2/src/TrackerPhase2DQMUtil.cc
+++ b/DQM/SiTrackerPhase2/src/TrackerPhase2DQMUtil.cc
@@ -87,3 +87,35 @@ MonitorElement* phase2tkutil::bookProfile1DFromPSet(const edm::ParameterSet& hpa
   }
   return temp;
 }
+
+void phase2tkutil::add1DDesc(edm::ParameterSetDescription& desc,
+                              const std::string& psetKey, const std::string& histName,
+                              const std::string& xlabel, const std::string& ylabel,
+                              int nbins, double xmin, double xmax) {
+  edm::ParameterSetDescription ps;
+  ps.add<bool>("switch", true);
+  ps.add<std::string>("name", histName);
+  ps.add<std::string>("title", histName + ";" + xlabel + ";" + ylabel);
+  ps.add<int>("NxBins", nbins);
+  ps.add<double>("xmin", xmin);
+  ps.add<double>("xmax", xmax);
+  desc.add<edm::ParameterSetDescription>(psetKey, ps);
+}
+
+void phase2tkutil::add2DDesc(edm::ParameterSetDescription& desc,
+                              const std::string& psetKey, const std::string& histName,
+                              const std::string& xlabel, const std::string& ylabel,
+                              int nbx, double xmin, double xmax,
+                              int nby, double ymin, double ymax) {
+  edm::ParameterSetDescription ps;
+  ps.add<bool>("switch", true);
+  ps.add<std::string>("name", histName);
+  ps.add<std::string>("title", histName + ";" + xlabel + ";" + ylabel);
+  ps.add<int>("NxBins", nbx);
+  ps.add<double>("xmin", xmin);
+  ps.add<double>("xmax", xmax);
+  ps.add<int>("NyBins", nby);
+  ps.add<double>("ymin", ymin);
+  ps.add<double>("ymax", ymax);
+  desc.add<edm::ParameterSetDescription>(psetKey, ps);
+}

--- a/DQM/SiTrackerPhase2/src/TrackerPhase2DQMUtil.cc
+++ b/DQM/SiTrackerPhase2/src/TrackerPhase2DQMUtil.cc
@@ -89,9 +89,13 @@ MonitorElement* phase2tkutil::bookProfile1DFromPSet(const edm::ParameterSet& hpa
 }
 
 void phase2tkutil::add1DDesc(edm::ParameterSetDescription& desc,
-                              const std::string& psetKey, const std::string& histName,
-                              const std::string& xlabel, const std::string& ylabel,
-                              int nbins, double xmin, double xmax) {
+                             const std::string& psetKey,
+                             const std::string& histName,
+                             const std::string& xlabel,
+                             const std::string& ylabel,
+                             int nbins,
+                             double xmin,
+                             double xmax) {
   edm::ParameterSetDescription ps;
   ps.add<bool>("switch", true);
   ps.add<std::string>("name", histName);
@@ -103,10 +107,16 @@ void phase2tkutil::add1DDesc(edm::ParameterSetDescription& desc,
 }
 
 void phase2tkutil::add2DDesc(edm::ParameterSetDescription& desc,
-                              const std::string& psetKey, const std::string& histName,
-                              const std::string& xlabel, const std::string& ylabel,
-                              int nbx, double xmin, double xmax,
-                              int nby, double ymin, double ymax) {
+                             const std::string& psetKey,
+                             const std::string& histName,
+                             const std::string& xlabel,
+                             const std::string& ylabel,
+                             int nbx,
+                             double xmin,
+                             double xmax,
+                             int nby,
+                             double ymin,
+                             double ymax) {
   edm::ParameterSetDescription ps;
   ps.add<bool>("switch", true);
   ps.add<std::string>("name", histName);

--- a/DQM/SiTrackerPhase2/test/dqmstep_phase2tk_cfg.py
+++ b/DQM/SiTrackerPhase2/test/dqmstep_phase2tk_cfg.py
@@ -10,7 +10,7 @@
 # step3_pre4_inDQM.root - input for the next step in the DQM sequence, harvestingstep_phase2tk_cfg.py
 
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
-# with command line options: step3 --conditions auto:phase2_realistic_T21 -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 --datatier DQMIO -n 10 --geometry Extended2026D98 --era Phase2C11M9 --eventcontent DQM --no_exec
+# with command line options: step3 --conditions auto:phase2_realistic_T21 -s RAW2DIGI,L1Reco,RECO,RECOSIM,VALIDATION:@phase2Validation,DQM:@phase2 --datatier DQMIO -n 10 --geometry Extended2026D110 --era Phase2C11M9 --eventcontent DQM --no_exec
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Phase2C11M9_cff import Phase2C11M9
@@ -41,7 +41,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('/store/relval/CMSSW_14_0_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_133X_mcRun4_realistic_v1_STD_2026D98_PU200_RV229-v1/2580000/0b2b0b0b-f312-48a8-9d46-ccbadc69bbfd.root'),
+    fileNames = cms.untracked.vstring('/store/relval/CMSSW_16_1_0_pre2/RelValTTbar_14TeV/GEN-SIM-RECO/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v1/2590000/06bf4d43-0cb7-450a-8b94-c29f447d84e9.root'),
     secondaryFileNames = cms.untracked.vstring()
 )
 


### PR DESCRIPTION
#### PR description:

Used existing helper functions in [TrackerPhase2DQMUtil.cc](https://github.com/brandiskip/cmssw/blob/clean_up/DQM/SiTrackerPhase2/src/TrackerPhase2DQMUtil.cc) (with declarations in [TrackerPhase2DQMUtil.h](https://github.com/brandiskip/cmssw/blob/clean_up/DQM/SiTrackerPhase2/interface/TrackerPhase2DQMUtil.h)) to reduce redundancy in `bookHistograms` and added new helper functions for `fillDescriptions` across the following files:
- [Phase2OTMonitorTTCluster.cc](https://github.com/brandiskip/cmssw/blob/clean_up/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTCluster.cc#L194-L262)
- [Phase2OTMonitorTTStub.cc](https://github.com/brandiskip/cmssw/blob/clean_up/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc#L210-L345)
- [Phase2OTMonitorTTTrack.cc](https://github.com/brandiskip/cmssw/blob/clean_up/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc#L235-L338)

Renamed histogram [Track_LQ_Eta_ECStubs](https://github.com/cms-sw/cmssw/blob/master/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc#L458-L468) to [Track_All_Eta_ECStubs](https://github.com/brandiskip/cmssw/blob/clean_up/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc#L308) to correct the naming convention.

Updated x-axis range and binning for `d0` histograms to match range found in Validation package. 

Removed magic numbers for the number of discs in [Phase2OTMonitorTTStub.cc](https://github.com/brandiskip/cmssw/blob/clean_up/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc#L92-L95), replacing them with a call to `Settings.h`.

The updated DQM output ROOT file can be reviewed [here](https://cernbox.cern.ch/files/spaces/eos/user/b/bskipwor/public/DQMPackageCleanup?items-per-page=100&files-spaces-generic-view-mode=resource-table&tiles-size=2).

Updated histograms in the following DQM folders:
- `TrackerPhase2OTL1Track`
- `TrackerPhase2OTStub`
- `TrackerPhase2TTCluster`

#### PR validation:
scram build code-checks
scram build code-format
