### PR TITLE
Fix trailing invalidClusterId in pixelClustering

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoAAlpaka.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoAAlpaka.cc
@@ -92,15 +92,27 @@ void SiPixelDigisClustersFromSoAAlpaka<TrackerTraits>::produce(edm::StreamID,
   edm::DetSet<PixelDigi>* detDigis = nullptr;
   uint32_t detId = 0;
 
+  // Get the first valid detId (same conditions below)
   for (uint32_t i = 0; i < nDigis; i++) {
     // check for uninitialized digis
-    // this is set in RawToDigi_kernel in SiPixelRawToClusterGPUKernel.cu
     if (digisView[i].rawIdArr() == 0)
       continue;
-
     // check for noisy/dead pixels (electrons set to 0)
     if (digisView[i].adc() == 0)
       continue;
+    // from clusters killed by charge cut
+    if (digisView[i].moduleId() == pixelClustering::invalidModuleId)
+      continue;
+    // not in cluster; TODO add an assert for the size
+    if (digisView[i].clus() == pixelClustering::invalidClusterId) {
+      continue;
+    }
+    // unexpected invalid value
+    if (digisView[i].clus() < 0) {
+      edm::LogError("SiPixelDigisClustersFromSoAAlpaka")
+          << "Skipping pixel digi with unexpected invalid cluster id " << digisView[i].clus();
+      continue;
+    }
 
     detId = digisView[i].rawIdArr();
     if (storeDigis_) {
@@ -167,19 +179,19 @@ void SiPixelDigisClustersFromSoAAlpaka<TrackerTraits>::produce(edm::StreamID,
     // check for noisy/dead pixels (electrons set to 0)
     if (digisView[i].adc() == 0)
       continue;
+    // from clusters killed by charge cut
+    if (digisView[i].moduleId() == pixelClustering::invalidModuleId)
+      continue;
     // not in cluster; TODO add an assert for the size
     if (digisView[i].clus() == pixelClustering::invalidClusterId) {
       continue;
     }
     // unexpected invalid value
-    if (digisView[i].clus() < pixelClustering::invalidClusterId) {
+    if (digisView[i].clus() < 0) {
       edm::LogError("SiPixelDigisClustersFromSoAAlpaka")
           << "Skipping pixel digi with unexpected invalid cluster id " << digisView[i].clus();
       continue;
     }
-    // from clusters killed by charge cut
-    if (digisView[i].clus() == pixelClustering::invalidModuleId)
-      continue;
 
 #ifdef EDM_ML_DEBUG
     assert(digisView[i].rawIdArr() > 109999);

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -257,6 +257,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelClustering {
         // FIXME if this happens frequently (and not only in simulation with low threshold) one will need to implement something cleverer.
         if (cms::alpakatools::once_per_block(acc)) {
           if (lastPixel - firstPixel > TrackerTraits::maxPixInModule) {
+            // The pixels past the clamp point are never clustered, so they still carry
+            // clus == their digi index (set by CountModules) together with a valid moduleId.
+            // Drop them explicitly
+            for (uint32_t i = TrackerTraits::maxPixInModule + firstPixel; i < lastPixel; ++i) {
+              digi_view[i].moduleId() = ::pixelClustering::invalidModuleId;
+              digi_view[i].clus() = ::pixelClustering::invalidClusterId;
+            }
             printf("Too many pixels in module %u: %u > %u\n",
                    thisModuleId,
                    lastPixel - firstPixel,


### PR DESCRIPTION
#### PR description:
Fix of https://github.com/cms-sw/cmssw/issues/51049 .

#### Explaination of original issue:
When `FindClus` (in `PixelClustering.h`) truncates a module that exceeds the `maxPixInModules`, the dropped pixels are left carrying a stale, out-of-range cluster id together with a still-valid moduleId. That id is later used to index a fixed-size per-module array out of bounds in the SoA to legacy converter, which segfaults.

When a module has more pixels than `maxPixInModule`, `FindClus` truncates it by only moving the fence:
```
  if (lastPixel - firstPixel > TrackerTraits::maxPixInModule)
    lastPixel = TrackerTraits::maxPixInModule + firstPixel;
 ```
The pixels beyond that fence are never reprocessed by the clusterizer. They therefore retain clus == their own digi index (the value assigned earlier by `CountModules`) and a still-valid moduleId. So they look like
normal, live pixels to every later stage, but their clus is an arbitrary digi index which is far outside `[0, maxNumClustersPerModules)`.

That out-of-range clus is then used directly as an array index in the converter, `SiPixelDigisClustersFromSoAAlpaka`:
```
  aclusters[digisView[i].clus()].add(...);   // aclusters[maxNumClustersPerModules]
 ```
Resulting in a segfault

#### PR validation:
Crash in the reported runs was successfully fixed as validated by @pietroGru