### PR TITLE
[17_0_X] Add rho map to egamma regression for HIN

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h
@@ -125,6 +125,16 @@ private:
   edm::Handle<reco::PFRecHitCollection> recHitsHgcal_;
   edm::Handle<reco::VertexCollection> vertices_;
 
+  std::vector<edm::Handle<std::vector<double>>> rhoMaps_;
+  std::vector<edm::EDGetTokenT<std::vector<double>>> rhoMapTokens_;
+  double getRho(double eta) const {
+    const auto& etaMap = *rhoMaps_[0];
+    const auto& rhoMap = *rhoMaps_[1];
+    assert(etaMap.size() == rhoMap.size() + 1);
+    const size_t n = std::upper_bound(etaMap.begin(), etaMap.end(), eta) - etaMap.begin();
+    return (n > 0 && n <= rhoMap.size()) ? rhoMap[n - 1] : 0.;
+  };
+
   bool isHLT_;
   bool isPhaseII_;
   bool regTrainedWithPS_;
@@ -178,5 +188,10 @@ void SCEnergyCorrectorSemiParm::setTokens(const edm::ParameterSet& iConfig, edm:
   if (not isHLT_) {
     tokenVertices_ = cc.consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"));
   }
+  for (const auto& tag : iConfig.getParameter<std::vector<edm::InputTag>>("rhoMaps"))
+    rhoMapTokens_.emplace_back(cc.consumes<std::vector<double>>(tag));
+  rhoMaps_.resize(rhoMapTokens_.size());
+  if (not rhoMaps_.empty() && rhoMaps_.size() != 2)
+    throw cms::Exception("InvalidConfiguration") << "SCEnergyCorrectorSemiParm expects only 2 tags in rhoMaps!";
 }
 #endif

--- a/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
@@ -84,6 +84,7 @@ void SCEnergyCorrectorSemiParm::fillPSetDescription(edm::ParameterSetDescription
   desc.add<double>("uncertaintyMinEE", 0.0002);
   desc.add<double>("uncertaintyMaxEE", 0.5);
   desc.add<edm::InputTag>("vertexCollection", edm::InputTag("offlinePrimaryVertices"));
+  desc.add<std::vector<edm::InputTag>>("rhoMaps", {});
   desc.add<double>("eRecHitThreshold", 1.);
   desc.add<edm::InputTag>("hgcalRecHits", edm::InputTag());
   desc.add<double>("hgcalCylinderR", EgammaHGCALIDParamDefaults::kRCylinder);
@@ -125,6 +126,8 @@ void SCEnergyCorrectorSemiParm::setEvent(const edm::Event& event) {
   if (!isHLT_) {
     event.getByToken(tokenVertices_, vertices_);
   }
+  for (size_t i = 0; i < rhoMapTokens_.size(); i++)
+    rhoMaps_[i] = event.getHandle(rhoMapTokens_[i]);
 }
 
 std::pair<double, double> SCEnergyCorrectorSemiParm::getCorrections(const reco::SuperCluster& sc) const {
@@ -271,7 +274,7 @@ std::vector<float> SCEnergyCorrectorSemiParm::getRegDataECALV1(const reco::Super
     ++iclus;
   }
 
-  eval[0] = vertices_->size();
+  eval[0] = rhoMaps_.empty() ? vertices_->size() : getRho(sc.eta());
   eval[1] = raw_energy;
   eval[2] = sc.etaWidth();
   eval[3] = sc.phiWidth();

--- a/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV3.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGRegressionModifierV3.cc
@@ -59,6 +59,15 @@ private:
 
   float rhoValue_;
   edm::EDGetTokenT<double> rhoToken_;
+  std::vector<edm::Handle<std::vector<double>>> rhoMaps_;
+  std::vector<edm::EDGetTokenT<std::vector<double>>> rhoMapTokens_;
+  double getRho(double eta) const {
+    const auto& etaMap = *rhoMaps_[0];
+    const auto& rhoMap = *rhoMaps_[1];
+    assert(etaMap.size() == rhoMap.size() + 1);
+    const size_t n = std::upper_bound(etaMap.begin(), etaMap.end(), eta) - etaMap.begin();
+    return (n > 0 && n <= rhoMap.size()) ? rhoMap[n - 1] : 0.;
+  };
 
   bool useClosestToCentreSeedCrysDef_;
   bool useBuggedHOverE_;  //this allows us to use the regression corrected H/E which is incorrect wrong
@@ -87,11 +96,22 @@ EGRegressionModifierV3::EGRegressionModifierV3(const edm::ParameterSet& conf, ed
   if (useClosestToCentreSeedCrysDef_) {
     caloGeomToken_ = cc.esConsumes();
   }
+  if (conf.exists("rhoMaps")) {
+    for (const auto& tag : conf.getParameter<std::vector<edm::InputTag>>("rhoMaps"))
+      rhoMapTokens_.emplace_back(cc.consumes<std::vector<double>>(tag));
+    rhoMaps_.resize(rhoMapTokens_.size());
+    if (not rhoMaps_.empty() && rhoMaps_.size() != 2)
+      throw cms::Exception("InvalidConfiguration") << "EGRegressionModifierV3 expects only 2 tags in rhoMaps!";
+  }
 }
 
 EGRegressionModifierV3::~EGRegressionModifierV3() {}
 
-void EGRegressionModifierV3::setEvent(const edm::Event& evt) { rhoValue_ = evt.get(rhoToken_); }
+void EGRegressionModifierV3::setEvent(const edm::Event& evt) {
+  rhoValue_ = evt.get(rhoToken_);
+  for (size_t i = 0; i < rhoMapTokens_.size(); i++)
+    rhoMaps_[i] = evt.getHandle(rhoMapTokens_[i]);
+}
 
 void EGRegressionModifierV3::setEventContent(const edm::EventSetup& iSetup) {
   if (eleRegs_)
@@ -223,7 +243,7 @@ std::array<float, 32> EGRegressionModifierV3::getRegData(const reco::GsfElectron
   data[4] = ssFull5x5.e5x5 / rawEnergy;
   //the full5x5 is not regression corrected and thus is the correct one to use
   data[5] = useBuggedHOverE_ ? ele.hcalOverEcalBc() : ele.full5x5_hcalOverEcalBc();
-  data[6] = rhoValue_;
+  data[6] = rhoMaps_.empty() ? rhoValue_ : getRho(superClus->eta());
   data[7] = seedClus->eta() - superClus->position().Eta();
   data[8] = reco::deltaPhi(seedClus->phi(), superClus->position().Phi());
   data[9] = ssFull5x5.r9;
@@ -289,7 +309,7 @@ std::array<float, 32> EGRegressionModifierV3::getRegData(const reco::Photon& pho
   //interestingly enough this differs from electrons where it uses cone based
   //naively Sam would have thought using cone based is even worse than tower based
   data[5] = pho.hadronicOverEm();
-  data[6] = rhoValue_;
+  data[6] = rhoMaps_.empty() ? rhoValue_ : getRho(superClus->eta());
   data[7] = seedClus->eta() - superClus->position().Eta();
   data[8] = reco::deltaPhi(seedClus->phi(), superClus->position().Phi());
   data[9] = pho.full5x5_r9();

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 regressionModifier106XUL = cms.PSet(
     modifierName = cms.string('EGRegressionModifierV3'),       
     rhoTag = cms.InputTag('fixedGridRhoFastjetAllTmp'),
+    rhoMaps = cms.VInputTag(),
     useClosestToCentreSeedCrysDef = cms.bool(False),
     useBuggedHOverE = cms.bool(False),
     maxRawEnergyForLowPtEBSigma = cms.double(-1), 
@@ -94,6 +95,7 @@ regressionModifier106XUL = cms.PSet(
 regressionModifier103XLowPtPho = cms.PSet(
     modifierName = cms.string('EGRegressionModifierV3'),       
     rhoTag = cms.InputTag('fixedGridRhoFastjetAllTmp'),
+    rhoMaps = cms.VInputTag(),
     useClosestToCentreSeedCrysDef = cms.bool(False),
     useBuggedHOverE = cms.bool(False),
     maxRawEnergyForLowPtEBSigma = cms.double(-1), 


### PR DESCRIPTION
#### PR description:

This PR introduces  in the Run3 egamma regression the option to use the rho derived per pseudo-rapidity as an estimator of the underlying event activity in heavy-ion collisions. This has shown to significantly improve the regression of ECAL super clusters for Run3 PbPb data, specially in most central events.

No change to any existing workflow is expected and since this is only for Run3, the target branch is done on 17_0_X directly.

@mandrenguyen 

#### PR validation:

Tested locally. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
