### PR TITLE
[GEM][Geoemtry] Introducing the new shape of the GE0 chambers

### DIFF
--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -199,6 +199,11 @@ GEMSuperChamber* GEMGeometryBuilder::buildSuperChamber(DDFilteredView& fv, GEMDe
   bool ge0Station = detId.station() == GEMDetId::minStationId0;
   std::vector<double> dpar = ge0Station ? solid.parameters() : solid.solidA().parameters();
 
+  if (dpar.empty()) {
+    const DDBooleanSolid bs(fv.logicalPart().solid());
+    dpar = bs.solidA().parameters();
+  }
+
   double dy = convertMmToCm(dpar[0]);   //length is along local Y
   double dz = convertMmToCm(dpar[3]);   // thickness is long local Z
   double dx1 = convertMmToCm(dpar[4]);  // bottom width is along local X
@@ -232,6 +237,11 @@ GEMChamber* GEMGeometryBuilder::buildChamber(DDFilteredView& fv, GEMDetId detId)
   DDBooleanSolid solid = (DDBooleanSolid)(fv.logicalPart().solid());
   bool ge0Station = detId.station() == GEMDetId::minStationId0;
   std::vector<double> dpar = ge0Station ? solid.parameters() : solid.solidA().parameters();
+
+  if (dpar.empty()) {
+    const DDBooleanSolid bs(fv.logicalPart().solid());
+    dpar = bs.solidA().parameters();
+  }
 
   double dy = convertMmToCm(dpar[0]);   //length is along local Y
   double dz = convertMmToCm(dpar[3]);   // thickness is long local Z
@@ -280,6 +290,11 @@ GEMEtaPartition* GEMGeometryBuilder::buildEtaPartition(DDFilteredView& fv, GEMDe
 #endif
   // EtaPartition specific parameter (size)
   std::vector<double> dpar = fv.logicalPart().solid().parameters();
+
+  if (dpar.empty()) {
+    const DDBooleanSolid bs(fv.logicalPart().solid());
+    dpar = bs.solidA().parameters();
+  }
 
   double be = convertMmToCm(dpar[4]);  // half bottom edge
   double te = convertMmToCm(dpar[8]);  // half top edge

--- a/Geometry/MuonCommonData/data/ge0/TDR_Dev/v6/ge0.xml
+++ b/Geometry/MuonCommonData/data/ge0/TDR_Dev/v6/ge0.xml
@@ -1,0 +1,592 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+  <ConstantsSection label="ge0.xml" eval="true">
+    <Constant name="rMin"   value="620*mm"/>
+    <Constant name="rMax"   value="1730*mm"/>
+    <Constant name="dZ"     value="395.686*mm"/>
+    <Constant name="rPos"   value="([dZ] + [rMin])"/>
+    <Constant name="dzGE0"  value="112.9*mm"/>
+    <Constant name="zFrGE0" value="10.0*mm"/>
+    <Constant name="zGpGE0" value="5.0*mm"/>
+    <Constant name="zPos"   value="([cms:CalorBeamZ3] + [zFrGE0] + [dzGE0])"/>
+    <Constant name="zShift" value="41.70*mm"/>
+    <Constant name="z10"    value="101.85*mm"/>
+    <Constant name="z20"    value="([z10]-[zShift])"/>  
+    <Constant name="z30"    value="([z20]-[zShift])"/> 
+    <Constant name="z40"    value="([z30]-[zShift])"/> 
+    <Constant name="z50"    value="([z40]-[zShift])"/> 
+    <Constant name="z60"    value="([z50]-[zShift])"/>
+    <Constant name="Angle"  value="10.0*deg"/>
+    <Constant name="slope"  value="tan([Angle])"/>
+    <Constant name="tol"    value="0.001*mm"/>
+    <Constant name="xBot"   value="([rMin]*[slope]-[tol])"/>
+    <Constant name="xTop"   value="(2.*[dZ]*[slope]+[xBot])"/>
+    <Constant name="tBase"  value="1.6*mm"/>
+    <Constant name="tFoil"  value="0.025*mm"/>
+    <Constant name="tSense" value="(6.0*mm-[tFoil])/2"/>
+    <Constant name="tGas1"  value="(1.0*mm-2*[tFoil])/2"/>
+    <Constant name="tGas2"  value="(2.0*mm-2*[tFoil])/2"/>
+    <Constant name="tGas3"  value="(1.0*mm-[tFoil])/2"/>
+    <Constant name="tRead"  value="1.5*mm"/>
+    <Constant name="tTop"   value="0.5*mm"/>
+    <Constant name="zBase"  value="-([tSense]+[tBase])"/>
+    <Constant name="zFoil1" value="([tSense]+[tFoil])"/>
+    <Constant name="zGas1"  value="([zFoil1]+[tFoil]+[tGas1])"/>
+    <Constant name="zFoil2" value="([zGas1]+[tFoil]+[tGas1])"/>
+    <Constant name="zGas2"  value="([zFoil2]+[tFoil]+[tGas2])"/>
+    <Constant name="zFoil3" value="([zGas2]+[tFoil]+[tGas2])"/>
+    <Constant name="zGas3"  value="([zFoil3]+[tFoil]+[tGas3])"/>
+    <Constant name="zRead"  value="([zGas3]+[tGas3]+[tRead])"/>
+    <Constant name="zTop"   value="([zRead]+[tRead]+[tTop])"/>
+  
+    <Constant name="dzGap"  value="0.0750*mm"/>
+    <Constant name="dzS1"   value="68.573*mm"/>
+    <Constant name="dzS2"   value="61.738*mm"/>
+    <Constant name="dzS3"   value="55.660*mm"/>
+    <Constant name="dzS4"   value="50.241*mm"/>
+    <Constant name="dzS5"   value="45.394*mm"/>
+    <Constant name="dzS6"   value="41.049*mm"/>
+    <Constant name="dzS7"   value="37.143*mm"/>
+    <Constant name="dzS8"   value="33.703*mm"/>
+    <Constant name="dzWing" value="78.790*mm"/>
+
+    <Constant name="dzInL"  value="([dzS1]+[dzS2]+[dzS3]+[dzS4]+[dzS5]+[dzS6]+[dzS7]+[dzS8]+7*[dzGap])"/>
+    <Constant name="z10L"   value="([dzInL]-[dzS1])"/> 
+    <Constant name="z20L"   value="([z10L]-[dzS1]-2*[dzGap]-[dzS2])"/>
+    <Constant name="z30L"   value="([z20L]-[dzS2]-2*[dzGap]-[dzS3])"/> 
+    <Constant name="z40L"   value="([z30L]-[dzS3]-2*[dzGap]-[dzS4])"/> 
+    <Constant name="z50L"   value="([z40L]-[dzS4]-2*[dzGap]-[dzS5])"/> 
+    <Constant name="z60L"   value="([z50L]-[dzS5]-2*[dzGap]-[dzS6])"/> 
+    <Constant name="z70L"   value="([z60L]-[dzS6]-2*[dzGap]-[dzS7])"/> 
+    <Constant name="z80L"   value="([z70L]-[dzS7]-2*[dzGap]-[dzS8])"/> 
+
+    <Constant name="dxTop"  value="(([rPos]+[dzInL])*[slope]-[tol])"/>
+    <Constant name="dx11"   value="([dxTop]-[slope]*([dzInL]-[z10L]+[dzS1]))"/>
+    <Constant name="dx12"   value="([dxTop]-[slope]*([dzInL]-[z10L]-[dzS1]))"/>
+    <Constant name="dx21"   value="([dxTop]-[slope]*([dzInL]-[z20L]+[dzS2]))"/>
+    <Constant name="dx22"   value="([dxTop]-[slope]*([dzInL]-[z20L]-[dzS2]))"/>
+    <Constant name="dx31"   value="([dxTop]-[slope]*([dzInL]-[z30L]+[dzS3]))"/>
+    <Constant name="dx32"   value="([dxTop]-[slope]*([dzInL]-[z30L]-[dzS3]))"/>
+    <Constant name="dx41"   value="([dxTop]-[slope]*([dzInL]-[z40L]+[dzS4]))"/>
+    <Constant name="dx42"   value="([dxTop]-[slope]*([dzInL]-[z40L]-[dzS4]))"/>
+    <Constant name="dx51"   value="([dxTop]-[slope]*([dzInL]-[z50L]+[dzS5]))"/>
+    <Constant name="dx52"   value="([dxTop]-[slope]*([dzInL]-[z50L]-[dzS5]))"/>
+    <Constant name="dx61"   value="([dxTop]-[slope]*([dzInL]-[z60L]+[dzS6]))"/>
+    <Constant name="dx62"   value="([dxTop]-[slope]*([dzInL]-[z60L]-[dzS6]))"/>
+    <Constant name="dx71"   value="([dxTop]-[slope]*([dzInL]-[z70L]+[dzS7]))"/>
+    <Constant name="dx72"   value="([dxTop]-[slope]*([dzInL]-[z70L]-[dzS7]))"/>
+    <Constant name="dx81"   value="([dxTop]-[slope]*([dzInL]-[z80L]+[dzS8]))"/>
+    <Constant name="dx82"   value="([dxTop]-[slope]*([dzInL]-[z80L]-[dzS8]))"/>
+    <Constant name="zero"   value="0.0*fm"/>
+
+  </ConstantsSection>
+
+  <SolidSection label="ge0.xml">
+    <Tubs name="GE0" rMin="[rMin]" rMax="[rMax]" dz="[dzGE0] " startPhi="0*deg" deltaPhi="360*deg"/>
+    <Trd1 name="GE0Box" dz="[dZ]" dy1="[dzGE0]" dy2="[dzGE0]" dx1="[xBot]" dx2="[xTop]" />
+    <Trd1 name="GE0L"    dz="[dZ]" dy1="[tSense]" dy2="[tSense]" dx1="[xBot]" dx2="[xTop]" />
+    <Trd1 name="GE0Base" dz="[dZ]" dy1="[tBase]"  dy2="[tBase]"  dx1="[xBot]" dx2="[xTop]" />
+    <Trd1 name="GE0Gas1" dz="[dZ]" dy1="[tGas1]"  dy2="[tGas1]"  dx1="[xBot]" dx2="[xTop]" />
+    <Trd1 name="GE0Gas2" dz="[dZ]" dy1="[tGas2]"  dy2="[tGas2]"  dx1="[xBot]" dx2="[xTop]" />
+    <Trd1 name="GE0Gas3" dz="[dZ]" dy1="[tGas3]"  dy2="[tGas3]"  dx1="[xBot]" dx2="[xTop]" />
+    <Trd1 name="GE0Foil" dz="[dZ]" dy1="[tFoil]"  dy2="[tFoil]"  dx1="[xBot]" dx2="[xTop]" />
+    <Trd1 name="GE0Read" dz="[dZ]" dy1="[tRead]"  dy2="[tRead]"  dx1="[xBot]" dx2="[xTop]" />
+    <Trd1 name="GE0Top"  dz="[dZ]" dy1="[tTop]"   dy2="[tTop]"   dx1="[xBot]" dx2="[xTop]" />
+  
+    <Trd1 name="GHA001_raw" dz="[dzS1]" dy1="[tSense]" dy2="[tSense]" dx1="[dx11]" dx2="[dx12]" />
+    <Trd1 name="GHA002_raw" dz="[dzS2]" dy1="[tSense]" dy2="[tSense]" dx1="[dx21]" dx2="[dx22]" />
+    <Trd1 name="GHA003" dz="[dzS3]" dy1="[tSense]" dy2="[tSense]" dx1="[dx31]" dx2="[dx32]" />
+    <Trd1 name="GHA004" dz="[dzS4]" dy1="[tSense]" dy2="[tSense]" dx1="[dx41]" dx2="[dx42]" />
+    <Trd1 name="GHA005" dz="[dzS5]" dy1="[tSense]" dy2="[tSense]" dx1="[dx51]" dx2="[dx52]" />
+    <Trd1 name="GHA006" dz="[dzS6]" dy1="[tSense]" dy2="[tSense]" dx1="[dx61]" dx2="[dx62]" />
+    <Trd1 name="GHA007" dz="[dzS7]" dy1="[tSense]" dy2="[tSense]" dx1="[dx71]" dx2="[dx72]" />
+    <Trd1 name="GHA008" dz="[dzS8]" dy1="[tSense]" dy2="[tSense]" dx1="[dx81]" dx2="[dx82]" />
+
+    <Box name="Eta1Wing" dz="[dzS1]" dy="[tSense]" dx="[slope]*[dzWing]"/>
+    <Box name="Eta2Wing" dz="[dzS2]" dy="[tSense]" dx="[slope]*[dzWing]"/>
+
+    <SubtractionSolid name="GHA001_left">
+      <rSolid name="GHA001_raw"/>
+      <rSolid name="Eta1Wing"/>
+      <Translation x="(-[dx12]+([slope]*[dzWing]))" y="[zero]" z="[zero]"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="GHA002_left">
+      <rSolid name="GHA002_raw"/>
+      <rSolid name="Eta2Wing"/>
+      <Translation x="(-[dx12]+([slope]*[dzWing]))" y="[zero]" z="[zero]"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="GHA001">
+      <rSolid name="GHA001_left"/>
+      <rSolid name="Eta1Wing"/>
+      <Translation x="([dx12]-([slope]*[dzWing]))" y="[zero]" z="[zero]"/>
+    </SubtractionSolid>
+    <SubtractionSolid name="GHA002">
+      <rSolid name="GHA002_left"/>
+      <rSolid name="Eta2Wing"/>
+      <Translation x="([dx12]-([slope]*[dzWing]))" y="[zero]" z="[zero]"/>
+    </SubtractionSolid>
+  </SolidSection>
+
+  <LogicalPartSection label="ge0.xml">
+    <LogicalPart name="GE0P" category="unspecified">
+      <rSolid name="GE0"/>
+      <rMaterial name="materials:ME_free_space"/>
+    </LogicalPart>
+    <LogicalPart name="GE0N" category="unspecified">
+      <rSolid name="GE0"/>
+      <rMaterial name="materials:ME_free_space"/>
+    </LogicalPart>
+    <LogicalPart name="GE0Box" category="unspecified">
+      <rSolid name="GE0Box"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="GE0L" category="unspecified">
+      <rSolid name="GE0L"/>
+      <rMaterial name="gemf:M_GEM_Gas"/>
+    </LogicalPart>
+    <LogicalPart name="GE0Foil" category="unspecified">
+      <rSolid name="GE0Foil"/>
+      <rMaterial name="gemf:M_GEM_Foil"/>
+    </LogicalPart>
+    <LogicalPart name="GE0Gas1" category="unspecified">
+      <rSolid name="GE0Gas1"/>
+      <rMaterial name="gemf:M_GEM_Gas"/>
+    </LogicalPart>
+    <LogicalPart name="GE0Gas2" category="unspecified">
+      <rSolid name="GE0Gas2"/>
+      <rMaterial name="gemf:M_GEM_Gas"/>
+    </LogicalPart>
+    <LogicalPart name="GE0Gas3" category="unspecified">
+      <rSolid name="GE0Gas3"/>
+      <rMaterial name="gemf:M_GEM_Gas"/>
+    </LogicalPart>
+    <LogicalPart name="GE0Read" category="unspecified">
+      <rSolid name="GE0Read"/>
+      <rMaterial name="gemf:M_Rdout_Brd"/>
+    </LogicalPart>
+    <LogicalPart name="GE0Base" category="unspecified">
+      <rSolid name="GE0Base"/>
+      <rMaterial name="materials:Aluminium"/>
+    </LogicalPart>
+    <LogicalPart name="GE0Top" category="unspecified">
+      <rSolid name="GE0Top"/>
+      <rMaterial name="materials:Aluminium"/>
+    </LogicalPart>
+
+  <LogicalPart name="GHA001" category="unspecified">
+    <rSolid name="GHA001"/>
+    <rMaterial name="gemf:M_GEM_Gas"/>
+  </LogicalPart>
+  <LogicalPart name="GHA002" category="unspecified">
+    <rSolid name="GHA002"/>
+    <rMaterial name="gemf:M_GEM_Gas"/>
+  </LogicalPart>
+  <LogicalPart name="GHA003" category="unspecified">
+    <rSolid name="GHA003"/>
+    <rMaterial name="gemf:M_GEM_Gas"/>
+  </LogicalPart>
+  <LogicalPart name="GHA004" category="unspecified">
+    <rSolid name="GHA004"/>
+    <rMaterial name="gemf:M_GEM_Gas"/>
+  </LogicalPart>
+  <LogicalPart name="GHA005" category="unspecified">
+    <rSolid name="GHA005"/>
+    <rMaterial name="gemf:M_GEM_Gas"/>
+  </LogicalPart>
+  <LogicalPart name="GHA006" category="unspecified">
+    <rSolid name="GHA006"/>
+    <rMaterial name="gemf:M_GEM_Gas"/>
+  </LogicalPart>
+  <LogicalPart name="GHA007" category="unspecified">
+    <rSolid name="GHA007"/>
+    <rMaterial name="gemf:M_GEM_Gas"/>
+  </LogicalPart>
+  <LogicalPart name="GHA008" category="unspecified">
+    <rSolid name="GHA008"/>
+    <rMaterial name="gemf:M_GEM_Gas"/>
+  </LogicalPart>
+
+  </LogicalPartSection>
+  <PosPartSection label="ge0.xml">
+    <PosPart copyNumber="1">
+      <rParent name="mf:GE0RingP"/>
+      <rChild name="ge0:GE0P"/>
+      <Translation x="0*fm" y="0*fm" z="[zPos]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="mf:GE0RingN"/>
+      <rChild name="ge0:GE0N"/>
+      <Translation x="0*fm" y="0*fm" z="[zPos]" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0L"/>
+      <Translation x="0*fm" y="[z10]" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Base"/>
+      <Translation x="0*fm" y="([z10]+[zBase])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z10]+[zFoil1])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas1"/>
+      <Translation x="0*fm" y="([z10]+[zGas1])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="11">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z10]+[zFoil2])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas2"/>
+      <Translation x="0*fm" y="([z10]+[zGas2])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="21">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z10]+[zFoil3])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas3"/>
+      <Translation x="0*fm" y="([z10]+[zGas3])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Read"/>
+      <Translation x="0*fm" y="([z10]+[zRead])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="1">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Top"/>
+      <Translation x="0*fm" y="([z10]+[zTop])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0L"/>
+      <Translation x="0*fm" y="[z20]" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Base"/>
+      <Translation x="0*fm" y="([z20]+[zBase])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z20]+[zFoil1])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas1"/>
+      <Translation x="0*fm" y="([z20]+[zGas1])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="12">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z20]+[zFoil2])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas2"/>
+      <Translation x="0*fm" y="([z20]+[zGas2])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="22">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z20]+[zFoil3])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas3"/>
+      <Translation x="0*fm" y="([z20]+[zGas3])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Read"/>
+      <Translation x="0*fm" y="([z20]+[zRead])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Top"/>
+      <Translation x="0*fm" y="([z20]+[zTop])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="3">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0L"/>
+      <Translation x="0*fm" y="[z30]" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="3">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Base"/>
+      <Translation x="0*fm" y="([z30]+[zBase])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="3">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z30]+[zFoil1])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="3">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas1"/>
+      <Translation x="0*fm" y="([z30]+[zGas1])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="13">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z30]+[zFoil2])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="3">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas2"/>
+      <Translation x="0*fm" y="([z30]+[zGas2])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="23">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z30]+[zFoil3])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="3">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas3"/>
+      <Translation x="0*fm" y="([z30]+[zGas3])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="3">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Read"/>
+      <Translation x="0*fm" y="([z30]+[zRead])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="3">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Top"/>
+      <Translation x="0*fm" y="([z30]+[zTop])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="4">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0L"/>
+      <Translation x="0*fm" y="[z40]" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="4">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Base"/>
+      <Translation x="0*fm" y="([z40]+[zBase])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="4">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z40]+[zFoil1])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="4">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas1"/>
+      <Translation x="0*fm" y="([z40]+[zGas1])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="14">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z40]+[zFoil2])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="4">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas2"/>
+      <Translation x="0*fm" y="([z40]+[zGas2])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="24">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z40]+[zFoil3])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="4">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas3"/>
+      <Translation x="0*fm" y="([z40]+[zGas3])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="4">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Read"/>
+      <Translation x="0*fm" y="([z40]+[zRead])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="4">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Top"/>
+      <Translation x="0*fm" y="([z40]+[zTop])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="5">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0L"/>
+      <Translation x="0*fm" y="[z50]" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="5">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Base"/>
+      <Translation x="0*fm" y="([z50]+[zBase])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="5">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z50]+[zFoil1])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="5">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas1"/>
+      <Translation x="0*fm" y="([z50]+[zGas1])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="15">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z50]+[zFoil2])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="5">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas2"/>
+      <Translation x="0*fm" y="([z50]+[zGas2])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="25">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z50]+[zFoil3])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="5">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas3"/>
+      <Translation x="0*fm" y="([z50]+[zGas3])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="5">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Read"/>
+      <Translation x="0*fm" y="([z50]+[zRead])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="5">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Top"/>
+      <Translation x="0*fm" y="([z50]+[zTop])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="6">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0L"/>
+      <Translation x="0*fm" y="[z60]" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="6">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Base"/>
+      <Translation x="0*fm" y="([z60]+[zBase])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="6">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z60]+[zFoil1])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="6">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas1"/>
+      <Translation x="0*fm" y="([z60]+[zGas1])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="16">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z60]+[zFoil2])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="6">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas2"/>
+      <Translation x="0*fm" y="([z60]+[zGas2])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="26">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Foil"/>
+      <Translation x="0*fm" y="([z60]+[zFoil3])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="6">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Gas3"/>
+      <Translation x="0*fm" y="([z60]+[zGas3])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="6">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Read"/>
+      <Translation x="0*fm" y="([z60]+[zRead])" z="0*fm" />
+    </PosPart>
+    <PosPart copyNumber="6">
+      <rParent name="ge0:GE0Box"/>
+      <rChild name="ge0:GE0Top"/>
+      <Translation x="0*fm" y="([z60]+[zTop])" z="0*fm" />
+    </PosPart>
+ 
+    <PosPart copyNumber="1">
+      <rParent name="ge0:GE0L"/>
+      <rChild name="ge0:GHA001"/>
+      <Translation x="0*fm" y="0*fm" z="[z10L]" />
+    </PosPart>
+    <PosPart copyNumber="2">
+      <rParent name="ge0:GE0L"/>
+      <rChild name="ge0:GHA002"/>
+      <Translation x="0*fm" y="0*fm" z="[z20L]" />
+    </PosPart>
+    <PosPart copyNumber="3">
+      <rParent name="ge0:GE0L"/>
+      <rChild name="ge0:GHA003"/>
+      <Translation x="0*fm" y="0*fm" z="[z30L]" />
+    </PosPart>
+    <PosPart copyNumber="4">
+      <rParent name="ge0:GE0L"/>
+      <rChild name="ge0:GHA004"/>
+      <Translation x="0*fm" y="0*fm" z="[z40L]" />
+    </PosPart>
+    <PosPart copyNumber="5">
+      <rParent name="ge0:GE0L"/>
+      <rChild name="ge0:GHA005"/>
+      <Translation x="0*fm" y="0*fm" z="[z50L]" />
+    </PosPart>
+    <PosPart copyNumber="6">
+      <rParent name="ge0:GE0L"/>
+      <rChild name="ge0:GHA006"/>
+      <Translation x="0*fm" y="0*fm" z="[z60L]" />
+    </PosPart>
+    <PosPart copyNumber="7">
+      <rParent name="ge0:GE0L"/>
+      <rChild name="ge0:GHA007"/>
+      <Translation x="0*fm" y="0*fm" z="[z70L]" />
+    </PosPart>
+    <PosPart copyNumber="8">
+      <rParent name="ge0:GE0L"/>
+      <rChild name="ge0:GHA008"/>
+      <Translation x="0*fm" y="0*fm" z="[z80L]" />
+    </PosPart>
+  </PosPartSection>
+
+  <Algorithm name="muon:DDGEMAngular">
+    <rParent name="GE0P"/>
+    <String name="ChildName" value="GE0Box"/>
+    <String name="RotNameSpace" value="ge0"/>
+    <Numeric name="n" value="18"/>
+    <Numeric name="startCopyNo" value="1"/>
+    <Numeric name="incrCopyNo"  value="1"/>
+    <Numeric name="invert"      value="1"/>
+    <Numeric name="stepAngle"   value="20*deg"/>
+    <Numeric name="startAngle"  value="10*deg"/>
+    <Numeric name="rPosition"   value="[rPos]"/>
+    <Numeric name="zoffset"     value="0*mm"/>
+  </Algorithm>
+  <Algorithm name="muon:DDGEMAngular">
+    <rParent name="GE0N"/>
+    <String name="ChildName" value="GE0Box"/>
+    <String name="RotNameSpace" value="ge0"/>
+    <Numeric name="n" value="18"/>
+    <Numeric name="startCopyNo" value="1"/>
+    <Numeric name="incrCopyNo"  value="1"/>
+    <Numeric name="invert"      value="1"/>
+    <Numeric name="stepAngle"   value="-20*deg"/>
+    <Numeric name="startAngle"  value="170*deg"/>
+    <Numeric name="rPosition"   value="[rPos]"/>
+    <Numeric name="zoffset"     value="0*mm"/>
+  </Algorithm>
+
+</DDDefinition>


### PR DESCRIPTION
#### PR description:

* Before this PR, we had only a trapezoidal shape for the GE0 chamber
* However, the GE0 chambers are supposed to have trapezoidal + rectagular shape
* So we are introducing the GE0 chamber with the correct shape through this PR
* The implementation of the shape is performed with the `G4SubtractionSolid` to keep the original trapezoidal shape parameters, which are used for generating the readout strip topology
* At the moment, the shape changing is applied only on the simulation side, not for the reconstruction geometry
* While we are introducing the new shape, we found that several parameters we were using before are wrong; the PR is fixing those also
* The main idea of the PR is described in the [slide](https://indico.cern.ch/event/1661573/#78-gem-geometry)

#### PR validation:
* The changes are tested with `scram b code-format` and corrected with `scram b code-checks`
* I personally checked that the new `ge0.xml` file is compatible with the updated `GEMGeometryBuilder`
* The backward compatibility is tested

@bsunanda @watson-ij