### PR TITLE
DBG: Fix build warning: redefinition of EDM_ML_DEBUG

### DIFF
--- a/Geometry/HGCalTBCommonData/plugins/DDHGCalTBSiliconRotatedCassette.cc
+++ b/Geometry/HGCalTBCommonData/plugins/DDHGCalTBSiliconRotatedCassette.cc
@@ -32,7 +32,6 @@
 #include <unordered_set>
 #include <vector>
 
-#define EDM_ML_DEBUG
 using namespace angle_units::operators;
 
 class DDHGCalTBSiliconRotatedCassette : public DDAlgorithm {
@@ -557,11 +556,11 @@ void DDHGCalTBSiliconRotatedCassette::positionPassive(const DDLogicalPart& glog,
   int kount(0);
 #endif
   bool type = (absType <= passiveTypes_);
-  int num = type ? (passiveAbsorb_.size() / (cassettes_ * layers_.size()))
-                 : (passiveCool_.size() / (cassettes_ * layers_.size()));
   int absnum = type ? (absType - 1) : (absType - 1 - passiveTypes_);
   absnum *= (cassettes_ * layers_.size());
 #ifdef EDM_ML_DEBUG
+  int num = type ? (passiveAbsorb_.size() / (cassettes_ * layers_.size()))
+                 : (passiveCool_.size() / (cassettes_ * layers_.size()));
   edm::LogVerbatim("HGCalGeom") << "DDHGCalTBSiliconRotatedCassette: Type " << type << ":" << absnum
                                 << " number per cassette " << num;
 #endif


### PR DESCRIPTION
This fixes the build warings for DBG_X IBs
```
[src/Geometry/HGCalTBCommonData/plugins/DDHGCalTBSiliconRotatedCassette.cc:35](https://github.com/cms-sw/cmssw/blob/CMSSW_17_0_DBG_X_2026-05-27-2300/Geometry/HGCalTBCommonData/plugins/DDHGCalTBSiliconRotatedCassette.cc#L35): warning: "EDM_ML_DEBUG" redefined
    35 | #define EDM_ML_DEBUG
```

by removing the explicit define of `EDM_ML_DEBUG` and then mobing the variable `num` in the `#ifdef EDM_ML_DEBUG ... #endif` block as it is only used when `EDM_ML_DEBUG`  is defined