### PR TITLE
[NGT] Improvements to `ScoutingTrackMonitor` (17.0.X)

### DIFF
--- a/DQM/HLTEvF/python/ScoutingTrackingMonitor_cff.py
+++ b/DQM/HLTEvF/python/ScoutingTrackingMonitor_cff.py
@@ -1,10 +1,22 @@
 import FWCore.ParameterSet.Config as cms
 
 ## See DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
-from HLTriggerOffline.Scouting.ScoutingTrackMonitor_cfi import *
+from HLTriggerOffline.Scouting.ScoutingTrackMonitor_cfi import  ScoutingTrackMonitor
+from HLTriggerOffline.Scouting.RecoTrackFromScoutingMonitor_cfi import scoutingRecoTrackMonitor as _scoutingRecoTrackMonitor
+from HLTriggerOffline.Scouting.RecoTrackFromScoutingMonitor_cff import recoTracksFromScouting,recoVerticesFromScouting
 
 ScoutingTrackMonitorOnline = ScoutingTrackMonitor.clone(
     topFolderName = 'HLT/ScoutingOnline/Tracks'
 )
 
-ScoutingTracksMonitoring = cms.Sequence(ScoutingTrackMonitorOnline)
+ScoutingRecoTrackMonitorOnline = _scoutingRecoTrackMonitor.clone(
+    doLumiAnalysis = False, # does not play nice with the online saver
+    FolderName     = 'HLT/ScoutingOnline/Tracks',
+    BSFolderName   = 'HLT/ScoutingOnline/Tracks',
+    PVFolderName   = 'HLT/ScoutingOnline/Tracks'
+)
+
+ScoutingTracksMonitoring = cms.Sequence(ScoutingTrackMonitorOnline *
+                                        recoTracksFromScouting *
+                                        recoVerticesFromScouting *
+                                        ScoutingRecoTrackMonitorOnline)

--- a/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ngt_dqm_sourceclient-live_cfg.py
@@ -62,6 +62,9 @@ process.hltOnlineBeamSpot = _onlineBeamSpotProducer.clone()
 ### for pp collisions
 process.load("DQM.HLTEvF.ScoutingTrackingMonitor_cff")
 process.ScoutingTrackMonitorOnline.topFolderName = 'NGT/ScoutingOnline/Tracks'
+process.ScoutingRecoTrackMonitorOnline.FolderName = 'NGT/ScoutingOnline/Tracks'
+process.ScoutingRecoTrackMonitorOnline.BSFolderName = 'NGT/ScoutingOnline/Tracks'
+process.ScoutingRecoTrackMonitorOnline.PVFolderName = 'NGT/ScoutingOnline/Tracks'
 
 process.load("DQM.HLTEvF.ScoutingCollectionMonitor_cfi")
 process.scoutingCollectionMonitor.topfoldername = "NGT/ScoutingOnline/ScoutingCollections"
@@ -117,7 +120,7 @@ process.hltObjectMonitor.topFolderName = cms.untracked.string("NGT/ObjectMonitor
 
 process.p = cms.Path(process.dqmcommon *
                      process.hltOnlineBeamSpot *
-                     process.ScoutingTrackMonitorOnline *
+                     process.ScoutingTracksMonitoring *
                      process.run3ScoutingElectronBestTrack *
                      process.scoutingCollectionMonitor *
                      process.ScoutingRecHitsMonitoring *

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -1169,10 +1169,12 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   auto pt = track.pt();
   auto phi = track.phi();
   // double eta   = track.eta();
-  auto phiIn = track.innerPosition().phi();
-  auto etaIn = track.innerPosition().eta();
-  auto phiOut = track.outerPosition().phi();
-  auto etaOut = track.outerPosition().eta();
+  const bool hasExtra = track.extra().isAvailable();
+
+  const float phiIn = hasExtra ? track.innerPosition().phi() : track.phi();
+  const float etaIn = hasExtra ? track.innerPosition().eta() : track.eta();
+  const float phiOut = hasExtra ? track.outerPosition().phi() : track.phi();
+  const float etaOut = hasExtra ? track.outerPosition().eta() : track.eta();
 
   int nRecHits = track.hitPattern().numberOfAllHits(reco::HitPattern::TRACK_HITS);
   int nValidRecHits = track.numberOfValidHits();

--- a/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
+++ b/DQMOffline/HLTScouting/python/HLTScoutingDqmOffline_cff.py
@@ -9,6 +9,7 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 ### Tracks
 from HLTriggerOffline.Scouting.ScoutingTrackMonitor_cfi import *
+from HLTriggerOffline.Scouting.RecoTrackFromScoutingMonitor_cff import *
 
 ### Muons monitoring
 from HLTriggerOffline.Scouting.ScoutingMuonTriggerAnalyzer_cfi import *
@@ -60,6 +61,7 @@ hltScoutingPi0Monitor = cms.Sequence(ScoutingPi0Monitor)
 hltScoutingDiMuonVertexMonitor = cms.Sequence(ScoutingDiMuonVertexMonitor)
 
 hltScoutingDqmOffline = cms.Sequence(hltScoutingTrackMonitor +
+                                     recoTrackFromScoutingMonitorSequence +
                                      hltScoutingMuonDqmOffline +
                                      hltScoutingEGammaDqmOffline +
                                      hltScoutingJetDqmOffline +

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackMonitor.cc
@@ -5,6 +5,9 @@
 #include <fmt/format.h>
 #include <boost/range/adaptor/indexed.hpp>
 
+// ROOT includes
+#include "TMath.h"
+
 // user includes
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -150,7 +153,15 @@ private:
   MonitorElement* p_dz_phi;
   MonitorElement* p2_dz_eta_phi;
 
-  MonitorElement *bsX, *bsY, *bsZ, *bsSigmaZ, *bsDxdz, *bsDydz, *bsBeamWidthX, *bsBeamWidthY, *bsType;
+  MonitorElement* h_vr;  // production radius for all tracks
+  MonitorElement* h_vz;  // productio  z for all tracks
+
+  // beamspot histograms
+  MonitorElement *h_bsX, *h_bsY, *h_bsZ, *h_bsSigmaZ, *h_bsDxdz, *h_bsDydz, *h_bsBeamWidthX, *h_bsBeamWidthY, *h_bsType;
+
+  // vertex histograms
+  MonitorElement *h_vtx_chi2ndf, *h_vtx_prob;
+  MonitorElement *h_vtx_sumPt2, *h_vtx_nTracks;
 
   // hit profiles configuration
   std::vector<ProfileConfig> hitProfiles_;
@@ -200,15 +211,15 @@ ScoutingTrackMonitor::ScoutingTrackMonitor(const edm::ParameterSet& iConfig)
       verticesToken_{consumes<std::vector<Run3ScoutingVertex>>(iConfig.getParameter<edm::InputTag>("vertices"))},
       beamSpotToken_{consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotLabel"))},
       topFolderName_{iConfig.getParameter<std::string>("topFolderName")},
-      bsX(nullptr),
-      bsY(nullptr),
-      bsZ(nullptr),
-      bsSigmaZ(nullptr),
-      bsDxdz(nullptr),
-      bsDydz(nullptr),
-      bsBeamWidthX(nullptr),
-      bsBeamWidthY(nullptr),
-      bsType(nullptr) {
+      h_bsX(nullptr),
+      h_bsY(nullptr),
+      h_bsZ(nullptr),
+      h_bsSigmaZ(nullptr),
+      h_bsDxdz(nullptr),
+      h_bsDydz(nullptr),
+      h_bsBeamWidthX(nullptr),
+      h_bsBeamWidthY(nullptr),
+      h_bsType(nullptr) {
   hitProfiles_ = {{"nValidPixelHits", "nValidPixelHits", 0., 10.},
                   {"nTrackerLayersWithMeasurement", "nTrackerLayersWithMeasurement", 0., 20.},
                   {"nValidStripHits", "nValidStripHits", 0., 30.}};
@@ -225,10 +236,21 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
 
   h_vtx_idx = ibooker.book1DD("vertexIndex", "tracks Vertex Index;Vertex index;Tracks", 17, -1.5, 15.5);
 
+  h_vtx_sumPt2 =
+      ibooker.book1DD("vtxSumPt2", "Vertex #Sigma p_{T}^{2};#Sigma p_{T}^{2} [GeV^{2}];Vertices", 100, 0., 10000.);
+
+  h_vtx_nTracks = ibooker.book1DD("vtxNTracks", "Tracks per vertex;N_{tracks};Vertices", 50, -0.5, 49.5);
+
   // 2D eta-phi occupancy histograms
   h2_eta_phi = ibooker.book2I(
       "eta_vs_phi", "Track occupancy;#eta;#phi [rad]", 50, -3.0, 3.0, 50, -std::numbers::pi, std::numbers::pi);
   h2_eta_phi->setOption("colz");
+
+  h_vtx_chi2ndf = ibooker.book1DD("vtxChi2ndf", "PV #chi^{2}/ndof", 100, 0., 20.);
+  h_vtx_prob = ibooker.book1DD("vtxChi2prob", "PV #chi^{2} probability", 100, 0., 1.);
+
+  h_vr = ibooker.book1DD("vr", "radius at DCA;r_{DCA} (cm);Tracks", 100, 0., 1.);
+  h_vz = ibooker.book1DD("vz", "z at DCA;z_{DCA} (cm);Tracks", 100, -30., 30.);
 
   // Profiles
   constexpr int nEtaBins = 50;
@@ -466,23 +488,22 @@ void ScoutingTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run c
   dz_pt10.bookIPMonitor(ibooker, conf_);
 
   // BeamSpot
-
   auto vposx = conf_.getParameter<double>("Xpos");
   auto vposy = conf_.getParameter<double>("Ypos");
 
-  bsX = ibooker.book1D("bsX", "BeamSpot x0", 100, vposx - 0.1, vposx + 0.1);
-  bsY = ibooker.book1D("bsY", "BeamSpot y0", 100, vposy - 0.1, vposy + 0.1);
-  bsZ = ibooker.book1D("bsZ", "BeamSpot z0", 100, -2., 2.);
-  bsSigmaZ = ibooker.book1D("bsSigmaZ", "BeamSpot sigmaZ", 100, 0., 10.);
-  bsDxdz = ibooker.book1D("bsDxdz", "BeamSpot dxdz", 100, -0.0003, 0.0003);
-  bsDydz = ibooker.book1D("bsDydz", "BeamSpot dydz", 100, -0.0003, 0.0003);
-  bsBeamWidthX = ibooker.book1D("bsBeamWidthX", "BeamSpot BeamWidthX", 500, 0., 15.);
-  bsBeamWidthY = ibooker.book1D("bsBeamWidthY", "BeamSpot BeamWidthY", 500, 0., 15.);
-  bsType = ibooker.book1D("bsType", "BeamSpot type", 4, -1.5, 2.5);
-  bsType->setBinLabel(1, "Unknown");
-  bsType->setBinLabel(2, "Fake");
-  bsType->setBinLabel(3, "LHC");
-  bsType->setBinLabel(4, "Tracker");
+  h_bsX = ibooker.book1D("bsX", "BeamSpot x0", 100, vposx - 0.1, vposx + 0.1);
+  h_bsY = ibooker.book1D("bsY", "BeamSpot y0", 100, vposy - 0.1, vposy + 0.1);
+  h_bsZ = ibooker.book1D("bsZ", "BeamSpot z0", 100, -2., 2.);
+  h_bsSigmaZ = ibooker.book1D("bsSigmaZ", "BeamSpot sigmaZ", 100, 0., 10.);
+  h_bsDxdz = ibooker.book1D("bsDxdz", "BeamSpot dxdz", 100, -0.0003, 0.0003);
+  h_bsDydz = ibooker.book1D("bsDydz", "BeamSpot dydz", 100, -0.0003, 0.0003);
+  h_bsBeamWidthX = ibooker.book1D("bsBeamWidthX", "BeamSpot BeamWidthX", 500, 0., 15.);
+  h_bsBeamWidthY = ibooker.book1D("bsBeamWidthY", "BeamSpot BeamWidthY", 500, 0., 15.);
+  h_bsType = ibooker.book1D("bsType", "BeamSpot type", 4, -1.5, 2.5);
+  h_bsType->setBinLabel(1, "Unknown");
+  h_bsType->setBinLabel(2, "Fake");
+  h_bsType->setBinLabel(3, "LHC");
+  h_bsType->setBinLabel(4, "Tracker");
 }
 
 void ScoutingTrackMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooker, const edm::ParameterSet& config) {
@@ -505,7 +526,6 @@ void ScoutingTrackMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
   PtMax_ = config.getParameter<double>("PtMax") * pTcut_;
 
   // 1D variables
-
   IP_ = iBooker.book1DD(fmt::format("d{}_pt{}", varname_, pTcut_),
                         fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_),
                         VarBin,
@@ -526,7 +546,6 @@ void ScoutingTrackMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
       5.);
 
   // IP profiles
-
   IPVsPhi_ = iBooker.bookProfile(fmt::format("d{}VsPhi_pt{}", varname_, pTcut_),
                                  fmt::format("PV tracks (p_{{T}} > {}) d_{{{}}} VS track #phi", pTcut_, varname_),
                                  PhiBin_,
@@ -567,7 +586,6 @@ void ScoutingTrackMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
   IPVsPt_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_), 2);
 
   // IP error profiles
-
   IPErrVsPhi_ =
       iBooker.bookProfile(fmt::format("d{}ErrVsPhi_pt{}", varname_, pTcut_),
                           fmt::format("PV tracks (p_{{T}} > {}) d_{{{}}} error VS track #phi", pTcut_, varname_),
@@ -610,7 +628,6 @@ void ScoutingTrackMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
   IPErrVsPt_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_), 2);
 
   // 2D profiles
-
   IPVsEtaVsPhi_ = iBooker.bookProfile2D(
       fmt::format("d{}VsEtaVsPhi_pt{}", varname_, pTcut_),
       fmt::format("PV tracks (p_{{T}} > {}) d_{{{}}} VS track #eta VS track #phi", pTcut_, varname_),
@@ -666,15 +683,11 @@ bool ScoutingTrackMonitor::getValidHandle(const edm::Event& iEvent,
 void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
   edm::Handle<std::vector<Run3ScoutingVertex>> primaryVerticesH;
   edm::Handle<std::vector<Run3ScoutingTrack>> tracksH;
-  edm::Handle<reco::BeamSpot> beamSpotHandle;
 
   if (!getValidHandle(iEvent, verticesToken_, primaryVerticesH, "primary vertices") ||
-      !getValidHandle(iEvent, tracksToken_, tracksH, "tracks") ||
-      !getValidHandle(iEvent, beamSpotToken_, beamSpotHandle, "beamspot")) {
+      !getValidHandle(iEvent, tracksToken_, tracksH, "tracks")) {
     return;
   }
-
-  iEvent.getByToken(beamSpotToken_, beamSpotHandle);
 
   // derefernce handles when it's safe to do so.
   auto const& tracks = *tracksH;
@@ -683,18 +696,31 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
   if (vertices.empty())
     return;
 
+  for (const auto& vtx : vertices) {
+    h_vtx_chi2ndf->Fill(vtx.chi2() / vtx.ndof());
+    h_vtx_prob->Fill(TMath::Prob(vtx.chi2(), vtx.ndof()));
+    const int scoutingTracksSize = static_cast<int>(vtx.tracksSize());
+    h_vtx_nTracks->Fill(scoutingTracksSize);
+  }
+
+  // --- Per-vertex accumulators (indexed by vertex index) ---
+  const unsigned int nVtx = vertices.size();
+  std::vector<double> vtxSumPt2(nVtx, 0.);
+  std::vector<unsigned int> vtxNTracks(nVtx, 0);
+
   for (const auto& trk : tracks) {
     // --- build reco track ---
     reco::Track recoTrk = makeRecoTrack(trk);
-    auto [vtxIndex, closestVtx] = findClosestScoutingVertex(&recoTrk, vertices);
-    if (!closestVtx)
-      continue;
 
-    // // initialize the impact parameters to large values
+    //auto [vtxIndex, closestVtx] = findClosestScoutingVertex(&recoTrk, vertices);
+    //if (!closestVtx)
+    //  continue;
+
+    // initialize the impact parameters to large values
     // std::pair<float, float> best_offset{9999.f, 99999.f};
 
     // // loop on all the vertices and find the closest one
-    // unsigned int vtxIndex = 999;
+    // unsigned int vtxIndex = 9999;
     // unsigned int idx = 0;
     // for (const auto& vtx : vertices) {
     //   const auto offset = trk_vtx_offSet(trk, vtx);
@@ -705,7 +731,19 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     //   idx++;
     // }
 
+    const unsigned int vtxIndex = static_cast<unsigned int>(trk.tk_vtxInd());
+    if (vtxIndex >= vertices.size())
+      continue;
+
+    const Run3ScoutingVertex* closestVtx = &vertices[vtxIndex];
     h_vtx_idx->Fill(vtxIndex);
+
+    // accumulate per-vertex quantities before filling per-track histos
+    if (vtxIndex < nVtx) {
+      const float pt = trk.tk_pt();
+      vtxSumPt2[vtxIndex] += pt * pt;
+      vtxNTracks[vtxIndex]++;
+    }
 
     const float eta = trk.tk_eta();
     const float phi = trk.tk_phi();
@@ -735,11 +773,29 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     // --- impact parameters (standard CMSSW definitions) ---
     float dxy = recoTrk.dxy(recoVtx.position()) * cmToUm;
     float dz = recoTrk.dz(recoVtx.position()) * cmToUm;
-    float dxyErr = recoTrk.dxyError() * cmToUm;
-    float dzErr = recoTrk.dzError() * cmToUm;
 
+    float dzErr = std::sqrt(recoTrk.dzError() * recoTrk.dzError() + recoVtx.zError() * recoVtx.zError()) * cmToUm;
+    float dxyErr = std::sqrt(recoTrk.dxyError() * recoTrk.dxyError() + recoVtx.xError() * recoVtx.xError() +
+                             recoVtx.yError() * recoVtx.yError()) *
+                   cmToUm;
+
+    // production radius from stored reference point
+    float vr = std::sqrt(trk.tk_vx() * trk.tk_vx() + trk.tk_vy() * trk.tk_vy());
+    h_vr->Fill(vr);
+    h_vz->Fill(trk.tk_vz());
+
+    // ---- impact parameters using offsets
     //float dxy = best_offset.first;
     //float dz = best_offset.second;
+
+    // --- impact parameters (directly from scouting) ---
+    //float dxy = trk.tk_dxy() * cmToUm;
+    //float dz = trk.tk_dz() * cmToUm;
+    //float dxyErr = trk.tk_dxy_Error() * cmToUm;
+    //float dzErr = trk.tk_dz_Error() * cmToUm;
+
+    //float dxyErr = recoTrk.dxyError() * cmToUm;
+    //float dzErr = recoTrk.dzError() * cmToUm;
 
     // --- fill histograms ---
     h_dxy->Fill(dxy);
@@ -806,6 +862,7 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     if (trk.tk_pt() < 1.)
       continue;
 
+    // dxy pT>1
     dxy_pt1.IP_->Fill(dxy);
     dxy_pt1.IPVsPhi_->Fill(phi, dxy);
     dxy_pt1.IPVsEta_->Fill(eta, dxy);
@@ -820,7 +877,6 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     dxy_pt1.IPErrVsEtaVsPhi_->Fill(eta, phi, dxyErr);
 
     // dz pT>1
-
     dz_pt1.IP_->Fill(dz);
     dz_pt1.IPVsPhi_->Fill(phi, dz);
     dz_pt1.IPVsEta_->Fill(eta, dz);
@@ -851,7 +907,7 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     dxy_pt10.IPErrVsPt_->Fill(pt, dxyErr);
     dxy_pt10.IPErrVsEtaVsPhi_->Fill(eta, phi, dxyErr);
 
-    // dxz pT>10
+    // dz pT>10
     dz_pt10.IP_->Fill(dz);
     dz_pt10.IPVsPhi_->Fill(phi, dz);
     dz_pt10.IPVsEta_->Fill(eta, dz);
@@ -866,18 +922,33 @@ void ScoutingTrackMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
     dz_pt10.IPErrVsEtaVsPhi_->Fill(eta, phi, dzErr);
   }
 
-  // BeamSpot
-  reco::BeamSpot beamSpot = *beamSpotHandle;
+  // --- Per-vertex histograms ---
+  for (unsigned int i = 0; i < nVtx; ++i) {
+    if (vtxNTracks[i] == 0)
+      continue;
+    h_vtx_sumPt2->Fill(vtxSumPt2[i]);
+  }
 
-  bsX->Fill(beamSpot.x0());
-  bsY->Fill(beamSpot.y0());
-  bsZ->Fill(beamSpot.z0());
-  bsSigmaZ->Fill(beamSpot.sigmaZ());
-  bsDxdz->Fill(beamSpot.dxdz());
-  bsDydz->Fill(beamSpot.dydz());
-  bsBeamWidthX->Fill(beamSpot.BeamWidthX() * cmToUm);
-  bsBeamWidthY->Fill(beamSpot.BeamWidthY() * cmToUm);
-  bsType->Fill(beamSpot.type());
+  // BeamSpot
+  edm::Handle<reco::BeamSpot> beamSpotH;
+  std::unique_ptr<Run3ScoutingVertex> beamspotVertex{nullptr};
+  if (!getValidHandle(iEvent, beamSpotToken_, beamSpotH, "beamSpot")) {
+    return;
+  }
+
+  const auto& beamSpot = *beamSpotH;
+  beamspotVertex = std::make_unique<Run3ScoutingVertex>(
+      beamSpot.x0(), beamSpot.y0(), beamSpot.z0(), 0., 0., 0., 0., 0., true, 0., 0., 0., 0);
+
+  h_bsX->Fill(beamSpot.x0());
+  h_bsY->Fill(beamSpot.y0());
+  h_bsZ->Fill(beamSpot.z0());
+  h_bsSigmaZ->Fill(beamSpot.sigmaZ());
+  h_bsDxdz->Fill(beamSpot.dxdz());
+  h_bsDydz->Fill(beamSpot.dydz());
+  h_bsBeamWidthX->Fill(beamSpot.BeamWidthX() * cmToUm);
+  h_bsBeamWidthY->Fill(beamSpot.BeamWidthY() * cmToUm);
+  h_bsType->Fill(beamSpot.type());
 }
 
 // helper: build reco::Track
@@ -960,7 +1031,7 @@ void ScoutingTrackMonitor::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<edm::InputTag>("beamSpotLabel", edm::InputTag("hltOnlineBeamSpot"));
   desc.add<std::string>("topFolderName", "HLT/ScoutingOffline/Tracks");
   desc.add<double>("Xpos", 0.1);
-  desc.add<double>("Ypos", 0.0);
+  desc.add<double>("Ypos", -0.2);
   desc.add<int>("DxyBin", 100);
   desc.add<double>("DxyMin", -5000.0);
   desc.add<double>("DxyMax", 5000.0);

--- a/HLTriggerOffline/Scouting/plugins/ScoutingTrackNtuplizer.cc
+++ b/HLTriggerOffline/Scouting/plugins/ScoutingTrackNtuplizer.cc
@@ -1,0 +1,407 @@
+// -*- C++ -*-
+//
+// Package:    HLTriggerOffline/Scouting
+// Class:      ScoutingTrackNtuplizer
+//
+// Description: EDAnalyzer that dumps a TTree with track/vertex quantities
+//
+// Usage: add to your cmsRun config, open output ROOT file, inspect the "trackTree" TTree.
+
+// system
+#include <cmath>
+#include <memory>
+#include <string>
+#include <vector>
+
+// CMSSW framework
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+// data formats
+#include "DataFormats/Scouting/interface/Run3ScoutingTrack.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingVertex.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Math/interface/Vector3D.h"
+
+// ROOT / TFileService
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "TTree.h"
+#include "TMath.h"
+
+class ScoutingTrackNtuplizer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit ScoutingTrackNtuplizer(const edm::ParameterSet&);
+  ~ScoutingTrackNtuplizer() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override {}
+
+  // helpers (same as ScoutingTrackMonitor)
+  reco::Track makeRecoTrack(const Run3ScoutingTrack&) const;
+  reco::Vertex makeRecoVertex(const Run3ScoutingVertex&) const;
+  std::pair<unsigned int, const Run3ScoutingVertex*> findClosestVertex(const reco::Track&,
+                                                                       const std::vector<Run3ScoutingVertex>&) const;
+
+  // tokens
+  const edm::EDGetTokenT<std::vector<Run3ScoutingTrack>> tracksToken_;
+  const edm::EDGetTokenT<std::vector<Run3ScoutingVertex>> verticesToken_;
+  const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+
+  static constexpr float cmToUm = 10000.f;
+
+  // TTree and branches
+  TTree* tree_ = nullptr;
+
+  // --- per-track branches ---
+
+  // kinematics
+  float b_pt, b_eta, b_phi;
+
+  // stored dz/dxy (directly from scouting track, w.r.t. beam line)
+  float b_dz_stored;      // trk.tk_dz()       [µm]
+  float b_dxy_stored;     // trk.tk_dxy()      [µm]
+  float b_dzErr_stored;   // trk.tk_dz_Error() [µm]
+  float b_dxyErr_stored;  // trk.tk_dxy_Error()[µm]
+
+  // recomputed dz/dxy w.r.t. closest vertex
+  float b_dz_vtx;   // recoTrk.dz(vtx)   [µm]
+  float b_dxy_vtx;  // recoTrk.dxy(vtx)  [µm]
+
+  // track uncertainties from covariance matrix
+  float b_dzErr_track;   // recoTrk.dzError() [µm]
+  float b_dxyErr_track;  // recoTrk.dxyError()[µm]
+
+  // vertex uncertainties
+  float b_vtx_zErr;  // closestVtx.zError()  [µm]
+  float b_vtx_xErr;  // closestVtx.xError()  [µm]
+  float b_vtx_yErr;  // closestVtx.yError()  [µm]
+
+  // combined uncertainties (track + vtx in quadrature)
+  float b_dzErr_combined;
+  float b_dxyErr_combined;
+
+  // pulls
+  float b_dzPull_stored;    // dz_stored   / dzErr_stored
+  float b_dzPull_vtx;       // dz_vtx      / dzErr_track
+  float b_dzPull_combined;  // dz_vtx      / dzErr_combined
+  float b_dxyPull_stored;
+  float b_dxyPull_vtx;
+  float b_dxyPull_combined;
+
+  // track reference point (stored vx/vy/vz from packer)
+  float b_vx_stored;  // trk.tk_vx() [cm]
+  float b_vy_stored;  // trk.tk_vy() [cm]
+  float b_vz_stored;  // trk.tk_vz() [cm]
+  float b_vr_stored;  // sqrt(vx^2+vy^2) [cm] — production radius
+
+  // closest vertex position
+  float b_vtx_x, b_vtx_y, b_vtx_z;
+  int b_vtx_index;
+  int b_vtx_ntracks;
+
+  // delta between stored reference point and vertex
+  float b_delta_vz;  // vz_stored - vtx_z  [cm]
+  float b_delta_vr;  // vr_stored           [cm] (distance from beam line)
+
+  // track quality
+  float b_chi2;
+  float b_normchi2;
+  int b_ndof;
+  int b_nPixelHits;
+  int b_nTrackerLayers;
+  int b_nStripHits;
+  int b_charge;
+
+  // beamspot
+  float b_bs_x, b_bs_y, b_bs_z;
+
+  // event info
+  unsigned int b_run, b_lumi;
+  unsigned long long b_event;
+
+  // flag: is this track in the spike (|dzPull_combined| < 0.3)?
+  int b_is_spike;
+};
+
+// ---------------------------------------------------------------------------
+ScoutingTrackNtuplizer::ScoutingTrackNtuplizer(const edm::ParameterSet& iConfig)
+    : tracksToken_{consumes<std::vector<Run3ScoutingTrack>>(iConfig.getParameter<edm::InputTag>("tracks"))},
+      verticesToken_{consumes<std::vector<Run3ScoutingVertex>>(iConfig.getParameter<edm::InputTag>("vertices"))},
+      beamSpotToken_{consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotLabel"))} {
+  usesResource("TFileService");
+}
+
+// ---------------------------------------------------------------------------
+void ScoutingTrackNtuplizer::beginJob() {
+  edm::Service<TFileService> fs;
+  tree_ = fs->make<TTree>("trackTree", "Scouting track debug tree");
+
+  // event
+  tree_->Branch("run", &b_run);
+  tree_->Branch("lumi", &b_lumi);
+  tree_->Branch("event", &b_event);
+
+  // kinematics
+  tree_->Branch("pt", &b_pt);
+  tree_->Branch("eta", &b_eta);
+  tree_->Branch("phi", &b_phi);
+
+  // stored (packer) quantities
+  tree_->Branch("dz_stored", &b_dz_stored);
+  tree_->Branch("dxy_stored", &b_dxy_stored);
+  tree_->Branch("dzErr_stored", &b_dzErr_stored);
+  tree_->Branch("dxyErr_stored", &b_dxyErr_stored);
+
+  // recomputed w.r.t. vertex
+  tree_->Branch("dz_vtx", &b_dz_vtx);
+  tree_->Branch("dxy_vtx", &b_dxy_vtx);
+
+  // track-only uncertainties
+  tree_->Branch("dzErr_track", &b_dzErr_track);
+  tree_->Branch("dxyErr_track", &b_dxyErr_track);
+
+  // vertex uncertainties
+  tree_->Branch("vtx_zErr", &b_vtx_zErr);
+  tree_->Branch("vtx_xErr", &b_vtx_xErr);
+  tree_->Branch("vtx_yErr", &b_vtx_yErr);
+
+  // combined uncertainties
+  tree_->Branch("dzErr_combined", &b_dzErr_combined);
+  tree_->Branch("dxyErr_combined", &b_dxyErr_combined);
+
+  // pulls (three variants so you can compare)
+  tree_->Branch("dzPull_stored", &b_dzPull_stored);
+  tree_->Branch("dzPull_vtx", &b_dzPull_vtx);
+  tree_->Branch("dzPull_combined", &b_dzPull_combined);
+  tree_->Branch("dxyPull_stored", &b_dxyPull_stored);
+  tree_->Branch("dxyPull_vtx", &b_dxyPull_vtx);
+  tree_->Branch("dxyPull_combined", &b_dxyPull_combined);
+
+  // stored reference point
+  tree_->Branch("vx_stored", &b_vx_stored);
+  tree_->Branch("vy_stored", &b_vy_stored);
+  tree_->Branch("vz_stored", &b_vz_stored);
+  tree_->Branch("vr_stored", &b_vr_stored);  // transverse production radius
+
+  // closest vertex
+  tree_->Branch("vtx_x", &b_vtx_x);
+  tree_->Branch("vtx_y", &b_vtx_y);
+  tree_->Branch("vtx_z", &b_vtx_z);
+  tree_->Branch("vtx_index", &b_vtx_index);
+  tree_->Branch("vtx_ntracks", &b_vtx_ntracks);
+
+  // deltas between stored ref point and vertex
+  tree_->Branch("delta_vz", &b_delta_vz);  // vz_stored - vtx_z: should be ~0 for prompt
+  tree_->Branch("delta_vr", &b_delta_vr);  // vr_stored: non-zero means non-prompt ref point
+
+  // track quality
+  tree_->Branch("chi2", &b_chi2);
+  tree_->Branch("normchi2", &b_normchi2);
+  tree_->Branch("ndof", &b_ndof);
+  tree_->Branch("nPixelHits", &b_nPixelHits);
+  tree_->Branch("nTrackerLayers", &b_nTrackerLayers);
+  tree_->Branch("nStripHits", &b_nStripHits);
+  tree_->Branch("charge", &b_charge);
+
+  // beamspot
+  tree_->Branch("bs_x", &b_bs_x);
+  tree_->Branch("bs_y", &b_bs_y);
+  tree_->Branch("bs_z", &b_bs_z);
+
+  // spike flag
+  tree_->Branch("is_spike", &b_is_spike);
+}
+
+// ---------------------------------------------------------------------------
+void ScoutingTrackNtuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
+  edm::Handle<std::vector<Run3ScoutingTrack>> tracksH;
+  edm::Handle<std::vector<Run3ScoutingVertex>> verticesH;
+  edm::Handle<reco::BeamSpot> bsH;
+
+  iEvent.getByToken(tracksToken_, tracksH);
+  iEvent.getByToken(verticesToken_, verticesH);
+  iEvent.getByToken(beamSpotToken_, bsH);
+
+  if (!tracksH.isValid() || !verticesH.isValid() || !bsH.isValid())
+    return;
+
+  const auto& vertices = *verticesH;
+  if (vertices.empty())
+    return;
+
+  b_run = iEvent.id().run();
+  b_lumi = iEvent.id().luminosityBlock();
+  b_event = iEvent.id().event();
+
+  b_bs_x = bsH->x0();
+  b_bs_y = bsH->y0();
+  b_bs_z = bsH->z0();
+
+  for (const auto& trk : *tracksH) {
+    reco::Track recoTrk = makeRecoTrack(trk);
+    auto [vtxIdx, closestVtx] = findClosestVertex(recoTrk, vertices);
+    if (!closestVtx)
+      continue;
+
+    reco::Vertex recoVtx = makeRecoVertex(*closestVtx);
+
+    // --- kinematics ---
+    b_pt = trk.tk_pt();
+    b_eta = trk.tk_eta();
+    b_phi = trk.tk_phi();
+
+    // --- stored quantities (packer, w.r.t. beam line ref point) ---
+    b_dz_stored = trk.tk_dz() * cmToUm;
+    b_dxy_stored = trk.tk_dxy() * cmToUm;
+    b_dzErr_stored = trk.tk_dz_Error() * cmToUm;
+    b_dxyErr_stored = trk.tk_dxy_Error() * cmToUm;
+
+    // --- recomputed w.r.t. closest vertex ---
+    b_dz_vtx = recoTrk.dz(recoVtx.position()) * cmToUm;
+    b_dxy_vtx = recoTrk.dxy(recoVtx.position()) * cmToUm;
+
+    // --- uncertainties ---
+    b_dzErr_track = recoTrk.dzError() * cmToUm;
+    b_dxyErr_track = recoTrk.dxyError() * cmToUm;
+
+    b_vtx_zErr = closestVtx->zError() * cmToUm;
+    b_vtx_xErr = closestVtx->xError() * cmToUm;
+    b_vtx_yErr = closestVtx->yError() * cmToUm;
+
+    b_dzErr_combined = std::sqrt(b_dzErr_track * b_dzErr_track + b_vtx_zErr * b_vtx_zErr);
+    b_dxyErr_combined = std::sqrt(b_dxyErr_track * b_dxyErr_track + b_vtx_xErr * b_vtx_xErr + b_vtx_yErr * b_vtx_yErr);
+
+    // --- pulls (all three variants — compare these to find the right one) ---
+    auto safeDivide = [](float num, float den) -> float { return (std::abs(den) > 1e-6f) ? num / den : -999.f; };
+
+    b_dzPull_stored = safeDivide(b_dz_stored, b_dzErr_stored);
+    b_dzPull_vtx = safeDivide(b_dz_vtx, b_dzErr_track);
+    b_dzPull_combined = safeDivide(b_dz_vtx, b_dzErr_combined);
+
+    b_dxyPull_stored = safeDivide(b_dxy_stored, b_dxyErr_stored);
+    b_dxyPull_vtx = safeDivide(b_dxy_vtx, b_dxyErr_track);
+    b_dxyPull_combined = safeDivide(b_dxy_vtx, b_dxyErr_combined);
+
+    // --- stored reference point ---
+    b_vx_stored = trk.tk_vx();
+    b_vy_stored = trk.tk_vy();
+    b_vz_stored = trk.tk_vz();
+    b_vr_stored = std::sqrt(trk.tk_vx() * trk.tk_vx() + trk.tk_vy() * trk.tk_vy());
+
+    // --- closest vertex ---
+    b_vtx_x = closestVtx->x();
+    b_vtx_y = closestVtx->y();
+    b_vtx_z = closestVtx->z();
+    b_vtx_index = static_cast<int>(vtxIdx);
+    b_vtx_ntracks = closestVtx->tracksSize();
+
+    // --- deltas: key diagnostic quantities ---
+    // delta_vz != 0 means stored ref point is displaced from vertex in z
+    // delta_vr != 0 means track has non-prompt production radius
+    b_delta_vz = trk.tk_vz() - closestVtx->z();
+    b_delta_vr = b_vr_stored;
+
+    // --- quality ---
+    b_chi2 = recoTrk.chi2();
+    b_normchi2 = recoTrk.normalizedChi2();
+    b_ndof = recoTrk.ndof();
+    b_nPixelHits = trk.tk_nValidPixelHits();
+    b_nTrackerLayers = trk.tk_nTrackerLayersWithMeasurement();
+    b_nStripHits = trk.tk_nValidStripHits();
+    b_charge = trk.tk_charge();
+
+    // spike flag: use combined pull
+    b_is_spike = (std::abs(b_dzPull_combined) < 0.3f) ? 1 : 0;
+
+    tree_->Fill();
+  }
+}
+
+// ---------------------------------------------------------------------------
+reco::Track ScoutingTrackNtuplizer::makeRecoTrack(const Run3ScoutingTrack& sTrack) const {
+  reco::Track::Point v(sTrack.tk_vx(), sTrack.tk_vy(), sTrack.tk_vz());
+  reco::Track::Vector p(math::RhoEtaPhiVector(sTrack.tk_pt(), sTrack.tk_eta(), sTrack.tk_phi()));
+
+  reco::TrackBase::CovarianceMatrix cov;
+  cov(0, 0) = std::pow(sTrack.tk_qoverp_Error(), 2);
+  cov(0, 1) = sTrack.tk_qoverp_lambda_cov();
+  cov(0, 2) = sTrack.tk_qoverp_phi_cov();
+  cov(0, 3) = sTrack.tk_qoverp_dxy_cov();
+  cov(0, 4) = sTrack.tk_qoverp_dsz_cov();
+  cov(1, 1) = std::pow(sTrack.tk_lambda_Error(), 2);
+  cov(1, 2) = sTrack.tk_lambda_phi_cov();
+  cov(1, 3) = sTrack.tk_lambda_dxy_cov();
+  cov(1, 4) = sTrack.tk_lambda_dsz_cov();
+  cov(2, 2) = std::pow(sTrack.tk_phi_Error(), 2);
+  cov(2, 3) = sTrack.tk_phi_dxy_cov();
+  cov(2, 4) = sTrack.tk_phi_dsz_cov();
+  cov(3, 3) = std::pow(sTrack.tk_dxy_Error(), 2);
+  cov(3, 4) = sTrack.tk_dxy_dsz_cov();
+  cov(4, 4) = std::pow(sTrack.tk_dsz_Error(), 2);
+
+  return reco::Track(sTrack.tk_chi2(), sTrack.tk_ndof(), v, p, sTrack.tk_charge(), cov);
+}
+
+// ---------------------------------------------------------------------------
+reco::Vertex ScoutingTrackNtuplizer::makeRecoVertex(const Run3ScoutingVertex& sVertex) const {
+  reco::Vertex::Error err;
+  err(0, 0) = std::pow(sVertex.xError(), 2);
+  err(1, 1) = std::pow(sVertex.yError(), 2);
+  err(2, 2) = std::pow(sVertex.zError(), 2);
+  err(0, 1) = sVertex.xyCov();
+  err(0, 2) = sVertex.xzCov();
+  err(1, 2) = sVertex.yzCov();
+
+  return reco::Vertex(reco::Vertex::Point(sVertex.x(), sVertex.y(), sVertex.z()),
+                      err,
+                      sVertex.chi2(),
+                      sVertex.ndof(),
+                      sVertex.tracksSize());
+}
+
+// ---------------------------------------------------------------------------
+std::pair<unsigned int, const Run3ScoutingVertex*> ScoutingTrackNtuplizer::findClosestVertex(
+    const reco::Track& track, const std::vector<Run3ScoutingVertex>& vertices) const {
+  double minDist = std::numeric_limits<double>::max();
+  const Run3ScoutingVertex* closest = nullptr;
+  unsigned int idx = 0, bestIdx = 999;
+
+  for (const auto& vtx : vertices) {
+    math::XYZPoint vtxPos(vtx.x(), vtx.y(), vtx.z());
+    const auto& mom = track.momentum();
+    const auto d = vtxPos - track.referencePoint();
+    double dist = d.Cross(mom).R() / mom.R();
+    if (dist < minDist) {
+      minDist = dist;
+      closest = &vtx;
+      bestIdx = idx;
+    }
+    ++idx;
+  }
+  return {bestIdx, closest};
+}
+
+// ---------------------------------------------------------------------------
+void ScoutingTrackNtuplizer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("tracks", edm::InputTag("hltScoutingTrackPacker"));
+  desc.add<edm::InputTag>("vertices", edm::InputTag("hltScoutingPrimaryVertexPacker", "primaryVtx"));
+  desc.add<edm::InputTag>("beamSpotLabel", edm::InputTag("hltOnlineBeamSpot"));
+  descriptions.addWithDefaultLabel(desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(ScoutingTrackNtuplizer);

--- a/HLTriggerOffline/Scouting/python/RecoTrackFromScoutingMonitor_cff.py
+++ b/HLTriggerOffline/Scouting/python/RecoTrackFromScoutingMonitor_cff.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+from .RecoTrackFromScoutingMonitor_cfi import scoutingRecoTrackMonitor
+
+# Tracks
+recoTracksFromScouting = cms.EDProducer("Run3ScoutingTrackToRecoTrackProducer",
+					src = cms.InputTag("hltScoutingTrackPacker"))
+
+# Vertices 
+recoVerticesFromScouting = cms.EDProducer("Run3ScoutingVertexToRecoVertexProducer",
+					  src = cms.InputTag("hltScoutingPrimaryVertexPacker", "primaryVtx"))
+
+recoTrackFromScoutingMonitorSequence = cms.Sequence(recoTracksFromScouting +
+                                                    recoVerticesFromScouting +
+                                                    scoutingRecoTrackMonitor)

--- a/HLTriggerOffline/Scouting/python/RecoTrackFromScoutingMonitor_cff.py
+++ b/HLTriggerOffline/Scouting/python/RecoTrackFromScoutingMonitor_cff.py
@@ -2,12 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 from .RecoTrackFromScoutingMonitor_cfi import scoutingRecoTrackMonitor
 
-# Tracks
+# Scouting Tracks to reco::Track conversion
 recoTracksFromScouting = cms.EDProducer("Run3ScoutingTrackToRecoTrackProducer",
+                                        skipMissingProduct = cms.bool(True), # do not throw on missing input
 					src = cms.InputTag("hltScoutingTrackPacker"))
 
-# Vertices 
+# Scouting Vertices to reco::Vertex conversion
 recoVerticesFromScouting = cms.EDProducer("Run3ScoutingVertexToRecoVertexProducer",
+                                          skipMissingProduct = cms.bool(True), # do not throw on missing input
 					  src = cms.InputTag("hltScoutingPrimaryVertexPacker", "primaryVtx"))
 
 recoTrackFromScoutingMonitorSequence = cms.Sequence(recoTracksFromScouting +

--- a/HLTriggerOffline/Scouting/python/RecoTrackFromScoutingMonitor_cfi.py
+++ b/HLTriggerOffline/Scouting/python/RecoTrackFromScoutingMonitor_cfi.py
@@ -1,0 +1,73 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQM.TrackingMonitor.TrackingMonitor_cfi import TrackMon as _TrackMon
+scoutingRecoTrackMonitor = _TrackMon.clone(
+    allTrackProducer = cms.InputTag("recoTracksFromScouting"),
+    TrackProducer    = cms.InputTag("recoTracksFromScouting"),
+    SeedProducer     = cms.InputTag(""),
+    TCProducer       = cms.InputTag(""),
+    MVAProducers     = cms.vstring(""),
+    TrackProducerForMVA = cms.InputTag(""),
+    ClusterLabels    = cms.vstring(''),
+    beamSpot         = cms.InputTag("hltOnlineBeamSpot"),
+    primaryVertex    = cms.InputTag("recoVerticesFromScouting"),
+    stripCluster     = cms.InputTag(''),
+    pixelCluster     = cms.InputTag(''),                          
+    BXlumiSetup      = cms.PSet(),
+    genericTriggerEventPSet = cms.PSet(),
+    
+    # PU monitoring
+    primaryVertexInputTags    = cms.VInputTag(),
+    selPrimaryVertexInputTags = cms.VInputTag(),
+    pvLabels = cms.vstring(),
+                          
+    # output parameters
+    AlgoName            = cms.string('ScoutingTk'),
+    Quality             = cms.string(''),
+    FolderName          = cms.string('HLT/ScoutingOffline/Tracks'),
+    BSFolderName        = cms.string('HLT/ScoutingOffline/Tracks'),
+    PVFolderName        = cms.string('HLT/ScoutingOffline/Tracks'),
+
+    # determines where to evaluate track parameters
+    # options: 'default'      --> straight up track parametes
+    #		   'ImpactPoint'  --> evalutate at impact point 
+    #		   'InnerSurface' --> evalutate at innermost measurement state 
+    #		   'OuterSurface' --> evalutate at outermost measurement state 
+
+    MeasurementState = cms.string('ImpactPoint'),
+    
+    # which plots to do
+
+    doAllPlots                          = cms.bool(False),
+    doGeneralPropertiesPlots            = cms.bool(True),   
+    doHitPropertiesPlots                = cms.bool(True),
+    doRecHitVsPhiVsEtaPerTrack          = cms.bool(True),
+    doRecHitVsPtVsEtaPerTrack           = cms.bool(True), 
+    doLayersVsPhiVsEtaPerTrack          = cms.bool(True),  
+    doRecHitsPerTrackProfile            = cms.bool(True),     
+    doBeamSpotPlots                     = cms.bool(True),  
+    doPrimaryVertexPlots                = cms.bool(True),   
+    doDCAPlots                          = cms.bool(True),  
+    doDCAwrtPVPlots                     = cms.bool(True),   
+    doDCAwrt000Plots                    = cms.bool(True),
+    doSIPPlots                          = cms.bool(True),
+    doThetaPlots                        = cms.bool(True),
+    doTrackPxPyPlots                    = cms.bool(True),
+    doLumiAnalysis                      = cms.bool(True),
+    doProfilesVsLS                      = cms.bool(True),
+    doPlotsVsGoodPVtx                   = cms.bool(False),
+    doEffFromHitPatternVsPU             = cms.bool(False),
+    doEffFromHitPatternVsBX             = cms.bool(False),
+    doEffFromHitPatternVsLUMI           = cms.bool(False),
+    doSeedParameterHistos               = cms.bool(False),
+    doTrackCandHistos                   = cms.bool(False),
+    doAllTrackCandHistos                = cms.bool(False),
+    doTestPlots                         = cms.bool(False),
+    doTrackerSpecific                   = cms.bool(False),
+    doMeasurementStatePlots             = cms.bool(False),
+    pvNDOF                              = cms.int32(4),
+    pixelCluster4lumi                   = cms.InputTag(''),
+    scal                                = cms.InputTag(''),
+    forceSCAL                           = cms.bool(False),
+    metadata                            = cms.InputTag('hltOnlineMetaDataDigis'),
+)

--- a/HLTriggerOffline/Scouting/test/ScoutingTrackNtuplizer_cfg.py
+++ b/HLTriggerOffline/Scouting/test/ScoutingTrackNtuplizer_cfg.py
@@ -1,0 +1,58 @@
+import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+options = VarParsing('analysis')
+
+options.register('globalTag',
+                 '160X_dataRun3_HLT_v1',  # adjust to your run era
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.string,
+                 'Global tag')
+options.parseArguments()
+
+from Configuration.Eras.Era_Run3_2025_cff import Run3_2025
+process = cms.Process('DZDEBUG',Run3_2025)
+
+# ---- number of events -------------------------------------------------------
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+)
+
+# ---- message logger (keep it quiet) -----------------------------------------
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+# ---- global tag -------------------------------------------------------------
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+
+# ---- geometry & magnetic field (needed to build reco::Track properly) -------
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+
+# ---- input ------------------------------------------------------------------
+process.source = cms.Source('PoolSource',
+    fileNames = cms.untracked.vstring(options.inputFiles),
+)
+
+# ---- TFileService (output TTree goes here) ----------------------------------
+process.TFileService = cms.Service('TFileService',
+    fileName = cms.string(options.outputFile),
+    closeFileFast = cms.untracked.bool(True)
+)
+
+# ---- the debugger module ----------------------------------------------------
+process.scoutingTrackNtuplizer = cms.EDAnalyzer('ScoutingTrackNtuplizer',
+    tracks        = cms.InputTag('hltScoutingTrackPacker'),
+    vertices      = cms.InputTag('hltScoutingPrimaryVertexPacker', 'primaryVtx'),
+    beamSpotLabel = cms.InputTag('hltOnlineBeamSpot'),
+)
+
+# ---- the beamspot module ----------------------------------------------------
+from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer as _onlineBeamSpotProducer
+process.hltOnlineBeamSpot = _onlineBeamSpotProducer.clone()
+
+# ---- path -------------------------------------------------------------------
+process.p = cms.Path(process.hltOnlineBeamSpot+process.scoutingTrackNtuplizer)
+process.schedule = cms.Schedule(process.p)

--- a/HLTriggerOffline/Scouting/test/test.sh
+++ b/HLTriggerOffline/Scouting/test/test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -ex
+
+LOCALPATH='/eos/cms/store/group/tsg-phase2/user/jprendi/NERD25/MoreStats/Muons/HLT/'
+echo "Input source: |${LOCALPATH}|"
+LOCALFILES=$(ls -1 ${LOCALPATH} | grep Scouting)
+ALL_FILES=""
+for f in ${LOCALFILES[@]}; do
+    ALL_FILES+="file:${LOCALPATH}/${f},"
+done
+
+# Remove the last character
+ALL_FILES="${ALL_FILES%?}"
+echo "Discovered files: $ALL_FILES"
+
+cmsDriver.py step2 -s DQM:hltScoutingTrackMonitor \
+             --conditions 160X_dataRun3_HLT_v1 \
+             --datatier DQMIO \
+             -n 10000 \
+             --eventcontent DQMIO \
+             --geometry DB:Extended \
+             --era Run3_2025 \
+             --filein file:$ALL_FILES \
+             --fileout file:step2.root \
+             --nThreads 24 \
+             --python_filename dqm.py \
+             --no_exec
+
+cat <<@EOF >> dqm.py 
+# import beamspot
+from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer as _onlineBeamSpotProducer
+process.hltOnlineBeamSpot = _onlineBeamSpotProducer.clone()
+process.scoutingCollectionMonitor.onlineMetaDataDigis = "hltOnlineMetaDataDigis"
+process.scoutingCollectionMonitor.onlyScouting = True
+process.dqmoffline_step = cms.EndPath(process.hltOnlineBeamSpot+process.hltScoutingCollectionMonitor+process.hltScoutingTrackMonitor)
+@EOF
+
+cmsRun dqm.py >& dqm.log
+
+cmsDriver.py step3 -s HARVESTING:@standardDQM \
+         --conditions 160X_dataRun3_HLT_v1 \
+         --data \
+         --geometry DB:Extended \
+         --scenario pp \
+         --filetype DQM \
+         --era Run3_2025 \
+         -n 10000 \
+         --filein file:step2.root \
+         --fileout file:step3.root \
+         --no_exec
+
+cmsRun step3_HARVESTING.py >& harvesting.log

--- a/PhysicsTools/PatFromScouting/plugins/Run3ScoutingTrackToRecoTrackProducer.cc
+++ b/PhysicsTools/PatFromScouting/plugins/Run3ScoutingTrackToRecoTrackProducer.cc
@@ -46,12 +46,14 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   const edm::EDGetTokenT<Run3ScoutingTrackCollection> trackToken_;
+  const bool skipMissingProduct_;
 
   std::vector<int> vertexIndex_;
 };
 
 Run3ScoutingTrackToRecoTrackProducer::Run3ScoutingTrackToRecoTrackProducer(const edm::ParameterSet& iConfig)
-    : trackToken_(consumes<Run3ScoutingTrackCollection>(iConfig.getParameter<edm::InputTag>("src"))) {
+    : trackToken_(consumes<Run3ScoutingTrackCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      skipMissingProduct_(iConfig.getParameter<bool>("skipMissingProduct")) {
   produces<reco::TrackCollection>();
   produces<edm::ValueMap<int>>("vertexIndex");
 }
@@ -61,9 +63,17 @@ void Run3ScoutingTrackToRecoTrackProducer::produce(edm::Event& iEvent, const edm
 
   vertexIndex_.clear();
 
-  const auto& scoutingTracks = iEvent.get(trackToken_);
+  const auto& scoutingTracksH = iEvent.getHandle(trackToken_);
+  if (!scoutingTracksH.isValid()) {
+    if (skipMissingProduct_) {
+      return;
+    } else {
+      throw cms::Exception("Run3ScoutingTrackToRecoTrackProducer")
+          << "Scouting Track input product is missing and skipMissingProduct is set to false.";
+    }
+  }
 
-  for (const auto& sTrack : scoutingTracks) {
+  for (const auto& sTrack : *scoutingTracksH) {
     reco::Track recoTrack = pat::makeRecoTrack(sTrack);
 
     // Populate hit pattern from scouting hit counts.
@@ -118,6 +128,7 @@ void Run3ScoutingTrackToRecoTrackProducer::produce(edm::Event& iEvent, const edm
 void Run3ScoutingTrackToRecoTrackProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("hltScoutingTrackPacker"));
+  desc.add<bool>("skipMissingProduct", false);
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/PhysicsTools/PatFromScouting/plugins/Run3ScoutingVertexToRecoVertexProducer.cc
+++ b/PhysicsTools/PatFromScouting/plugins/Run3ScoutingVertexToRecoVertexProducer.cc
@@ -42,19 +42,29 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   const edm::EDGetTokenT<Run3ScoutingVertexCollection> vertexToken_;
+  const bool skipMissingProduct_;
 };
 
 Run3ScoutingVertexToRecoVertexProducer::Run3ScoutingVertexToRecoVertexProducer(const edm::ParameterSet& iConfig)
-    : vertexToken_(consumes<Run3ScoutingVertexCollection>(iConfig.getParameter<edm::InputTag>("src"))) {
+    : vertexToken_(consumes<Run3ScoutingVertexCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      skipMissingProduct_(iConfig.getParameter<bool>("skipMissingProduct")) {
   produces<reco::VertexCollection>();
 }
 
 void Run3ScoutingVertexToRecoVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   auto recoVertices = std::make_unique<reco::VertexCollection>();
 
-  const auto& scoutingVertices = iEvent.get(vertexToken_);
+  const auto& scoutingVerticesH = iEvent.getHandle(vertexToken_);
+  if (!scoutingVerticesH.isValid()) {
+    if (skipMissingProduct_) {
+      return;
+    } else {
+      throw cms::Exception("Run3ScoutingVertexToRecoVertexProducer")
+          << "Scoutiing Vertex input product is missing and skipMissingProduct is set to false.";
+    }
+  }
 
-  for (const auto& sVtx : scoutingVertices) {
+  for (const auto& sVtx : *scoutingVerticesH) {
     if (!sVtx.isValidVtx()) {
       continue;
     }
@@ -69,6 +79,7 @@ void Run3ScoutingVertexToRecoVertexProducer::produce(edm::Event& iEvent, const e
 void Run3ScoutingVertexToRecoVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("hltScoutingPrimaryVertexPacker", "primaryVtx"));
+  desc.add<bool>("skipMissingProduct", false);
   descriptions.addWithDefaultLabel(desc);
 }
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/51101

#### PR description:

From the original PR:

> This PR is a follow-up to commit https://github.com/cms-sw/cmssw/pull/50926/changes/b1bb704810849cad55a5450335844c9d6fb8897e (introduced in https://github.com/cms-sw/cmssw/pull/50926) and introduces various improvements for `ScoutingTrackMonitor`:
> - use embedded `tk_vtxInd()` index in `Run3ScoutingTrack` for finding closest vertex
> - do not early return if beam spot is not available (e.g. `ScoutingPFMonitor`)
> - add histogram of track radius and z at DCA
> - add more monitoring of vertices (`sumpT2`, `nTracks`, `chi2prob`, `chi2ndf`)
> - include vertexing error in the `dxyErr`/`dzErr` computation

#### PR validation:

The PR was validated by:
- successful compilation with `scram b`
- successful testing with `scram b runtests_testHLTScoutingDQMAnalyzers`
- successful testing with `scram b runtests_TestDQMOnlineClient-ngt_dqm_sourceclient`
- running the relevant DQM configuration workflows locally
- verifying the booking and filling of the new histograms in the DQM output

The script used was committed at 4594a4d0fd7efd8c25446e44d5235f1b209e3b22.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/51101 to CMSSW_17_0_X for future re-processings of scouting datasets.