### PR TITLE
ECAL - Do not attempt to unpack MEM box data as normal digis - 161X

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/alpaka/UnpackPortable.dev.cc
+++ b/EventFilter/EcalRawToDigi/plugins/alpaka/UnpackPortable.dev.cc
@@ -134,6 +134,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::raw {
         // prepare for the next iteration
         next_tower_id = exp_ttids[iCh];
 
+        // do not unpack the membox data
+        if (ttid > NUMB_FE) {
+          continue;
+        }
+
         uint16_t const dccbx = bx & 0xfff;
         uint16_t const dccl1 = lv1 & 0xfff;
         // fov>=1 is required to support simulated data for which bx==bxlocal==0


### PR DESCRIPTION
#### PR description:

The MEM box data of the ECAL laser calibration system should not be unpacked as normal digis. Addresses the crash in #50981.

#### PR validation:

Fixes the crash with the ECAL laser event 713677357 of run 388390 reported in #50981.

Backport of #51019 for HI data taking.