### PR TITLE
[132x] backport of #49704 Pointer safety protection in XrdAdaptor error reporting

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -125,7 +125,7 @@ namespace {
   std::unique_ptr<std::string> getQueryTransport(const XrdCl::URL &url, uint16_t query) {
     XrdCl::AnyObject result;
     XrdCl::DefaultEnv::GetPostMaster()->QueryTransport(url, query, result);
-    std::string *tmp;
+    std::string *tmp{nullptr};
     result.Get(tmp);
     return std::unique_ptr<std::string>(tmp);
   }
@@ -143,7 +143,7 @@ namespace {
         std::string type_resource = "endpoint";
         std::string authentication;
         // Organize redirection info
-        if (!auth_method->empty()) {
+        if (auth_method && !auth_method->empty()) {
           authentication = *auth_method;
         } else {
           authentication = "no auth";
@@ -151,11 +151,12 @@ namespace {
         if (host.loadBalancer == 1) {
           type_resource = "load balancer";
         };
+        const std::string noresp{"(null)"};
         li.format("{}. || {} / {} / {} / {} / {} / {} ||\n",
                   idx_redirection,
-                  *hostname_method,
-                  *stack_ip_method,
-                  *ip_method,
+                  hostname_method ? *hostname_method : noresp,
+                  stack_ip_method ? *stack_ip_method : noresp,
+                  ip_method ? *ip_method : noresp,
                   host.url.GetPort(),
                   authentication,
                   type_resource);


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/49704 to 132x per https://github.com/cms-sw/cmssw/issues/51138#issuecomment-4649942480 and https://github.com/cms-sw/framework-team/issues/2273