### PR TITLE
remove PixelTriplets_InvPrbl_prec from automatic unit tests

### DIFF
--- a/RecoTracker/PixelSeeding/test/BuildFile.xml
+++ b/RecoTracker/PixelSeeding/test/BuildFile.xml
@@ -15,6 +15,7 @@
 
 <bin file="PixelTriplets_InvPrbl_prec.cpp">
   <use name="RecoTracker/PixelSeeding"/>
+  <flags NO_TESTRUN="1"/>
 </bin>
 
 <bin file="fastDPHI_t.cpp">


### PR DESCRIPTION
`PixelTriplets_InvPrbl_prec` reads from `std::cin`. This breaks usual unit test running.
The unit test was introduced in 2013; I'm not sure why it didn't come across as an issue when running `scram b runtests` sooner.

This is a partial resolution to #51126 ; just marking it as not for unit tests.

A longer term solution would be to recover this test in the unit tests (if still considered useful). 
Catch2 ([example](https://github.com/cms-sw/cmssw/blob/140d0f0f1f2ee369bc8996185c9399384005bab6/FWCore/TestProcessor/Readme.md#example-using-catch2) ) can be a possibility.
