### PR TITLE
mkfit for LST-seeded in offline phase-2

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -528,8 +528,8 @@ upgradeWFs['trackingMkFitPhase2'].step3 = {
     '--procModifiers': 'trackingMkFitCommon,trackingMkFitInitialStep'
 }
 
-# LST on CPU, initialStep+highPtTripletStep-only tracking-only
-class UpgradeWorkflow_lstOnCPUIters01TrackingOnly(UpgradeWorkflowTracking):
+# LST and mkFit on CPU, initialStep+highPtTripletStep-only tracking-only
+class UpgradeWorkflow_lstmkFitOnCPUIters01TrackingOnly(UpgradeWorkflowTracking):
     def setup__(self, step, stepName, stepDict, k, properties):
         if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
         elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, stepDict[step][k]])
@@ -537,7 +537,7 @@ class UpgradeWorkflow_lstOnCPUIters01TrackingOnly(UpgradeWorkflowTracking):
     def condition(self, fragment, stepList, key, hasHarvest):
         result = (fragment=="TTbar_14TeV") and hasHarvest and ('Run4' in key)
         return result
-upgradeWFs['lstOnCPUIters01TrackingOnly'] = UpgradeWorkflow_lstOnCPUIters01TrackingOnly(
+upgradeWFs['lstmkFitOnCPUIters01TrackingOnly'] = UpgradeWorkflow_lstmkFitOnCPUIters01TrackingOnly(
     steps = [
         'RecoGlobal',
         'HARVESTGlobal',
@@ -549,24 +549,24 @@ upgradeWFs['lstOnCPUIters01TrackingOnly'] = UpgradeWorkflow_lstOnCPUIters01Track
         'RecoGlobal',
         'HARVESTGlobal',
     ],
-    suffix = '_lstOnCPUIters01TrackingOnly',
+    suffix = '_lstmkFitOnCPUIters01TrackingOnly',
     offset = 0.711,
 )
-upgradeWFs['lstOnCPUIters01TrackingOnly'].step3 = upgradeWFs['trackingOnly'].step3 | {
-    '--procModifiers': 'trackingIters01,trackingLST',
+upgradeWFs['lstmkFitOnCPUIters01TrackingOnly'].step3 = upgradeWFs['trackingOnly'].step3 | {
+    '--procModifiers': 'trackingLST,seedingLST,trackingMkFitHighPtTripletStep,trackingIters01',
     '--accelerators' : 'cpu'
 }
 
-# LST on GPU (if available), initialStep+highPtTripletStep-only tracking-only
-class UpgradeWorkflow_lstOnGPUIters01TrackingOnly(UpgradeWorkflowTracking):
+# LST and mkFit on GPU (if available), initialStep+highPtTripletStep-only tracking-only
+class UpgradeWorkflow_lstmkFitOnGPUIters01TrackingOnly(UpgradeWorkflowTracking):
     def setup__(self, step, stepName, stepDict, k, properties):
         if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
-        elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM', '--procModifiers': 'trackingIters01,trackingLST'}, stepDict[step][k]])
+        elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM', '--procModifiers': 'trackingLST,seedingLST,trackingMkFitHighPtTripletStep,trackingIters01'}, stepDict[step][k]])
         elif 'ALCA' in step: stepDict[stepName][k] = None
     def condition(self, fragment, stepList, key, hasHarvest):
         result = (fragment=="TTbar_14TeV") and hasHarvest and ('Run4' in key)
         return result
-upgradeWFs['lstOnGPUIters01TrackingOnly'] = UpgradeWorkflow_lstOnGPUIters01TrackingOnly(
+upgradeWFs['lstmkFitOnGPUIters01TrackingOnly'] = UpgradeWorkflow_lstmkFitOnGPUIters01TrackingOnly(
     steps = [
         'RecoGlobal',
         'HARVESTGlobal',
@@ -578,21 +578,21 @@ upgradeWFs['lstOnGPUIters01TrackingOnly'] = UpgradeWorkflow_lstOnGPUIters01Track
         'RecoGlobal',
         'HARVESTGlobal',
     ],
-    suffix = '_lstOnGPUIters01TrackingOnly',
+    suffix = '_lstmkFitOnGPUIters01TrackingOnly',
     offset = 0.712,
 )
-upgradeWFs['lstOnGPUIters01TrackingOnly'].step3 = upgradeWFs['trackingOnly'].step3 | {
-    '--procModifiers': 'trackingIters01,trackingLST',
+upgradeWFs['lstmkFitOnGPUIters01TrackingOnly'].step3 = upgradeWFs['trackingOnly'].step3 | {
+    '--procModifiers': 'trackingLST,seedingLST,trackingMkFitHighPtTripletStep,trackingIters01'
 }
 
 # LST on GPU (if available), initialStep+highPtTripletStep-only tracking-only, CPU vs. GPU comparison
-class UpgradeWorkflow_lstOnGPUIters01TrackingOnlyAlpakaValidationLST(UpgradeWorkflow_lstOnGPUIters01TrackingOnly):
+class UpgradeWorkflow_lstmkFitOnGPUIters01TrackingOnlyAlpakaValidationLST(UpgradeWorkflow_lstmkFitOnGPUIters01TrackingOnly):
     pass
-upgradeWFs['lstOnGPUIters01TrackingOnlyAlpakaValidationLST'] = deepcopy(upgradeWFs['lstOnGPUIters01TrackingOnly'])
-upgradeWFs['lstOnGPUIters01TrackingOnlyAlpakaValidationLST'].suffix = '_lstOnGPUIters01TrackingOnlyAlpakaValidationLST'
-upgradeWFs['lstOnGPUIters01TrackingOnlyAlpakaValidationLST'].offset = 0.713
-upgradeWFs['lstOnGPUIters01TrackingOnlyAlpakaValidationLST'].step3 = upgradeWFs['trackingOnly'].step3 | {
-    '--procModifiers': 'alpakaValidationLST,trackingIters01,trackingLST',
+upgradeWFs['lstmkFitOnGPUIters01TrackingOnlyAlpakaValidationLST'] = deepcopy(upgradeWFs['lstmkFitOnGPUIters01TrackingOnly'])
+upgradeWFs['lstmkFitOnGPUIters01TrackingOnlyAlpakaValidationLST'].suffix = '_lstmkFitOnGPUIters01TrackingOnlyAlpakaValidationLST'
+upgradeWFs['lstmkFitOnGPUIters01TrackingOnlyAlpakaValidationLST'].offset = 0.713
+upgradeWFs['lstmkFitOnGPUIters01TrackingOnlyAlpakaValidationLST'].step3 = upgradeWFs['trackingOnly'].step3 | {
+    '--procModifiers': 'alpakaValidationLST,trackingLST,seedingLST,trackingMkFitHighPtTripletStep,trackingIters01'
 }
 
 #DeepCore seeding for JetCore iteration workflow

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -400,6 +400,9 @@ from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 trackingLST.toModify(locals()["TrackSeedMonhighPtTripletStep"],
     SeedProducer = "lstInputProducer"
 )
+seedingLST.toModify(locals()["TrackSeedMonhighPtTripletStep"],
+    SeedProducer = "highPtTripletStepTrajectorySeedsLST"
+)
 _LST_TrackSeedMonSequence = TrackSeedMonSequence.copyAndExclude([locals()["TrackSeedMoninitialStep"]])
 (seedingLST | trackingLST).toReplaceWith(TrackSeedMonSequence, _LST_TrackSeedMonSequence)
 

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -401,7 +401,7 @@ trackingLST.toModify(locals()["TrackSeedMonhighPtTripletStep"],
     SeedProducer = "lstInputProducer"
 )
 seedingLST.toModify(locals()["TrackSeedMonhighPtTripletStep"],
-    SeedProducer = "highPtTripletStepTrajectorySeedsLST"
+    SeedProducer = "highPtTripletStepSeedsPixelsWithLST"
 )
 _LST_TrackSeedMonSequence = TrackSeedMonSequence.copyAndExclude([locals()["TrackSeedMoninitialStep"]])
 (seedingLST | trackingLST).toReplaceWith(TrackSeedMonSequence, _LST_TrackSeedMonSequence)

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -256,7 +256,7 @@ highPtTripletStepTrackCandidatesMkFit = mkFitProducer_cfi.mkFitProducer.clone(
 ))
 (pp_on_XeXe_2017 | pp_on_AA).toModify(highPtTripletStepTrackCandidatesMkFitConfig, minPt=0.7)
 (trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toModify(highPtTripletStepTrackCandidatesMkFitSeeds,
-    seeds = 'highPtTripletStepTrajectorySeedsLST'
+    seeds = 'highPtTripletStepSeedsPixelsWithLST'
 )
 (trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toModify(highPtTripletStepTrackCandidatesMkFit,
     stripHits = cms.InputTag("mkFitSiPhase2Hits"),
@@ -282,12 +282,12 @@ trackingPhase2PU140.toModify(highPtTripletStepTrackCandidates,
 
 from RecoTracker.LST.lstOutputConverter_cfi import lstOutputConverter as _lstOutputConverter
 (trackingPhase2PU140 & trackingLST).toReplaceWith(highPtTripletStepTrackCandidates, _lstOutputConverter.clone())
-highPtTripletStepTrajectorySeedsLST = _lstOutputConverter.clone(
+highPtTripletStepSeedsPixelsWithLST = _lstOutputConverter.clone(
     includeNonpLSTSs = cms.bool(True)
 )
 
 (trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toReplaceWith(highPtTripletStepTrackCandidates, mkFitOutputConverter_cfi.mkFitOutputConverter.clone(
-    seeds = 'highPtTripletStepTrajectorySeedsLST',
+    seeds = 'highPtTripletStepSeedsPixelsWithLST',
     mkFitSeeds = 'highPtTripletStepTrackCandidatesMkFitSeeds',
     tracks = 'highPtTripletStepTrackCandidatesMkFit',
     candMVASel = False,
@@ -435,7 +435,12 @@ _HighPtTripletStepTask_LST_mkFit = _HighPtTripletStepTask_LST.copy()
 (trackingPhase2PU140 & seedingLST & trackingLST & trackingMkFitHighPtTripletStep).toModify(lstInputProducer,
     ptCut = cms.double(0.1)
 )
-_HighPtTripletStepTask_LST_mkFit.add(highPtTripletStepTrajectorySeedsLST,highPtTripletStepTrackCandidatesMkFitSeeds, highPtTripletStepTrackCandidatesMkFit, highPtTripletStepTrackCandidatesMkFitConfig)
+import RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi
+highPtTripletStepSeedsPixelsOnly = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone(
+    seedCollections = ['initialStepSeeds','highPtTripletStepSeeds']
+)
+
+_HighPtTripletStepTask_LST_mkFit.add(highPtTripletStepSeedsPixelsWithLST,highPtTripletStepTrackCandidatesMkFitSeeds, highPtTripletStepTrackCandidatesMkFit, highPtTripletStepTrackCandidatesMkFitConfig,highPtTripletStepSeedsPixelsOnly)
 (trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toReplaceWith(HighPtTripletStepTask,_HighPtTripletStepTask_LST_mkFit)
 
 from Configuration.ProcessModifiers.alpakaValidationLST_cff import alpakaValidationLST
@@ -444,7 +449,7 @@ lstInputProducerSerialSync = makeSerialClone(lstInputProducer)
 lstProducerSerialSync = makeSerialClone(lstProducer, lstInput = "lstInputProducerSerialSync")
 
 highPtTripletStepTrackCandidatesSerialSync = highPtTripletStepTrackCandidates.clone()
-(trackingPhase2PU140 & alpakaValidationLST & trackingLST).toModify(highPtTripletStepTrackCandidatesSerialSync,
+(~seedingLST & trackingPhase2PU140 & alpakaValidationLST & trackingLST).toModify(highPtTripletStepTrackCandidatesSerialSync,
     lstOutput = "lstProducerSerialSync",
     lstInput = "lstInputProducerSerialSync",
     lstPixelSeeds = "lstInputProducerSerialSync"
@@ -459,7 +464,18 @@ _HighPtTripletStepTask_LSTSerialSync.add(siPhase2RecHits, lstInputProducerSerial
                                          highPtTripletStepTracksSerialSync, highPtTripletStepSelectorSerialSync
 )
 _HighPtTripletStepTask_LST_mkFitSerialSync = _HighPtTripletStepTask_LSTSerialSync.copy()
-_HighPtTripletStepTask_LST_mkFitSerialSync.add(highPtTripletStepTrajectorySeedsLST,highPtTripletStepTrackCandidatesMkFitSeeds, highPtTripletStepTrackCandidatesMkFit, highPtTripletStepTrackCandidatesMkFitConfig)
+highPtTripletStepSeedsPixelsWithLSTSerialSync  =  highPtTripletStepSeedsPixelsWithLST.clone()
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST & seedingLST & trackingMkFitHighPtTripletStep).toModify(highPtTripletStepSeedsPixelsWithLSTSerialSync,
+    lstOutput = "lstProducerSerialSync",
+    lstInput = "lstInputProducerSerialSync",
+    lstPixelSeeds = "lstInputProducerSerialSync"
+)
+(trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toModify(highPtTripletStepTrackCandidatesSerialSync, seeds = 'highPtTripletStepSeedsPixelsWithLSTSerialSync')
+highPtTripletStepTrackCandidatesMkFitSeedsSerialSync = highPtTripletStepTrackCandidatesMkFitSeeds.clone()
+(trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toModify(highPtTripletStepTrackCandidatesMkFitSeedsSerialSync, seeds = 'highPtTripletStepSeedsPixelsWithLSTSerialSync')
+highPtTripletStepTrackCandidatesMkFitSerialSync = highPtTripletStepTrackCandidatesMkFit.clone()
+(trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toModify(highPtTripletStepTrackCandidatesMkFitSerialSync, seeds = 'highPtTripletStepTrackCandidatesMkFitSeedsSerialSync')
+_HighPtTripletStepTask_LST_mkFitSerialSync.add(highPtTripletStepSeedsPixelsWithLSTSerialSync,highPtTripletStepTrackCandidatesMkFitSeedsSerialSync, highPtTripletStepTrackCandidatesMkFitSerialSync, highPtTripletStepTrackCandidatesMkFitConfig)
 HighPtTripletStepTaskSerialSync = cms.Task()
 (trackingPhase2PU140 & alpakaValidationLST & trackingLST).toReplaceWith(HighPtTripletStepTaskSerialSync, _HighPtTripletStepTask_LSTSerialSync)
 (trackingPhase2PU140 & alpakaValidationLST & trackingLST & seedingLST & trackingMkFitHighPtTripletStep).toReplaceWith(HighPtTripletStepTaskSerialSync,_HighPtTripletStepTask_LST_mkFitSerialSync)

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -247,7 +247,7 @@ highPtTripletStepTrackCandidatesMkFit = mkFitProducer_cfi.mkFitProducer.clone(
     config = ('', 'highPtTripletStepTrackCandidatesMkFitConfig'),
     clustersToSkip = 'highPtTripletStepClusters',
 )
-trackingMkFitHighPtTripletStep.toReplaceWith(highPtTripletStepTrackCandidates, mkFitOutputConverter_cfi.mkFitOutputConverter.clone(
+(~trackingPhase2PU140 & trackingMkFitHighPtTripletStep).toReplaceWith(highPtTripletStepTrackCandidates, mkFitOutputConverter_cfi.mkFitOutputConverter.clone(
     seeds = 'highPtTripletStepSeeds',
     mkFitSeeds = 'highPtTripletStepTrackCandidatesMkFitSeeds',
     tracks = 'highPtTripletStepTrackCandidatesMkFit',
@@ -255,6 +255,17 @@ trackingMkFitHighPtTripletStep.toReplaceWith(highPtTripletStepTrackCandidates, m
     candWP = -0.3,
 ))
 (pp_on_XeXe_2017 | pp_on_AA).toModify(highPtTripletStepTrackCandidatesMkFitConfig, minPt=0.7)
+(trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toModify(highPtTripletStepTrackCandidatesMkFitSeeds,
+    seeds = 'highPtTripletStepTrajectorySeedsLST'
+)
+(trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toModify(highPtTripletStepTrackCandidatesMkFit,
+    stripHits = cms.InputTag("mkFitSiPhase2Hits"),
+    clustersToSkip = cms.InputTag("")
+)
+(trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toModify(highPtTripletStepTrackCandidatesMkFitConfig,
+    config = cms.FileInPath('RecoTracker/MkFit/data/mkfit-phase2-lstStep.json'),
+    minPt = cms.double(0)                                                    
+)
 
 # For Phase2PU140
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits as _trajectoryCleanerBySharedHits
@@ -263,7 +274,7 @@ highPtTripletStepTrajectoryCleanerBySharedHits = _trajectoryCleanerBySharedHits.
     fractionShared      = 0.16,
     allowSharedFirstHit = True
 )
-trackingPhase2PU140.toModify(highPtTripletStepTrackCandidates, 
+trackingPhase2PU140.toModify(highPtTripletStepTrackCandidates,
     TrajectoryCleaner    = 'highPtTripletStepTrajectoryCleanerBySharedHits', 
     clustersToSkip       = '',
     phase2clustersToSkip = 'highPtTripletStepClusters'
@@ -271,6 +282,18 @@ trackingPhase2PU140.toModify(highPtTripletStepTrackCandidates,
 
 from RecoTracker.LST.lstOutputConverter_cfi import lstOutputConverter as _lstOutputConverter
 (trackingPhase2PU140 & trackingLST).toReplaceWith(highPtTripletStepTrackCandidates, _lstOutputConverter.clone())
+highPtTripletStepTrajectorySeedsLST = _lstOutputConverter.clone(
+    includeNonpLSTSs = cms.bool(True)
+)
+
+(trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toReplaceWith(highPtTripletStepTrackCandidates, mkFitOutputConverter_cfi.mkFitOutputConverter.clone(
+    seeds = 'highPtTripletStepTrajectorySeedsLST',
+    mkFitSeeds = 'highPtTripletStepTrackCandidatesMkFitSeeds',
+    tracks = 'highPtTripletStepTrackCandidatesMkFit',
+    candMVASel = False,
+    candCutSel = False,
+    mkFitStripHits = 'mkFitSiPhase2Hits'
+))
 
 #For FastSim phase1 tracking 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
@@ -406,6 +429,10 @@ from RecoTracker.LST.lstProducerTask_cff import *
 _HighPtTripletStepTask_LST.add(siPhase2RecHits, lstGeometryESProducer, lstInputProducer, lstProducerTask)
 (trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_LST)
 
+_HighPtTripletStepTask_LST_mkFit = _HighPtTripletStepTask_LST.copy()
+_HighPtTripletStepTask_LST_mkFit.add(highPtTripletStepTrajectorySeedsLST,highPtTripletStepTrackCandidatesMkFitSeeds, highPtTripletStepTrackCandidatesMkFit, highPtTripletStepTrackCandidatesMkFitConfig)
+(trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toReplaceWith(HighPtTripletStepTask,_HighPtTripletStepTask_LST_mkFit)
+
 from Configuration.ProcessModifiers.alpakaValidationLST_cff import alpakaValidationLST
 from HeterogeneousCore.AlpakaCore.functions import makeSerialClone
 lstInputProducerSerialSync = makeSerialClone(lstInputProducer)
@@ -426,9 +453,11 @@ _HighPtTripletStepTask_LSTSerialSync.add(siPhase2RecHits, lstInputProducerSerial
                                          lstProducerSerialSync, highPtTripletStepTrackCandidatesSerialSync,
                                          highPtTripletStepTracksSerialSync, highPtTripletStepSelectorSerialSync
 )
+_HighPtTripletStepTask_LST_mkFitSerialSync = _HighPtTripletStepTask_LSTSerialSync.copy()
+_HighPtTripletStepTask_LST_mkFitSerialSync.add(highPtTripletStepTrajectorySeedsLST,highPtTripletStepTrackCandidatesMkFitSeeds, highPtTripletStepTrackCandidatesMkFit, highPtTripletStepTrackCandidatesMkFitConfig)
 HighPtTripletStepTaskSerialSync = cms.Task()
 (trackingPhase2PU140 & alpakaValidationLST & trackingLST).toReplaceWith(HighPtTripletStepTaskSerialSync, _HighPtTripletStepTask_LSTSerialSync)
-
+(trackingPhase2PU140 & alpakaValidationLST & trackingLST & seedingLST & trackingMkFitHighPtTripletStep).toReplaceWith(HighPtTripletStepTaskSerialSync,_HighPtTripletStepTask_LST_mkFitSerialSync)
 # fast tracking mask producer 
 _HighPtTripletStepTask_fastSim = cms.Task(highPtTripletStepMasks
                                          ,highPtTripletStepTrackingRegions

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -263,7 +263,7 @@ highPtTripletStepTrackCandidatesMkFit = mkFitProducer_cfi.mkFitProducer.clone(
     clustersToSkip = cms.InputTag("")
 )
 (trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toModify(highPtTripletStepTrackCandidatesMkFitConfig,
-    config = cms.FileInPath('RecoTracker/MkFit/data/mkfit-phase2-lstStep.json'),
+    config = cms.FileInPath('RecoTracker/MkFit/data/mkfit-phase2-lstStep-offline.json'),
     minPt = cms.double(0)                                                    
 )
 
@@ -399,6 +399,8 @@ vectorHits.toModify(highPtTripletStepSelector.trackSelectors[2], minNumberLayers
 
 (trackingPhase2PU140 & seedingLST).toModify(highPtTripletStepSelector, passThroughForAll = True)
 
+(trackingPhase2PU140 & seedingLST & trackingMkFitHighPtTripletStep).toModify(highPtTripletStepSelector, passThroughForAll = False)
+
 # Final sequence
 HighPtTripletStepTask = cms.Task(highPtTripletStepClusters,
                                  highPtTripletStepSeedLayers,
@@ -430,6 +432,9 @@ _HighPtTripletStepTask_LST.add(siPhase2RecHits, lstGeometryESProducer, lstInputP
 (trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_LST)
 
 _HighPtTripletStepTask_LST_mkFit = _HighPtTripletStepTask_LST.copy()
+(trackingPhase2PU140 & seedingLST & trackingLST & trackingMkFitHighPtTripletStep).toModify(lstInputProducer,
+    ptCut = cms.double(0.1)
+)
 _HighPtTripletStepTask_LST_mkFit.add(highPtTripletStepTrajectorySeedsLST,highPtTripletStepTrackCandidatesMkFitSeeds, highPtTripletStepTrackCandidatesMkFit, highPtTripletStepTrackCandidatesMkFitConfig)
 (trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toReplaceWith(HighPtTripletStepTask,_HighPtTripletStepTask_LST_mkFit)
 

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -112,6 +112,12 @@ seedingDeepCore.toModify(_multipleSeedProducers_trackingPhase1, func=lambda x: x
 
 
 _multipleSeedProducers_trackingPhase2PU140 = {}
+from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+from Configuration.ProcessModifiers.trackingMkFitHighPtTripletStep_cff import trackingMkFitHighPtTripletStep
+(trackingPhase2PU140 & seedingLST & trackingLST & trackingMkFitHighPtTripletStep).toModify(_multipleSeedProducers_trackingPhase2PU140, func=lambda x: x.update({"highPtTripletStep": ["PixelsOnly", "PixelsWithLST"]}))
+
 _oldStyleHasSelector = set([
     "InitialStep",
     "HighPtTripletStep",
@@ -189,8 +195,6 @@ def iterationAlgos(postfix, includeSequenceName=False):
     else:
         return [_modulePrefix(i) for i in iterations]
 
-from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
-from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 def _seedOrTrackProducers(postfix, typ):
     ret = []
     iters = globals()["_iterations"+postfix]

--- a/RecoTracker/LST/python/lstProducerTask_cff.py
+++ b/RecoTracker/LST/python/lstProducerTask_cff.py
@@ -8,4 +8,22 @@ from RecoTracker.LST.lstInputProducer_cfi import lstInputProducer
 
 from RecoTracker.LSTGeometry.lstGeometryESProducer_cfi import lstGeometryESProducer
 
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+from Configuration.ProcessModifiers.trackingMkFitHighPtTripletStep_cff import trackingMkFitHighPtTripletStep
+from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+
+(trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toModify(lstProducer,
+    ptCut = cms.double(0.6),
+    nopLSDupClean = cms.bool(True),
+    tcpLSTriplets = cms.bool(True)
+)
+(trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toModify(lstModulesDevESProducer,
+    ptCut = cms.double(0.6)
+)
+
+(trackingPhase2PU140 & trackingMkFitHighPtTripletStep & seedingLST & trackingLST).toModify(lstGeometryESProducer,
+    ptCut = cms.double(0.6)
+)
+
 lstProducerTask = cms.Task(lstGeometryESProducer, lstModulesDevESProducer, lstInputProducer, lstProducer)

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -21,10 +21,10 @@ import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 import RecoTracker.IterativeTracking.iterativeTkUtils as _utils
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from Configuration.ProcessModifiers.hltClusterSplitting_cff import hltClusterSplitting
-
 ####Importing phase2 modifier
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
-
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 ### First define the stuff for the standard validation sequence
 ## Track selectors
 for _eraName, _postfix, _era in _cfg.allEras():
@@ -33,11 +33,12 @@ for _eraName, _postfix, _era in _cfg.allEras():
     if _eraName in ["trackingLowPU", "trackingPhase2PU140"]: # these don't have preSplitting
         _seedProd = []
         _trackProd = []
-
     locals()["_algos"+_postfix] = ["generalTracks"] + _cfg.iterationAlgos(_postfix) + ["duplicateMerge"]
     locals()["_seedProducersPreSplitting"+_postfix] = _seedProd
     locals()["_trackProducersPreSplitting"+_postfix] = _trackProd
     locals()["_seedProducers"+_postfix] = _cfg.seedProducers(_postfix)
+    if seedingLST._isChosen():
+        locals()["_seedProducers"+_postfix] = _cfg.seedProducers(_postfix) + ["highPtTripletStepSeedsPixelsWithLST"] + ["highPtTripletStepSeedsPixelsOnly"]
     locals()["_trackProducers"+_postfix] = _cfg.trackProducers(_postfix)
 
     if _eraName != "trackingPhase2PU140":
@@ -48,6 +49,8 @@ for _eraName, _postfix, _era in _cfg.allEras():
 _removeForFastSimSeedProducers =["initialStepSeedsPreSplitting",
                                  "jetCoreRegionalStepSeeds",
                                  "jetCoreRegionalStepSeedsBarrel","jetCoreRegionalStepSeedsEndcap",
+                                 "highPtTripletStepSeedsPixelsWithLST",
+                                 "highPtTripletStepSeedsPixelsOnly",
                                  "displacedRegionalStepSeeds",
                                  "muonSeededSeedsInOut",
                                  "muonSeededSeedsOutIn"]
@@ -140,12 +143,15 @@ def _addSelectorsByOriginalAlgoMask(modules, midfix, algoParam,modDict):
         names.append(modNameNew)
         task.add(mod)
     return (names, task)
+
 def _addSeedToTrackProducers(seedProducers,modDict):
     names = []
     task = cms.Task()
     for seed in seedProducers:
         modName = ("seedTracks"+seed).replace(":", "MI")
         if modName not in modDict:
+            if modName == "seedTracksinitialStepSeeds" and seedingLST._isChosen():
+                continue
             mod = _trajectorySeedTracks.clone(src=seed)
             modDict[modName] = mod
         else:
@@ -986,6 +992,11 @@ for _eraName, _postfix, _era in _relevantEras:
                  label = [ "seedTracksjetCoreRegionalStepSeedsBarrel","seedTracksjetCoreRegionalStepSeedsEndcap" ],
                  doResolutionPlotsForLabels = [ "seedTracksjetCoreRegionalStepSeedsBarrel","seedTracksjetCoreRegionalStepSeedsEndcap" ]
       )
+    if 'highPtTripletStep' in _cfg.iterationAlgos(_postfix) :
+        _setForEra(trackValidatorSeedingTrackingOnly, _eraName, _era,
+                 label = ["seedTrackshighPtTripletStepSeedsPixelsWithLST", "highPtTripletStepSeedsPixelsOnly"],
+                doResolutionPlotsForLabels = ["seedTrackshighPtTripletStepSeedsPixelsWithLST", "highPtTripletStepSeedsPixelsOnly"]
+)
     
 for _eraName, _postfix, _era in _relevantErasAndFastSim:
     _setForEra(trackValidatorSeedingTrackingOnly, _eraName, _era, label = locals()["_seedSelectors"+_postfix])

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -1489,6 +1489,8 @@ _iterations = [
                      "mkFitSiPixelHits",
                      "mkFitEventOfHits"]),
     Iteration("highPtTripletStep",
+              seeding=["highPtTripletStepSeedsPixelsWithLST",
+                       "highPtTripletStepSeedsPixelsOnly"],
               selection=["highPtTripletStepClassifier1",
                          "highPtTripletStepClassifier2",
                          "highPtTripletStepClassifier3",


### PR DESCRIPTION
#### PR description:

This PR enables via the procModifiers combination `trackingMkFitHighPtTripletStep & seedingLST & trackingLST` the usage of mkFit track building after LST seeds and legacy pixel triplets and quadruplets, in a baseline HLT-like configuration. 
It depends on the external PR [RecoTracker-MkFit/pull/20](https://github.com/cms-data/RecoTracker-MkFit/pull/20).

#### PR validation:

Configuration tested for CMS week contributions June 2026 https://indico.cern.ch/event/1690107/#93-study-on-offline-track-reco and https://indico.cern.ch/event/1690107/#93-study-on-offline-track-reco

This PR can be tested, e.g., with workflows 36034.711,36034.712,36034.713 that are using the corresponding procModifiers in an offline tracking-only workflow.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No

@mmasciov @slava77