### PR TITLE
Enable CPU memory usage monitoring in Phase-2 HLT timing

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
+++ b/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
@@ -194,7 +194,7 @@ run_benchmark() {
 	local TMP_LOG_FILE="${logdir}/benchmark.tmp.log"
 
 	echo "elapsed_seconds,memory_mib" > "$CSV_FILE"
-	echo "elapsed_seconds,cpu_memory_mib" >"$CSV_CPU_FILE"
+	echo "elapsed_seconds,memory_mib" >"$CSV_CPU_FILE"
 	echo "elapsed_seconds,gpu_usage" > "$CSV_GPU_FILE"
 
 	# gpu counters
@@ -295,11 +295,12 @@ run_benchmark() {
 	{
 	    echo ""
 	    echo "----- HARDWARE USAGE SUMMARY -----"
+	    echo "Peak CPU memory: ${max_mem_cpu} MiB"
+	    echo "Mean CPU memory: ${mean_mem_cpu} MiB"
+	    echo ""
 	    echo "Peak GPU memory: ${max_mem} MiB"
 	    echo "Mean GPU memory: ${mean_mem} MiB"
 	    echo ""
-	    echo "Peak CPU memory: ${max_mem_cpu} MiB"
-	    echo "Mean CPU memory: ${mean_mem_cpu} MiB"
 	    echo "Per-GPU usage:"
 	    for i in "${!totals[@]}"; do
 		avg=$((totals[$i] / count))

--- a/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
+++ b/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
@@ -26,8 +26,8 @@ MONITOR_INTERVAL=1
 # Check dependencies
 if [[ "$ENABLE_RESOURCES_MONITORING" = true ]]; then
     if ! command -v nvidia-smi &>/dev/null; then
-        echo "Error: nvidia-smi not found but resources monitoring enabled"
-        exit 1
+	echo "Error: nvidia-smi not found but resources monitoring enabled"
+	exit 1
     fi
 fi
 
@@ -40,34 +40,34 @@ check_logs_for_errors() {
     local error_found=0
 
     for f in $log_dirs/stdout $log_dirs/stderr; do
-        if [[ -f "$f" ]]; then
-            if grep -qiE 'error|fail|exception|traceback' "$f"; then
-                echo "Error keyword found in: $f"
-                error_found=1
-            fi
-        fi
+	if [[ -f "$f" ]]; then
+	    if grep -qiE 'error|fail|exception|traceback' "$f"; then
+		echo "Error keyword found in: $f"
+		error_found=1
+	    fi
+	fi
     done
 
     if [[ $error_found -eq 1 ]]; then
-        echo "Failure detected in logs."
-        return 1
+	echo "Failure detected in logs."
+	return 1
     fi
 }
 
 ensure_patatrack_scripts() {
     if [[ ! -d patatrack-scripts ]]; then
-        git clone https://github.com/cms-patatrack/patatrack-scripts --depth 1
+	git clone https://github.com/cms-patatrack/patatrack-scripts --depth 1
     fi
 }
 
 get_current_total_gpu_mem() {
     nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits \
-        | awk '{ total += $1 } END { print total }'
+	| awk '{ total += $1 } END { print total }'
 }
 
 get_current_gpus_usage() {
     nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits \
-        | paste -sd ','
+	| paste -sd ','
 }
 
 # Helper function to recursively get all child PIDs
@@ -75,7 +75,7 @@ get_all_pids() {
     local parent=$1
     echo $parent
     for child in $(pgrep -P $parent 2>/dev/null); do
-        get_all_pids $child
+	get_all_pids $child
     done
 }
 
@@ -83,11 +83,11 @@ get_all_pids() {
 get_current_cpu_mem() {
     local pids=$(get_all_pids "$1" | tr '\n' ',' | sed 's/,$//')
     if [[ -n "$pids" ]]; then
-        local total_rss_kb=$(ps -o rss= -p "$pids" 2>/dev/null | awk '{sum+=$1} END {print sum}')
-        if [[ -n "$total_rss_kb" ]]; then
-            echo $((total_rss_kb / 1024))
-            return
-        fi
+	local total_rss_kb=$(ps -o rss= -p "$pids" 2>/dev/null | awk '{sum+=$1} END {print sum}')
+	if [[ -n "$total_rss_kb" ]]; then
+	    echo $((total_rss_kb / 1024))
+	    return
+	fi
     fi
     echo "error"
 }
@@ -99,22 +99,22 @@ get_current_cpu_mem() {
 fetch_files() {
 
     mapfile -t FILES < <(
-        dasgoclient -query="file dataset=${DATASET}" --limit=-1 |
-        sort |
-        head -4
+	dasgoclient -query="file dataset=${DATASET}" --limit=-1 |
+	    sort |
+	    head -4
     )
 
     for f in "${FILES[@]}"; do
 
-        local mypath
-        mypath=$(dirname "$f")
+	local mypath
+	mypath=$(dirname "$f")
 
-        mkdir -p "${FOLDER_FILES}${mypath}"
+	mkdir -p "${FOLDER_FILES}${mypath}"
 
-        if [[ -e "/eos/cms/$f" && ! -e "${FOLDER_FILES}${f}" ]]; then
-            echo "Copying $f"
-            cp "/eos/cms/$f" "${FOLDER_FILES}${mypath}"
-        fi
+	if [[ -e "/eos/cms/$f" && ! -e "${FOLDER_FILES}${f}" ]]; then
+	    echo "Copying $f"
+	    cp "/eos/cms/$f" "${FOLDER_FILES}${mypath}"
+	fi
     done
 }
 
@@ -127,7 +127,7 @@ build_input_file_string() {
     ALL_FILES=""
 
     for f in $(ls -1 ${LOCALPATH}); do
-        ALL_FILES+="file:${LOCALPATH}/${f},"
+	ALL_FILES+="file:${LOCALPATH}/${f},"
     done
 
     ALL_FILES="${ALL_FILES%?}"
@@ -148,22 +148,22 @@ run_cmsdriver() {
     local extra_args=$5
 
     cmsDriver.py ${fragment} \
-        -s ${menu} \
-        --processName=${process} \
-        --conditions auto:phase2_realistic_T35 \
-        --geometry ExtendedRun4D110 \
-        --era Phase2C17I13M9 \
-        --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
-        --eventcontent FEVTDEBUGHLT \
-        --filein="${ALL_FILES}" \
-        --mc \
-        --nThreads ${THREADS} \
-        --inputCommands 'keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
-        -n ${EVENTS} \
-        --no_exec \
-        --output {} \
-        ${extra_args} \
-        --python_filename ${output_py}
+		 -s ${menu} \
+		 --processName=${process} \
+		 --conditions auto:phase2_realistic_T35 \
+		 --geometry ExtendedRun4D110 \
+		 --era Phase2C17I13M9 \
+		 --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
+		 --eventcontent FEVTDEBUGHLT \
+		 --filein="${ALL_FILES}" \
+		 --mc \
+		 --nThreads ${THREADS} \
+		 --inputCommands 'keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
+		 -n ${EVENTS} \
+		 --no_exec \
+		 --output {} \
+		 ${extra_args} \
+		 --python_filename ${output_py}
 }
 
 ############################
@@ -177,8 +177,8 @@ run_benchmark() {
     local logdir="logs.$(basename ${cfg%.py})"
 
     if [[ ! -e "$cfg" ]]; then
-        echo "Config $cfg not found"
-        return
+	echo "Config $cfg not found"
+	return
     fi
 
     ensure_patatrack_scripts
@@ -186,113 +186,113 @@ run_benchmark() {
 
     if [[ "$ENABLE_RESOURCES_MONITORING" = true ]]; then
 
-        echo "Running benchmark WITH RESOURCES monitoring"
+	echo "Running benchmark WITH RESOURCES monitoring"
 
-        local CSV_FILE="${logdir}/gpu_memory.csv"
-        local CSV_GPU_FILE="${logdir}/gpu_usage.csv"
+	local CSV_FILE="${logdir}/gpu_memory.csv"
+	local CSV_GPU_FILE="${logdir}/gpu_usage.csv"
 	local CSV_CPU_FILE="${logdir}/cpu_memory.csv"
-        local TMP_LOG_FILE="${logdir}/benchmark.tmp.log"
+	local TMP_LOG_FILE="${logdir}/benchmark.tmp.log"
 
-        echo "elapsed_seconds,memory_mib" > "$CSV_FILE"
+	echo "elapsed_seconds,memory_mib" > "$CSV_FILE"
 	echo "elapsed_seconds,cpu_memory_mib" >"$CSV_CPU_FILE"
-        echo "elapsed_seconds,gpu_usage" > "$CSV_GPU_FILE"
+	echo "elapsed_seconds,gpu_usage" > "$CSV_GPU_FILE"
 
 	# gpu counters
-        local max_mem=0
-        local sum_mem=0
-        local count=0
+	local max_mem=0
+	local sum_mem=0
+	local count=0
 
 	# cpu counters
 	local max_mem_cpu=0
 	local sum_mem_cpu=0
 	local count_cpu=0
 
-        declare -a totals
-        declare -a max_usage
+	declare -a totals
+	declare -a max_usage
 
-        local START_TIME=$(date +%s)
+	local START_TIME=$(date +%s)
 
-        # Run benchmark in background
-        patatrack-scripts/benchmark \
-            -j 8 -t 16 -s 16 \
-            -e ${EVENTS} \
-            --no-input-benchmark \
-            --slot "numa=0-3:mem=0-3" \
-            --event-skip 100 \
-            --event-resolution 10 \
-            --debug-logs \
-            -k Phase2Timing_resources.json \
-            -- ${cfg} > "$TMP_LOG_FILE" 2>&1 &
+	# Run benchmark in background
+	patatrack-scripts/benchmark \
+	    -j 8 -t 16 -s 16 \
+	    -e ${EVENTS} \
+	    --no-input-benchmark \
+	    --slot "numa=0-3:mem=0-3" \
+	    --event-skip 100 \
+	    --event-resolution 10 \
+	    --debug-logs \
+	    -k Phase2Timing_resources.json \
+	    -- ${cfg} > "$TMP_LOG_FILE" 2>&1 &
 
-        local PID=$!
+	local PID=$!
 
-        # Ensure cleanup on failure
-        trap 'kill $PID 2>/dev/null || true' EXIT
-        
-        # Live output
-        tail -f --pid=$PID "$TMP_LOG_FILE" &
-        local TAIL_PID=$!
+	# Ensure cleanup on failure
+	trap 'kill $PID 2>/dev/null || true' EXIT
 
-        while kill -0 $PID 2>/dev/null; do
+	# Live output
+	tail -f --pid=$PID "$TMP_LOG_FILE" &
+	local TAIL_PID=$!
 
-            # Memory
-            mem=$(get_current_total_gpu_mem)
-            now=$(date +%s)
-            elapsed=$((now - START_TIME))
+	while kill -0 $PID 2>/dev/null; do
 
-            if [[ "$mem" =~ ^[0-9]+$ ]]; then
-                echo "$elapsed,$mem" >> "$CSV_FILE"
-                ((mem > max_mem)) && max_mem=$mem
-                sum_mem=$((sum_mem + mem))
-                count=$((count + 1))
-            fi
+	    # Memory
+	    mem=$(get_current_total_gpu_mem)
+	    now=$(date +%s)
+	    elapsed=$((now - START_TIME))
+
+	    if [[ "$mem" =~ ^[0-9]+$ ]]; then
+		echo "$elapsed,$mem" >> "$CSV_FILE"
+		((mem > max_mem)) && max_mem=$mem
+		sum_mem=$((sum_mem + mem))
+		count=$((count + 1))
+	    fi
 
 	    # CPU Memory Monitor
-            cpu_mem=$(get_current_cpu_mem $PID)
-            if [[ "$cpu_mem" =~ ^[0-9]+$ ]]; then
-                echo "$elapsed,$cpu_mem" >>"$CSV_CPU_FILE"
-                if ((cpu_mem > max_mem_cpu)); then max_mem_cpu=$cpu_mem; fi
-                sum_mem_cpu=$((sum_mem_cpu + cpu_mem))
-                count_cpu=$((count_cpu + 1))
-            fi
+	    cpu_mem=$(get_current_cpu_mem $PID)
+	    if [[ "$cpu_mem" =~ ^[0-9]+$ ]]; then
+		echo "$elapsed,$cpu_mem" >>"$CSV_CPU_FILE"
+		if ((cpu_mem > max_mem_cpu)); then max_mem_cpu=$cpu_mem; fi
+		sum_mem_cpu=$((sum_mem_cpu + cpu_mem))
+		count_cpu=$((count_cpu + 1))
+	    fi
 
-            # GPU usage
-            usage=$(get_current_gpus_usage)
-            if [[ "$usage" =~ ^[0-9,]+$ ]]; then
-                echo "$elapsed,$usage" >> "$CSV_GPU_FILE"
+	    # GPU usage
+	    usage=$(get_current_gpus_usage)
+	    if [[ "$usage" =~ ^[0-9,]+$ ]]; then
+		echo "$elapsed,$usage" >> "$CSV_GPU_FILE"
 
-                IFS=',' read -ra vals <<< "$usage"
-                for i in "${!vals[@]}"; do
-                    totals[$i]=$((${totals[$i]:-0} + vals[$i]))
-                    ((vals[$i] > ${max_usage[$i]:-0})) && max_usage[$i]=${vals[$i]}
-                done
-            fi
+		IFS=',' read -ra vals <<< "$usage"
+		for i in "${!vals[@]}"; do
+		    totals[$i]=$((${totals[$i]:-0} + vals[$i]))
+		    ((vals[$i] > ${max_usage[$i]:-0})) && max_usage[$i]=${vals[$i]}
+		done
+	    fi
 
-            sleep $MONITOR_INTERVAL
-        done
+	    sleep $MONITOR_INTERVAL
+	done
 
-        wait $PID
+	wait $PID
 
-        #tail should already exit due to --pid=$PID
-        wait $TAIL_PID 2>/dev/null || true
+	#tail should already exit due to --pid=$PID
+	wait $TAIL_PID 2>/dev/null || true
 
-        mv "$TMP_LOG_FILE" "${logdir}/output.log"
+	mv "$TMP_LOG_FILE" "${logdir}/output.log"
 
-        # Compute GPU memory mean
-        if ((count > 0)); then
-            mean_mem=$((sum_mem / count))
-        else
-            mean_mem=0
-        fi
+	# Compute GPU memory mean
+	if ((count > 0)); then
+	    mean_mem=$((sum_mem / count))
+	else
+	    mean_mem=0
+	fi
 
 	# Compute CPU memory mean
 	if ((count_cpu > 0)); then
-            mean_mem_cpu=$((sum_mem_cpu / count_cpu))
-        else
-            mean_mem_cpu=0
-        fi
+	    mean_mem_cpu=$((sum_mem_cpu / count_cpu))
+	else
+	    mean_mem_cpu=0
+	fi
 
-        {
+	{
 	    echo ""
 	    echo "----- HARDWARE USAGE SUMMARY -----"
 	    echo "Peak GPU memory: ${max_mem} MiB"
@@ -306,22 +306,22 @@ run_benchmark() {
 		echo "GPU $i: avg=${avg}% max=${max_usage[$i]}%"
 	    done
 	    echo "----------------------------------"
-        } | tee -a "${logdir}/output.log"
+	} | tee -a "${logdir}/output.log"
 
     else
 
-        echo "Running benchmark WITHOUT RESOURCES monitoring"
+	echo "Running benchmark WITHOUT RESOURCES monitoring"
 
-        patatrack-scripts/benchmark \
-            -j 8 -t 16 -s 16 \
-            -e ${EVENTS} \
-            --no-input-benchmark \
-            --slot "numa=0-3:mem=0-3" \
-            --event-skip 100 \
-            --event-resolution 10 \
-            --debug-logs \
-            -k Phase2Timing_resources.json \
-            -- ${cfg} | tee "${logdir}/output.log"
+	patatrack-scripts/benchmark \
+	    -j 8 -t 16 -s 16 \
+	    -e ${EVENTS} \
+	    --no-input-benchmark \
+	    --slot "numa=0-3:mem=0-3" \
+	    --event-skip 100 \
+	    --event-resolution 10 \
+	    --debug-logs \
+	    -k Phase2Timing_resources.json \
+	    -- ${cfg} | tee "${logdir}/output.log"
     fi
 
     check_logs_for_errors || exit 1
@@ -336,47 +336,47 @@ run_benchmark() {
 run_phase2_gpu() {
 
     run_cmsdriver \
-        "Phase2" \
-        "L1P2GT,HLT:75e33_timing" \
-        "HLTX" \
-        "Phase2_L1P2GT_HLT.py" \
-        ""
+	"Phase2" \
+	"L1P2GT,HLT:75e33_timing" \
+	"HLTX" \
+	"Phase2_L1P2GT_HLT.py" \
+	""
 
     run_benchmark \
-        "Phase2_L1P2GT_HLT.py" \
-        "Phase2Timing_resources.json"
+	"Phase2_L1P2GT_HLT.py" \
+	"Phase2Timing_resources.json"
 
     if [[ -e "$(dirname $0)/augmentResources.py" ]]; then
-        python3 $(dirname $0)/augmentResources.py
+	python3 $(dirname $0)/augmentResources.py
     fi
 }
 
 run_phase2_cpu() {
 
     run_cmsdriver \
-        "Phase2" \
-        "L1P2GT,HLT:75e33_timing" \
-        "HLTX" \
-        "Phase2_L1P2GT_HLT_OnCPU.py" \
-        "--accelerators cpu"
+	"Phase2" \
+	"L1P2GT,HLT:75e33_timing" \
+	"HLTX" \
+	"Phase2_L1P2GT_HLT_OnCPU.py" \
+	"--accelerators cpu"
 
     run_benchmark \
-        "Phase2_L1P2GT_HLT_OnCPU.py" \
-        "Phase2Timing_resources_OnCPU.json"
+	"Phase2_L1P2GT_HLT_OnCPU.py" \
+	"Phase2Timing_resources_OnCPU.json"
 }
 
 run_ngt_scouting() {
 
     run_cmsdriver \
-        "NGTScouting" \
-        "L1P2GT,HLT:NGTScouting" \
-        "NLTX" \
-        "NGTScouting_L1P2GT_HLT.py" \
-        "--procModifiers ngtScouting"
+	"NGTScouting" \
+	"L1P2GT,HLT:NGTScouting" \
+	"NLTX" \
+	"NGTScouting_L1P2GT_HLT.py" \
+	"--procModifiers ngtScouting"
 
     run_benchmark \
-        "NGTScouting_L1P2GT_HLT.py" \
-        "Phase2Timing_resources_NGT.json"
+	"NGTScouting_L1P2GT_HLT.py" \
+	"Phase2Timing_resources_NGT.json"
 }
 
 ############################

--- a/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
+++ b/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
@@ -20,13 +20,13 @@ THREADS=4
 # GPU Monitoring config
 ############################
 
-ENABLE_GPU_MONITORING=true
+ENABLE_RESOURCES_MONITORING=true
 MONITOR_INTERVAL=1
 
 # Check dependencies
-if [[ "$ENABLE_GPU_MONITORING" = true ]]; then
+if [[ "$ENABLE_RESOURCES_MONITORING" = true ]]; then
     if ! command -v nvidia-smi &>/dev/null; then
-        echo "Error: nvidia-smi not found but GPU monitoring enabled"
+        echo "Error: nvidia-smi not found but resources monitoring enabled"
         exit 1
     fi
 fi
@@ -68,6 +68,28 @@ get_current_total_gpu_mem() {
 get_current_gpus_usage() {
     nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits \
         | paste -sd ','
+}
+
+# Helper function to recursively get all child PIDs
+get_all_pids() {
+    local parent=$1
+    echo $parent
+    for child in $(pgrep -P $parent 2>/dev/null); do
+        get_all_pids $child
+    done
+}
+
+# Function to get current CPU memory (RSS) in MiB for a process and all its children
+get_current_cpu_mem() {
+    local pids=$(get_all_pids "$1" | tr '\n' ',' | sed 's/,$//')
+    if [[ -n "$pids" ]]; then
+        local total_rss_kb=$(ps -o rss= -p "$pids" 2>/dev/null | awk '{sum+=$1} END {print sum}')
+        if [[ -n "$total_rss_kb" ]]; then
+            echo $((total_rss_kb / 1024))
+            return
+        fi
+    fi
+    echo "error"
 }
 
 ############################
@@ -162,20 +184,28 @@ run_benchmark() {
     ensure_patatrack_scripts
     mkdir -p "$logdir"
 
-    if [[ "$ENABLE_GPU_MONITORING" = true ]]; then
+    if [[ "$ENABLE_RESOURCES_MONITORING" = true ]]; then
 
-        echo "Running benchmark WITH GPU monitoring"
+        echo "Running benchmark WITH RESOURCES monitoring"
 
         local CSV_FILE="${logdir}/gpu_memory.csv"
         local CSV_GPU_FILE="${logdir}/gpu_usage.csv"
+	local CSV_CPU_FILE="${logdir}/cpu_memory.csv"
         local TMP_LOG_FILE="${logdir}/benchmark.tmp.log"
 
         echo "elapsed_seconds,memory_mib" > "$CSV_FILE"
+	echo "elapsed_seconds,cpu_memory_mib" >"$CSV_CPU_FILE"
         echo "elapsed_seconds,gpu_usage" > "$CSV_GPU_FILE"
 
+	# gpu counters
         local max_mem=0
         local sum_mem=0
         local count=0
+
+	# cpu counters
+	local max_mem_cpu=0
+	local sum_mem_cpu=0
+	local count_cpu=0
 
         declare -a totals
         declare -a max_usage
@@ -217,6 +247,15 @@ run_benchmark() {
                 count=$((count + 1))
             fi
 
+	    # CPU Memory Monitor
+            cpu_mem=$(get_current_cpu_mem $PID)
+            if [[ "$cpu_mem" =~ ^[0-9]+$ ]]; then
+                echo "$elapsed,$cpu_mem" >>"$CSV_CPU_FILE"
+                if ((cpu_mem > max_mem_cpu)); then max_mem_cpu=$cpu_mem; fi
+                sum_mem_cpu=$((sum_mem_cpu + cpu_mem))
+                count_cpu=$((count_cpu + 1))
+            fi
+
             # GPU usage
             usage=$(get_current_gpus_usage)
             if [[ "$usage" =~ ^[0-9,]+$ ]]; then
@@ -239,30 +278,39 @@ run_benchmark() {
 
         mv "$TMP_LOG_FILE" "${logdir}/output.log"
 
-        # Compute mean
+        # Compute GPU memory mean
         if ((count > 0)); then
             mean_mem=$((sum_mem / count))
         else
             mean_mem=0
         fi
 
+	# Compute CPU memory mean
+	if ((count_cpu > 0)); then
+            mean_mem_cpu=$((sum_mem_cpu / count_cpu))
+        else
+            mean_mem_cpu=0
+        fi
+
         {
-            echo ""
-            echo "----- GPU SUMMARY -----"
-            echo "Peak memory: ${max_mem} MiB"
-            echo "Mean memory: ${mean_mem} MiB"
-            echo ""
-            echo "Per-GPU usage:"
-            for i in "${!totals[@]}"; do
-                avg=$((totals[$i] / count))
-                echo "GPU $i: avg=${avg}% max=${max_usage[$i]}%"
-            done
-            echo "-----------------------"
+	    echo ""
+	    echo "----- HARDWARE USAGE SUMMARY -----"
+	    echo "Peak GPU memory: ${max_mem} MiB"
+	    echo "Mean GPU memory: ${mean_mem} MiB"
+	    echo ""
+	    echo "Peak CPU memory: ${max_mem_cpu} MiB"
+	    echo "Mean CPU memory: ${mean_mem_cpu} MiB"
+	    echo "Per-GPU usage:"
+	    for i in "${!totals[@]}"; do
+		avg=$((totals[$i] / count))
+		echo "GPU $i: avg=${avg}% max=${max_usage[$i]}%"
+	    done
+	    echo "----------------------------------"
         } | tee -a "${logdir}/output.log"
 
     else
 
-        echo "Running benchmark WITHOUT GPU monitoring"
+        echo "Running benchmark WITHOUT RESOURCES monitoring"
 
         patatrack-scripts/benchmark \
             -j 8 -t 16 -s 16 \

--- a/HLTrigger/Configuration/scripts/compareMemoryProfiles.py
+++ b/HLTrigger/Configuration/scripts/compareMemoryProfiles.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-CMS-style GPU memory comparison plotter.
+CMS-style hardware memory comparison plotter.
 
 Features
 --------
@@ -14,10 +14,11 @@ Features
 - Automatic PDF + PNG output
 - Metadata box
 - Optional interactive display
+- Option to display CPU or GPU
 
 Example
 -------
-python3 compareGPUMemoryProfiles.py \
+python3 compareMemoryProfiles.py \
     gpu_memory_HLTTimingNewBaseline_16j_16t_16s.csv \
     gpu_memory_HLTTimingCurrent_16j_16t_16s.csv \
     --label1 NewBaseline \
@@ -26,7 +27,7 @@ python3 compareGPUMemoryProfiles.py \
 
 Typical CMSSW integration usage
 -------------------------------
-python3 compareGPUMemoryProfiles.py \
+python3 compareMemoryProfiles.py \
     baseline.csv current.csv \
     --output gpu_memory_PR_comparison \
     --no-show
@@ -91,11 +92,13 @@ def annotate_peak(ax, stats, color):
     )
 
 
-def save_outputs(fig, output_base):
+def save_outputs(fig, output_base, isGPU):
     """Save figure in multiple formats."""
-    png_name = f"{output_base}.png"
-    pdf_name = f"{output_base}.pdf"
 
+    prefix = "gpu" if isGPU else "cpu"
+    png_name = f"{prefix}_{output_base}.png"
+    pdf_name = f"{prefix}_{output_base}.pdf"
+    
     fig.savefig(
         png_name,
         dpi=220,
@@ -122,7 +125,7 @@ def main(args):
     # Convert MiB -> GiB
     df1["memory_gib"] = df1["memory_mib"] / 1024.0
     df2["memory_gib"] = df2["memory_mib"] / 1024.0
-
+        
     # Labels
     label1 = args.label1 or default_label(args.file1)
     label2 = args.label2 or default_label(args.file2)
@@ -170,10 +173,10 @@ def main(args):
     )
 
     ax.set_ylabel(
-        "GPU memory usage [GiB]",
+        f"{'GPU' if args.gpu else 'CPU'} memory usage [GiB]",
         fontsize=15,
     )
-
+    
     # Dynamic y-axis scaling
     ymax = max(
         stats1["peak"],
@@ -272,7 +275,7 @@ def main(args):
     plt.tight_layout()
 
     # Save outputs
-    save_outputs(fig, args.output)
+    save_outputs(fig, args.output, args.gpu)
 
     # Interactive display
     if not args.no_show:
@@ -281,7 +284,7 @@ def main(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="CMS-style GPU memory comparison plotter"
+        description="CMS-style hardware memory comparison plotter"
     )
 
     parser.add_argument(
@@ -320,6 +323,12 @@ if __name__ == "__main__":
         ),
     )
 
+    parser.add_argument(
+        "--gpu",
+        action="store_true",
+        help="Make CPU or GPU memory profile",
+    )
+    
     parser.add_argument(
         "--cms-label",
         default="cmssw integration testing",


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to https://github.com/cms-sw/cmssw/pull/50479. We enable with these changes the monitoring of the overall CPU memory usage in the job that is going to be saved into a dedicated `.csv` file that can be used for further post-processing. 

#### PR validation:

run privately the script [runHLTTiming.sh](https://github.com/cms-sw/cmssw/compare/master...mmusich:mm_dev_cpu_memory_usage_hlt_timing?expand=1#diff-84e5227d72249635800dd93548a355f3fba239b0bcaf8d4e4fe91cec27661a1e) and obtained the following profile:

<img width="2182" height="1303" alt="image" src="https://github.com/user-attachments/assets/6f41d798-7973-4077-af8b-103fda9184dc" />

The script `compareGPUMemoryProfiles.py` is renamed and adapted to digest the CPU memory time series.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A