### PR TITLE
[HLT] Drop Geometry/CommonDetUnit package

### DIFF
--- a/HLTrigger/special/plugins/HLTMuonPointingFilter.h
+++ b/HLTrigger/special/plugins/HLTMuonPointingFilter.h
@@ -23,7 +23,7 @@ class Propagator;
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"

--- a/HLTrigger/special/plugins/HLTPixelClusterShapeFilter.cc
+++ b/HLTrigger/special/plugins/HLTPixelClusterShapeFilter.cc
@@ -13,10 +13,10 @@
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 
 //
 // class declaration

--- a/HLTrigger/special/plugins/HLTPixelThrustFilter.cc
+++ b/HLTrigger/special/plugins/HLTPixelThrustFilter.cc
@@ -6,7 +6,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "PhysicsTools/CandUtils/interface/Thrust.h"

--- a/HLTrigger/special/plugins/HLTRPCTrigNoSyncFilter.h
+++ b/HLTrigger/special/plugins/HLTRPCTrigNoSyncFilter.h
@@ -28,7 +28,7 @@
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 #include "Geometry/RPCGeometry/interface/RPCRoll.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
 
 //


### PR DESCRIPTION
In order to avoid cyclic dependency (https://github.com/cms-sw/cmssw/issues/28415) we had merged `Geometry/CommonDetUnit` in to  `Geometry/CommonTopologies` (https://github.com/cms-sw/cmssw/pull/28500) . This PR is to cleanup the usage of `Geometry/CommonDetUnit` 