### PR TITLE
Fix bug in P2 Tracker cluster EDAnalyzer

### DIFF
--- a/RecoLocalTracker/Phase2TrackerRecHits/test/RecHitsValidationTest_cfg.py
+++ b/RecoLocalTracker/Phase2TrackerRecHits/test/RecHitsValidationTest_cfg.py
@@ -7,7 +7,7 @@ process = cms.Process('cluTest')
 # Import all the necessary files
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
-process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4D110Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
@@ -30,18 +30,20 @@ process.TFileService = cms.Service('TFileService',
     fileName = cms.string('file:rechits_validation.root')
 )
 
-process.load('RecoLocalTracker.SiPhase2Clusterizer.phase2TrackerClusterizer_cfi')
-process.load('RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEESProducer_cfi')
-#process.load('RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEGeometricESProducer_cfi')
+#process.load('RecoLocalTracker.SiPhase2Clusterizer.phase2TrackerClusterizer_cfi')
+#process.load('RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEESProducer_cfi')
+process.load('RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEGeometricESProducer_cfi')
 process.load('RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi')
 #process.siPhase2RecHits.Phase2StripCPE = cms.ESInputTag("phase2StripCPEESProducer", "Phase2StripCPE")
 #process.siPhase2RecHits.Phase2StripCPE = cms.ESInputTag("phase2StripCPEGeometricESProducer", "Phase2StripCPEGeometric")
 
+process.siPhase2RecHits.src = "hltSiPhase2Clusters"
 
 # Analyzer
 process.analysis = cms.EDAnalyzer('Phase2TrackerRecHitsValidation',
     src = cms.InputTag("siPhase2RecHits"),
-    clusters = cms.InputTag("siPhase2Clusters"),
+    #clusters = cms.InputTag("siPhase2Clusters"),
+    clusters = cms.InputTag("hltSiPhase2Clusters"),
     links = cms.InputTag("simSiPixelDigis", "Tracker"),
     simhitsbarrel = cms.InputTag("g4SimHits", "TrackerHitsPixelBarrelLowTof"),
     simhitsendcap = cms.InputTag("g4SimHits", "TrackerHitsPixelEndcapLowTof"),

--- a/RecoLocalTracker/SiPhase2Clusterizer/test/ClustersValidation.cc
+++ b/RecoLocalTracker/SiPhase2Clusterizer/test/ClustersValidation.cc
@@ -239,7 +239,7 @@ void Phase2TrackerClusterizerValidation::analyze(const edm::Event& event, const 
       const PSimHit* simhit = 0;  // bad naming to avoid changing code below. This is the closest simhit in x
       float minx = 10000;
       for (unsigned int simhitidx = 0; simhitidx < 2; ++simhitidx) {  // loop over both barrel and endcap hits
-        for (auto simhitIt : *simHitsRaw[simhitidx]) {
+        for (const auto& simhitIt : *simHitsRaw[simhitidx]) {
           if (rawid == simhitIt.detUnitId()) {
             //std::cout << "=== " << rawid << " " << &simhitIt << " " << simhitIt.trackId() << " " << simhitIt.localPosition().x() << " " << simhitIt.localPosition().y() << std::endl;
             auto it = std::lower_bound(clusterSimTrackIds.begin(), clusterSimTrackIds.end(), simhitIt.trackId());

--- a/RecoLocalTracker/SiPhase2Clusterizer/test/ClustersValidationTest_cfg.py
+++ b/RecoLocalTracker/SiPhase2Clusterizer/test/ClustersValidationTest_cfg.py
@@ -8,8 +8,8 @@ process = cms.Process('cluTest')
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 #process.load('Configuration.EventContent.EventContent_cff')
-process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
-process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4D110Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.GlobalTag import GlobalTag
@@ -42,7 +42,8 @@ process.TFileService = cms.Service('TFileService',
 
 # Analyzer
 process.analysis = cms.EDAnalyzer('Phase2TrackerClusterizerValidation',
-    src = cms.InputTag("siPhase2Clusters"),
+    #src = cms.InputTag("siPhase2Clusters"),
+    src = cms.InputTag("hltSiPhase2Clusters"),
     links = cms.InputTag("simSiPixelDigis", "Tracker"),
     simhitsbarrel = cms.InputTag("g4SimHits", "TrackerHitsPixelBarrelLowTof"),
     simhitsendcap = cms.InputTag("g4SimHits", "TrackerHitsPixelEndcapLowTof"),


### PR DESCRIPTION
#### PR description:

Fixed bug inside an EDAnalyzer used to study P2 Tracker offline clusters (Phase2TrackerCluster1D EDProduct).

The line https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPhase2Clusterizer/test/ClustersValidation.cc#L249 was getting a pointer to a temporary variable, which later went out of scope. As a result, most of the histograms were junk.

The PR also makes trivial updates to cfg.py files to latest CMSSW.

Since this changes only an EDAnalyzer, it doesn't affect performance.

