### PR TITLE
ME0 integration in PFMuon algorithm

### DIFF
--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -296,6 +296,7 @@ namespace reco {
       static const unsigned int GEMMuon = 1 << 7;
       static const unsigned int ME0Muon = 1 << 8;
       static const unsigned int ScoutingMuon = 1 << 9;
+      static const unsigned int Phase2Muon = 1 << 10;
 
       void setType(unsigned int type) { type_ = type; }
       unsigned int type() const { return type_; }
@@ -311,6 +312,7 @@ namespace reco {
       bool isGEMMuon() const { return type_ & GEMMuon; }
       bool isME0Muon() const { return type_ & ME0Muon; }
       bool isScoutingMuon() const { return type_ & ScoutingMuon; }
+      bool isPhase2Muon() const { return type_ & Phase2Muon; }
 
     private:
       /// check overlap with another candidate

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -51,6 +51,16 @@ unsigned int muon::RequiredStationMask(const reco::Muon& muon,
         theMask += 1 << ((stationIdx - 1) + 4 * (detectorIdx - 1));
     }
   }
+
+  // Adding ME0 for Phase-2
+  int station0Idx = 0;
+  int detector4Idx = 4;
+  float dist0 = muon.trackDist(station0Idx, detector4Idx, arbitrationType);
+  if (dist0 < maxChamberDist &&
+      dist0 < maxChamberDistPull * muon.trackDistErr(station0Idx, detector4Idx, arbitrationType)) {
+    theMask += 1 << 8;
+  }
+
   return theMask;
 }
 
@@ -63,15 +73,16 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
   bool use_match_dist_penalty = true;
 
   int nr_of_stations_crossed = 0;
-  std::vector<int> stations_w_track(8);
-  std::vector<int> station_has_segmentmatch(8);
-  std::vector<int> station_was_crossed(8);
-  std::vector<float> stations_w_track_at_boundary(8);
-  std::vector<float> station_weight(8);
+  constexpr int n_muon_stations = 9;  // 4 DT + 1 ME0 + 4CSC
+  std::vector<int> stations_w_track(n_muon_stations);
+  std::vector<int> station_has_segmentmatch(n_muon_stations);
+  std::vector<int> station_was_crossed(n_muon_stations);
+  std::vector<float> stations_w_track_at_boundary(n_muon_stations);
+  std::vector<float> station_weight(n_muon_stations);
   int position_in_stations = 0;
   float full_weight = 0.;
-
-  for (int i = 1; i <= 8; ++i) {
+  int ME0_nHits = -1;
+  for (int i = 1; i <= n_muon_stations; ++i) {
     // ********************************************************;
     // *** fill local info for this muon (do some counting) ***;
     // ************** begin ***********************************;
@@ -89,8 +100,23 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
       if (muon.segmentX(i, 1, arbitrationType) < 999999) {
         station_has_segmentmatch[i - 1] = 1;
       }
+    } else if (i == 5) {  // this is the section for ME0 only considered in Phase-2
+      float thisTrackDist = muon.trackDist(i - 5, 4, reco::Muon::GEMSegmentAndTrackArbitration);
+      if (thisTrackDist < 999999) {  //current "raw" info that a track is close to a chamber
+        ++nr_of_stations_crossed;
+        station_was_crossed[i - 1] = 1;
+        if (thisTrackDist > -10.) {
+          stations_w_track_at_boundary[i - 1] = thisTrackDist;
+        } else {
+          stations_w_track_at_boundary[i - 1] = 0.;
+        }
+      }
+      //current "raw" info that a segment is matched to the current track
+      if (muon.segmentX(i - 5, 4, reco::Muon::GEMSegmentAndTrackArbitration) < 999999) {
+        station_has_segmentmatch[i - 1] = 1;
+      }
     } else {  // this is the section for the CSCs
-      float thisTrackDist = muon.trackDist(i - 4, 2, arbitrationType);
+      float thisTrackDist = muon.trackDist(i - 5, 2, arbitrationType);
       if (thisTrackDist < 999999) {  //current "raw" info that a track is close to a chamber
         ++nr_of_stations_crossed;
         station_was_crossed[i - 1] = 1;
@@ -100,7 +126,7 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
           stations_w_track_at_boundary[i - 1] = 0.;
       }
       //current "raw" info that a segment is matched to the current track
-      if (muon.segmentX(i - 4, 2, arbitrationType) < 999999) {
+      if (muon.segmentX(i - 5, 2, arbitrationType) < 999999) {
         station_has_segmentmatch[i - 1] = 1;
       }
     }
@@ -122,7 +148,7 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
   // if attenuate_weight_regain < 1., additional punishment if track is close to boundary and no segment
   const float attenuate_weight_regain = 0.5;
 
-  for (int i = 1; i <= 8; ++i) {  // loop over all possible stations
+  for (int i = 1; i <= n_muon_stations; ++i) {  // loop over all possible stations
 
     // first set all weights if a station has been crossed
     // later penalize if a station did not have a matching segment
@@ -164,11 +190,27 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
           else
             station_weight[i - 1] = 0.40f;
           break;
+        // this condition is necessary for Phase-2 conditions
+        // since for eta > 2., the muon can cross up to 5 stations (1 ME0 + 4 CSC)
+        // does not influence DTs and CSC up to eta<~2.
+        case 5:
+          if (position_in_stations <= 2)
+            station_weight[i - 1] = 0.10f;
+          else if (position_in_stations == 3)
+            station_weight[i - 1] = 0.20f;
+          else if (position_in_stations == 4)
+            station_weight[i - 1] = 0.25f;
+          else
+            station_weight[i - 1] = 0.35f;
+          break;
 
         default:
           // 	LogTrace("MuonIdentification")<<"            // Message: A muon candidate track has more than 4 stations with matching segments.";
           // 	LogTrace("MuonIdentification")<<"            // Did not expect this - please let me know: ibloch@fnal.gov";
           // for all other cases
+          if (nr_of_stations_crossed > 5)
+            throw cms::Exception("LogicError")
+                << "A muon candidate track has more than 5 stations with matching segments. This should not happen.";
           station_weight[i - 1] = 1.f / nr_of_stations_crossed;
       }
 
@@ -240,14 +282,14 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
               }
             }
           }
-        } else {  // We are in the CSCs
+        } else if (i > 5 && i <= 9) {  // We are in the CSCs
           const float pullTot2 =
-              std::pow(muon.pullX(i - 4, 2, arbitrationType), 2.) + std::pow(muon.pullY(i - 4, 2, arbitrationType), 2.);
+              std::pow(muon.pullX(i - 5, 2, arbitrationType), 2.) + std::pow(muon.pullY(i - 5, 2, arbitrationType), 2.);
           if (pullTot2 > 1.f) {
             // reduce weight
             if (use_match_dist_penalty) {
               const float dxy2 =
-                  std::pow(muon.dX(i - 4, 2, arbitrationType), 2.) + std::pow(muon.dY(i - 4, 2, arbitrationType), 2.);
+                  std::pow(muon.dX(i - 5, 2, arbitrationType), 2.) + std::pow(muon.dY(i - 5, 2, arbitrationType), 2.);
               // only use pull if 3 sigma is not smaller than 3 cm
               if (dxy2 < 9.f && pullTot2 > 9.f) {
                 if (dxy2 > 1.f)
@@ -256,6 +298,33 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
                 station_weight[i - 1] *= 1.f / std::pow(pullTot2, .125);
               }
             }
+          }
+        } else {  // We are in the ME0
+          // no Y info because it's rough for ME0, a future implementation could be adding dXdZ
+          const float pullX2 = std::pow(muon.pullX(i - 5, 4, reco::Muon::GEMSegmentAndTrackArbitration), 2.);
+          if (pullX2 > 1.f) {  // reduce weight
+            if (use_match_dist_penalty) {
+              station_weight[i - 1] *= 1.f / std::pow(fabs(pullX2), .125);
+            }
+          }
+          // add a penalization based on the number of hits along the ME0 station:
+          for (const auto& chamberMatch : muon.matches()) {
+            if (chamberMatch.detector() == MuonSubdetId::GEM && chamberMatch.station() == 0) {
+              for (const auto& segment_match : chamberMatch.gemMatches) {
+                if (segment_match.gemSegmentRef.isNonnull()) {
+                  ME0_nHits = segment_match.gemSegmentRef->recHits().size();
+                  break;  // take the first valid
+                }
+              }
+              break;
+            }
+          }
+          if (ME0_nHits >= 4) {
+            // Has valid ME0 segment - apply hit-based penalty
+            station_weight[i - 1] *= (ME0_nHits == 6) ? 1.0f : (ME0_nHits == 5) ? 0.85f : 0.77f;
+          } else {
+            // No ME0 segments - full penalization
+            station_weight[i - 1] = 0.f;
           }
         }
       }
@@ -298,12 +367,11 @@ bool muon::isGoodMuon(const reco::Muon& muon,
   switch (type) {
     case TM2DCompatibility:
       // Simplistic first cut in the 2D segment- vs calo-compatibility plane. Will have to be refined!
-      if (((0.8 * caloCompatibility(muon)) + (1.2 * segmentCompatibility(muon, arbitrationType))) > minCompatibility)
-        goodMuon = true;
+      if (muon.isPhase2Muon() && std::abs(muon.eta()) >= 1.52)
+        //only rely on segmentCompatibility since caloCompatibility is not correct in the HGCAL coverage
+        return ((2 * segmentCompatibility(muon, arbitrationType)) > minCompatibility);
       else
-        goodMuon = false;
-      return goodMuon;
-      break;
+        return (0.8 * caloCompatibility(muon) + 1.2 * segmentCompatibility(muon, arbitrationType)) > minCompatibility;
     default:
       // 	LogTrace("MuonIdentification")<<"            // Invalid Algorithm Type called!";
       goodMuon = false;

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonsNoID_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2L3MuonsNoID_cfi.py
@@ -234,6 +234,7 @@ hltPhase2L3MuonsNoID = cms.EDProducer("MuonIdProducer",
         OverlapDPhi = cms.double(0.0786),
         OverlapDTheta = cms.double(0.02)
     ),
+    isPhase2 = cms.bool(True),
     debugWithTruthMatching = cms.bool(False),
     ecalDepositName = cms.string('ecal'),
     fillCaloCompatibility = cms.bool(False),

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -37,6 +37,13 @@ def customiseForOffline(process):
 
     return process
 
+def customizeHLTFor51053(process):
+    for module in producers_by_type(process, "MuonIdProducer"):
+        if not hasattr(module, "isPhase2"):
+            module.isPhase2 = cms.bool(False)
+
+    return process
+
 def replace_all_pixel_seed_inputtags(process):
     import FWCore.ParameterSet.Config as cms
 
@@ -208,5 +215,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # process = customiseFor12718(process)
 
     # process = customizeHLTfor49436(process)
+    process = customizeHLTFor51053(process)
 
     return process

--- a/RecoMuon/MuonIdentification/interface/MuonCaloCompatibility.h
+++ b/RecoMuon/MuonIdentification/interface/MuonCaloCompatibility.h
@@ -26,12 +26,13 @@
 class MuonCaloCompatibility {
 public:
   MuonCaloCompatibility() : isConfigured_(false) {}
-  void configure(const edm::ParameterSet&);
+  void configure(const edm::ParameterSet&, const bool);
   double evaluate(const reco::Muon&);
 
 private:
   bool accessing_overflow(const TH2D& histo, double x, double y);
   bool isConfigured_;
+  bool isPhase2_;
 
   // used input templates for given eta
   std::shared_ptr<TH2D> pion_template_em;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -76,6 +76,7 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
       iConfig.getParameter<double>("sigmaThresholdToFillCandidateP4WithGlobalFit");
   caloCut_ = iConfig.getParameter<double>("minCaloCompatibility");  //CaloMuons
   arbClean_ = iConfig.getParameter<bool>("runArbitrationCleaner");  // muon mesh
+  isPhase2_ = iConfig.getParameter<bool>("isPhase2");
 
   // Load TrackDetectorAssociator parameters
   const edm::ParameterSet parameters = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
@@ -97,7 +98,7 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
   if (fillCaloCompatibility_) {
     // Load MuonCaloCompatibility parameters
     const auto caloParams = iConfig.getParameter<edm::ParameterSet>("MuonCaloCompatibility");
-    muonCaloCompatibility_.configure(caloParams);
+    muonCaloCompatibility_.configure(caloParams, isPhase2_);
   }
 
   if (fillIsolation_) {
@@ -620,6 +621,8 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
               muon.setType(muon.type() | reco::Muon::GEMMuon);
             if (goodME0Muon)
               muon.setType(muon.type() | reco::Muon::ME0Muon);
+            if (isPhase2_)
+              muon.setType(muon.type() | reco::Muon::Phase2Muon);
             LogTrace("MuonIdentification") << "Found a corresponding global muon. Set energy, matches and move on";
             break;
           }
@@ -1528,6 +1531,7 @@ void MuonIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<bool>("arbitrateTrackerMuons", false);
   desc.add<bool>("storeCrossedHcalRecHits", false);
   desc.add<bool>("fillShowerDigis", false);
+  desc.add<bool>("isPhase2", false);
   desc.ifValue(
       edm::ParameterDescription<bool>("selectHighPurity", false, true),
       true >> (edm::ParameterDescription<edm::InputTag>("pvInputTag", edm::InputTag("offlinePrimaryVertices"), true)) or

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -225,6 +225,7 @@ private:
 
   bool arbitrateTrackerMuons_;
 
+  bool isPhase2_;
   bool debugWithTruthMatching_;
 
   edm::Handle<reco::TrackCollection> innerTrackCollectionHandle_;

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -43,6 +43,7 @@ muons1stStep = cms.EDProducer("MuonIdProducer",
     fillGlobalTrackRefits = cms.bool(True),
 
     # internal
+    isPhase2 = cms.bool(False),
     debugWithTruthMatching = cms.bool(False),
     # input tracks
     inputCollectionLabels = cms.VInputTag(cms.InputTag("generalTracks"), cms.InputTag("globalMuons"), cms.InputTag("standAloneMuons","UpdatedAtVtx"), cms.InputTag("standAloneMuons"),
@@ -100,6 +101,7 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( muons1stStep, TrackAssociatorParameters = dict(useME0 = True ) )
 from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
 phase2_GE0.toModify( muons1stStep, TrackAssociatorParameters = dict(useME0 = False ) )
+(phase2_muon | phase2_GE0).toModify( muons1stStep, isPhase2 = True )
 
 muonEcalDetIds = cms.EDProducer("InterestingEcalDetIdProducer",
                                 inputCollection = cms.InputTag("muons1stStep")

--- a/RecoMuon/MuonIdentification/src/MuonCaloCompatibility.cc
+++ b/RecoMuon/MuonIdentification/src/MuonCaloCompatibility.cc
@@ -18,7 +18,7 @@
 
 #include "TFile.h"
 
-void MuonCaloCompatibility::configure(const edm::ParameterSet& iConfig) {
+void MuonCaloCompatibility::configure(const edm::ParameterSet& iConfig, const bool isPhase2) {
   const std::string muonfileName = (iConfig.getParameter<edm::FileInPath>("MuonTemplateFileName")).fullPath();
   const std::string pionfileName = (iConfig.getParameter<edm::FileInPath>("PionTemplateFileName")).fullPath();
   TFile muon_templates(muonfileName.c_str(), "READ");
@@ -137,6 +137,7 @@ void MuonCaloCompatibility::configure(const edm::ParameterSet& iConfig) {
   use_corrected_hcal = true;
   use_em_special = true;
   isConfigured_ = true;
+  isPhase2_ = isPhase2;
 }
 
 bool MuonCaloCompatibility::accessing_overflow(const TH2D& histo, double x, double y) {
@@ -152,6 +153,9 @@ bool MuonCaloCompatibility::accessing_overflow(const TH2D& histo, double x, doub
 }
 
 double MuonCaloCompatibility::evaluate(const reco::Muon& amuon) {
+  // Muon calo compatibility not yet updated for Phase2
+  if (isPhase2_ && std::abs(amuon.eta()) >= 1.52)
+    return 0.5;  // return "unknown" for Phase2 until we have updated templates for Phase2
   if (!isConfigured_) {
     edm::LogWarning("MuonIdentification") << "MuonCaloCompatibility is not configured! Nothing is calculated.";
     return -9999;

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -177,7 +177,9 @@ bool PFMuonAlgo::isTrackerTightMuon(const reco::MuonRef& muonRef) {
 
   unsigned nTrackerHits = track.hitPattern().numberOfValidTrackerHits();
 
-  if (nTrackerHits <= 12)
+  if (muonRef->isPhase2Muon() && std::abs(muonRef->eta()) > 2.3)
+    return nTrackerHits > 8;
+  else if (nTrackerHits <= 12)
     return false;
 
   bool isAllArbitrated = muon::isGoodMuon(*muonRef, muon::AllArbitrated);
@@ -208,6 +210,10 @@ bool PFMuonAlgo::isGlobalLooseMuon(const reco::MuonRef& muonRef) {
 
   unsigned nMuonHits =
       standAloneMu->hitPattern().numberOfValidMuonDTHits() + 2 * standAloneMu->hitPattern().numberOfValidMuonCSCHits();
+
+  if (muonRef->isPhase2Muon()) {
+    nMuonHits += standAloneMu->hitPattern().numberOfValidMuonGEMHits();
+  }
 
   bool quality = false;
 


### PR DESCRIPTION
#### PR description:

This PR addresses the integration of ME0 chambers into the muon system and their inclusion in the Particle Flow (PF) algorithm within the Phase-2 reconstruction framework. The main changes concern the computation of `segmentCompatibility` and `caloCompatibility`. [Here](https://indico.cern.ch/event/1675696/#10-update-on-phase-2-muon-reco) is the link to the reference slides.

**segmentCompatibility**
The ME0 station is now taken into account, assigned to index `i == 5`. The compatibility computation follows an approach similar to CSC and DT segments, with one key difference: due to the coarse eta-partitioning of ME0 modules, compatibility is computed without using `|d\eta|`; a possible future implementation could add `d\phi/dz`. Additionally, a reweighting based on the number of hits per segment is applied to reduce the fake rate. As a result, muons with a segment in the ME0 station can now receive a non-zero `segmentCompatibility`.

**caloCompatibility**
The algorithm has been modified to return a neutral value when the muon candidate falls within the HGCAL pseudorapidity coverage (`|eta| > 1.52`). This is necessary because `caloCompatibility` is computed assuming the Phase-1 geometry and does not account for HGCAL. For the moment, `TM2DCompatibility` relies solely on `segmentCompatibility` when running in Phase-2 geometry and the muon candidate passes through HGCAL coverage.
The flag `isPhase2` has been added to handle these changes in the Phase-2 configuration only; corresponding modifications in some HLT configuration files were made to ensure backward compatibility and prevent missing parameter exceptions in Phase-1 workflows.

**PFMuonAlgorithm**
No changes are applied under Phase-1 conditions. Under Phase-2 conditions:

* For `|eta| < 2.3`: the same selection cuts as in Run 3 are retained;
* For `|eta| > 2.3`: the cuts are loosened to require only `nTrackerHits > 8`.

To allow the algorithm to determine whether it is running in Phase-1 or Phase-2 conditions via an external parameter, a dedicated flag `isPhase2Muon()` has been added to the reco::muon object. 

#### PR validation:

* This PR has been validated using `runTheMatrix.py -l limited -i all --ibeos`.

In the following picture, the comparison between the PFMuon efficiency trends before and after the PR is shown:
<img width="1328" height="829" alt="effComparison_PR51053" src="https://github.com/user-attachments/assets/594ee215-1d75-4cc9-8613-67d6d88068ab" />
