### PR TITLE
[bugfix] Must use streamer when writing CSCSegment to RNTuple

### DIFF
--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -18,7 +18,8 @@
 
   <class name="std::vector<io_v1::CSCSegment>"/>
   <class name="std::vector<io_v1::CSCSegment*>"/>
-  <class name="io_v1::CSCSegment" ClassVersion="3">
+  <!-- CSCSegment holds a std::vector of CSCSegment<RNTuple> cannott handle the recursion -->
+  <class name="io_v1::CSCSegment" ClassVersion="3" rntupleStreamerMode="true">
    <version ClassVersion="3" checksum="1566595635"/>
   </class>
   <class name="edm::OwnVector<io_v1::CSCSegment,edm::ClonePolicy<io_v1::CSCSegment> >"  rntupleStreamerMode="true" />


### PR DESCRIPTION

#### PR description:

The CSCSegment can recursively hold instances of itself which RNTuple cannot handle without using streamers.

#### PR validation:

Code compiles. Doing `runTheMatrix.py --use_rntuple -l 1.0` succeeded

resolves https://github.com/cms-sw/framework-team/issues/2277