### PR TITLE
Fixed value of `lastPixels` which triggered warnings in `PixelClustering.h'

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -190,10 +190,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
             printf("start clusterizer for module %4d in block %4d\n", thisModuleId, block);
 #endif
 
-        // Find the index of the first pixel not belonging to this module (or invalid).
+        // Find the index just past the last pixel belonging to this module.
+        // Invalid pixels (e.g. ROCs/modules masked via quality info) leave holes in digi_view. Trailing holes
+        // from fully-masked modules must be excluded from the range: otherwise they inflate `lastPixel - firstPixel`
+        // and spuriously trip the "too many pixels" guard below (and would skew the clamp applied there).
         // Note: modules are not consecutive in clus_view, so we cannot use something like
         // lastPixel = (module + 1 == lastModule) ? numElements : clus_view[2 + module].moduleStart();
-        lastPixel = numElements;
+        lastPixel = firstPixel;
         const uint32_t firstFake = maxFakesInModule * block;
         fakePixels = 0;
 #ifdef GPU_DEBUG
@@ -203,14 +206,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
 
         for (uint32_t i : cms::alpakatools::independent_group_elements(acc, firstPixel, numElements)) {
           auto id = digi_view[i].moduleId();
-          // skip invalid pixels
+          // skip invalid pixels (holes left by masked ROCs/modules)
           if (id == ::pixelClustering::invalidModuleId)
             continue;
-          // find the first pixel in a different module
-          if (id != thisModuleId) {
-            alpaka::atomicMin(acc, &lastPixel, i, alpaka::hierarchy::Threads{});
+          // the first valid pixel of a different module marks the end of this module's region
+          if (id != thisModuleId)
             break;
-          }
+          // valid pixel of this module: extend the range to just past it, ignoring any trailing holes
+          alpaka::atomicMax(acc, &lastPixel, i + 1, alpaka::hierarchy::Threads{});
         }
 
         // clear the fake pixels


### PR DESCRIPTION
#### PR description:

Use of the flag `process.hltESPSiPixelCablingSoA.UseQualityInfo = cms.bool( True )` triggers warnings in the `PixelClustering.h` such as:

```
Too many pixels in module 513 (305238024): 6378 > 6000
Too many pixels in module 1455 (353306628): 7960 > 6000
Too many pixels in module 513 (305238024): 6378 > 6000
Too many pixels in module 1455 (353306628): 7960 > 6000
```

The warning fires because `lastPixel - firstPixel` counts invalidModuleId entries that sit between the real module's pixels and the next module's pixels in digi_view. The bad-ROC skip at `SiPixelRawToClusterKernel.dev.cc:364`:

```
 if (useQualityInfo) {
    skipROC = cablingMap.badRocs()[index];
    if (skipROC) continue;   // <-- leaves the slot as invalidModuleId, never compacted out
  }
```
uses continue, so those word slots keep their initialised values (pdigi=0, rawIdArr=0, moduleId=invalidModuleId). They're never removed from the buffer, so they accumulate as holes adjacent to real modules and inflate.

The proposed fix is to modify the value of `lastPixels` and the first pixel after module end instead of first pixel of the next module as done previously.

#### PR validation:

Modified the "Too many pixels in module" warning to include valid and invalid clusters 

##### Before Fix:

```
  Too many pixels in module 1455 (353306628): range=6086 valid=61   invalid=6025 limit=6000
  Too many pixels in module 1455 (353306628): range=7468 valid=24   invalid=7444 limit=6000
  Too many pixels in module 1455 (353306628): range=9474 valid=51   invalid=9423 limit=6000
  Too many pixels in module 513  (305238024): range=6322 valid=26   invalid=6296 limit=6000
  Too many pixels in module 513  (305238024): range=7006 valid=50   invalid=6956 limit=6000
```

##### After Fix:

Warnings disappear as verified by @pietroGru 

Also cross verified by @pietroGru , to check for differences in pixeltracks: https://pgrutta.web.cern.ch/hltL3/special/FPIXoff/test_tooManyPix_messageFix/ . No differences found.