### PR TITLE
access const TGeoManager

### DIFF
--- a/DetectorDescription/DDCMS/interface/DDDetector.h
+++ b/DetectorDescription/DDCMS/interface/DDDetector.h
@@ -27,7 +27,7 @@ namespace cms {
     dd4hep::DetElement world() const;
 
     //! The geometry manager of this instance
-    TGeoManager& manager() const;
+    const TGeoManager& manager() const;
 
     //! Find DetElement as child of the top level volume by it's absolute path
     dd4hep::DetElement findElement(const std::string&) const;

--- a/DetectorDescription/DDCMS/plugins/test/DDTestDumpFile.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestDumpFile.cc
@@ -45,7 +45,7 @@ void DDTestDumpFile::analyze(const Event&, const EventSetup& iEventSetup) {
   LogVerbatim("Geometry") << "DDTestDumpFile::analyze: " << m_label;
   ESTransientHandle<DDDetector> det = iEventSetup.getTransientHandle(m_token);
 
-  TGeoManager& geom = det->manager();
+  const TGeoManager& geom = det->manager();
 
   int level = 1 + geom.GetTopVolume()->CountNodes(100, 3);
 

--- a/DetectorDescription/DDCMS/src/DDDetector.cc
+++ b/DetectorDescription/DDCMS/src/DDDetector.cc
@@ -74,7 +74,7 @@ namespace cms {
     return m_description->world();
   }
 
-  TGeoManager& DDDetector::manager() const {
+  const TGeoManager& DDDetector::manager() const {
     assert(m_description);
     return m_description->manager();
   }


### PR DESCRIPTION
#### PR description:

Non-const access to `TGeoManager` is unsafe.

#### PR validation:

Code compiles after running checkdeps.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A (unless issues related to this are observed in older releases, then it will be backported)