### PR TITLE
add hybrid PU workflow to PR tests

### DIFF
--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -68,7 +68,7 @@ class WorkFlowRunner(Thread):
 
         # Inner patterns to match individual file entries
         # For stepN naming need to know the N
-        file_pattern_step = re.compile('file:step([1-9]+)(_[a-zA-Z]+)?\.[a-z]+')
+        file_pattern_step = re.compile(r'file:step([1-9]+)(_[a-zA-Z]+)?\.[a-z]+')
         # Some ALCA steps use special file names without stepN, those
         # are assumed to use the default extension
         file_pattern_gen = re.compile(r'file:([a-zA-Z0-9_]+)\.[a-z]+')

--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -57,6 +57,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #        (Nu Gun)
 #   2025 (TTbar, TTbar PU, TTbar PU prod-like)
 #        (TTbar FastSim, TTbar FastSim PU, MinBiasFS for mixing)
+#        (TTbar hybrid PU)
 #   2026 (TTbar, TTbar PU, TTbar PU prod-like)
 
 numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009.0,10059.0,10071.0,
@@ -109,6 +110,7 @@ numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009
            # 2025
            16834.0, 17034.0, 17034.21,
            18034.0, 18234.0, 18040.303,
+           17034.96,
            # 2026
            18434.0, 18634.0, 18634.21,
 ]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3886,7 +3886,7 @@ steps['ALCAReAlCaHLTHGComb'] = {'-s': 'ALCA:PromptCalibProdSiPixelAliHLTHGC',
                                 '\\"TriggerResults::ReAlCa\\"; '
                                 'extend_file_name = lambda n,e: \\".\\".join(n.split(\\".\\")[:-1])+e+\\".\\"+n.split(\\".\\")[-1]; '
                                 'process.ALCARECOStreamPromptCalibProdSiPixelAliHLTHGC.fileName = '
-                                'extend_file_name(process.ALCARECOStreamPromptCalibProdSiPixelAliHLTHGC.fileName.value(), \\"_0\\"\"\)',
+                                'extend_file_name(process.ALCARECOStreamPromptCalibProdSiPixelAliHLTHGC.fileName.value(), \\"_0\\"\"\\)',
                                 '--triggerResultsProcess': 'ReAlCa'
                                 }
 
@@ -3907,7 +3907,7 @@ steps['ALCAReAlCaHLTHGCombZMUMU'] = {'-s': 'ALCA:PromptCalibProdSiPixelAliHLTHGC
                                      '\\"TriggerResults::ReAlCa\\"; '
                                      'extend_file_name = lambda n,e: \\".\\".join(n.split(\\".\\")[:-1])+e+\\".\\"+n.split(\\".\\")[-1]; '
                                      'process.ALCARECOStreamPromptCalibProdSiPixelAliHLTHGC.fileName = '
-                                     'extend_file_name(process.ALCARECOStreamPromptCalibProdSiPixelAliHLTHGC.fileName.value(), \\"_1\\"\"\)',
+                                     'extend_file_name(process.ALCARECOStreamPromptCalibProdSiPixelAliHLTHGC.fileName.value(), \\"_1\\"\"\\)',
                                      '--triggerResultsProcess': 'ReAlCa'
                                      }
 

--- a/Configuration/PyReleaseValidation/scripts/README.md
+++ b/Configuration/PyReleaseValidation/scripts/README.md
@@ -321,14 +321,20 @@ MC workflows for pp collisions:
 | 11634.0 	| TTbar_14TeV 	| phase1_2022_realistic 	| Run3 	|  	|  	
 | 13234.0 	| RelValTTbar_14TeV 	| phase1_2022_realistic 	| Run3_FastSim 	| *FastSim*  |  	
 | 12434.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2023 	|  	|  	
+| 14034.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2023_FastSim 	|  	*FastSim* |  	
+| 14234.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2023_FastSim 	| *FastSim*  Run3_Flat55To75_PoissonOOTPU 	|  	
 | 12834.0 	| RelValTTbar_14TeV 	| phase1_2024_realistic 	| Run3_2024 	|  	| 
 | 12846.0 	| RelValZEE_14 	| phase1_2023_realistic 	| Run3_2024 	|  	|  	
 | 13034.0 	| RelValTTbar_14TeV 	| phase1_2024_realistic 	| Run3_2024 	|  Run3_Flat55To75_PoissonOOTPU 	|  	
 | 12834.7 	| RelValTTbar_14TeV 	| phase1_2024_realistic 	| Run3_2024 	| mkFit 	|  	
 | 12834.0 	| RelValTTbar_14TeV 	| phase1_2024_realistic 	| Run3_2024 	|  	| 
 | 16834.0 	| RelValTTbar_14TeV 	| phase1_2025_realistic 	| Run3_2025 	|  	| 
-| 14034.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2023_FastSim 	|  	*FastSim* |  	
-| 14234.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2023_FastSim 	| *FastSim*  Run3_Flat55To75_PoissonOOTPU 	|  	
+| 17034.0 	| RelValTTbar_14TeV 	| phase1_2025_realistic 	| Run3_2025 	| with PU 	| 
+| 17034.21 	| RelValTTbar_14TeV 	| phase1_2025_realistic 	| Run3_2025 	| with PU (prodlike)	| 
+| 18034.0 	| RelValTTbar_14TeV 	| phase1_2025_realistic 	| Run3_2025 	| *FastSim* 	| 
+| 18234.0 	| RelValTTbar_14TeV 	| phase1_2025_realistic 	| Run3_2025 	| *FastSim* PU 	| 
+| 18040.303 	| RelValTTbar_14TeV 	| phase1_2025_realistic 	| Run3_2025 	| *FastSim* MinBias for premixing 	| 
+| 17034.96 	| RelValTTbar_14TeV 	| phase1_2025_realistic 	| Run3_2025 	| hybrid PU mixing 	| 
 | 2500.301 	| RelValTTbar_14TeV 	| phase1_2025_realistic 	| Run3_2025 	| NanoAOD from existing MINI 	|  	
 | 18434.0 	| RelValTTbar_14TeV 	| phase1_2026_realistic 	| Run3_2026 	|  	| 
 | 18634.0 	| RelValTTbar_14TeV 	| phase1_2026_realistic 	| Run3_2026 	|  	| 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -101,6 +101,7 @@ if __name__ == '__main__':
             13034.0,    # RelValTTbar_14TeV             2024 PU = Run3_Flat55To75_PoissonOOTPU
             16834.0,    # RelValTTbar_14TeV             2025
             17034.0,    # RelValTTbar_14TeV             2025 PU = Run3_Flat55To75_PoissonOOTPU
+            17034.96,   # RelValTTbar_14TeV             2025 Hybrid PU
             14034.0,    # RelValTTbar_14TeV             Run3_2023_FastSim
             14234.0,    # RelValTTbar_14TeV             Run3_2023_FastSim   PU = Run3_Flat55To75_PoissonOOTPU
             2500.3001,   # RelValTTbar_14TeV            NanoAOD from existing MINI


### PR DESCRIPTION
#### PR description:

Now that the hybrid PU implementation is in the master branch (#50886), the workflow should be tested routinely. I have added one of the example workflows into the short matrix for PR tests.

I also dealt with these syntax warnings emitted by Python 3.12:
```
src/Configuration/PyReleaseValidation/python/WorkFlowRunner.py:71: SyntaxWarning: invalid escape sequence '\.'
  file_pattern_step = re.compile('file:step([1-9]+)(_[a-zA-Z]+)?\.[a-z]+')
src/Configuration/PyReleaseValidation/python/relval_steps.py:3889: SyntaxWarning: invalid escape sequence '\)'
  'extend_file_name(process.ALCARECOStreamPromptCalibProdSiPixelAliHLTHGC.fileName.value(), \\"_0\\"\"\)',
src/Configuration/PyReleaseValidation/python/relval_steps.py:3910: SyntaxWarning: invalid escape sequence '\)'
  'extend_file_name(process.ALCARECOStreamPromptCalibProdSiPixelAliHLTHGC.fileName.value(), \\"_1\\"\"\)',
```
(probably there should be a larger campaign to check for these; I only dealt with this one package)

attn: @civanch @subirsarkar @suchandradutta @bsunanda 

#### PR validation:

`runTheMatrix.py -l 17034.96` succeeds.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A