### PR TITLE
use new AdePT file layout, specify dead regions for CMS

### DIFF
--- a/SimG4Core/PhysicsLists/plugins/adept/CMSEmStandardPhysicsA.cc
+++ b/SimG4Core/PhysicsLists/plugins/adept/CMSEmStandardPhysicsA.cc
@@ -45,8 +45,8 @@
 #include "G4RegionStore.hh"
 #include "G4Region.hh"
 
-#include <AdePT/core/AdePTConfiguration.hh>
-#include <AdePT/integration/AdePTTrackingManager.hh>
+#include <AdePT/g4integration/AdePTConfiguration.hh>
+#include <AdePT/g4integration/AdePTTrackingManager.hh>
 
 #include "G4HepEmConfig.hh"
 
@@ -113,6 +113,10 @@ void CMSEmStandardPhysicsA::ConstructProcess() {
 
   // number of worker threads must be passed to AdePT
   fAdePTConfiguration->SetNumThreads(CurrentG4Track::numberOfWorkers());
+
+  // Specify dead regions in CMS
+  fAdePTConfiguration->AddDeadRegionName("QuadRegion");
+  fAdePTConfiguration->AddDeadRegionName("InterimRegion");
 
   // Construct the AdePT tracking manager
   auto* hepEmTM = new AdePTTrackingManager(fAdePTConfiguration, verboseLevel);

--- a/SimG4Core/PhysicsLists/plugins/adept/CMSEmStandardPhysicsA.cc
+++ b/SimG4Core/PhysicsLists/plugins/adept/CMSEmStandardPhysicsA.cc
@@ -76,6 +76,7 @@ CMSEmStandardPhysicsA::CMSEmStandardPhysicsA(G4int ver, const edm::ParameterSet&
   if (msc == "Minimal") {
     fStepLimitType = fMinimal;
   }
+  fDeadRegionNames = p.getParameter<std::vector<std::string>>("DeadRegions");
   double tcut = p.getParameter<double>("G4TrackingCut") * CLHEP::MeV;
   param->SetLowestElectronEnergy(tcut);
   param->SetLowestMuHadEnergy(tcut);
@@ -114,9 +115,10 @@ void CMSEmStandardPhysicsA::ConstructProcess() {
   // number of worker threads must be passed to AdePT
   fAdePTConfiguration->SetNumThreads(CurrentG4Track::numberOfWorkers());
 
-  // Specify dead regions in CMS
-  fAdePTConfiguration->AddDeadRegionName("QuadRegion");
-  fAdePTConfiguration->AddDeadRegionName("InterimRegion");
+  // Write dead regions to AdePT configuration
+  for (const auto& deadRegionName : fDeadRegionNames) {
+    fAdePTConfiguration->AddDeadRegionName(deadRegionName);
+  }
 
   // Construct the AdePT tracking manager
   auto* hepEmTM = new AdePTTrackingManager(fAdePTConfiguration, verboseLevel);

--- a/SimG4Core/PhysicsLists/plugins/adept/CMSEmStandardPhysicsA.h
+++ b/SimG4Core/PhysicsLists/plugins/adept/CMSEmStandardPhysicsA.h
@@ -14,6 +14,9 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include <string>
+#include <vector>
+
 class AdePTConfiguration;
 
 class CMSEmStandardPhysicsA : public G4VPhysicsConstructor {
@@ -30,6 +33,7 @@ private:
   G4double fSafetyFactor;
   G4double fLambdaLimit;
   G4MscStepLimitType fStepLimitType;
+  std::vector<std::string> fDeadRegionNames;
   AdePTConfiguration* fAdePTConfiguration;
 };
 


### PR DESCRIPTION
#### PR description:

This PR updates the AdePT physics list.
It uses the new file tree structure in AdePT, and adds the default configuration for dead regions in CMS. 
@civanch 

#### PR validation:

As there is no CI yet for any GPU runs with AdePT, it was only verified locally.

