### PR TITLE
[bugfix] Force HFNose pattern recognition to use CA

### DIFF
--- a/RecoHGCal/TICL/python/EMStep_cff.py
+++ b/RecoHGCal/TICL/python/EMStep_cff.py
@@ -63,6 +63,7 @@ ticlTrackstersHFNoseEM = ticlTrackstersEM.clone(
     seeding_regions = "ticlSeedingGlobalHFNose",
     time_layerclusters = "hgcalLayerClustersHFNose:timeLayerCluster",
     itername = "EMn",
+    patternRecognitionBy = cms.string('CA'),
     pluginPatternRecognitionByCA = dict(
        filter_on_categories = [0, 1],
        min_layers_per_trackster = 5,

--- a/RecoHGCal/TICL/python/HADStep_cff.py
+++ b/RecoHGCal/TICL/python/HADStep_cff.py
@@ -58,6 +58,7 @@ ticlTrackstersHFNoseHAD = ticlTrackstersHAD.clone(
     filtered_mask = "filteredLayerClustersHFNoseHAD:HADn",
     seeding_regions = "ticlSeedingGlobalHFNose",
     time_layerclusters = "hgcalLayerClustersHFNose:timeLayerCluster",
+    patternRecognitionBy = cms.string('CA'),
     pluginPatternRecognitionByCA = dict(
        pid_threshold = 0.,
        skip_layers = 1,

--- a/RecoHGCal/TICL/python/MIPStep_cff.py
+++ b/RecoHGCal/TICL/python/MIPStep_cff.py
@@ -48,6 +48,7 @@ ticlTrackstersHFNoseMIP = ticlTrackstersMIP.clone(
     filtered_mask = "filteredLayerClustersHFNoseMIP:MIPn",
     seeding_regions = "ticlSeedingGlobalHFNose",
     time_layerclusters = "hgcalLayerClustersHFNose:timeLayerCluster",
+    patternRecognitionBy = cms.string('CA'),
     pluginPatternRecognitionByCA = dict(min_layers_per_trackster = 6)
 )
 

--- a/RecoHGCal/TICL/python/TrkEMStep_cff.py
+++ b/RecoHGCal/TICL/python/TrkEMStep_cff.py
@@ -61,6 +61,7 @@ ticlTrackstersHFNoseTrkEM = ticlTrackstersTrkEM.clone(
     filtered_mask = "filteredLayerClustersHFNoseTrkEM:TrkEMn",
     seeding_regions = "ticlSeedingTrkHFNose",
     time_layerclusters = "hgcalLayerClustersHFNose:timeLayerCluster",
+    patternRecognitionBy = cms.string('CA'),
     itername = "TrkEMn",
     pluginPatternRecognitionByCA = dict(
         filter_on_categories = [0, 1],

--- a/RecoHGCal/TICL/python/TrkStep_cff.py
+++ b/RecoHGCal/TICL/python/TrkStep_cff.py
@@ -60,6 +60,7 @@ ticlTrackstersHFNoseTrk = ticlTrackstersTrk.clone(
     filtered_mask = "filteredLayerClustersHFNoseTrk:Trkn",
     seeding_regions = "ticlSeedingTrkHFNose",
     time_layerclusters = "hgcalLayerClustersHFNose:timeLayerCluster",
+    patternRecognitionBy = cms.string('CA'),
     pluginPatternRecognitionByCA = dict(
         filter_on_categories = [2, 4], # filter muons and charged hadrons
         pid_threshold = 0.0,


### PR DESCRIPTION
PR https://github.com/cms-sw/cmssw/pull/49932 switched default TICL Pattern Recognition to CLUE3D. 
However, the unmaintained HFNose reconstruction should still be using CA as per TICLv3. 

This PR fixes the issue https://github.com/cms-sw/cmssw/issues/51017