### PR TITLE
[NGT] Fix Phase-2 HLT MET validation (persist collections)

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -736,6 +736,9 @@ phase2_common.toModify(FEVTDEBUGHLTEventContent,
                            'keep *_hltMergeLayerClusters_*_*',
                            'keep *_hltParticleFlowRecHit*_*_*',
                            'keep *_hltEgammaGsfTracksL1Seeded_*_*',
+                           'keep *_hltPFMET_*_*',
+                           'keep *_hltPFPuppiMET_*_*',
+                           'keep *_hltPFPuppiMETTypeOne_*_*',
                        ])
 
 phase2_muon.toModify(FEVTDEBUGHLTEventContent, 

--- a/HLTriggerOffline/JetMET/python/Validation/HLTJetMETValidation_cff.py
+++ b/HLTriggerOffline/JetMET/python/Validation/HLTJetMETValidation_cff.py
@@ -1,15 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-from functools import reduce
 
 from HLTriggerOffline.JetMET.Validation.SingleJetValidation_cfi import *
 from Validation.RecoJets.hltJetValidation_cff import *
 from Validation.RecoMET.hltMETValidation_cff import *
-
-def sumModules(alist):
-    return reduce(lambda x, y: x + y, alist)
-
-met_run3_analyzers = [hltMetAnalyzerPF, hltMetAnalyzerPFCalo]
-met_ph2_analyzers = [hltMetAnalyzerPF, hltMetAnalyzerPFPuppi, hltMetTypeOneAnalyzerPFPuppi]
 
 ##please do NOT include paths here!
 HLTJetMETValSeq = cms.Sequence(
@@ -17,11 +10,15 @@ HLTJetMETValSeq = cms.Sequence(
     + hltJetAnalyzerAK4PFPuppi
     + hltJetAnalyzerAK4PF
     + hltJetAnalyzerAK4PFCHS
-    + sumModules(met_run3_analyzers)
+    + hltMetAnalyzerPF
+    + hltMetAnalyzerPFCalo
 )
 
-_phase2_HLTJetMETValSeq = HLTJetMETValSeq.copyAndExclude(met_run3_analyzers)
-_phase2_HLTJetMETValSeq += cms.Sequence(sumModules(met_ph2_analyzers))
-
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toReplaceWith(HLTJetMETValSeq, _phase2_HLTJetMETValSeq)
+phase2_common.toReplaceWith(HLTJetMETValSeq, 
+    cms.Sequence(
+        HLTJetMETValSeq.copy()
+        + hltMetAnalyzerPFPuppi
+        + hltMetTypeOneAnalyzerPFPuppi
+    )
+)


### PR DESCRIPTION
#### PR description:

This PR restores and fixes the Phase‑2 HLT MET validation by ensuring that the required collections are correctly persisted in the `FEVTDEBUGHLT` event content.
In addition, it introduces the `hltMetAnalyzerPFCalo` sequence (for `hltCaloMET`), which is available in Phase‑2 but had been unintentionally left out of the validation workflow.

This work builds on the previously introduced HLT MET validation framework for both Run‑3 and Phase‑2:
- https://github.com/cms-sw/cmssw/pull/48745
- https://github.com/cms-sw/cmssw/pull/49082
- https://github.com/cms-sw/cmssw/pull/49381

Before this PR, all HLT MET validation plots appeared empty in the RelVal and RelMon GUIs, making the validation effectively unusable for JME studies. The root cause is the standard two-step workflow:
\- step2: `L1,HLT`
\- step3: `RECO,VALIDATION`
The HLT MET validation relies on collections produced during the HLT step, but these were not persisted into the event content. As a result, they were unavailable in the validation step, leading to empty histograms.

<img width="1512" height="748" alt="Screenshot 2026-05-27 at 09 03 38" src="https://github.com/user-attachments/assets/46f506f0-5f4c-4de6-baf8-167dfa9652c6" />

With this PR, the HLT MET collections are persisted in the step2 output and the validation plots are correctly filled.

#### Impact

The event size increase due to the additional collections has been estimated on 10 TTbar events:
- Before this PR: 59,577,071 bytes
- After this PR: 59,580,377 bytes

This corresponds to an increase of 3,306 bytes (~0,0055%).

#### PR validation:

This PR has been successfully validated on the two-step workflow `34434.0`.
```
runTheMatrix.py -l 34434.0 -w upgrade -j 10 --ibeos --nEvents 10 -j 10 -i all
```
The HLT MET validation histograms in the DQM output compare:
- before this PR (left): empty distributions
- after this PR (right): correctly filled distributions
<img width="2513" height="1177" alt="Screenshot 2026-05-27 at 09 09 16" src="https://github.com/user-attachments/assets/ad3ab1ab-1c13-4cce-a7d4-89c19f8abe8d" />
