### PR TITLE
Fix finding operator<< for reco::io_v1::PFTau

### DIFF
--- a/DataFormats/TauReco/src/PFTau.cc
+++ b/DataFormats/TauReco/src/PFTau.cc
@@ -4,7 +4,7 @@
 #include "DataFormats/TauReco/interface/PFTau.h"
 
 //using namespace std;
-namespace reco {
+namespace reco::io_v1 {
 
   PFTau::PFTau() {
     leadPFChargedHadrCandsignedSipt_ = NAN;
@@ -449,4 +449,4 @@ namespace reco {
     return out;
   }
 
-}  // namespace reco
+}  // namespace reco::io_v1


### PR DESCRIPTION
#### PR description:

Needs to be defined in the reco::io_v1 namespace.

#### PR validation:

Building in CMSSW_20_0_DBG_X_2026-06-05-2300 now avoids the link error seen in the equivalent IB.

The change is purely technical.

resolves https://github.com/cms-sw/framework-team/issues/2272