### PR TITLE
Ask ROOT to attach to our TBB task arena for IMT

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -871,8 +871,7 @@ namespace edm {
       if (imt && not ROOT::IsImplicitMTEnabled()) {
         //cmsRun uses global_control to set the number of allowed threads to use
         // we need to tell ROOT the same value in order to avoid unnecessary warnings
-        ROOT::EnableImplicitMT(
-            oneapi::tbb::global_control::active_value(oneapi::tbb::global_control::max_allowed_parallelism));
+        ROOT::EnableImplicitMT(ROOT::EIMTConfig::kExistingTBBArena);
       }
     }
 


### PR DESCRIPTION
#### PR description:

If ROOT creates their own task arena, the main thread can not join that arena. That implies that e.g. in a 2-thread job, if the worker thread spawns tasks in the ROOT arena, the main thread won't run those tasks and might be idle. We really want ROOT to use our task arena (see discussion in https://github.com/root-project/root/issues/18301).

Resolves https://github.com/cms-sw/framework-team/issues/2188

#### PR validation:

Used for https://indico.cern.ch/event/1680459/#17-miniaod-ttree-auto-flush-se and https://indico.cern.ch/event/1683422/#17-update-on-rntuple-performan

Here is a read throughput comparison of MiniAOD reading with TTree prompt reading strategy without and with this PR with one concurrent event and different number of threads on 16_1_0_pre3:

<img width="549" height="402" alt="image" src="https://github.com/user-attachments/assets/f59eb390-bdc5-4750-ab38-0b9ce5800807" />