### PR TITLE
Move `ThreadHandoff` to `FWCore/Utilities`

### DIFF
--- a/FWCore/Utilities/interface/ThreadHandoff.h
+++ b/FWCore/Utilities/interface/ThreadHandoff.h
@@ -1,5 +1,5 @@
-#ifndef SimG4Core_Application_ThreadHandoff_h
-#define SimG4Core_Application_ThreadHandoff_h
+#ifndef FWCore_Utilities_ThreadHandoff_h
+#define FWCore_Utilities_ThreadHandoff_h
 // -*- C++ -*-
 //
 // Package:     SimG4Core/Application
@@ -29,7 +29,7 @@
 
 // forward declarations
 
-namespace omt {
+namespace edm {
   class ThreadHandoff {
   public:
     explicit ThreadHandoff(int stackSize);
@@ -94,5 +94,5 @@ namespace omt {
     bool m_loopReady{false};
     bool m_stopThread{false};
   };
-}  // namespace omt
+}  // namespace edm
 #endif

--- a/FWCore/Utilities/src/ThreadHandoff.cc
+++ b/FWCore/Utilities/src/ThreadHandoff.cc
@@ -13,8 +13,8 @@
 // system include files
 
 // user include files
-#include "SimG4Core/Application/interface/ThreadHandoff.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/ThreadHandoff.h"
 #include <array>
 
 //
@@ -36,7 +36,7 @@ namespace {
 //
 // constructors and destructor
 //
-using namespace omt;
+using namespace edm;
 
 ThreadHandoff::ThreadHandoff(int stackSize) {
   pthread_attr_t attr;

--- a/FWCore/Utilities/test/test_catch2_ThreadHandoff.cc
+++ b/FWCore/Utilities/test/test_catch2_ThreadHandoff.cc
@@ -1,20 +1,22 @@
-#include "SimG4Core/Application/interface/ThreadHandoff.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/ThreadHandoff.h"
 #define CATCH_CONFIG_MAIN
 #include "catch2/catch_all.hpp"
 
-using namespace omt;
-TEST_CASE("Test omt::ThreadHandoff", "[ThreadHandoff]") {
-  SECTION("Do nothing") { ThreadHandoff th; }
+using namespace edm;
+TEST_CASE("Test edm::ThreadHandoff", "[ThreadHandoff]") {
+  constexpr unsigned stackSize = 1024 * 1024;  // MB
+
+  SECTION("Do nothing") { ThreadHandoff th(stackSize); }
   SECTION("Simple") {
-    ThreadHandoff th;
+    ThreadHandoff th(stackSize);
     bool value = false;
     th.runAndWait([&value]() { value = true; });
     REQUIRE(value == true);
   }
 
   SECTION("Exception") {
-    ThreadHandoff th;
+    ThreadHandoff th(stackSize);
     REQUIRE_THROWS_AS(th.runAndWait([]() { throw cms::Exception("Test"); }), cms::Exception);
   }
 }

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -17,6 +17,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/ThreadHandoff.h"
 
 #include "SimG4Core/Application/interface/OscarMTMasterThread.h"
 #include "SimG4Core/Application/interface/RunManagerMT.h"
@@ -33,8 +34,6 @@
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
-
-#include "SimG4Core/Application/interface/ThreadHandoff.h"
 
 #include "Randomize.hh"
 
@@ -59,7 +58,7 @@ public:
   void produce(edm::Event& e, const edm::EventSetup& c) override;
 
 private:
-  omt::ThreadHandoff m_handoff;
+  edm::ThreadHandoff m_handoff;
   std::unique_ptr<RunManagerMTWorker> m_runManagerWorker;
   const OscarMTMasterThread* m_masterThread;
   const edm::ParameterSetID m_psetID;


### PR DESCRIPTION
#### PR description:

More demand for this utility has surfaced (latest one being https://github.com/cms-sw/cmssw/issues/50935, could be used also for https://github.com/cms-sw/cmssw/issues/43526). I'm plaing it to `FWCore/Utilities` instead of `FWCore/Concurrency` because it does not depend on TBB.

I noticed the unit test code has not been used in `SimG4Core/Applications`. It needed a small change to compile and run.

Resolves https://github.com/cms-sw/framework-team/issues/2255

#### PR validation:

Unit test runs.