### PR TITLE
`ALCARECOTkAlHLT*TkAlDQM`: change reference HLT track collection in PbPb

### DIFF
--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -396,6 +396,10 @@ ALCARECOTkAlHLTTracksTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
     SumChargeMax = 50.5
 )
 
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(ALCARECOTkAlHLTTracksTkAlDQM,
+                         ReferenceTrackProducer= "hltMergedTracksPPOnAA")
+
 ALCARECOTkAlHLTTracksDQM = cms.Sequence( ALCARECOTkAlHLTTracksTrackingDQM  + ALCARECOTkAlHLTTracksTkAlDQM )
 
 ########################################################
@@ -432,11 +436,18 @@ ALCARECOTkAlHLTTracksZMuMuTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
     SumChargeMax = 50.5
 )
 
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(ALCARECOTkAlHLTTracksZMuMuTkAlDQM,
+                         ReferenceTrackProducer= "hltMergedTracksPPOnAA")
+
 ALCARECOTkAlHLTTracksZMuMuVtxDQM = ALCARECOTkAlDiMuonAndVertexVtxDQM.clone(
     muonTracks = 'ALCARECO'+__selectionName,
     vertices = 'hltPixelVertices',
     FolderName = "AlCaReco/"+__selectionName,
 )
+
+pp_on_PbPb_run3.toModify(ALCARECOTkAlHLTTracksZMuMuVtxDQM,
+                         vertices = 'hltPixelVerticesPPOnAA')
 
 ALCARECOTkAlHLTTracksZMuMuMassBiasDQM = ALCARECOTkAlDiMuonMassBiasDQM.clone(
     muonTracks = 'ALCARECO'+__selectionName,


### PR DESCRIPTION
#### PR description:

This is a quick follow-up to https://github.com/cms-sw/cmssw/pull/51031 in order to be able to run `PromptCalibProdSiPixelAliHLTHGC` at Tier0.

#### PR validation:

I prepared the input RAW data as:

```bash
#!/bin/bash -ex

# cmsrel CMSSW_16_1_1_patch1
# cd CMSSW_16_1_1_patch1/src
# cmsenv


LOCALPATH='/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/daleyvap/CMSHLT-3754-AllMinBias_ZB35/'
echo "Input source: |${LOCALPATH}|"
LOCALFILES=$(ls -1 ${LOCALPATH})
ALL_FILES=""
for f in ${LOCALFILES[@]}; do
    ALL_FILES+="file:${LOCALPATH}/${f},"
done

# Remove the last character
ALL_FILES="${ALL_FILES%?}"
echo "Discovered files: $ALL_FILES"

hltGetConfiguration /users/STORM/CMSSW_16_1_0/CMSHLT-3855/HLT/V2 \
		    --globaltag 161X_dataRun3_HLT_v1 \
		    --data \
		    --unprescale \
		    --output none \
		    --max-events -1 \
		    --eras Run3_2026 --l1-emulator uGT --l1 L1Menu_CollisionsHeavyIons2026_v1_0_2_xml \
		    --input $ALL_FILES \
		    --paths Dataset_HIHLTMonitor,HIHLTMonitorOutput,HLT_HICentrality50100MinimumBiasHF1AND_Beamspot_v* \
		    > test.py

cat <<@EOF >> test.py
# make summary avaliable
process.options.wantSummary = True
@EOF

cmsRun test.py >& test.log
```

The resulting file is store at `/eos/cms/store/group/tsg/STORM/outputHIHLTMonitor.root ` and then run the following script to test the alignment PCL:

```bash
#!/bin/bash -ex

cmsDriver.py ReAlCaHLT \
  -s ALCA:TkAlHLTTracks+TkAlHLTTracksZMuMu+PromptCalibProdSiPixelAliHLTHGC \
  --conditions 161X_dataRun3_Express_v1 \
  --scenario pp \
  --data \
  --era Run3_pp_on_PbPb_2026 \
  --datatier ALCARECO \
  --eventcontent ALCARECO \
  --process RECO \
  --processName ReAlCa \
  --customise_commands 'process.ALCARECOTkAlHLTTracksHLT.TriggerResultsTag = cms.InputTag("TriggerResults","","HLTX"); process.ALCARECOTkAlHLTTracksZMuMuHLT.TriggerResultsTag = cms.InputTag("TriggerResults","","HLTX")' \
  --filein file:/eos/cms/store/group/tsg/STORM/outputHIHLTMonitor.root \
  -n 1000 \
  --no_exec

cat <<@EOF >> ReAlCaHLT_ALCA.py
# the following is needed in order to run directly on the "RAW" data
import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
process.pathALCARECOTkAlHLTTracks.insert(0,process.offlineBeamSpot)
process.pathALCARECOTkAlHLTTracksZMuMu.insert(0,process.offlineBeamSpot)
process.ALCARECOTkAlHLTTracksZMuMuTkAlDQM.runsOnReco = False
process.ALCARECOTkAlHLTTracksTkAlDQM.runsOnReco = False
@EOF

cmsRun ReAlCaHLT_ALCA.py >& ReAlCa.log

cmsDriver.py ALCAHARVDSIPIXELALIHLTHGCOMBINED \
  -s ALCAHARVEST:SiPixelAliHLTHGCombined \
  --conditions 161X_dataRun3_Express_v1 \
  --scenario pp \
  --era Run3_pp_on_PbPb_2026 \
  --data \
  -n -1 \
  --filein file:PromptCalibProdSiPixelAliHLTHGC.root \
  --customise Alignment/CommonAlignmentProducer/customizeLSNumberFilterForRelVals.lowerHitsPerStructure >& Harvesting.log
```

with no errors.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but this commit will be included in https://github.com/cms-sw/cmssw/pull/51032.