### PR TITLE
[L1-SIMULATION] Drop Geometry/CommonDetUnit package

### DIFF
--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
@@ -32,7 +32,7 @@
 #include "L1Trigger/TrackTrigger/interface/TTStubAlgorithmRecord.h"
 
 #include "Geometry/CommonTopologies/interface/Topology.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 

--- a/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.h
@@ -31,7 +31,7 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 #include "Geometry/CommonTopologies/interface/Topology.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 


### PR DESCRIPTION
In order to avoid cyclic dependency (https://github.com/cms-sw/cmssw/issues/28415) we had merged `Geometry/CommonDetUnit` in to  `Geometry/CommonTopologies` (https://github.com/cms-sw/cmssw/pull/28500) . This PR is to cleanup the usage of `Geometry/CommonDetUnit` 