### PR TITLE
[170X]Fix static analyzer warnings in ESHandle and bloom filter generator

### DIFF
--- a/FWCore/Framework/interface/ESHandle.h
+++ b/FWCore/Framework/interface/ESHandle.h
@@ -64,7 +64,7 @@ namespace edm {
       }
       return data_;
     }
-    static void throwIfDataNotAvailable();
+    [[noreturn]] static void throwIfDataNotAvailable();
 
   private:
     // ---------- member data --------------------------------

--- a/FWCore/Framework/src/ESHandle.cc
+++ b/FWCore/Framework/src/ESHandle.cc
@@ -12,7 +12,7 @@ namespace edm {
     }
     return description_;
   }
-  void ESHandleBase::throwIfDataNotAvailable() {
+  [[noreturn]] void ESHandleBase::throwIfDataNotAvailable() {
     throw edm::Exception(edm::errors::InvalidReference, "ESHandle was not set.");
   }
 }  // namespace edm

--- a/Utilities/StaticAnalyzers/bin/bloom_filter_generator.c
+++ b/Utilities/StaticAnalyzers/bin/bloom_filter_generator.c
@@ -41,6 +41,7 @@ int generate_bloom_filter(const char *bloom_file, const char *words_file) {
     scaling_bloom_add(bloom, word, strlen(word), i);
   }
 
+  fclose(fp);
   int result = bitmap_flush(bloom->bitmap);
 
   return result;


### PR DESCRIPTION
### PR Description

This PR backports the fixes for two clang static analyzer warnings:

Mark ESHandleBase::throwIfDataNotAvailable() as [[noreturn]].
Close the file stream in bloom_filter_generator.c to avoid a reported resource leak.

Backport of #51122 to CMSSW_17_0_X.