### PR TITLE
[RECONSTRUCTION-XPOG] Drop Geometry/CommonDetUnit package

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -36,7 +36,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/transform.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 #include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
 #include "PhysicsTools/PatAlgos/interface/EfficiencyLoader.h"


### PR DESCRIPTION
In order to avoid cyclic dependency (https://github.com/cms-sw/cmssw/issues/28415) we had merged `Geometry/CommonDetUnit` in to  `Geometry/CommonTopologies` (https://github.com/cms-sw/cmssw/pull/28500) . This PR is to cleanup the usage of `Geometry/CommonDetUnit` 