### PR TITLE
Displaced Particle Gun

### DIFF
--- a/Configuration/Generator/python/DisplacedParticleGun_cfi.py
+++ b/Configuration/Generator/python/DisplacedParticleGun_cfi.py
@@ -1,8 +1,7 @@
-# File: Configuration/Generator/python/DisplacedHGCalParticleGun_Photon_cfi.py
 import FWCore.ParameterSet.Config as cms
 
 generator = cms.EDProducer(
-    "DisplacedHGCalParticleGunProducer",
+    "DisplacedParticleGunProducer",
     PGunParameters = cms.PSet(
         # particle direction
         MinPt  = cms.double(5.0),

--- a/Configuration/Generator/python/DisplacedParticleGun_cfi.py
+++ b/Configuration/Generator/python/DisplacedParticleGun_cfi.py
@@ -9,15 +9,16 @@ generator = cms.EDProducer(
         MinPhi = cms.double(-3.141592653589793),
         MaxPhi = cms.double(+3.141592653589793),
 
-        # displaced vertex in transverse plane (cm)
-        RMin     = cms.double(0.0),
-        RMax     = cms.double(10.0),
+        # displaced vertex in the transverse plane (cm)
+        # located in front of HGCAL's CE-E surface (also avoiding the moderator)
+        RMin     = cms.double(50.),
+        RMax     = cms.double(130.),
         MinVtxPhi = cms.double(0.0),
         MaxVtxPhi = cms.double(2.0 * 3.141592653589793),
-        ZVtx     = cms.double(0.0),
+        ZVtx     = cms.double(321.),
 
         NParticles = cms.int32(1),
-        PartID     = cms.vint32(22), # photon
+        PartID     = cms.int32(22), # photon
 
         # how to sample the vertex radius
         UniformDensityInR = cms.bool(False),
@@ -28,11 +29,12 @@ generator = cms.EDProducer(
 
         # only used if PointingToHGCAL == True (cm),
         # corresponds to the central third of HGCAL's CE-E back surface
+        # note that these values might not be optimal if the default vertex coordinates are modified
         RminBackSurfaceHGCAL = cms.double(75.80),
         RmaxBackSurfaceHGCAL = cms.double(120.23),
 
         # only used if PointingToHGCAL == False (radians)
-        MinTheta = cms.double(0.),
+        MinTheta = cms.double(1E-6),
         MaxTheta = cms.double(3.141592653589793),
     ),
     Verbosity = cms.untracked.int32(0),

--- a/Configuration/Generator/python/DisplacedParticleGun_cfi.py
+++ b/Configuration/Generator/python/DisplacedParticleGun_cfi.py
@@ -27,9 +27,9 @@ generator = cms.EDProducer(
         PointingToHGCAL = cms.bool(True),
 
         # only used if PointingToHGCAL == True (cm),
-        # corresponds to the central third of HGCAL's front surface
-        RminFrontSurfaceHGCAL = cms.double(58.79),
-        RmaxFrontSurfaceHGCAL = cms.double(91.58),
+        # corresponds to the central third of HGCAL's CE-E back surface
+        RminBackSurfaceHGCAL = cms.double(75.80),
+        RmaxBackSurfaceHGCAL = cms.double(120.23),
 
         # only used if PointingToHGCAL == False (radians)
         MinTheta = cms.double(0.),

--- a/Configuration/Generator/python/DisplacedParticleGun_cfi.py
+++ b/Configuration/Generator/python/DisplacedParticleGun_cfi.py
@@ -1,0 +1,42 @@
+# File: Configuration/Generator/python/DisplacedHGCalParticleGun_Photon_cfi.py
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDProducer(
+    "DisplacedHGCalParticleGunProducer",
+    PGunParameters = cms.PSet(
+        # particle direction
+        MinPt  = cms.double(5.0),
+        MaxPt  = cms.double(100.0),
+        MinPhi = cms.double(-3.141592653589793),
+        MaxPhi = cms.double(+3.141592653589793),
+
+        # displaced vertex in transverse plane (cm)
+        RMin     = cms.double(0.0),
+        RMax     = cms.double(10.0),
+        MinVtxPhi = cms.double(0.0),
+        MaxVtxPhi = cms.double(2.0 * 3.141592653589793),
+        ZVtx     = cms.double(0.0),
+
+        NParticles = cms.int32(1),
+        PartID     = cms.vint32(22), # photon
+
+        # how to sample the vertex radius
+        UniformDensityInR = cms.bool(False),
+
+        # if True: derive theta to hit a region of the HGCAL front surface
+        # if False: use MinTheta/MaxTheta
+        PointingToHGCAL = cms.bool(True),
+
+        # only used if PointingToHGCAL == True (cm),
+        # corresponds to the central third of HGCAL's front surface
+        RminFrontSurfaceHGCAL = cms.double(58.79),
+        RmaxFrontSurfaceHGCAL = cms.double(91.58),
+
+        # only used if PointingToHGCAL == False (radians)
+        MinTheta = cms.double(0.),
+        MaxTheta = cms.double(3.141592653589793),
+    ),
+    Verbosity = cms.untracked.int32(0),
+    firstRun  = cms.untracked.uint32(1),
+    psethack  = cms.string("displaced gun with theta, optionally pointing to hard-coded HGCAL front surface"),
+)

--- a/Configuration/Generator/python/DisplacedParticleGun_cfi.py
+++ b/Configuration/Generator/python/DisplacedParticleGun_cfi.py
@@ -4,15 +4,17 @@ generator = cms.EDProducer(
     "DisplacedParticleGunProducer",
     PGunParameters = cms.PSet(
         # particle direction
-        MinPt  = cms.double(5.0),
-        MaxPt  = cms.double(100.0),
+        MinPt  = cms.double(5.),
+        MaxPt  = cms.double(100.),
         MinPhi = cms.double(-3.141592653589793),
         MaxPhi = cms.double(+3.141592653589793),
+        MinTheta = cms.double(-3.141592653589793 / 4),
+        MaxTheta = cms.double(3.141592653589793 / 4),
 
         # displaced vertex in the transverse plane (cm)
         # located in front of HGCAL's CE-E surface (also avoiding the moderator)
-        RMin     = cms.double(50.),
-        RMax     = cms.double(130.),
+        RMin     = cms.double(60.),
+        RMax     = cms.double(90.),
         MinVtxPhi = cms.double(0.0),
         MaxVtxPhi = cms.double(2.0 * 3.141592653589793),
         ZVtx     = cms.double(321.),
@@ -22,22 +24,28 @@ generator = cms.EDProducer(
 
         # how to sample the vertex radius
         UniformDensityInR = cms.bool(False),
-
-        # if True: derive theta to hit a region of the HGCAL front surface
+        
+        MaxTries = cms.uint32(10000),
+        
+        # if True: derive theta to hit a region of the HGCAL CE-E back surface
+        #  the phi of the particle's direction is matched to the phi of the vertex
+        #  which avoid particles crossing the beamline and restricts particles to a tighter region of the detector
         # if False: use MinTheta/MaxTheta
         PointingToHGCAL = cms.bool(True),
 
-        # only used if PointingToHGCAL == True (cm),
+        # only used if PointingToHGCAL == True,
         # corresponds to the central third of HGCAL's CE-E back surface
-        # note that these values might not be optimal if the default vertex coordinates are modified
-        RminBackSurfaceHGCAL = cms.double(75.80),
-        RmaxBackSurfaceHGCAL = cms.double(120.23),
+        # note that these values might not be optimal if the default vertex coordinates' configuration is modified
+        RMinBackSurfaceHGCAL = cms.double(75.80),
+        RMaxBackSurfaceHGCAL = cms.double(120.23),
+        
+        # if True: the particle's direction is projected back to the z=0 plane,
+        #  ensuring compatibility with the specified range
+        RestrictRInZPlaneAtZero = cms.bool(True),
+        RMinAtZero = cms.double(0.),
+        RMaxAtZero = cms.double(100.),
 
-        # only used if PointingToHGCAL == False (radians)
-        MinTheta = cms.double(1E-6),
-        MaxTheta = cms.double(3.141592653589793),
     ),
-    Verbosity = cms.untracked.int32(0),
+    Verbosity = cms.untracked.int32(1),
     firstRun  = cms.untracked.uint32(1),
-    psethack  = cms.string("displaced gun with theta, optionally pointing to hard-coded HGCAL front surface"),
 )

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4786,13 +4786,13 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                     }
     
     if beamspot is not None: upgradeStepDict['GenSim'][k]['--beamspot']=beamspot
-
+    
     upgradeStepDict['GenSimCloseBy'][k] = deepcopy(upgradeStepDict['GenSim'][k])
     upgradeStepDict['GenSimCloseBy'][k]['--beamspot'] = 'CloseBy'
 
     upgradeStepDict['GenSimDisplaced'][k] = deepcopy(upgradeStepDict['GenSim'][k])
     upgradeStepDict['GenSimDisplaced'][k]['--beamspot'] = 'CloseBy'
-    
+
     upgradeStepDict['GenSimHLBeamSpot'][k] = {'-s' : 'GEN,SIM',
                                               '-n' : 10,
                                               '--conditions' : gt+'_13TeV',

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4789,6 +4789,9 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
     upgradeStepDict['GenSimCloseBy'][k] = deepcopy(upgradeStepDict['GenSim'][k])
     upgradeStepDict['GenSimCloseBy'][k]['--beamspot'] = 'CloseBy'
+
+    upgradeStepDict['GenSimDisplaced'][k] = deepcopy(upgradeStepDict['GenSim'][k])
+    upgradeStepDict['GenSimDisplaced'][k]['--beamspot'] = 'CloseBy'
     
     upgradeStepDict['GenSimHLBeamSpot'][k] = {'-s' : 'GEN,SIM',
                                               '-n' : 10,
@@ -4802,7 +4805,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
     upgradeStepDict['GenSimHLBeamSpot14'][k] = deepcopy(upgradeStepDict['GenSimHLBeamSpot'][k])
     upgradeStepDict['GenSimHLBeamSpot14'][k]['--conditions'] = gt
 
-    upgradeStepDict['GenSimHLBeamSpotCloseBy'][k] = upgradeStepDict['GenSimCloseBy'][k]
+    upgradeStepDict['GenSimHLBeamSpotCloseBy'][k] = deepcopy(upgradeStepDict['GenSimCloseBy'][k])
     
     upgradeStepDict['Sim'][k] = {'-s' : 'SIM',
                                  '-n' : 10,
@@ -5040,7 +5043,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
             # in case special WF has PU-specific changes: apply *after* basic PU step is created
             specialWF.setupPU(upgradeStepDict, k, upgradeProperties[year][k])
-
+    
 for step in upgradeStepDict.keys():
     # we need to do this for each fragment
     if ('Sim' in step and ('Fast' not in step and step != 'Sim')) or ('Premix' in step) or ('Sim' not in step and 'Gen' in step):

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4791,8 +4791,8 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
     upgradeStepDict['GenSimCloseBy'][k]['--beamspot'] = 'CloseBy'
 
     upgradeStepDict['GenSimDisplaced'][k] = deepcopy(upgradeStepDict['GenSim'][k])
-    upgradeStepDict['GenSimDisplaced'][k]['--beamspot'] = 'CloseBy'
-
+    upgradeStepDict['GenSimDisplaced'][k]['--beamspot'] = 'CloseBy' # still using DBrealisticHLLHC
+        
     upgradeStepDict['GenSimHLBeamSpot'][k] = {'-s' : 'GEN,SIM',
                                               '-n' : 10,
                                               '--conditions' : gt+'_13TeV',

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -45,7 +45,7 @@ for year in upgradeKeys:
                             step = 'GenSimHLBeamSpotCloseBy'
                     elif 'CloseBy' in frag or 'CE_E' in frag or 'CE_H' in frag:
                         step = 'GenSimCloseBy'
-                    elif 'Displaced' in frag:
+                    elif 'DisplacedParticleGun' in frag:
                         step = 'GenSimDisplaced'
                     stepMaker = makeStepNameSim
                 elif 'Gen' in step:

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -53,7 +53,7 @@ for year in upgradeKeys:
                         if '14TeV' in frag:
                             step = 'GenHLBeamSpot14'
                     stepMaker = makeStepNameSim
-                
+
                 if 'HARVEST' in step: hasHarvest = True
                 for specialType,specialWF in upgradeWFs.items():
                     if notForGenOnly(key,specialType): ## we don't need all the flavors for the GEN

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -45,6 +45,8 @@ for year in upgradeKeys:
                             step = 'GenSimHLBeamSpotCloseBy'
                     elif 'CloseBy' in frag or 'CE_E' in frag or 'CE_H' in frag:
                         step = 'GenSimCloseBy'
+                    elif 'Displaced' in frag:
+                        step = 'GenSimDisplaced'
                     stepMaker = makeStepNameSim
                 elif 'Gen' in step:
                     if 'HLBeamSpot' in step:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -224,6 +224,7 @@ upgradeWFs['baseline'] = UpgradeWorkflow_baseline(
         'Sim',
         'GenSim',
         'GenSimCloseBy',
+        'GenSimDisplaced',
         'GenSimHLBeamSpot',
         'GenSimHLBeamSpot14',
         'GenSimHLBeamSpotCloseBy',
@@ -3978,4 +3979,5 @@ upgradeFragments = OrderedDict([
     ('Hydjet_Quenched_MinBias_5519GeV_cfi', UpgradeFragment(U2000by1,'HydjetQMinBias_5519GeV')),
     ('SingleMuPt15Eta0_0p4_cfi', UpgradeFragment(Kby(9,100),'SingleMuPt15Eta0p_0p4')),
     ('CloseByPGun_Barrel_Front_cfi', UpgradeFragment(Kby(9,100),'CloseByPGun_Barrel_Front')),
+    ('DisplacedParticleGun_cfi', UpgradeFragment(Kby(9,100),'DisplacedPGun')),
 ])

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -922,7 +922,7 @@ class UpgradeWorkflow_ticl_barrel(UpgradeWorkflow):
         if 'HARVESTGlobal' in step:
             stepDict[stepName][k] = merge([self.step4, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
-        return ('CloseByPGun_Barrel') in fragment and ('Run4' in key)
+        return 'CloseByPGun_Barrel' in fragment and 'Run4' in key
 
 upgradeWFs['ticl_barrel'] = UpgradeWorkflow_ticl_barrel(
     steps = [
@@ -953,7 +953,7 @@ class UpgradeWorkflow_ticl_barrel_CPfromPU(UpgradeWorkflow):
         if 'HARVESTGlobal' in step:
             stepDict[stepName][k] = merge([self.step4, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
-        return ('CloseByPGun_Barrel') in fragment and ('Run4' in key) and ('PU' in key)
+        return 'CloseByPGun_Barrel' in fragment and 'Run4' in key and 'PU' in key
 
 upgradeWFs['ticl_barrel_CPfromPU'] = UpgradeWorkflow_ticl_barrel_CPfromPU(
     steps = [

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2166,7 +2166,7 @@ upgradeWFs['HLTwDIGI75e33'] = UpgradeWorkflow_HLTwDIGI75e33(
 class UpgradeWorkflow_NGTScouting(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         # skip RECO, ALCA and HARVEST
-        if ('ALCA' in step) or ('Reco' in step) or ('HLT' in step):
+        if any(x in step for x in ('ALCA', 'Reco', 'HLT')):
             stepDict[stepName][k] = None
         elif 'DigiTrigger' in step:
             # Add the aging customization
@@ -2180,8 +2180,10 @@ class UpgradeWorkflow_NGTScouting(UpgradeWorkflow):
             stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
         else:
             stepDict[stepName][k] = merge([stepDict[step][k]])
+
     def condition(self, fragment, stepList, key, hasHarvest):
-        return (fragment=="TTbar_14TeV" or fragment=="SingleMuPt15Eta0p_0p4") and 'Run4' in key
+        return (fragment=='TTbar_14TeV' or fragment=='SingleMuPt15Eta0p_0p4' or 'Displaced' in fragment) and 'Run4' in key
+    
 upgradeWFs['NGTScouting'] = UpgradeWorkflow_NGTScouting(
     steps = [
         'Reco',

--- a/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
@@ -1,0 +1,378 @@
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <numbers>
+#include <utility>
+#include <vector>
+#include <tuple>
+#include <optional>
+
+#include "BaseFlatGunProducer.h"
+
+#include "FWCore/AbstractServices/interface/RandomNumberGenerator.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+
+#include <CLHEP/Random/RandFlat.h>
+#include <CLHEP/Units/SystemOfUnits.h>
+
+namespace edm {
+
+  namespace {
+
+    // --- Hard-coded HGCAL front surface ---
+    constexpr double kHGCalZ = 296.50;
+    constexpr double kHGCalRMin = 26.00;
+    constexpr double kHGCalRMax = 124.37;
+
+    // Sample r uniformly in area between [rmin, rmax] (uniform point density)
+    double shootUniformDensity(CLHEP::HepRandomEngine* eng, double rmin, double rmax) {
+      const double r2 = CLHEP::RandFlat::shoot(eng, rmin * rmin, rmax * rmax);
+      return std::sqrt(r2);
+    }
+
+	// Sample r uniformly between [rmin, rmax]
+    double shootUniformR(CLHEP::HepRandomEngine* eng, double rmin, double rmax) {
+      return CLHEP::RandFlat::shoot(eng, rmin, rmax);
+    }
+
+	// Ensure the particle hits HGCAL's front surface within [rMin; rMax]
+	bool hitsZPlaneWithinR(double x0, double y0, double z0, // vertex coordinates
+                           double px, double py, double pz, // particle momentum
+                           double zPlane, double rMin, double rMax) { // hard-coded HGCAL geometry
+      // Must move towards the plane: require (zPlane - z0) / pz > 0
+      const double dz = zPlane - z0;
+      if (pz == 0.0) {
+        return false;
+      }
+      const double t = dz / pz;
+      if (t <= 0.0) {
+        return false;
+      }
+
+      const double xHit = x0 + t * px;
+      const double yHit = y0 + t * py;
+      const double rHit = std::hypot(xHit, yHit);
+
+      return (rHit >= rMin && rHit <= rMax);
+    }
+	
+    // Compute the theta range (in radians) that intersects a plane at z=zFront,
+    // within radial bounds [rMin, rMax], from a vertex at transverse radius R0 and z0.
+    std::pair<double, double> thetaRangeToPointToHGCALSurface(double R, double z, double zHGCAL, double rminHGCAL, double rmaxHGCAL) {
+      const double dz = zHGCAL - z;
+      if (dz <= 0. or rminHGCAL > rmaxHGCAL) {
+        return {0., 0.};
+      }
+
+      double thetaMin = std::atan((rminHGCAL - R) / dz);
+      double thetaMax = std::atan((rmaxHGCAL - R) / dz);
+	  
+      // For +z endcap, theta should be in (-pi/2, pi/2)
+      thetaMin = std::clamp(thetaMin, 1e-6, 0.5 * std::numbers::pi - 1e-6);
+      thetaMax = std::clamp(thetaMax, 1e-6, 0.5 * std::numbers::pi - 1e-6);
+
+      if (thetaMax <= thetaMin) {
+        return {0., 0.};
+      }
+      return {thetaMin, thetaMax};
+    }
+
+	std::tuple<double, double, double> computeMomentum(double pt, double theta, double phi) {
+	  double px = pt * std::cos(phi);
+	  double py = pt * std::sin(phi);
+	  double pz = pt / std::tan(theta);
+	  return {px, py, pz};
+	}
+
+  }  // namespace
+
+  class DisplacedParticleGunProducer : public BaseFlatGunProducer {
+  public:
+    explicit DisplacedParticleGunProducer(const ParameterSet&);
+    ~DisplacedParticleGunProducer() override = default;
+
+    static void fillDescriptions(ConfigurationDescriptions& descriptions);
+
+  private:
+    void produce(Event& e, const EventSetup& es) override;
+
+    double fPtMin = 0.;
+    double fPtMax = 0.;
+    double fPhiMin = 0.;
+    double fPhiMax = 0.;
+    double fRMin = 0.;
+    double fRMax = 0.;
+	double fPhiVtxMin = 0.;
+	double fPhiVtxMax = 0.;
+    double fZVtx = 0.;
+    int fNParticles = 1;
+    std::vector<int> fPartIDs;
+    bool fUniformDensityInR = false;
+	unsigned int fMaxTries = 1000;
+	
+    // If true: derive theta range from hard-coded HGCAL front surface envelope
+	//   (with R in [RminFrontSurfaceHGCAL, RmaxFrontSurfaceHGCAL]) and vertex rho
+    // If false: sample theta uniformly in [MinTheta, MaxTheta]
+    bool fPointingToHGCAL = true;
+	std::optional<double> fRminFrontSurfaceHGCAL = kHGCalRMin;
+	std::optional<double> fRmaxFrontSurfaceHGCAL = kHGCalRMax;
+	std::optional<double> fThetaMin = 0.;
+	std::optional<double> fThetaMax = 0.;
+  };
+
+  DisplacedParticleGunProducer::DisplacedParticleGunProducer(const ParameterSet& pset) : BaseFlatGunProducer(pset) {
+    const auto pgun = pset.getParameter<ParameterSet>("PGunParameters");
+
+    fPtMin = pgun.getParameter<double>("MinPt");
+    fPtMax = pgun.getParameter<double>("MaxPt");
+    fPhiMin = pgun.getParameter<double>("MinPhi");
+    fPhiMax = pgun.getParameter<double>("MaxPhi");
+    fPhiVtxMin = pgun.getParameter<double>("MinVtxPhi");
+	fPhiVtxMax = pgun.getParameter<double>("MaxVtxPhi");
+    fRMin = pgun.getParameter<double>("RMin");
+    fRMax = pgun.getParameter<double>("RMax");
+    fZVtx = pgun.getParameter<double>("ZVtx");
+    fNParticles = pgun.getParameter<int>("NParticles");
+    fPartIDs = pgun.getParameter<std::vector<int>>("PartID");
+	fUniformDensityInR = pgun.getParameter<bool>("UniformDensityInR");
+	fMaxTries = pgun.getParameter<unsigned int>("MaxTries");
+    fPointingToHGCAL = pgun.getParameter<bool>("PointingToHGCAL");
+	
+	if (!fPointingToHGCAL) {
+	  fThetaMin = pgun.getParameter<double>("MinTheta");
+	  fThetaMax = pgun.getParameter<double>("MaxTheta");
+	  if (*fThetaMax <= *fThetaMin) {
+		throw cms::Exception("DisplacedParticleGunProducer") << "Please ensure MinTheta <= MaxTheta.";
+	  }
+	  fRminFrontSurfaceHGCAL  = std::nullopt;
+	  fRmaxFrontSurfaceHGCAL  = std::nullopt;
+	}
+	else {
+	  fRminFrontSurfaceHGCAL = pgun.getParameter<double>("RminFrontSurfaceHGCAL");
+	  fRmaxFrontSurfaceHGCAL = pgun.getParameter<double>("RmaxFrontSurfaceHGCAL");
+	  if (*fRmaxFrontSurfaceHGCAL <= *fRminFrontSurfaceHGCAL) {
+		throw cms::Exception("DisplacedParticleGunProducer") << "Please ensure RmaxFrontSurfaceHGCAL <= RminFrontSurfaceHGCAL.";
+	  }
+	  if (*fRmaxFrontSurfaceHGCAL > kHGCalRMax || *fRminFrontSurfaceHGCAL < kHGCalRMin) {
+		throw cms::Exception("DisplacedParticleGunProducer") << "Please ensure RmaxFrontSurfaceHGCAL <= kHGCalRMax and RminFrontSurfaceHGCAL >= kHGCalRMin.";
+	  }
+      fThetaMin = std::nullopt;
+      fThetaMax = std::nullopt;
+    }
+	
+    if (fPtMax <= fPtMin) {
+      throw cms::Exception("DisplacedParticleGunProducer") << "Please fix MinPt/MaxPt";
+    }
+    if (fPhiMax <= fPhiMin) {
+      throw cms::Exception("DisplacedParticleGunProducer") << "Please fix MinPhi/MaxPhi";
+    }
+	if (fPhiVtxMax <= fPhiVtxMin) {
+      throw cms::Exception("DisplacedParticleGunProducer") << "Please fix MinVtxPhi/MaxVtxPhi";
+    }	
+    if (fRMax <= fRMin) {
+      throw cms::Exception("DisplacedParticleGunProducer") << "Please fix RMin/RMax";
+    }
+    if (fPartIDs.empty()) {
+      throw cms::Exception("DisplacedParticleGunProducer") << "PartID must be non-empty";
+    }
+	if (fMaxTries == 0) {
+	  throw cms::Exception("DisplacedParticleGunProducer") << "MaxTries must be > 0";
+	}
+
+
+    produces<HepMCProduct>("unsmeared");
+    produces<GenEventInfoProduct>();
+  }
+
+  void DisplacedParticleGunProducer::fillDescriptions(ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<bool>("AddAntiParticle", false);
+
+    edm::ParameterSetDescription pgun;
+
+	// particle direction	
+    pgun.add<double>("MinPt", 5.);
+    pgun.add<double>("MaxPt", 100.);
+    pgun.add<double>("MinPhi", -std::numbers::pi);
+    pgun.add<double>("MaxPhi", +std::numbers::pi);
+
+	// vertex displacement (cm)
+    pgun.add<double>("RMin", 0.);
+    pgun.add<double>("RMax", 10.);
+	pgun.add<double>("MinVtxPhi", 0.);
+    pgun.add<double>("MaxVtxPhi", 2 * std::numbers::pi);
+    pgun.add<double>("ZVtx", 0.);
+
+    pgun.add<int>("NParticles", 1);
+    pgun.add<std::vector<int>>("PartID", {22});
+
+	pgun.add<bool>("UniformDensityInR", false);
+
+	pgun.add<unsigned int>("MaxTries", 1000u);
+	
+	// A particle shot at the extremities of the HGCAL surface will not traverse a substantial fraction of the detector.
+	// We use RminFrontSurfaceHGCAL and RmaxFrontSurfaceHGCAL to expose only a given region of the HGCAL surface
+	// THe default arguments correspond to the inner third of HGCAL's surface (R in ~[58.79, 91.58]cm).
+	// At (R=200,z=0)cm, an uncharged particle pointing to R=58.79cm at the HGCAL surface (the most extreme case) exits the calorimeter at the
+	//  back face of the CE-E, crossing all its layers.
+	// For R>200cm there is no guarantee all CE-E layers will be crossed, so a tighter R range might be needed.
+	// For z>0cm the angles will become more extreme, so a tighter R range might be needed.
+	// The above reasoning breaks for charged particles, since the bending under the magnetic filed can enormously extend the particle's reach.
+    pgun.add<bool>("PointingToHGCAL", true);
+	pgun.addOptionalNode(edm::ParameterDescription<double>("RminFrontSurfaceHGCAL", 58.79, true), true);
+	pgun.addOptionalNode(edm::ParameterDescription<double>("RmaxFrontSurfaceHGCAL", 91.58, true), true);
+	pgun.addOptionalNode(edm::ParameterDescription<double>("MinTheta", 0.2, true), true);
+	pgun.addOptionalNode(edm::ParameterDescription<double>("MaxTheta", 1.2, true), true);
+
+    desc.add<edm::ParameterSetDescription>("PGunParameters", pgun);
+
+    desc.addUntracked<int>("Verbosity", 0);
+    desc.addUntracked<unsigned int>("firstRun", 1);
+    desc.add<std::string>("psethack",
+                          "displaced gun with theta, optionally pointing to hard-coded HGCAL front surface");
+	
+    descriptions.add("DisplacedParticleGunProducer", desc);
+  }
+
+  void DisplacedParticleGunProducer::produce(Event& e, const EventSetup& /*es*/) {
+    edm::Service<edm::RandomNumberGenerator> rng;
+    CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
+
+	if (fVerbosity > 0) {
+      LogDebug("DisplacedParticleGunProducer") << " DisplacedParticleGunProducer : Begin New Event Generation" << std::endl;
+    }
+
+    fEvt = new HepMC::GenEvent();
+
+    const double zFront = kHGCalZ;
+    const double rMinFace = fRminFrontSurfaceHGCAL.value();
+    const double rMaxFace = fRmaxFrontSurfaceHGCAL.value();
+
+    if (fPointingToHGCAL) {
+      if (!(rMaxFace > rMinFace) || zFront <= fZVtx) {
+        throw cms::Exception("DisplacedParticleGunProducer")
+		  << "Invalid hard-coded HGCAL surface envelope: "
+		  << "zFront =" << zFront << "cm, rMin =" << rMinFace << "cm, rMax=" << rMaxFace << "cm"
+		  << " (check ZVtx).";
+      }
+	}
+
+    int barcode = 1;
+
+    for (int ip = 0; ip < fNParticles; ++ip) {
+      // --- Sample displaced vertex in transverse annulus (z fixed) ---
+      const double RVtx = fUniformDensityInR ? shootUniformDensity(engine, fRMin, fRMax) : shootUniformR(engine, fRMin, fRMax);
+      const double phiVtx = CLHEP::RandFlat::shoot(engine, fPhiVtxMin, fPhiVtxMax);
+      const double xVtx = RVtx * std::cos(phiVtx);
+      const double yVtx = RVtx * std::sin(phiVtx);
+      const double zVtx = fZVtx;
+
+      const auto idx = static_cast<std::size_t>(CLHEP::RandFlat::shoot(engine, 0, fPartIDs.size()));
+      const int partID = fPartIDs[idx];
+
+      const HepPDT::ParticleData* pData = fPDGTable->particle(HepPDT::ParticleID(std::abs(partID)));
+      if (!pData) {
+        throw cms::Exception("DisplacedParticleGunProducer") << "Particle ID " << partID << " not found in PDG table";
+      }
+      const double mass = pData->mass().value();
+
+	  if (pData->charge()!=0 && fPointingToHGCAL) {
+		throw cms::Exception("DisplacedParticleGunProducer")
+		  << "The logic that points particles to HGCAL's front face assumes that particles move in straight lines.";
+	  }
+		
+      double theta=0., phi=phiVtx, px=0., py=0., pz=0.;
+	  const double pt = CLHEP::RandFlat::shoot(engine, fPtMin, fPtMax);
+	  if (fPointingToHGCAL)
+		{
+		  const double RVtx0 = std::hypot(xVtx, yVtx);
+		  auto [thetaMin, thetaMax] = thetaRangeToPointToHGCALSurface(RVtx0, zVtx, zFront, rMinFace, rMaxFace);
+		  if (!(thetaMax >= thetaMin)) {
+			throw cms::Exception("DisplacedParticleGunProducer")
+			  << "No valid theta window for this vertex at RVtx=" << RVtx0 << "cm within HGCAL's front surface.";
+		  }
+
+		  bool accepted = false;
+		  for (unsigned int itry = 0; itry < fMaxTries; ++itry) {
+			theta = CLHEP::RandFlat::shoot(engine, thetaMin, thetaMax);
+			phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
+			std::tie(px, py, pz) = computeMomentum(pt, theta, phi);
+			if (std::isnan(pz) || std::isinf(pz) || pz <= 0.0) {
+			  continue;  // must go towards +z plane
+			}
+
+			if (hitsZPlaneWithinR(xVtx, yVtx, zVtx,
+								  px, py, pz,
+								  zFront, *fRminFrontSurfaceHGCAL, *fRmaxFrontSurfaceHGCAL)) {
+			  accepted = true;
+			  break;
+			}
+		  }
+		  if (!accepted) {
+			throw cms::Exception("DisplacedParticleGunProducer")
+			  << "Failed to generate a particle intersecting HGCAL front surface after MaxTries=" << fMaxTries
+			  << ". Vertex: (R=" << RVtx << "cm, phiVtx=" << phiVtx << ", z=" << zVtx
+			  << "cm). HGCAL band: [" << *fRminFrontSurfaceHGCAL << "," << *fRmaxFrontSurfaceHGCAL
+			  << "]cm at z=" << zFront << "cm.";
+		  }
+		}
+	  else { // if (fPointingToHGCAL)
+		theta = CLHEP::RandFlat::shoot(engine, fThetaMin.value(), fThetaMax.value());
+		phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
+		std::tie(px, py, pz) = computeMomentum(pt, theta, phi);
+	  }
+
+      const double p2 = px * px + py * py + pz * pz;
+      const double energy = std::sqrt(p2 + mass * mass);
+
+      HepMC::FourVector p(px, py, pz, energy);
+
+      HepMC::GenVertex* vtx = new HepMC::GenVertex(
+          HepMC::FourVector(xVtx * CLHEP::cm, yVtx * CLHEP::cm, zVtx * CLHEP::cm, 0.0));
+
+      HepMC::GenParticle* part = new HepMC::GenParticle(p, partID, 1);
+      part->suggest_barcode(barcode++);
+
+      vtx->add_particle_out(part);
+      fEvt->add_vertex(vtx);
+
+	  if (fVerbosity > 0) {
+        vtx->print();
+        part->print();
+      }
+
+    }
+
+    fEvt->set_event_number(e.id().event());
+    fEvt->set_signal_process_id(20);
+
+	if (fVerbosity > 0) {
+      fEvt->print();
+    }
+
+    auto bProduct = std::make_unique<HepMCProduct>();
+    bProduct->addHepMCData(fEvt);
+    e.put(std::move(bProduct), "unsmeared");
+
+    auto genEventInfo = std::make_unique<GenEventInfoProduct>(fEvt);
+    e.put(std::move(genEventInfo));
+
+	if (fVerbosity > 0) {
+      LogDebug("DisplacedParticleGunProducer") << " DisplacedParticleGunProducer : Event Generation Done " << std::endl;
+    }
+  }
+
+}  // namespace edm
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using edm::DisplacedParticleGunProducer;
+DEFINE_FWK_MODULE(DisplacedParticleGunProducer);

--- a/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
@@ -4,25 +4,30 @@
 #include <numbers>
 #include <utility>
 #include <vector>
+#include <string>
 #include <tuple>
 #include <optional>
 
-#include "BaseFlatGunProducer.h"
+#include <CLHEP/Random/RandFlat.h>
+#include <CLHEP/Units/SystemOfUnits.h>
+
+#include "HepMC/GenEvent.h"
 
 #include "FWCore/AbstractServices/interface/RandomNumberGenerator.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-
-#include <CLHEP/Random/RandFlat.h>
-#include <CLHEP/Units/SystemOfUnits.h>
+#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 
 namespace edm {
 
@@ -39,18 +44,24 @@ namespace edm {
       return std::sqrt(r2);
     }
 
-	// Sample r uniformly between [rmin, rmax]
+    // Sample r uniformly between [rmin, rmax]
     double shootUniformR(CLHEP::HepRandomEngine* eng, double rmin, double rmax) {
       return CLHEP::RandFlat::shoot(eng, rmin, rmax);
     }
 
-	// Ensure the particle hits HGCAL's front surface within [rMin; rMax]
-	bool hitsZPlaneWithinR(double x0, double y0, double z0, // vertex coordinates
-                           double px, double py, double pz, // particle momentum
-                           double zPlane, double rMin, double rMax) { // hard-coded HGCAL geometry
+    // Ensure the particle hits HGCAL's front surface within [rMin; rMax]
+    bool hitsZPlaneWithinR(double x0,
+                           double y0,
+                           double z0,  // vertex coordinates
+                           double px,
+                           double py,
+                           double pz,  // particle momentum
+                           double zPlane,
+                           double rMin,
+                           double rMax) {  // hard-coded HGCAL geometry
       // Must move towards the plane: require (zPlane - z0) / pz > 0
       const double dz = zPlane - z0;
-      if (pz == 0.0) {
+      if (pz < 1e-6) {
         return false;
       }
       const double t = dz / pz;
@@ -64,10 +75,11 @@ namespace edm {
 
       return (rHit >= rMin && rHit <= rMax);
     }
-	
+
     // Compute the theta range (in radians) that intersects a plane at z=zFront,
     // within radial bounds [rMin, rMax], from a vertex at transverse radius R0 and z0.
-    std::pair<double, double> thetaRangeToPointToHGCALSurface(double R, double z, double zHGCAL, double rminHGCAL, double rmaxHGCAL) {
+    std::pair<double, double> thetaRangeToPointToHGCALSurface(
+        double R, double z, double zHGCAL, double rminHGCAL, double rmaxHGCAL) {
       const double dz = zHGCAL - z;
       if (dz <= 0. or rminHGCAL > rmaxHGCAL) {
         return {0., 0.};
@@ -75,8 +87,9 @@ namespace edm {
 
       double thetaMin = std::atan((rminHGCAL - R) / dz);
       double thetaMax = std::atan((rmaxHGCAL - R) / dz);
-	  
-      // For +z endcap, theta should be in (-pi/2, pi/2)
+
+      // For +z endcap, theta should be in (0, pi/2)
+      // clamping removes instabilities for pz
       thetaMin = std::clamp(thetaMin, 1e-6, 0.5 * std::numbers::pi - 1e-6);
       thetaMax = std::clamp(thetaMax, 1e-6, 0.5 * std::numbers::pi - 1e-6);
 
@@ -86,19 +99,28 @@ namespace edm {
       return {thetaMin, thetaMax};
     }
 
-	std::tuple<double, double, double> computeMomentum(double pt, double theta, double phi) {
-	  double px = pt * std::cos(phi);
-	  double py = pt * std::sin(phi);
-	  double pz = pt / std::tan(theta);
-	  return {px, py, pz};
-	}
+    std::tuple<double, double, double> computeMomentum(double pt, double theta, double phi) {
+      double px = pt * std::cos(phi);
+      double py = pt * std::sin(phi);
+      double pz = 0.;
+      if (theta < 1e-6) {
+        throw cms::Exception("DisplacedParticleGunProducer") << "Theta is too small. Unstable pz.";
+      } else {
+        pz = pt / std::tan(theta);
+      }
+      return {px, py, pz};
+    }
 
   }  // namespace
 
-  class DisplacedParticleGunProducer : public BaseFlatGunProducer {
+  class DisplacedParticleGunProducer : public one::EDProducer<one::WatchRuns, EndRunProducer> {
   public:
     explicit DisplacedParticleGunProducer(const ParameterSet&);
     ~DisplacedParticleGunProducer() override = default;
+
+    void beginRun(const edm::Run& r, const edm::EventSetup&) override;
+    void endRun(edm::Run const& r, const edm::EventSetup&) override;
+    void endRunProduce(edm::Run& r, const edm::EventSetup&) override;
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
@@ -111,25 +133,39 @@ namespace edm {
     double fPhiMax = 0.;
     double fRMin = 0.;
     double fRMax = 0.;
-	double fPhiVtxMin = 0.;
-	double fPhiVtxMax = 0.;
+    double fPhiVtxMin = 0.;
+    double fPhiVtxMax = 0.;
     double fZVtx = 0.;
     int fNParticles = 1;
     std::vector<int> fPartIDs;
     bool fUniformDensityInR = false;
-	unsigned int fMaxTries = 1000;
-	
+    unsigned int fMaxTries = 1000;
+
     // If true: derive theta range from hard-coded HGCAL front surface envelope
-	//   (with R in [RminFrontSurfaceHGCAL, RmaxFrontSurfaceHGCAL]) and vertex rho
+    //   (with R in [RminFrontSurfaceHGCAL, RmaxFrontSurfaceHGCAL]) and vertex rho
     // If false: sample theta uniformly in [MinTheta, MaxTheta]
     bool fPointingToHGCAL = true;
-	std::optional<double> fRminFrontSurfaceHGCAL = kHGCalRMin;
-	std::optional<double> fRmaxFrontSurfaceHGCAL = kHGCalRMax;
-	std::optional<double> fThetaMin = 0.;
-	std::optional<double> fThetaMax = 0.;
+    std::optional<double> fRminFrontSurfaceHGCAL = kHGCalRMin;
+    std::optional<double> fRmaxFrontSurfaceHGCAL = kHGCalRMax;
+    std::optional<double> fThetaMin = 0.;
+    std::optional<double> fThetaMax = 0.;
+
+    ESHandle<HepPDT::ParticleDataTable> fPDGTable;
+    const ESGetToken<HepPDT::ParticleDataTable, edm::DefaultRecord> fPDGTableToken;
+    HepMC::GenEvent* fEvt;
+    int fVerbosity;
   };
 
-  DisplacedParticleGunProducer::DisplacedParticleGunProducer(const ParameterSet& pset) : BaseFlatGunProducer(pset) {
+  DisplacedParticleGunProducer::DisplacedParticleGunProducer(const ParameterSet& pset)
+      : fPDGTableToken(esConsumes<Transition::BeginRun>()), fEvt(nullptr) {
+    Service<RandomNumberGenerator> rng;
+    if (!rng.isAvailable()) {
+      throw cms::Exception("Configuration")
+          << "The RandomNumberProducer module requires the RandomNumberGeneratorService\n"
+             "which appears to be absent.  Please add that service to your configuration\n"
+             "or remove the modules that require it.";
+    }
+
     const auto pgun = pset.getParameter<ParameterSet>("PGunParameters");
 
     fPtMin = pgun.getParameter<double>("MinPt");
@@ -137,61 +173,70 @@ namespace edm {
     fPhiMin = pgun.getParameter<double>("MinPhi");
     fPhiMax = pgun.getParameter<double>("MaxPhi");
     fPhiVtxMin = pgun.getParameter<double>("MinVtxPhi");
-	fPhiVtxMax = pgun.getParameter<double>("MaxVtxPhi");
+    fPhiVtxMax = pgun.getParameter<double>("MaxVtxPhi");
     fRMin = pgun.getParameter<double>("RMin");
     fRMax = pgun.getParameter<double>("RMax");
     fZVtx = pgun.getParameter<double>("ZVtx");
     fNParticles = pgun.getParameter<int>("NParticles");
     fPartIDs = pgun.getParameter<std::vector<int>>("PartID");
-	fUniformDensityInR = pgun.getParameter<bool>("UniformDensityInR");
-	fMaxTries = pgun.getParameter<unsigned int>("MaxTries");
+    fUniformDensityInR = pgun.getParameter<bool>("UniformDensityInR");
+    fMaxTries = pgun.getParameter<unsigned int>("MaxTries");
     fPointingToHGCAL = pgun.getParameter<bool>("PointingToHGCAL");
-	
-	if (!fPointingToHGCAL) {
-	  fThetaMin = pgun.getParameter<double>("MinTheta");
-	  fThetaMax = pgun.getParameter<double>("MaxTheta");
-	  if (*fThetaMax <= *fThetaMin) {
-		throw cms::Exception("DisplacedParticleGunProducer") << "Please ensure MinTheta <= MaxTheta.";
-	  }
-	  fRminFrontSurfaceHGCAL  = std::nullopt;
-	  fRmaxFrontSurfaceHGCAL  = std::nullopt;
-	}
-	else {
-	  fRminFrontSurfaceHGCAL = pgun.getParameter<double>("RminFrontSurfaceHGCAL");
-	  fRmaxFrontSurfaceHGCAL = pgun.getParameter<double>("RmaxFrontSurfaceHGCAL");
-	  if (*fRmaxFrontSurfaceHGCAL <= *fRminFrontSurfaceHGCAL) {
-		throw cms::Exception("DisplacedParticleGunProducer") << "Please ensure RmaxFrontSurfaceHGCAL <= RminFrontSurfaceHGCAL.";
-	  }
-	  if (*fRmaxFrontSurfaceHGCAL > kHGCalRMax || *fRminFrontSurfaceHGCAL < kHGCalRMin) {
-		throw cms::Exception("DisplacedParticleGunProducer") << "Please ensure RmaxFrontSurfaceHGCAL <= kHGCalRMax and RminFrontSurfaceHGCAL >= kHGCalRMin.";
-	  }
+
+    if (!fPointingToHGCAL) {
+      fThetaMin = pgun.getParameter<double>("MinTheta");
+      fThetaMax = pgun.getParameter<double>("MaxTheta");
+      if (*fThetaMax <= *fThetaMin) {
+        throw cms::Exception("DisplacedParticleGunProducer") << "Please ensure MinTheta <= MaxTheta.";
+      }
+      fRminFrontSurfaceHGCAL = std::nullopt;
+      fRmaxFrontSurfaceHGCAL = std::nullopt;
+    } else {
+      fRminFrontSurfaceHGCAL = pgun.getParameter<double>("RminFrontSurfaceHGCAL");
+      fRmaxFrontSurfaceHGCAL = pgun.getParameter<double>("RmaxFrontSurfaceHGCAL");
+      if (*fRmaxFrontSurfaceHGCAL <= *fRminFrontSurfaceHGCAL) {
+        throw cms::Exception("DisplacedParticleGunProducer")
+            << "Please ensure RmaxFrontSurfaceHGCAL > RminFrontSurfaceHGCAL.";
+      }
+      if (*fRmaxFrontSurfaceHGCAL > kHGCalRMax || *fRminFrontSurfaceHGCAL < kHGCalRMin) {
+        throw cms::Exception("DisplacedParticleGunProducer")
+            << "Please ensure RmaxFrontSurfaceHGCAL <= kHGCalRMax and RminFrontSurfaceHGCAL >= kHGCalRMin.";
+      }
       fThetaMin = std::nullopt;
       fThetaMax = std::nullopt;
     }
-	
+
     if (fPtMax <= fPtMin) {
       throw cms::Exception("DisplacedParticleGunProducer") << "Please fix MinPt/MaxPt";
     }
     if (fPhiMax <= fPhiMin) {
       throw cms::Exception("DisplacedParticleGunProducer") << "Please fix MinPhi/MaxPhi";
     }
-	if (fPhiVtxMax <= fPhiVtxMin) {
+    if (fPhiVtxMax <= fPhiVtxMin) {
       throw cms::Exception("DisplacedParticleGunProducer") << "Please fix MinVtxPhi/MaxVtxPhi";
-    }	
+    }
     if (fRMax <= fRMin) {
       throw cms::Exception("DisplacedParticleGunProducer") << "Please fix RMin/RMax";
     }
     if (fPartIDs.empty()) {
       throw cms::Exception("DisplacedParticleGunProducer") << "PartID must be non-empty";
     }
-	if (fMaxTries == 0) {
-	  throw cms::Exception("DisplacedParticleGunProducer") << "MaxTries must be > 0";
-	}
-
+    if (fMaxTries == 0) {
+      throw cms::Exception("DisplacedParticleGunProducer") << "MaxTries must be > 0";
+    }
 
     produces<HepMCProduct>("unsmeared");
     produces<GenEventInfoProduct>();
   }
+
+  void DisplacedParticleGunProducer::beginRun(const edm::Run& r, const EventSetup& es) {
+    fPDGTable = es.getHandle(fPDGTableToken);
+    return;
+  }
+
+  void DisplacedParticleGunProducer::endRun(const Run& run, const EventSetup& es) {}
+
+  void DisplacedParticleGunProducer::endRunProduce(Run& run, const EventSetup& es) {}
 
   void DisplacedParticleGunProducer::fillDescriptions(ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
@@ -199,39 +244,39 @@ namespace edm {
 
     edm::ParameterSetDescription pgun;
 
-	// particle direction	
+    // particle direction
     pgun.add<double>("MinPt", 5.);
     pgun.add<double>("MaxPt", 100.);
     pgun.add<double>("MinPhi", -std::numbers::pi);
     pgun.add<double>("MaxPhi", +std::numbers::pi);
 
-	// vertex displacement (cm)
+    // vertex displacement (cm)
     pgun.add<double>("RMin", 0.);
     pgun.add<double>("RMax", 10.);
-	pgun.add<double>("MinVtxPhi", 0.);
+    pgun.add<double>("MinVtxPhi", 0.);
     pgun.add<double>("MaxVtxPhi", 2 * std::numbers::pi);
     pgun.add<double>("ZVtx", 0.);
 
     pgun.add<int>("NParticles", 1);
     pgun.add<std::vector<int>>("PartID", {22});
 
-	pgun.add<bool>("UniformDensityInR", false);
+    pgun.add<bool>("UniformDensityInR", false);
 
-	pgun.add<unsigned int>("MaxTries", 1000u);
-	
-	// A particle shot at the extremities of the HGCAL surface will not traverse a substantial fraction of the detector.
-	// We use RminFrontSurfaceHGCAL and RmaxFrontSurfaceHGCAL to expose only a given region of the HGCAL surface
-	// THe default arguments correspond to the inner third of HGCAL's surface (R in ~[58.79, 91.58]cm).
-	// At (R=200,z=0)cm, an uncharged particle pointing to R=58.79cm at the HGCAL surface (the most extreme case) exits the calorimeter at the
-	//  back face of the CE-E, crossing all its layers.
-	// For R>200cm there is no guarantee all CE-E layers will be crossed, so a tighter R range might be needed.
-	// For z>0cm the angles will become more extreme, so a tighter R range might be needed.
-	// The above reasoning breaks for charged particles, since the bending under the magnetic filed can enormously extend the particle's reach.
+    pgun.add<unsigned int>("MaxTries", 1000u);
+
+    // A particle shot at the extremities of the HGCAL surface will not traverse a substantial fraction of the detector.
+    // We use RminFrontSurfaceHGCAL and RmaxFrontSurfaceHGCAL to expose only a given region of the HGCAL surface
+    // THe default arguments correspond to the inner third of HGCAL's surface (R in ~[58.79, 91.58]cm).
+    // At (R=200,z=0)cm, an uncharged particle pointing to R=58.79cm at the HGCAL surface (the most extreme case) exits the calorimeter at the
+    //  back face of the CE-E, crossing all its layers.
+    // For R>200cm there is no guarantee all CE-E layers will be crossed, so a tighter R range might be needed.
+    // For z>0cm the angles will become more extreme, so a tighter R range might be needed.
+    // The above reasoning breaks for charged particles, since the bending under the magnetic filed can enormously extend the particle's reach.
     pgun.add<bool>("PointingToHGCAL", true);
-	pgun.addOptionalNode(edm::ParameterDescription<double>("RminFrontSurfaceHGCAL", 58.79, true), true);
-	pgun.addOptionalNode(edm::ParameterDescription<double>("RmaxFrontSurfaceHGCAL", 91.58, true), true);
-	pgun.addOptionalNode(edm::ParameterDescription<double>("MinTheta", 0.2, true), true);
-	pgun.addOptionalNode(edm::ParameterDescription<double>("MaxTheta", 1.2, true), true);
+    pgun.addOptionalNode(edm::ParameterDescription<double>("RminFrontSurfaceHGCAL", 58.79, true), true);
+    pgun.addOptionalNode(edm::ParameterDescription<double>("RmaxFrontSurfaceHGCAL", 91.58, true), true);
+    pgun.addOptionalNode(edm::ParameterDescription<double>("MinTheta", 0.2, true), true);
+    pgun.addOptionalNode(edm::ParameterDescription<double>("MaxTheta", 1.2, true), true);
 
     desc.add<edm::ParameterSetDescription>("PGunParameters", pgun);
 
@@ -239,7 +284,7 @@ namespace edm {
     desc.addUntracked<unsigned int>("firstRun", 1);
     desc.add<std::string>("psethack",
                           "displaced gun with theta, optionally pointing to hard-coded HGCAL front surface");
-	
+
     descriptions.add("DisplacedParticleGunProducer", desc);
   }
 
@@ -247,8 +292,9 @@ namespace edm {
     edm::Service<edm::RandomNumberGenerator> rng;
     CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
 
-	if (fVerbosity > 0) {
-      LogDebug("DisplacedParticleGunProducer") << " DisplacedParticleGunProducer : Begin New Event Generation" << std::endl;
+    if (fVerbosity > 0) {
+      LogDebug("DisplacedParticleGunProducer")
+          << " DisplacedParticleGunProducer : Begin New Event Generation" << std::endl;
     }
 
     fEvt = new HepMC::GenEvent();
@@ -260,17 +306,18 @@ namespace edm {
     if (fPointingToHGCAL) {
       if (!(rMaxFace > rMinFace) || zFront <= fZVtx) {
         throw cms::Exception("DisplacedParticleGunProducer")
-		  << "Invalid hard-coded HGCAL surface envelope: "
-		  << "zFront =" << zFront << "cm, rMin =" << rMinFace << "cm, rMax=" << rMaxFace << "cm"
-		  << " (check ZVtx).";
+            << "Invalid hard-coded HGCAL surface envelope: "
+            << "zFront =" << zFront << "cm, rMin =" << rMinFace << "cm, rMax=" << rMaxFace << "cm"
+            << " (check ZVtx).";
       }
-	}
+    }
 
     int barcode = 1;
 
     for (int ip = 0; ip < fNParticles; ++ip) {
       // --- Sample displaced vertex in transverse annulus (z fixed) ---
-      const double RVtx = fUniformDensityInR ? shootUniformDensity(engine, fRMin, fRMax) : shootUniformR(engine, fRMin, fRMax);
+      const double RVtx =
+          fUniformDensityInR ? shootUniformDensity(engine, fRMin, fRMax) : shootUniformR(engine, fRMin, fRMax);
       const double phiVtx = CLHEP::RandFlat::shoot(engine, fPhiVtxMin, fPhiVtxMax);
       const double xVtx = RVtx * std::cos(phiVtx);
       const double yVtx = RVtx * std::sin(phiVtx);
@@ -285,59 +332,55 @@ namespace edm {
       }
       const double mass = pData->mass().value();
 
-	  if (pData->charge()!=0 && fPointingToHGCAL) {
-		throw cms::Exception("DisplacedParticleGunProducer")
-		  << "The logic that points particles to HGCAL's front face assumes that particles move in straight lines.";
-	  }
-		
-      double theta=0., phi=phiVtx, px=0., py=0., pz=0.;
-	  const double pt = CLHEP::RandFlat::shoot(engine, fPtMin, fPtMax);
-	  if (fPointingToHGCAL)
-		{
-		  const double RVtx0 = std::hypot(xVtx, yVtx);
-		  auto [thetaMin, thetaMax] = thetaRangeToPointToHGCALSurface(RVtx0, zVtx, zFront, rMinFace, rMaxFace);
-		  if (!(thetaMax >= thetaMin)) {
-			throw cms::Exception("DisplacedParticleGunProducer")
-			  << "No valid theta window for this vertex at RVtx=" << RVtx0 << "cm within HGCAL's front surface.";
-		  }
+      if (pData->charge() != 0 && fPointingToHGCAL) {
+        throw cms::Exception("DisplacedParticleGunProducer")
+            << "The logic that points particles to HGCAL's front face assumes that particles move in straight lines.";
+      }
 
-		  bool accepted = false;
-		  for (unsigned int itry = 0; itry < fMaxTries; ++itry) {
-			theta = CLHEP::RandFlat::shoot(engine, thetaMin, thetaMax);
-			phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
-			std::tie(px, py, pz) = computeMomentum(pt, theta, phi);
-			if (std::isnan(pz) || std::isinf(pz) || pz <= 0.0) {
-			  continue;  // must go towards +z plane
-			}
+      double theta = 0., phi = phiVtx, px = 0., py = 0., pz = 0.;
+      const double pt = CLHEP::RandFlat::shoot(engine, fPtMin, fPtMax);
+      if (fPointingToHGCAL) {
+        const double RVtx0 = std::hypot(xVtx, yVtx);
+        auto [thetaMin, thetaMax] = thetaRangeToPointToHGCALSurface(RVtx0, zVtx, zFront, rMinFace, rMaxFace);
+        if (!(thetaMax >= thetaMin)) {
+          throw cms::Exception("DisplacedParticleGunProducer")
+              << "No valid theta window for this vertex at RVtx=" << RVtx0 << "cm within HGCAL's front surface.";
+        }
 
-			if (hitsZPlaneWithinR(xVtx, yVtx, zVtx,
-								  px, py, pz,
-								  zFront, *fRminFrontSurfaceHGCAL, *fRmaxFrontSurfaceHGCAL)) {
-			  accepted = true;
-			  break;
-			}
-		  }
-		  if (!accepted) {
-			throw cms::Exception("DisplacedParticleGunProducer")
-			  << "Failed to generate a particle intersecting HGCAL front surface after MaxTries=" << fMaxTries
-			  << ". Vertex: (R=" << RVtx << "cm, phiVtx=" << phiVtx << ", z=" << zVtx
-			  << "cm). HGCAL band: [" << *fRminFrontSurfaceHGCAL << "," << *fRmaxFrontSurfaceHGCAL
-			  << "]cm at z=" << zFront << "cm.";
-		  }
-		}
-	  else { // if (fPointingToHGCAL)
-		theta = CLHEP::RandFlat::shoot(engine, fThetaMin.value(), fThetaMax.value());
-		phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
-		std::tie(px, py, pz) = computeMomentum(pt, theta, phi);
-	  }
+        bool accepted = false;
+        for (unsigned int itry = 0; itry < fMaxTries; ++itry) {
+          theta = CLHEP::RandFlat::shoot(engine, thetaMin, thetaMax);
+          phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
+          std::tie(px, py, pz) = computeMomentum(pt, theta, phi);
+          if (std::isnan(pz) || std::isinf(pz) || pz <= 0.0) {
+            continue;  // must go towards +z plane
+          }
+
+          if (hitsZPlaneWithinR(
+                  xVtx, yVtx, zVtx, px, py, pz, zFront, *fRminFrontSurfaceHGCAL, *fRmaxFrontSurfaceHGCAL)) {
+            accepted = true;
+            break;
+          }
+        }
+        if (!accepted) {
+          throw cms::Exception("DisplacedParticleGunProducer")
+              << "Failed to generate a particle intersecting HGCAL front surface after MaxTries=" << fMaxTries
+              << ". Vertex: (R=" << RVtx << "cm, phiVtx=" << phiVtx << ", z=" << zVtx << "cm). HGCAL band: ["
+              << *fRminFrontSurfaceHGCAL << "," << *fRmaxFrontSurfaceHGCAL << "]cm at z=" << zFront << "cm.";
+        }
+      } else {  // if (fPointingToHGCAL)
+        theta = CLHEP::RandFlat::shoot(engine, fThetaMin.value(), fThetaMax.value());
+        phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
+        std::tie(px, py, pz) = computeMomentum(pt, theta, phi);
+      }
 
       const double p2 = px * px + py * py + pz * pz;
       const double energy = std::sqrt(p2 + mass * mass);
 
       HepMC::FourVector p(px, py, pz, energy);
 
-      HepMC::GenVertex* vtx = new HepMC::GenVertex(
-          HepMC::FourVector(xVtx * CLHEP::cm, yVtx * CLHEP::cm, zVtx * CLHEP::cm, 0.0));
+      HepMC::GenVertex* vtx =
+          new HepMC::GenVertex(HepMC::FourVector(xVtx * CLHEP::cm, yVtx * CLHEP::cm, zVtx * CLHEP::cm, 0.0));
 
       HepMC::GenParticle* part = new HepMC::GenParticle(p, partID, 1);
       part->suggest_barcode(barcode++);
@@ -345,17 +388,16 @@ namespace edm {
       vtx->add_particle_out(part);
       fEvt->add_vertex(vtx);
 
-	  if (fVerbosity > 0) {
+      if (fVerbosity > 0) {
         vtx->print();
         part->print();
       }
-
     }
 
     fEvt->set_event_number(e.id().event());
     fEvt->set_signal_process_id(20);
 
-	if (fVerbosity > 0) {
+    if (fVerbosity > 0) {
       fEvt->print();
     }
 
@@ -366,7 +408,7 @@ namespace edm {
     auto genEventInfo = std::make_unique<GenEventInfoProduct>(fEvt);
     e.put(std::move(genEventInfo));
 
-	if (fVerbosity > 0) {
+    if (fVerbosity > 0) {
       LogDebug("DisplacedParticleGunProducer") << " DisplacedParticleGunProducer : Event Generation Done " << std::endl;
     }
   }

--- a/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
@@ -146,8 +146,8 @@ namespace edm {
     //   (with R in [RminFrontSurfaceHGCAL, RmaxFrontSurfaceHGCAL]) and vertex rho
     // If false: sample theta uniformly in [MinTheta, MaxTheta]
     bool fPointingToHGCAL = true;
-    std::optional<double> fRminFrontSurfaceHGCAL = kHGCalRMin;
-    std::optional<double> fRmaxFrontSurfaceHGCAL = kHGCalRMax;
+    double fRminFrontSurfaceHGCAL = kHGCalRMin;
+    double fRmaxFrontSurfaceHGCAL = kHGCalRMax;
     std::optional<double> fThetaMin = 0.;
     std::optional<double> fThetaMax = 0.;
 
@@ -190,19 +190,9 @@ namespace edm {
       if (*fThetaMax <= *fThetaMin) {
         throw cms::Exception("DisplacedParticleGunProducer") << "Please ensure MinTheta <= MaxTheta.";
       }
-      fRminFrontSurfaceHGCAL = std::nullopt;
-      fRmaxFrontSurfaceHGCAL = std::nullopt;
     } else {
       fRminFrontSurfaceHGCAL = pgun.getParameter<double>("RminFrontSurfaceHGCAL");
       fRmaxFrontSurfaceHGCAL = pgun.getParameter<double>("RmaxFrontSurfaceHGCAL");
-      if (*fRmaxFrontSurfaceHGCAL <= *fRminFrontSurfaceHGCAL) {
-        throw cms::Exception("DisplacedParticleGunProducer")
-            << "Please ensure RmaxFrontSurfaceHGCAL > RminFrontSurfaceHGCAL.";
-      }
-      if (*fRmaxFrontSurfaceHGCAL > kHGCalRMax || *fRminFrontSurfaceHGCAL < kHGCalRMin) {
-        throw cms::Exception("DisplacedParticleGunProducer")
-            << "Please ensure RmaxFrontSurfaceHGCAL <= kHGCalRMax and RminFrontSurfaceHGCAL >= kHGCalRMin.";
-      }
       fThetaMin = std::nullopt;
       fThetaMax = std::nullopt;
     }
@@ -225,7 +215,15 @@ namespace edm {
     if (fMaxTries == 0) {
       throw cms::Exception("DisplacedParticleGunProducer") << "MaxTries must be > 0";
     }
-
+	if (fRmaxFrontSurfaceHGCAL <= fRminFrontSurfaceHGCAL) {
+	  throw cms::Exception("DisplacedParticleGunProducer")
+		<< "Please ensure RmaxFrontSurfaceHGCAL > RminFrontSurfaceHGCAL.";
+	}
+	if (fRmaxFrontSurfaceHGCAL > kHGCalRMax || fRminFrontSurfaceHGCAL < kHGCalRMin) {
+	  throw cms::Exception("DisplacedParticleGunProducer")
+		<< "Please ensure RmaxFrontSurfaceHGCAL <= kHGCalRMax and RminFrontSurfaceHGCAL >= kHGCalRMin.";
+	}
+	  
     produces<HepMCProduct>("unsmeared");
     produces<GenEventInfoProduct>();
   }
@@ -301,8 +299,8 @@ namespace edm {
     fEvt = new HepMC::GenEvent();
 
     const double zFront = kHGCalZ;
-    const double rMinFace = fRminFrontSurfaceHGCAL.value();
-    const double rMaxFace = fRmaxFrontSurfaceHGCAL.value();
+    const double rMinFace = fRminFrontSurfaceHGCAL;
+    const double rMaxFace = fRmaxFrontSurfaceHGCAL;
 
     if (fPointingToHGCAL) {
       if (!(rMaxFace > rMinFace) || zFront <= fZVtx) {
@@ -358,7 +356,7 @@ namespace edm {
           }
 
           if (hitsZPlaneWithinR(
-                  xVtx, yVtx, zVtx, px, py, pz, zFront, *fRminFrontSurfaceHGCAL, *fRmaxFrontSurfaceHGCAL)) {
+                  xVtx, yVtx, zVtx, px, py, pz, zFront, fRminFrontSurfaceHGCAL, fRmaxFrontSurfaceHGCAL)) {
             accepted = true;
             break;
           }
@@ -367,7 +365,7 @@ namespace edm {
           throw cms::Exception("DisplacedParticleGunProducer")
               << "Failed to generate a particle intersecting HGCAL front surface after MaxTries=" << fMaxTries
               << ". Vertex: (R=" << RVtx << "cm, phiVtx=" << phiVtx << ", z=" << zVtx << "cm). HGCAL band: ["
-              << *fRminFrontSurfaceHGCAL << "," << *fRmaxFrontSurfaceHGCAL << "]cm at z=" << zFront << "cm.";
+              << fRminFrontSurfaceHGCAL << "," << fRmaxFrontSurfaceHGCAL << "]cm at z=" << zFront << "cm.";
         }
       } else {  // if (fPointingToHGCAL)
         theta = CLHEP::RandFlat::shoot(engine, fThetaMin.value(), fThetaMax.value());

--- a/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
@@ -154,7 +154,7 @@ namespace edm {
     ESHandle<HepPDT::ParticleDataTable> fPDGTable;
     const ESGetToken<HepPDT::ParticleDataTable, edm::DefaultRecord> fPDGTableToken;
     HepMC::GenEvent* fEvt;
-    int fVerbosity;
+    int fVerbosity = 0;
   };
 
   DisplacedParticleGunProducer::DisplacedParticleGunProducer(const ParameterSet& pset)
@@ -303,11 +303,10 @@ namespace edm {
     const double rMaxFace = fRmaxFrontSurfaceHGCAL;
 
     if (fPointingToHGCAL) {
-      if (!(rMaxFace > rMinFace) || zFront <= fZVtx) {
+      if (zFront <= fZVtx) {
         throw cms::Exception("DisplacedParticleGunProducer")
             << "Invalid hard-coded HGCAL surface envelope: "
-            << "zFront =" << zFront << "cm, rMin =" << rMinFace << "cm, rMax=" << rMaxFace << "cm"
-            << " (check ZVtx).";
+            << "zFront = " << zFront << "cm, fZVtx = " << fZVtx << " (check ZVtx).";
       }
     }
 

--- a/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
@@ -24,6 +24,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
@@ -337,7 +338,7 @@ namespace edm {
             << "The logic that points particles to HGCAL's front face assumes that particles move in straight lines.";
       }
 
-      double theta = 0., phi = phiVtx, px = 0., py = 0., pz = 0.;
+      double theta = 0., phi = 0., px = 0., py = 0., pz = 0.;
       const double pt = CLHEP::RandFlat::shoot(engine, fPtMin, fPtMax);
       if (fPointingToHGCAL) {
         const double RVtx0 = std::hypot(xVtx, yVtx);
@@ -352,7 +353,7 @@ namespace edm {
           theta = CLHEP::RandFlat::shoot(engine, thetaMin, thetaMax);
           phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
           std::tie(px, py, pz) = computeMomentum(pt, theta, phi);
-          if (std::isnan(pz) || std::isinf(pz) || pz <= 0.0) {
+          if (edm::isNotFinite(pz) || pz <= 0.0) {
             continue;  // must go towards +z plane
           }
 

--- a/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
@@ -41,6 +41,7 @@ namespace edm {
 
 	// Hard-coded HGCAL CE-E back surface of layer 25/26
 	// or, equivalently, of front face of CE-E backplate absorber 1
+	// values in centimeters
     constexpr double kCeeBackZ = 362.18;
     constexpr double kCeeBackRMin = 31.36;
     constexpr double kCeeBackRMax = 164.67;
@@ -67,15 +68,16 @@ namespace edm {
                            double rMin,
                            double rMax) {
       // Must move towards the plane: require (zPlane - z0) / pz > 0
-      const double dz = zPlane - z0;
       if (pz < 1e-6) {
         return false;
       }
-      const double t = dz / pz;
+
+      const double t = (zPlane - z0) / pz;
       if (t <= 0.0) {
         return false;
       }
 
+	  // project (x, y) into the plane assuming straight trajectories
       const double xHit = x0 + t * px;
       const double yHit = y0 + t * py;
       const double rHit = std::hypot(xHit, yHit);
@@ -84,12 +86,14 @@ namespace edm {
     }
 
     // Compute the theta range (in radians) that intersects a plane at z=kCeeBackZ,
-    // within radial bounds [rMin, rMax], from a vertex at transverse radius R0 and z0.
+    // within radial bounds [rMin, rMax], from a vertex at transverse radius R and z.
     std::pair<double, double> thetaRangeToPointToHGCALSurface(
         double R, double z, double zHGCAL, double rminHGCAL, double rmaxHGCAL) {
       const double dz = zHGCAL - z;
       if (dz <= 0. or rminHGCAL > rmaxHGCAL) {
-        return {0., 0.};
+        throw cms::Exception("DisplacedParticleGunProducer")
+		  << "[thetaRangeToPointToHGCALSurface] Your coordinates are wrong: "
+		  << "zHGCAL=" << zHGCAL << "cm, z=" << z << "cm, rminHGCAL=" << rminHGCAL << "cm, rmaxHGCAL=" << rmaxHGCAL << ".";
       }
 
       double thetaMin = std::atan((rminHGCAL - R) / dz);
@@ -101,7 +105,11 @@ namespace edm {
       thetaMax = std::clamp(thetaMax, 1e-6, 0.5 * std::numbers::pi - 1e-6);
 
       if (thetaMax <= thetaMin) {
-        return {0., 0.};
+        throw cms::Exception("DisplacedParticleGunProducer")
+		  << "[thetaRangeToPointToHGCALSurface] Your theta limits are wrong: "
+		  << "thetaMax=" << thetaMax << ", thetaMin=" << thetaMin << ", "
+		  << "with rminHGCAL=" << rminHGCAL << "cm, rmaxHGCAL=" << rminHGCAL << "cm, R="
+		  << R << "cm, zHGCAL=" << zHGCAL << "cm, z=" << z << "cm." << std::endl;
       }
       return {thetaMin, thetaMax};
     }
@@ -110,8 +118,9 @@ namespace edm {
       double px = pt * std::cos(phi);
       double py = pt * std::sin(phi);
       double pz = 0.;
+	  std::cout << theta << std::endl;
       if (theta < 1e-6) {
-        throw cms::Exception("DisplacedParticleGunProducer") << "Theta is too small. Unstable pz.";
+        throw cms::Exception("DisplacedParticleGunProducer") << "Theta is too small: " << theta << ". Unstable pz.";
       } else {
         pz = pt / std::tan(theta);
       }
@@ -144,7 +153,7 @@ namespace edm {
     double fPhiVtxMax = 0.;
     double fZVtx = 0.;
     int fNParticles = 1;
-    std::vector<int> fPartIDs;
+    int fPartID;
     bool fUniformDensityInR = false;
     unsigned int fMaxTries = 1000;
 
@@ -159,12 +168,11 @@ namespace edm {
 
     ESHandle<HepPDT::ParticleDataTable> fPDGTable;
     const ESGetToken<HepPDT::ParticleDataTable, edm::DefaultRecord> fPDGTableToken;
-    HepMC::GenEvent* fEvt;
     int fVerbosity = 0;
   };
 
   DisplacedParticleGunProducer::DisplacedParticleGunProducer(const ParameterSet& pset)
-      : fPDGTableToken(esConsumes<Transition::BeginRun>()), fEvt(nullptr) {
+      : fPDGTableToken(esConsumes<Transition::BeginRun>()) {
     Service<RandomNumberGenerator> rng;
     if (!rng.isAvailable()) {
       throw cms::Exception("Configuration")
@@ -185,7 +193,7 @@ namespace edm {
     fRMax = pgun.getParameter<double>("RMax");
     fZVtx = pgun.getParameter<double>("ZVtx");
     fNParticles = pgun.getParameter<int>("NParticles");
-    fPartIDs = pgun.getParameter<std::vector<int>>("PartID");
+    fPartID = pgun.getParameter<int>("PartID");
     fUniformDensityInR = pgun.getParameter<bool>("UniformDensityInR");
     fMaxTries = pgun.getParameter<unsigned int>("MaxTries");
     fPointingToHGCAL = pgun.getParameter<bool>("PointingToHGCAL");
@@ -214,9 +222,6 @@ namespace edm {
     }
     if (fRMax <= fRMin) {
       throw cms::Exception("DisplacedParticleGunProducer") << "Please fix RMin/RMax";
-    }
-    if (fPartIDs.empty()) {
-      throw cms::Exception("DisplacedParticleGunProducer") << "PartID must be non-empty";
     }
     if (fMaxTries == 0) {
       throw cms::Exception("DisplacedParticleGunProducer") << "MaxTries must be > 0";
@@ -263,7 +268,7 @@ namespace edm {
     pgun.add<double>("ZVtx", 0.);
 
     pgun.add<int>("NParticles", 1);
-    pgun.add<std::vector<int>>("PartID", {22});
+    pgun.add<int>("PartID", 22);
 
     pgun.add<bool>("UniformDensityInR", false);
 
@@ -302,7 +307,7 @@ namespace edm {
           << " DisplacedParticleGunProducer : Begin New Event Generation" << std::endl;
     }
 
-    fEvt = new HepMC::GenEvent();
+    std::unique_ptr<HepMC::GenEvent> fEvt = std::make_unique<HepMC::GenEvent>();
 
     if (fPointingToHGCAL) {
       if (kCeeBackZ <= fZVtx) {
@@ -321,14 +326,10 @@ namespace edm {
       const double phiVtx = CLHEP::RandFlat::shoot(engine, fPhiVtxMin, fPhiVtxMax);
       const double xVtx = RVtx * std::cos(phiVtx);
       const double yVtx = RVtx * std::sin(phiVtx);
-      const double zVtx = fZVtx;
 
-      const auto idx = static_cast<std::size_t>(CLHEP::RandFlat::shoot(engine, 0, fPartIDs.size()));
-      const int partID = fPartIDs[idx];
-
-      const HepPDT::ParticleData* pData = fPDGTable->particle(HepPDT::ParticleID(std::abs(partID)));
+      const HepPDT::ParticleData* pData = fPDGTable->particle(HepPDT::ParticleID(std::abs(fPartID)));
       if (!pData) {
-        throw cms::Exception("DisplacedParticleGunProducer") << "Particle ID " << partID << " not found in PDG table";
+        throw cms::Exception("DisplacedParticleGunProducer") << "Particle ID " << fPartID << " not found in PDG table";
       }
       const double mass = pData->mass().value();
 
@@ -340,7 +341,7 @@ namespace edm {
       double theta = 0., phi = 0., px = 0., py = 0., pz = 0.;
       const double pt = CLHEP::RandFlat::shoot(engine, fPtMin, fPtMax);
       if (fPointingToHGCAL) {
-        auto [thetaMin, thetaMax] = thetaRangeToPointToHGCALSurface(RVtx, zVtx,
+        auto [thetaMin, thetaMax] = thetaRangeToPointToHGCALSurface(RVtx, fZVtx,
 																	kCeeBackZ, fRminBackSurfaceHGCAL, fRmaxBackSurfaceHGCAL);
         if (!(thetaMax >= thetaMin)) {
           throw cms::Exception("DisplacedParticleGunProducer")
@@ -357,7 +358,7 @@ namespace edm {
           }
 
           if (hitsZPlaneWithinR(
-                  xVtx, yVtx, zVtx, px, py, pz, kCeeBackZ, fRminBackSurfaceHGCAL, fRmaxBackSurfaceHGCAL)) {
+                  xVtx, yVtx, fZVtx, px, py, pz, kCeeBackZ, fRminBackSurfaceHGCAL, fRmaxBackSurfaceHGCAL)) {
             accepted = true;
             break;
           }
@@ -365,10 +366,10 @@ namespace edm {
         if (!accepted) {
           throw cms::Exception("DisplacedParticleGunProducer")
               << "Failed to generate a particle intersecting HGCAL CE-E back surface after MaxTries=" << fMaxTries
-              << ". Vertex: (R=" << RVtx << "cm, phiVtx=" << phiVtx << ", z=" << zVtx << "cm). HGCAL band: ["
+              << ". Vertex: (R=" << RVtx << "cm, phiVtx=" << phiVtx << ", z=" << fZVtx << "cm). HGCAL band: ["
               << fRminBackSurfaceHGCAL << "," << fRmaxBackSurfaceHGCAL << "]cm at z=" << kCeeBackZ << "cm.";
         }
-      } else {  // if (fPointingToHGCAL)
+      } else {  // if (!fPointingToHGCAL)
         theta = CLHEP::RandFlat::shoot(engine, fThetaMin.value(), fThetaMax.value());
         phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
         std::tie(px, py, pz) = computeMomentum(pt, theta, phi);
@@ -380,9 +381,9 @@ namespace edm {
       HepMC::FourVector p(px, py, pz, energy);
 
       HepMC::GenVertex* vtx =
-          new HepMC::GenVertex(HepMC::FourVector(xVtx * CLHEP::cm, yVtx * CLHEP::cm, zVtx * CLHEP::cm, 0.0));
+          new HepMC::GenVertex(HepMC::FourVector(xVtx * CLHEP::cm, yVtx * CLHEP::cm, fZVtx * CLHEP::cm, 0.0));
 
-      HepMC::GenParticle* part = new HepMC::GenParticle(p, partID, 1);
+      HepMC::GenParticle* part = new HepMC::GenParticle(p, fPartID, 1);
       part->suggest_barcode(barcode++);
 
       vtx->add_particle_out(part);
@@ -401,12 +402,12 @@ namespace edm {
       fEvt->print();
     }
 
-    auto bProduct = std::make_unique<HepMCProduct>();
-    bProduct->addHepMCData(fEvt);
-    e.put(std::move(bProduct), "unsmeared");
-
-    auto genEventInfo = std::make_unique<GenEventInfoProduct>(fEvt);
+	auto genEventInfo = std::make_unique<GenEventInfoProduct>(fEvt.get()); // does not transfer pointer ownership to GenEventInfoProduct
     e.put(std::move(genEventInfo));
+
+    auto bProduct = std::make_unique<HepMCProduct>();
+    bProduct->addHepMCData(fEvt.release()); // transfer pointer ownership to HepMCProduct
+    e.put(std::move(bProduct), "unsmeared");
 
     if (fVerbosity > 0) {
       LogDebug("DisplacedParticleGunProducer") << " DisplacedParticleGunProducer : Event Generation Done " << std::endl;

--- a/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
@@ -17,8 +17,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/Run.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -26,7 +25,6 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
-#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 
@@ -34,14 +32,9 @@ namespace edm {
 
   namespace {
 
-    // Hard-coded HGCAL front surface
-    // constexpr double kHGCalZ = 296.50;
-    // constexpr double kHGCalRMin = 26.00;
-    // constexpr double kHGCalRMax = 124.37;
-
-	// Hard-coded HGCAL CE-E back surface of layer 25/26
-	// or, equivalently, of front face of CE-E backplate absorber 1
-	// values in centimeters
+    // Hard-coded HGCAL CE-E back surface of layer 25/26
+    // or, equivalently, of front face of CE-E backplate absorber 1
+    // values in centimeters
     constexpr double kCeeBackZ = 362.18;
     constexpr double kCeeBackRMin = 31.36;
     constexpr double kCeeBackRMax = 164.67;
@@ -66,52 +59,68 @@ namespace edm {
                            double pz,  // particle momentum
                            double zPlane,
                            double rMin,
-                           double rMax) {
-      // Must move towards the plane: require (zPlane - z0) / pz > 0
-      if (pz < 1e-6) {
-        return false;
-      }
-
+                           double rMax,
+                           int verbose) {
       const double t = (zPlane - z0) / pz;
       if (t <= 0.0) {
         return false;
       }
 
-	  // project (x, y) into the plane assuming straight trajectories
+      // project (x, y) into the plane assuming straight trajectories
       const double xHit = x0 + t * px;
       const double yHit = y0 + t * py;
       const double rHit = std::hypot(xHit, yHit);
 
+      if (verbose > 0) {
+        std::cout << "hitsZPlaneWithin " << " | return=" << static_cast<int>(rHit >= rMin && rHit <= rMax)
+                  << " | rHit=" << rHit << ", rMin=" << rMin << ", rMax=" << rMax << ", t=" << t
+                  << ", zPlane=" << zPlane << ", z0=" << z0 << ", pz=" << pz << std::endl;
+      }
+
       return (rHit >= rMin && rHit <= rMax);
+    }
+
+    // ensures theta is never too close to zero, which makes the computation of pz unstable
+    double pickSensibleTheta(CLHEP::HepRandomEngine* eng, double amin, double amax) {
+      double theta = 0.;
+      while (std::abs(theta) < 1e-6) {
+        theta = CLHEP::RandFlat::shoot(eng, amin, amax);
+      }
+      return theta;
     }
 
     std::tuple<double, double, double> computeMomentum(double pt, double theta, double phi) {
       double px = pt * std::cos(phi);
       double py = pt * std::sin(phi);
       double pz = 0.;
-      if (theta < 1e-6) {
-        throw cms::Exception("DisplacedParticleGunProducer") << "Theta is too small: " << theta << ". Unstable pz.";
-      } else {
-        pz = pt / std::tan(theta);
+      if (std::abs(theta) < 1e-6) {
+        throw cms::Exception("DisplacedParticleGunProducer")
+            << "Theta is too close to zero: " << theta << ". Unstable pz.";
       }
+
+      pz = pt / std::abs(std::tan(theta));
+
+      // shoot the particle along the same plane but in the negative theta direction
+      // reminder: theta is measured from the x axis in counter-clockwise fashion
+      if (theta < 0.) {
+        px = -px;
+        py = -py;
+      }
+
       return {px, py, pz};
     }
 
   }  // namespace
 
-  class DisplacedParticleGunProducer : public one::EDProducer<one::WatchRuns, EndRunProducer> {
+  class DisplacedParticleGunProducer : public edm::global::EDProducer<> {
   public:
     explicit DisplacedParticleGunProducer(const ParameterSet&);
     ~DisplacedParticleGunProducer() override = default;
 
-    void beginRun(const edm::Run& r, const edm::EventSetup&) override;
-    void endRun(edm::Run const& r, const edm::EventSetup&) override;
-    void endRunProduce(edm::Run& r, const edm::EventSetup&) override;
-
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
-    void produce(Event& e, const EventSetup& es) override;
+    void produce(edm::StreamID, edm::Event& e, const edm::EventSetup& es) const override;
 
     double fPtMin = 0.;
     double fPtMax = 0.;
@@ -128,21 +137,23 @@ namespace edm {
     unsigned int fMaxTries = 1000;
 
     // If true: derive theta range from hard-coded HGCAL CE-E back surface envelope
-    //   (with R in [RminBackSurfaceHGCAL, RmaxBackSurfaceHGCAL]) and vertex rho
+    //   (with R in [RMinBackSurfaceHGCAL, RMaxBackSurfaceHGCAL]) and vertex rho
     // If false: sample theta uniformly in [MinTheta, MaxTheta]
     bool fPointingToHGCAL = true;
-    double fRminBackSurfaceHGCAL = kCeeBackRMin;
-    double fRmaxBackSurfaceHGCAL = kCeeBackRMax;
+    bool fRestrictRInZPlaneAtZero = true;
+    double fRMinBackSurfaceHGCAL = kCeeBackRMin;
+    double fRMaxBackSurfaceHGCAL = kCeeBackRMax;
     double fThetaMin = 0.;
     double fThetaMax = 0.;
+    std::optional<double> fRMinAtZero = std::nullopt;
+    std::optional<double> fRMaxAtZero = std::nullopt;
 
-    ESHandle<HepPDT::ParticleDataTable> fPDGTable;
     const ESGetToken<HepPDT::ParticleDataTable, edm::DefaultRecord> fPDGTableToken;
     int fVerbosity = 0;
   };
 
   DisplacedParticleGunProducer::DisplacedParticleGunProducer(const ParameterSet& pset)
-      : fPDGTableToken(esConsumes<Transition::BeginRun>()) {
+      : fPDGTableToken(esConsumes<>()) {
     Service<RandomNumberGenerator> rng;
     if (!rng.isAvailable()) {
       throw cms::Exception("Configuration")
@@ -157,8 +168,8 @@ namespace edm {
     fPtMax = pgun.getParameter<double>("MaxPt");
     fPhiMin = pgun.getParameter<double>("MinPhi");
     fPhiMax = pgun.getParameter<double>("MaxPhi");
-	fThetaMin = pgun.getParameter<double>("MinTheta");
-	fThetaMax = pgun.getParameter<double>("MaxTheta");
+    fThetaMin = pgun.getParameter<double>("MinTheta");
+    fThetaMax = pgun.getParameter<double>("MaxTheta");
     fPhiVtxMin = pgun.getParameter<double>("MinVtxPhi");
     fPhiVtxMax = pgun.getParameter<double>("MaxVtxPhi");
     fRMin = pgun.getParameter<double>("RMin");
@@ -168,11 +179,29 @@ namespace edm {
     fPartID = pgun.getParameter<int>("PartID");
     fUniformDensityInR = pgun.getParameter<bool>("UniformDensityInR");
     fMaxTries = pgun.getParameter<unsigned int>("MaxTries");
+    fVerbosity = pset.getUntrackedParameter<int>("Verbosity");
     fPointingToHGCAL = pgun.getParameter<bool>("PointingToHGCAL");
+    fRestrictRInZPlaneAtZero = pgun.getParameter<bool>("RestrictRInZPlaneAtZero");
+
+    if (fRestrictRInZPlaneAtZero && !fPointingToHGCAL) {
+      throw cms::Exception("DisplacedParticleGunProducer")
+          << "Currently RestrictRInZPlaneAtZero only works if PointingToHGCAL is active.";
+    }
 
     if (fPointingToHGCAL) {
-      fRminBackSurfaceHGCAL = pgun.getParameter<double>("RminBackSurfaceHGCAL");
-      fRmaxBackSurfaceHGCAL = pgun.getParameter<double>("RmaxBackSurfaceHGCAL");
+      fRMinBackSurfaceHGCAL = pgun.getParameter<double>("RMinBackSurfaceHGCAL");
+      fRMaxBackSurfaceHGCAL = pgun.getParameter<double>("RMaxBackSurfaceHGCAL");
+    }
+
+    if (fRestrictRInZPlaneAtZero) {
+      fRMinAtZero = pgun.getParameter<double>("RMinAtZero");
+      fRMaxAtZero = pgun.getParameter<double>("RMaxAtZero");
+      if (fRMaxAtZero <= fRMinAtZero) {
+        throw cms::Exception("DisplacedParticleGunProducer") << "Please fix RMaxAtZero/RMinAtZero";
+      }
+      if (fRMinAtZero < 0.) {
+        throw cms::Exception("DisplacedParticleGunProducer") << "RMinAtZero must be positive.";
+      }
     }
 
     if (fPtMax <= fPtMin) {
@@ -181,39 +210,38 @@ namespace edm {
     if (fPhiMax <= fPhiMin) {
       throw cms::Exception("DisplacedParticleGunProducer") << "Please fix MinPhi/MaxPhi";
     }
-	if (fThetaMax <= fThetaMin) {
-	  throw cms::Exception("DisplacedParticleGunProducer") << "Please ensure MinTheta <= MaxTheta.";
-	}
+    if (fThetaMax <= fThetaMin) {
+      throw cms::Exception("DisplacedParticleGunProducer") << "Please ensure MinTheta <= MaxTheta.";
+    }
     if (fPhiVtxMax <= fPhiVtxMin) {
       throw cms::Exception("DisplacedParticleGunProducer") << "Please fix MinVtxPhi/MaxVtxPhi";
     }
     if (fRMax <= fRMin) {
       throw cms::Exception("DisplacedParticleGunProducer") << "Please fix RMin/RMax";
     }
+    if (fRestrictRInZPlaneAtZero && fPointingToHGCAL && fRMax > fRMaxAtZero && fRMax > fRMaxBackSurfaceHGCAL) {
+      throw cms::Exception("DisplacedParticleGunProducer")
+          << "There are values of R at z=" << fZVtx << "cm for which an intersection for R in [" << *fRMinAtZero << "; "
+          << *fRMaxAtZero << "]cm at z=0cm is impossible. Please update your configuration.";
+    }
+    if (fRMin < 0) {
+      throw cms::Exception("DisplacedParticleGunProducer") << "RMin must be positive.";
+    }
     if (fMaxTries == 0) {
       throw cms::Exception("DisplacedParticleGunProducer") << "MaxTries must be > 0";
     }
-	if (fRmaxBackSurfaceHGCAL <= fRminBackSurfaceHGCAL) {
-	  throw cms::Exception("DisplacedParticleGunProducer")
-		<< "Please ensure RmaxBackSurfaceHGCAL > RminBackSurfaceHGCAL.";
-	}
-	if (fRmaxBackSurfaceHGCAL > kCeeBackRMax || fRminBackSurfaceHGCAL < kCeeBackRMin) {
-	  throw cms::Exception("DisplacedParticleGunProducer")
-		<< "Please ensure RmaxBackSurfaceHGCAL <= kCeeBackRMax and RminBackSurfaceHGCAL >= kCeeBackRMin.";
-	}
-	  
+    if (fRMaxBackSurfaceHGCAL <= fRMinBackSurfaceHGCAL) {
+      throw cms::Exception("DisplacedParticleGunProducer")
+          << "Please ensure RMaxBackSurfaceHGCAL > RMinBackSurfaceHGCAL.";
+    }
+    if (fRMaxBackSurfaceHGCAL > kCeeBackRMax || fRMinBackSurfaceHGCAL < kCeeBackRMin) {
+      throw cms::Exception("DisplacedParticleGunProducer")
+          << "Please ensure RMaxBackSurfaceHGCAL <= kCeeBackRMax and RMinBackSurfaceHGCAL >= kCeeBackRMin.";
+    }
+
     produces<HepMCProduct>("unsmeared");
     produces<GenEventInfoProduct>();
   }
-
-  void DisplacedParticleGunProducer::beginRun(const edm::Run& r, const EventSetup& es) {
-    fPDGTable = es.getHandle(fPDGTableToken);
-    return;
-  }
-
-  void DisplacedParticleGunProducer::endRun(const Run& run, const EventSetup& es) {}
-
-  void DisplacedParticleGunProducer::endRunProduce(Run& run, const EventSetup& es) {}
 
   void DisplacedParticleGunProducer::fillDescriptions(ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
@@ -242,30 +270,32 @@ namespace edm {
     pgun.add<unsigned int>("MaxTries", 1000u);
 
     // A particle shot at the extremities of the HGCAL surface will not traverse a substantial fraction of the detector.
-    // We use RminBackSurfaceHGCAL and RmaxBackSurfaceHGCAL to expose only a given region of the HGCAL surface
-    // THe default arguments correspond to the inner third of HGCAL's surface (R in ~[58.79, 91.58]cm).
+    // We use RMinBackSurfaceHGCAL and RMaxBackSurfaceHGCAL to expose only a given region of the HGCAL surface
+    // The default arguments correspond to the inner third of HGCAL's surface (R in ~[58.79, 91.58]cm).
     // At (R=200,z=0)cm, an uncharged particle pointing to R=58.79cm at the HGCAL surface (the most extreme case) exits the calorimeter at the
     //  back face of the CE-E, crossing all its layers.
     // For R>200cm there is no guarantee all CE-E layers will be crossed, so a tighter R range might be needed.
     // For z>0cm the angles will become more extreme, so a tighter R range might be needed.
     // The above reasoning breaks for charged particles, since the bending under the magnetic filed can enormously extend the particle's reach.
     pgun.add<bool>("PointingToHGCAL", true);
-    pgun.addOptionalNode(edm::ParameterDescription<double>("RminBackSurfaceHGCAL", 58.79, true), true);
-    pgun.addOptionalNode(edm::ParameterDescription<double>("RmaxBackSurfaceHGCAL", 91.58, true), true);
-    pgun.addOptionalNode(edm::ParameterDescription<double>("MinTheta", 0.2, true), true);
-    pgun.addOptionalNode(edm::ParameterDescription<double>("MaxTheta", 1.2, true), true);
+    pgun.add<double>("RMinBackSurfaceHGCAL", 58.79);
+    pgun.add<double>("RMaxBackSurfaceHGCAL", 91.58);
+    pgun.add<double>("MinTheta", -std::numbers::pi / 2 + 1e-6);
+    pgun.add<double>("MaxTheta", std::numbers::pi / 2 - 1e-6);
+
+    pgun.add<bool>("RestrictRInZPlaneAtZero", true);
+    pgun.addOptionalNode(edm::ParameterDescription<double>("RMinAtZero", 0., true), true);
+    pgun.addOptionalNode(edm::ParameterDescription<double>("RMaxAtZero", 150., true), true);
 
     desc.add<edm::ParameterSetDescription>("PGunParameters", pgun);
 
     desc.addUntracked<int>("Verbosity", 0);
     desc.addUntracked<unsigned int>("firstRun", 1);
-    desc.add<std::string>("psethack",
-                          "displaced gun with theta, optionally pointing to hard-coded HGCAL CE-E back surface");
 
     descriptions.add("DisplacedParticleGunProducer", desc);
   }
 
-  void DisplacedParticleGunProducer::produce(Event& e, const EventSetup& /*es*/) {
+  void DisplacedParticleGunProducer::produce(edm::StreamID, edm::Event& e, const edm::EventSetup& es) const {
     edm::Service<edm::RandomNumberGenerator> rng;
     CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
 
@@ -274,7 +304,7 @@ namespace edm {
           << " DisplacedParticleGunProducer : Begin New Event Generation" << std::endl;
     }
 
-    std::unique_ptr<HepMC::GenEvent> fEvt = std::make_unique<HepMC::GenEvent>();
+    HepMC::GenEvent* fEvt = new HepMC::GenEvent();
 
     if (fPointingToHGCAL) {
       if (kCeeBackZ <= fZVtx) {
@@ -294,31 +324,42 @@ namespace edm {
       const double xVtx = RVtx * std::cos(phiVtx);
       const double yVtx = RVtx * std::sin(phiVtx);
 
-      const HepPDT::ParticleData* pData = fPDGTable->particle(HepPDT::ParticleID(std::abs(fPartID)));
+      auto const& pdgTable = es.getData(fPDGTableToken);
+      const HepPDT::ParticleData* pData = pdgTable.particle(HepPDT::ParticleID(std::abs(fPartID)));
       if (!pData) {
         throw cms::Exception("DisplacedParticleGunProducer") << "Particle ID " << fPartID << " not found in PDG table";
       }
       const double mass = pData->mass().value();
 
       if (pData->charge() != 0 && fPointingToHGCAL) {
-        throw cms::Exception("DisplacedParticleGunProducer")
-            << "The logic that points particles to HGCAL's CE-E back face assumes that particles move in straight lines.";
+        throw cms::Exception("DisplacedParticleGunProducer") << "The logic that points particles to HGCAL's CE-E back "
+                                                                "face assumes that particles move in straight lines.";
       }
 
-      double theta = 0., phi = 0., px = 0., py = 0., pz = 0.;
+      double theta = 0., px = 0., py = 0., pz = 0.;
+      double phi = phiVtx; /* the particle's direction has the same phi as its vertex, ie.,
+							  it moves on a 2D plane parallel to the z axis */
       const double pt = CLHEP::RandFlat::shoot(engine, fPtMin, fPtMax);
-      if (fPointingToHGCAL) {				  
+      if (fPointingToHGCAL) {
         bool accepted = false;
         for (unsigned int itry = 0; itry < fMaxTries; ++itry) {
-          theta = CLHEP::RandFlat::shoot(engine, fThetaMin, fThetaMax);
-          phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
+          theta = pickSensibleTheta(engine, fThetaMin, fThetaMax);
           std::tie(px, py, pz) = computeMomentum(pt, theta, phi);
           if (edm::isNotFinite(pz) || pz <= 0.0) {
             continue;  // must go towards +z plane
           }
+          if (fVerbosity > 0) {
+            std::cout << "phiVtx=" << phiVtx << ", RVtx=" << RVtx << ", pT=" << pt << ", theta=" << theta
+                      << ", phi=" << phi << std::endl;
+          }
 
-          if (hitsZPlaneWithinR(
-                  xVtx, yVtx, fZVtx, px, py, pz, kCeeBackZ, fRminBackSurfaceHGCAL, fRmaxBackSurfaceHGCAL)) {
+          bool checkBackSurface = hitsZPlaneWithinR(
+              xVtx, yVtx, fZVtx, px, py, pz, kCeeBackZ, fRMinBackSurfaceHGCAL, fRMaxBackSurfaceHGCAL, fVerbosity);
+          bool checkZero =
+              fRestrictRInZPlaneAtZero &&
+              hitsZPlaneWithinR(
+                  xVtx, yVtx, fZVtx, -px, -py, -pz, 0., fRMinAtZero.value(), fRMaxAtZero.value(), fVerbosity);
+          if (checkBackSurface && checkZero) {
             accepted = true;
             break;
           }
@@ -326,11 +367,12 @@ namespace edm {
         if (!accepted) {
           throw cms::Exception("DisplacedParticleGunProducer")
               << "Failed to generate a particle intersecting HGCAL CE-E back surface after MaxTries=" << fMaxTries
-              << ". Vertex: (R=" << RVtx << "cm, phiVtx=" << phiVtx << ", z=" << fZVtx << "cm). HGCAL band: ["
-              << fRminBackSurfaceHGCAL << "," << fRmaxBackSurfaceHGCAL << "]cm at z=" << kCeeBackZ << "cm.";
+              << ". Vertex located at: (R=" << RVtx << "cm, phiVtx=" << phiVtx << ", z=" << fZVtx
+              << "cm). HGCAL band located at R in [" << fRMinBackSurfaceHGCAL << "; " << fRMaxBackSurfaceHGCAL
+              << "]cm at z=" << kCeeBackZ << "cm.";
         }
       } else {  // if (!fPointingToHGCAL)
-        theta = CLHEP::RandFlat::shoot(engine, fThetaMin, fThetaMax);
+        theta = pickSensibleTheta(engine, fThetaMin, fThetaMax);
         phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
         std::tie(px, py, pz) = computeMomentum(pt, theta, phi);
       }
@@ -362,15 +404,15 @@ namespace edm {
       fEvt->print();
     }
 
-	auto genEventInfo = std::make_unique<GenEventInfoProduct>(fEvt.get()); // does not transfer pointer ownership to GenEventInfoProduct
-    e.put(std::move(genEventInfo));
-
     auto bProduct = std::make_unique<HepMCProduct>();
-    bProduct->addHepMCData(fEvt.release()); // transfer pointer ownership to HepMCProduct
+    bProduct->addHepMCData(fEvt);
     e.put(std::move(bProduct), "unsmeared");
 
+    auto genEventInfo = std::make_unique<GenEventInfoProduct>(fEvt);
+    e.put(std::move(genEventInfo));
+
     if (fVerbosity > 0) {
-      LogDebug("DisplacedParticleGunProducer") << " DisplacedParticleGunProducer : Event Generation Done " << std::endl;
+      std::cout << " DisplacedParticleGunProducer : Event Generation Done. " << std::endl;
     }
   }
 

--- a/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
@@ -34,10 +34,16 @@ namespace edm {
 
   namespace {
 
-    // --- Hard-coded HGCAL front surface ---
-    constexpr double kHGCalZ = 296.50;
-    constexpr double kHGCalRMin = 26.00;
-    constexpr double kHGCalRMax = 124.37;
+    // Hard-coded HGCAL front surface
+    // constexpr double kHGCalZ = 296.50;
+    // constexpr double kHGCalRMin = 26.00;
+    // constexpr double kHGCalRMax = 124.37;
+
+	// Hard-coded HGCAL CE-E back surface of layer 25/26
+	// or, equivalently, of front face of CE-E backplate absorber 1
+    constexpr double kCeeBackZ = 362.18;
+    constexpr double kCeeBackRMin = 31.36;
+    constexpr double kCeeBackRMax = 164.67;
 
     // Sample r uniformly in area between [rmin, rmax] (uniform point density)
     double shootUniformDensity(CLHEP::HepRandomEngine* eng, double rmin, double rmax) {
@@ -50,7 +56,7 @@ namespace edm {
       return CLHEP::RandFlat::shoot(eng, rmin, rmax);
     }
 
-    // Ensure the particle hits HGCAL's front surface within [rMin; rMax]
+    // Ensure the particle hits HGCAL's CE-E back surface within [rMin; rMax]
     bool hitsZPlaneWithinR(double x0,
                            double y0,
                            double z0,  // vertex coordinates
@@ -59,7 +65,7 @@ namespace edm {
                            double pz,  // particle momentum
                            double zPlane,
                            double rMin,
-                           double rMax) {  // hard-coded HGCAL geometry
+                           double rMax) {
       // Must move towards the plane: require (zPlane - z0) / pz > 0
       const double dz = zPlane - z0;
       if (pz < 1e-6) {
@@ -77,7 +83,7 @@ namespace edm {
       return (rHit >= rMin && rHit <= rMax);
     }
 
-    // Compute the theta range (in radians) that intersects a plane at z=zFront,
+    // Compute the theta range (in radians) that intersects a plane at z=kCeeBackZ,
     // within radial bounds [rMin, rMax], from a vertex at transverse radius R0 and z0.
     std::pair<double, double> thetaRangeToPointToHGCALSurface(
         double R, double z, double zHGCAL, double rminHGCAL, double rmaxHGCAL) {
@@ -142,12 +148,12 @@ namespace edm {
     bool fUniformDensityInR = false;
     unsigned int fMaxTries = 1000;
 
-    // If true: derive theta range from hard-coded HGCAL front surface envelope
-    //   (with R in [RminFrontSurfaceHGCAL, RmaxFrontSurfaceHGCAL]) and vertex rho
+    // If true: derive theta range from hard-coded HGCAL CE-E back surface envelope
+    //   (with R in [RminBackSurfaceHGCAL, RmaxBackSurfaceHGCAL]) and vertex rho
     // If false: sample theta uniformly in [MinTheta, MaxTheta]
     bool fPointingToHGCAL = true;
-    double fRminFrontSurfaceHGCAL = kHGCalRMin;
-    double fRmaxFrontSurfaceHGCAL = kHGCalRMax;
+    double fRminBackSurfaceHGCAL = kCeeBackRMin;
+    double fRmaxBackSurfaceHGCAL = kCeeBackRMax;
     std::optional<double> fThetaMin = 0.;
     std::optional<double> fThetaMax = 0.;
 
@@ -191,8 +197,8 @@ namespace edm {
         throw cms::Exception("DisplacedParticleGunProducer") << "Please ensure MinTheta <= MaxTheta.";
       }
     } else {
-      fRminFrontSurfaceHGCAL = pgun.getParameter<double>("RminFrontSurfaceHGCAL");
-      fRmaxFrontSurfaceHGCAL = pgun.getParameter<double>("RmaxFrontSurfaceHGCAL");
+      fRminBackSurfaceHGCAL = pgun.getParameter<double>("RminBackSurfaceHGCAL");
+      fRmaxBackSurfaceHGCAL = pgun.getParameter<double>("RmaxBackSurfaceHGCAL");
       fThetaMin = std::nullopt;
       fThetaMax = std::nullopt;
     }
@@ -215,13 +221,13 @@ namespace edm {
     if (fMaxTries == 0) {
       throw cms::Exception("DisplacedParticleGunProducer") << "MaxTries must be > 0";
     }
-	if (fRmaxFrontSurfaceHGCAL <= fRminFrontSurfaceHGCAL) {
+	if (fRmaxBackSurfaceHGCAL <= fRminBackSurfaceHGCAL) {
 	  throw cms::Exception("DisplacedParticleGunProducer")
-		<< "Please ensure RmaxFrontSurfaceHGCAL > RminFrontSurfaceHGCAL.";
+		<< "Please ensure RmaxBackSurfaceHGCAL > RminBackSurfaceHGCAL.";
 	}
-	if (fRmaxFrontSurfaceHGCAL > kHGCalRMax || fRminFrontSurfaceHGCAL < kHGCalRMin) {
+	if (fRmaxBackSurfaceHGCAL > kCeeBackRMax || fRminBackSurfaceHGCAL < kCeeBackRMin) {
 	  throw cms::Exception("DisplacedParticleGunProducer")
-		<< "Please ensure RmaxFrontSurfaceHGCAL <= kHGCalRMax and RminFrontSurfaceHGCAL >= kHGCalRMin.";
+		<< "Please ensure RmaxBackSurfaceHGCAL <= kCeeBackRMax and RminBackSurfaceHGCAL >= kCeeBackRMin.";
 	}
 	  
     produces<HepMCProduct>("unsmeared");
@@ -264,7 +270,7 @@ namespace edm {
     pgun.add<unsigned int>("MaxTries", 1000u);
 
     // A particle shot at the extremities of the HGCAL surface will not traverse a substantial fraction of the detector.
-    // We use RminFrontSurfaceHGCAL and RmaxFrontSurfaceHGCAL to expose only a given region of the HGCAL surface
+    // We use RminBackSurfaceHGCAL and RmaxBackSurfaceHGCAL to expose only a given region of the HGCAL surface
     // THe default arguments correspond to the inner third of HGCAL's surface (R in ~[58.79, 91.58]cm).
     // At (R=200,z=0)cm, an uncharged particle pointing to R=58.79cm at the HGCAL surface (the most extreme case) exits the calorimeter at the
     //  back face of the CE-E, crossing all its layers.
@@ -272,8 +278,8 @@ namespace edm {
     // For z>0cm the angles will become more extreme, so a tighter R range might be needed.
     // The above reasoning breaks for charged particles, since the bending under the magnetic filed can enormously extend the particle's reach.
     pgun.add<bool>("PointingToHGCAL", true);
-    pgun.addOptionalNode(edm::ParameterDescription<double>("RminFrontSurfaceHGCAL", 58.79, true), true);
-    pgun.addOptionalNode(edm::ParameterDescription<double>("RmaxFrontSurfaceHGCAL", 91.58, true), true);
+    pgun.addOptionalNode(edm::ParameterDescription<double>("RminBackSurfaceHGCAL", 58.79, true), true);
+    pgun.addOptionalNode(edm::ParameterDescription<double>("RmaxBackSurfaceHGCAL", 91.58, true), true);
     pgun.addOptionalNode(edm::ParameterDescription<double>("MinTheta", 0.2, true), true);
     pgun.addOptionalNode(edm::ParameterDescription<double>("MaxTheta", 1.2, true), true);
 
@@ -282,7 +288,7 @@ namespace edm {
     desc.addUntracked<int>("Verbosity", 0);
     desc.addUntracked<unsigned int>("firstRun", 1);
     desc.add<std::string>("psethack",
-                          "displaced gun with theta, optionally pointing to hard-coded HGCAL front surface");
+                          "displaced gun with theta, optionally pointing to hard-coded HGCAL CE-E back surface");
 
     descriptions.add("DisplacedParticleGunProducer", desc);
   }
@@ -298,15 +304,11 @@ namespace edm {
 
     fEvt = new HepMC::GenEvent();
 
-    const double zFront = kHGCalZ;
-    const double rMinFace = fRminFrontSurfaceHGCAL;
-    const double rMaxFace = fRmaxFrontSurfaceHGCAL;
-
     if (fPointingToHGCAL) {
-      if (zFront <= fZVtx) {
+      if (kCeeBackZ <= fZVtx) {
         throw cms::Exception("DisplacedParticleGunProducer")
             << "Invalid hard-coded HGCAL surface envelope: "
-            << "zFront = " << zFront << "cm, fZVtx = " << fZVtx << " (check ZVtx).";
+            << "kCeeBackZ = " << kCeeBackZ << "cm, fZVtx = " << fZVtx << " (check ZVtx).";
       }
     }
 
@@ -332,17 +334,17 @@ namespace edm {
 
       if (pData->charge() != 0 && fPointingToHGCAL) {
         throw cms::Exception("DisplacedParticleGunProducer")
-            << "The logic that points particles to HGCAL's front face assumes that particles move in straight lines.";
+            << "The logic that points particles to HGCAL's CE-E back face assumes that particles move in straight lines.";
       }
 
       double theta = 0., phi = 0., px = 0., py = 0., pz = 0.;
       const double pt = CLHEP::RandFlat::shoot(engine, fPtMin, fPtMax);
       if (fPointingToHGCAL) {
-        const double RVtx0 = std::hypot(xVtx, yVtx);
-        auto [thetaMin, thetaMax] = thetaRangeToPointToHGCALSurface(RVtx0, zVtx, zFront, rMinFace, rMaxFace);
+        auto [thetaMin, thetaMax] = thetaRangeToPointToHGCALSurface(RVtx, zVtx,
+																	kCeeBackZ, fRminBackSurfaceHGCAL, fRmaxBackSurfaceHGCAL);
         if (!(thetaMax >= thetaMin)) {
           throw cms::Exception("DisplacedParticleGunProducer")
-              << "No valid theta window for this vertex at RVtx=" << RVtx0 << "cm within HGCAL's front surface.";
+              << "No valid theta window for this vertex at RVtx=" << RVtx << "cm within HGCAL's CE-E back surface.";
         }
 
         bool accepted = false;
@@ -355,16 +357,16 @@ namespace edm {
           }
 
           if (hitsZPlaneWithinR(
-                  xVtx, yVtx, zVtx, px, py, pz, zFront, fRminFrontSurfaceHGCAL, fRmaxFrontSurfaceHGCAL)) {
+                  xVtx, yVtx, zVtx, px, py, pz, kCeeBackZ, fRminBackSurfaceHGCAL, fRmaxBackSurfaceHGCAL)) {
             accepted = true;
             break;
           }
         }
         if (!accepted) {
           throw cms::Exception("DisplacedParticleGunProducer")
-              << "Failed to generate a particle intersecting HGCAL front surface after MaxTries=" << fMaxTries
+              << "Failed to generate a particle intersecting HGCAL CE-E back surface after MaxTries=" << fMaxTries
               << ". Vertex: (R=" << RVtx << "cm, phiVtx=" << phiVtx << ", z=" << zVtx << "cm). HGCAL band: ["
-              << fRminFrontSurfaceHGCAL << "," << fRmaxFrontSurfaceHGCAL << "]cm at z=" << zFront << "cm.";
+              << fRminBackSurfaceHGCAL << "," << fRmaxBackSurfaceHGCAL << "]cm at z=" << kCeeBackZ << "cm.";
         }
       } else {  // if (fPointingToHGCAL)
         theta = CLHEP::RandFlat::shoot(engine, fThetaMin.value(), fThetaMax.value());

--- a/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/DisplacedParticleGunProducer.cc
@@ -85,40 +85,10 @@ namespace edm {
       return (rHit >= rMin && rHit <= rMax);
     }
 
-    // Compute the theta range (in radians) that intersects a plane at z=kCeeBackZ,
-    // within radial bounds [rMin, rMax], from a vertex at transverse radius R and z.
-    std::pair<double, double> thetaRangeToPointToHGCALSurface(
-        double R, double z, double zHGCAL, double rminHGCAL, double rmaxHGCAL) {
-      const double dz = zHGCAL - z;
-      if (dz <= 0. or rminHGCAL > rmaxHGCAL) {
-        throw cms::Exception("DisplacedParticleGunProducer")
-		  << "[thetaRangeToPointToHGCALSurface] Your coordinates are wrong: "
-		  << "zHGCAL=" << zHGCAL << "cm, z=" << z << "cm, rminHGCAL=" << rminHGCAL << "cm, rmaxHGCAL=" << rmaxHGCAL << ".";
-      }
-
-      double thetaMin = std::atan((rminHGCAL - R) / dz);
-      double thetaMax = std::atan((rmaxHGCAL - R) / dz);
-
-      // For +z endcap, theta should be in (0, pi/2)
-      // clamping removes instabilities for pz
-      thetaMin = std::clamp(thetaMin, 1e-6, 0.5 * std::numbers::pi - 1e-6);
-      thetaMax = std::clamp(thetaMax, 1e-6, 0.5 * std::numbers::pi - 1e-6);
-
-      if (thetaMax <= thetaMin) {
-        throw cms::Exception("DisplacedParticleGunProducer")
-		  << "[thetaRangeToPointToHGCALSurface] Your theta limits are wrong: "
-		  << "thetaMax=" << thetaMax << ", thetaMin=" << thetaMin << ", "
-		  << "with rminHGCAL=" << rminHGCAL << "cm, rmaxHGCAL=" << rminHGCAL << "cm, R="
-		  << R << "cm, zHGCAL=" << zHGCAL << "cm, z=" << z << "cm." << std::endl;
-      }
-      return {thetaMin, thetaMax};
-    }
-
     std::tuple<double, double, double> computeMomentum(double pt, double theta, double phi) {
       double px = pt * std::cos(phi);
       double py = pt * std::sin(phi);
       double pz = 0.;
-	  std::cout << theta << std::endl;
       if (theta < 1e-6) {
         throw cms::Exception("DisplacedParticleGunProducer") << "Theta is too small: " << theta << ". Unstable pz.";
       } else {
@@ -163,8 +133,8 @@ namespace edm {
     bool fPointingToHGCAL = true;
     double fRminBackSurfaceHGCAL = kCeeBackRMin;
     double fRmaxBackSurfaceHGCAL = kCeeBackRMax;
-    std::optional<double> fThetaMin = 0.;
-    std::optional<double> fThetaMax = 0.;
+    double fThetaMin = 0.;
+    double fThetaMax = 0.;
 
     ESHandle<HepPDT::ParticleDataTable> fPDGTable;
     const ESGetToken<HepPDT::ParticleDataTable, edm::DefaultRecord> fPDGTableToken;
@@ -187,6 +157,8 @@ namespace edm {
     fPtMax = pgun.getParameter<double>("MaxPt");
     fPhiMin = pgun.getParameter<double>("MinPhi");
     fPhiMax = pgun.getParameter<double>("MaxPhi");
+	fThetaMin = pgun.getParameter<double>("MinTheta");
+	fThetaMax = pgun.getParameter<double>("MaxTheta");
     fPhiVtxMin = pgun.getParameter<double>("MinVtxPhi");
     fPhiVtxMax = pgun.getParameter<double>("MaxVtxPhi");
     fRMin = pgun.getParameter<double>("RMin");
@@ -198,17 +170,9 @@ namespace edm {
     fMaxTries = pgun.getParameter<unsigned int>("MaxTries");
     fPointingToHGCAL = pgun.getParameter<bool>("PointingToHGCAL");
 
-    if (!fPointingToHGCAL) {
-      fThetaMin = pgun.getParameter<double>("MinTheta");
-      fThetaMax = pgun.getParameter<double>("MaxTheta");
-      if (*fThetaMax <= *fThetaMin) {
-        throw cms::Exception("DisplacedParticleGunProducer") << "Please ensure MinTheta <= MaxTheta.";
-      }
-    } else {
+    if (fPointingToHGCAL) {
       fRminBackSurfaceHGCAL = pgun.getParameter<double>("RminBackSurfaceHGCAL");
       fRmaxBackSurfaceHGCAL = pgun.getParameter<double>("RmaxBackSurfaceHGCAL");
-      fThetaMin = std::nullopt;
-      fThetaMax = std::nullopt;
     }
 
     if (fPtMax <= fPtMin) {
@@ -217,6 +181,9 @@ namespace edm {
     if (fPhiMax <= fPhiMin) {
       throw cms::Exception("DisplacedParticleGunProducer") << "Please fix MinPhi/MaxPhi";
     }
+	if (fThetaMax <= fThetaMin) {
+	  throw cms::Exception("DisplacedParticleGunProducer") << "Please ensure MinTheta <= MaxTheta.";
+	}
     if (fPhiVtxMax <= fPhiVtxMin) {
       throw cms::Exception("DisplacedParticleGunProducer") << "Please fix MinVtxPhi/MaxVtxPhi";
     }
@@ -340,17 +307,10 @@ namespace edm {
 
       double theta = 0., phi = 0., px = 0., py = 0., pz = 0.;
       const double pt = CLHEP::RandFlat::shoot(engine, fPtMin, fPtMax);
-      if (fPointingToHGCAL) {
-        auto [thetaMin, thetaMax] = thetaRangeToPointToHGCALSurface(RVtx, fZVtx,
-																	kCeeBackZ, fRminBackSurfaceHGCAL, fRmaxBackSurfaceHGCAL);
-        if (!(thetaMax >= thetaMin)) {
-          throw cms::Exception("DisplacedParticleGunProducer")
-              << "No valid theta window for this vertex at RVtx=" << RVtx << "cm within HGCAL's CE-E back surface.";
-        }
-
+      if (fPointingToHGCAL) {				  
         bool accepted = false;
         for (unsigned int itry = 0; itry < fMaxTries; ++itry) {
-          theta = CLHEP::RandFlat::shoot(engine, thetaMin, thetaMax);
+          theta = CLHEP::RandFlat::shoot(engine, fThetaMin, fThetaMax);
           phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
           std::tie(px, py, pz) = computeMomentum(pt, theta, phi);
           if (edm::isNotFinite(pz) || pz <= 0.0) {
@@ -370,7 +330,7 @@ namespace edm {
               << fRminBackSurfaceHGCAL << "," << fRmaxBackSurfaceHGCAL << "]cm at z=" << kCeeBackZ << "cm.";
         }
       } else {  // if (!fPointingToHGCAL)
-        theta = CLHEP::RandFlat::shoot(engine, fThetaMin.value(), fThetaMax.value());
+        theta = CLHEP::RandFlat::shoot(engine, fThetaMin, fThetaMax);
         phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
         std::tie(px, py, pz) = computeMomentum(pt, theta, phi);
       }


### PR DESCRIPTION
#### PR description:

This PR introduces a displaced particle gun producer, and adds corresponding workflows.
The producer is useful for studies considering displaced topologies.

The producer selects a vertex position by randomly generating a set of $R>0$, $\phi_{\text{Vtx}} \in [0;2\pi[$, and $z>0$ coordinates. The momentum of the particle is then randomly generated using $p_{\text{T}}$, $\theta \in [0, \pi[$ and $\phi \in [-\pi; \pi[$ coordinates. The vertex displacement $R$ can be generated uniformly along $R$, or uniformly along the area of an annulus of radius $R_{\text{max}}-R_{\text{min}}$.

The gun can be forced to only generate particles reaching the surface of HGCAL via the `PointingToHGCAL` flag. In this case, $\theta$ and $\phi$ are generated multiple times until a configuration enables the particle to lie within `RminFrontSurfaceHGCAL` and `RmaxFrontSurfaceHGCAL`. Note that, given a displaced vertex, setting only a $\theta$ range is not sufficient to guarantee  that a particle is produced in the right direction. By default, `RminFrontSurfaceHGCAL` and `RmaxFrontSurfaceHGCAL` delimit the inner third of HGCAL's front surface, ensuring virtually all showers produced up to $R=200\text{cm}$ traverse the entirety of the CE-E. The `PointingToHGCAL` flag cannot be used with charged particles, since their curved trajectories under the magnetic field breaks the implemented logic.

#### PR validation

Inspecting the output of `step2` with `cmsShow` shows photons produced at the right $R$ values, and always pointing towards the positive endcap.

Running the workflows produces the intended commands:

```bash
$ runTheMatrix.py -l 34554.0 -w upgrade 
...
Preparing to run 34554.0 DisplacedPGun+Run4D121                                                                                                                                                                    
                                                                                                                                                                                                                   
# in: /cms-hlt-nfs/user/bfontana/DisplacedSamples/src going to execute cd 34554.0_DisplacedPGun+Run4D121                                                                                                           
 cmsDriver.py DisplacedParticleGun_cfi  -s GEN,SIM -n 10 --conditions auto:phase2_realistic_T35_13TeV --beamspot DBrealisticHLLHC --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry ExtendedRun4D121 --era Pha
se2C22I13M9 --relval 9000,100 --fileout file:step1.root  > step1_DisplacedPGun+Run4D121.log  2>&1                                                                                                                  
                                                                                                                                                                                                                   
                                                                                                                                                                                                                   
# in: /cms-hlt-nfs/user/bfontana/DisplacedSamples/src going to execute cd 34554.0_DisplacedPGun+Run4D121                                                                                                           
 cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:@relvalRun4 --conditions auto:phase2_realistic_T35 --datatier GEN-SIM-DIGI-RAW -n 10 --eventcontent FEVTDEBUGHLT --geometry Extended
Run4D121 --era Phase2C22I13M9 --filein  file:step1.root  --fileout file:step2.root  > step2_DisplacedPGun+Run4D121.log  2>&1                                                                                       
                                                                                                                                                                                                                   
                                                                                                                                                                                                                   
# in: /cms-hlt-nfs/user/bfontana/DisplacedSamples/src going to execute cd 34554.0_DisplacedPGun+Run4D121                                                                                                           
 cmsDriver.py step3  -s RAW2DIGI,RECO,RECOSIM,PAT,VALIDATION:@phase2Validation+@miniAODValidation,DQM:@phase2+@miniAODDQM --conditions auto:phase2_realistic_T35 --datatier GEN-SIM-RECO,MINIAODSIM,DQMIO -n 10 --e
ventcontent FEVTDEBUGHLT,MINIAODSIM,DQM --geometry ExtendedRun4D121 --era Phase2C22I13M9 --filein  file:step2.root  --fileout file:step3.root  > step3_DisplacedPGun+Run4D121.log  2>&1                            
                                                                                                                                                                                                                   
                                                                                                                                                                                                                   
# in: /cms-hlt-nfs/user/bfontana/DisplacedSamples/src going to execute cd 34554.0_DisplacedPGun+Run4D121                                                                                                           
 cmsDriver.py step4  -s HARVESTING:@phase2Validation+@phase2+@miniAODValidation+@miniAODDQM --conditions auto:phase2_realistic_T35 --mc  --geometry ExtendedRun4D121 --scenario pp --filetype DQM --era Phase2C22I1
3M9 -n 100  --filein file:step3_inDQM.root --fileout file:step4.root  > step4_DisplacedPGun+Run4D121.log  2>&1                                                                                                     
                                                                                                                                                                                                                   
                                                                                                                                                                                                                   
# in: /cms-hlt-nfs/user/bfontana/DisplacedSamples/src going to execute cd 34554.0_DisplacedPGun+Run4D121                                                                                                           
 cmsDriver.py step5  -s ALCA:SiPixelCalSingleMuonLoose+SiPixelCalSingleMuonTight+TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+TkAlDiMuonAndVertex+HcalCalHBHEMuonProducerFilter+TkAlUpsilonMuMu+
TkAlJpsiMuMu --conditions auto:phase2_realistic_T35 --datatier ALCARECO -n 10 --eventcontent ALCARECO --geometry ExtendedRun4D121 --era Phase2C22I13M9 --filein file:step3.root --fileout file:step5.root  > step5_
DisplacedPGun+Run4D121.log  2>&1                                                                                                                                                                                   
                                                                                                                                                                                                                   
34554.0_DisplacedPGun+Run4D121 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Thu May 21 01:14:13 2026-date Thu May 21 01:07:37 2026; exit: 0 0 0 0 0                               
1 1 1 1 1 tests passed, 0 0 0 0 0 failed 
```

*Update:*

I've also added a HLT-only displaced workflow (with the `NGTScouting` HLT menu):

```shell
$ runTheMatrix.py -l 34554.77 -w upgrade

...

Preparing to run 34554.77 DisplacedPGun+Run4D121_NGTScouting                                                                                                                            
                                                                                                                                                                                        
# in: /cms-hlt-nfs/user/bfontana/DisplacedSamples/src going to execute cd 34554.77_DisplacedPGun+Run4D121_NGTScouting                                                                   
 cmsDriver.py DisplacedParticleGun_cfi  -s GEN,SIM -n 10 --conditions auto:phase2_realistic_T35_13TeV --beamspot DBrealisticHLLHC --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry
 ExtendedRun4D121 --era Phase2C22I13M9 --relval 9000,100 --fileout file:step1.root  > step1_DisplacedPGun+Run4D121_NGTScouting.log  2>&1                                                
                                                                                                                                                                                        
                                                                                                                                                                                        
# in: /cms-hlt-nfs/user/bfontana/DisplacedSamples/src going to execute cd 34554.77_DisplacedPGun+Run4D121_NGTScouting                                                                   
 cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,VALIDATION:@hltValidation --conditions auto:phase2_realistic_T35 --datatier GEN-SIM-DIGI-RAW,
DQMIO -n 10 --eventcontent FEVTDEBUGHLT,DQMIO --geometry ExtendedRun4D121 --era Phase2C22I13M9 --procModifiers ngtScouting --customise SLHCUpgradeSimulations/Configuration/aging.custom
ise_aging_1000 --filein  file:step1.root  --fileout file:step2.root  > step2_DisplacedPGun+Run4D121_NGTScouting.log  2>&1                                                               
                                                                                                                                                                                        
                                                                                                                                                                                        
# in: /cms-hlt-nfs/user/bfontana/DisplacedSamples/src going to execute cd 34554.77_DisplacedPGun+Run4D121_NGTScouting                                                                   
 cmsDriver.py step3  -s HARVESTING:@hltValidation --conditions auto:phase2_realistic_T35 --mc  --geometry ExtendedRun4D121 --scenario pp --filetype DQM --era Phase2C22I13M9 --procModif
iers ngtScouting -n 100  --filein file:step2_inDQM.root --fileout file:step3.root  > step3_DisplacedPGun+Run4D121_NGTScouting.log  2>&1                                                 
                                                                                                                                                                                        
34554.77_DisplacedPGun+Run4D121_NGTScouting Step0-PASSED Step1-PASSED Step2-PASSED  - time date Thu May 28 17:07:11 2026-date Thu May 28 17:03:56 2026; exit: 0 0 0                     
1 1 1 tests passed, 0 0 0 failed 
```
