### PR TITLE
[NGT] Add workflow to produce Phase2 NANOAOD with L1 and HLT objects

### DIFF
--- a/Configuration/ProcessModifiers/python/nano_l1_hlt_cff.py
+++ b/Configuration/ProcessModifiers/python/nano_l1_hlt_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is for running NANOAOD production from L1 and HLT steps, 
+# whitout running RECO and PAT steps. 
+# It excludes all GEN sequences that depend on PAT collections.
+
+nano_l1_hlt = cms.Modifier()

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -74,6 +74,7 @@ The offsets currently in use are:
 * 0.771: HLT phase-2 NGT Scouting menu, Alpaka, TICL-v5, TICL-Barrel
 * 0.772: HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
 * 0.773: HLT phase-2 NGT Scouting menu, with NANO:@NGTScoutingVal
+* 0.774: HLT phase-2 NGT Scouting menu, with NANO:@NGTScoutingVal+@Phase2L1DPGwithGen (L1+HLT objects)
 * 0.775: HLT phase-2 NGT Scouting menu with Pixeltracks CA Extension + LST T5s as GeneralTracks
 * 0.778 L3 Tracker Muons reconstruction Outside-In first, HLT Muon NanoAOD
 * 0.78: Complete L1 workflow

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -76,6 +76,7 @@ numWFIB.extend([prefixDet+34.77])   # NGTScouting
 numWFIB.extend([prefixDet+34.771])  # NGTScouting + alpaka + TICL-v5 + TICL-Barrel
 numWFIB.extend([prefixDet+34.772])  # NGTScouting + NANO
 numWFIB.extend([prefixDet+34.773])  # NGTScouting + NANO (including validation)
+numWFIB.extend([prefixDet+34.774])  # NGTScouting + NANO containing both L1 and HLT objects (including validation)
 numWFIB.extend([prefixDet+34.775])  # NGTScouting + Phase2CAExtension&LSTT5 as GeneralTracks
 
 for numWF in numWFIB:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2205,12 +2205,22 @@ upgradeWFs['NGTScoutingWithNano'].step2 = {
 }
 
 upgradeWFs['NGTScoutingWithNanoValid'] = deepcopy(upgradeWFs['HLTPhase2WithNano'])
-upgradeWFs['NGTScoutingWithNanoValid'].suffix = '_NGTScoutingWithNanoVal'
+upgradeWFs['NGTScoutingWithNanoValid'].suffix = '_NGTScoutingWithNanoValid'
 upgradeWFs['NGTScoutingWithNanoValid'].offset = 0.773
 upgradeWFs['NGTScoutingWithNanoValid'].step2 = {
     '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,VALIDATION:@hltValidation,NANO:@NGTScoutingVal',
     '--datatier':'GEN-SIM-DIGI-RAW,NANOAODSIM',
     '--procModifiers': 'ngtScouting',
+    '--eventcontent':'FEVTDEBUGHLT,NANOAODSIM'
+}
+
+upgradeWFs['L1NGTScoutingWithNano'] = deepcopy(upgradeWFs['HLTPhase2WithNano'])
+upgradeWFs['L1NGTScoutingWithNano'].suffix = '_L1NGTScoutingWithNanoValid'
+upgradeWFs['L1NGTScoutingWithNano'].offset = 0.774
+upgradeWFs['L1NGTScoutingWithNano'].step2 = {
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,VALIDATION:@hltValidation,NANO:@NGTScoutingVal+@Phase2L1DPGwithGen',
+    '--datatier':'GEN-SIM-DIGI-RAW,NANOAODSIM',
+    '--procModifiers': 'ngtScouting,nano_l1_hlt',
     '--eventcontent':'FEVTDEBUGHLT,NANOAODSIM'
 }
 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -176,6 +176,7 @@ if __name__ == '__main__':
                      prefixDet+34.771,   # HLT phase-2 NGT Scouting menu, Alpaka, TICL-v5, TICL-Barrel
                      prefixDet+34.772,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScouting
                      prefixDet+34.773,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScoutingVal
+                     prefixDet+34.774,   # HLT phase-2 NGT Scouting menu, with NANO:@NGTScoutingVal+@Phase2L1DPGwithGen
                      prefixDet+34.775],  # HLT phase-2 NGT Scouting menu, Phase2CAExtension&LSTT5 as GeneralTracks
     }
 

--- a/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nano_cff.py
+++ b/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nano_cff.py
@@ -16,7 +16,7 @@ def addPh2L1Objects(process):
     process.l1tPh2NanoTask.add(p2L1TablesTask)
 
     # This modifier excludes the hpsTauTable, which is based on the l1tHPSPFTauProducerPuppi collection, no longer available in the L1 menu.
-    # This allows to run the NANOAOD production from L1 and HLT steps, whitout assuming old inputs from the Spring24 datasets.
+    # This allows to run the NANOAOD production from L1 and HLT steps, whitout requiring old inputs from the Spring24 datasets.
     from Configuration.ProcessModifiers.nano_l1_hlt_cff import nano_l1_hlt
     nano_l1_hlt.toReplaceWith(p2L1TablesTask, p2L1TablesTask.copyAndExclude([hpsTauTable]))
 
@@ -73,7 +73,7 @@ def addGenObjects(process):
     process.l1tPh2NanoTask.add(process.genNanoTask)
  
     # This modifier excludes all GEN sequences that depend on PAT collections.
-    # This allows to run the NANOAOD production from L1 and HLT steps, whitout assuming the PAT inputs.
+    # This allows to run the NANOAOD production from L1 and HLT steps, whitout requiring PAT inputs.
     from Configuration.ProcessModifiers.nano_l1_hlt_cff import nano_l1_hlt
     nano_l1_hlt.toReplaceWith(process.genNanoTask, 
         process.genNanoTask.copyAndExclude(

--- a/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nano_cff.py
+++ b/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nano_cff.py
@@ -14,6 +14,12 @@ def addPh2GTObjects(process):
 from DPGAnalysis.Phase2L1TNanoAOD.l1tPh2Nanotables_cff import *
 def addPh2L1Objects(process):
     process.l1tPh2NanoTask.add(p2L1TablesTask)
+
+    # This modifier excludes the hpsTauTable, which is based on the l1tHPSPFTauProducerPuppi collection, no longer available in the L1 menu.
+    # This allows to run the NANOAOD production from L1 and HLT steps, whitout assuming old inputs from the Spring24 datasets.
+    from Configuration.ProcessModifiers.nano_l1_hlt_cff import nano_l1_hlt
+    nano_l1_hlt.toReplaceWith(p2L1TablesTask, p2L1TablesTask.copyAndExclude([hpsTauTable]))
+
     return process
 
 #### GENERATOR INFO
@@ -24,6 +30,8 @@ from PhysicsTools.NanoAOD.met_cff import metMCTable ## for GenMET
 from PhysicsTools.NanoAOD.globals_cff import puTable ## for PU
 from PhysicsTools.NanoAOD.taus_cff import * ## for Gen taus
 def addGenObjects(process):
+
+    process.genNanoTask = cms.Task()
 
     ## add more GenVariables
     # from L1Ntuple Gen: https://github.com/artlbv/cmssw/blob/94a5ec13b8ce76afb8ea4f157bb92fb547fadee2/L1Trigger/L1TNtuples/plugins/L1GenTreeProducer.cc#L203
@@ -45,22 +53,35 @@ def addGenObjects(process):
         process.prunedGenParticleTable = genParticleTable.clone()
         process.prunedGenParticleTable.src = "prunedGenParticles"
         process.prunedGenParticleTable.name = "prunedGenPart"
-        process.l1tPh2NanoTask.add(process.prunedGenParticleTable)
+        process.genNanoTask.add(process.prunedGenParticleTable)
 
     # lower genVisTau pt threshold
     process.genVisTauTable.cut = "pt > 1"
     # lower AK8 gen jet threshold
     process.genJetAK8Table.cut = "pt > 10"
 
-    process.l1tPh2NanoTask.add(
+    process.genNanoTask.add(
                 puTable, metMCTable,
                 genParticleTask, genParticleTablesTask,
                 genTauTask,
     )
     
     # add all GenJets: AK4 and AK8
-    process.l1tPh2NanoTask.add(genJetTable,patJetPartonsNano,genJetFlavourTable)
-    process.l1tPh2NanoTask.add(genJetAK8Table,genJetAK8FlavourAssociation,genJetAK8FlavourTable)
+    process.genNanoTask.add(genJetTable,patJetPartonsNano,genJetFlavourTable)
+    process.genNanoTask.add(genJetAK8Table,genJetAK8FlavourAssociation,genJetAK8FlavourTable)
+
+    process.l1tPh2NanoTask.add(process.genNanoTask)
+ 
+    # This modifier excludes all GEN sequences that depend on PAT collections.
+    # This allows to run the NANOAOD production from L1 and HLT steps, whitout assuming the PAT inputs.
+    from Configuration.ProcessModifiers.nano_l1_hlt_cff import nano_l1_hlt
+    nano_l1_hlt.toReplaceWith(process.genNanoTask, 
+        process.genNanoTask.copyAndExclude(
+            [puTable,
+             metMCTable,
+             genJetAK8Table, 
+             genJetAK8FlavourAssociation, 
+             genJetAK8FlavourTable]))
 
     return process
 

--- a/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
+++ b/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
@@ -132,6 +132,9 @@ hltPixelOnlyNanoFlavour = cms.Sequence(
     + NanoPixelTables
 )
 
+from Configuration.ProcessModifiers.nano_l1_hlt_cff import nano_l1_hlt
+nano_l1_hlt.toReplaceWith(dstValidationNanoFlavour, dstValidationNanoFlavour.copyAndExclude([dstTriggerAcceptFilter]))
+
 ######################################
 # Customization
 ######################################
@@ -149,6 +152,12 @@ def hltNanoCustomize(process):
             SelectEvents = cms.vstring(
                 [p for p in process.paths if p.startswith('HLT_') or p.startswith('MC_') or p.startswith('DST_')]
             )
+        )
+
+        # disable SelectEvents for nano_l1_hlt
+        nano_l1_hlt.toModify(
+            process.NANOAODSIMoutput,
+            SelectEvents = cms.untracked.PSet()
         )
 
     return process

--- a/PhysicsTools/NanoAOD/plugins/TrackingAssocValueMapsProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/TrackingAssocValueMapsProducer.cc
@@ -143,6 +143,10 @@ void TrackingAssocValueMapsProducer::produce(edm::Event& iEvent, const edm::Even
       iEvent.getByToken(trackAssociatorToken_, associatorH);
       inputsValid = inputsValid && associatorH.isValid();
     }
+  } else {
+    LogDebug(metname) << "Invalid handles: Track handle valid: " << tracksH.isValid()
+                      << ", TP handle valid: " << tpH.isValid();
+    return;
   }
 
   const size_t nTracks = tracksH->size();


### PR DESCRIPTION
#### PR description:

This PR introduces a new Phase-2 workflow to produce NanoAOD samples containing both L1 and HLT objects.
It combines the configurations of:
- L1 NanoAOD based on `NANO:@Phase2L1DPGwithGen` flavour from [Phase2 L1Nano instructions](https://github.com/cms-sw/cmssw/tree/master/DPGAnalysis/Phase2L1TNanoAOD)
- HLT NanoAOD based on `NANO:@NGTScoutingVal` flavour from [Phase2 HLTNano instructions](https://cmshltupgrade.docs.cern.ch/NanoAOD/NanoAOD/)

**Without this PR**, the L1+HLT NanoAOD sample could only be produced starting from `GEN-SIM-DIGI-RAW-MINIAOD` inputs from the [TSG Spring24 samples](https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fglobal&input=%2F*%2F*Spring24*Run4*%2F*), since the L1 NanoAOD assumes the presence of PAT collections in the input data.
**With this PR**, it is possible to produce the L1+HLT NanoAOD sample directly from `GEN-SIM` inputs, without the need to run all the reconstruction chain up to MINIAOD. 

A dedicated workflow (suffix `.774`) has been introduced to monitor possible failures during future developments.
```
runTheMatrix.py -l 34434.774 -w upgrade --nEvents 10 -i all 
```
The workflow is based on the procModifier `nano_l1_hlt`, which 
- disables all GEN sequences that depend on PAT collections to avoid crashes ([here](https://github.com/cms-ngt-hlt/cmssw/blob/74ef3bd329838af9ec61d954cd1412009e55c3db/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nano_cff.py#L78))
- disables the `hpsTauTable` since the corresponding input collection was present in the Spring24 samples but is no longer available in more recent L1 menus ([here](https://github.com/cms-ngt-hlt/cmssw/blob/74ef3bd329838af9ec61d954cd1412009e55c3db/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nano_cff.py#L21))
- removes the `dstTriggerAcceptFilter` filter for the production of the HLT Tables ([here](https://github.com/cms-ngt-hlt/cmssw/blob/74ef3bd329838af9ec61d954cd1412009e55c3db/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py#L136)) and removes the event selection in the output ([here](https://github.com/cms-ngt-hlt/cmssw/blob/74ef3bd329838af9ec61d954cd1412009e55c3db/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py#L158)): these changes allow us to store all events in the output NanoAOD, regardless of whether they pass the L1 and HLT selections. This feature provides a change compared to the `NANO:@NGTScoutingVal` flavour, where only the events passing the OR of the L1 seeds are stored in the output.

#### Instructions to run the L1+HLT NanoAOD production:
- Starting from `GEN-SIM` input:
```
cmsDriver.py step2 -n 10 \
 -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,VALIDATION:@hltValidation,NANO:@NGTScoutingVal+@Phase2L1DPGwithGen \
 --procModifiers ngtScouting,nano_l1_hlt \
 --conditions auto:phase2_realistic_T35 --geometry ExtendedRun4D121  --era Phase2C22I13M9 \
 --datatier NANOAODSIM --eventcontent NANOAODSIM \
 --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
 --filein file:step1.root --fileout file:step2.root
```
- Starting from `GEN-SIM-DIGI-RAW-MINIAOD` input:
```
cmsDriver.py step2 -n 10 \
 -s L1,L1TrackTrigger,L1P2GT,HLT:NGTScouting,NANO:@NGTScoutingVal+@Phase2L1DPG,VALIDATION:@hltValidation \
 --procModifiers ngtScouting,nano_l1_hlt --processName HLTX \
 --datatier GEN-SIM-DIGI-RAW-MINIAOD --eventcontent NANOAODSIM \
 --conditions auto:phase2_realistic_T35 --geometry ExtendedRun4D110 --era Phase2C17I13M9 \
 --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,L1Trigger/Configuration/customisePhase2TTOn110.customisePhase2TTOn110 \
 --filein /store/mc/Phase2Spring24DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_AllTP_140X_mcRun4_realistic_v4-v1/2560000/11d1f6f0-5f03-421e-90c7-b5815197fc85.root --fileout file:step2.root --python_filename rerun_L1_HLT_NANO_cfg.py \
 --mc --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT, drop *_simEcalUnsuppressedDigis_*_*, drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT'
```

#### PR validation:

This PR has been validated by running the new workflow `34434.774`:
```
runTheMatrix.py -l 34434.774 -w upgrade --ibeos --nEvents 10 -i all
```
The workflow produces correctly the output NanoAOD sample, containing the L1 and HLT Tables.
By adding the option `--customise_commands='process.options.wantSummary = True'`, it is possible to verify that the Nano Tables are filled independently of the L1/HLT filters: in this example, 8 events out of 10 pass the`DST_PFScouting` filter (corresponding to the OR of all L1 seeds), but all 10 events are saved in the output.
```
TrigReport ---------- Path   Summary ------------
TrigReport  Trig Bit#   Executed     Passed     Failed      Error Name
TrigReport     1    1         10         10          0          0 L1TrackTrigger_step
TrigReport     1    3         10         10          0          0 Phase2L1GTProducer
TrigReport     1    4         10         10          0          0 Phase2L1GTAlgoBlockProducer
TrigReport     1    5         10          1          9          0 pDoubleEGEle37_24
...
TrigReport     1   45         10          0         10          0 pTripleTkMuon_5_3p5_2p5_OS_Mass5to17
TrigReport     1   47         10          8          2          0 DST_PFScouting
TrigReport     1   48         10          0         10          0 HLTriggerFinalPath
TrigReport     1   49         10         10          0          0 prevalidation_step
TrigReport     1   50         10         10          0          0 nanoAOD_step0
```

The other two recipes for the L1+HLT NanoAOD production based on `GEN-SIM` and `GEN-SIM-DIGI-RAW-MINIAOD` have also been successfully validated.