### PR TITLE
[WarningFix]CommonTools/CandUtils: remove unnecessary const_cast

### DIFF
--- a/CommonTools/CandUtils/src/AddFourMomenta.cc
+++ b/CommonTools/CandUtils/src/AddFourMomenta.cc
@@ -7,8 +7,9 @@ void AddFourMomenta::set(Candidate &c) const {
   Candidate::LorentzVector p4(0, 0, 0, 0);
   Candidate::Charge charge = 0;
   size_t n = c.numberOfDaughters();
+  const Candidate& constC = c;
   for (size_t i = 0; i < n; ++i) {
-    const Candidate *d = c.daughter(i);
+    const Candidate *d = constC.daughter(i);
     p4 += d->p4();
     charge += d->charge();
   }

--- a/CommonTools/CandUtils/src/AddFourMomenta.cc
+++ b/CommonTools/CandUtils/src/AddFourMomenta.cc
@@ -8,7 +8,7 @@ void AddFourMomenta::set(Candidate &c) const {
   Candidate::Charge charge = 0;
   size_t n = c.numberOfDaughters();
   for (size_t i = 0; i < n; ++i) {
-    const Candidate *d = (const_cast<const Candidate &>(c)).daughter(i);
+    const Candidate *d = c.daughter(i);
     p4 += d->p4();
     charge += d->charge();
   }

--- a/CommonTools/CandUtils/src/AddFourMomenta.cc
+++ b/CommonTools/CandUtils/src/AddFourMomenta.cc
@@ -7,7 +7,7 @@ void AddFourMomenta::set(Candidate &c) const {
   Candidate::LorentzVector p4(0, 0, 0, 0);
   Candidate::Charge charge = 0;
   size_t n = c.numberOfDaughters();
-  const Candidate& constC = c;
+  const Candidate &constC = c;
   for (size_t i = 0; i < n; ++i) {
     const Candidate *d = constC.daughter(i);
     p4 += d->p4();


### PR DESCRIPTION
#### PR description:


This PR fixes a clang thread-safety analyzer warning in `CommonTools/CandUtils`.

Warning:

```text
src/CommonTools/CandUtils/src/AddFourMomenta.cc:11:27:
warning: const_cast was used, this may result in thread-unsafe code
[threadsafety.ConstCast]

const Candidate *d = (const_cast<const Candidate &>(c)).daughter(i);
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The fix replaces:

```cpp
const Candidate *d = (const_cast<const Candidate &>(c)).daughter(i);
```

with:

```cpp
+  const Candidate &constC = c;
   for (size_t i = 0; i < n; ++i) {
-    const Candidate *d = (const_cast<const Candidate &>(c)).daughter(i);
+    const Candidate *d = constC.daughter(i);

```
## Alternative
Another possible approach would be to keep the original code unchanged and suppress the analyzer warning using:

```cpp
[[clang::suppress]]
const Candidate *d = (const_cast<const Candidate &>(c)).daughter(i);
```
Since the warning appears to be a false positive and the original code may have intentionally selected the const overload, I would appreciate feedback from the **reconstruction** experts on whether they prefer the explicit const-reference solution in this PR or an analyzer suppression.
