### PR TITLE
[16.1.X] move `@relvalHI2025` to `Fake2`

### DIFF
--- a/Configuration/HLT/python/autoHLT.py
+++ b/Configuration/HLT/python/autoHLT.py
@@ -18,7 +18,7 @@ autoHLT = {
   'relvalHI2022'        : 'Fake2',
   'relvalHI2023'        : 'Fake2',
   'relvalHI2024'        : 'Fake2',
-  'relvalHI2025'        : 'HIon',
+  'relvalHI2025'        : 'Fake2',
   'relvalHI2026'        : 'HIon',
   'relvalRun4'          : '75e33',
   'relvalRun4_timing'   : '75e33_timing',


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/50983

#### PR description:

From the original PR description:

> Title says it all, necessary after https://github.com/cms-sw/cmssw/pull/50963 as the 2026 HLT menu is incompatible with the 2025 L1T menu in the autoCond GT entry `auto:phase1_2025_realistic_hi` used in relval workflows.
> Fixes the IB relval crashes seen e.g. [here](https://cmssdt.cern.ch/SDT/html/cmssdt-ib/#/relVal/CMSSW_17_0/2026-05-19-1100?selectedArchs=el8_amd64_gcc13&selectedFlavors=X&selectedStatus=failed).

#### PR validation:

E.g. `runTheMatrix.py -l 162.0 -t 4 -j 8` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/50983 to CMSSW_16_1_X
