### PR TITLE
[16.1.X] Adjust TICL v4 track linking to work with (extended) pixel tracks

### DIFF
--- a/RecoHGCal/TICL/plugins/LinkingAlgoByDirectionGeometric.cc
+++ b/RecoHGCal/TICL/plugins/LinkingAlgoByDirectionGeometric.cc
@@ -303,7 +303,17 @@ void LinkingAlgoByDirectionGeometric::linkTracksters(const edm::Handle<std::vect
       continue;
 
     int iSide = int(tk.eta() > 0);
-    const auto &fts = trajectoryStateTransform::outerFreeState((tk), bFieldProd);
+    FreeTrajectoryState fts;
+
+    // Check whether the outer state is actually valid
+    if (tk.outerOk()) {
+      // Use outer state if available
+      fts = trajectoryStateTransform::outerFreeState(tk, bFieldProd);
+    } else {
+      // Fallback: use PCA (reference point)
+      fts = trajectoryStateTransform::initialFreeState(tk, bFieldProd);
+    }
+
     // to the HGCal front
     const auto &tsos = prop.propagate(fts, firstDisk_[iSide]->surface());
     if (tsos.isValid()) {


### PR DESCRIPTION
#### PR description:

As it has become clear in the meanwhile that in this release cycle the default TICL reconstruction will remain **v4** ([This PR](https://github.com/cms-sw/cmssw/pull/49932) enabling TICL v5 targets the cycle 17.0.X), I forward-port part of commit https://github.com/cms-sw/cmssw/commit/fa4b17031882bc9f0c7bbf204a5e8cb3ff474c36 (from PR https://github.com/cms-sw/cmssw/pull/50179) to allow efficient track linking in TICLv4 with extended pixel tracks in 16.1.X.

#### PR validation:

See description in PR https://github.com/cms-sw/cmssw/pull/50031

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Partial forward port of https://github.com/cms-sw/cmssw/pull/50179 to CMSSW_16_1_X.