### PR TITLE
[backport 20_0] Must use streamer when writing CSCSegment to RNTuple

### DIFF
--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -18,7 +18,8 @@
 
   <class name="std::vector<io_v1::CSCSegment>"/>
   <class name="std::vector<io_v1::CSCSegment*>"/>
-  <class name="io_v1::CSCSegment" ClassVersion="3">
+  <!-- CSCSegment holds a std::vector of CSCSegment<RNTuple> cannott handle the recursion -->
+  <class name="io_v1::CSCSegment" ClassVersion="3" rntupleStreamerMode="true">
    <version ClassVersion="3" checksum="1566595635"/>
   </class>
   <class name="edm::OwnVector<io_v1::CSCSegment,edm::ClonePolicy<io_v1::CSCSegment> >"  rntupleStreamerMode="true" />


### PR DESCRIPTION
#### PR description:

The CSCSegment can recursively hold instances of itself which RNTuple cannot handle without using streamers.

#### PR validation:

master branch version compiles and runs an RNTuple workflow fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #51156 
