### PR TITLE
First frozen data taking GTs for 161X in autoCond

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,12 +31,12 @@ autoCond = {
     'run2_data_promptlike_hi'      :    '140X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              :    '140X_dataRun2_HLT_relval_v1',
-    # GlobalTag for Run3 HLT: identical the online GT 160X_dataRun3_HLT_v1 but with snapshot at 2026-02-23 14:53:19 (UTC)
-    'run3_hlt'                     :    '160X_dataRun3_HLT_frozen260223_v1',
-    # GlobalTag for Run3 data relvals (express GT): same as 160X_dataRun3_Express_v1 but with snapshot at 2026-02-23 14:53:19 (UTC)
-    'run3_data_express'            :    '160X_dataRun3_Express_frozen260223_v1',
-    # GlobalTag for Run3 data relvals (prompt GT): same as 160X_dataRun3_Prompt_v1 but with snapshot at 2026-02-23 14:53:19 (UTC)
-    'run3_data_prompt'             :    '160X_dataRun3_Prompt_frozen260223_v1',
+    # GlobalTag for Run3 HLT: identical the online GT 161X_dataRun3_HLT_v1 but with snapshot at 2026-05-20 10:10:39 (UTC)
+    'run3_hlt'                     :    '161X_dataRun3_HLT_frozen260520_v1',
+    # GlobalTag for Run3 data relvals (express GT): same as 161X_dataRun3_Express_v1 but with snapshot at 2026-05-20 10:12:15 (UTC)
+    'run3_data_express'            :    '161X_dataRun3_Express_frozen260520_v1',
+    # GlobalTag for Run3 data relvals (prompt GT): same as 161X_dataRun3_Prompt_v1 but with snapshot at 2026-05-20 10:14:30 (UTC)
+    'run3_data_prompt'             :    '161X_dataRun3_Prompt_frozen260520_v1',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2026-03-30 15:14:30 (UTC)
     'run3_data'                    :    '150X_dataRun3_v8',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currently for 2022FG - snapshot at 2024-05-31 08:53:25 (UTC)
@@ -98,7 +98,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
-    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v14',
+    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v17',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for ppRef5TeV
     'phase1_2024_realistic_ppRef5TeV' : '141X_mcRun3_2024_realistic_ppRef5TeV_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2025


### PR DESCRIPTION
#### PR description:

The following **frozen data taking GTs** for the 161X cycles (for the HI datat taking) are added in autocond:
- [161X_dataRun3_HLT_frozen260520_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/161X_dataRun3_HLT_frozen260520_v1)
- [161X_dataRun3_Express_frozen260520_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/161X_dataRun3_Express_frozen260520_v1)
- [161X_dataRun3_Prompt_frozen260520_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/161X_dataRun3_Prompt_frozen260520_v1)

They differ from the previous ones in autoCond (which were in the 160X cycles) only for the snapshot:
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/161X_dataRun3_HLT_frozen260520_v1/160X_dataRun3_HLT_frozen260223_v1
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/161X_dataRun3_Express_frozen260520_v1/160X_dataRun3_Express_frozen260223_v1
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/161X_dataRun3_Prompt_frozen260520_v1/160X_dataRun3_Prompt_frozen260223_v1

Moreover, also the **2024 HI MC GT** was updated with the latest analysis related updates:
- dE/dx Calibration Tag for 2024 PbPb MC GT in 141X, as requested in [cmsTalk](https://cms-talk.web.cern.ch/t/gt-mc-de-dx-calibration-tag-for-2024-pbpb-mc-gt-in-141x/128862)
- Centrality tag. as requested in [cmsTalk]( https://cms-talk.web.cern.ch/t/2024-pbpb-calibration/136052/42)
The new 2024 HI MC GT is [141X_mcRun3_2024_realistic_HI_v17](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2024_realistic_HI_v17), and its difference with respect to previous in autoCond _v14 is [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_HI_v14/141X_mcRun3_2024_realistic_HI_v17)

#### PR validation:

Relies on PR tests

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

It will be backported to CMSSW_16_1_X
