### PR TITLE
[NGT] Updates for Phase2-HLT nanoAODs

### DIFF
--- a/HLTrigger/NGTScouting/plugins/HLTVertexTableProducer.cc
+++ b/HLTrigger/NGTScouting/plugins/HLTVertexTableProducer.cc
@@ -169,7 +169,7 @@ void HLTVertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   }
 
   //table for all primary vertices
-  auto pvTable = std::make_unique<nanoaod::FlatTable>(nPVs, pvName_, true);
+  auto pvTable = std::make_unique<nanoaod::FlatTable>(nPVs, pvName_, /*singleton*/ false);
   pvTable->addColumn<float>("ndof", v_ndof, "primary vertex number of degrees of freedom", 8);
   pvTable->addColumn<float>("chi2", v_chi2, "primary vertex reduced chi2", 8);
   pvTable->addColumn<float>("x", v_x, "primary vertex x coordinate", 10);

--- a/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
+++ b/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
@@ -60,6 +60,7 @@ NanoGenTables = cms.Sequence(
 # Store hlt objects for NGT scouting
 NanoHltTables = cms.Sequence(
     hltVertexTable
+    + hltSecondaryVertexTable
     + hltPixelVertexTable
     + hltGeneralTrackTable
     + hltGeneralTrackExtTable

--- a/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
+++ b/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
@@ -2,8 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.JetMCAlgos.AK4GenJetFlavourInfos_cfi import *
 from PhysicsTools.JetMCAlgos.HadronAndPartonSelector_cfi import *
-from PhysicsTools.JetMCAlgos.TauGenJetsDecayModeSelectorAllHadrons_cfi import *
-from PhysicsTools.JetMCAlgos.TauGenJets_cfi import *
 from PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.genparticles_cff import *
 from PhysicsTools.NanoAOD.jetMC_cff import *
@@ -49,9 +47,7 @@ NanoGenTables = cms.Sequence(
     + slimmedGenJetsFlavourInfos
     + genJetTable
     + genJetFlavourTable
-    + tauGenJets
     + tauGenJetsForNano
-    + tauGenJetsSelectorAllHadrons
     + tauGenJetsSelectorAllHadronsForNano
     + genVisTaus
     + genVisTauTable

--- a/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
+++ b/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
@@ -2,9 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.JetMCAlgos.AK4GenJetFlavourInfos_cfi import *
 from PhysicsTools.JetMCAlgos.HadronAndPartonSelector_cfi import *
+from PhysicsTools.JetMCAlgos.TauGenJetsDecayModeSelectorAllHadrons_cfi import *
+from PhysicsTools.JetMCAlgos.TauGenJets_cfi import *
 from PhysicsTools.NanoAOD.common_cff import *
-from PhysicsTools.NanoAOD.jetMC_cff import *
 from PhysicsTools.NanoAOD.genparticles_cff import *
+from PhysicsTools.NanoAOD.jetMC_cff import *
+from PhysicsTools.NanoAOD.taus_cff import *
 from PhysicsTools.PatAlgos.slimming.genParticles_cff import *
 from PhysicsTools.PatAlgos.slimming.packedGenParticles_cfi import *
 from PhysicsTools.PatAlgos.slimming.prunedGenParticles_cfi import *
@@ -46,6 +49,12 @@ NanoGenTables = cms.Sequence(
     + slimmedGenJetsFlavourInfos
     + genJetTable
     + genJetFlavourTable
+    + tauGenJets
+    + tauGenJetsForNano
+    + tauGenJetsSelectorAllHadrons
+    + tauGenJetsSelectorAllHadronsForNano
+    + genVisTaus
+    + genVisTauTable
 )
 
 # Store hlt objects for NGT scouting

--- a/HLTrigger/NGTScouting/python/hltVertices_cfi.py
+++ b/HLTrigger/NGTScouting/python/hltVertices_cfi.py
@@ -19,3 +19,21 @@ hltPixelVertexTable = cms.EDProducer("HLTVertexTableProducer",
                                      dlenMin = cms.double(0),
                                      dlenSigMin = cms.double(3),
                                      pvName = cms.string("hltPixelVertex"))
+
+hltSecondaryVertexTable = cms.EDProducer("SimpleSecondaryVertexFlatTableProducer",
+                                         skipNonExistingSrc = cms.bool(False),
+                                         src = cms.InputTag("hltDeepInclusiveMergedVerticesPF"),
+                                         name = cms.string("hltSecondaryVertex"),
+                                         extension = cms.bool(False),
+                                         variables = cms.PSet(P4Vars,
+                                                              x   = Var("position().x()", float, doc = "secondary vertex X position, in cm",precision=10),
+                                                              y   = Var("position().y()", float, doc = "secondary vertex Y position, in cm",precision=10),
+                                                              z   = Var("position().z()", float, doc = "secondary vertex Z position, in cm",precision=14),
+                                                              ndof    = Var("vertexNdof()", float, doc = "number of degrees of freedom",precision=8),
+                                                              chi2    = Var("vertexNormalizedChi2()", float, doc = "reduced chi2, i.e. chi/ndof",precision=8),
+                                                              ntracks = Var("numberOfDaughters()", "uint8", doc = "number of tracks"),
+                                                              ),
+                                         )
+
+hltSecondaryVertexTable.variables.pt.precision=10
+hltSecondaryVertexTable.variables.phi.precision=12


### PR DESCRIPTION
#### PR description:

The goal of this PR is to add a few improvements to the phase-2 HLT nanoAOD flavours
- add tau GEN information to hlt nano: https://github.com/cms-sw/cmssw/commit/a45908bccf0b9a5aabbd1f4a148b3fad902b3382, (descoped from https://github.com/cms-sw/cmssw/pull/49637)
- add a table for the HLT secondary vertices: https://github.com/cms-sw/cmssw/commit/0794cf09ff86ac3e2a530f0ca33e478a1ae8302f
- do not declare pvTable as a singleton: https://github.com/cms-sw/cmssw/commit/0a3d0f6f7b3a32107d32b147afc0070c4a1da065 (bug-fix)

#### PR validation:

`runTheMatrix.py -l ph2_hlt` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not to be backported.
