### PR TITLE
[16.1.X] Ingore `HIon` table for list of trigger expressions in `ScoutingMuonTriggerAnalyzer`

### DIFF
--- a/HLTriggerOffline/Scouting/plugins/ScoutingMuonTriggerAnalyzer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingMuonTriggerAnalyzer.cc
@@ -128,21 +128,26 @@ void ScoutingMuonTriggerAnalyzer::dqmBeginRun(edm::Run const& iRun, edm::EventSe
   bool changed{false};
   hltConfig_.init(iRun, iSetup, hltProcessName_, changed);
 
-  // deal with Fake HLT menus
-  if (hltConfig_.tableName().find("Fake") != std::string::npos) {
+  // deal with Fake and HIon HLT menus
+  const std::string& tableName = hltConfig_.tableName();
+
+  const bool toIgnore = tableName.find("Fake") != std::string::npos || tableName.find("HIon") != std::string::npos;
+
+  if (toIgnore) {
     edm::LogPrint("ScoutingMuonTriggerAnalyzer")
-        << "Detected Fake in HLT Config tableName(): " << hltConfig_.tableName()
+        << "Detected special HLT menu in HLT Config tableName(): " << tableName
         << "; the list of trigger expressions is going to be overridden!" << std::endl;
+
     vtriggerSelector_.clear();
     return;
   }
 
   for (const auto& menu : special_HLT_Menus_) {
-    std::size_t found = hltConfig_.tableName().find(menu);
+    std::size_t found = tableName.find(menu);
     if (found != std::string::npos) {
       isSpecial_ = true;
       edm::LogPrint("ScoutingMuonTriggerAnalyzer")
-          << "Detected " << menu << " in HLT Config tableName(): " << hltConfig_.tableName()
+          << "Detected " << menu << " in HLT Config tableName(): " << tableName
           << "; the list of trigger expressions is going to be overridden!" << std::endl;
       break;
     }


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/51119

#### PR description:

Title says it. Now that (via https://github.com/cms-sw/cmssw/pull/51108) the `HIon` table contains a pp-scouting like trigger ([CMSHLT-3853](https://its.cern.ch/jira/browse/CMSHLT-3853)) in order to avoid crashing on not existing trigger expressions in the `HIon` menu, ignore the table in `ScoutingMuonTriggerAnalyzer`.
Fixes the crashes seen in the IBs, e.g. see [log](https://cmssdt.cern.ch/SDT/html/cmssdt-ib/#/relVal/CMSSW_17_0/2026-06-02-2300?selectedArchs=el10_amd64_gcc15&selectedFlavors=X&selectedStatus=failed).

#### PR validation:

`runTheMatrix.py -l 144.201,183.0,183.01,183.1` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/51119  to CMSSW_16_1X.