### PR TITLE
add TrackGenJetSoftActivityHT1 scalar variable

### DIFF
--- a/PhysicsTools/NanoAOD/python/jetMC_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetMC_cff.py
@@ -143,6 +143,7 @@ trackGenJetAK4Table.variables.phi.precision = 8
 trackGenJetsAK4Pt10 = cms.EDFilter("CandPtrSelector", src = cms.InputTag("ak4GenJetsChargedOnly"), cut = cms.string('pt>10'))
 trackGenJetsAK4Pt5 = cms.EDFilter("CandPtrSelector", src = cms.InputTag("ak4GenJetsChargedOnly"), cut = cms.string('pt>5'))
 trackGenJetsAK4Pt2 = cms.EDFilter("CandPtrSelector", src = cms.InputTag("ak4GenJetsChargedOnly"), cut = cms.string('pt>2'))
+trackGenJetsAK4Pt1 = cms.EDFilter("CandPtrSelector", src = cms.InputTag("ak4GenJetsChargedOnly"), cut = cms.string('pt>1'))
 
 # Event-level scalar pT sums of TrackGenJets
 trackGenJetSoftActivityTable = globalVariablesTableProducer.clone(
@@ -150,12 +151,14 @@ trackGenJetSoftActivityTable = globalVariablesTableProducer.clone(
         TrackGenJetSoftActivityHT10 = ExtVar( cms.InputTag("trackGenJetsAK4Pt10"), "candidatescalarsum", doc = "scalar sum of TrackGenJetAK4 pt, pt>10" ),
         TrackGenJetSoftActivityHT5 = ExtVar( cms.InputTag("trackGenJetsAK4Pt5"), "candidatescalarsum", doc = "scalar sum of TrackGenJetAK4 pt, pt>5" ),
         TrackGenJetSoftActivityHT2 = ExtVar( cms.InputTag("trackGenJetsAK4Pt2"), "candidatescalarsum", doc = "scalar sum of TrackGenJetAK4 pt, pt>2" ),
+        TrackGenJetSoftActivityHT1 = ExtVar( cms.InputTag("trackGenJetsAK4Pt1"), "candidatescalarsum", doc = "scalar sum of TrackGenJetAK4 pt, pt>1" ),
         TrackGenJetAK4Njets10 = ExtVar( cms.InputTag("trackGenJetsAK4Pt10"), "candidatesize", doc = "number of TrackGenJetAK4 with pt>10" ),
         TrackGenJetAK4Njets5 = ExtVar( cms.InputTag("trackGenJetsAK4Pt5"), "candidatesize", doc = "number of TrackGenJetAK4 with pt>5" ),
         TrackGenJetAK4Njets2 = ExtVar( cms.InputTag("trackGenJetsAK4Pt2"), "candidatesize", doc = "number of TrackGenJetAK4 with pt>2" ),
+        TrackGenJetAK4Njets1 = ExtVar( cms.InputTag("trackGenJetsAK4Pt1"), "candidatesize", doc = "number of TrackGenJetAK4 with pt>1" ),
     )
 )
 
-jetMCTaskak4 = cms.Task(jetMCTable,genJetTable,patJetPartonsNano,genJetFlavourTable,genParticlesForJetsCharged,ak4GenJetsChargedOnly,trackGenJetAK4Table,trackGenJetsAK4Pt10,trackGenJetsAK4Pt5,trackGenJetsAK4Pt2,trackGenJetSoftActivityTable)
+jetMCTaskak4 = cms.Task(jetMCTable,genJetTable,patJetPartonsNano,genJetFlavourTable,genParticlesForJetsCharged,ak4GenJetsChargedOnly,trackGenJetAK4Table,trackGenJetsAK4Pt10,trackGenJetsAK4Pt5,trackGenJetsAK4Pt2,trackGenJetsAK4Pt1,trackGenJetSoftActivityTable)
 jetMCTaskak8 = cms.Task(genJetAK8Table,genJetAK8FlavourAssociation,genJetAK8FlavourTable,fatJetMCTable,genSubJetAK8Table,subjetMCTable)
 jetMCTask = jetMCTaskak4.copyAndAdd(jetMCTaskak8)


### PR DESCRIPTION
#### PR description:

This PR adds 2 new scalar variables, computing the HT and number of the TrackGenJetAK4 collection with a $p_T=1$ GeV threshold.

This change is being made in order to make the TrackGenJet collection a useful input for the production of SoftActivityJet and SoftActivity scalars with FlashSim, as discussed in e.g. https://indico.cern.ch/event/1629400/#179-flashsim-for-hmm-pisa (slide 4)

#### PR validation:
We validated the PR with syntax and naming checks. The logic is exactly the same as the previously validated PRs introducing the other scalar variables, e.g.  #50386 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
We are opening the PR against master. However, if a NanoAOD v16 production campaign is planned, we would need to backport this addition to the release which will be used for that campaing. If that is the case, could someone point us to the relase to target for our backport? Many thanks

@arizzi (tagged to keep him in the loop)