### PR TITLE
Add support for zstd de/compression of HDF5 conditions payloads

### DIFF
--- a/CondCore/CondHDF5ESSource/README.md
+++ b/CondCore/CondHDF5ESSource/README.md
@@ -11,8 +11,10 @@ CondHDF5ESSource is an EventSetup source that can read conditions data from an H
 In general, one will specify the file to read and the global tag stored within that file to use. E.g.
 
 ```python
-
-globalTag = cms.ESSource("CondHDF5ESSource", filename = cms.string("JobConditions.h5cond"), globalTag = cms.string("SomeTag") ) 
+process.GlobalTag = cms.ESSource("CondHDF5ESSource",
+    filename = cms.untracked.string("JobConditions.h5cond"),
+    globalTag = cms.string("SomeTag")
+)
 ```
 
 ## Utilities for creating an HDF5 conditions file

--- a/CondCore/CondHDF5ESSource/plugins/BuildFile.xml
+++ b/CondCore/CondHDF5ESSource/plugins/BuildFile.xml
@@ -1,12 +1,13 @@
 <environment>
   <library file="*.cc" name = "CondCoreCondHDF5ESSource">
-    <flags EDM_PLUGIN="1"/>
     <use name="boost"/>
+    <use name="hdf5"/>
+    <use name="xz"/>
+    <use name="zlib"/>
+    <use name="zstd"/>
+    <use name="CondFormats/SerializationHelper"/>
     <use name="FWCore/Framework"/>
     <use name="FWCore/ParameterSet"/>
-    <use name="CondFormats/SerializationHelper"/>
-    <use name="hdf5"/>
-    <use name="zlib"/>
+    <flags EDM_PLUGIN="1"/>
   </library>
-
 </environment>

--- a/CondCore/CondHDF5ESSource/plugins/Compression.h
+++ b/CondCore/CondHDF5ESSource/plugins/Compression.h
@@ -25,7 +25,7 @@
 // forward declarations
 
 namespace cond::hdf5 {
-  enum class Compression { kNone, kZLIB, kLZMA };
+  enum class Compression { kNone, kZLIB, kLZMA, kZSTD };
 }
 
 #endif

--- a/CondCore/CondHDF5ESSource/plugins/CondHDF5ESSource.cc
+++ b/CondCore/CondHDF5ESSource/plugins/CondHDF5ESSource.cc
@@ -76,6 +76,8 @@ namespace {
       return Compression::kZLIB;
     } else if (iName == "lzma") {
       return Compression::kLZMA;
+    } else if (iName == "zstd") {
+      return Compression::kZSTD;
     } else if (iName == "none") {
       return Compression::kNone;
     } else {

--- a/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
+++ b/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
@@ -14,8 +14,11 @@
 #include <iostream>
 #include <fstream>
 #include <cassert>
-#include "zlib.h"
-#include "lzma.h"
+
+// compression libraries
+#include <zlib.h>
+#include <lzma.h>
+#include <zstd.h>
 
 // user include files
 #include "HDF5ProductResolver.h"
@@ -206,6 +209,37 @@ std::vector<char> HDF5ProductResolver::decompress_lzma(std::vector<char> compres
   return buffer;
 }
 
+std::vector<char> HDF5ProductResolver::decompress_zstd(std::vector<char> compressedBuffer, std::size_t iMemSize) const {
+  std::vector<char> buffer;
+  if (iMemSize == compressedBuffer.size()) {
+    //memory was not compressed
+    //std::cout <<"NOT COMPRESSED"<<std::endl;
+    buffer = std::move(compressedBuffer);
+  } else {
+    //zstd compression was used
+    // TODO: use an explicit decompression context (one per thread) to reduce memory churn
+    std::size_t size = ZSTD_getFrameContentSize(compressedBuffer.data(), compressedBuffer.size());
+    if (size == ZSTD_CONTENTSIZE_UNKNOWN) {
+      // decompressed size field is not present, assume iMemSize
+      size = iMemSize;
+    } else if (ZSTD_isError(size)) {
+      throw cms::Exception("H5CondFailedDecompress")
+          << "error detected before attempting to decompress buffer using zstd";
+    } else if (size != iMemSize) {
+      throw cms::Exception("H5CondFailedDecompress")
+          << "unexpected payload size before attempting to decompress buffer using zstd";
+    }
+    buffer = std::vector<char>(iMemSize);
+    size = ZSTD_decompress(buffer.data(), buffer.size(), compressedBuffer.data(), compressedBuffer.size());
+    if (ZSTD_isError(size)) {
+      throw cms::Exception("H5CondFailedDecompress") << "error detected during zstd buffer decompression";
+    } else if (size != iMemSize) {
+      throw cms::Exception("H5CondFailedDecompress") << "unexpected payload size after zstd buffer decompression";
+    }
+  }
+  return buffer;
+}
+
 void HDF5ProductResolver::threadFriendlyPrefetch(uint64_t iFileOffset,
                                                  std::size_t iStorageSize,
                                                  std::size_t iMemSize,
@@ -223,12 +257,14 @@ void HDF5ProductResolver::threadFriendlyPrefetch(uint64_t iFileOffset,
     buffer = decompress_zlib(std::move(compressedBuffer), iMemSize);
   } else if (compression_ == cond::hdf5::Compression::kLZMA) {
     buffer = decompress_lzma(std::move(compressedBuffer), iMemSize);
+  } else if (compression_ == cond::hdf5::Compression::kZSTD) {
+    buffer = decompress_zstd(std::move(compressedBuffer), iMemSize);
   } else {
     buffer = std::move(compressedBuffer);
   }
 
   std::stringbuf sBuffer;
-  sBuffer.pubsetbuf(&buffer[0], buffer.size());
+  sBuffer.pubsetbuf(buffer.data(), buffer.size());
   data_ = helper_->deserialize(sBuffer, iTypeName);
   if (data_.get() == nullptr) {
     throw cms::Exception("H5CondFailedDeserialization")

--- a/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.h
+++ b/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.h
@@ -69,6 +69,7 @@ private:
 
   std::vector<char> decompress_zlib(std::vector<char>, std::size_t iMemSize) const;
   std::vector<char> decompress_lzma(std::vector<char>, std::size_t iMemSize) const;
+  std::vector<char> decompress_zstd(std::vector<char>, std::size_t iMemSize) const;
   // ---------- member data --------------------------------
   edm::SerialTaskQueue* queue_;
   cond::serialization::unique_void_ptr data_;

--- a/CondCore/CondHDF5ESSource/python/hdf5Writer.py
+++ b/CondCore/CondHDF5ESSource/python/hdf5Writer.py
@@ -105,6 +105,7 @@ def writeH5File(fileName, globalTags, excludeRecords, includeRecords, tagReader,
                 if includeRecords and (not rcd in includeRecords):
                     continue
                 recordDataSize = 0
+                compressedSize = 0
                 
                 payloadToRefs = { None: null_dataset.ref}
                 
@@ -120,23 +121,33 @@ def writeH5File(fileName, globalTags, excludeRecords, includeRecords, tagReader,
                     payloadsGroup = dataProductGroup.create_group("Payloads")
                     print(" product: %s"%dataProduct.name())
                     for p_index, payload in enumerate(dataProduct.payloads()):
-                        print("  %i payload: %s size: %i"%(p_index,payload.name(),len(payload.data())))
-                        recordDataSize +=len(payload.data())
+                        print("  %i payload: %s size: %i"%(p_index,payload.name(),len(payload.data())), end="")
+                        recordDataSize += len(payload.data())
                         if default_compressor:
                             b = default_compressor.compress(payload.data())
-                            if len(b) >= len(payload.data()):
+                            if len(b) < len(payload.data()):
+                                print(", compressed size: %i"%(len(b)))
+                            else:
                                 #compressing isn't helping
                                 b = payload.data()
+                                print(", uncompressed")
                         else:
                             b = payload.data()
+                            print(", uncompressed")
+                        compressedSize += len(b)
                         pl = payloadsGroup.create_dataset(payload.name(), data=np.frombuffer(b,dtype='b'))
                         pl.attrs["memsize"] = len(payload.data())
                         pl.attrs["type"] = payload.actualType()
                         payloadToRefs[payload.name()] = pl.ref
                         
                 tagGroupRefs.append(writeTag(tagsGroup, tag.time_type(), tag.iovsNPayloadNames(), payloadToRefs, tag.originalTagNames(), rcd, productNames))
-                print(" total size:",recordDataSize)
+                print(" total size:", recordDataSize, end="")
+                if (recordDataSize == compressedSize):
+                    print(", uncompressed")
+                else:
+                    print(", compressed size:", compressedSize)
                 recordDataSize = 0
+                compressedSize = 0
 
             globalTagGroup = globalTagsGroup.create_group(name)
             globalTagGroup.create_dataset("Tags", data=tagGroupRefs, dtype=h5py.ref_dtype)

--- a/CondCore/CondHDF5ESSource/python/hdf5Writer.py
+++ b/CondCore/CondHDF5ESSource/python/hdf5Writer.py
@@ -1,6 +1,11 @@
+import sys
 import h5py
 import zlib
 import lzma
+if sys.version_info >= (3, 14):
+    from compression import zstd
+else:
+    from backports import zstd
 import numpy as np
 
 #The file structure
@@ -79,6 +84,8 @@ def writeH5File(fileName, globalTags, excludeRecords, includeRecords, tagReader,
         default_compressor = zlib
     elif default_compressor_name == "lzma":
         default_compressor = lzma
+    elif default_compressor_name == "zstd":
+        default_compressor = zstd
     with h5py.File(fileName, 'w') as h5file:
         h5file.attrs["file_format"] = 1
         h5file.attrs["default_payload_compressor"] = default_compressor_name.encode("ascii")

--- a/CondCore/CondHDF5ESSource/scripts/conddb2hdf5.py
+++ b/CondCore/CondHDF5ESSource/scripts/conddb2hdf5.py
@@ -568,7 +568,7 @@ def main():
     parser.add_argument('--exclude', '-e', nargs='*', help = 'list of records to exclude from the file (can not be used with --include)')
     parser.add_argument('--include', '-i', nargs='*', help = 'lost of the only records that should be included in the file (can not be used with --exclude')
     parser.add_argument('--output', '-o', default='test.h5cond', help='name of hdf5 output file to write')
-    parser.add_argument('--compressor', '-c', default='zlib', choices =['zlib','lzma','none'], help="compress data using 'zlib', 'lzma' or 'none'")    
+    parser.add_argument('--compressor', '-c', default='zlib', choices=['zlib', 'lzma', 'zstd', 'none'], help="compress data using 'zlib', 'lzma', 'zstd', or 'none'")
     args = parser.parse_args()
 
     if args.exclude and args.include:

--- a/CondCore/CondHDF5ESSource/scripts/condhdf5tohdf5.py
+++ b/CondCore/CondHDF5ESSource/scripts/condhdf5tohdf5.py
@@ -69,10 +69,12 @@ class H5Tag(object):
 
         compressor = None
         compressorName = self._file.attrs['default_payload_compressor']
-        if compressorName == 'lzma':
-            compressor = lzma
         if compressorName == 'zlib':
             compressor = zlib
+        elif compressorName == 'lzma':
+            compressor = lzma
+        elif compressorName == 'zstd':
+            compressor = zstd
         self._group = group
         self._record = self._group.attrs['record']
         self._name = name
@@ -133,7 +135,7 @@ def main():
     parser.add_argument('--exclude', '-e', nargs='*', help = 'list of records to exclude from the file (can not be used with --include)')
     parser.add_argument('--include', '-i', nargs='*', help = 'lost of the only records that should be included in the file (can not be used with --exclude')
     parser.add_argument('--output', '-o', default='test.h5cond', help='name of hdf5 output file to write')
-    parser.add_argument('--compressor', '-c', default='zlib', choices=['zlib', 'lzma', 'none'], help="compress data using 'zlib', 'lzma' or 'none'")
+    parser.add_argument('--compressor', '-c', default='zlib', choices=['zlib', 'lzma', 'zstd', 'none'], help="compress data using 'zlib', 'lzma', 'zstd', or 'none'")
     args = parser.parse_args()
 
     if args.exclude and args.include:


### PR DESCRIPTION
#### PR description:

  - add support for zstd de/compression of HDF5 conditions payloads;
  - `hdf5Writer`: print compressed sizes
  - fix the `CondHDF5ESSource` example in the README.md

#### PR validation:

Tested dumping a global tag to HDF5 format compressed with zstd with
```bash
conddb2hdf5.py --run 402360 160X_dataRun3_HLT_v1 --output .160X_dataRun3_HLT_v1.hdf5 --compressor zstd
```

and running an HLT job with
```python
process.GlobalTag = cms.ESSource("CondHDF5ESSource",
    filename = cms.untracked.string("160X_dataRun3_HLT_v1.hdf5"),
    globalTag = cms.string("160X_dataRun3_HLT_v1")
) 
```