### PR TITLE
[PDMV] Drop Geometry/CommonDetUnit package

### DIFF
--- a/DPGAnalysis/Skims/interface/CSCSkim.h
+++ b/DPGAnalysis/Skims/interface/CSCSkim.h
@@ -44,7 +44,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"
 
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"

--- a/DPGAnalysis/Skims/src/RPCNoise.cc
+++ b/DPGAnalysis/Skims/src/RPCNoise.cc
@@ -35,7 +35,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <Geometry/CommonDetUnit/interface/GeomDet.h>  //
+#include <Geometry/CommonTopologies/interface/GeomDet.h>  //
 #include <FWCore/ServiceRegistry/interface/Service.h>
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 #include <DataFormats/RPCRecHit/interface/RPCRecHit.h>

--- a/DPGAnalysis/Skims/src/RPCRecHitFilter.cc
+++ b/DPGAnalysis/Skims/src/RPCRecHitFilter.cc
@@ -19,7 +19,7 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 


### PR DESCRIPTION
In order to avoid cyclic dependency (https://github.com/cms-sw/cmssw/issues/28415) we had merged `Geometry/CommonDetUnit` in to  `Geometry/CommonTopologies` (https://github.com/cms-sw/cmssw/pull/28500) . This PR is to cleanup the usage of `Geometry/CommonDetUnit` 