### PR TITLE
[SIM] Added Geant4 headers to custom physics

### DIFF
--- a/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
@@ -9,6 +9,8 @@
 #include "G4Material.hh"
 #include "G4Element.hh"
 #include "G4Isotope.hh"
+#include "G4HadronicException.hh"
+#include "G4ReactionProduct.hh"
 
 using namespace CLHEP;
 

--- a/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc
@@ -10,6 +10,8 @@
 #include <iostream>
 #include "G4ParticleTable.hh"
 #include "G4Poisson.hh"
+#include "G4HadronicException.hh"
+#include "G4ReactionProduct.hh"
 
 using namespace CLHEP;
 


### PR DESCRIPTION
#### PR description:
In old hadronic model used by CustomPhysics package some Geant4 headers were not explicit. It is fixed in this PR. No effect to any work flow. Fix of https://github.com/cms-sw/cmsdist/pull/10558 

#### PR validation:
Compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO

