### PR TITLE
[HLT-RECONSTRUCTION] Drop Geometry/CommonDetUnit package

### DIFF
--- a/RecoMuon/L2MuonSeedGenerator/plugins/BuildFile.xml
+++ b/RecoMuon/L2MuonSeedGenerator/plugins/BuildFile.xml
@@ -9,7 +9,7 @@
     <use name="FWCore/Framework"/>
     <use name="FWCore/MessageLogger"/>
     <use name="FWCore/ParameterSet"/>
-    <use name="Geometry/CommonDetUnit" source_only="1"/>
+    <use name="Geometry/CommonTopologies" source_only="1"/>
     <use name="RecoMuon/TrackingTools"/>
     <use name="TrackingTools/DetLayers"/>
     <use name="TrackingTools/KalmanUpdators"/>

--- a/RecoMuon/L2MuonSeedGenerator/plugins/L2MuonSeedGenerator.h
+++ b/RecoMuon/L2MuonSeedGenerator/plugins/L2MuonSeedGenerator.h
@@ -39,7 +39,7 @@
 
 #include "CLHEP/Vector/ThreeVector.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetEnumerators.h"
+#include "Geometry/CommonTopologies/interface/GeomDetEnumerators.h"
 
 class MuonServiceProxy;
 class MeasurementEstimator;

--- a/RecoMuon/L2MuonSeedGenerator/plugins/L2MuonSeedGeneratorFromL1T.h
+++ b/RecoMuon/L2MuonSeedGenerator/plugins/L2MuonSeedGeneratorFromL1T.h
@@ -37,7 +37,7 @@
 
 #include "CLHEP/Vector/ThreeVector.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetEnumerators.h"
+#include "Geometry/CommonTopologies/interface/GeomDetEnumerators.h"
 
 class MuonServiceProxy;
 class MeasurementEstimator;

--- a/RecoMuon/L2MuonSeedGenerator/plugins/L2MuonSeedGeneratorFromL1TkMu.cc
+++ b/RecoMuon/L2MuonSeedGenerator/plugins/L2MuonSeedGeneratorFromL1TkMu.cc
@@ -34,7 +34,7 @@
 #include "DataFormats/L1TMuonPhase2/interface/TrackerMuon.h"
 
 #include "CLHEP/Vector/ThreeVector.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetEnumerators.h"
+#include "Geometry/CommonTopologies/interface/GeomDetEnumerators.h"
 #include "TrackingTools/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h"
 #include "TrackingTools/TrajectoryParametrization/interface/CurvilinearTrajectoryError.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"


### PR DESCRIPTION
In order to avoid cyclic dependency (https://github.com/cms-sw/cmssw/issues/28415) we had merged `Geometry/CommonDetUnit` in to  `Geometry/CommonTopologies` (https://github.com/cms-sw/cmssw/pull/28500) . This PR is to cleanup the usage of `Geometry/CommonDetUnit` 