### PR TITLE
Intergration of TOoLLiP_v3.

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/JetId.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/JetId.h
@@ -31,7 +31,7 @@ public:
 
   void setNNVectorVar();
   float EvaluateNN();
-  ap_fixed<16, 6> EvaluateNNFixed();
+  ap_fixed<14, 8, AP_TRN, AP_SAT, 0> EvaluateNNFixed();
   float compute(const l1t::PFJet &iJet, float vz, bool useRawPt);
   ap_fixed<16, 6> computeFixed(const l1t::PFJet &iJet, float vz, bool useRawPt);
 

--- a/L1Trigger/Phase2L1ParticleFlow/interface/JetId.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/JetId.h
@@ -33,7 +33,7 @@ public:
   float EvaluateNN();
   ap_fixed<14, 8, AP_TRN, AP_SAT, 0> EvaluateNNFixed();
   float compute(const l1t::PFJet &iJet, float vz, bool useRawPt);
-  ap_fixed<16, 6> computeFixed(const l1t::PFJet &iJet, float vz, bool useRawPt);
+  ap_fixed<14, 8, AP_TRN, AP_SAT, 0> computeFixed(const l1t::PFJet &iJet, float vz, bool useRawPt);
 
 private:
   std::vector<float> NNvectorVar_;

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/TOoLLiPProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/TOoLLiPProducer.cc
@@ -16,6 +16,9 @@
 #include <cmath>
 #include <vector>
 
+#include <filesystem>  ///////////////
+#include <iostream>    //////////////
+
 #include <string>
 #include "ap_fixed.h"
 #include "hls4ml/emulator.h"
@@ -30,7 +33,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  std::unique_ptr<JetId> fJetId_;
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   edm::EDGetTokenT<edm::View<l1t::PFJet>> const jets_;
@@ -43,6 +45,7 @@ private:
 
   hls4mlEmulator::ModelLoader loader;
   std::shared_ptr<hls4mlEmulator::Model> model;
+  std::unique_ptr<JetId> fJetId_;
 };
 
 TOoLLiPProducer::TOoLLiPProducer(const edm::ParameterSet& cfg)
@@ -53,10 +56,10 @@ TOoLLiPProducer::TOoLLiPProducer(const edm::ParameterSet& cfg)
       fMaxJets_(cfg.getParameter<int>("maxJets")),
       fNParticles_(cfg.getParameter<int>("nParticles")),
       fVtxEmu_(consumes<std::vector<l1t::VertexWord>>(cfg.getParameter<edm::InputTag>("vtx"))),
-      loader(hls4mlEmulator::ModelLoader(cfg.getParameter<string>("TOoLLiPVersion"))) {
-  model = loader.load_model();
-  fJetId_ = std::make_unique<JetId>(
-      cfg.getParameter<std::string>("NNInput"), cfg.getParameter<std::string>("NNOutput"), model, fNParticles_);
+      loader(cfg.getParameter<std::string>("TOoLLiPVersion")),
+      model(loader.load_model()),
+      fJetId_(std::make_unique<JetId>(
+          cfg.getParameter<std::string>("NNInput"), cfg.getParameter<std::string>("NNOutput"), model, fNParticles_)) {
   produces<edm::ValueMap<float>>("L1PFLLPJets");
 }
 
@@ -78,10 +81,10 @@ void TOoLLiPProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   for (const auto& srcjet : *jets) {
     if (((fUseRawPt_ ? srcjet.rawPt() : srcjet.pt()) < fMinPt_) || std::abs(srcjet.eta()) > fMaxEta_ ||
         LLPScores.size() >= fMaxJets_) {
-      LLPScores.push_back(-1.);
+      LLPScores.push_back(-999.);
       continue;
     }
-    ap_fixed<16, 6> LLPScore = fJetId_->computeFixed(srcjet, vz, fUseRawPt_);
+    ap_fixed<14, 8, AP_TRN, AP_SAT, 0> LLPScore = fJetId_->computeFixed(srcjet, vz, fUseRawPt_);
     LLPScores.push_back(LLPScore);
   }
 
@@ -97,7 +100,9 @@ void TOoLLiPProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("jets", edm::InputTag("scPFL1Puppi"));
   desc.add<bool>("useRawPt", true);
-  desc.add<std::string>("TOoLLiPVersion", std::string("TOoLLiP_v1"));
+  std::string path = std::getenv("TOOLLIP_PATH") ? std::getenv("TOOLLIP_PATH") : "";
+  desc.add<std::string>("TOoLLiPVersion", std::string(path));
+
   desc.add<std::string>("NNInput", "input:0");
   desc.add<std::string>("NNOutput", "sequential/dense_2/Sigmoid");
   desc.add<int>("maxJets", 10);

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/TOoLLiPProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/TOoLLiPProducer.cc
@@ -16,9 +16,6 @@
 #include <cmath>
 #include <vector>
 
-#include <filesystem>  ///////////////
-#include <iostream>    //////////////
-
 #include <string>
 #include "ap_fixed.h"
 #include "hls4ml/emulator.h"
@@ -100,8 +97,7 @@ void TOoLLiPProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("jets", edm::InputTag("scPFL1Puppi"));
   desc.add<bool>("useRawPt", true);
-  std::string path = std::getenv("TOOLLIP_PATH") ? std::getenv("TOOLLIP_PATH") : "";
-  desc.add<std::string>("TOoLLiPVersion", std::string(path));
+  desc.add<std::string>("TOoLLiPVersion", std::string("TOoLLiP_v3"));
 
   desc.add<std::string>("NNInput", "input:0");
   desc.add<std::string>("NNOutput", "sequential/dense_2/Sigmoid");

--- a/L1Trigger/Phase2L1ParticleFlow/src/JetId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/JetId.cc
@@ -57,7 +57,7 @@ void JetId::setNNVectorVar() {
     NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::ChargedHadron && fCharge_.get()[i0] < 0);  // Pion
     NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::ChargedHadron && fCharge_.get()[i0] > 0);  // Anti-Pion
     NNvectorVar_.push_back(fDZ_.get()[i0]);                                                               //dZ
-    NNvectorVar_.push_back(std::hypot(fDX_.get()[i0], fDY_.get()[i0]));
+    NNvectorVar_.push_back(std::hypot(fDX_.get()[i0], fDY_.get()[i0]));                                   //d0
     NNvectorVar_.push_back(fPt_.get()[i0]);   //pT as a fraction of jet pT
     NNvectorVar_.push_back(fEta_.get()[i0]);  //dEta from jet axis
     NNvectorVar_.push_back(fPhi_.get()[i0]);  //dPhi from jet axis

--- a/L1Trigger/Phase2L1ParticleFlow/src/JetId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/JetId.cc
@@ -57,7 +57,7 @@ void JetId::setNNVectorVar() {
     NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::ChargedHadron && fCharge_.get()[i0] < 0);  // Pion
     NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::ChargedHadron && fCharge_.get()[i0] > 0);  // Anti-Pion
     NNvectorVar_.push_back(fDZ_.get()[i0]);                                                               //dZ
-    NNvectorVar_.push_back(std::hypot(fDX_.get()[i0], fDY_.get()[i0]));                                   //d0
+    NNvectorVar_.push_back(std::hypot(fDX_.get()[i0], fDY_.get()[i0]));
     NNvectorVar_.push_back(fPt_.get()[i0]);   //pT as a fraction of jet pT
     NNvectorVar_.push_back(fEta_.get()[i0]);  //dEta from jet axis
     NNvectorVar_.push_back(fPhi_.get()[i0]);  //dPhi from jet axis
@@ -73,17 +73,17 @@ float JetId::EvaluateNN() {
   return outputs[0].matrix<float>()(0, 0);
 }  //end EvaluateNN
 
-ap_fixed<16, 6> JetId::EvaluateNNFixed() {
-  ap_fixed<16, 6> modelInput[140] = {};
+ap_fixed<14, 8, AP_TRN, AP_SAT, 0> JetId::EvaluateNNFixed() {
+  ap_fixed<12, 6, AP_TRN, AP_SAT, 0> modelInput[130] = {};
   for (unsigned int i = 0; i < NNvectorVar_.size(); i++) {
     modelInput[i] = NNvectorVar_[i];
   }
-  ap_fixed<16, 6> modelResult[1] = {-1};
+  ap_fixed<14, 8, AP_TRN, AP_SAT, 0> modelResult[1] = {-1};
 
   modelRef_->prepare_input(modelInput);
   modelRef_->predict();
   modelRef_->read_result(modelResult);
-  ap_fixed<16, 6> modelResult_ = modelResult[0];
+  ap_fixed<14, 8, AP_TRN, AP_SAT, 0> modelResult_ = modelResult[0];
   return modelResult_;
 }  //end EvaluateNNFixed
 
@@ -152,5 +152,6 @@ ap_fixed<16, 6> JetId::computeFixed(const l1t::PFJet &iJet, float vz, bool useRa
     }
   }
   setNNVectorVar();
+
   return EvaluateNNFixed();
 }

--- a/L1Trigger/Phase2L1ParticleFlow/src/JetId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/JetId.cc
@@ -121,7 +121,7 @@ float JetId::compute(const l1t::PFJet &iJet, float vz, bool useRawPt) {
   return EvaluateNN();
 }
 
-ap_fixed<16, 6> JetId::computeFixed(const l1t::PFJet &iJet, float vz, bool useRawPt) {
+ap_fixed<14, 8, AP_TRN, AP_SAT, 0> JetId::computeFixed(const l1t::PFJet &iJet, float vz, bool useRawPt) {
   for (int i0 = 0; i0 < fNParticles_; i0++) {
     fPt_.get()[i0] = 0;
     fEta_.get()[i0] = 0;


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->
  
  - This PR integrates TOoLLiP_v3 into CMSSW, which involves the newest development of the Level-1 long-lived-particle jet trigger. The official TOoLLiP development repository is found [here](https://github.com/cms-hls4ml/TOoLLiP/tree/main).
      - The submodule with all relevant files is found under `TOoLLiP/TOoLLiP_v3` and linked [here](https://github.com/Brainz22/L1LLPJetTagger/tree/b4688947ceec19d873c28cf4373199ced70ed0e4), e.g. ROC curves, HLS firmware `TOoLLiP_v3` folder, Python to HLS conversion scripts, and layer tracing, and model plots.

- The PR to pass in the correct TOoLLiP version on `cms-sw/cmsdist` can be found [here](https://github.com/cms-sw/cmsdist/pull/10591)

#### PR validation:


* This PR has been validated through the emulation of the trigger using the [fastPuppi](https://github.com/p2l1pfp/FastPUPPI/tree/15_1_X/NtupleProducer) ntuple producer. The validation method is as follows:

```bash
cmsrel CMSSW_17_0_0_pre1
cd CMSSW_17_0_0_pre1/src
cmsenv
git cms-init 
git branch 
git cms-checkout-topic -u Brainz22:prtestingbranch

git cms-addpkg L1Trigger/Phase2L1ParticleFlow
git cms-addpkg L1Trigger/Configuration
git cms-addpkg DataFormats
git cms-addpkg L1Trigger/TrackTrigger
git cms-addpkg SimTracker/TrackTriggerAssociation
scram b -j8 

#steps for model binary
git clone https://github.com/cms-hls4ml/hls4mlEmulatorExtras.git 
cd hls4mlEmulatorExtras 
git checkout -b v1.1.3 tags/v1.1.3
make install
cd ..

git clone --quiet https://github.com/Xilinx/HLS_arbitrary_Precision_Types.git hls

git clone git@github.com:cms-hls4ml/TOoLLiP.git
cd TOoLLiP
git checkout -b v3.1.0 tags/v3.1.0
make install
export TOOLLIP_PATH=$PWD/TOoLLiP_v3 #need because binary is not in cmsdist yet
cd ..

#add testing
git clone git@github.com:Brainz22/FastPUPPI.git -b 15_1_X_LLPtagging #clones LLPtagging branch
cd FastPUPPI
git checkout 04aa685101d9454eab134d079599178b3099ee89 # checks out and specific commit
cd ..
scram b -j8

#produce nanoAOD file
cmsRun FastPUPPI/NtupleProducer/python/runPerformanceNTuple.py

```
`perfNano.root` will appeat at `$PWD`. This ntuple contains the branch `scPuppiL1TTOOLLIPJet_llpTagScore` as defined by the lines [here](https://github.com/Brainz22/FastPUPPI/blob/04aa685101d9454eab134d079599178b3099ee89/NtupleProducer/python/runPerformanceNTuple.py#L174-L178).

* `TOoLLiP_v3` emulation checks have been performed on signal and minbias samples, where inputs are taken from cmssw directly and used to test `qkeras` and `HLS` models. Their predictions are compared against the emulation predictions. Plot are shown below (`original_score` axis has distribution of `qkeras` model predictions):

![MinBias](https://raw.githubusercontent.com/Brainz22/L1LLPJetTagger/main/minBias_emu_check.png)

![Signal](https://raw.githubusercontent.com/Brainz22/L1LLPJetTagger/main/signal_emu_check.png)

The `qkeras` model outputs differ from `hls` (and  thus, `cmssw`) outputs due to arithmetic precision and quantization mismatches in the shift from `qkeras` to `hls`. This conclusion can be inferred from the spread in the `hls` and `qkeras` model final layer outputs:

![q_dense_1](https://raw.githubusercontent.com/Brainz22/L1LLPJetTagger/main/LayerTraces/profiling_q_dense_1.png)


<!--  #### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:  -->


<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->

No backports needed. The workflow works fine for CMSSW_17_0_0_pre1.