### PR TITLE
[CMSSW_16_1_X] Bugfix for index increment in SiStrip zero suppression word digi unpacker kernel

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToClusterAlgo.dev.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToClusterAlgo.dev.cc
@@ -112,14 +112,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::sistrip::fedchannelunpacker {
         if ((num_bits > BITS_PER_BYTE) || (bOffset > BITS_PER_BYTE)) {
           bOffset -= BITS_PER_BYTE;
           out.adc(*idx) = ::sistrip::fedchannelunpacker::detail::getADC_B2<mask>(channel_data, wOffset, bOffset);
-          (*idx)++;
           ++wOffset;
         } else {
           out.adc(*idx) = ::sistrip::fedchannelunpacker::detail::getADC_B1<mask>(channel_data, wOffset, bOffset);
-          (*idx)++;
         }
         out.channel(*idx) = chan;
         out.stripId(*idx) = stripStart + firstStrip + inCluster;
+        (*idx)++;
         ++inCluster;
         if (bOffset == BITS_PER_BYTE) {
           bOffset = 0;


### PR DESCRIPTION
#### PR description:
Verbatim backport of #50978. Description from there:

> Bug fix the the https://github.com/cms-sw/cmssw/issues/50956. The crash was caused by out of range access in the line [SiStripRawToClusterAlgo.dev.cc#L121](https://github.com/cms-sw/cmssw/blob/CMSSW_16_1_X/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToClusterAlgo.dev.cc#L121). It was occurring both when running cpu-only and on gpu.
> 
> The (*idx)++ was mistakenly incremented after writing the adc value (e.g., in [#L114](https://github.com/cms-sw/cmssw/blob/CMSSW_16_1_X/RecoLocalTracker/SiStripClusterizer/plugins/alpaka/SiStripRawToClusterAlgo.dev.cc#L114)) and before storing channel and stripId - while it must be incremented after. This caused (a) trying to access index N of the collection sized-N and (b) mismatch of channel/stripId index with adc column.
> 
> This issue affected the unpacking kernel ZS word, while the ZS byte was not bugged.

#### PR validation:
Analogous validation of #50978 is ran on CMSSW_16_1_X.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of #50978 to CMSSW_16_1_X. It is meant to solve issue #50956, which is related to the [CMSHLT-3841](https://its.cern.ch/jira/browse/CMSHLT-3841) for HI preparation.