### PR TITLE
[ANALYSIS] Drop Geometry/CommonDetUnit package

### DIFF
--- a/AnalysisAlgos/TrackInfoProducer/BuildFile.xml
+++ b/AnalysisAlgos/TrackInfoProducer/BuildFile.xml
@@ -6,7 +6,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="TrackingTools/PatternTools"/>

--- a/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
+++ b/AnalysisAlgos/TrackInfoProducer/src/TrackInfoProducerAlgorithm.cc
@@ -8,8 +8,8 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GluedGeomDet.h"
 
 using namespace reco;
 

--- a/DPGAnalysis/SiStripTools/plugins/BuildFile.xml
+++ b/DPGAnalysis/SiStripTools/plugins/BuildFile.xml
@@ -43,7 +43,7 @@
 <use name="DataFormats/TrackerRecHit2D"/>
 <use name="HLTrigger/HLTcore"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="DataFormats/TrackerCommon"/>
 <use name="SimDataFormats/TrackingAnalysis"/>

--- a/DPGAnalysis/SiStripTools/plugins/DetIdSelectorTest.cc
+++ b/DPGAnalysis/SiStripTools/plugins/DetIdSelectorTest.cc
@@ -38,7 +38,7 @@
 
 #include "Geometry/TrackerNumberingBuilder/interface/utils.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelGeomDetUnit.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileReader.h"

--- a/DPGAnalysis/SiStripTools/plugins/OccupancyPlots.cc
+++ b/DPGAnalysis/SiStripTools/plugins/OccupancyPlots.cc
@@ -49,8 +49,8 @@
 #include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"

--- a/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
+++ b/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
@@ -53,11 +53,11 @@
 #include <CondFormats/DataRecord/interface/SiStripFedCablingRcd.h>
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDetType.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 #include <Geometry/CommonTopologies/interface/Topology.h>
 #include <Geometry/CommonTopologies/interface/StripTopology.h>
-#include <Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h>
+#include <Geometry/CommonTopologies/interface/PixelGeomDetUnit.h>
 #include <Geometry/CommonTopologies/interface/PixelTopology.h>
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/DetId/interface/DetId.h"

--- a/JetMETCorrections/IsolatedParticles/test/BuildFile.xml
+++ b/JetMETCorrections/IsolatedParticles/test/BuildFile.xml
@@ -7,7 +7,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="Geometry/CaloGeometry"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="SimDataFormats/Vertex"/>
 <use name="MagneticField/Engine"/>

--- a/JetMETCorrections/IsolatedParticles/test/TestIsoSimTracks.cc
+++ b/JetMETCorrections/IsolatedParticles/test/TestIsoSimTracks.cc
@@ -63,7 +63,7 @@
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"

--- a/JetMETCorrections/IsolatedParticles/test/TestIsoTracks.cc
+++ b/JetMETCorrections/IsolatedParticles/test/TestIsoTracks.cc
@@ -63,7 +63,7 @@
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"

--- a/MuonAnalysis/MuonAssociators/BuildFile.xml
+++ b/MuonAnalysis/MuonAssociators/BuildFile.xml
@@ -11,7 +11,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="MagneticField/Engine"/>
 <use name="MagneticField/Records"/>

--- a/MuonAnalysis/MuonAssociators/interface/MatcherUsingTracksAlgorithm.h
+++ b/MuonAnalysis/MuonAssociators/interface/MatcherUsingTracksAlgorithm.h
@@ -20,7 +20,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"

--- a/PhysicsTools/RecoUtils/src/CheckHitPattern.cc
+++ b/PhysicsTools/RecoUtils/src/CheckHitPattern.cc
@@ -2,7 +2,7 @@
 
 // To get Tracker Geometry
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 
 // To convert detId to subdet/layer number.
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"


### PR DESCRIPTION
In order to avoid cyclic dependency (https://github.com/cms-sw/cmssw/issues/28415) we had merged `Geometry/CommonDetUnit` in to  `Geometry/CommonTopologies` (https://github.com/cms-sw/cmssw/pull/28500) . This PR is to cleanup the usage of `Geometry/CommonDetUnit` 