### PR TITLE
[ANALYSIS] [GCC16] cleanup for unused variables

### DIFF
--- a/PhysicsTools/PatExamples/bin/PatBasicFWLiteJetUnitTest.cc
+++ b/PhysicsTools/PatExamples/bin/PatBasicFWLiteJetUnitTest.cc
@@ -55,13 +55,12 @@ int main(int argc, char* argv[]) {
   // ----------------------------------------------------------------------
 
   // loop the events
-  unsigned int iEvent = 0;
   fwlite::Event ev(inFile);
   TStopwatch timer;
   timer.Start();
 
   unsigned int nEventsAnalyzed = 0;
-  for (ev.toBegin(); !ev.atEnd(); ++ev, ++iEvent) {
+  for (ev.toBegin(); !ev.atEnd(); ++ev) {
     edm::EventBase const& event = ev;
 
     // Handle to the jet collection


### PR DESCRIPTION
Cleanup set but unused variables which are causing build errors for GCC16 IBs https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el9_amd64_gcc16/www/tue/17.0-tue-23/CMSSW_17_0_X_2026-05-19-2300