### PR TITLE
Convert pybind11 exception to CMS exception

### DIFF
--- a/FWCore/PythonParameterSet/src/initializePyBind11Module.cc
+++ b/FWCore/PythonParameterSet/src/initializePyBind11Module.cc
@@ -5,6 +5,7 @@
 //
 
 #include "FWCore/PythonParameterSet/src/initializePyBind11Module.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include "PyBind11Module.h"
 #include <pybind11/embed.h>
 #include <iostream>
@@ -13,7 +14,11 @@ namespace edm {
   namespace python {
     void initializePyBind11Module() {
       char *libFWCoreParameterSet = const_cast<char *>("libFWCorePythonParameterSet");
-      pybind11::module::import(libFWCoreParameterSet);
+      try {
+        pybind11::module::import(libFWCoreParameterSet);
+      } catch (const std::exception &e) {
+        throw cms::Exception("PyBind11ImportError") << "Failed to import PyBind11 module: " << e.what();
+      }
     }
   }  // namespace python
 }  // namespace edm


### PR DESCRIPTION
#### PR description:

If the pybind11 exception propagates out of initializePyBind11Module we get a segmentation fault. The theory is the exception holds memory owned by the python interpreter and that goes out of scope by the time the exception message is accessed.

#### PR validation:

Code compiles. A simple test where the code was temporarily changed to pass the wrong library name properly outputs the exception message without a segmentation fault. 

resolves https://github.com/cms-sw/framework-team/issues/2231