### PR TITLE
[DQM-L1] Drop Geometry/CommonDetUnit package

### DIFF
--- a/DQMOffline/L1Trigger/src/L1TPhase2OuterTrackerTkMET.cc
+++ b/DQMOffline/L1Trigger/src/L1TPhase2OuterTrackerTkMET.cc
@@ -24,7 +24,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"


### PR DESCRIPTION
In order to avoid cyclic dependency (https://github.com/cms-sw/cmssw/issues/28415) we had merged `Geometry/CommonDetUnit` in to  `Geometry/CommonTopologies` (https://github.com/cms-sw/cmssw/pull/28500) . This PR is to cleanup the usage of `Geometry/CommonDetUnit` 