### PR TITLE
das-up-to-nevents:Fix python invalid escape sequence warning

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/das-up-to-nevents.py
+++ b/Configuration/PyReleaseValidation/scripts/das-up-to-nevents.py
@@ -184,7 +184,7 @@ if __name__ == '__main__':
             json_list_full = get_url_clean(web_path).split("\n")
             logger.info(f"Found JSON files on web: {json_list_full}")
 
-        pattern = re.compile("(cert_collisions\d{4}_\d*_\d*_golden.json)(\s|$)", re.IGNORECASE)
+        pattern = re.compile(r"(cert_collisions\d{4}_\d*_\d*_golden.json)(\s|$)", re.IGNORECASE)
         json_list = [match.group(1) for entry in json_list_full for match in [re.search(pattern, entry)] if match and match.group(1)]
         if len(json_list)==0:
             logger.error(f"No matching JSON files found from {source} ({path}). The full list was:\n{list_full}")


### PR DESCRIPTION
This fixes the python  invalid escape sequence warning [a] which currently is endup in the `step1_dasquery.log` file.


[a] https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc13/CMSSW_17_0_X_2026-05-27-2300/pyRelValMatrixLogs/run/2025.0010001_RunJetMET02025C_10k/step1_RunJetMET02025C_10k.log#/
```
/cvmfs/cms-ci.cern.ch/week1/cms-sw/cmssw/51058/53512/CMSSW_17_0_X_2026-05-27-2300/bin/el8_amd64_gcc13/das-up-to-nevents.py:187: SyntaxWarning: invalid escape sequence '\d'
  pattern = re.compile("(cert_collisions\d{4}_\d*_\d*_golden.json)(\s|$)", re.IGNORECASE)
```