### PR TITLE
[CORE] [GCC16] cleanup for unused variables

### DIFF
--- a/DataFormats/Common/interface/RefVector.h
+++ b/DataFormats/Common/interface/RefVector.h
@@ -180,8 +180,7 @@ namespace edm {
     pointers.reserve(this->size());
     helpers.reserve(this->size());
 
-    size_type key = 0;
-    for (const_iterator i = begin(), e = end(); i != e; ++i, ++key) {
+    for (const_iterator i = begin(), e = end(); i != e; ++i) {
       member_type const* address = i->isNull() ? nullptr : &**i;
       pointers.push_back(address);
       helpers.emplace_back(i->id(), i->key());


### PR DESCRIPTION
Cleanup set but unused variables which are causing build errors for GCC16 IBs https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el9_amd64_gcc16/www/tue/17.0-tue-23/CMSSW_17_0_X_2026-05-19-2300