### PR TITLE
Disable tests that read existing non-RAW files

### DIFF
--- a/Alignment/APEEstimation/test/BuildFile.xml
+++ b/Alignment/APEEstimation/test/BuildFile.xml
@@ -1,3 +1,3 @@
 <environment>
-  <test name="ApeTest" command="bash unitTest.sh"/>
+  <!-- <test name="ApeTest" command="bash unitTest.sh"/> COMMENT: reads old format files -->
 </environment>

--- a/Alignment/CommonAlignmentMonitor/test/BuildFile.xml
+++ b/Alignment/CommonAlignmentMonitor/test/BuildFile.xml
@@ -1,3 +1,3 @@
 <environment>
-  <test name="testAlignmentStats" command="testAlignmentStats.sh"/>
+  <!-- <test name="testAlignmentStats" command="testAlignmentStats.sh"/> COMMENT: reads old format file -->
 </environment>

--- a/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
@@ -11,7 +11,7 @@
   <use name="millepede"/>
 </test>
 
-<test name="test_MilleZmm" command="test_mille.sh"/>
+<!-- <test name="test_MilleZmm" command="test_mille.sh"/> COMMENT: reads old format file -->
 <test name="test_PedeCampaign" command="test_pede.sh"/>
 <test name="test_PedeConversion" command="test_pedeConversion.sh">
   <flags PRE_TEST="test_PedeCampaign"/>
@@ -19,8 +19,8 @@
 <test name="test_PayloadSanity" command="test_payload_sanity.sh">
   <flags PRE_TEST="test_PedeCampaign"/>
 </test>
-<test name="test_ZMuMuMassConstraintParameterFinder" command="test_ZMuMuMassConstraintParameterFinder.sh"/>
-<bin file="testFindMassContraintParameters.cpp" name="test_ExtractMassConstraint">
-  <flags PRE_TEST="test_ZMuMuMassConstraintParameterFinder"/>
+<!-- <test name="test_ZMuMuMassConstraintParameterFinder" command="test_ZMuMuMassConstraintParameterFinder.sh"/> COMMENT: reads old format file -->
+<!-- <bin file="testFindMassContraintParameters.cpp" name="test_ExtractMassConstraint"> COMMENT: reads old format file
+  <flags PRE_TEST="test_ZMuMuMassConstraintParameterFinder"/> 
   <use name="roothistmatrix"/>
-</bin>
+</bin> -->

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -1,73 +1,73 @@
 <environment>
   <test name="validateAlignments" command="testingScripts/validateAlignments.sh"/>
-  <test name="DMRall" command="testingScripts/test_unitDMR.sh">
+  <!-- <test name="DMRall" command="testingScripts/test_unitDMR.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
-  <test name="PVall" command="testingScripts/test_unitPV.sh">
+  </test> -->
+  <!-- <test name="PVall" command="testingScripts/test_unitPV.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
-  <test name="Zmumuall" command="testingScripts/test_unitZmumu.sh">
+  </test> -->
+  <!-- <test name="Zmumuall" command="testingScripts/test_unitZmumu.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
-  <test name="SplitVall" command="testingScripts/test_unitSplitV.sh">
+  </test> -->
+  <!-- <test name="SplitVall" command="testingScripts/test_unitSplitV.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
-  <test name="JetHTall" command="testingScripts/test_unitJetHT.sh">
+  </test> -->
+  <!-- <test name="JetHTall" command="testingScripts/test_unitJetHT.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
+  </test> -->
   <test name="GCPall" command="testingScripts/test_unitGCP.sh">
     <flags PRE_TEST="validateAlignments"/>
   </test>
-  <test name="DiMuonVall" command="testingScripts/test_unitDiMuonV.sh">
+  <!-- <test name="DiMuonVall" command="testingScripts/test_unitDiMuonV.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
-  <test name="MTSall" command="testingScripts/test_unitMTS.sh">
+  </test> -->
+  <!-- <test name="MTSall" command="testingScripts/test_unitMTS.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>  
+  </test>  -->
   <test name="PixBaryall" command="testingScripts/test_unitPixBary.sh">
     <flags PRE_TEST="validateAlignments"/>
   </test>
-  <test name="Genericall" command="testingScripts/test_unitGeneric.sh">
+  <!-- <test name="Genericall" command="testingScripts/test_unitGeneric.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>
-  <test name="PVValidation" command="testingScripts/test_unitPVValidation.sh"/>
+  </test> -->
+  <!-- <test name="PVValidation" command="testingScripts/test_unitPVValidation.sh"/> COMMENT: reads old format file -->
   <bin file="testTrackAnalyzers.cc" name="testTrackAnalysis">
     <use name="FWCore/TestProcessor"/>
     <use name="catch2"/>
   </bin>
-  <test name="PrimaryVertex" command="testingScripts/test_unitPrimaryVertex.sh"/>
-  <bin file="testPVPlotting.cpp" name="testPVPlotting">
+  <!-- <test name="PrimaryVertex" command="testingScripts/test_unitPrimaryVertex.sh"/> COMMENT: reads old format file -->
+  <!-- <bin file="testPVPlotting.cpp" name="testPVPlotting"> COMMENT: dependent test disabled
     <flags PRE_TEST="PrimaryVertex"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>
     <use name="rootgraphics"/>
     <use name="Alignment/OfflineValidation"/>
-  </bin>
+  </bin> -->
   <bin file="testTkAlStyle.C" name="testTkAlStyle">
     <use name="rootgraphics"/>
     <use name="Alignment/OfflineValidation"/>
   </bin>
-  <test name="DiMuonVertex" command="testingScripts/test_unitDiMuonVertex.sh"/>
-  <test name="DiElectronVertex" command="testingScripts/test_unitDiElectronVertex.sh"/>
+  <!-- <test name="DiMuonVertex" command="testingScripts/test_unitDiMuonVertex.sh"/> COMMENT: reads old format file -->
+  <!-- <test name="DiElectronVertex" command="testingScripts/test_unitDiElectronVertex.sh"/> COMMENT: reads old format file -->
   <test name="SubmitPVrbr" command="testingScripts/test_unitSubmitPVrbr.sh"/>
   <test name="SubmitPVsplit" command="testingScripts/test_unitSubmitPVsplit.sh"/>
-  <test name="EoP" command="testingScripts/test_unitEoP.sh"/>
-  <bin file="testEoPPlotting.cpp" name="testEoPPlotting">
+  <!-- <test name="EoP" command="testingScripts/test_unitEoP.sh"/> COMMENT: reads old format file -->
+  <!-- <bin file="testEoPPlotting.cpp" name="testEoPPlotting">
     <flags PRE_TEST="EoP"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>
     <use name="rootgraphics"/>
     <use name="Alignment/OfflineValidation"/>
-  </bin>
-  <test name="Miscellanea" command="testingScripts/test_unitMiscellanea.sh"/>
-  <test name="ShortTrackValidation" command="testingScripts/test_unitShortTrackValidation.sh"/>
-  <test name="SagittaBiasNtuplizer" command="testingScripts/test_unitSagittaBiasNtuplizer.sh"/>
+  </bin> -->
+  <!-- <test name="Miscellanea" command="testingScripts/test_unitMiscellanea.sh"/> COMMENT: reads old format file -->
+  <!-- <test name="ShortTrackValidation" command="testingScripts/test_unitShortTrackValidation.sh"/> COMMENT: reads old format file -->
+  <!-- <test name="SagittaBiasNtuplizer" command="testingScripts/test_unitSagittaBiasNtuplizer.sh"/> COMMENT: reads old format file -->
   <test name="BeamSpotPlotting" command="testingScripts/test_unitBeamSpotPlotting.sh"/>
-  <bin file="testanalyzeDiMuonBiases.cpp" name="testDiMuonBiasesPlotting">
+  <!-- <bin file="testanalyzeDiMuonBiases.cpp" name="testDiMuonBiasesPlotting"> COMMENT: dependent test disabled
     <flags PRE_TEST="SagittaBiasNtuplizer"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>
     <use name="rootgraphics"/>
     <use name="Alignment/OfflineValidation"/>
-  </bin>
+  </bin> -->
 </environment>

--- a/CalibPPS/TimingCalibration/test/BuildFile.xml
+++ b/CalibPPS/TimingCalibration/test/BuildFile.xml
@@ -1,2 +1,4 @@
 <test name="testDiamondLUTCalibration" command="test_timing_LUT_cal.sh"/>
+<!-- COMMENT: reads old format file
 <test name="testHptdcPcl" command="test_hptdc_pcl.sh"/>
+-->

--- a/CalibTracker/SiStripChannelGain/test/BuildFile.xml
+++ b/CalibTracker/SiStripChannelGain/test/BuildFile.xml
@@ -1,9 +1,11 @@
 <environment>
+  <!-- COMMENT: reads old format file
   <test name="testSSTGainPCL_fromRECO" command="testSSTGain_PCL_FromRECO.sh"/>
   <bin name="checkMultiRunHarvestingOutput" file="checkMultiRunHarvesting.cpp">
     <flags PRE_TEST="testSSTGainPCL_fromRECO"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>
   </bin>
+  -->
   <test name="testSSTGainPCL_fromCalibTree" command="testSSTGain_PCL_FromCalibTree.sh"/>
 </environment>

--- a/CalibTracker/SiStripCommon/test/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/test/BuildFile.xml
@@ -1,5 +1,5 @@
-<test name="testCalibTrackerSiStripCommonOneByOne" command="run_tests.sh"/>
-<test name="testCalibTrackerSiStripCommonAll" command="test_all.sh"/>
+<!-- <test name="testCalibTrackerSiStripCommonOneByOne" command="run_tests.sh"/> COMMENT: reads old format file -->
+<!-- <test name="testCalibTrackerSiStripCommonAll" command="test_all.sh"/> COMMENT: reads old format file -->
 
 <use name="CalibTracker/SiStripCommon"/>
 <library file="*.cc" name="CalibTrackerSiStripCommonTest">

--- a/CalibTracker/SiStripHitEfficiency/test/BuildFile.xml
+++ b/CalibTracker/SiStripHitEfficiency/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testSiStripHitEfficiency" command="test_SiStripHitEfficiency.sh"/>
+<!-- <test name="testSiStripHitEfficiency" command="test_SiStripHitEfficiency.sh"/> COMMENT: reads old format file -->

--- a/CalibTracker/SiStripHitResolution/test/BuildFile.xml
+++ b/CalibTracker/SiStripHitResolution/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testSiStripHitResolution" command="test_SiStripHitResolution.sh"/>
+<!-- <test name="testSiStripHitResolution" command="test_SiStripHitResolution.sh"/> COMMENT: reads old format file -->

--- a/CalibTracker/SiStripLorentzAngle/test/BuildFile.xml
+++ b/CalibTracker/SiStripLorentzAngle/test/BuildFile.xml
@@ -1,1 +1,3 @@
+<!-- COMMENT: reads old format file
 <test name="testPromptCalibProdSiStripLA" command="testPromptCalibProdSiStripLA.sh"/>
+-->

--- a/Calibration/LumiAlCaRecoProducers/test/BuildFile.xml
+++ b/Calibration/LumiAlCaRecoProducers/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="TestCalibrationLumiAlCaRecoProducers" command="test.sh"/>
+<!-- <test name="TestCalibrationLumiAlCaRecoProducers" command="test.sh"/> COMMENT: reads old format file -->

--- a/Calibration/TkAlCaRecoProducers/test/BuildFile.xml
+++ b/Calibration/TkAlCaRecoProducers/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <test name="testAlCaHarvesting" command="testAlCaHarvesting.sh"/>
-<test name="testBeamSpotWorkflow" command="testBeamSpotWorkflow.sh"/>
+<!-- <test name="testBeamSpotWorkflow" command="testBeamSpotWorkflow.sh"/> COMMENT: reads old format file -->
 
 <use name="DQMServices/Core"/>
 <use name="FWCore/Framework"/>

--- a/CommonTools/CandAlgos/test/BuildFile.xml
+++ b/CommonTools/CandAlgos/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testCandView" command="cmsRun ${LOCALTOP}/src/CommonTools/CandAlgos/test/candview_tester.py"/>
+<!-- <test name="testCandView" command="cmsRun ${LOCALTOP}/src/CommonTools/CandAlgos/test/candview_tester.py"/> COMMENT: reads old format file -->

--- a/DQM/BeamMonitor/test/BuildFile.xml
+++ b/DQM/BeamMonitor/test/BuildFile.xml
@@ -2,4 +2,4 @@
   <use name="FWCore/TestProcessor"/>
   <use name="catch2"/>
 </bin>
-<test name="testOnlineBeamMonitor" command="testOnlineBeamMonitor.sh"/>
+<!-- <test name="testOnlineBeamMonitor" command="testOnlineBeamMonitor.sh"/> COMMENT: reads old format file -->

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -1,41 +1,41 @@
-<test name="TestDQMOnlineClient-beam_dqm_sourceclient" command="runtest.sh beam_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-beamhlt_dqm_sourceclient" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py 381594"/>
-<test name="TestDQMOnlineClient-beampixel_dqm_sourceclient" command="runtest.sh beampixel_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-csc_dqm_sourceclient" command="runtest.sh csc_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-ctpps_dqm_sourceclient" command="runtest.sh ctpps_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-dt_dqm_sourceclient" command="runtest.sh dt_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-ecal_dqm_sourceclient" command="runtest.sh ecal_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-es_dqm_sourceclient" command="runtest.sh es_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-fed_dqm_sourceclient" command="runtest.sh fed_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-gem_dqm_sourceclient" command="runtest.sh gem_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-hcalreco_dqm_sourceclient" command="runtest.sh hcalreco_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-hcal_dqm_sourceclient" command="runtest.sh hcal_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-hlt_dqm_clientPB" command="runtest.sh hlt_dqm_clientPB-live_cfg.py"/>
-<test name="TestDQMOnlineClient-hlt_dqm_sourceclient" command="runtest.sh hlt_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-ngt_dqm_sourceclient" command="runtest.sh ngt_dqm_sourceclient-live_cfg.py 402360"/>
-<test name="TestDQMOnlineClient-scouting_dqm_sourceclient" command="runtest.sh scouting_dqm_sourceclient-live_cfg.py 398183"/>
-<test name="TestDQMOnlineClient-info_dqm_sourceclient" command="runtest.sh info_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-l1tstage2_dqm_sourceclient" command="runtest.sh l1tstage2_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-l1tstage2emulator_dqm_sourceclient" command="runtest.sh l1tstage2emulator_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-mutracking_dqm_sourceclient" command="runtest.sh mutracking_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-pixel_dqm_sourceclient" command="runtest.sh pixel_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-pixellumi_dqm_sourceclient" command="runtest.sh pixellumi_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-rpc_dqm_sourceclient" command="runtest.sh rpc_dqm_sourceclient-live_cfg.py"/>
+<!-- <test name="TestDQMOnlineClient-beam_dqm_sourceclient" command="runtest.sh beam_dqm_sourceclient-live_cfg.py"/> COMMENT: reads old format file -->
+<!-- <test name="TestDQMOnlineClient-beamhlt_dqm_sourceclient" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py 381594"/> COMMENT: reads old format file -->
+<!-- <test name="TestDQMOnlineClient-beampixel_dqm_sourceclient" command="runtest.sh beampixel_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-csc_dqm_sourceclient" command="runtest.sh csc_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-ctpps_dqm_sourceclient" command="runtest.sh ctpps_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-dt_dqm_sourceclient" command="runtest.sh dt_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-ecal_dqm_sourceclient" command="runtest.sh ecal_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-es_dqm_sourceclient" command="runtest.sh es_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-fed_dqm_sourceclient" command="runtest.sh fed_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-gem_dqm_sourceclient" command="runtest.sh gem_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-hcalreco_dqm_sourceclient" command="runtest.sh hcalreco_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-hcal_dqm_sourceclient" command="runtest.sh hcal_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-hlt_dqm_clientPB" command="runtest.sh hlt_dqm_clientPB-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-hlt_dqm_sourceclient" command="runtest.sh hlt_dqm_sourceclient-live_cfg.py"/ COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-ngt_dqm_sourceclient" command="runtest.sh ngt_dqm_sourceclient-live_cfg.py 398183"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-scouting_dqm_sourceclient" command="runtest.sh scouting_dqm_sourceclient-live_cfg.py 398183"/> COMMENT:reads old format file -->
+<!--<test name="TestDQMOnlineClient-info_dqm_sourceclient" command="runtest.sh info_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-l1tstage2_dqm_sourceclient" command="runtest.sh l1tstage2_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-l1tstage2emulator_dqm_sourceclient" command="runtest.sh l1tstage2emulator_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-mutracking_dqm_sourceclient" command="runtest.sh mutracking_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-pixel_dqm_sourceclient" command="runtest.sh pixel_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-pixellumi_dqm_sourceclient" command="runtest.sh pixellumi_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-rpc_dqm_sourceclient" command="runtest.sh rpc_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
 <!-- The SCAL FED has been removed from DAQ since the end of Run 2 -->
 <!-- <test name="TestDQMOnlineClient-scal_dqm_sourceclient" command="runtest.sh scal_dqm_sourceclient-live_cfg.py"/> -->
-<test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-sistrip_approx_dqm_sourceclient" command="runtest.sh sistrip_approx_dqm_sourceclient-live_cfg.py 362321 hi_run"/>
-<test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py 381594 pp_run"/>
-<test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 398183"/>
-<test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 398183"/>
-<test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 398183"/>
-<test name="TestDQMOnlineClient-pfgpu_dqm_sourceclient" command="runtest.sh pfgpu_dqm_sourceclient-live_cfg.py 398183"/>
+<!-- <test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-sistrip_approx_dqm_sourceclient" command="runtest.sh sistrip_approx_dqm_sourceclient-live_cfg.py 362321 hi_run"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py 381594 pp_run"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 398183"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 398183"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 398183"/> COMMENT:reads old format file -->
+<!-- <test name="TestDQMOnlineClient-pfgpu_dqm_sourceclient" command="runtest.sh pfgpu_dqm_sourceclient-live_cfg.py 398183"/> COMMENT:reads old format file -->
 <!-- streamDQMCalibration is required -->
 <!-- <test name="TestDQMOnlineClient-ecalcalib_dqm_sourceclient" command="runtest.sh ecalcalib_dqm_sourceclient-live_cfg.py" /> -->
 <!-- streamDQMCalibration is required -->
 <!-- <test name="TestDQMOnlineClient-hcalcalib_dqm_sourceclient" command="runtest.sh hcalcalib_dqm_sourceclient-live_cfg.py" /> -->
-<test name="TestDQMOnlineClient-visualization" command="runtest.sh visualization-live_cfg.py" />
-<test name="TestDQMOnlineClient-visualization_secondInstance" command="runtest.sh visualization-live-secondInstance_cfg.py" />
+<!-- <test name="TestDQMOnlineClient-visualization" command="runtest.sh visualization-live_cfg.py" /> COMMENT: reads an old format file -->
+<!-- <test name="TestDQMOnlineClient-visualization_secondInstance" command="runtest.sh visualization-live-secondInstance_cfg.py" /> COMMENT: reads an old format file-->
 <!--tests that the configuration is compilable for the full matrix of combinations -->
 <test name="TestDQMOnlineClients-compilation_pp_run" command="runCompilationTest.sh pp_run"/>
 <test name="TestDQMOnlineClients-compilation_pp_run_stage1" command="runCompilationTest.sh pp_run_stage1"/>

--- a/DQM/TrackerCommon/test/BuildFile.xml
+++ b/DQM/TrackerCommon/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="test_DetectorStateFilter" command="test_DetectorStateFilter.sh"/>
+<!-- <test name="test_DetectorStateFilter" command="test_DetectorStateFilter.sh"/> COMMENT: reads old format files -->

--- a/DQM/TrackingMonitorSource/test/BuildFile.xml
+++ b/DQM/TrackingMonitorSource/test/BuildFile.xml
@@ -1,5 +1,5 @@
-<test name="testTrackingDATAMC" command="testTrackingDATAMC.sh"/>
-<test name="testTrackingResolution" command="testTrackingResolution.sh"/>
+<!-- <test name="testTrackingDATAMC" command="testTrackingDATAMC.sh"/> COMMENT: reads old format file -->
+<!-- <test name="testTrackingResolution" command="testTrackingResolution.sh"/> COMMENT: reads old format file -->
 <environment>
   <bin file="testTrackingDQMAnalyzers.cc" name="testTrackingDQMAnalyzers">
     <use name="FWCore/TestProcessor"/>

--- a/DQMOffline/Alignment/test/BuildFile.xml
+++ b/DQMOffline/Alignment/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testDiMuonVertexMonitor" command="testDiMuonVertexMonitor.sh"/>
+<!-- <test name="testDiMuonVertexMonitor" command="testDiMuonVertexMonitor.sh"/> COMMENT: reads old format files -->

--- a/DQMOffline/Trigger/test/BuildFile.xml
+++ b/DQMOffline/Trigger/test/BuildFile.xml
@@ -4,4 +4,4 @@
 </bin>
 
 <!-- test the HLTFiltersDQMonitor plugin -->
-<test name="testHLTFiltersDQMonitor" command="testHLTFiltersDQMonitor.sh"/>
+<!-- <test name="testHLTFiltersDQMonitor" command="testHLTFiltersDQMonitor.sh"/> COMMENT: reads old format file-->

--- a/DataFormats/Common/test/BuildFile.xml
+++ b/DataFormats/Common/test/BuildFile.xml
@@ -10,7 +10,7 @@
 
 <test name="TestTriggerResultsFormat" command="TestTriggerResultsFormat.sh"/>
 
-<bin name="testDataFormatsCommon" file="testOwnVector.cc,testOneToOneAssociation.cc,testValueMap.cc,testOneToManyAssociation.cc,testAssociationVector.cc,testAssociationNew.cc,testValueMapNew.cc,testSortedCollection.cc,testRangeMap.cc,ref_t.catch2.cc,DetSetRefVector_t.catch2.cc,reftobasevector_t.catch2.cc,cloningptr_t.catch2.cc,ptr_t.catch2.cc,containermask_t.catch2.cc,reftobaseprod_t.catch2.cc,handle_t.catch2.cc">
+<bin name="testDataFormatsCommon" file="testOwnVector.cc,testOneToOneAssociation.cc,testValueMap.cc,testOneToManyAssociation.cc,testAssociationVector.cc,testAssociationNew.cc,testValueMapNew.cc,testSortedCollection.cc,testRangeMap.cc,ref_t.catch2.cc,DetSetRefVector_t.catch2.cc,reftobasevector_t.catch2.cc,cloningptr_t.catch2.cc,ptr_t.catch2.cc,containermask_t.catch2.cc,reftobaseprod_t.catch2.cc,handle_t.catch2.cc,IdToHitRange_t.cpp">
   <use name="catch2"/>
   <use name="boost"/>
   <use name="DataFormats/Common"/>

--- a/GeneratorInterface/RivetInterface/test/BuildFile.xml
+++ b/GeneratorInterface/RivetInterface/test/BuildFile.xml
@@ -11,6 +11,6 @@
 </test>
 <test name="test-particleLevel_fromHepMC3" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/RivetInterface/test/particleLevel_fromHepMC3_cfg.py"/>
 <test name="test-particleLevel_fromGenParticles" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/RivetInterface/test/particleLevel_fromGenParticles_cfg.py"/>
-<test name="test-particleLevel_fromMiniAod" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/RivetInterface/test/particleLevel_cfg.py"/>
+<!-- <test name="test-particleLevel_fromMiniAod" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/RivetInterface/test/particleLevel_cfg.py"/> COMMENT: reads old format file -->
 <test name="test-particleLevel_fromPtGun" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/RivetInterface/test/particleLevel_fromPtGun_cfg.py"/>
-<test name="test-HTXS" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/RivetInterface/test/runRivetHTXS_cfg.py"/>
+<!-- <test name="test-HTXS" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/RivetInterface/test/runRivetHTXS_cfg.py"/> COMMENT: reads old format file -->

--- a/HLTrigger/Configuration/test/BuildFile.xml
+++ b/HLTrigger/Configuration/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <!-- test access to EDM files used in HLT-AddOnTests and HLT-Validation tests -->
-<test name="testAccessToEDMInputsOfHLTTests" command="testAccessToEDMInputsOfHLTTests.sh"/>
+<!-- <test name="testAccessToEDMInputsOfHLTTests" command="testAccessToEDMInputsOfHLTTests.sh"/> COMMENT: reads old format files -->
 
 <!-- test script hltPrintMenuVersions
      enabled only for the x86-64 architecture, because the python module cx_Oracle

--- a/HLTrigger/HLTcore/test/BuildFile.xml
+++ b/HLTrigger/HLTcore/test/BuildFile.xml
@@ -16,7 +16,7 @@
 </bin>
 
 <!-- test the HLTPrescaleExample plugin -->
-<test name="testHLTPrescaleExample" command="testHLTPrescaleExample.sh"/>
+<!-- <test name="testHLTPrescaleExample" command="testHLTPrescaleExample.sh"/> COMMENT: reads old format file -->
 
 <!-- test EDAnalyzers using TriggerEvent and TriggerEventWithRefs -->
-<test name="testTriggerEventAnalyzers" command="testTriggerEventAnalyzers.sh"/>
+<!-- <test name="testTriggerEventAnalyzers" command="testTriggerEventAnalyzers.sh"/> COMMENT: reads old format file -->

--- a/HLTrigger/NGTScouting/test/BuildFile.xml
+++ b/HLTrigger/NGTScouting/test/BuildFile.xml
@@ -1,4 +1,4 @@
 <environment>
-  <test name="testProduceNanoHLT" command="testNanohltDQM.sh unitTest"/>
+  <!-- <test name="testProduceNanoHLT" command="testNanohltDQM.sh unitTest"/> COMMENT: reads old format file -->
 </environment>
 

--- a/JetMETCorrections/Modules/test/BuildFile.xml
+++ b/JetMETCorrections/Modules/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="TestJetMETCorrectionsModulesJetResolutionObject" command="test_jetresolution.sh"/>
+<!-- <test name="TestJetMETCorrectionsModulesJetResolutionObject" command="test_jetresolution.sh"/> COMMENT: reads old format file -->

--- a/L1Trigger/L1TGlobal/test/BuildFile.xml
+++ b/L1Trigger/L1TGlobal/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testL1TGlobalProducer" command="testL1TGlobalProducer.sh"/>
+<!-- <test name="testL1TGlobalProducer" command="testL1TGlobalProducer.sh"/> COMMENT: reads old format file -->

--- a/PhysicsTools/NanoAOD/test/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/test/BuildFile.xml
@@ -4,8 +4,8 @@
   <use name="catch2"/>
 </bin>
 
-<test name="test-btvNano-run" command="test-btvNano.sh"/>
-<test name="test-btvNano-runDY" command="test-btvNanoDY.sh"/>
-<test name="test-btvNano-check" command="test-btvNano.py">
+<!-- <test name="test-btvNano-run" command="test-btvNano.sh"/> COMMENT: reads old format files -->
+<!-- <test name="test-btvNano-runDY" command="test-btvNanoDY.sh"/> COMMENT: reads old format files -->
+<!-- <test name="test-btvNano-check" command="test-btvNano.py"> COMMENT: depends on disabled test 
   <flags PRE_TEST="test-btvNano-run"/>
-</test>
+</test> -->

--- a/PhysicsTools/PatAlgos/test/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/test/BuildFile.xml
@@ -8,4 +8,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<test name="runtestPhysicsToolsPatAlgos" command="runtests.sh"/>
+<!-- <test name="runtestPhysicsToolsPatAlgos" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/PhysicsTools/SelectorUtils/test/BuildFile.xml
+++ b/PhysicsTools/SelectorUtils/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testPhysicsToolsSelectorUtilsPythonTestsDriver" command="runPythonTests.sh"/>
+<!-- <test name="testPhysicsToolsSelectorUtilsPythonTestsDriver" command="runPythonTests.sh"/> COMMENT: reads old format file -->

--- a/PhysicsTools/UtilAlgos/test/BuildFile.xml
+++ b/PhysicsTools/UtilAlgos/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestUtilAlgos" command="runtests.sh"/>
+<!-- <test name="runtestUtilAlgos" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/RecoBTag/FeatureTools/test/BuildFile.xml
+++ b/RecoBTag/FeatureTools/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testRecoBTagInfoWithUnsubJets" command="cmsRun ${LOCALTOP}/src/RecoBTag/FeatureTools/test/u0_cfg.py"/>
+<!-- <test name="testRecoBTagInfoWithUnsubJets" command="cmsRun ${LOCALTOP}/src/RecoBTag/FeatureTools/test/u0_cfg.py"/> COMMENT: read old format file -->

--- a/RecoEcal/EgammaClusterProducers/test/BuildFile.xml
+++ b/RecoEcal/EgammaClusterProducers/test/BuildFile.xml
@@ -9,4 +9,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<test name="DRNTest" command="runtests.sh"/>
+<!-- <test name="DRNTest" command="runtests.sh"/> COMMENT: reads old format file -->

--- a/RecoEgamma/ElectronIdentification/test/BuildFile.xml
+++ b/RecoEgamma/ElectronIdentification/test/BuildFile.xml
@@ -8,4 +8,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<test name="runtestRecoEgammaElectronIdentification" command="runtests.sh"/>
+<!-- <test name="runtestRecoEgammaElectronIdentification" command="runtests.sh"/> COMMENT: reads old format file -->

--- a/RecoEgamma/PhotonIdentification/test/BuildFile.xml
+++ b/RecoEgamma/PhotonIdentification/test/BuildFile.xml
@@ -5,4 +5,4 @@
   <use name="RecoEgamma/PhotonIdentification"/>
 </bin>
 
-<test name="runtestRecoEgammaPhotonIdentification" command="runtests.sh"/>
+<!-- <test name="runtestRecoEgammaPhotonIdentification" command="runtests.sh"/> COMMENT: reads old format file -->

--- a/RecoMET/METProducers/test/BuildFile.xml
+++ b/RecoMET/METProducers/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="testRecoMETMETProducers" command="runtests.sh"/>
+<!-- <test name="testRecoMETMETProducers" command="runtests.sh"/> COMMENT: reads old format file -->

--- a/RecoPPS/Local/test/BuildFile.xml
+++ b/RecoPPS/Local/test/BuildFile.xml
@@ -1,3 +1,3 @@
 <test name="RecoPPSLocalNewT2" command="testNT2.sh"/>
-<test name="PPSReconstructionDefault" command="global_reco_PPS_test.sh"/>
-<test name="PPSReconstructionStrips" command="global_reco_PPS_test_strips.sh"/>
+<!-- <test name="PPSReconstructionDefault" command="global_reco_PPS_test.sh"/> COMMENT: reads old format file -->
+<!-- <test name="PPSReconstructionStrips" command="global_reco_PPS_test_strips.sh"/> COMMENT: reads old format file -->

--- a/RecoTauTag/RecoTau/test/BuildFile.xml
+++ b/RecoTauTag/RecoTau/test/BuildFile.xml
@@ -29,4 +29,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<test name="runtestRecoTauTagRecoTau" command="runtests.sh"/>
+<!-- <test name="runtestRecoTauTagRecoTau" command="runtests.sh"/> COMMENT: reads old format file -->

--- a/RecoTracker/TrackProducer/test/BuildFile.xml
+++ b/RecoTracker/TrackProducer/test/BuildFile.xml
@@ -30,4 +30,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<test name="testMuonTrackRefitting" command="testMuonTrackRefitting.sh"/>
+<!-- <test name="testMuonTrackRefitting" command="testMuonTrackRefitting.sh"/> COMMENT: reads old format file -->

--- a/RecoVertex/BeamSpotProducer/test/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/test/BuildFile.xml
@@ -11,7 +11,7 @@
 
 <test name="testReadWriteBSFromDB" command="testReadWriteBSFromDB.sh"/>
 
-<test name="testBeamSpotCompatibilityEventData" command="testBeamSpotCompatibility.sh"/>
+<!-- <test name="testBeamSpotCompatibilityEventData" command="testBeamSpotCompatibility.sh"/> COMMENT: reads old format file -->
 
 <bin file="testBeamSpotAnalyzer.cc">
   <use name="FWCore/TestProcessor"/>

--- a/SLHCUpgradeSimulations/Geometry/test/BuildFile.xml
+++ b/SLHCUpgradeSimulations/Geometry/test/BuildFile.xml
@@ -40,7 +40,7 @@
     <use name="RecoTracker/TransientTrackingRecHit"/>
   </library>
 
-  <test name="testPhase2PixelNtuple" command="phase2_digi_reco_pixelntuple.sh"/>
+  <!-- <test name="testPhase2PixelNtuple" command="phase2_digi_reco_pixelntuple.sh"/> COMMENT: reads old format file -->
 
   <test name="testPhase2SkimmedGeometry" command="phase2_skimmed_geometry.sh"/>
 

--- a/TopQuarkAnalysis/TopEventProducers/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopEventProducers/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestTqafTopEventProducers" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopEventProducers" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/TopQuarkAnalysis/TopEventSelection/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopEventSelection/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestTqafTopEventSelection" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopEventSelection" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/TopQuarkAnalysis/TopHitFit/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopHitFit/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestTqafTopHitFit" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopHitFit" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/TopQuarkAnalysis/TopJetCombination/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopJetCombination/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestTqafTopJetCombination" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopJetCombination" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/TopQuarkAnalysis/TopKinFitter/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopKinFitter/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestTqafTopKinFitter" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopKinFitter" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/TopQuarkAnalysis/TopSkimming/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopSkimming/test/BuildFile.xml
@@ -1,1 +1,1 @@
-<test name="runtestTqafTopSkimming" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopSkimming" command="runtests.sh"/> COMMENT: reads old format files -->

--- a/TopQuarkAnalysis/TopTools/test/BuildFile.xml
+++ b/TopQuarkAnalysis/TopTools/test/BuildFile.xml
@@ -1,4 +1,4 @@
-<test name="runtestTqafTopTools" command="runtests.sh"/>
+<!-- <test name="runtestTqafTopTools" command="runtests.sh"/> COMMENT: reads old format files -->
 
 <library file="TestGenTtbarCategories.cc">
   <flags EDM_PLUGIN="1"/>

--- a/TrackPropagation/Geant4e/test/BuildFile.xml
+++ b/TrackPropagation/Geant4e/test/BuildFile.xml
@@ -15,6 +15,6 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<test name="testG4Refitter" command="cmsRun ${LOCALTOP}/src/TrackPropagation/Geant4e/test/Geant4e_example_cfg.py"/>
+<!-- <test name="testG4Refitter" command="cmsRun ${LOCALTOP}/src/TrackPropagation/Geant4e/test/Geant4e_example_cfg.py"/> COMMENT: reads old format file -->
 <test name="testG4SimplePropagator" command="cmsRun ${LOCALTOP}/src/TrackPropagation/Geant4e/test/simpleTestPropagator_cfg.py"/>
-<test name="testG4PropagatorAnalyzer" command="cmsRun ${LOCALTOP}/src/TrackPropagation/Geant4e/test/testPropagatorAnalyzer_cfg.py"/>
+<!-- <test name="testG4PropagatorAnalyzer" command="cmsRun ${LOCALTOP}/src/TrackPropagation/Geant4e/test/testPropagatorAnalyzer_cfg.py"/> COMMENT: reads old format file -->

--- a/Utilities/ReleaseScripts/scripts/addOnTests.py
+++ b/Utilities/ReleaseScripts/scripts/addOnTests.py
@@ -79,7 +79,7 @@ class StandardTester(object):
                   'fastsim'   : ["cmsDriver.py TTbar_8TeV_TuneCUETP8M1_cfi  --conditions auto:run1_mc --fast  -n 100 --eventcontent AODSIM,DQM --relval 100000,1000 -s GEN,SIM,RECOBEFMIX,DIGI:pdigi_valid,L1,DIGI2RAW,L1Reco,RECO,VALIDATION  --customise=HLTrigger/Configuration/CustomConfigs.L1THLT --datatier GEN-SIM-DIGI-RECO,DQMIO --beamspot Realistic8TeVCollision"],
                   'fastsim1'  : ["cmsDriver.py TTbar_13TeV_TuneCUETP8M1_cfi --conditions auto:run2_mc_l1stage1 --fast  -n 100 --eventcontent AODSIM,DQM --relval 100000,1000 -s GEN,SIM,RECOBEFMIX,DIGI:pdigi_valid,L1,DIGI2RAW,L1Reco,RECO,VALIDATION  --customise=HLTrigger/Configuration/CustomConfigs.L1THLT --datatier GEN-SIM-DIGI-RECO,DQMIO --beamspot NominalCollision2015 --era Run2_25ns"],
                   'fastsim2'  : ["cmsDriver.py TTbar_13TeV_TuneCUETP8M1_cfi --conditions auto:run2_mc --fast  -n 100 --eventcontent AODSIM,DQM --relval 100000,1000 -s GEN,SIM,RECOBEFMIX,DIGI:pdigi_valid,L1,DIGI2RAW,L1Reco,RECO,VALIDATION  --customise=HLTrigger/Configuration/CustomConfigs.L1THLT --datatier GEN-SIM-DIGI-RECO,DQMIO --beamspot NominalCollision2015 --era Run2_2016"],
-                  'pat1'      : ['cmsRun '+self.file2Path('PhysicsTools/PatAlgos/test/IntegrationTest_cfg.py')],
+                  #'pat1'      : ['cmsRun '+self.file2Path('PhysicsTools/PatAlgos/test/IntegrationTest_cfg.py')], COMMENT: reads old format file
                 }
 
         hltTests = {}

--- a/Validation/RecoTrack/test/BuildFile.xml
+++ b/Validation/RecoTrack/test/BuildFile.xml
@@ -1,2 +1,2 @@
 <test name="testMakeTrackValidationPlots" command="test_makeTrackValidationPlots.sh"/>
-<test name="testSimpleTrackValidation" command="test_SimpleTrackValidation.sh"/>
+<!-- <test name="testSimpleTrackValidation" command="test_SimpleTrackValidation.sh"/> COMMENT: reads old format file -->


### PR DESCRIPTION
#### PR description:

This PR is part of integrating the changes from the `EVOLUTION_X` branch to the `master` branch in CMSSW_20_0_X. It disables tests that read existing non-RAW files, that will not be readable in 20_0_X.

Following the strategy agreed in ORP 2026-05-05, it is opened already now to allow it to be reviewed such that it could be merged quickly when the `master` branch moves to 20_0_X. 

**Note unusual integration:** This PR will be merged in 20_0_X regardless of the review status unless major flaws come up during the review and they have not been addressed.

Resolves https://github.com/cms-sw/framework-team/issues/2225

#### PR validation:

None beyond the tests of EVOLUTION_X IBs