### PR TITLE
change phase-2 HLT nano workflows numbers in nano matrix to avoid clashes

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -723,7 +723,8 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 from Configuration.PyReleaseValidation.relval_Run4 import prefixDet
 
 # Phase-2 HLT NANO workflows
-workflows[prefixDet+34.759]  = _upgrade_workflows[prefixDet+34.759] # HLT75e33 + NANO
-workflows[prefixDet+34.7591] = _upgrade_workflows[prefixDet+34.7591] # HLT75e33 + NANO (including validation)
-workflows[prefixDet+34.772]  = _upgrade_workflows[prefixDet+34.772] # NGTScouting + NANO
-workflows[prefixDet+34.773]  = _upgrade_workflows[prefixDet+34.773] # NGTScouting + NANO (including validation)
+_wfn = WFN(3000)
+workflows[_wfn()]  = _upgrade_workflows[prefixDet+34.759]  # HLT75e33 + NANO
+workflows[_wfn()]  = _upgrade_workflows[prefixDet+34.7591] # HLT75e33 + NANO (including validation)
+workflows[_wfn()]  = _upgrade_workflows[prefixDet+34.772]  # NGTScouting + NANO
+workflows[_wfn()]  = _upgrade_workflows[prefixDet+34.773]  # NGTScouting + NANO (including validation)


### PR DESCRIPTION
#### PR description:

This is a quick follow-up to https://github.com/cms-sw/cmssw/pull/51013.
That PR caused failures when running the `ph2_hlt` sub-matrix, see:
- https://github.com/cms-sw/cmssw/pull/49063#issuecomment-4586132459
- https://github.com/cms-sw/cmssw/pull/51042#issuecomment-4585479841

because of clashes in the workflow numbers.
Trying to reproduce locally indeed there are runtime warnings:

```
==> duplicate name found for  34434.759_TTbar_14TeV+Run4D121_HLTPhase2WithNano
    keeping  :  (34434.759, 'TTbar_14TeV+Run4D121_HLTPhase2WithNano', [<Configuration.PyReleaseValidation.MatrixUtil.InputInfo object at 0x7f1b15b7bec0>, 'export CMSSW_USE_IBEOS=true; cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33,NANO:@Phase2HLT --conditions auto:phase2_realistic_T35 --datatier NANOAODSIM -n 10 --eventcontent NANOAODSIM --geometry ExtendedRun4D121 --era Phase2C22I13M9 --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000'], ['TTbar_14TeV_TuneCP5_Run4D121_GenSimHLBeamSpot14INPUT', 'DigiTrigger_HLTPhase2WithNano_Run4D121'])
    ignoring :  (34434.759, 'TTbar_14TeV+Run4D121_HLTPhase2WithNano', [<Configuration.PyReleaseValidation.MatrixUtil.InputInfo object at 0x7f1b15b7bec0>, 'export CMSSW_USE_IBEOS=true; cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33,NANO:@Phase2HLT --conditions auto:phase2_realistic_T35 --datatier NANOAODSIM -n 10 --eventcontent NANOAODSIM --geometry ExtendedRun4D121 --era Phase2C22I13M9 --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000'], ['TTbar_14TeV_TuneCP5_Run4D121_GenSimHLBeamSpot14INPUT', 'DigiTrigger_HLTPhase2WithNano_Run4D121'])
==> duplicate name found for  34434.7591_TTbar_14TeV+Run4D121_HLTPhase2WithNanoValid
    keeping  :  (34434.7591, 'TTbar_14TeV+Run4D121_HLTPhase2WithNanoValid', [<Configuration.PyReleaseValidation.MatrixUtil.InputInfo object at 0x7f1b15b7bec0>, 'export CMSSW_USE_IBEOS=true; cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33,VALIDATION:@hltValidation,NANO:@Phase2HLTVal --conditions auto:phase2_realistic_T35 --datatier NANOAODSIM -n 10 --eventcontent NANOAODSIM --geometry ExtendedRun4D121 --era Phase2C22I13M9 --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000'], ['TTbar_14TeV_TuneCP5_Run4D121_GenSimHLBeamSpot14INPUT', 'DigiTrigger_HLTPhase2WithNanoValid_Run4D121'])
    ignoring :  (34434.7591, 'TTbar_14TeV+Run4D121_HLTPhase2WithNanoValid', [<Configuration.PyReleaseValidation.MatrixUtil.InputInfo object at 0x7f1b15b7bec0>, 'export CMSSW_USE_IBEOS=true; cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33,VALIDATION:@hltValidation,NANO:@Phase2HLTVal --conditions auto:phase2_realistic_T35 --datatier NANOAODSIM -n 10 --eventcontent NANOAODSIM --geometry ExtendedRun4D121 --era Phase2C22I13M9 --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000'], ['TTbar_14TeV_TuneCP5_Run4D121_GenSimHLBeamSpot14INPUT', 'DigiTrigger_HLTPhase2WithNanoValid_Run4D121'])
==> duplicate name found for  34434.772_TTbar_14TeV+Run4D121_NGTScoutingWithNano
    keeping  :  (34434.772, 'TTbar_14TeV+Run4D121_NGTScoutingWithNano', [<Configuration.PyReleaseValidation.MatrixUtil.InputInfo object at 0x7f1b15b7bec0>, 'export CMSSW_USE_IBEOS=true; cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,NANO:@NGTScouting --conditions auto:phase2_realistic_T35 --datatier NANOAODSIM -n 10 --eventcontent NANOAODSIM --geometry ExtendedRun4D121 --era Phase2C22I13M9 --procModifiers ngtScouting --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000'], ['TTbar_14TeV_TuneCP5_Run4D121_GenSimHLBeamSpot14INPUT', 'DigiTrigger_NGTScoutingWithNano_Run4D121'])
    ignoring :  (34434.772, 'TTbar_14TeV+Run4D121_NGTScoutingWithNano', [<Configuration.PyReleaseValidation.MatrixUtil.InputInfo object at 0x7f1b15b7bec0>, 'export CMSSW_USE_IBEOS=true; cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,NANO:@NGTScouting --conditions auto:phase2_realistic_T35 --datatier NANOAODSIM -n 10 --eventcontent NANOAODSIM --geometry ExtendedRun4D121 --era Phase2C22I13M9 --procModifiers ngtScouting --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000'], ['TTbar_14TeV_TuneCP5_Run4D121_GenSimHLBeamSpot14INPUT', 'DigiTrigger_NGTScoutingWithNano_Run4D121'])
==> duplicate name found for  34434.773_TTbar_14TeV+Run4D121_NGTScoutingWithNanoVal
    keeping  :  (34434.773, 'TTbar_14TeV+Run4D121_NGTScoutingWithNanoVal', [<Configuration.PyReleaseValidation.MatrixUtil.InputInfo object at 0x7f1b15b7bec0>, 'export CMSSW_USE_IBEOS=true; cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,VALIDATION:@hltValidation,NANO:@NGTScoutingVal --conditions auto:phase2_realistic_T35 --datatier NANOAODSIM -n 10 --eventcontent NANOAODSIM --geometry ExtendedRun4D121 --era Phase2C22I13M9 --procModifiers ngtScouting --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000'], ['TTbar_14TeV_TuneCP5_Run4D121_GenSimHLBeamSpot14INPUT', 'DigiTrigger_NGTScoutingWithNanoVal_Run4D121'])
    ignoring :  (34434.773, 'TTbar_14TeV+Run4D121_NGTScoutingWithNanoVal', [<Configuration.PyReleaseValidation.MatrixUtil.InputInfo object at 0x7f1b15b7bec0>, 'export CMSSW_USE_IBEOS=true; cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:NGTScouting,VALIDATION:@hltValidation,NANO:@NGTScoutingVal --conditions auto:phase2_realistic_T35 --datatier NANOAODSIM -n 10 --eventcontent NANOAODSIM --geometry ExtendedRun4D121 --era Phase2C22I13M9 --procModifiers ngtScouting --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000'], ['TTbar_14TeV_TuneCP5_Run4D121_GenSimHLBeamSpot14INPUT', 'DigiTrigger_NGTScoutingWithNanoVal_Run4D121'])
```

#### PR validation:

With this branch run successfully:
- `runTheMatrix.py -l 34434.773,34434.772 -t 4 -j 8 -i all --ibeos`
- `runTheMatrix.py --what nano -l 3000.0001,3000.0002,3000.0003,3000.0004`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A