### PR TITLE
`FlatEvtVtxGenerator`: do check on R/Phi limits only if `UseCylindricalCoords` is chosen and other fixes

### DIFF
--- a/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
@@ -27,7 +27,7 @@ public:
   FlatEvtVtxGenerator(const FlatEvtVtxGenerator& p) = delete;
   /** Copy assignment operator */
   FlatEvtVtxGenerator& operator=(const FlatEvtVtxGenerator& rhs) = delete;
-  ~FlatEvtVtxGenerator() override;
+  ~FlatEvtVtxGenerator() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -42,6 +42,10 @@ public:
   inline void minY(double m = 0.0) { fMinY = m; }
   /// set min in Z in cm
   inline void minZ(double m = 0.0) { fMinZ = m; }
+  /// set min in R in cm
+  inline void minR(double m = 0.0) { fMinR = m; }
+  /// set min in phi in rad
+  inline void minPhi(double m = 0.0) { fMinPhi = m; }
 
   /// set max in X in cm
   inline void maxX(double m = 0) { fMaxX = m; }
@@ -49,11 +53,22 @@ public:
   inline void maxY(double m = 0) { fMaxY = m; }
   /// set max in Z in cm
   inline void maxZ(double m = 0) { fMaxZ = m; }
+  /// set max in R in cm
+  inline void maxR(double m = 0.0) { fMaxR = m; }
+  /// set max in phi in rad
+  inline void maxPhi(double m = 0.0) { fMaxPhi = m; }
 
 private:
-  double fMinX, fMinY, fMinZ, fMinT, fMinR, fMinPhi;
-  double fMaxX, fMaxY, fMaxZ, fMaxT, fMaxR, fMaxPhi;
-  bool fFixedR;
+  // parameters always configured
+  const bool fFixedR;
+  double fMinZ, fMaxZ;
+  double fMinT, fMaxT;
+
+  // parameters conditionally configured
+  double fMaxX, fMaxY;
+  double fMinX, fMinY;
+  double fMinR, fMaxR;
+  double fMinPhi, fMaxPhi;
 };
 
 #endif

--- a/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
@@ -60,7 +60,7 @@ public:
 
 private:
   // parameters always configured
-  const bool fFixedR;
+  const bool fUseCylindricalCoords;
   double fMinZ, fMaxZ;
   double fMinT, fMaxT;
 

--- a/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h
@@ -13,6 +13,7 @@
  *
  */
 
+#include <optional>
 #include "IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
@@ -65,10 +66,10 @@ private:
   double fMinT, fMaxT;
 
   // parameters conditionally configured
-  double fMaxX, fMaxY;
-  double fMinX, fMinY;
-  double fMinR, fMaxR;
-  double fMinPhi, fMaxPhi;
+  std::optional<double> fMaxX, fMaxY;
+  std::optional<double> fMinX, fMinY;
+  std::optional<double> fMinR, fMaxR;
+  std::optional<double> fMinPhi, fMaxPhi;
 };
 
 #endif

--- a/IOMC/EventVertexGenerators/python/VtxDisplacedFlat_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxDisplacedFlat_cfi.py
@@ -5,6 +5,3 @@ VtxSmeared = cms.EDProducer("FlatEvtVtxGenerator",
     FlatVtxDisplacedParameters,
     src = cms.InputTag("generator", "unsmeared"),
 )
-
-
-

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -85,7 +85,7 @@ Run3FlatOpticsGaussVtxSigmaZ5p3cmSmearingParameters = cms.PSet(
 # Can restore correlation via MinT += (MinZ - MaxZ)/2 and MaxT += (MaxZ - MinZ)/2
 # in [ns] units (recall c_light = 29.98cm/ns)
 FlatVtxSmearingParameters = cms.PSet(
-    FixedR = cms.bool(False),
+    UseCylindricalCoords = cms.bool(False),
     MaxZ = cms.double(5.3),
     MaxX = cms.double(0.0015),
     MaxY = cms.double(0.0015),
@@ -97,7 +97,7 @@ FlatVtxSmearingParameters = cms.PSet(
 )
 
 FlatVtxDisplacedParameters = cms.PSet(
-    FixedR = cms.bool(True),
+    UseCylindricalCoords = cms.bool(True),
     MaxR = cms.double(10.1),
     MinR = cms.double(10.0),
     MaxZ = cms.double(0.001),

--- a/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
@@ -26,11 +26,19 @@ FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p)
     fMinR = p.getParameter<double>("MinR") * cm;
     fMaxPhi = p.getParameter<double>("MaxPhi") * radian;
     fMinPhi = p.getParameter<double>("MinPhi") * radian;
+    fMinX = std::nullopt;
+    fMaxX = std::nullopt;
+    fMinY = std::nullopt;
+    fMaxY = std::nullopt;
   } else {
     fMinX = p.getParameter<double>("MinX") * cm;
     fMaxX = p.getParameter<double>("MaxX") * cm;
     fMinY = p.getParameter<double>("MinY") * cm;
     fMaxY = p.getParameter<double>("MaxY") * cm;
+    fMaxR = std::nullopt;
+    fMinR = std::nullopt;
+    fMaxPhi = std::nullopt;
+    fMinPhi = std::nullopt;
   }
 
   if (fMinZ > fMaxZ) {
@@ -44,44 +52,44 @@ FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p)
 
   // configuration dependent checks
   if (fUseCylindricalCoords) {
-    if (fMinR > fMaxR) {
+    if (fMinR.value() > fMaxR.value()) {
       throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
                                             << "MinR is greater than MaxR";
     }
-    if (fMinPhi > fMaxPhi) {
+    if (fMinPhi.value() > fMaxPhi.value()) {
       throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
                                             << "MinPhi is greater than MaxPhi";
     }
 
-    edm::LogVerbatim("FlatEvtVtx") << "FlatEvtVtxGenerator Initialized with r[" << fMinR << ":" << fMaxR << "] cm; phi["
-                                   << fMinPhi << ":" << fMaxPhi << "] rad; z[" << fMinZ << ":" << fMaxZ << "] cm; t["
-                                   << fMinT << ":" << fMaxT << "] ns" << std::endl;
+    edm::LogVerbatim("FlatEvtVtx") << "FlatEvtVtxGenerator Initialized with r[" << *fMinR << ":" << *fMaxR
+                                   << "] cm; phi[" << *fMinPhi << ":" << *fMaxPhi << "] rad; z[" << fMinZ << ":"
+                                   << fMaxZ << "] cm; t[" << fMinT << ":" << fMaxT << "] mm";
   } else {
-    if (fMinX > fMaxX) {
+    if (fMinX.value() > fMaxX.value()) {
       throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
                                             << "MinX is greater than MaxX";
     }
-    if (fMinY > fMaxY) {
+    if (fMinY.value() > fMaxY.value()) {
       throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
                                             << "MinY is greater than MaxY";
     }
 
-    edm::LogVerbatim("FlatEvtVtx") << "FlatEvtVtxGenerator Initialized with x[" << fMinX << ":" << fMaxX << "] cm; y["
-                                   << fMinY << ":" << fMaxY << "] cm; z[" << fMinZ << ":" << fMaxZ << "] cm; t["
-                                   << fMinT << ":" << fMaxT << "] ns" << std::endl;
+    edm::LogVerbatim("FlatEvtVtx") << "FlatEvtVtxGenerator Initialized with x[" << *fMinX << ":" << *fMaxX << "] cm; y["
+                                   << *fMinY << ":" << *fMaxY << "] cm; z[" << fMinZ << ":" << fMaxZ << "] cm; t["
+                                   << fMinT << ":" << fMaxT << "] mm" << std::endl;
   }
 }
 
 ROOT::Math::XYZTVector FlatEvtVtxGenerator::vertexShift(CLHEP::HepRandomEngine* engine) const {
   double aX, aY, aZ, aT;
   if (fUseCylindricalCoords) {
-    double aR = CLHEP::RandFlat::shoot(engine, fMinR, fMaxR);
-    double aPhi = CLHEP::RandFlat::shoot(engine, fMinPhi, fMaxPhi);
+    double aR = CLHEP::RandFlat::shoot(engine, *fMinR, *fMaxR);
+    double aPhi = CLHEP::RandFlat::shoot(engine, *fMinPhi, *fMaxPhi);
     aX = aR * std::cos(aPhi);
     aY = aR * std::sin(aPhi);
   } else {
-    aX = CLHEP::RandFlat::shoot(engine, fMinX, fMaxX);
-    aY = CLHEP::RandFlat::shoot(engine, fMinY, fMaxY);
+    aX = CLHEP::RandFlat::shoot(engine, *fMinX, *fMaxX);
+    aY = CLHEP::RandFlat::shoot(engine, *fMinY, *fMaxY);
   }
   aZ = CLHEP::RandFlat::shoot(engine, fMinZ, fMaxZ);
   aT = CLHEP::RandFlat::shoot(engine, fMinT, fMaxT);
@@ -106,7 +114,7 @@ void FlatEvtVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions& descr
                           edm::ParameterDescription<double>("MaxX", 0.001, true) and
                           edm::ParameterDescription<double>("MinY", 0.0, true) and
                           edm::ParameterDescription<double>("MaxY", 0.001, true))) or
-                   // Polar (UseCylindricalCoords = true) branch
+                   // Cylindrical (UseCylindricalCoords = true) branch
                    (true >> (edm::ParameterDescription<double>("MinR", 0.0, true) and
                              edm::ParameterDescription<double>("MaxR", 0.001, true) and
                              edm::ParameterDescription<double>("MinPhi", -std::numbers::pi, true) and

--- a/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
@@ -30,14 +30,6 @@ FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVt
   fMinT = p.getParameter<double>("MinT") * ns * c_light;
   fMaxT = p.getParameter<double>("MaxT") * ns * c_light;
 
-  if (fMinX > fMaxX) {
-    throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
-                                          << "MinX is greater than MaxX";
-  }
-  if (fMinY > fMaxY) {
-    throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
-                                          << "MinY is greater than MaxY";
-  }
   if (fMinZ > fMaxZ) {
     throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
                                           << "MinZ is greater than MaxZ";
@@ -46,17 +38,35 @@ FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVt
     throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
                                           << "MinT is greater than MaxT";
   }
-  if (fMinR > fMaxR) {
-    throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
-                                          << "MinR is greater than MaxR";
+
+  // configuration dependent checks
+  if (fFixedR) {
+    if (fMinR > fMaxR) {
+      throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
+                                            << "MinR is greater than MaxR";
+    }
+    if (fMinPhi > fMaxPhi) {
+      throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
+                                            << "MinPhi is greater than MaxPhi";
+    }
+
+    edm::LogVerbatim("FlatEvtVtx") << "FlatEvtVtxGenerator Initialized with r[" << fMinR << ":" << fMaxR << "] cm; phi["
+                                   << fMinPhi << ":" << fMaxPhi << "] rad; z[" << fMinZ << ":" << fMaxZ << "] cm; t["
+                                   << fMinT << ":" << fMaxT << "]";
+  } else {
+    if (fMinX > fMaxX) {
+      throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
+                                            << "MinX is greater than MaxX";
+    }
+    if (fMinY > fMaxY) {
+      throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
+                                            << "MinY is greater than MaxY";
+    }
+
+    edm::LogVerbatim("FlatEvtVtx") << "FlatEvtVtxGenerator Initialized with x[" << fMinX << ":" << fMaxX << "] cm; y["
+                                   << fMinY << ":" << fMaxY << "] cm; z[" << fMinZ << ":" << fMaxZ << "] cm; t["
+                                   << fMinT << ":" << fMaxT << "]";
   }
-  if (fMinPhi > fMaxPhi) {
-    throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
-                                          << "MinPhi is greater than MaxPhi";
-  }
-  edm::LogVerbatim("FlatEvtVtx") << "FlatEvtVtxGenerator Initialized with x[" << fMinX << ":" << fMaxX << "] cm; y["
-                                 << fMinY << ":" << fMaxY << "] cm; z[" << fMinZ << ":" << fMaxZ << "] cm; t[" << fMinT
-                                 << ":" << fMaxT << "]";
 }
 
 FlatEvtVtxGenerator::~FlatEvtVtxGenerator() {}
@@ -94,8 +104,8 @@ void FlatEvtVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<bool>("FixedR", false);
   desc.add<double>("MinR", 0.0)->setComment("in cm");
   desc.add<double>("MaxR", 0.001)->setComment("in cm");
-  desc.add<double>("MinPhi", -3.14159265359)->setComment("in radians");
-  desc.add<double>("MaxPhi", 3.14159265359)->setComment("in radians");
+  desc.add<double>("MinPhi", -M_PI)->setComment("in radians");
+  desc.add<double>("MaxPhi", M_PI)->setComment("in radians");
   desc.add<edm::InputTag>("src");
   descriptions.add("FlatEvtVtxGenerator", desc);
 }

--- a/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
@@ -1,19 +1,26 @@
-#include "IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h"
-#include "FWCore/Utilities/interface/Exception.h"
+// system includes
+#include <numbers>
+#include <CLHEP/Random/RandFlat.h>
+#include <CLHEP/Units/GlobalPhysicalConstants.h>
+#include <CLHEP/Units/SystemOfUnits.h>
 
+// user includes
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include <CLHEP/Random/RandFlat.h>
-#include <CLHEP/Units/SystemOfUnits.h>
-#include <CLHEP/Units/GlobalPhysicalConstants.h>
+#include "FWCore/Utilities/interface/Exception.h"
+#include "IOMC/EventVertexGenerators/interface/FlatEvtVtxGenerator.h"
 
 using CLHEP::cm;
 using CLHEP::ns;
 using CLHEP::radian;
 
-FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVtxGenerator(p) {
-  fFixedR = p.getParameter<bool>("FixedR");
+FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p)
+    : BaseEvtVtxGenerator(p),
+      fFixedR(p.getParameter<bool>("FixedR")),
+      fMinZ(p.getParameter<double>("MinZ") * cm),
+      fMaxZ(p.getParameter<double>("MaxZ") * cm),
+      fMinT(p.getParameter<double>("MinT") * ns * c_light),
+      fMaxT(p.getParameter<double>("MaxT") * ns * c_light) {
   if (fFixedR) {
     fMaxR = p.getParameter<double>("MaxR") * cm;
     fMinR = p.getParameter<double>("MinR") * cm;
@@ -25,10 +32,6 @@ FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVt
     fMinY = p.getParameter<double>("MinY") * cm;
     fMaxY = p.getParameter<double>("MaxY") * cm;
   }
-  fMaxZ = p.getParameter<double>("MaxZ") * cm;
-  fMinZ = p.getParameter<double>("MinZ") * cm;
-  fMinT = p.getParameter<double>("MinT") * ns * c_light;
-  fMaxT = p.getParameter<double>("MaxT") * ns * c_light;
 
   if (fMinZ > fMaxZ) {
     throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
@@ -52,7 +55,7 @@ FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVt
 
     edm::LogVerbatim("FlatEvtVtx") << "FlatEvtVtxGenerator Initialized with r[" << fMinR << ":" << fMaxR << "] cm; phi["
                                    << fMinPhi << ":" << fMaxPhi << "] rad; z[" << fMinZ << ":" << fMaxZ << "] cm; t["
-                                   << fMinT << ":" << fMaxT << "]";
+                                   << fMinT << ":" << fMaxT << "] ns" << std::endl;
   } else {
     if (fMinX > fMaxX) {
       throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
@@ -65,11 +68,9 @@ FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVt
 
     edm::LogVerbatim("FlatEvtVtx") << "FlatEvtVtxGenerator Initialized with x[" << fMinX << ":" << fMaxX << "] cm; y["
                                    << fMinY << ":" << fMaxY << "] cm; z[" << fMinZ << ":" << fMaxZ << "] cm; t["
-                                   << fMinT << ":" << fMaxT << "]";
+                                   << fMinT << ":" << fMaxT << "] ns" << std::endl;
   }
 }
-
-FlatEvtVtxGenerator::~FlatEvtVtxGenerator() {}
 
 ROOT::Math::XYZTVector FlatEvtVtxGenerator::vertexShift(CLHEP::HepRandomEngine* engine) const {
   double aX, aY, aZ, aT;
@@ -93,19 +94,23 @@ ROOT::Math::XYZTVector FlatEvtVtxGenerator::vertexShift(CLHEP::HepRandomEngine* 
 
 void FlatEvtVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<double>("MinX", 0.0)->setComment("in cm");
-  desc.add<double>("MaxX", 0.001)->setComment("in cm");
-  desc.add<double>("MinY", 0.0)->setComment("in cm");
-  desc.add<double>("MaxY", 0.001)->setComment("in cm");
   desc.add<double>("MinZ", 0.0)->setComment("in cm");
   desc.add<double>("MaxZ", 0.001)->setComment("in cm");
   desc.add<double>("MinT", 0.0)->setComment("in ns");
   desc.add<double>("MaxT", 0.001)->setComment("in ns");
-  desc.add<bool>("FixedR", false);
-  desc.add<double>("MinR", 0.0)->setComment("in cm");
-  desc.add<double>("MaxR", 0.001)->setComment("in cm");
-  desc.add<double>("MinPhi", -M_PI)->setComment("in radians");
-  desc.add<double>("MaxPhi", M_PI)->setComment("in radians");
   desc.add<edm::InputTag>("src");
-  descriptions.add("FlatEvtVtxGenerator", desc);
+
+  desc.ifValue(edm::ParameterDescription<bool>("FixedR", false, true),
+               // Cartesian (FixedR = false) branch
+               (false >> (edm::ParameterDescription<double>("MinX", 0.0, true) and
+                          edm::ParameterDescription<double>("MaxX", 0.001, true) and
+                          edm::ParameterDescription<double>("MinY", 0.0, true) and
+                          edm::ParameterDescription<double>("MaxY", 0.001, true))) or
+                   // Polar (FixedR = true) branch
+                   (true >> (edm::ParameterDescription<double>("MinR", 0.0, true) and
+                             edm::ParameterDescription<double>("MaxR", 0.001, true) and
+                             edm::ParameterDescription<double>("MinPhi", -std::numbers::pi, true) and
+                             edm::ParameterDescription<double>("MaxPhi", std::numbers::pi, true))));
+
+  descriptions.addWithDefaultLabel(desc);
 }

--- a/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/FlatEvtVtxGenerator.cc
@@ -16,12 +16,12 @@ using CLHEP::radian;
 
 FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p)
     : BaseEvtVtxGenerator(p),
-      fFixedR(p.getParameter<bool>("FixedR")),
+      fUseCylindricalCoords(p.getParameter<bool>("UseCylindricalCoords")),
       fMinZ(p.getParameter<double>("MinZ") * cm),
       fMaxZ(p.getParameter<double>("MaxZ") * cm),
       fMinT(p.getParameter<double>("MinT") * ns * c_light),
       fMaxT(p.getParameter<double>("MaxT") * ns * c_light) {
-  if (fFixedR) {
+  if (fUseCylindricalCoords) {
     fMaxR = p.getParameter<double>("MaxR") * cm;
     fMinR = p.getParameter<double>("MinR") * cm;
     fMaxPhi = p.getParameter<double>("MaxPhi") * radian;
@@ -43,7 +43,7 @@ FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p)
   }
 
   // configuration dependent checks
-  if (fFixedR) {
+  if (fUseCylindricalCoords) {
     if (fMinR > fMaxR) {
       throw cms::Exception("Configuration") << "Error in FlatEvtVtxGenerator: "
                                             << "MinR is greater than MaxR";
@@ -74,7 +74,7 @@ FlatEvtVtxGenerator::FlatEvtVtxGenerator(const edm::ParameterSet& p)
 
 ROOT::Math::XYZTVector FlatEvtVtxGenerator::vertexShift(CLHEP::HepRandomEngine* engine) const {
   double aX, aY, aZ, aT;
-  if (fFixedR) {
+  if (fUseCylindricalCoords) {
     double aR = CLHEP::RandFlat::shoot(engine, fMinR, fMaxR);
     double aPhi = CLHEP::RandFlat::shoot(engine, fMinPhi, fMaxPhi);
     aX = aR * std::cos(aPhi);
@@ -100,13 +100,13 @@ void FlatEvtVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<double>("MaxT", 0.001)->setComment("in ns");
   desc.add<edm::InputTag>("src");
 
-  desc.ifValue(edm::ParameterDescription<bool>("FixedR", false, true),
-               // Cartesian (FixedR = false) branch
+  desc.ifValue(edm::ParameterDescription<bool>("UseCylindricalCoords", false, true),
+               // Cartesian (UseCylindricalCoords = false) branch
                (false >> (edm::ParameterDescription<double>("MinX", 0.0, true) and
                           edm::ParameterDescription<double>("MaxX", 0.001, true) and
                           edm::ParameterDescription<double>("MinY", 0.0, true) and
                           edm::ParameterDescription<double>("MaxY", 0.001, true))) or
-                   // Polar (FixedR = true) branch
+                   // Polar (UseCylindricalCoords = true) branch
                    (true >> (edm::ParameterDescription<double>("MinR", 0.0, true) and
                              edm::ParameterDescription<double>("MaxR", 0.001, true) and
                              edm::ParameterDescription<double>("MinPhi", -std::numbers::pi, true) and


### PR DESCRIPTION
#### PR description:

Title says it all, in response of https://github.com/cms-sw/cmssw/pull/50904#issuecomment-4458343630.
I profit of this PR to introduce some other modernization.

#### PR validation:

```
runTheMatrix.py -l 7.0 -j 8 -t 4
```

now runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
