### PR TITLE
[XPOG] Drop Geometry/CommonDetUnit package

### DIFF
--- a/DPGAnalysis/MuonTools/interface/MuLocalRecoBaseProducer.h
+++ b/DPGAnalysis/MuonTools/interface/MuLocalRecoBaseProducer.h
@@ -22,7 +22,7 @@
 
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
 #include <algorithm>

--- a/DPGAnalysis/MuonTools/plugins/MuDTSegmentExtTableProducer.cc
+++ b/DPGAnalysis/MuonTools/plugins/MuDTSegmentExtTableProducer.cc
@@ -26,7 +26,7 @@
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
-#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
 class MuDTSegmentExtTableProducer : public MuBaseFlatTableProducer {

--- a/PhysicsTools/NanoAOD/plugins/ElectronVertexTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/ElectronVertexTableProducer.cc
@@ -41,7 +41,7 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
+#include "Geometry/CommonTopologies/interface/TrackingGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include "TrackingTools/IPTools/interface/IPTools.h"

--- a/PhysicsTools/NanoAOD/plugins/MuonVertexTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/MuonVertexTableProducer.cc
@@ -32,7 +32,7 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
+#include "Geometry/CommonTopologies/interface/TrackingGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include "TrackingTools/IPTools/interface/IPTools.h"


### PR DESCRIPTION
In order to avoid cyclic dependency (https://github.com/cms-sw/cmssw/issues/28415) we had merged `Geometry/CommonDetUnit` in to  `Geometry/CommonTopologies` (https://github.com/cms-sw/cmssw/pull/28500) . This PR is to cleanup the usage of `Geometry/CommonDetUnit` 