### PR TITLE
support `hltMergedTracksPPOnAA` track variant in HLT Alignment PCL

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAliHLT_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAliHLT_cff.py
@@ -24,6 +24,11 @@ ALCARECOTkAlMinBiasHLTTracks = ALCARECOTkAlMinBias.clone(
     src = cms.InputTag("hltMergedTracks")
 )
 
+## modify input tracks for HLT Aligmment PCL during Heavy Ions
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(ALCARECOTkAlMinBiasHLTTracks,
+                         src = "hltMergedTracksPPOnAA")
+
 # Ingredient: AlignmentTrackSelector
 # track selector for HighPurity tracks
 #-- AlignmentTrackSelector

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_cff.py
@@ -35,6 +35,11 @@ ALCARECOTkAlHLTTracksZMuMu = Alignment.CommonAlignmentProducer.AlignmentTrackSel
 ALCARECOTkAlHLTTracksZMuMu.src = cms.InputTag("hltMergedTracks") 
 ALCARECOTkAlHLTTracksZMuMu.filter = True ##do not store empty events
 
+## modify input tracks for HLT Aligmment PCL during Heavy Ions
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(ALCARECOTkAlHLTTracksZMuMu,
+                         src = "hltMergedTracksPPOnAA")
+
 ALCARECOTkAlHLTTracksZMuMu.applyBasicCuts = True
 ALCARECOTkAlHLTTracksZMuMu.ptMin = 15.0 ##GeV
 ALCARECOTkAlHLTTracksZMuMu.etaMin = -3.5
@@ -65,6 +70,11 @@ ALCARECOTkAlHLTPixelZMuMuVertexTracks = _TracksFromPixelVertex.AlignmentTracksFr
     leptonTracks = 'ALCARECOTkAlHLTTracksZMuMu',
     useClosestVertexToDilepton = True,
 )
+
+pp_on_PbPb_run3.toModify(ALCARECOTkAlHLTPixelZMuMuVertexTracks,
+                         src = 'hltPixelTracksPPOnAA',
+                         vertices = 'hltPixelVerticesPPOnAA')
+
 
 seqALCARECOTkAlHLTTracksZMuMu = cms.Sequence(ALCARECOTkAlHLTTracksZMuMuHLT+
                                              ALCARECOTkAlHLTTracksZMuMuDCSFilter+

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_cff.py
@@ -27,6 +27,11 @@ ALCARECOTkAlHLTTracks = Alignment.CommonAlignmentProducer.AlignmentTrackSelector
 ALCARECOTkAlHLTTracks.src = cms.InputTag("hltMergedTracks") # run on hltMergedTracks instead of generalTracks
 ALCARECOTkAlHLTTracks.filter = True ##do not store empty events	
 
+## modify input tracks for HLT Aligmment PCL during Heavy Ions
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(ALCARECOTkAlHLTTracks,
+                         src = "hltMergedTracksPPOnAA")
+
 ALCARECOTkAlHLTTracks.applyBasicCuts = True
 ALCARECOTkAlHLTTracks.ptMin = 0.65 ##GeV
 ALCARECOTkAlHLTTracks.pMin = 1.5 ##GeV


### PR DESCRIPTION
#### PR description:

Title says it all, to support [CMSHLT-3855](https://its.cern.ch/jira/browse/CMSHLT-3855).

#### PR validation:

None yet.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, it will be backported to CMSSW_16_1_X for 2026 data-taking operations.
