### PR TITLE
Makes CUDA driver version lookup fallback if NVML is not availble (gaming GPUs)

### DIFF
--- a/HeterogeneousCore/CUDAServices/plugins/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/plugins/CUDAService.cc
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -199,10 +200,18 @@ CUDAService::CUDAService(edm::ParameterSet const& config) : verbose_(config.getU
   computeCapabilities_.reserve(numberOfDevices_);
 
   // NVIDIA system driver version, e.g. 470.57.02
+  // The NVML interface is not available on gaming GPUs. Just report "unknown" in that case.
   char systemDriverVersion[NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE];
-  nvmlCheck(nvmlInitWithFlags(NVML_INIT_FLAG_NO_GPUS | NVML_INIT_FLAG_NO_ATTACH));
-  nvmlCheck(nvmlSystemGetDriverVersion(systemDriverVersion, sizeof(systemDriverVersion)));
-  nvmlCheck(nvmlShutdown());
+  nvmlReturn_t result = nvmlInitWithFlags(NVML_INIT_FLAG_NO_GPUS | NVML_INIT_FLAG_NO_ATTACH);
+  if (NVML_SUCCESS != result) {
+    edm::LogWarning("CUDAService") << "NVML library not available, cannot query NVIDIA driver version:\n"
+                                   << nvmlErrorString(result) << "\nReporting NVIDIA driver version as \"unknown\".";
+    std::strncpy(systemDriverVersion, "unknown", sizeof(systemDriverVersion) - 1);
+    systemDriverVersion[sizeof(systemDriverVersion) - 1] = '\0';
+  } else {
+    nvmlCheck(nvmlSystemGetDriverVersion(systemDriverVersion, sizeof(systemDriverVersion)));
+    nvmlCheck(nvmlShutdown());
+  }
 
   // CUDA driver version, e.g. 11.4
   // the full version, like 11.4.1 or 11.4.100, is not reported


### PR DESCRIPTION
#### PR description:

The CUDA driver version lookup via NVML fails when using gaming GPUs. This PR makes the driver name fallback to "unknown" instead of failing CMSSW entirely.

#### PR validation:

A reduced version of the HLT (GPU part only) runs fine and like on enterprise GPUs after this change. Did not run before.
