### PR TITLE
[UBSAN] Initialize DQHarvester::_totalLS to avoid int overflow runtime error

### DIFF
--- a/DQM/HcalCommon/src/DQHarvester.cc
+++ b/DQM/HcalCommon/src/DQHarvester.cc
@@ -6,6 +6,7 @@ namespace hcaldqm {
 
   DQHarvester::DQHarvester(edm::ParameterSet const &ps)
       : DQModule(ps),
+        _totalLS(0),
         hcalDbServiceToken_(esConsumes<HcalDbService, HcalDbRecord, edm::Transition::BeginRun>()),
         runInfoToken_(esConsumes<RunInfo, RunInfoRcd, edm::Transition::BeginRun>()),
         hcalChannelQualityToken_(


### PR DESCRIPTION
Initialize the data member `DQHarvester::_totalLS`. This is reported by UBSAN IBs as runtime int overflow error.

https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/CMSSW_17_0_X_2026-05-26-1100/logs/11/11b6add01a6236f364cb95a826afc366/log
```
10.0/step4:DQM/HcalCommon/src/DQHarvester.cc:107:13: runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'
11834.24/step4:DQM/HcalCommon/src/DQHarvester.cc:107:13: runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'
```