### PR TITLE
Fix unit test exit status.

### DIFF
--- a/Validation/RecoJets/test/test_makeJetValidationPlots.sh
+++ b/Validation/RecoJets/test/test_makeJetValidationPlots.sh
@@ -17,5 +17,5 @@ if [ $STATUS -eq 0 ]; then
     (${SCRIPT} --file ./${DQMFILE} --odir ./${OUTDIR} --jet hltAK4PFPuppiJets) || die 'failed running ${SCRIPT} ${DQMFILE}' $?
     rm -fr ./${DQMFILE}
 else 
-	die "SKIPPING test, file ${DQMFILE} not found" 0
+	die "SKIPPING test, file ${DQMFILE} not found" $STATUS
 fi

--- a/Validation/RecoMET/test/test_makeHLTMETValidationPlots.sh
+++ b/Validation/RecoMET/test/test_makeHLTMETValidationPlots.sh
@@ -17,5 +17,5 @@ if [ $STATUS -eq 0 ]; then
     (${SCRIPT} --file ./${DQMFILE} --odir ./${OUTDIR} --met hltPFPuppiMETTypeOne) || die 'failed running ${SCRIPT} ${DQMFILE}' $?
     rm -fr ./${DQMFILE}
 else 
-	die "SKIPPING test, file ${DQMFILE} not found" 0
+	die "SKIPPING test, file ${DQMFILE} not found" $STATUS
 fi

--- a/Validation/RecoTrack/test/test_makeTrackValidationPlots.sh
+++ b/Validation/RecoTrack/test/test_makeTrackValidationPlots.sh
@@ -11,5 +11,5 @@ if [ $STATUS -eq 0 ]; then
     (makeTrackValidationPlots.py --jobs 4 ./${DQMFILE}) || die 'failed running makeTrackValidationPlots.py $DQMFILE' $?
     rm -fr ./${DQMFILE}
 else 
-  die "SKIPPING test, file ${DQMFILE} not found" 0
+  die "SKIPPING test, file ${DQMFILE} not found" $STATUS
 fi


### PR DESCRIPTION
Some unit tests were exiting with code `0` (success) even when the command being tested failed to run.
