### PR TITLE
Update NGJet model version

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TSC4NGJetProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TSC4NGJetProducer.cc
@@ -152,7 +152,7 @@ void L1TSC4NGJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<bool>("returnRawPt", false);
   desc.add<std::string>("correctorFile", "");
   desc.add<std::string>("correctorDir", "");
-  desc.add<std::string>("l1tSC4NGJetModelPath", std::string("L1TSC4NGJetModel_v0"));
+  desc.add<std::string>("l1tSC4NGJetModelPath", std::string("L1TSC4NGJetModel_v1_0_1"));
   desc.add<int>("maxJets", 16);
   desc.add<int>("nParticles", 16);
   desc.add<double>("minPt", 10);


### PR DESCRIPTION
#### PR description:

This PR updates the default model version for the L1TSC4NGJetModel from v0 to v1_0_1

Corresponding cms-hls4ml emulator: https://github.com/cms-hls4ml/L1TSC4NGJetModel

Corresponding PR to cms-dist: https://github.com/cms-sw/cmsdist/pull/10485

This PR is for CMSSW 17 as this is the version after which the above cms-dist PR was merged into

Changes to the model inputs were made in this PR: https://github.com/cms-sw/cmssw/pull/50174 which necessitated an update to the model 

