### PR TITLE
Fix `searchInCommands` option for `runTheMatrix.py --interactive`

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -869,7 +869,7 @@ if __name__ == '__main__':
                 for wfl in self.matrices_[args[0]].workFlows:
                     if re.match(pattern_dataset, wfl.nameId):
                         for step, command in enumerate(wfl.cmds):
-                            if re.match(pattern_command, command):
+                            if command is not None and re.match(pattern_command, str(command)):
                                 if wfl.numId not in cached:
                                     cached.append(wfl.numId)
                                     cached_steps[wfl.nameId] = {

--- a/Configuration/PyReleaseValidation/test/test-runTheMatrix_interactive.sh
+++ b/Configuration/PyReleaseValidation/test/test-runTheMatrix_interactive.sh
@@ -6,5 +6,6 @@ echo 'showWorkflow' | runTheMatrix.py --interactive || exit 1
 echo 'search .*D88.*' | runTheMatrix.py --interactive || exit 1
 echo 'dumpWorkflowId 1.0' | runTheMatrix.py --interactive || exit 1
 echo 'searchInWorkflow standard .*' | runTheMatrix.py --interactive || exit 1
+echo 'searchInCommands standard .* .*HLT:@relvalHI2026.*' | runTheMatrix.py --interactive || exit 1
 echo 'wrongCommand' | runTheMatrix.py --interactive || exit 0
 


### PR DESCRIPTION
#### PR description:

Title says it all.
Before this PR:

```
searchInCommands standard .* .*HLT:HIon.*
Traceback (most recent call last):
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el8_amd64_gcc13/cms/cmssw/CMSSW_17_0_X_2026-05-18-2300/bin/el8_amd64_gcc13/runTheMatrix.py", line 1040, in <module>
    TheMatrix(opt).cmdloop()
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el8_amd64_gcc13/external/python3/3.12.4-1d56c354f154d4b4623813614af4d338/lib/python3.12/cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
           ^^^^^^^^^^^^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el8_amd64_gcc13/external/python3/3.12.4-1d56c354f154d4b4623813614af4d338/lib/python3.12/cmd.py", line 217, in onecmd
    return func(arg)
           ^^^^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el8_amd64_gcc13/cms/cmssw/CMSSW_17_0_X_2026-05-18-2300/bin/el8_amd64_gcc13/runTheMatrix.py", line 872, in do_searchInCommands
    if re.match(pattern_command, command):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el8_amd64_gcc13/external/python3/3.12.4-1d56c354f154d4b4623813614af4d338/lib/python3.12/re/__init__.py", line 167, in match
    return _compile(pattern, flags).match(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'InputInfo'
```
This is likely a regression introduced by Python 3.12 becoming stricter about regex argument types.

Additionally I include a test case for `searchInCommands` in `test-runTheMatrix_interactive`.

#### PR validation:

`scram b runtests_test-runTheMatrix-interactive` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A