### PR TITLE
MTD Geometry: clean compiler warnings 

### DIFF
--- a/DataFormats/ForwardDetId/interface/MTDDetId.h
+++ b/DataFormats/ForwardDetId/interface/MTDDetId.h
@@ -61,13 +61,13 @@ namespace io_v1 {
     /** Returns enumerated type specifying MTD sub-detector, i.e. BTL or ETL. */
     inline int mtdSubDetector() const { return (id_ >> kMTDsubdOffset) & kMTDsubdMask; }
 
-    static inline bool const testForMTD(const DetId& id) {
+    static inline bool testForMTD(const DetId& id) {
       return (id.rawId() >> MTDDetId::kMTDOffset) == MTDDetId::kMTDMask;
     }
-    static inline bool const testForBTL(const DetId& id) {
+    static inline bool testForBTL(const DetId& id) {
       return (id.rawId() >> MTDDetId::kMTDsubdOffset) == MTDDetId::kBTLMask;
     }
-    static inline bool const testForETL(const DetId& id) {
+    static inline bool testForETL(const DetId& id) {
       return (id.rawId() >> MTDDetId::kMTDsubdOffset) == MTDDetId::kETLMask;
     }
 

--- a/Geometry/MTDGeometryBuilder/interface/MTDGeometry.h
+++ b/Geometry/MTDGeometryBuilder/interface/MTDGeometry.h
@@ -31,7 +31,7 @@ public:
   const MTDGeomDet* idToDetUnit(DetId) const override;
   const MTDGeomDet* idToDet(DetId) const override;
 
-  const GeomDetEnumerators::SubDetector geomDetSubDetector(int subdet) const;
+  GeomDetEnumerators::SubDetector geomDetSubDetector(int subdet) const;
   unsigned int numberOfLayers(int subdet) const;
   bool isThere(GeomDetEnumerators::SubDetector subdet) const;
 

--- a/Geometry/MTDGeometryBuilder/src/MTDGeometry.cc
+++ b/Geometry/MTDGeometryBuilder/src/MTDGeometry.cc
@@ -176,7 +176,7 @@ const MTDGeomDet* MTDGeometry::idToDet(DetId s) const {
   return nullptr;
 }
 
-const GeomDetEnumerators::SubDetector MTDGeometry::geomDetSubDetector(int subdet) const {
+GeomDetEnumerators::SubDetector MTDGeometry::geomDetSubDetector(int subdet) const {
   if (subdet >= 1 && subdet <= 2) {
     return theSubDetTypeMap[subdet - 1];
   } else {


### PR DESCRIPTION
#### PR description:

```MTDDetId``` and ```MTDGeometry``` show compiler warnings about ```const``` declaration being useless, and they propagate to all dependencies. This PR cleans the issue.

#### PR validation:

Code compiles, and wf. 34434.0 runs smoothly.