### PR TITLE
Remove possible out of bounds operation in CaloDirectionOperations and cleanup

### DIFF
--- a/FastSimulation/CaloGeometryTools/interface/BaseCrystal.h
+++ b/FastSimulation/CaloGeometryTools/interface/BaseCrystal.h
@@ -20,25 +20,14 @@ public:
   typedef math::XYZVector XYZPoint;
   typedef ROOT::Math::Plane3D Plane3D;
 
-  // side numbering
-  //  enum CrystalSide{EAST=0,NORTH=1,WEST=2,SOUTH=3,FRONT=4,BACK=5};
   /// Empty constructor
   BaseCrystal() = default;
   /// constructor from DetId
   BaseCrystal(const DetId& cell);
 
-  /// Copy constructor
-  //    BaseCrystal (const BaseCrystal& bc):corners_(bc.getCorners()),cellid_(bc.getDetId())
-  //    {
-  //      std::cout << " Copy constructor " ;
-  //      computeBasicProperties();
-  //      std::cout << " done " << std::endl;
-  //    }
   ~BaseCrystal() = default;
-  ///
-  void setCorners(const CaloCellGeometry::CornersVec& vec, const GlobalPoint& pos);
 
-  // inline const std::vector<XYZPoint>& getCorners() const {return corners_;}
+  void setCorners(const CaloCellGeometry::CornersVec& vec, const GlobalPoint& pos);
 
   /// get the i-th corner
   inline const XYZPoint& getCorner(unsigned i) const { return corners_[i]; };

--- a/FastSimulation/CaloGeometryTools/interface/Crystal.h
+++ b/FastSimulation/CaloGeometryTools/interface/Crystal.h
@@ -21,8 +21,6 @@ public:
   typedef math::XYZVector XYZPoint;
   typedef ROOT::Math::Plane3D Plane3D;
 
-  // side numbering
-  //  enum CrystalSide{EAST=0,NORTH=1,WEST=2,SOUTH=3,FRONT=4,BACK=5};
   /// Empty constructor
   Crystal() = default;
   /// constructor from DetId

--- a/FastSimulation/CaloGeometryTools/src/BaseCrystal.cc
+++ b/FastSimulation/CaloGeometryTools/src/BaseCrystal.cc
@@ -70,7 +70,6 @@ void BaseCrystal::setCorners(const CaloCellGeometry::CornersVec &vec, const Glob
 }
 
 void BaseCrystal::computeBasicProperties() {
-  //if(corners_.size()==0) return;
   center_ = XYZPoint(0., 0., 0.);
   for (unsigned ic = 0; ic < 8; ++ic) {
     center_ += corners_[ic];
@@ -78,13 +77,11 @@ void BaseCrystal::computeBasicProperties() {
 
   center_ *= 0.125;
 
-  //  std::cout << " Ncorners ? " << corners_.size() << std::endl;
   frontcenter_ = 0.25 * (corners_[0] + corners_[1] + corners_[2] + corners_[3]);
   backcenter_ = 0.25 * (corners_[4] + corners_[5] + corners_[6] + corners_[7]);
   crystalaxis_ = backcenter_ - frontcenter_;
   firstedgedirection_ = -(corners_[1] - corners_[0]).Unit();
   fifthedgedirection_ = -(corners_[5] - corners_[4]).Unit();
-  //  std::cout << " Direction laterales " << std::endl;
   for (unsigned il = 0; il < 4; ++il) {
     lateraldirection_[il] = -(corners_[(il + 1) % 4] - corners_[il]).Unit();
   }

--- a/FastSimulation/CaloGeometryTools/src/CaloDirectionOperations.cc
+++ b/FastSimulation/CaloGeometryTools/src/CaloDirectionOperations.cc
@@ -1,8 +1,8 @@
 #include "FastSimulation/CaloGeometryTools/interface/CaloDirectionOperations.h"
 
+#include <cassert>
+
 CaloDirection CaloDirectionOperations::add2d(const CaloDirection& dir1, const CaloDirection& dir2) {
-  //  unsigned d1=Side(dir1);
-  //  unsigned d2=Side(dir2);
   constexpr CaloDirection tab[4][4] = {{NORTH, NORTHEAST, NONE, NORTHWEST},
                                        {NORTHEAST, EAST, SOUTHEAST, NONE},
                                        {NONE, SOUTHEAST, SOUTH, SOUTHWEST},
@@ -11,8 +11,8 @@ CaloDirection CaloDirectionOperations::add2d(const CaloDirection& dir1, const Ca
 }
 
 CaloDirection CaloDirectionOperations::Side(unsigned i) {
-  constexpr CaloDirection sides[6] = {NORTH, EAST, SOUTH, WEST, UP, DOWN};
-  //  if(i<0||i>5) return DOWN;
+  constexpr CaloDirection sides[4] = {NORTH, EAST, SOUTH, WEST};
+  assert(i<4);
   return sides[i];
 }
 
@@ -44,6 +44,7 @@ unsigned CaloDirectionOperations::neighbourDirection(const CaloDirection& side) 
       result = 7;
       break;
     default:
+      assert(false);
       result = 999;
   }
   return result;
@@ -52,7 +53,6 @@ unsigned CaloDirectionOperations::neighbourDirection(const CaloDirection& side) 
 // It should be merged with the previous one. But I am afraid to break something
 CaloDirection CaloDirectionOperations::neighbourDirection(unsigned i) {
   constexpr CaloDirection sides[8] = {NORTH, EAST, SOUTH, WEST, NORTHEAST, SOUTHEAST, SOUTHWEST, NORTHWEST};
-  //  if(i<0||i>7) return SOUTH;
   return sides[i];
 }
 
@@ -71,13 +71,8 @@ unsigned CaloDirectionOperations::Side(const CaloDirection& side) {
     case WEST:
       result = 3;
       break;
-    case UP:
-      result = 4;
-      break;
-    case DOWN:
-      result = 5;
-      break;
     default:
+      assert(false);
       result = 999;
   }
   return result;
@@ -126,6 +121,4 @@ CaloDirection CaloDirectionOperations::oppositeSide(const CaloDirection& side) {
 unsigned CaloDirectionOperations::oppositeDirection(unsigned iside) {
   constexpr unsigned od[8] = {2, 3, 0, 1, 6, 7, 4, 5};
   return od[iside];
-  //  if(iside>=0&&iside<8) return od[iside];
-  //  return 999;
 }

--- a/FastSimulation/CaloGeometryTools/src/CaloDirectionOperations.cc
+++ b/FastSimulation/CaloGeometryTools/src/CaloDirectionOperations.cc
@@ -1,7 +1,5 @@
 #include "FastSimulation/CaloGeometryTools/interface/CaloDirectionOperations.h"
 
-#include <cassert>
-
 CaloDirection CaloDirectionOperations::add2d(const CaloDirection& dir1, const CaloDirection& dir2) {
   constexpr CaloDirection tab[4][4] = {{NORTH, NORTHEAST, NONE, NORTHWEST},
                                        {NORTHEAST, EAST, SOUTHEAST, NONE},
@@ -12,7 +10,6 @@ CaloDirection CaloDirectionOperations::add2d(const CaloDirection& dir1, const Ca
 
 CaloDirection CaloDirectionOperations::Side(unsigned i) {
   constexpr CaloDirection sides[4] = {NORTH, EAST, SOUTH, WEST};
-  assert(i<4);
   return sides[i];
 }
 
@@ -44,7 +41,6 @@ unsigned CaloDirectionOperations::neighbourDirection(const CaloDirection& side) 
       result = 7;
       break;
     default:
-      assert(false);
       result = 999;
   }
   return result;
@@ -72,7 +68,6 @@ unsigned CaloDirectionOperations::Side(const CaloDirection& side) {
       result = 3;
       break;
     default:
-      assert(false);
       result = 999;
   }
   return result;

--- a/FastSimulation/CaloHitMakers/interface/EcalHitMaker.h
+++ b/FastSimulation/CaloHitMakers/interface/EcalHitMaker.h
@@ -2,16 +2,12 @@
 #define FastSimulation_CaloHitMakers_EcalHitMaker_h
 
 #include "Geometry/CaloTopology/interface/CaloDirection.h"
-
-//#include "FastSimulation/Event/interface/FSimTrack.h"
 #include "FastSimulation/CaloHitMakers/interface/CaloHitMaker.h"
 #include "FastSimulation/CaloGeometryTools/interface/CaloPoint.h"
 #include "FastSimulation/CaloGeometryTools/interface/CaloSegment.h"
 #include "FastSimulation/CaloGeometryTools/interface/CrystalPad.h"
 #include "FastSimulation/CaloGeometryTools/interface/Crystal.h"
 #include "FastSimulation/Utilities/interface/FamosDebug.h"
-
-//#include <boost/cstdint.hpp>
 
 #include <vector>
 

--- a/FastSimulation/CaloHitMakers/src/EcalHitMaker.cc
+++ b/FastSimulation/CaloHitMakers/src/EcalHitMaker.cc
@@ -2,11 +2,6 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
-
-//#include "Geometry/EcalAlgo/interface/EcalBarrelGeometry.h"
-//#include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
-//#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
-
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "FastSimulation/CaloHitMakers/interface/EcalHitMaker.h"
 #include "FastSimulation/CaloGeometryTools/interface/CaloGeometryHelper.h"
@@ -18,9 +13,6 @@
 #include "FastSimulation/CalorimeterProperties/interface/PreshowerLayer2Properties.h"
 #include "FastSimulation/CalorimeterProperties/interface/HCALProperties.h"
 #include "FastSimulation/Utilities/interface/RandomEngineAndDistribution.h"
-//#include "FastSimulation/Utilities/interface/Histos.h"
-
-//#include "Math/GenVector/Transform3D.h"
 #include "FastSimulation/CaloGeometryTools/interface/Transform3DPJ.h"
 
 #include <algorithm>
@@ -45,7 +37,6 @@ EcalHitMaker::EcalHitMaker(const CaloGeometryHelper* theCalo,
 #ifdef FAMOSDEBUG
   myHistos = Histos::instance();
 #endif
-  //  myHistos->debug("Constructeur EcalHitMaker");
   simulatePreshower_ = true;
   X0depthoffset_ = 0.;
   X0PS1_ = 0.;
@@ -95,7 +86,6 @@ EcalHitMaker::EcalHitMaker(const CaloGeometryHelper* theCalo,
   myCalorimeter->getWindow(pivot_.getDetId(), size, size, CellsWindow_);
 
   buildGeometry();
-  //  std::cout << " Geometry built " << regionOfInterest_.size() << std::endl;
 
   truncatedGrid_ = CellsWindow_.size() != (etasize_ * phisize_);
 
@@ -131,67 +121,30 @@ EcalHitMaker::~EcalHitMaker() {
 }
 
 bool EcalHitMaker::addHitDepth(double r, double phi, double depth) {
-  //  std::cout << " Add hit depth called; Current deph is "  << currentdepth_;
-  //  std::cout << " Required depth is " << depth << std::endl;
   depth += X0depthoffset_;
   double sp(1.);
   r *= radiusFactor_;
   CLHEP::Hep2Vector point(r * std::cos(phi), r * std::sin(phi));
 
   unsigned xtal = fastInsideCell(point, sp);
-  //  if(cellid.isZero()) std::cout << " cell is Zero " << std::endl;
-  //  if(xtal<1000)
-  //    {
-  //      std::cout << "Result " << regionOfInterest_[xtal].getX0Back() << " " ;
-  //      std::cout << depth << std::endl;
-  //    }
-  //  myHistos->fill("h5000",depth);
   if (xtal < 1000) {
-    //      myHistos->fill("h5002",regionOfInterest_[xtal].getX0Back(),depth);
-    //      myHistos->fill("h5003",ecalentrance_.eta(),maxX0_);
     if (regionOfInterest_[xtal].getX0Back() > depth) {
       hits_[xtal] += spotEnergy;
-      //	  myHistos->fill("h5005",r);
       return true;
     } else {
       rearleakage_ += spotEnergy;
     }
-  } else {
-    //      std::cout << " Return false " << std::endl;
-    //      std::cout << " Add hit depth called; Current deph is "  << currentdepth_;
-    //      std::cout << " Required depth is " << depth << std::endl;
-    //      std::cout << " R = " << r << " " << radiusFactor_ << std::endl;
   }
 
   outsideWindowEnergy_ += spotEnergy;
   return false;
 }
 
-//bool EcalHitMaker::addHitDepth(double r,double phi,double depth)
-//{
-//  std::map<unsigned,float>::iterator itcheck=hitMap_.find(pivot_.getDetId().rawId());
-//  if(itcheck==hitMap_.end())
-//    {
-//      hitMap_.insert(std::pair<uint32_t,float>(pivot_.getDetId().rawId(),spotEnergy));
-//    }
-//  else
-//    {
-//      itcheck->second+=spotEnergy;
-//    }
-//  return true;
-//}
-
 bool EcalHitMaker::addHit(double r, double phi, unsigned layer) {
-  //  std::cout <<" Addhit " << std::endl;
-  //  std::cout << " Before insideCell " << std::endl;
   double sp(1.);
-  //  std::cout << " Trying to add " << r << " " << phi << " " << radiusFactor_ << std::endl;
   r *= radiusFactor_;
   CLHEP::Hep2Vector point(r * std::cos(phi), r * std::sin(phi));
-  //  std::cout << "point " << point << std::endl;
-  //  CellID cellid=insideCell(point,sp);
   unsigned xtal = fastInsideCell(point, sp);
-  //  if(cellid.isZero()) std::cout << " cell is Zero " << std::endl;
   if (xtal < 1000) {
     if (sp == 1.)
       hits_[xtal] += spotEnergy;
@@ -201,90 +154,42 @@ bool EcalHitMaker::addHit(double r, double phi, unsigned layer) {
   }
 
   outsideWindowEnergy_ += spotEnergy;
-  //  std::cout << " This hit ; r= " << point << " hasn't been added "<<std::endl;
-  //  std::cout << " Xtal " << xtal << std::endl;
-  //  for(unsigned ip=0;ip<npadsatdepth_;++ip)
-  //    {
-  //      std::cout << padsatdepth_[ip] << std::endl;
-  //    }
 
   return false;
 }
 
-// Temporary solution
-//bool EcalHitMaker::addHit(double r,double phi,unsigned layer)
-//{
-//  std::map<unsigned,float>::iterator itcheck=hitMap_.find(pivot_.getDetId().rawId());
-//  if(itcheck==hitMap_.end())
-//    {
-//      hitMap_.insert(std::pair<uint32_t,float>(pivot_.getDetId().rawId(),spotEnergy));
-//    }
-//  else
-//    {
-//      itcheck->second+=spotEnergy;
-//    }
-//  return true;
-//}
-
 unsigned EcalHitMaker::fastInsideCell(const CLHEP::Hep2Vector& point, double& sp, bool debug) {
-  //  debug = true;
   bool found = false;
   // something clever has to be implemented here
   unsigned d1, d2;
   convertIntegerCoordinates(point.x(), point.y(), d1, d2);
-  //  std::cout << "Fastinside cell " << point.x() << " " <<  point.y() << " " << d1 << " "<< d2 << " " << nx_ << " " << ny_ << std::endl;
   if (d1 >= nx_ || d2 >= ny_) {
-    //      std::cout << " Not in the map " <<std::endl;
     return 9999;
   }
   unsigned cell = myCrystalNumberArray_[d1][d2];
   // We are likely to be lucky
-  //  std::cout << " Got the cell " << cell << std::endl;
   if (validPads_[cell] && padsatdepth_[cell].inside(point)) {
-    //      std::cout << " We are lucky " << cell << std::endl;
     sp = padsatdepth_[cell].survivalProbability();
     return cell;
   }
 
-  //  std::cout << "Starting the loop " << std::endl;
   bool status(true);
   const std::vector<unsigned>& localCellVector(myCrystalWindowMap_->getCrystalWindow(cell, status));
   if (status) {
     unsigned size = localCellVector.size();
-    //      std::cout << " Starting from " << EBDetId(regionOfInterest_[cell].getDetId()) << std::endl;
-    //      const std::vector<DetId>& neighbours=myCalorimeter->getNeighbours(regionOfInterest_[cell].getDetId());
-    //      std::cout << " The neighbours are " << std::endl;
-    //      for(unsigned ic=0;ic<neighbours.size(); ++ic)
-    //	{
-    //	  std::cout << EBDetId(neighbours[ic]) << std::endl;
-    //	}
-    //      std::cout << " Done " << std::endl;
     for (unsigned ic = 0; ic < 8 && ic < size; ++ic) {
       unsigned iq = localCellVector[ic];
-      //	  std::cout << " Testing " << EBDetId(regionOfInterest_[iq].getDetId()) << std::endl; ;
-      //	  std::cout << " " << iq << std::endl;
-      //	  std::cout << padsatdepth_[iq] ;
       if (validPads_[iq] && padsatdepth_[iq].inside(point)) {
-        //	      std::cout << " Yes " << std::endl;
-        //	      myHistos->fill("h1000",niter);
         sp = padsatdepth_[iq].survivalProbability();
-        //	      std::cout << "Finished the loop " << niter << std::endl;
-        //	      std::cout << "Inside " << std::endl;
         return iq;
       }
-      //	  std::cout << " Not inside " << std::endl;
-      //	  std::cout << "No " << std::endl;
     }
   }
   if (debug)
     std::cout << " not found in a quad, let's check the " << ncrackpadsatdepth_ << " cracks " << std::endl;
-  //  std::cout << "Finished the loop " << niter << std::endl;
-  // Let's check the cracks
-  //  std::cout << " Let's check the cracks " << ncrackpadsatdepth_ << " " << crackpadsatdepth_.size() << std::endl;
   unsigned iquad = 0;
   unsigned iquadinside = 999;
   while (iquad < ncrackpadsatdepth_ && !found) {
-    //      std::cout << " Inside the while " << std::endl;
     if (crackpadsatdepth_[iquad].inside(point)) {
       iquadinside = iquad;
       found = true;
@@ -292,15 +197,12 @@ unsigned EcalHitMaker::fastInsideCell(const CLHEP::Hep2Vector& point, double& sp
     }
     ++iquad;
   }
-  //  myHistos->fill("h1002",niter);
   if (!found && debug)
     std::cout << " Not found in the cracks " << std::endl;
   return (found) ? crackpadsatdepth_[iquadinside].getNumber() : 9999;
 }
 
 void EcalHitMaker::setTrackParameters(const XYZNormal& normal, double X0depthoffset, const FSimTrack& theTrack) {
-  //  myHistos->debug("setTrackParameters");
-  //  std::cout << " Track " << theTrack << std::endl;
   intersections_.clear();
   // This is certainly enough
   intersections_.reserve(50);
@@ -309,15 +211,9 @@ void EcalHitMaker::setTrackParameters(const XYZNormal& normal, double X0depthoff
   X0depthoffset_ = X0depthoffset;
   cellLine(intersections_);
   buildSegments(intersections_);
-  //  std::cout << " Segments " << segments_.size() << std::endl;
-  //  for(unsigned ii=0; ii<segments_.size() ; ++ii)
-  //    {
-  //      std::cout << segments_[ii] << std::endl;
-  //    }
 
   // This is only needed in case of electromagnetic showers
   if (EMSHOWER && onEcal_ && ecalTotalX0() > 0.) {
-    //      std::cout << "Total X0  " << ecalTotalX0() << std::endl;
     for (unsigned ic = 0; ic < ncrystals_; ++ic) {
       for (unsigned idir = 0; idir < 4; ++idir) {
         XYZVector norm = regionOfInterest_[ic].exitingNormal(CaloDirectionOperations::Side(idir));
@@ -331,11 +227,7 @@ void EcalHitMaker::setTrackParameters(const XYZNormal& normal, double X0depthoff
         double absciss = dist + segments_[ecalFirstSegment_].sEntrance();
         std::vector<CaloSegment>::const_iterator segiterator;
         // First identify the correct segment
-        //      std::cout << " Crystal " << ic  << regionOfInterest_[ic].getBackCenter() ;
-        //      std::cout << " Entrance : " << segments_[ecalFirstSegment_].entrance()<< std::endl;
-        //      std::cout << " Looking for the segment " << dist << std::endl;
         segiterator = find_if(segments_.begin(), segments_.end(), CaloSegment::inSegment(absciss));
-        //      std::cout << " Done " << std::endl;
         if (segiterator == segments_.end()) {
           // in this case, we won't have any problem. No need to
           // calculate the real depth.
@@ -351,30 +243,17 @@ void EcalHitMaker::setTrackParameters(const XYZNormal& normal, double X0depthoff
             regionOfInterest_[ic].setX0Back(x0);
           }
         }
-        //  myHistos->fill("h4000",ecalentrance_.eta(), regionOfInterest_[ic].getX0Back());
-        //}
-        //      else
-        //{
-        //   // in this case, we won't have any problem. No need to
-        //  // calculate the real depth.
-        //  regionOfInterest_[ic].setX0Back(9999);
-        //}
       }  //EMSHOWER
     }  // ndir
-    //      myHistos->fill("h6000",segments_[ecalFirstSegment_].entrance().eta(),maxX0_);
   }
-  //  std::cout << "Leaving setTrackParameters" << std::endl
 }
 
 void EcalHitMaker::cellLine(std::vector<CaloPoint>& cp) {
   cp.clear();
-  //  if(myTrack->onVFcal()!=2)
-  //    {
   if (!central_ && onEcal_ && simulatePreshower_)
     preshowerCellLine(cp);
   if (onEcal_)
     ecalCellLine(EcalEntrance_, EcalEntrance_ + normal_, cp);
-  //    }
 
   XYZPoint vertex(myTrack_->vertex().position().Vect());
 
@@ -407,22 +286,9 @@ void EcalHitMaker::cellLine(std::vector<CaloPoint>& cp) {
   // The intersections with the HCAL shouldn't need to be sorted
   // with the N.I it is actually a source of problems
   hcalCellLine(cp);
-
-  //  std::cout << " Intersections ordered by distance to " << vertex << std::endl;
-  //
-  //  for (unsigned ic=0;ic<cp.size();++ic)
-  //    {
-  //      XYZVector t=cp[ic]-vertex;
-  //      std::cout << cp[ic] << " " << t.mag() << std::endl;
-  //    }
 }
 
 void EcalHitMaker::preshowerCellLine(std::vector<CaloPoint>& cp) const {
-  //  FSimEvent& mySimEvent = myEventMgr->simSignal();
-  //  FSimTrack myTrack = mySimEvent.track(fsimtrack_);
-  //  std::cout << "FsimTrack " << fsimtrack_<< std::endl;
-  //  std::cout << " On layer 1 " << myTrack.onLayer1() << std::endl;
-  // std::cout << " preshowerCellLine " << std::endl;
   if (myTrack_->onLayer1()) {
     XYZPoint point1 = (myTrack_->layer1Entrance().vertex()).Vect();
     double phys_eta = myTrack_->layer1Entrance().eta();
@@ -436,8 +302,6 @@ void EcalHitMaker::preshowerCellLine(std::vector<CaloPoint>& cp) const {
       CaloPoint cp2(DetId::Ecal, EcalPreshower, 1, point2);
       cp.push_back(cp1);
       cp.push_back(cp2);
-    } else {
-      //      std::cout << "Track on ECAL " << myTrack.EcalEntrance_().vertex()*0.1<< std::endl;
     }
   }
 
@@ -455,16 +319,11 @@ void EcalHitMaker::preshowerCellLine(std::vector<CaloPoint>& cp) const {
 
       cp.push_back(cp1);
       cp.push_back(cp2);
-    } else {
-      //      std::cout << "Track on ECAL " << myTrack.EcalEntrance_().vertex()*0.1 << std::endl;
     }
   }
-  //  std::cout << " Exit preshower CellLine " << std::endl;
 }
 
 void EcalHitMaker::hcalCellLine(std::vector<CaloPoint>& cp) const {
-  //  FSimEvent& mySimEvent = myEventMgr->simSignal();
-  //  FSimTrack myTrack = mySimEvent.track(fsimtrack_);
   int onHcal = myTrack_->onHcal();
 
   if (onHcal <= 2 && onHcal > 0) {
@@ -495,48 +354,34 @@ void EcalHitMaker::hcalCellLine(std::vector<CaloPoint>& cp) const {
 }
 
 void EcalHitMaker::ecalCellLine(const XYZPoint& a, const XYZPoint& b, std::vector<CaloPoint>& cp) {
-  //  std::vector<XYZPoint> corners;
-  //  corners.resize(4);
   unsigned ic = 0;
   double t;
   XYZPoint xp;
   DetId c_entrance, c_exit;
   bool entrancefound(false), exitfound(false);
-  //  std::cout << " Look for intersections " << ncrystals_ << std::endl;
-  //  std::cout << " regionOfInterest_ " << truncatedGrid_ << " " << regionOfInterest_.size() << std::endl;
   // try to determine the number of crystals to test
   // First determine the incident angle
   double angle = std::acos(normal_.Dot(regionOfInterest_[0].getAxis().Unit()));
 
-  //  std::cout << " Normal " << normal_<< " Axis " << regionOfInterest_[0].getAxis().Unit() << std::endl;
   double backdistance = std::sqrt(regionOfInterest_[0].getAxis().mag2()) * std::tan(angle);
   // 1/2.2cm = 0.45
-  //   std::cout << " Angle " << angle << std::endl;
-  //   std::cout << " Back distance " << backdistance << std::endl;
   unsigned ncrystals = (unsigned)(backdistance * 0.45);
   unsigned highlim = (ncrystals + 4);
   highlim *= highlim;
   if (highlim > ncrystals_)
     highlim = ncrystals_;
-  //  unsigned lowlim=(ncrystals>2)? (ncrystals-2):0;
-  //  std::cout << " Ncrys " << ncrystals << std::endl;
 
   while (ic < ncrystals_ && (ic < highlim || !exitfound)) {
     // Check front side
     //      if(!entrancefound)
     {
       const Plane3D& plan = regionOfInterest_[ic].getFrontPlane();
-      //	  XYZVector axis1=(plan.Normal());
-      //	  XYZVector axis2=regionOfInterest_[ic].getFirstEdge();
       xp = intersect(plan, a, b, t, false);
       regionOfInterest_[ic].getFrontSide(corners);
-      //	  CrystalPad pad(9999,onEcal_,corners,regionOfInterest_[ic].getCorner(0),axis1,axis2);
-      //	  if(pad.globalinside(xp))
       if (inside3D(corners, xp)) {
         cp.push_back(CaloPoint(regionOfInterest_[ic].getDetId(), UP, xp));
         entrancefound = true;
         c_entrance = regionOfInterest_[ic].getDetId();
-        //      myHistos->fill("j12",highlim,ic);
       }
     }
 
@@ -544,18 +389,12 @@ void EcalHitMaker::ecalCellLine(const XYZPoint& a, const XYZPoint& b, std::vecto
     //	if(!exitfound)
     {
       const Plane3D& plan = regionOfInterest_[ic].getBackPlane();
-      //	  XYZVector axis1=(plan.Normal());
-      //	  XYZVector axis2=regionOfInterest_[ic].getFifthEdge();
       xp = intersect(plan, a, b, t, false);
       regionOfInterest_[ic].getBackSide(corners);
-      //	  CrystalPad pad(9999,onEcal_,corners,regionOfInterest_[ic].getCorner(4),axis1,axis2);
-      //	  if(pad.globalinside(xp))
       if (inside3D(corners, xp)) {
         cp.push_back(CaloPoint(regionOfInterest_[ic].getDetId(), DOWN, xp));
         exitfound = true;
         c_exit = regionOfInterest_[ic].getDetId();
-        //	      std::cout << " Crystal : " << ic << std::endl;
-        //	      myHistos->fill("j10",highlim,ic);
       }
     }
 
@@ -565,14 +404,9 @@ void EcalHitMaker::ecalCellLine(const XYZPoint& a, const XYZPoint& b, std::vecto
     for (unsigned iside = 0; iside < 4; ++iside) {
       const Plane3D& plan = regionOfInterest_[ic].getLateralPlane(iside);
       xp = intersect(plan, a, b, t, false);
-      //	  XYZVector axis1=(plan.Normal());
-      //	  XYZVector axis2=regionOfInterest_[ic].getLateralEdge(iside);
       regionOfInterest_[ic].getLateralSide(iside, corners);
-      //	  CrystalPad pad(9999,onEcal_,corners,regionOfInterest_[ic].getCorner(iside),axis1,axis2);
-      //	  if(pad.globalinside(xp))
       if (inside3D(corners, xp)) {
         cp.push_back(CaloPoint(regionOfInterest_[ic].getDetId(), CaloDirectionOperations::Side(iside), xp));
-        //	      std::cout << cp[cp.size()-1] << std::endl;
       }
     }
     // Go to next crystal
@@ -581,14 +415,10 @@ void EcalHitMaker::ecalCellLine(const XYZPoint& a, const XYZPoint& b, std::vecto
 }
 
 void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
-  //  myHistos->debug();
-  //  TimeMe theT("FamosGrid::buildSegments");
   unsigned size = cp.size();
   if (size % 2 != 0) {
-    //      std::cout << " There is a problem " << std::endl;
     return;
   }
-  //  myHistos->debug();
   unsigned nsegments = size / 2;
   segments_.reserve(nsegments);
   if (size == 0)
@@ -605,24 +435,18 @@ void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
   while (is < nsegments) {
     if (cp[2 * is].getDetId() != cp[2 * is + 1].getDetId() && cp[2 * is].whichDetector() != DetId::Hcal &&
         cp[2 * is + 1].whichDetector() != DetId::Hcal) {
-      //	  std::cout << " Problem with the segments " << std::endl;
-      //	  std::cout << cp[2*is].whichDetector() << " " << cp[2*is+1].whichDetector() << std::endl;
-      //	  std::cout << is << " " <<cp[2*is].getDetId().rawId() << std::endl;
-      //	  std::cout << (2*is+1) << " " <<cp[2*is+1].getDetId().rawId() << std::endl;
       ++is;
       continue;
     }
 
     // Check if it is a Preshower segment - Layer 1
     // One segment per layer, nothing between
-    //      myHistos->debug("Just avant Preshower");
     if (cp[2 * is].whichDetector() == DetId::Ecal && cp[2 * is].whichSubDetector() == EcalPreshower &&
         cp[2 * is].whichLayer() == 1) {
       if (cp[2 * is + 1].whichDetector() == DetId::Ecal && cp[2 * is + 1].whichSubDetector() == EcalPreshower &&
           cp[2 * is + 1].whichLayer() == 1) {
         CaloSegment preshsegment(cp[2 * is], cp[2 * is + 1], s, sX0, sL0, CaloSegment::PS, myCalorimeter);
         segments_.push_back(preshsegment);
-        //	      std::cout << " Added (1-1)" << preshsegment << std::endl;
         s += preshsegment.length();
         sX0 += preshsegment.X0length();
         sL0 += preshsegment.L0length();
@@ -644,7 +468,6 @@ void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
           cp[2 * is + 1].whichLayer() == 2) {
         CaloSegment preshsegment(cp[2 * is], cp[2 * is + 1], s, sX0, sL0, CaloSegment::PS, myCalorimeter);
         segments_.push_back(preshsegment);
-        //	      std::cout << " Added (1-2)" << preshsegment << std::endl;
         s += preshsegment.length();
         sX0 += preshsegment.X0length();
         sL0 += preshsegment.L0length();
@@ -661,7 +484,6 @@ void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
           sL0 += gapsef.L0length();
           X0PS2EE_ += gapsef.X0length();
           L0PS2EE_ += gapsef.L0length();
-          //		  std::cout << " Created  a segment " << gapsef.length()<< " " << gapsef.X0length()<< std::endl;
         }
       } else {
         std::cout << " Strange segment between Preshower2 and " << cp[2 * is + 1].whichDetector();
@@ -672,7 +494,6 @@ void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
     }
     // Now deal with the ECAL
     // One segment in each crystal. Segment corresponding to cracks/gaps are added
-    //      myHistos->debug("Just avant ECAL");
     if (cp[2 * is].whichDetector() == DetId::Ecal &&
         (cp[2 * is].whichSubDetector() == EcalBarrel || cp[2 * is].whichSubDetector() == EcalEndcap)) {
       if (cp[2 * is + 1].whichDetector() == DetId::Ecal &&
@@ -686,7 +507,6 @@ void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
         if (cp[2 * is].getDetId() == cell2) {
           CaloSegment segment(cp[2 * is], cp[2 * is + 1], s, sX0, sL0, CaloSegment::PbWO4, myCalorimeter);
           segments_.push_back(segment);
-          // std::cout << " Added (2)" << segment << std::endl;
           s += segment.length();
           sX0 += segment.X0length();
           sL0 += segment.L0length();
@@ -719,7 +539,6 @@ void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
             sL0 += cracksegment.L0length();
             X0ECAL_ += cracksegment.X0length();
             L0ECAL_ += cracksegment.L0length();
-            //   std::cout <<" Added(3) "<< cracksegment << std::endl;
           } else {
             // a segment corresponding to ECAL/HCAL transition should be
             // added here
@@ -740,7 +559,6 @@ void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
         continue;
       }
     }
-    //      myHistos->debug("Just avant HCAL");
     // HCAL
     if (cp[2 * is].whichDetector() == DetId::Hcal && cp[2 * is + 1].whichDetector() == DetId::Hcal) {
       CaloSegment segment(cp[2 * is], cp[2 * is + 1], s, sX0, sL0, CaloSegment::HCAL, myCalorimeter);
@@ -750,31 +568,18 @@ void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
       sL0 += segment.L0length();
       X0HCAL_ += segment.X0length();
       L0HCAL_ += segment.L0length();
-      //	  std::cout <<" Added(4) "<< segment << std::endl;
       ++is;
     }
   }
-  //  std::cout << " PS1 " << X0PS1_ << " " << L0PS1_ << std::endl;
-  //  std::cout << " PS2 " << X0PS2_ << " " << L0PS2_ << std::endl;
-  //  std::cout << " ECAL " << X0ECAL_ << " " << L0ECAL_ << std::endl;
-  //  std::cout << " HCAL " << X0HCAL_ << " " << L0HCAL_ << std::endl;
 
   totalX0_ = X0PS1_ + X0PS2_ + X0PS2EE_ + X0ECAL_ + X0EHGAP_ + X0HCAL_;
   totalL0_ = L0PS1_ + L0PS2_ + L0PS2EE_ + L0ECAL_ + L0EHGAP_ + L0HCAL_;
-  //  myHistos->debug("Just avant le fill");
 
 #ifdef DEBUGCELLLINE
   myHistos->fill("h200", fabs(EcalEntrance_.eta()), X0ECAL_);
   myHistos->fill("h210", EcalEntrance_.phi(), X0ECAL_);
   if (X0ECAL_ < 20)
     myHistos->fill("h212", EcalEntrance_.phi(), X0ECAL_);
-  //  if(X0ECAL_<1.)
-  //    {
-  //      for(unsigned ii=0; ii<segments_.size() ; ++ii)
-  //	{
-  //	  std::cout << segments_[ii] << std::endl;
-  //	}
-  //    }
   myHistos->fillByNumber("h30", ncrossedxtals, EcalEntrance_.eta(), X0ECAL_);
 
   double zvertex = myTrack_->vertex().position().z();
@@ -784,7 +589,6 @@ void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
     myHistos->fill("h410", EcalEntrance_.phi());
   myHistos->fill("h400", zvertex, X0ECAL_);
 #endif
-  //  std::cout << " Finished the segments " << std::endl;
 }
 
 void EcalHitMaker::buildGeometry() {
@@ -819,7 +623,6 @@ void EcalHitMaker::buildGeometry() {
 
 // depth is in X0 , L0 (depending on EMSHOWER/HADSHOWER) or in CM if inCM
 bool EcalHitMaker::getPads(double depth, bool inCm) {
-  //std::cout << " New depth " << depth << std::endl;
   // The first time, the relationship between crystals must be calculated
   // but only in the case of EM showers
 
@@ -832,14 +635,6 @@ bool EcalHitMaker::getPads(double depth, bool inCm) {
     currentdepth_ = depth + X0depthoffset_;
   else
     currentdepth_ = depth;
-
-  //  if(currentdepth_>maxX0_+ps1TotalX0()+ps2TotalX0())
-  //    {
-  //      currentdepth_=maxX0_+ps1TotalX0()+ps2TotalX0()-1.; // the -1 is for safety
-  //      detailedShowerTail_=true;
-  //    }
-
-  //  std::cout << " FamosGrid::getQuads " << currentdepth_ << " " << maxX0_ << std::endl;
 
   ncrackpadsatdepth_ = 0;
 
@@ -874,15 +669,12 @@ bool EcalHitMaker::getPads(double depth, bool inCm) {
 
     return false;
   }
-  //  std::cout << *segiterator << std::endl;
 
   if (segiterator->whichDetector() != DetId::Ecal) {
     std::cout << " In  " << segiterator->whichDetector() << std::endl;
-    //      buildPreshower();
     return false;
   }
 
-  //  std::cout << *segiterator << std::endl;
   // get the position of the origin
 
   XYZPoint origin;
@@ -894,13 +686,8 @@ bool EcalHitMaker::getPads(double depth, bool inCm) {
     if (HADSHOWER)
       origin = segiterator->positionAtDepthinL0(currentdepth_);
   }
-  //  std::cout << " currentdepth_ " << currentdepth_ << " " << origin << std::endl;
   XYZVector newaxis = pivot_.getFirstEdge().Cross(normal_);
 
-  //  std::cout  << "Normal " << normal_ << std::endl;
-  //  std::cout << " New axis " << newaxis << std::endl;
-
-  //  std::cout << " ncrystals  " << ncrystals << std::endl;
   plan_ = Plane3D((Vector)normal_, (Point)origin);
 
   unsigned nquads = 0;
@@ -912,13 +699,7 @@ bool EcalHitMaker::getPads(double depth, bool inCm) {
                      Point(0., 0., sign),
                      Point(0., 1., 0.));
   for (unsigned ic = 0; ic < ncrystals_; ++ic) {
-    //      std::cout << " Building geometry for " << regionOfInterest_[ic].getCellID() << std::endl;
     XYZPoint a, b;
-
-    //      std::cout << " Origin " << origin << std::endl;
-
-    //      std::vector<XYZPoint> corners;
-    //      corners.reserve(4);
     double dummyt;
     bool hasbeenpulled = false;
     bool behindback = false;
@@ -940,13 +721,11 @@ bool EcalHitMaker::getPads(double depth, bool inCm) {
 
       if (dummyt > 1)
         behindback = true;
-      //	  std::cout << " Intersect " << il << " " << a << " " << b << " " << plan_ << " " << xx << std::endl;
       // check that the intersection actually exists
       if (xx.mag2() != 0) {
         corners[il] = xx;
       }
     }
-    //      std::cout << " ncorners " << corners.size() << std::endl;
     if (behindback && EMSHOWER)
       detailedShowerTail_ = true;
     // If the quad is completly defined. Store it !
@@ -957,23 +736,14 @@ bool EcalHitMaker::getPads(double depth, bool inCm) {
         padsatdepth_[ic].setSurvivalProbability(pulledPadProbability_);
       validPads_[ic] = true;
       ++nquads;
-      // In principle, this should be done after the quads reorganization. But it would cost one more loop
-      //  quadsatdepth_[ic].extrems(locxmin,locxmax,locymin,locymax);
-      //  if(locxmin<xmin_) xmin_=locxmin;
-      //  if(locymin<ymin_) ymin_=locymin;
-      //  if(locxmax>xmax_) xmax_=locxmax;
-      //  if(locymax>ymax_) ymax_=locymax;
     } else {
       padsatdepth_[ic] = CrystalPad();
       validPads_[ic] = false;
     }
   }
-  //  std::cout << " Number of quads " << quadsatdepth_.size() << std::endl;
   if (doreorg_)
     reorganizePads();
-  //  std::cout << "Finished to reorganize " << std::endl;
   npadsatdepth_ = nquads;
-  //  std::cout << " prepareCellIDMap " << std::endl;
 
   // Resize the Quads to allow for some numerical inaccuracy
   // in the "inside" function
@@ -1001,7 +771,6 @@ bool EcalHitMaker::getPads(double depth, bool inCm) {
   // Make sure that sizex_ and sizey_ are set before running prepareCellIDMap
   prepareCrystalNumberArray();
 
-  //  std::cout << " Finished  prepareCellIDMap " << std::endl;
   ncrackpadsatdepth_ = crackpadsatdepth_.size();
 
   return true;
@@ -1010,13 +779,11 @@ bool EcalHitMaker::getPads(double depth, bool inCm) {
 void EcalHitMaker::configureGeometry() {
   configuredGeometry_ = true;
   for (unsigned ic = 0; ic < ncrystals_; ++ic) {
-    //      std::cout << " Building " << cellids_[ic] << std::endl;
     for (unsigned idir = 0; idir < 8; ++idir) {
       unsigned oppdir = CaloDirectionOperations::oppositeDirection(idir);
       // Is there something else to do ?
       // The relationship with the neighbour may have been set previously.
       if (regionOfInterest_[ic].crystalNeighbour(idir).status() >= 0) {
-        //	      std::cout << " Nothing to do " << std::endl;
         continue;
       }
 
@@ -1029,28 +796,20 @@ void EcalHitMaker::configureGeometry() {
         continue;
       }
       // Determine the number of this neighbour
-      //	  std::cout << " The neighbour is " << newcell << std::endl;
       std::map<DetId, unsigned>::const_iterator niter(DetIdMap_.find(newcell));
       if (niter == DetIdMap_.end()) {
-        //	      std::cout << " The neighbour is not in the map " << std::endl;
         regionOfInterest_[ic].crystalNeighbour(idir).setStatus(-1);
         continue;
       }
       // Now there is a neighbour
-      //	  std::cout << " The neighbour is " << niter->second << " " << cellids_[niter->second] << std::endl;
       regionOfInterest_[ic].crystalNeighbour(idir).setNumber(niter->second);
-      //	  std::cout << " Managed to set crystalNeighbour " << ic << " " << idir << std::endl;
-      //	  std::cout << " Trying  " << niter->second << " " << oppdir << std::endl;
       regionOfInterest_[niter->second].crystalNeighbour(oppdir).setNumber(ic);
-      //	  std::cout << " Crack/gap " << std::endl;
       if (myCalorimeter->borderCrossing(oldcell, newcell)) {
         regionOfInterest_[ic].crystalNeighbour(idir).setStatus(1);
         regionOfInterest_[niter->second].crystalNeighbour(oppdir).setStatus(1);
-        //	      std::cout << " Crack ! " << std::endl;
       } else {
         regionOfInterest_[ic].crystalNeighbour(idir).setStatus(0);
         regionOfInterest_[niter->second].crystalNeighbour(oppdir).setStatus(0);
-        //	      std::cout << " Gap" << std::endl;
       }
     }
   }
@@ -1122,13 +881,11 @@ const CaloHitMap& EcalHitMaker::getHits() {
 
 void EcalHitMaker::reorganizePads() {
   // Some cleaning first
-  //  std::cout << " Starting reorganize " << std::endl;
   crackpadsatdepth_.clear();
   crackpadsatdepth_.reserve(etasize_ * phisize_);
   ncrackpadsatdepth_ = 0;
   std::vector<neighbour> gaps;
   std::vector<std::vector<neighbour> > cracks;
-  //  cracks.clear();
   cracks.resize(ncrystals_);
 
   for (unsigned iq = 0; iq < ncrystals_; ++iq) {
@@ -1136,10 +893,8 @@ void EcalHitMaker::reorganizePads() {
       continue;
 
     gaps.clear();
-    //   std::cout << padsatdepth_[iq] << std::endl;
     //check all the directions
     for (unsigned iside = 0; iside < 4; ++iside) {
-      //	  std::cout << " To be glued " << iside << " " << regionOfInterest_[iq].crystalNeighbour(iside).toBeGlued() << std::endl;
       CaloDirection thisside = CaloDirectionOperations::Side(iside);
       if (regionOfInterest_[iq].crystalNeighbour(iside).toBeGlued()) {
         // look for the neighbour and check that it exists
@@ -1152,7 +907,6 @@ void EcalHitMaker::reorganizePads() {
           continue;
         // there is a crack between
         if (neighbourstatus == 1) {
-          //		  std::cout << " 1 Crack : " << thisside << " " << cellids_[iq]<< " " << cellids_[neighbourNumber] << std::endl;
           cracks[iq].push_back(neighbour(thisside, neighbourNumber));
         }  // else it is a gap
         else {
@@ -1165,9 +919,7 @@ void EcalHitMaker::reorganizePads() {
   }
 
   unsigned ncracks = cracks.size();
-  //  std::cout << " Cracks treatment : " << cracks.size() << std::endl;
   for (unsigned icrack = 0; icrack < ncracks; ++icrack) {
-    //      std::cout << " Crack number " << crackiter->first << std::endl;
     cracksPads(cracks[icrack], icrack);
   }
 }
@@ -1176,7 +928,6 @@ void EcalHitMaker::reorganizePads() {
 CLHEP::Hep2Vector& EcalHitMaker::correspondingEdge(neighbour& myneighbour, CaloDirection dir2) {
   CaloDirection dir = CaloDirectionOperations::oppositeSide(myneighbour.first);
   CaloDirection corner = CaloDirectionOperations::add2d(dir, dir2);
-  //  std::cout << "Corresponding Edge " << dir<< " " << dir2 << " " << corner << std::endl;
   return padsatdepth_[myneighbour.second].edge(corner);
 }
 
@@ -1186,7 +937,6 @@ bool EcalHitMaker::diagonalEdge(unsigned myPad, CaloDirection dir, CLHEP::Hep2Ve
     return false;
   unsigned nneighbour = regionOfInterest_[myPad].crystalNeighbour(idir).number();
   if (!validPads_[nneighbour]) {
-    //      std::cout << " Wasn't able to move " << std::endl;
     return false;
   }
   point = padsatdepth_[nneighbour].edge(CaloDirectionOperations::oppositeSide(dir));
@@ -1223,7 +973,6 @@ bool EcalHitMaker::unbalancedDirection(const std::vector<neighbour>& dirs,
 }
 
 void EcalHitMaker::gapsLifting(std::vector<neighbour>& gaps, unsigned iq) {
-  //  std::cout << " Entering gapsLifting "  << std::endl;
   CrystalPad& myPad = padsatdepth_[iq];
   unsigned ngaps = gaps.size();
   constexpr bool debug = false;
@@ -1297,13 +1046,10 @@ void EcalHitMaker::gapsLifting(std::vector<neighbour>& gaps, unsigned iq) {
     unsigned iubd, idir1, idir2;
     CaloDirection diag;
     CLHEP::Hep2Vector point(0., 0.);
-    //	  std::cout << " Yes : 3 gaps" << std::endl;
     if (unbalancedDirection(gaps, iubd, idir1, idir2)) {
       CaloDirection ubd(gaps[iubd].first), dir1(gaps[idir1].first);
       CaloDirection dir2(gaps[idir2].first);
 
-      //	      std::cout << " Avant " << std::endl << myPad << std::endl;
-      //	      std::cout << ubd << " " << dir1 << " " << dir2 << std::endl;
       diag = CaloDirectionOperations::add2d(ubd, dir1);
       if (diagonalEdge(iq, diag, point))
         myPad.edge(diag) = point;
@@ -1313,12 +1059,8 @@ void EcalHitMaker::gapsLifting(std::vector<neighbour>& gaps, unsigned iq) {
       CaloDirection oppside = CaloDirectionOperations::oppositeSide(ubd);
       myPad.edge(CaloDirectionOperations::add2d(oppside, dir1)) = correspondingEdge(gaps[idir1], oppside);
       myPad.edge(CaloDirectionOperations::add2d(oppside, dir2)) = correspondingEdge(gaps[idir2], oppside);
-      //	      std::cout << " Apres " << std::endl << myPad << std::endl;
     }
   } else if (ngaps == 4) {
-    //	    std::cout << " Waouh :4 gaps" << std::endl;
-    //	    std::cout << " Avant " << std::endl;
-    //	    std::cout << myPad<< std::endl;
     CLHEP::Hep2Vector point(0., 0.);
     if (diagonalEdge(iq, NORTHEAST, point))
       myPad.edge(NORTHEAST) = point;
@@ -1328,18 +1070,13 @@ void EcalHitMaker::gapsLifting(std::vector<neighbour>& gaps, unsigned iq) {
       myPad.edge(SOUTHWEST) = point;
     if (diagonalEdge(iq, SOUTHEAST, point))
       myPad.edge(SOUTHEAST) = point;
-    //	    std::cout << " Apres " << std::endl;
-    //	    std::cout << myPad<< std::endl;
   }
 }
 
 void EcalHitMaker::cracksPads(std::vector<neighbour>& cracks, unsigned iq) {
-  //  std::cout << " myPad " << &myPad << std::endl;
   unsigned ncracks = cracks.size();
   CrystalPad& myPad = padsatdepth_[iq];
   for (unsigned ic = 0; ic < ncracks; ++ic) {
-    //      std::vector<CLHEP::Hep2Vector> mycorners;
-    //      mycorners.reserve(4);
     switch (cracks[ic].first) {
       case NORTH: {
         mycorners[0] = (padsatdepth_[cracks[ic].second].edge(SOUTHWEST));
@@ -1373,7 +1110,6 @@ void EcalHitMaker::cracksPads(std::vector<neighbour>& cracks, unsigned iq) {
     crackpad.setSurvivalProbability(crackPadProbability_);
     crackpadsatdepth_.push_back(crackpad);
   }
-  //  std::cout << " Finished cracksPads " << std::endl;
 }
 
 bool EcalHitMaker::inside3D(const std::vector<XYZPoint>& corners, const XYZPoint& p) const {

--- a/FastSimulation/CaloHitMakers/src/EcalHitMaker.cc
+++ b/FastSimulation/CaloHitMakers/src/EcalHitMaker.cc
@@ -14,6 +14,7 @@
 #include "FastSimulation/CalorimeterProperties/interface/HCALProperties.h"
 #include "FastSimulation/Utilities/interface/RandomEngineAndDistribution.h"
 #include "FastSimulation/CaloGeometryTools/interface/Transform3DPJ.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <algorithm>
 #include <cmath>
@@ -275,7 +276,7 @@ void EcalHitMaker::cellLine(std::vector<CaloPoint>& cp) {
     vertex = (myTrack_->vfcalEntrance().vertex()).Vect();
     dir = myTrack_->vfcalEntrance().Vect().Unit();
   } else {
-    std::cout << " Problem with the grid " << std::endl;
+    edm::LogError("EcalHitMaker") << " Problem with the grid ";
   }
 
   // Move the vertex for distance comparison (5cm)
@@ -305,7 +306,6 @@ void EcalHitMaker::preshowerCellLine(std::vector<CaloPoint>& cp) const {
     }
   }
 
-  //  std::cout << " On layer 2 " << myTrack.onLayer2() << std::endl;
   if (myTrack_->onLayer2()) {
     XYZPoint point1 = (myTrack_->layer2Entrance().vertex()).Vect();
     double phys_eta = myTrack_->layer2Entrance().eta();
@@ -453,8 +453,7 @@ void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
         X0PS1_ += preshsegment.X0length();
         L0PS1_ += preshsegment.L0length();
       } else {
-        std::cout << " Strange segment between Preshower1 and " << cp[2 * is + 1].whichDetector();
-        std::cout << std::endl;
+        edm::LogError("EcalHitMaker") << " Strange segment between Preshower1 and " << cp[2 * is + 1].whichDetector();
       }
       ++is;
       continue;
@@ -486,8 +485,7 @@ void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
           L0PS2EE_ += gapsef.L0length();
         }
       } else {
-        std::cout << " Strange segment between Preshower2 and " << cp[2 * is + 1].whichDetector();
-        std::cout << std::endl;
+        edm::LogError("EcalHitMaker") << " Strange segment between Preshower2 and " << cp[2 * is + 1].whichDetector();
       }
       ++is;
       continue;
@@ -517,7 +515,7 @@ void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
 #endif
           ++is;
         } else {
-          std::cout << " One more bug in the segment " << std::endl;
+          edm::LogError("EcalHitMaker") << " One more bug in the segment ";
           ++is;
         }
         // Now check if a gap or crack should be added
@@ -553,8 +551,8 @@ void EcalHitMaker::buildSegments(const std::vector<CaloPoint>& cp) {
         }
         continue;
       } else {
-        std::cout << " Strange segment between " << cp[2 * is].whichDetector();
-        std::cout << " and " << cp[2 * is + 1].whichDetector() << std::endl;
+        edm::LogError("EcalHitMaker") << " Strange segment between " << cp[2 * is].whichDetector() << " and "
+                                      << cp[2 * is + 1].whichDetector();
         ++is;
         continue;
       }
@@ -659,19 +657,21 @@ bool EcalHitMaker::getPads(double depth, bool inCm) {
       segiterator = find_if(segments_.begin(), segments_.end(), CaloSegment::inL0Segment(currentdepth_));
   }
   if (segiterator == segments_.end()) {
-    std::cout << " FamosGrid: Could not go at such depth " << depth << std::endl;
-    std::cout << " EMSHOWER " << EMSHOWER << std::endl;
-    std::cout << " Track " << *myTrack_ << std::endl;
-    std::cout << " Segments " << segments_.size() << std::endl;
-    for (unsigned ii = 0; ii < segments_.size(); ++ii) {
-      std::cout << segments_[ii] << std::endl;
-    }
+    edm::LogError("EcalHitMaker").log([&](auto& le) {
+      le << " FamosGrid: Could not go at such depth " << depth << "\n"
+         << " EMSHOWER " << EMSHOWER << "\n"
+         << " Track " << *myTrack_ << "\n"
+         << " Segments " << segments_.size() << "\n";
+      for (unsigned ii = 0; ii < segments_.size(); ++ii) {
+        le << segments_[ii] << "\n";
+      }
+    });
 
     return false;
   }
 
   if (segiterator->whichDetector() != DetId::Ecal) {
-    std::cout << " In  " << segiterator->whichDetector() << std::endl;
+    edm::LogError("EcalHitMaker") << " In  " << segiterator->whichDetector();
     return false;
   }
 


### PR DESCRIPTION
#### PR description:

1. Resolve #46452: all `CaloDirectionOperations` functions (only in `EcalHitMaker`, `BaseCrystal`, and `Crystal`) are only used for cardinal directions, not 'up' or 'down'. (These are handled [separately](https://github.com/cms-sw/cmssw/blob/e3f9e1564233e8629d9429bd586fefa664782078/FastSimulation/CaloGeometryTools/src/BaseCrystal.cc#L250) in `BaseCrystal`.) Therefore, `CaloDirectionOperations` does not need to support these other directions, and they are removed.
2. There was a lot of commented-out code in these classes, which is removed to make it easier to read and search.
3. There were unprotected `cout`s in `EcalHitMaker`. These are replaced with `LogError`. Some should probably be exceptions, but this requires further analysis and testing to ensure there are not unexpected stops in production workflows.

#### PR validation:

Asserts were temporarily added to see if any directions with index > 4 were ever used in `CaloDirectionOperation` functions and did not trigger after 10,000 ttbar events. The unprotected `cout`s also did not trigger after 10,000 ttbar events.

The workflow used for testing was 16434.0 (Run 3 FastSim).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A