### PR TITLE
Fix static analyzer warnings in ESHandle and bloom filter generator

### DIFF
--- a/FWCore/Framework/interface/ESHandle.h
+++ b/FWCore/Framework/interface/ESHandle.h
@@ -64,7 +64,7 @@ namespace edm {
       }
       return data_;
     }
-    static void throwIfDataNotAvailable();
+    [[noreturn]] static void throwIfDataNotAvailable();
 
   private:
     // ---------- member data --------------------------------

--- a/FWCore/Framework/src/ESHandle.cc
+++ b/FWCore/Framework/src/ESHandle.cc
@@ -12,7 +12,7 @@ namespace edm {
     }
     return description_;
   }
-  void ESHandleBase::throwIfDataNotAvailable() {
+  [[noreturn]] void ESHandleBase::throwIfDataNotAvailable() {
     throw edm::Exception(edm::errors::InvalidReference, "ESHandle was not set.");
   }
 }  // namespace edm

--- a/Utilities/StaticAnalyzers/bin/bloom_filter_generator.c
+++ b/Utilities/StaticAnalyzers/bin/bloom_filter_generator.c
@@ -41,6 +41,7 @@ int generate_bloom_filter(const char *bloom_file, const char *words_file) {
     scaling_bloom_add(bloom, word, strlen(word), i);
   }
 
+  fclose(fp);
   int result = bitmap_flush(bloom->bitmap);
 
   return result;


### PR DESCRIPTION
#### PR description:

This PR fixes two clang static analyzer warnings:

1. Mark ESHandleBase::throwIfDataNotAvailable() as [[noreturn]] to avoid false-positive "Returning null reference" warnings.
2. Close the file stream in bloom_filter_generator.c to avoid a potential resource leak warning.

### Warnings:
```Alignment/CommonAlignmentAlgorithm/log.html

src/FWCore/Framework/interface/ESHandle.h:94:7:
warning: Returning null reference [core.uninitialized.UndefReturn]

94 |       return *p;
   |       ^~~~~~~~~
   ```
   ```Analyzing  src/Utilities/StaticAnalyzers/bin/bloom_filter_generator.c

src/Utilities/StaticAnalyzers/bin/bloom_filter_generator.c:44:16:
warning: Opened stream never closed. Potential resource leak [unix.Stream]

44 |   int result = bitmap_flush(bloom->bitmap);
   |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
   ```
   