### PR TITLE
CLANG: Added non-inlined destructor for GluedGeomDet and StackGeomDet

### DIFF
--- a/Geometry/CommonTopologies/interface/GluedGeomDet.h
+++ b/Geometry/CommonTopologies/interface/GluedGeomDet.h
@@ -9,7 +9,7 @@ public:
   GluedGeomDet(BoundPlane* sp, const GeomDetUnit* monoDet, const GeomDetUnit* stereoDet, DetId gluedDetId)
       : DoubleSensGeomDet(sp, monoDet, stereoDet, gluedDetId) {}
 
-  ~GluedGeomDet() override = default;
+  ~GluedGeomDet() override;
 
   const GeomDetUnit* monoDet() const { return firstDet(); }
   const GeomDetUnit* stereoDet() const { return secondDet(); }

--- a/Geometry/CommonTopologies/interface/StackGeomDet.h
+++ b/Geometry/CommonTopologies/interface/StackGeomDet.h
@@ -9,7 +9,7 @@ public:
   StackGeomDet(BoundPlane* sp, const GeomDetUnit* lowerDet, const GeomDetUnit* upperDet, const DetId stackDetId)
       : DoubleSensGeomDet(sp, lowerDet, upperDet, stackDetId) {}
 
-  ~StackGeomDet() override = default;
+  ~StackGeomDet() override;
 
   const GeomDetUnit* lowerDet() const { return firstDet(); };
   const GeomDetUnit* upperDet() const { return secondDet(); };

--- a/Geometry/CommonTopologies/src/GluedGeomDet.cc
+++ b/Geometry/CommonTopologies/src/GluedGeomDet.cc
@@ -1,0 +1,2 @@
+#include "Geometry/CommonTopologies/interface/GluedGeomDet.h"
+GluedGeomDet::~GluedGeomDet() = default;

--- a/Geometry/CommonTopologies/src/StackGeomDet.cc
+++ b/Geometry/CommonTopologies/src/StackGeomDet.cc
@@ -1,0 +1,2 @@
+#include "Geometry/CommonTopologies/interface/StackGeomDet.h"
+StackGeomDet::~StackGeomDet() = default;


### PR DESCRIPTION
Few relvals are failing for CLANG_X IBs with error [a]. Looks like `dynamic_cast` on `GluedGeomDet` returned nullptr even though:
- `typeid(*geomDet)` correctly reported GluedGeomDet
- The object was valid and correctly constructed
- The inheritance hierarchy was correct

Debugging showed that:
- `typeid(*geomDet)` and `typeid(GluedGeomDet)` referred to different RTTI instances
- The addresses of the RTTI/typeinfo objects differed between DSOs

Introduce a single out-of-line definition of the destructor to create a key function for `GluedGeomDet`  and `StackGeomDet` classes (these destructors were removed in #50985 as a part of fix for UBSAN runtime and cleanup.

[a] https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc13/CMSSW_17_0_CLANG_X_2026-05-27-2300/pyRelValMatrixLogs/run/138.5_ExpressCollisions2021/step3_ExpressCollisions2021.log#/
```
----- Begin Fatal Exception 28-May-2026 04:06:51 CEST-----------------------
An exception of category 'LogicError' occurred while
   [0] Processing global begin Run run: 346512
   [1] Calling method for module AlignmentProducerAsAnalyzer/'SiPixelAliMilleAlignmentProducerHGDimuon'
Exception Message:
[AlignableTrackerBuilder] dynamic_cast<const GluedGeomDet*> failed.
----- End Fatal Exception -------------------------------------------------
```