### PR TITLE
Make unpacking RAW data easier for newcomers

### DIFF
--- a/DataFormats/FEDRawData/test/BuildFile.xml
+++ b/DataFormats/FEDRawData/test/BuildFile.xml
@@ -10,7 +10,7 @@
 <test name="TestFEDRawDataCollectionFormat" command="TestFEDRawDataCollectionFormat.sh"/>
 
 
-<library name="testRawDataBuffer" file="TestReadRawDataBuffer.cc,TestWriteRawDataBuffer.cc">
+<library name="testRawDataBuffer" file="TestReadRawDataBuffer.cc,TestWriteRawDataBuffer.cc, DumpRawDataBuffer.cc">
   <flags EDM_PLUGIN="1"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>

--- a/DataFormats/FEDRawData/test/DumpRawDataBuffer.cc
+++ b/DataFormats/FEDRawData/test/DumpRawDataBuffer.cc
@@ -1,0 +1,110 @@
+// -*- C++ -*-
+//
+// Package:    DataFormats/FEDRawData
+// Class:      DumpRawDataBuffer
+//
+/**\class edmtest::DumpRawDataBuffer
+  Description: Prints the RawDataBuffer EDProduct 
+                (corresponding to the DAQ RAW data),
+               either in its entirety, or for a range of S-Link sources.
+*/
+
+#include "DataFormats/FEDRawData/interface/RawDataBuffer.h"
+#include "DataFormats/FEDRawData/interface/SLinkRocketHeaders.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <vector>
+#include <cmath>
+#include <iostream>
+
+namespace edmtest {
+
+  class DumpRawDataBuffer : public edm::global::EDAnalyzer<> {
+  public:
+    DumpRawDataBuffer(edm::ParameterSet const&);
+    void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override;
+    void throwWithMessage(const char*) const;
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    // Two FEDRawData elements should be enough to verify we can read
+    // and write the whole collection. I arbitrarily chose elements
+    // 0 and 3 of the Collection. Values are meaningless, we just
+    // verify what we read matches what we wrote. For purposes of
+    // this test that is enough.
+    
+    unsigned int minSLinkID_;
+    unsigned int maxSLinkID_;
+    edm::EDGetTokenT<RawDataBuffer> rawDataBufferToken_;
+  };
+
+  DumpRawDataBuffer::DumpRawDataBuffer(edm::ParameterSet const& iPSet)
+      : minSLinkID_(iPSet.getParameter<unsigned int>("minSLinkID")),
+        maxSLinkID_(iPSet.getParameter<unsigned int>("maxSLinkID")),
+        rawDataBufferToken_(consumes(iPSet.getParameter<edm::InputTag>("rawDataBufferTag"))) {}
+
+void DumpRawDataBuffer::analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const&) const {
+  auto const& rawDataBuffer = iEvent.get(rawDataBufferToken_);
+
+  edm::LogSystem out("DumpRawDataBuffer");
+
+    auto hdrsize = sizeof(SLinkRocketHeader_v3);
+    auto trsize = sizeof(SLinkRocketTrailer_v3);
+    out<<"\n      S-Link CMS Header & Trailer size (bytes) = "<<hdrsize<<" "<<trsize<<"\n";
+  
+  for (unsigned int idSource = minSLinkID_; idSource < maxSLinkID_; idSource++) {
+    
+    auto const& fragData = rawDataBuffer.fragmentData(idSource);
+    if (fragData.size() == 0) continue;
+
+    out<<std::dec<<"\n\n";
+    out<<"=== Found SOURCE ID = "<<idSource<<" with size = "<<fragData.size()<<"\n";
+
+    //auto srcdata = fragData.payload(hdrsize, trsize);
+    auto srcdata = fragData.payload(0, 0); // Dump entire payload including header & trailer.
+    const int bytesPerWord = 16;
+    const int nWords = std::ceil(float(srcdata.size())/float(bytesPerWord));
+    
+    // Print 128b S-Link word as 16 bytes, with LSB at right of each word.
+    for (int word = 0; word < nWords;word++) {
+      out<<"\n"<<" Word "<<std::dec<<std::setw(6)<<word<<" : ";
+      for (int j = bytesPerWord - 1; j >=0; j--) {
+        unsigned int addr = static_cast<unsigned int>(word * bytesPerWord + j);
+        if (addr < srcdata.size()) {
+          unsigned int byte = static_cast<unsigned int>(srcdata[addr]);
+          out<<std::hex<<std::setw(2)<<byte<<"  ";
+        } else {
+          out<<"    ";
+        }
+      }
+    }
+  }
+  out<<"\n";
+}
+
+  void DumpRawDataBuffer::throwWithMessage(const char* msg) const {
+    throw cms::Exception("TestFailure") << "DumpRawDataBuffer::analyze, " << msg;
+  }
+
+  void DumpRawDataBuffer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<unsigned int>("minSLinkID", 0);
+    desc.add<unsigned int>("maxSLinkID", 99999);
+    desc.add<edm::InputTag>("rawDataBufferTag");    
+    descriptions.addDefault(desc);
+  }
+}  // namespace edmtest
+
+using edmtest::DumpRawDataBuffer;
+DEFINE_FWK_MODULE(DumpRawDataBuffer);

--- a/DataFormats/FEDRawData/test/DumpRawDataBuffer.cc
+++ b/DataFormats/FEDRawData/test/DumpRawDataBuffer.cc
@@ -43,7 +43,7 @@ namespace edmtest {
     // 0 and 3 of the Collection. Values are meaningless, we just
     // verify what we read matches what we wrote. For purposes of
     // this test that is enough.
-    
+
     unsigned int minSLinkID_;
     unsigned int maxSLinkID_;
     edm::EDGetTokenT<RawDataBuffer> rawDataBufferToken_;
@@ -54,44 +54,42 @@ namespace edmtest {
         maxSLinkID_(iPSet.getParameter<unsigned int>("maxSLinkID")),
         rawDataBufferToken_(consumes(iPSet.getParameter<edm::InputTag>("rawDataBufferTag"))) {}
 
-void DumpRawDataBuffer::analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const&) const {
-  auto const& rawDataBuffer = iEvent.get(rawDataBufferToken_);
+  void DumpRawDataBuffer::analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const&) const {
+    auto const& rawDataBuffer = iEvent.get(rawDataBufferToken_);
 
-  edm::LogSystem out("DumpRawDataBuffer");
+    edm::LogSystem out("DumpRawDataBuffer");
 
     auto hdrsize = sizeof(SLinkRocketHeader_v3);
     auto trsize = sizeof(SLinkRocketTrailer_v3);
-    out<<"\n      S-Link CMS Header & Trailer size (bytes) = "<<hdrsize<<" "<<trsize<<"\n";
-  
-  for (unsigned int idSource = minSLinkID_; idSource < maxSLinkID_; idSource++) {
-    
-    auto const& fragData = rawDataBuffer.fragmentData(idSource);
-    if (fragData.size() == 0) continue;
+    out << "\n      S-Link CMS Header & Trailer size (bytes) = " << hdrsize << " " << trsize << "\n";
 
-    out<<std::dec<<"\n\n";
-    out<<"=== Found SOURCE ID = "<<idSource<<" with size = "<<fragData.size()<<"\n";
+    for (unsigned int idSource = minSLinkID_; idSource < maxSLinkID_; idSource++) {
+      auto const& fragData = rawDataBuffer.fragmentData(idSource);
+      if (fragData.size() == 0)
+        continue;
 
-    //auto srcdata = fragData.payload(hdrsize, trsize);
-    auto srcdata = fragData.payload(0, 0); // Dump entire payload including header & trailer.
-    const int bytesPerWord = 16;
-    const int nWords = std::ceil(float(srcdata.size())/float(bytesPerWord));
-    
-    // Print 128b S-Link word as 16 bytes, with LSB at right of each word.
-    for (int word = 0; word < nWords;word++) {
-      out<<"\n"<<" Word "<<std::dec<<std::setw(6)<<word<<" : ";
-      for (int j = bytesPerWord - 1; j >=0; j--) {
-        unsigned int addr = static_cast<unsigned int>(word * bytesPerWord + j);
-        if (addr < srcdata.size()) {
+      out << std::dec << "\n\n";
+      out << "=== Found SOURCE ID = " << idSource << " with size = " << fragData.size() << "\n";
+
+      //auto srcdata = fragData.payload(hdrsize, trsize);
+      auto srcdata = fragData.payload(0, 0);  // Dump entire payload including header & trailer.
+      const int bytesPerWord = 16;
+      if (srcdata.size() % bytesPerWord != 0)
+        throwWithMessage("Data length not a multiple of 16 bytes");
+      const int nWords = srcdata.size() / bytesPerWord;
+
+      // Print 128b S-Link word as 16 bytes, with LSB at right of each word.
+      for (int word = 0; word < nWords; word++) {
+        out << "\n" << " Word " << std::dec << std::setw(6) << word << " : ";
+        for (int j = bytesPerWord - 1; j >= 0; j--) {
+          unsigned int addr = static_cast<unsigned int>(word * bytesPerWord + j);
           unsigned int byte = static_cast<unsigned int>(srcdata[addr]);
-          out<<std::hex<<std::setw(2)<<byte<<"  ";
-        } else {
-          out<<"    ";
+          out << std::hex << std::setw(2) << byte << "  ";
         }
       }
     }
+    out << "\n";
   }
-  out<<"\n";
-}
 
   void DumpRawDataBuffer::throwWithMessage(const char* msg) const {
     throw cms::Exception("TestFailure") << "DumpRawDataBuffer::analyze, " << msg;
@@ -101,7 +99,7 @@ void DumpRawDataBuffer::analyze(edm::StreamID, edm::Event const& iEvent, edm::Ev
     edm::ParameterSetDescription desc;
     desc.add<unsigned int>("minSLinkID", 0);
     desc.add<unsigned int>("maxSLinkID", 99999);
-    desc.add<edm::InputTag>("rawDataBufferTag");    
+    desc.add<edm::InputTag>("rawDataBufferTag");
     descriptions.addDefault(desc);
   }
 }  // namespace edmtest

--- a/DataFormats/FEDRawData/test/DumpRawDataBuffer_cfg.py
+++ b/DataFormats/FEDRawData/test/DumpRawDataBuffer_cfg.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+import sys
+##################################################################
+# Print the contents of the RawDataBuffer EDProduct (corresponding to DAQ raw data)
+##################################################################
+options = VarParsing.VarParsing ('analysis')
+
+options.register ('inputDataSet',
+                  'file:dth_dataset.root', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string, 
+                  "Input ROOT dataset")
+
+process = cms.Process("READ")
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(options.inputDataSet))
+process.maxEvents.input = 1
+
+process.dumpRawDataBuffer = cms.EDAnalyzer("DumpRawDataBuffer",
+    minSLinkID = cms.uint32(0),
+    maxSLinkID = cms.uint32(99999),
+    #rawDataBufferTag = cms.InputTag("rawDataBufferProducer", "", "PROD"),
+    rawDataBufferTag = cms.InputTag("rawDataCollector", "", "LHC"),
+)
+
+process.path = cms.Path(process.dumpRawDataBuffer)

--- a/EventFilter/Utilities/doc/README-DTH.md
+++ b/EventFilter/Utilities/doc/README-DTH.md
@@ -2,7 +2,7 @@
 # DTH orbit/event unpacker for DAQSource
 
 <br>
-This patch implements unpacking of the the DTH data format by `DAQSource` into `FedRawDataCollection`.
+This code implements unpacking of the the DTH data format by `DAQSource` into `RawDataBuffer`.
 It both generates and consumes files with DTH format.
 
 #Run the unit test
@@ -34,10 +34,26 @@ FU cmsRun configuration used in above tests:
 <br>
 [test/unittest_FU_daqsource.py](../test/unittest_FU_daqsource.py)
 
-## Running on custom input files
-`unittest_FU_daqsource.py` script can be used as a starting point to create a custom runner with inputs such as DTH dumps (not generated as in the unit test). DAQSource should be set to `dataMode = cms.untracked.string("DTH")` to process DTH format. Change `fileListMode` to `True` and fill in `fileList` parameter with file paths to run with custom files, however they should be named similarly and could also be placed in similar directory structure, `ramdisk/runXX`, to provide initial run and lumisection to the source. Run number is also passed to the source via the command line as well as the working directory (see `testDTH.sh` script).
+## Generating test DTH RAW binary payloads
 
-Note on the file format: apart of parsing single DTH orbit dump, input source plugin is capable also of building events from multiple DTH orbit blocks, but for the same orbit they must come sequentially in the file. Source scans the file and will find all blocks with orbit headers from the same orbit number, until a different orbit number is found or EOF, then it proceeds to build events from them by starting from last DTH event fragment trailer in each of the orbits found. This is then iterated for the next set of orbit blocks with the same orbit number in the file until file is processed. This is also valid at the level of individual files for the striped mode.
+Binary files corresponding to test raw DTH output data can be generated
+with the `startBU.py' script, which uses the DTHFakeReader. e.g.
+```
+cmsRun startBU.py fffBaseDir=myDTHdataDir maxLS=1 fedMeanSize=128 eventsPerFile=256 frdFileVersion=0 dataType=DTH
+```
+N.B. Output directory myDTHdataDir/ must not exist prior to running this, as it won't overwrite it.
+
+Optionally inspect output .raw files with linux "hexdump -C" command.
+
+## Running on custom input files and creating raw data EDProduct
+
+`unittest_FU_daqsource.py` script can be used as a starting point to create a custom runner with inputs such as DTH dumps from hardware (not generated as in the unit test) or test DTH payloads (generated above). The DAQ Source should be set to `daqSourceMode = cms.untracked.string("DTH")` to process DTH format. Set buBaseDir to the location of the input DTH files, and edit the input 'fileNames'. However they should be named similarly and could also be placed in similar directory structure, `ramdisk/runXX`, to provide initial run and lumisection to the source. Run number is also passed to the source via the command line as well as the working directory (see `testDTH.sh` script). e.g. Run this to create a dataset dth_output.root containing RawDataBuffer EDProduct corresponding to the input DTH data:
+```
+cmsRun unittest_FU_daqsource.py daqSourceMode=DTH buBaseDir=myDTHdataDir/ramdisk/ numFwkStreams=1
+```
+N.B. Output directory data/ must not exist prior to running this, as it won't overwrite it. You can optionally inspect the RawDataBuffer EDProduct in the output dataset using DataFormats/FEDRawData/test/DumpRawDataBuffer_cfg.py .
+
+Note on the input file format: apart of parsing single DTH orbit dump, input source plugin is capable also of building events from multiple DTH orbit blocks, but for the same orbit they must come sequentially in the file. Source scans the file and will find all blocks with orbit headers from the same orbit number, until a different orbit number is found or EOF, then it proceeds to build events from them by starting from last DTH event fragment trailer in each of the orbits found. This is then iterated for the next set of orbit blocks with the same orbit number in the file until file is processed. This is also valid at the level of individual files for the striped mode.
 
 Striped mode is now supported for DTH, see `startFU_ds_multi.py` script. Multiple input directories can be specified, and number of sources for each can be provided in NumStreams (sources) vector. 1 is assumed if not specified. if num streams is specified, streamIDs (sourceIDs) numbers need to be provided in corresponding vector. Finally, sourceIdenfier (if specified) specifies prefix before the source number.
 Example file name for this mode is `run123456_ls000_index000000_source01234.raw` with corresponding zfilled spaces zeroed.
@@ -51,7 +67,7 @@ Documentation:
 https://twiki.cern.ch/twiki/bin/view/CMS/FFFMetafileFormats
 
 
-# DAQSOurce DataMode Class Interface Reference
+# DAQSource DataMode Class Interface Reference
 
 ## Overview
 


### PR DESCRIPTION
#### PR description:

1) Added to EventFilter/Utilities/doc/README-DTH.md info to help novice users who have created RAW binary data files corresponding the DTH (DAQ) output from their hardware at Integration centres, and want to unpack this into a RAW EDProduct (RawDataBuffer). In particular:

       a) cmsRun command to produce test RAW binary file.
       b) cmsRun command to convert either test or real RAW binary file to RawDataBuffer EDProduct.
       c) Analysis job to dump contents of RawDataBuffer.

2) Added to DataFormats/FEDRawData/test/ an EDAnalyzer DumpRawDataBuffer to dump contents of RawDataBuffer in hex format, for any S-Link sources (within a configurable range) that are present in the dataset. This will be useful for people who are debugging how (1b) works, what their RAW data contains, and which S-Link sources are present in it.