### PR TITLE
[16.1.X] support `hltMergedTracksPPOnAA` track variant in HLT Alignment PCL

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAliHLT_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAliHLT_cff.py
@@ -24,6 +24,11 @@ ALCARECOTkAlMinBiasHLTTracks = ALCARECOTkAlMinBias.clone(
     src = cms.InputTag("hltMergedTracks")
 )
 
+## modify input tracks for HLT Aligmment PCL during Heavy Ions
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(ALCARECOTkAlMinBiasHLTTracks,
+                         src = "hltMergedTracksPPOnAA")
+
 # Ingredient: AlignmentTrackSelector
 # track selector for HighPurity tracks
 #-- AlignmentTrackSelector

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_cff.py
@@ -35,6 +35,11 @@ ALCARECOTkAlHLTTracksZMuMu = Alignment.CommonAlignmentProducer.AlignmentTrackSel
 ALCARECOTkAlHLTTracksZMuMu.src = cms.InputTag("hltMergedTracks") 
 ALCARECOTkAlHLTTracksZMuMu.filter = True ##do not store empty events
 
+## modify input tracks for HLT Aligmment PCL during Heavy Ions
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(ALCARECOTkAlHLTTracksZMuMu,
+                         src = "hltMergedTracksPPOnAA")
+
 ALCARECOTkAlHLTTracksZMuMu.applyBasicCuts = True
 ALCARECOTkAlHLTTracksZMuMu.ptMin = 15.0 ##GeV
 ALCARECOTkAlHLTTracksZMuMu.etaMin = -3.5
@@ -65,6 +70,11 @@ ALCARECOTkAlHLTPixelZMuMuVertexTracks = _TracksFromPixelVertex.AlignmentTracksFr
     leptonTracks = 'ALCARECOTkAlHLTTracksZMuMu',
     useClosestVertexToDilepton = True,
 )
+
+pp_on_PbPb_run3.toModify(ALCARECOTkAlHLTPixelZMuMuVertexTracks,
+                         src = 'hltPixelTracksPPOnAA',
+                         vertices = 'hltPixelVerticesPPOnAA')
+
 
 seqALCARECOTkAlHLTTracksZMuMu = cms.Sequence(ALCARECOTkAlHLTTracksZMuMuHLT+
                                              ALCARECOTkAlHLTTracksZMuMuDCSFilter+

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_cff.py
@@ -27,6 +27,11 @@ ALCARECOTkAlHLTTracks = Alignment.CommonAlignmentProducer.AlignmentTrackSelector
 ALCARECOTkAlHLTTracks.src = cms.InputTag("hltMergedTracks") # run on hltMergedTracks instead of generalTracks
 ALCARECOTkAlHLTTracks.filter = True ##do not store empty events	
 
+## modify input tracks for HLT Aligmment PCL during Heavy Ions
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(ALCARECOTkAlHLTTracks,
+                         src = "hltMergedTracksPPOnAA")
+
 ALCARECOTkAlHLTTracks.applyBasicCuts = True
 ALCARECOTkAlHLTTracks.ptMin = 0.65 ##GeV
 ALCARECOTkAlHLTTracks.pMin = 1.5 ##GeV

--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -396,6 +396,10 @@ ALCARECOTkAlHLTTracksTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
     SumChargeMax = 50.5
 )
 
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(ALCARECOTkAlHLTTracksTkAlDQM,
+                         ReferenceTrackProducer= "hltMergedTracksPPOnAA")
+
 ALCARECOTkAlHLTTracksDQM = cms.Sequence( ALCARECOTkAlHLTTracksTrackingDQM  + ALCARECOTkAlHLTTracksTkAlDQM )
 
 ########################################################
@@ -432,11 +436,18 @@ ALCARECOTkAlHLTTracksZMuMuTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
     SumChargeMax = 50.5
 )
 
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(ALCARECOTkAlHLTTracksZMuMuTkAlDQM,
+                         ReferenceTrackProducer= "hltMergedTracksPPOnAA")
+
 ALCARECOTkAlHLTTracksZMuMuVtxDQM = ALCARECOTkAlDiMuonAndVertexVtxDQM.clone(
     muonTracks = 'ALCARECO'+__selectionName,
     vertices = 'hltPixelVertices',
     FolderName = "AlCaReco/"+__selectionName,
 )
+
+pp_on_PbPb_run3.toModify(ALCARECOTkAlHLTTracksZMuMuVtxDQM,
+                         vertices = 'hltPixelVerticesPPOnAA')
 
 ALCARECOTkAlHLTTracksZMuMuMassBiasDQM = ALCARECOTkAlDiMuonMassBiasDQM.clone(
     muonTracks = 'ALCARECO'+__selectionName,


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/51039
backport of https://github.com/cms-sw/cmssw/pull/51031

#### PR description:

Title says it all, to support [CMSHLT-3855](https://its.cern.ch/jira/browse/CMSHLT-3855).

#### PR validation:

None yet.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/51031 to CMSSW_16_1_X for 2026 data-taking operations.

