### PR TITLE
[NGT] Add local and remote HLT config files to EvFDaqDirector copy [16_1_X]

### DIFF
--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -255,7 +255,7 @@ namespace evf {
           } catch (...) {
           }
 
-          std::string optfiles[3] = {"hltinfo", "blacklist", "whitelist"};
+          std::string optfiles[5] = {"hltinfo", "blacklist", "whitelist", "HltConfig_local.py", "HltConfig_remote.py"};
           for (auto& optfile : optfiles) {
             try {
               std::filesystem::copy_file(hltSourceDirectory_ + "/" + optfile, tmphltdir + "/" + optfile);


### PR DESCRIPTION
#### PR description:

Adds split local and remote HLT configuration files (`HltConfig_local.py`, `HltConfig_remote.py`) used for MPI offloading to `EvFDaqDirector` as optional files for copy. Needed so that it can automatically be picked up by HLTD on the FUs from the BU (see [HLTD Issue #4](https://gitlab.cern.ch/cms-daq/FFF/hltd/-/issues/4)).

N.B. There is no urgency, however, it is a nice-to-have.

CC: @smorovic @fwyzard @Annnnya @ghyls

#### PR validation:

The change is trivial and has been successfully compiled and tested with the basic battery of `runTheMatrix` and `scram` tests.
```
Pass   99s ... EventFilter/Utilities/BUFU_TEST
Pass   71s ... EventFilter/Utilities/EventFilterUtilitiesReadStreamerFile
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/50947 for `CMSSW_16_1_X`