### PR TITLE
[PDMV] [GCC16] cleanup for unused variables

### DIFF
--- a/DPGAnalysis/Skims/src/TagProbeMassProducer.cc
+++ b/DPGAnalysis/Skims/src/TagProbeMassProducer.cc
@@ -82,9 +82,8 @@ void TagProbeMassProducer::produce(edm::Event& iEvent, const edm::EventSetup& iS
       vprobes.push_back(probes->refAt(i));
     }
 
-    int itag = 0;
     edm::RefToBaseVector<reco::Candidate>::const_iterator tag = vtags.begin();
-    for (; tag != vtags.end(); ++tag, ++itag) {
+    for (; tag != vtags.end(); ++tag) {
       int iprobe = 0;
       edm::RefToBaseVector<reco::Candidate>::const_iterator probe = vprobes.begin();
       for (; probe != vprobes.end(); ++probe, ++iprobe) {


### PR DESCRIPTION
Cleanup set but unused variables which are causing build errors for GCC16 IBs https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el9_amd64_gcc16/www/tue/17.0-tue-23/CMSSW_17_0_X_2026-05-19-2300