### PR TITLE
Disable MC-based TSG tests in 20_1_X

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
+++ b/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
@@ -385,7 +385,25 @@ run_ngt_scouting() {
 ############################
 
 main() {
+    # create fake input files
+    touch Phase2Timing_resources.json
+    touch Phase2Timing_resources_NGT.json
+    touch Phase2Timing_resources_OnCPU.json
 
+    mkdir -p logs.Phase2_L1P2GT_HLT
+    mkdir -p logs.Phase2_L1P2GT_HLT_OnCPU
+    mkdir -p logs.NGTScouting_L1P2GT_HLT
+    
+    touch logs.Phase2_L1P2GT_HLT/cpu_memory.csv       
+    touch logs.Phase2_L1P2GT_HLT/gpu_memory.csv       
+    touch logs.Phase2_L1P2GT_HLT/gpu_usage.csv        
+    touch logs.Phase2_L1P2GT_HLT_OnCPU/cpu_memory.csv 
+    touch logs.NGTScouting_L1P2GT_HLT/cpu_memory.csv  
+    touch logs.NGTScouting_L1P2GT_HLT/gpu_memory.csv  
+    touch logs.NGTScouting_L1P2GT_HLT/gpu_usage.csv   
+    
+    exit 0 # temporarily until we have samples in CMSSW_20_0_X
+    
     fetch_files
     build_input_file_string
 

--- a/HLTrigger/Configuration/test/examLogs.csh
+++ b/HLTrigger/Configuration/test/examLogs.csh
@@ -2,7 +2,8 @@
 
 set base = RelVal_HLT
 
-foreach gtag ( MC DATA )
+#foreach gtag ( MC DATA ) do not run MC based tests in CMSSW_20_0_X
+foreach gtag ( DATA )
 
   echo
   echo $gtag

--- a/HLTrigger/Configuration/test/runAll.csh
+++ b/HLTrigger/Configuration/test/runAll.csh
@@ -20,8 +20,8 @@ echo "Running selected cfg files from:"
 pwd
 
 rm -f                           ./runOne.log 
-time ./runOne.csh DATA    $1 >& ./runOne.log &
-time ./runOne.csh MC      $1
+time ./runOne.csh DATA    $1   # >& ./runOne.log
+# & time ./runOne.csh MC  $1   # do not run MC based test in CMSSW_20_0_X
 
   set N = 0
   cp -f ./runOne.log ./runOne.tmp  


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/51143

#### PR description:

Title says it all, since when master moved to CMSSW_2_0_X several MC-based TSG integration tests have been failing due to the change in the data-format layout introduced in https://github.com/cms-sw/cmssw/pull/50968.
The goal of this PR is to disable the failing tests [log1](https://cmssdt.cern.ch/SDT/jenkins-artifacts/HLT-Validation/CMSSW_20_0_X_2026-06-07-2300/el8_amd64_gcc13/HLT_Integration_GRun_MC.log), [log2](https://cmssdt.cern.ch/SDT/jenkins-artifacts/hlt-p2-timing/CMSSW_20_0_X_2026-06-07-2300/el8_amd64_gcc13/run.log).

#### PR validation:

To be tested by the bot.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A