### PR TITLE
[DQM] [GCC16] cleanup for unused variables

### DIFF
--- a/DQM/SiStripCommissioningAnalysis/src/CalibrationAlgorithm.cc
+++ b/DQM/SiStripCommissioningAnalysis/src/CalibrationAlgorithm.cc
@@ -49,8 +49,7 @@ void CalibrationAlgorithm::extract(const std::vector<TH1*>& histos) {
 
   // Extract histograms
   std::vector<TH1*>::const_iterator ihis = histos.begin();
-  unsigned int cnt = 0;
-  for (; ihis != histos.end(); ihis++, cnt++) {
+  for (; ihis != histos.end(); ihis++) {
     // Check for NULL pointer
     if (!(*ihis)) {
       continue;

--- a/DQM/SiStripCommissioningAnalysis/src/CalibrationScanAlgorithm.cc
+++ b/DQM/SiStripCommissioningAnalysis/src/CalibrationScanAlgorithm.cc
@@ -51,8 +51,7 @@ void CalibrationScanAlgorithm::extract(const std::vector<TH1*>& histos) {
 
   // Extract histograms
   std::vector<TH1*>::const_iterator ihis = histos.begin();
-  unsigned int cnt = 0;
-  for (; ihis != histos.end(); ihis++, cnt++) {
+  for (; ihis != histos.end(); ihis++) {
     // Check for NULL pointer
     if (!(*ihis)) {
       continue;

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDMonitor.cc
@@ -424,10 +424,8 @@ void SiStripFEDMonitorPlugin::getMajority(const std::vector<std::pair<unsigned i
   unsigned int lCounter = 0;
 
   //std::cout << " --- First element: addr = " << lMajAddr << " counter = " << lCounter << std::endl;
-  unsigned int iele = 0;
   //bool foundMaj = false;
-  for (; lIter != aFeMajVec.end(); ++lIter, ++iele) {
-    //std::cout << " ---- Ele " << iele << " " << (*lIter).first << " " << (*lIter).second << " ref " << lMajAddr << std::endl;
+  for (; lIter != aFeMajVec.end(); ++lIter) {
     if ((*lIter).second == lMajAddr) {
       ++lCounter;
       //std::cout << " ----- =ref: Counter = " << lCounter << std::endl;
@@ -444,7 +442,6 @@ void SiStripFEDMonitorPlugin::getMajority(const std::vector<std::pair<unsigned i
       lCounter = 0;
       lMajAddr = (*lIter).second;
       --lIter;
-      --iele;
     }
   }
   // AV Bug here? The check has to be done regardless foundMaj == false or true

--- a/DQMServices/Components/plugins/DQMStoreStats.cc
+++ b/DQMServices/Components/plugins/DQMStoreStats.cc
@@ -506,8 +506,7 @@ void DQMStoreStats::calcIgProfDump(Folder& root) {
   root.mainrows_cumulative(sql_statement);
   root.summary(sql_statement);
   VIterator<Folder*> subsystems = root.CreateIterator();
-  size_t ii = 0;
-  for (subsystems.First(); !subsystems.IsDone(); subsystems.Next(), ++ii) {
+  for (subsystems.First(); !subsystems.IsDone(); subsystems.Next()) {
     subsystems.CurrentItem()->mainrows(sql_statement);
     subsystems.CurrentItem()->parents(sql_statement);
     subsystems.CurrentItem()->children(sql_statement);

--- a/Validation/MuonIsolation/src/MuIsoValidation.cc
+++ b/Validation/MuonIsolation/src/MuIsoValidation.cc
@@ -326,8 +326,7 @@ void MuIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& i
   h_nMuons->Fill(theMuonData);
 
   //Fill historgams concerning muon isolation
-  uint iMuon = 0;
-  for (MuonIterator muon = muonsHandle->begin(); muon != muonsHandle->end(); ++muon, ++iMuon) {
+  for (MuonIterator muon = muonsHandle->begin(); muon != muonsHandle->end(); ++muon) {
     ++nIncMuons;
     if (requireCombinedMuon) {
       if (muon->combinedMuon().isNull())

--- a/Validation/SiTrackerPhase2V/plugins/Phase2TrackerValidateDigi.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2TrackerValidateDigi.cc
@@ -907,9 +907,8 @@ unsigned int Phase2TrackerValidateDigi::getSimTrackId(const edm::DetSetVector<Pi
 
   edm::DetSet<PixelDigiSimLink> link_detset = (*simLinks)[detId];
   // Loop over DigiSimLink in this det unit
-  int iSimLink = 0;
   for (edm::DetSet<PixelDigiSimLink>::const_iterator it = link_detset.data.begin(); it != link_detset.data.end();
-       it++, iSimLink++) {
+       it++) {
     if (channel == it->channel()) {
       simTrkId = it->SimTrackId();
       break;


### PR DESCRIPTION
Cleanup set but unused variables which are causing build errors for GCC16 IBs https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el9_amd64_gcc16/www/tue/17.0-tue-23/CMSSW_17_0_X_2026-05-19-2300