### PR TITLE
[NGT] Fix jet validation removing AK4PFPuppiHLT corrector in run1 and run2 workflows

### DIFF
--- a/Validation/RecoJets/python/JetCorrectionServices_cff.py
+++ b/Validation/RecoJets/python/JetCorrectionServices_cff.py
@@ -60,10 +60,6 @@ hltAK4PFCHSJetCorrector_ForValidation = hltAK4PFCHSJetCorrector.clone(
 )
 
 hltJetCorrectionTask = cms.Task(
-    hltAK4PFPuppiJetCorrectorL1_ForValidation,
-    hltAK4PFPuppiJetCorrectorL2_ForValidation,
-    hltAK4PFPuppiJetCorrectorL3_ForValidation,
-    hltAK4PFPuppiJetCorrector_ForValidation,
     hltAK4PFJetCorrectorL1_ForValidation,
     hltAK4PFJetCorrectorL2_ForValidation,
     hltAK4PFJetCorrectorL3_ForValidation,
@@ -72,4 +68,27 @@ hltJetCorrectionTask = cms.Task(
     hltAK4PFCHSJetCorrectorL2_ForValidation,
     hltAK4PFCHSJetCorrectorL3_ForValidation,
     hltAK4PFCHSJetCorrector_ForValidation,
+)
+
+hltJetCorrectionTask_Puppi = cms.Task(
+    hltAK4PFPuppiJetCorrectorL1_ForValidation,
+    hltAK4PFPuppiJetCorrectorL2_ForValidation,
+    hltAK4PFPuppiJetCorrectorL3_ForValidation,
+    hltAK4PFPuppiJetCorrector_ForValidation,
+)
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toReplaceWith(hltJetCorrectionTask, 
+    cms.Task(
+        hltJetCorrectionTask.copy(),
+        hltJetCorrectionTask_Puppi # not safe for Run-1/Run-2 worflows
+    )
+)
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(hltJetCorrectionTask, 
+    cms.Task(
+        hltJetCorrectionTask.copy(),
+        hltJetCorrectionTask_Puppi # not safe for Run-1/Run-2 worflows
+    )
 )


### PR DESCRIPTION
#### PR description:

This PR is a follow-up of #51045.
It fixes failures in Run 1 and Run 2 relvals caused by the scheduling of the `AK4PFPuppiHLT` jet correctors in HLT jet validation. The affected workflows were failing with:
```
----- Begin Fatal Exception 30-May-2026 20:34:39 CEST-----------------------
An exception of category 'NoProductResolverException' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 1 stream: 3
   [1] Running path 'validation_step'
   [2] Prefetching for module JetTester/'hltJetAnalyzerAK4PFPuppi'
   [3] Prefetching for module ChainedJetCorrectorProducer/'hltAK4PFPuppiJetCorrector_ForValidation'
   [4] Calling method for module LXXXCorrectorProducer/'hltAK4PFPuppiJetCorrectorL3_ForValidation'
Exception Message:
Cannot find EventSetup module to produce data of type "JetCorrectorParametersCollection" in
record "JetCorrectionsRecord" with product label "AK4PFPuppiHLT".
Please add an ESSource or ESProducer to your job which can deliver this data.
----- End Fatal Exception -------------------------------------------------
```

The AK4PFPuppiHLT JECs are available for Run-3 and Phase-2 workflows, but not for Run-1 and Run-2. Therefore, the HLT jet corrector chain has been removed from the default validation correction task and is included only for Run-3 and Phase-2 workflows (preserving the intended purpose for these eras).

#### PR validation:

This PR has been successfully validated on the following workflows, without any failure:
- `34434.0` (Phase-2)
- `11.0` (Run-1)
- `281.0` (Run-2)
- `1311.0` (Run-2)