### PR TITLE
Alignment/MuonAlignmentAlgorithms: fix static analyzer warnings

### DIFF
--- a/Alignment/MuonAlignmentAlgorithms/interface/ReadPGInfo.h
+++ b/Alignment/MuonAlignmentAlgorithms/interface/ReadPGInfo.h
@@ -17,7 +17,7 @@ class ReadPGInfo {
 public:
   ReadPGInfo(const char *name);
   ~ReadPGInfo();
-  char *getId(int, int, int);
+  const char *getId(int, int, int);
   TMatrixD giveR(int, int, int);
   TMatrixD giveQC(int, int, int);
   TMatrixD giveSurvey(int, int, int);

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
@@ -1615,7 +1615,11 @@ void MuonAlignmentFromReference::readTmpFiles() {
       throw cms::Exception("MuonAlignmentFromReference")
           << "file \"" << *fileName << "\" can't be opened (doesn't exist?)" << std::endl;
 
-    fread(&size, sizeof(int), 1, file);
+    if (fread(&size, sizeof(int), 1, file) != 1) {
+      fclose(file);
+      throw cms::Exception("MuonAlignmentFromReference")
+          << "file \"" << *fileName << "\" ended unexpectedly while reading the number of fitters" << std::endl;
+    }
     if (int(m_indexes.size()) != size)
       throw cms::Exception("MuonAlignmentFromReference")
           << "file \"" << *fileName << "\" has " << size << " fitters, but this job has " << m_indexes.size()
@@ -1625,7 +1629,12 @@ void MuonAlignmentFromReference::readTmpFiles() {
     for (std::vector<unsigned int>::const_iterator index = m_indexes.begin(); index != m_indexes.end(); ++index, ++i) {
       MuonResidualsTwoBin* fitter = m_fitterOrder[*index];
       unsigned int index_toread;
-      fread(&index_toread, sizeof(unsigned int), 1, file);
+      if (fread(&index_toread, sizeof(unsigned int), 1, file) != 1) {
+        fclose(file);
+        throw cms::Exception("MuonAlignmentFromReference")
+            << "file \"" << *fileName << "\" ended unexpectedly while reading fitter index at position " << i
+            << std::endl;
+      }
       if (*index != index_toread)
         throw cms::Exception("MuonAlignmentFromReference")
             << "file \"" << *fileName << "\" has index " << index_toread << " at position " << i

--- a/Alignment/MuonAlignmentAlgorithms/src/ReadPGInfo.cc
+++ b/Alignment/MuonAlignmentAlgorithms/src/ReadPGInfo.cc
@@ -240,7 +240,7 @@ static char mapping[][2][20] = {
 
 */
 
-static char chambers[TOTALCHAMBERS][20] = {
+static const char chambers[TOTALCHAMBERS][20] = {
     "351010100100009", "351010100100016", "351010100100014", "351010100100017", "351010100100011", "351010100100038",
     "351010100100035", "351010100100023", "351010100100036", "351010100100072", "351010100200013", "351010100200015",
     "351010100200020", "351010100200019", "351010100200010", "351010100200025", "351010100200037", "351010100200028",
@@ -286,7 +286,7 @@ static char chambers[TOTALCHAMBERS][20] = {
     "351010103600031", "351010103600032", "351010103600033", "351010103600049", "351010103600046", "351030103700058",
     "351030103800032", "351030103800057", "351030103900056", "351030104000029", "351030104000055", "351040104100001"};
 
-static int position[TOTALCHAMBERS][3] = {
+static const int position[TOTALCHAMBERS][3] = {
     {2, 3, 1},   {2, 5, 1},   {2, 9, 1},   {2, 11, 1},  {1, 2, 1},   {1, 6, 1},   {1, 12, 1},  {1, 10, 1},  {1, 8, 1},
     {0, 0, 0},   {2, 6, 1},   {2, 10, 1},  {2, 12, 1},  {1, 5, 1},   {2, 8, 1},   {1, 11, 1},  {1, 3, 1},   {2, 2, 1},
     {2, 4, 1},   {1, 9, 1},   {0, 0, 0},   {0, 0, 0},   {0, 0, 0},   {1, 8, 2},   {2, 5, 2},   {2, 11, 2},  {1, 12, 2},
@@ -326,7 +326,7 @@ ReadPGInfo::ReadPGInfo(const char *name) {
 
 ReadPGInfo::~ReadPGInfo() { delete rootFile; }
 
-char *ReadPGInfo::getId(int wheel, int station, int sector) {
+const char *ReadPGInfo::getId(int wheel, int station, int sector) {
   for (int counter = 0; counter < TOTALCHAMBERS; ++counter) {
     if (wheel == position[counter][0] && sector == position[counter][1] && station == position[counter][2])
       return chambers[counter];
@@ -336,7 +336,7 @@ char *ReadPGInfo::getId(int wheel, int station, int sector) {
 
 TMatrixD ReadPGInfo::giveR(int wheel, int station, int sector) {
   TMatrixD *empty = new TMatrixD(0, 0);
-  char *id = getId(wheel, station, sector);
+  const char *id = getId(wheel, station, sector);
   if (id == nullptr)
     return *empty;
   TDirectoryFile *myDir = (TDirectoryFile *)rootFile->Get(id);
@@ -370,7 +370,7 @@ TMatrixD ReadPGInfo::giveQCCal(int wheel, int station, int sector) {
 
 TMatrixD ReadPGInfo::giveQC(int wheel, int station, int sector) {
   TMatrixD *empty = new TMatrixD(0, 0);
-  char *id = getId(wheel, station, sector);
+  const char *id = getId(wheel, station, sector);
   if (id == nullptr)
     return *empty;
   TDirectoryFile *myDir = (TDirectoryFile *)rootFile->Get(id);
@@ -386,7 +386,7 @@ TMatrixD ReadPGInfo::giveQC(int wheel, int station, int sector) {
 
 TMatrixD ReadPGInfo::giveSurvey(int wheel, int station, int sector) {
   TMatrixD *empty = new TMatrixD(0, 0);
-  char *id = getId(wheel, station, sector);
+  const char *id = getId(wheel, station, sector);
   if (id == nullptr)
     return *empty;
   TDirectoryFile *myDir = (TDirectoryFile *)rootFile->Get(id);


### PR DESCRIPTION
#### PR description:
This PR fixes a few static analyzer warnings in Alignment/MuonAlignmentAlgorithms.

- Check fread() return values in MuonAlignmentFromReference and throw a  exception when the input file is truncated or malformed.
- Make static lookup tables read-only.
- Improve const-correctness in ReadPGInfo.

#### Warnings:

``` 
warning: function 'ReadPGInfo::getId' accesses or modifies non-const global static variable chambers[cms.FunctionChecker]
```
```[src/Alignment/MuonAlignmentAlgorithms/src/ReadPGInfo.cc:243](https://github.com/cms-sw/cmssw/blob/CMSSW_17_0_X_2026-06-01-1100/Alignment/MuonAlignmentAlgorithms/src/ReadPGInfo.cc#L243):1: warning: Non-const variable 'char[264][20] chambers' is static and might be thread-unsafe [threadsafety.GlobalStatic]
   243 | static char chambers[TOTALCHAMBERS][20] = {
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  244 |     "351010100100009", "351010100100016", "351010100100014", "351010100100017", "351010100100011", "351010100100038",
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  245 |     "351010100100035", "351010100100023", "351010100100036", "351010100100072", "351010100200013", "351010100200015",
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  246 |     "351010100200020", "351010100200019", "351010100200010", "351010100200025", "351010100200037", "351010100200028",
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  247 |     "351010100200034", "351010100200022", "351010100200070", "351010100300002", "351010100300061", "351030100500025",
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  [src/Alignment/MuonAlignmentAlgorithms/src/ReadPGInfo.cc:243](https://github.com/cms-sw/cmssw/blob/CMSSW_17_0_X_2026-06-01-1100/Alignment/MuonAlignmentAlgorithms/src/ReadPGInfo.cc#L243):1: warning: function 'ReadPGInfo::getId' accesses or modifies non-const global static variable 'chambers'.
  ```
```
[src/Alignment/MuonAlignmentAlgorithms/src/ReadPGInfo.cc:289](https://github.com/cms-sw/cmssw/blob/CMSSW_17_0_X_2026-06-01-1100/Alignment/MuonAlignmentAlgorithms/src/ReadPGInfo.cc#L289):1: warning: Non-const variable 'int[264][3] position' is static and might be thread-unsafe [threadsafety.GlobalStatic]
   289 | static int position[TOTALCHAMBERS][3] = {
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  290 |     {2, 3, 1},   {2, 5, 1},   {2, 9, 1},   {2, 11, 1},  {1, 2, 1},   {1, 6, 1},   {1, 12, 1},  {1, 10, 1},  {1, 8, 1},
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  291 |     {0, 0, 0},   {2, 6, 1},   {2, 10, 1},  {2, 12, 1},  {1, 5, 1},   {2, 8, 1},   {1, 11, 1},  {1, 3, 1},   {2, 2, 1},
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  292 |     {2, 4, 1},   {1, 9, 1},   {0, 0, 0},   {0, 0, 0},   {0, 0, 0},   {1, 8, 2},   {2, 5, 2},   {2, 11, 2},  {1, 12, 2},
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  293 |     {2, 9, 2},   {1, 6, 2},   {1, 2, 2},   {2, 3, 2},   {1, 10, 2},  {0, 0, 0},   {1, 9, 2},   {2, 12, 2},  {0, 0, 0},
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  294 |     {2, 10, 2},  {2, 8, 2},   {1, 11, 2},  {1, 5, 2},   {1, 3, 2},   {2, 6, 2},   {2, 2, 2},   {2, 4, 2},   {0, 0, 0},
      |     
  ```
