### PR TITLE
Remove unnecessary conversion of `std::filesystem::path` and back in PluginManager CacheParser

### DIFF
--- a/FWCore/PluginManager/BuildFile.xml
+++ b/FWCore/PluginManager/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="boost"/>
 <use name="tbb"/>
 <use name="rootcling"/>
 <use name="FWCore/Utilities"/>

--- a/FWCore/PluginManager/src/CacheParser.cc
+++ b/FWCore/PluginManager/src/CacheParser.cc
@@ -13,7 +13,6 @@
 // system include files
 #include <algorithm>
 #include <limits>
-#include "boost/version.hpp"
 
 // user include files
 #include "FWCore/PluginManager/interface/CacheParser.h"
@@ -147,11 +146,7 @@ namespace edmplugin {
       std::string type(it->first);
       for (std::vector<PluginInfo>::const_iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2) {
         //remove any directory specification
-#if (BOOST_VERSION / 100000) >= 1 && ((BOOST_VERSION / 100) % 1000) >= 47
-        std::string loadable(it2->loadable_.filename().string());
-#else
-        std::string loadable(it2->loadable_.filename());
-#endif
+        auto loadable = it2->loadable_.filename();
         std::string name(it2->name_);
         ordered[loadable].push_back(NameAndType(name, type));
       }


### PR DESCRIPTION
#### PR description:

The boost version check has been obsolete for a long time, and the conversion to string and back seemed unnecessary.

Resolves https://github.com/cms-sw/framework-team/issues/2253

#### PR validation:

Code compiles