### PR TITLE
Warning fix: Make EcalContainer invalid-id dummy thread-local

### DIFF
--- a/DataFormats/EcalDetId/interface/EcalContainer.h
+++ b/DataFormats/EcalDetId/interface/EcalContainer.h
@@ -37,7 +37,7 @@ public:
 
   inline Item& operator[](uint32_t rawId) {
     checkAndResize();
-    static Item dummy;
+    thread_local Item dummy{};
     DetId id(rawId);
     if (!isValidId(id))
       return dummy;


### PR DESCRIPTION
#### PR description:

This PR fixes static analyzer thread-safety warnings in EcalContainer by changing the invalid-id fallback dummy object from static to thread_local.
```
In file included from src/CondFormats/EcalObjects/interface/EcalCondObjectContainer.h:6:
  [src/DataFormats/EcalDetId/interface/EcalContainer.h:40](https://github.com/cms-sw/cmssw/blob/CMSSW_20_0_X_2026-06-07-2300/DataFormats/EcalDetId/interface/EcalContainer.h#L40):5: warning: function 'EcalContainer::operator[]' accesses or modifies non-const static local variable 'dummy'.
  [cms.FunctionChecker]
   40 |     static Item dummy;
      |     ^
[src/DataFormats/EcalDetId/interface/EcalContainer.h:40](https://github.com/cms-sw/cmssw/blob/CMSSW_20_0_X_2026-06-07-2300/DataFormats/EcalDetId/interface/EcalContainer.h#L40):5: warning: Non-const variable 'Item dummy' is static local or static member data and might be thread-unsafe [threadsafety.StaticLocal]
    40 |     static Item dummy;
      |     ^~~~~~~~~~~~~~~~~
```