### PR TITLE
[NGT] Fix Phase-2 HLT CorrectedJet validation (re-run correction)

### DIFF
--- a/JetMETCorrections/Algorithms/interface/L1FastjetCorrectorImpl.h
+++ b/JetMETCorrections/Algorithms/interface/L1FastjetCorrectorImpl.h
@@ -29,6 +29,7 @@ public:
 
 private:
   edm::EDGetTokenT<double> rhoToken_;
+  bool skipMissingProduct_;
 };
 
 class L1FastjetCorrectorImpl : public reco::JetCorrectorImpl {

--- a/JetMETCorrections/Algorithms/src/L1FastjetCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L1FastjetCorrectorImpl.cc
@@ -29,7 +29,8 @@ using namespace std;
 L1FastjetCorrectorImplMaker::L1FastjetCorrectorImplMaker(edm::ParameterSet const& fConfig,
                                                          edm::ConsumesCollector fCollector)
     : JetCorrectorImplMakerBase(fConfig, fCollector),
-      rhoToken_(fCollector.consumes<double>(fConfig.getParameter<edm::InputTag>("srcRho"))) {}
+      rhoToken_(fCollector.consumes<double>(fConfig.getParameter<edm::InputTag>("srcRho"))),
+      skipMissingProduct_(fConfig.getParameter<bool>("skipMissingProduct")) {}
 
 std::unique_ptr<reco::JetCorrectorImpl> L1FastjetCorrectorImplMaker::make(edm::Event const& fEvent,
                                                                           edm::EventSetup const& fSetup) {
@@ -41,13 +42,25 @@ std::unique_ptr<reco::JetCorrectorImpl> L1FastjetCorrectorImplMaker::make(edm::E
 
   edm::Handle<double> hRho;
   fEvent.getByToken(rhoToken_, hRho);
-  return std::make_unique<L1FastjetCorrectorImpl>(corrector, *hRho);
+
+  if (hRho.isValid()) {
+    return std::make_unique<L1FastjetCorrectorImpl>(corrector, *hRho);
+  }
+  // Handle missing product
+  else if (skipMissingProduct_) {
+    edm::LogWarning("L1FastjetCorrector")
+        << "Rho product is missing, but skipMissingProduct is set to true. Returning corrector with rho = 0.";
+    return std::make_unique<L1FastjetCorrectorImpl>(corrector, 0.0);
+  } else {
+    throw cms::Exception("L1FastjetCorrector") << "Rho product is missing and skipMissingProduct is set to false.";
+  }
 }
 
 void L1FastjetCorrectorImplMaker::fillDescriptions(edm::ConfigurationDescriptions& iDescriptions) {
   edm::ParameterSetDescription desc;
   addToDescription(desc);
   desc.add<edm::InputTag>("srcRho", edm::InputTag(""));
+  desc.add<bool>("skipMissingProduct", false);
   iDescriptions.addWithDefaultLabel(desc);
 }
 

--- a/Validation/RecoJets/python/JetCorrectionServices_AK4CHS_cff.py
+++ b/Validation/RecoJets/python/JetCorrectionServices_AK4CHS_cff.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from JetMETCorrections.Configuration.JetCorrectionServices_cff import ak4PFCHSL1Offset, ak4PFCHSL1Fastjet, ak4PFCHSL2Relative, ak4PFCHSL3Absolute, ak4PFCHSResidual, ak4PFCHSL2L3, ak4PFCHSL2L3Residual
-

--- a/Validation/RecoJets/python/JetCorrectionServices_cff.py
+++ b/Validation/RecoJets/python/JetCorrectionServices_cff.py
@@ -1,0 +1,75 @@
+import FWCore.ParameterSet.Config as cms
+
+# reproduce JetCorrector modules when not available
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFPuppiJetCorrectorL1_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFPuppiJetCorrectorL2_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFPuppiJetCorrectorL3_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFPuppiJetCorrector_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFJetCorrectorL1_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFJetCorrectorL2_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFJetCorrectorL3_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFJetCorrector_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFCHSJetCorrectorL1_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFCHSJetCorrectorL2_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFCHSJetCorrectorL3_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFCHSJetCorrector_cfi import *
+
+hltAK4PFPuppiJetCorrectorL1_ForValidation = cms.EDProducer("L1FastjetCorrectorProducer", 
+    algorithm = cms.string('AK4PFPuppiHLT'),
+    level = cms.string('L1FastJet'),
+    srcRho = cms.InputTag("hltFixedGridRhoFastjetAll"),
+    skipMissingProduct = cms.bool(True)
+)
+hltAK4PFPuppiJetCorrectorL2_ForValidation = hltAK4PFPuppiJetCorrectorL2.clone()
+hltAK4PFPuppiJetCorrectorL3_ForValidation = hltAK4PFPuppiJetCorrectorL3.clone()
+hltAK4PFPuppiJetCorrector_ForValidation = hltAK4PFPuppiJetCorrector.clone(
+    correctors = cms.VInputTag(
+        "hltAK4PFPuppiJetCorrectorL1_ForValidation",
+        "hltAK4PFPuppiJetCorrectorL2_ForValidation", 
+        "hltAK4PFPuppiJetCorrectorL3_ForValidation")
+)
+
+hltAK4PFJetCorrectorL1_ForValidation = cms.EDProducer("L1FastjetCorrectorProducer", 
+    algorithm = cms.string('AK4PF'),
+    level = cms.string('L1FastJet'),
+    srcRho = cms.InputTag("hltFixedGridRhoFastjetAll"),
+    skipMissingProduct = cms.bool(True)
+)
+hltAK4PFJetCorrectorL2_ForValidation = hltAK4PFJetCorrectorL2.clone()
+hltAK4PFJetCorrectorL3_ForValidation = hltAK4PFJetCorrectorL3.clone()
+hltAK4PFJetCorrector_ForValidation = hltAK4PFJetCorrector.clone(
+    correctors = cms.VInputTag(
+        "hltAK4PFJetCorrectorL1_ForValidation",
+        "hltAK4PFJetCorrectorL2_ForValidation", 
+        "hltAK4PFJetCorrectorL3_ForValidation")
+)
+
+hltAK4PFCHSJetCorrectorL1_ForValidation = cms.EDProducer("L1FastjetCorrectorProducer", 
+    algorithm = cms.string('AK4PFchs'),
+    level = cms.string('L1FastJet'),
+    srcRho = cms.InputTag("hltFixedGridRhoFastjetAll"),
+    skipMissingProduct = cms.bool(True)
+)
+hltAK4PFCHSJetCorrectorL2_ForValidation = hltAK4PFCHSJetCorrectorL2.clone()
+hltAK4PFCHSJetCorrectorL3_ForValidation = hltAK4PFCHSJetCorrectorL3.clone()
+hltAK4PFCHSJetCorrector_ForValidation = hltAK4PFCHSJetCorrector.clone(
+    correctors = cms.VInputTag(
+        "hltAK4PFCHSJetCorrectorL1_ForValidation",
+        "hltAK4PFCHSJetCorrectorL2_ForValidation", 
+        "hltAK4PFCHSJetCorrectorL3_ForValidation")
+)
+
+hltJetCorrectionTask = cms.Task(
+    hltAK4PFPuppiJetCorrectorL1_ForValidation,
+    hltAK4PFPuppiJetCorrectorL2_ForValidation,
+    hltAK4PFPuppiJetCorrectorL3_ForValidation,
+    hltAK4PFPuppiJetCorrector_ForValidation,
+    hltAK4PFJetCorrectorL1_ForValidation,
+    hltAK4PFJetCorrectorL2_ForValidation,
+    hltAK4PFJetCorrectorL3_ForValidation,
+    hltAK4PFJetCorrector_ForValidation,
+    hltAK4PFCHSJetCorrectorL1_ForValidation,
+    hltAK4PFCHSJetCorrectorL2_ForValidation,
+    hltAK4PFCHSJetCorrectorL3_ForValidation,
+    hltAK4PFCHSJetCorrector_ForValidation,
+)

--- a/Validation/RecoJets/python/hltJetValidation_cff.py
+++ b/Validation/RecoJets/python/hltJetValidation_cff.py
@@ -3,43 +3,16 @@ from PhysicsTools.NanoAOD.genparticles_cff import *
 from RecoJets.Configuration.GenJetParticles_cff import *
 from RecoJets.Configuration.RecoGenJets_cff import *
 
-from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFPuppiJetCorrectorL1_cfi import *
-from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFPuppiJetCorrectorL2_cfi import *
-from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFPuppiJetCorrectorL3_cfi import *
-from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFPuppiJetCorrector_cfi import *
-from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFJetCorrectorL1_cfi import *
-from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFJetCorrectorL2_cfi import *
-from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFJetCorrectorL3_cfi import *
-from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFJetCorrector_cfi import *
-from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFCHSJetCorrectorL1_cfi import *
-from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFCHSJetCorrectorL2_cfi import *
-from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFCHSJetCorrectorL3_cfi import *
-from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFCHSJetCorrector_cfi import *
-
-# reproduce JetCorrector modules when not available
-hltJetCorrectionSequence = cms.Sequence(
-    hltAK4PFPuppiJetCorrectorL1
-    + hltAK4PFPuppiJetCorrectorL2
-    + hltAK4PFPuppiJetCorrectorL3
-    + hltAK4PFPuppiJetCorrector
-    + hltAK4PFJetCorrectorL1
-    + hltAK4PFJetCorrectorL2
-    + hltAK4PFJetCorrectorL3
-    + hltAK4PFJetCorrector
-    + hltAK4PFCHSJetCorrectorL1
-    + hltAK4PFCHSJetCorrectorL2
-    + hltAK4PFCHSJetCorrectorL3
-    + hltAK4PFCHSJetCorrector
-)
-
 hltJetPreValidSeq = cms.Sequence(
     prunedGenParticlesWithStatusOne
     + prunedGenParticles
     + finalGenParticles
     + genParticlesForJetsNoNu
     + ak4GenJetsNoNu
-    + hltJetCorrectionSequence
 )
+
+from Validation.RecoJets.JetCorrectionServices_cff import *
+hltJetPreValidSeq.associate(hltJetCorrectionTask)
 
 from Validation.RecoJets.jetTester_cfi import jetTester as _jetTester
 _hltJetTester = _jetTester.clone(
@@ -54,16 +27,15 @@ _hltJetTester = _jetTester.clone(
 
 hltJetAnalyzerAK4PFPuppi = _hltJetTester.clone(
     src = "hltAK4PFPuppiJets",
-    JetCorrections = "hltAK4PFPuppiJetCorrector",
+    JetCorrections = "hltAK4PFPuppiJetCorrector_ForValidation",
 )
 
 hltJetAnalyzerAK4PF = _hltJetTester.clone(
     src = "hltAK4PFJets",
-    JetCorrections = "hltAK4PFJetCorrector",
+    JetCorrections = "hltAK4PFJetCorrector_ForValidation",
 )
 
 hltJetAnalyzerAK4PFCHS = _hltJetTester.clone(
     src = "hltAK4PFCHSJets",
-    JetCorrections = "hltAK4PFCHSJetCorrector",
+    JetCorrections = "hltAK4PFCHSJetCorrector_ForValidation",
 )
-

--- a/Validation/RecoJets/python/hltJetValidation_cff.py
+++ b/Validation/RecoJets/python/hltJetValidation_cff.py
@@ -3,12 +3,42 @@ from PhysicsTools.NanoAOD.genparticles_cff import *
 from RecoJets.Configuration.GenJetParticles_cff import *
 from RecoJets.Configuration.RecoGenJets_cff import *
 
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFPuppiJetCorrectorL1_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFPuppiJetCorrectorL2_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFPuppiJetCorrectorL3_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFPuppiJetCorrector_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFJetCorrectorL1_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFJetCorrectorL2_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFJetCorrectorL3_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFJetCorrector_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFCHSJetCorrectorL1_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFCHSJetCorrectorL2_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFCHSJetCorrectorL3_cfi import *
+from HLTrigger.Configuration.HLT_75e33.modules.hltAK4PFCHSJetCorrector_cfi import *
+
+# reproduce JetCorrector modules when not available
+hltJetCorrectionSequence = cms.Sequence(
+    hltAK4PFPuppiJetCorrectorL1
+    + hltAK4PFPuppiJetCorrectorL2
+    + hltAK4PFPuppiJetCorrectorL3
+    + hltAK4PFPuppiJetCorrector
+    + hltAK4PFJetCorrectorL1
+    + hltAK4PFJetCorrectorL2
+    + hltAK4PFJetCorrectorL3
+    + hltAK4PFJetCorrector
+    + hltAK4PFCHSJetCorrectorL1
+    + hltAK4PFCHSJetCorrectorL2
+    + hltAK4PFCHSJetCorrectorL3
+    + hltAK4PFCHSJetCorrector
+)
+
 hltJetPreValidSeq = cms.Sequence(
     prunedGenParticlesWithStatusOne
     + prunedGenParticles
     + finalGenParticles
     + genParticlesForJetsNoNu
     + ak4GenJetsNoNu
+    + hltJetCorrectionSequence
 )
 
 from Validation.RecoJets.jetTester_cfi import jetTester as _jetTester


### PR DESCRIPTION
#### PR description:

This PR fixes the Phase‑2 HLT validation for corrected jets (HLT jets after applying JECs), by ensuring that the required collections are available in the validation sequence.

This work builds on the previously introduced HLT Jet validation framework for both Run‑3 and Phase‑2:
- https://github.com/cms-sw/cmssw/pull/48722
- https://github.com/cms-sw/cmssw/pull/48806
- https://github.com/cms-sw/cmssw/pull/49129
- https://github.com/cms-sw/cmssw/pull/49384

Before this PR, all HLT validation plots for CorrectedJets appeared empty in the RelVal and RelMon GUIs, making the validation effectively unusable for JME studies. The root cause is the standard two-step workflow:
\- step2: `L1,HLT`
\- step3: `RECO,VALIDATION`
The HLT Jet validation logic is based on the [`hlt*JetCorrector`](https://github.com/cms-sw/cmssw/blob/5e8590e9b619b67ac1aa4780e2f21954e3d63818/Validation/RecoJets/python/hltJetValidation_cff.py#L27) collections, however these collections are produced during the HLT step and cannot be persisted in the `FEVTDEBUGHLT` event content. As a result, they are not available in the validation step, leading to empty histograms.
<img width="1383" height="1043" alt="Screenshot 2026-05-27 at 11 01 03" src="https://github.com/user-attachments/assets/89ad0e5a-f11a-42f0-8302-76f00ecbdd79" />
With this PR, the jet energy corrections are recomputed in the validation step by extending the `hltJetPreValidSeq`. This ensures that corrected jet collections are available at validation time and all corresponding histograms are properly filled.

#### PR validation:

This PR has been successfully validated on the two-step workflow `34434.0`.
```
runTheMatrix.py -l 34434.0 -w upgrade -j 10 --ibeos --nEvents 10 -j 10 -i all
```

The HLT MET validation histograms in the DQM output compare:
- before this PR (left): empty distributions
- after this PR (right): correctly filled distributions
<img width="2180" height="1151" alt="Screenshot 2026-05-27 at 11 07 06" src="https://github.com/user-attachments/assets/23a00679-84e2-4e5a-b8f0-d3145f47b677" />