### PR TITLE
[FASTSIM] Drop Geometry/CommonDetUnit package

### DIFF
--- a/FastSimulation/Muons/plugins/FastTSGFromPropagation.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromPropagation.cc
@@ -36,7 +36,7 @@
 #include "FastSimulation/Tracking/interface/TrajectorySeedHitCandidate.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/GenericTransientTrackingRecHit.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastTrackDeDxProducer.cc
@@ -30,8 +30,8 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
+#include "Geometry/CommonTopologies/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/GluedGeomDet.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include "DataFormats/Common/interface/ValueMap.h"

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/TrackerSimHitProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/TrackerSimHitProducer.cc
@@ -34,7 +34,7 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 // other
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 #include "CondFormats/External/interface/DetID.h"
 
 ///////////////////////////////////////////////

--- a/FastSimulation/Tracking/BuildFile.xml
+++ b/FastSimulation/Tracking/BuildFile.xml
@@ -7,7 +7,7 @@
 <use name="DataFormats/TrackerCommon"/>
 <use name="DataFormats/TrackingRecHit"/>
 <use name="DataFormats/TrackerRecHit2D"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonTopologies"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="RecoTracker/TkHitPairs"/>
 <use name="RecoTracker/PixelSeeding"/>

--- a/FastSimulation/Tracking/interface/TrajectorySeedHitCandidate.h
+++ b/FastSimulation/Tracking/interface/TrajectorySeedHitCandidate.h
@@ -2,7 +2,7 @@
 
 #define FastSimulation_Tracking_TrajectorySeedHitCandidate_H_
 
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
@@ -12,7 +12,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/FastSingleTrackerRecHit.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "Geometry/CommonTopologies/interface/GeomDetType.h"
 
 #include "FastSimulation/Tracking/interface/TrackingLayer.h"
 

--- a/FastSimulation/Tracking/test/testGeneralTracks.cc
+++ b/FastSimulation/Tracking/test/testGeneralTracks.cc
@@ -6,7 +6,7 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 

--- a/FastSimulation/TrackingRecHitProducer/BuildFile.xml
+++ b/FastSimulation/TrackingRecHitProducer/BuildFile.xml
@@ -11,7 +11,7 @@
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
 <use name="FastSimulation/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="SimDataFormats/TrackingHit"/>

--- a/FastSimulation/TrackingRecHitProducer/interface/PixelTemplateSmearerBase.h
+++ b/FastSimulation/TrackingRecHitProducer/interface/PixelTemplateSmearerBase.h
@@ -18,8 +18,8 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
 // Geometry
-#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/GeomDetType.h"
+#include "Geometry/CommonTopologies/interface/PixelGeomDetUnit.h"
 // template object
 #include "CondFormats/SiPixelTransient/interface/SiPixelTemplate.h"
 

--- a/FastSimulation/TrackingRecHitProducer/plugins/BuildFile.xml
+++ b/FastSimulation/TrackingRecHitProducer/plugins/BuildFile.xml
@@ -9,7 +9,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="FastSimulation/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="SimDataFormats/TrackingHit"/>

--- a/FastSimulation/TrackingRecHitProducer/plugins/FastTrackerRecHitMatcher.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/FastTrackerRecHitMatcher.cc
@@ -18,9 +18,9 @@
 // geometry stuff
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
-#include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
+#include "Geometry/CommonTopologies/interface/GluedGeomDet.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 // sim stuff

--- a/FastSimulation/TrackingRecHitProducer/plugins/PixelTemplateSmearerPlugin.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/PixelTemplateSmearerPlugin.cc
@@ -6,8 +6,8 @@
 #include "FastSimulation/TrackingRecHitProducer/interface/PixelResolutionHistograms.h"
 
 // Geometry
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-/// If we ever need to port back to 9X: #include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelGeomDetUnit.h"
+/// If we ever need to port back to 9X: #include "Geometry/CommonTopologies/interface/GeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"

--- a/FastSimulation/TrackingRecHitProducer/src/PixelTemplateSmearerBase.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/PixelTemplateSmearerBase.cc
@@ -19,8 +19,8 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelTemplateDBObject.h"
 
 // Geometry
-/// #include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"  // Keep... needed if we backport to CMSSW_9
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+/// #include "Geometry/CommonTopologies/interface/GeomDetUnit.h"  // Keep... needed if we backport to CMSSW_9
+#include "Geometry/CommonTopologies/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"

--- a/FastSimulation/TrajectoryManager/BuildFile.xml
+++ b/FastSimulation/TrajectoryManager/BuildFile.xml
@@ -8,7 +8,7 @@
 <use name="FastSimulation/ParticlePropagator"/>
 <use name="FastSimulation/TrackerSetup"/>
 <use name="FastSimulation/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonTopologies"/>
 <use name="MagneticField/Engine"/>
 <use name="RecoTracker/TkDetLayers"/>
 <use name="TrackingTools/DetLayers"/>

--- a/FastSimulation/TrajectoryManager/interface/TrajectoryManager.h
+++ b/FastSimulation/TrajectoryManager/interface/TrajectoryManager.h
@@ -4,7 +4,7 @@
 //DataFormats
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 
 //FAMOS Headers
 #include "FastSimulation/MaterialEffects/interface/MaterialEffects.h"

--- a/FastSimulation/TrajectoryManager/src/TrajectoryManager.cc
+++ b/FastSimulation/TrajectoryManager/src/TrajectoryManager.cc
@@ -13,7 +13,7 @@
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
 #include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
 #include "FastSimulation/TrajectoryManager/interface/InsideBoundsMeasurementEstimator.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 #include "TrackingTools/GeomPropagators/interface/HelixArbitraryPlaneCrossing.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
 //#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"


### PR DESCRIPTION
In order to avoid cyclic dependency (https://github.com/cms-sw/cmssw/issues/28415) we had merged `Geometry/CommonDetUnit` in to  `Geometry/CommonTopologies` (https://github.com/cms-sw/cmssw/pull/28500) . This PR is to cleanup the usage of `Geometry/CommonDetUnit` 