### PR TITLE
[HLT] [GCC16] cleanup for unused variables

### DIFF
--- a/HLTrigger/Muon/plugins/HLTL1MuonSelector.cc
+++ b/HLTrigger/Muon/plugins/HLTL1MuonSelector.cc
@@ -61,9 +61,8 @@ void HLTL1MuonSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
   LogTrace(metname) << "Number of muons " << muColl->size() << endl;
 
   L1MuonParticleCollection::const_iterator it;
-  L1MuonParticleRef::key_type l1ParticleIndex = 0;
 
-  for (it = muColl->begin(); it != muColl->end(); ++it, ++l1ParticleIndex) {
+  for (it = muColl->begin(); it != muColl->end(); ++it) {
     const L1MuGMTExtendedCand muonCand = (*it).gmtMuonCand();
     unsigned int quality = 0;
     bool valid_charge = false;


### PR DESCRIPTION
Cleanup set but unused variables which are causing build errors for GCC16 IBs https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el9_amd64_gcc16/www/tue/17.0-tue-23/CMSSW_17_0_X_2026-05-19-2300