### PR TITLE
`pp_on_PbPb_run3`: replace vertex collections in `ALCARECOTkAlHLTTracks` and `ALCARECOTkAlHLTTracksZMuMu` with PbPb equivalents

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_Output_cff.py
@@ -24,6 +24,23 @@ OutALCARECOTkAlHLTTracksZMuMu_noDrop = cms.PSet(
     )
 )
 
+# PbPb customization
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+
+_pp_on_PbPb_run3_outputCommands = OutALCARECOTkAlHLTTracksZMuMu_noDrop.outputCommands.copy()
+_pp_on_PbPb_run3_outputCommands.remove('keep *_hltPixelVertices_*_*')
+_pp_on_PbPb_run3_outputCommands.remove('keep *_hltVerticesPFFilter_*_*')
+
+_pp_on_PbPb_run3_outputCommands.extend([
+    'keep *_hltPixelVerticesPPOnAA_*_*',
+    'keep *_hltVerticesPFFilterPPOnAA_*_*',
+])
+
+pp_on_PbPb_run3.toModify(
+    OutALCARECOTkAlHLTTracksZMuMu_noDrop,
+    outputCommands=_pp_on_PbPb_run3_outputCommands
+)
+
 # in Phase2, remove the SiStrip clusters and keep the OT ones instead
 _phase2_common_removedCommands = OutALCARECOTkAlHLTTracksZMuMu_noDrop.outputCommands.copy()
 _phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlHLTTracksZMuMu_*_*')

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_Output_cff.py
@@ -20,6 +20,22 @@ OutALCARECOTkAlHLTTracks_noDrop = cms.PSet(
     )
 )
 
+# PbPb customization
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+
+_pp_on_PbPb_run3_outputCommands = OutALCARECOTkAlHLTTracks_noDrop.outputCommands.copy()
+_pp_on_PbPb_run3_outputCommands.remove('keep *_hltPixelVertices_*_*')
+_pp_on_PbPb_run3_outputCommands.remove('keep *_hltVerticesPFFilter_*_*')
+_pp_on_PbPb_run3_outputCommands.extend([
+    'keep *_hltPixelVerticesPPOnAA_*_*',
+    'keep *_hltVerticesPFFilterPPOnAA_*_*',
+])
+
+pp_on_PbPb_run3.toModify(
+    OutALCARECOTkAlHLTTracks_noDrop,
+    outputCommands=_pp_on_PbPb_run3_outputCommands
+)
+
 # in Phase2, remove the SiStrip clusters and keep the OT ones instead
 _phase2_common_removedCommands = OutALCARECOTkAlHLTTracks_noDrop.outputCommands.copy()
 _phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlHLTTracks_*_*')


### PR DESCRIPTION
#### PR description:

The goal of this PR is to follow-up to PR https://github.com/cms-sw/cmssw/pull/51031 by changing the names of the vertices collections that are saved in `ALCARECOTkAlHLTTracks` and `ALCARECOTkAlHLTTracksZMuMu` when the `pp_on_PbPb_run3` modifier is active.

#### PR validation:

Tested with the following script:

```bash
#!/bin/bash -ex                                                                                                                                                                                             

cmsDriver.py ReAlCaHLT \
  -s ALCA:TkAlHLTTracks+TkAlHLTTracksZMuMu \
  --conditions 161X_dataRun3_Express_v1 \
  --scenario pp \
  --data \
  --era Run3_pp_on_PbPb_2026 \
  --datatier ALCARECO \
  --eventcontent ALCARECO \
  --process RECO \
  --processName ReAlCa \
  --filein file:/eos/cms/store/express/HIRun2026A/HIHLTMonitor/FEVTHLTALL/Express-v1/000/404/735/00000/e0bfb4e1-767f-45e0-a410-86a5a24eabed.root \
  -n -1 \
  --no_exec
                                                                                                                                                                                                 
cmsRun ReAlCaHLT_ALCA.py >& ReAlCaHLT_ALCA.log
```

The obtained event content is:

```
File TkAlHLTTracks.root Events 1049
Branch Name | Average Uncompressed Size (Bytes/Event) | Average Compressed Size (Bytes/Event) 
recoTrackExtras_ALCARECOTkAlHLTTracks__ReAlCa. 14907.7 11633.3
SiStripClusteredmNewDetSetVector_ALCARECOTkAlHLTTracks__ReAlCa. 26775.6 10827
recoTracks_ALCARECOTkAlHLTTracks__ReAlCa. 20669.9 6687.13
TrackingRecHitsOwned_ALCARECOTkAlHLTTracks__ReAlCa. 67155.6 6317.21
SiPixelClusteredmNewDetSetVector_ALCARECOTkAlHLTTracks__ReAlCa. 8762.37 3283.99
recoVertexs_hltVerticesPFFilterPPOnAA__HLT. 4100.11 333.971
recoVertexs_hltPixelVerticesPPOnAA__HLT. 1893.69 149.446
recoBeamSpot_hltOnlineBeamSpot__HLT. 323.043 40.5529
EventAuxiliary 116.292 35.5844
edmTriggerResults_TriggerResults__HLT. 872.69 20.3251
EventProductProvenance 164.67 12.0238
edmTriggerResults_TriggerResults__ReAlCa. 81.8684 7.62822
edmTriggerResults_TriggerResults__RECO. 87.8151 7.62631
DCSRecord_onlineMetaDataDigis__RECO. 106.697 7.09724
L1AcceptBunchCrossings_scalersRawToDigi__RECO. 21.0439 6.65777
EventSelections 75.2545 6.11439
BranchListIndexes 21.3184 2.9142
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will be backported to CMSSW_16_1_X for 2026 PbPb operations.
