### PR TITLE
[EVOLUTION_X] Move sources of `l1t::Calo{Cluster,Tower}` inside `io_v1` namespace

### DIFF
--- a/DataFormats/L1TCalorimeter/src/CaloCluster.cc
+++ b/DataFormats/L1TCalorimeter/src/CaloCluster.cc
@@ -1,67 +1,69 @@
 
 #include "DataFormats/L1TCalorimeter/interface/CaloCluster.h"
 
-l1t::CaloCluster::CaloCluster(const LorentzVector p4, int pt, int eta, int phi)
-    : L1Candidate(p4, pt, eta, phi),
-      m_clusterFlags(0x7FF)  // first 11 flags at 1
-{}
+namespace l1t::io_v1 {
+  CaloCluster::CaloCluster(const LorentzVector p4, int pt, int eta, int phi)
+      : L1Candidate(p4, pt, eta, phi),
+        m_clusterFlags(0x7FF)  // first 11 flags at 1
+  {}
 
-l1t::CaloCluster::~CaloCluster() {}
+  CaloCluster::~CaloCluster() {}
 
-void l1t::CaloCluster::setClusterFlag(ClusterFlag flag, bool val) {
-  if (val) {
-    m_clusterFlags |= (0x1 << flag);
-  } else {
-    m_clusterFlags &= ~(0x1 << flag);
-  }
-};
-
-void l1t::CaloCluster::setHwPtEm(int pt) { m_hwPtEm = pt; }
-
-void l1t::CaloCluster::setHwPtHad(int pt) { m_hwPtHad = pt; }
-
-void l1t::CaloCluster::setHwSeedPt(int pt) { m_hwSeedPt = pt; }
-
-void l1t::CaloCluster::setFgEta(int fgEta) { m_fgEta = fgEta; }
-
-void l1t::CaloCluster::setFgPhi(int fgPhi) { m_fgPhi = fgPhi; }
-
-void l1t::CaloCluster::setHOverE(int hOverE) { m_hOverE = hOverE; }
-
-void l1t::CaloCluster::setFgECAL(int fgECAL) { m_fgECAL = fgECAL; }
-
-bool l1t::CaloCluster::checkClusterFlag(ClusterFlag flag) const { return (m_clusterFlags & (0x1 << flag)); };
-
-bool l1t::CaloCluster::isValid() const { return (checkClusterFlag(INCLUDE_SEED)); }
-
-int l1t::CaloCluster::hwPtEm() const { return m_hwPtEm; }
-
-int l1t::CaloCluster::hwPtHad() const { return m_hwPtHad; }
-
-int l1t::CaloCluster::hwSeedPt() const { return m_hwSeedPt; }
-
-int l1t::CaloCluster::fgEta() const { return m_fgEta; }
-
-int l1t::CaloCluster::fgPhi() const { return m_fgPhi; }
-
-int l1t::CaloCluster::hOverE() const { return m_hOverE; }
-
-int l1t::CaloCluster::fgECAL() const { return m_fgECAL; }
-
-bool l1t::CaloCluster::operator<(const CaloCluster& cl) const {
-  bool res = false;
-  // Favour high pT
-  if (hwPt() < cl.hwPt())
-    res = true;
-  else if (hwPt() == cl.hwPt()) {
-    // Favour central clusters
-    if (abs(hwEta()) > abs(cl.hwEta()))
-      res = true;
-    else if (abs(hwEta()) == abs(cl.hwEta())) {
-      // Favour small phi (arbitrary)
-      if (hwPhi() > cl.hwPhi())
-        res = true;
+  void CaloCluster::setClusterFlag(ClusterFlag flag, bool val) {
+    if (val) {
+      m_clusterFlags |= (0x1 << flag);
+    } else {
+      m_clusterFlags &= ~(0x1 << flag);
     }
+  };
+
+  void CaloCluster::setHwPtEm(int pt) { m_hwPtEm = pt; }
+
+  void CaloCluster::setHwPtHad(int pt) { m_hwPtHad = pt; }
+
+  void CaloCluster::setHwSeedPt(int pt) { m_hwSeedPt = pt; }
+
+  void CaloCluster::setFgEta(int fgEta) { m_fgEta = fgEta; }
+
+  void CaloCluster::setFgPhi(int fgPhi) { m_fgPhi = fgPhi; }
+
+  void CaloCluster::setHOverE(int hOverE) { m_hOverE = hOverE; }
+
+  void CaloCluster::setFgECAL(int fgECAL) { m_fgECAL = fgECAL; }
+
+  bool CaloCluster::checkClusterFlag(ClusterFlag flag) const { return (m_clusterFlags & (0x1 << flag)); };
+
+  bool CaloCluster::isValid() const { return (checkClusterFlag(INCLUDE_SEED)); }
+
+  int CaloCluster::hwPtEm() const { return m_hwPtEm; }
+
+  int CaloCluster::hwPtHad() const { return m_hwPtHad; }
+
+  int CaloCluster::hwSeedPt() const { return m_hwSeedPt; }
+
+  int CaloCluster::fgEta() const { return m_fgEta; }
+
+  int CaloCluster::fgPhi() const { return m_fgPhi; }
+
+  int CaloCluster::hOverE() const { return m_hOverE; }
+
+  int CaloCluster::fgECAL() const { return m_fgECAL; }
+
+  bool CaloCluster::operator<(const CaloCluster& cl) const {
+    bool res = false;
+    // Favour high pT
+    if (hwPt() < cl.hwPt())
+      res = true;
+    else if (hwPt() == cl.hwPt()) {
+      // Favour central clusters
+      if (abs(hwEta()) > abs(cl.hwEta()))
+        res = true;
+      else if (abs(hwEta()) == abs(cl.hwEta())) {
+        // Favour small phi (arbitrary)
+        if (hwPhi() > cl.hwPhi())
+          res = true;
+      }
+    }
+    return res;
   }
-  return res;
-}
+}  // namespace l1t::io_v1

--- a/DataFormats/L1TCalorimeter/src/CaloTower.cc
+++ b/DataFormats/L1TCalorimeter/src/CaloTower.cc
@@ -1,41 +1,43 @@
 
 #include "DataFormats/L1TCalorimeter/interface/CaloTower.h"
 
-l1t::CaloTower::CaloTower(const LorentzVector& p4,
-                          double etEm,
-                          double etHad,
-                          int pt,
-                          int eta,
-                          int phi,
-                          int qual,
-                          int hwEtEm,
-                          int hwEtHad,
-                          int hwEtRatio)
-    : L1Candidate(p4, pt, eta, phi, qual),
-      etEm_(etEm),
-      etHad_(etHad),
-      hwEtEm_(hwEtEm),
-      hwEtHad_(hwEtHad),
-      hwEtRatio_(hwEtRatio) {}
+namespace l1t::io_v1 {
+  CaloTower::CaloTower(const LorentzVector& p4,
+                       double etEm,
+                       double etHad,
+                       int pt,
+                       int eta,
+                       int phi,
+                       int qual,
+                       int hwEtEm,
+                       int hwEtHad,
+                       int hwEtRatio)
+      : L1Candidate(p4, pt, eta, phi, qual),
+        etEm_(etEm),
+        etHad_(etHad),
+        hwEtEm_(hwEtEm),
+        hwEtHad_(hwEtHad),
+        hwEtRatio_(hwEtRatio) {}
 
-l1t::CaloTower::~CaloTower() {}
+  CaloTower::~CaloTower() {}
 
-void l1t::CaloTower::setEtEm(double et) { etEm_ = et; }
+  void CaloTower::setEtEm(double et) { etEm_ = et; }
 
-void l1t::CaloTower::setEtHad(double et) { etHad_ = et; }
+  void CaloTower::setEtHad(double et) { etHad_ = et; }
 
-void l1t::CaloTower::setHwEtEm(int et) { hwEtEm_ = et; }
+  void CaloTower::setHwEtEm(int et) { hwEtEm_ = et; }
 
-void l1t::CaloTower::setHwEtHad(int et) { hwEtHad_ = et; }
+  void CaloTower::setHwEtHad(int et) { hwEtHad_ = et; }
 
-void l1t::CaloTower::setHwEtRatio(int ratio) { hwEtRatio_ = ratio; }
+  void CaloTower::setHwEtRatio(int ratio) { hwEtRatio_ = ratio; }
 
-double l1t::CaloTower::etEm() const { return etEm_; }
+  double CaloTower::etEm() const { return etEm_; }
 
-double l1t::CaloTower::etHad() const { return etHad_; }
+  double CaloTower::etHad() const { return etHad_; }
 
-int l1t::CaloTower::hwEtEm() const { return hwEtEm_; }
+  int CaloTower::hwEtEm() const { return hwEtEm_; }
 
-int l1t::CaloTower::hwEtHad() const { return hwEtHad_; }
+  int CaloTower::hwEtHad() const { return hwEtHad_; }
 
-int l1t::CaloTower::hwEtRatio() const { return hwEtRatio_; }
+  int CaloTower::hwEtRatio() const { return hwEtRatio_; }
+}  // namespace l1t::io_v1


### PR DESCRIPTION
#### PR description:

To fix clang warnings in https://github.com/cms-sw/cmssw/pull/50968#issuecomment-4511230914

Resolves https://github.com/cms-sw/framework-team/issues/2247

#### PR validation:

Code compiles.