### PR TITLE
Add explicit compression levels of HDF5 conditions payloads

### DIFF
--- a/CondCore/CondHDF5ESSource/python/hdf5Writer.py
+++ b/CondCore/CondHDF5ESSource/python/hdf5Writer.py
@@ -7,6 +7,40 @@ if sys.version_info >= (3, 14):
 else:
     from backports import zstd
 import numpy as np
+from typing import Optional
+
+
+class ZLibWrapper:
+    @staticmethod
+    def compress(data: bytes, level: Optional[int] = None) -> bytes:
+        """
+        Compresses the provided data using the zlib algorithm.
+
+        :param data: The bytes-like object to compress.
+        :param level: The compression level (0-9). If None, the level argument is omitted.
+        :return: The compressed bytes.
+        """
+        if level is None:
+            return zlib.compress(data)
+        else:
+            return zlib.compress(data, level=level)
+
+
+class LZMAWrapper:
+    @staticmethod
+    def compress(data: bytes, level: Optional[int] = None) -> bytes:
+        """
+        Compresses the provided data using the LZMA algorithm.
+
+        :param data: The bytes-like object to compress.
+        :param level: The compression level (0-9). If None, the preset argument is omitted.
+        :return: The compressed bytes.
+        """
+        if level is None:
+            return lzma.compress(data)
+        else:
+            return lzma.compress(data, preset=level)
+
 
 #The file structure
 #
@@ -65,14 +99,14 @@ def writeTagImpl(tagsGroup, name, recName, time_type, IOV_payloads, payloadToRef
     tagGroup.create_dataset("payload", data=payloads, dtype=h5py.ref_dtype, compression = compressor)
     return tagGroup.ref
 
-    
+
 def writeTag(tagsGroup, time_type, IOV_payloads, payloadToRefs, originalTagNames, recName, productNames):
     name = originalTagNames[0]
     if len(originalTagNames) != 1:
         name = name+"@joined"
     return writeTagImpl(tagsGroup, name, recName, time_type, IOV_payloads, payloadToRefs, productNames, originalTagNames)
 
-def writeH5File(fileName, globalTags, excludeRecords, includeRecords, tagReader, compressorName):
+def writeH5File(fileName, globalTags, excludeRecords, includeRecords, tagReader, compressorName, compressionLevel=None):
     #what are key lists??? They seem to hold objects of type 'cond::persistency::KeyList'
     # and have their own proxy type
     keyListRecords = set(["ExDwarfListRcd", "DTKeyedConfigListRcd", "DTKeyedConfigContainerRcd"])
@@ -81,9 +115,9 @@ def writeH5File(fileName, globalTags, excludeRecords, includeRecords, tagReader,
     print(default_compressor_name)
     default_compressor = None
     if default_compressor_name == "zlib":
-        default_compressor = zlib
+        default_compressor = ZLibWrapper
     elif default_compressor_name == "lzma":
-        default_compressor = lzma
+        default_compressor = LZMAWrapper
     elif default_compressor_name == "zstd":
         default_compressor = zstd
     with h5py.File(fileName, 'w') as h5file:
@@ -93,7 +127,7 @@ def writeH5File(fileName, globalTags, excludeRecords, includeRecords, tagReader,
         globalTagsGroup = h5file.create_group("GlobalTags")
         null_dataset = h5file.create_dataset("null_payload", data=np.array([], dtype='b') )
         tagGroupRefs = []
-        
+
         for name in globalTags:
             gt = tagReader(name)
             for tag in gt.tags():
@@ -106,9 +140,9 @@ def writeH5File(fileName, globalTags, excludeRecords, includeRecords, tagReader,
                     continue
                 recordDataSize = 0
                 compressedSize = 0
-                
+
                 payloadToRefs = { None: null_dataset.ref}
-                
+
                 recordGroup = recordsGroup.create_group(rcd)
                 tagsGroup = recordGroup.create_group("Tags")
                 dataProductsGroup = recordGroup.create_group("DataProducts")
@@ -124,7 +158,7 @@ def writeH5File(fileName, globalTags, excludeRecords, includeRecords, tagReader,
                         print("  %i payload: %s size: %i"%(p_index,payload.name(),len(payload.data())), end="")
                         recordDataSize += len(payload.data())
                         if default_compressor:
-                            b = default_compressor.compress(payload.data())
+                            b = default_compressor.compress(payload.data(), level=compressionLevel)
                             if len(b) < len(payload.data()):
                                 print(", compressed size: %i"%(len(b)))
                             else:
@@ -139,7 +173,7 @@ def writeH5File(fileName, globalTags, excludeRecords, includeRecords, tagReader,
                         pl.attrs["memsize"] = len(payload.data())
                         pl.attrs["type"] = payload.actualType()
                         payloadToRefs[payload.name()] = pl.ref
-                        
+
                 tagGroupRefs.append(writeTag(tagsGroup, tag.time_type(), tag.iovsNPayloadNames(), payloadToRefs, tag.originalTagNames(), rcd, productNames))
                 print(" total size:", recordDataSize, end="")
                 if (recordDataSize == compressedSize):

--- a/CondCore/CondHDF5ESSource/scripts/conddb2hdf5.py
+++ b/CondCore/CondHDF5ESSource/scripts/conddb2hdf5.py
@@ -569,11 +569,29 @@ def main():
     parser.add_argument('--include', '-i', nargs='*', help = 'lost of the only records that should be included in the file (can not be used with --exclude')
     parser.add_argument('--output', '-o', default='test.h5cond', help='name of hdf5 output file to write')
     parser.add_argument('--compressor', '-c', default='zlib', choices=['zlib', 'lzma', 'zstd', 'none'], help="compress data using 'zlib', 'lzma', 'zstd', or 'none'")
+    parser.add_argument('--level', '-l', default=None, type=int, help='Compression level: 1..9 for zlib (default is 6), 1..9 for lzma (default is 6), -9..-1,1-19,20-22 for zstd (default is 3)')
     args = parser.parse_args()
 
     if args.exclude and args.include:
         print("Can not use --exclude and --include at the same time")
         exit(-1)
+
+    if args.compressor == 'none':
+        if args.level is not None:
+            print("Can not use a compression level if the compression is set to 'none'")
+            exit(-1)
+    elif args.compressor == 'zlib':
+        if args.level < 1 or args.level > 9:
+            print("Invalid compression level '%d': 'zlib' supports compression levels from 1 (fastest) to 9 (best)" % args.level)
+            exit(-1)
+    elif args.compressor == 'lzma':
+        if args.level < 1 or args.level > 9:
+            print("Invalid compression level '%d': 'lzma' supports compression levels from 1 (fastest) to 9 (best)" % args.level)
+            exit(-1)
+    elif args.compressor == 'zstd':
+        if args.level < -9 or args.level == 0 or args.level > 22:
+            print("Invalid compression level '%d': 'zstd' supports compression levels from 1 (fast) to 19 (best), 20 to 22 (ultra) and from -1 to -9 (fastest)" % args.level)
+            exit(-1)
 
     connection = connect(args)
     session = connection.session()
@@ -585,7 +603,7 @@ def main():
     if args.include:
         includeRecords = set(args.include)
 
-    writeH5File(args.output, args.name, excludeRecords, includeRecords, lambda x: DBGlobalTag(args, session, x), args.compressor)
+    writeH5File(args.output, args.name, excludeRecords, includeRecords, lambda x: DBGlobalTag(args, session, x), args.compressor, args.level)
     
 if __name__ == '__main__':
     main()

--- a/CondCore/CondHDF5ESSource/scripts/condhdf5tohdf5.py
+++ b/CondCore/CondHDF5ESSource/scripts/condhdf5tohdf5.py
@@ -136,11 +136,29 @@ def main():
     parser.add_argument('--include', '-i', nargs='*', help = 'lost of the only records that should be included in the file (can not be used with --exclude')
     parser.add_argument('--output', '-o', default='test.h5cond', help='name of hdf5 output file to write')
     parser.add_argument('--compressor', '-c', default='zlib', choices=['zlib', 'lzma', 'zstd', 'none'], help="compress data using 'zlib', 'lzma', 'zstd', or 'none'")
+    parser.add_argument('--level', '-l', default=None, type=int, help='Compression level: 1..9 for zlib (default is 6), 1..9 for lzma (default is 6), -9..22 for zstd (default is 3)')
     args = parser.parse_args()
 
     if args.exclude and args.include:
         print("Can not use --exclude and --include at the same time")
         exit(-1)
+
+    if args.compressor == 'none':
+        if args.level is not None:
+            print("Can not use a compression level if the compression is set to 'none'")
+            exit(-1)
+    elif args.compressor == 'zlib':
+        if args.level < 1 or args.level > 9:
+            print("Invalid compression level '%d': 'zlib' supports compression levels from 1 (fastest) to 9 (best)" % args.level)
+            exit(-1)
+    elif args.compressor == 'lzma':
+        if args.level < 1 or args.level > 9:
+            print("Invalid compression level '%d': 'lzma' supports compression levels from 1 (fastest) to 9 (best)" % args.level)
+            exit(-1)
+    elif args.compressor == 'zstd':
+        if args.level < -9 or args.level == 0 or args.level > 22:
+            print("Invalid compression level '%d': 'zstd' supports compression levels from 1 (fast) to 19 (best), 20 to 22 (ultra) and from -1 to -9 (fastest)" % args.level)
+            exit(-1)
 
     excludeRecords = set()
     if args.exclude:
@@ -149,6 +167,6 @@ def main():
     if args.include:
         includeRecords = set(args.include)
 
-    writeH5File(args.output, args.name, excludeRecords, includeRecords, lambda x: H5GlobalTag(args.input, x),  args.compressor)
+    writeH5File(args.output, args.name, excludeRecords, includeRecords, lambda x: H5GlobalTag(args.input, x),  args.compressor, args.level)
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
#### PR description:

Add explicit compression levels of HDF5 conditions payloads:
  - zlib from 1 to 9,
  - lzma from 1 to 9,
  - zstd from -9 to -1, 1 to 19, and 20 to 22

Here is an example of the compression ratio vs dumping time:
<img width="4200" height="2700" alt="compression_benchmark" src="https://github.com/user-attachments/assets/19b728c2-8687-4b7b-8323-57f93844d7e5" />

#### PR validation:

Extracted the content of an online global tag for a single run using
```bash
conddb2hdf5.py --run 402360 160X_dataRun3_HLT_v1 --output .160X_dataRun3_HLT_v1.hdf5 --compressor xxxx --level nn
```
for all supported compressors and compression level, and tested that CMSSW can read back some of them at random.