### PR TITLE
Fix separate option in HGCAL validation

### DIFF
--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -3,6 +3,7 @@
 import os
 import argparse
 import datetime
+import ROOT
 
 from Validation.RecoTrack.plotting.validation import SeparateValidation, SimpleValidation, SimpleSample
 from Validation.HGCalValidation.HGCalValidator_cff import hgcalValidator
@@ -49,6 +50,19 @@ def _write_top_index(output_dir, entries):
     with open(index_path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines))
 
+from Validation.RecoTrack.plotting import html
+
+from dataclasses import dataclass
+@dataclass
+class ValidLabels:    
+    hitCalLabel: str = 'hitCalibration'
+    hitValLabel: str = 'hitValidation'
+    layerClustersLabel: str = 'layerClusters'
+    trackstersLabel: str = 'tracksters'
+    trackstersWithEdgesLabel: str = 'trackstersWithEdges'
+    candidatesLabel: str = 'candidates'
+    simLabel: str = 'simulation'
+    allLabel: str = 'all'
 
 def main(opts):
 
@@ -64,13 +78,6 @@ def main(opts):
         extendedFlag = True
     if opts.verbose:
         plotting.verbose = True
-
-    collections = [c.strip() for c in opts.collection.split(",")]
-    for coll in collections:
-        if coll not in collection_choices:
-            raise ValueError(f"Unknown collection '{coll}'. Valid options: {collection_choices}.")
-
-    import ROOT
 
     def _discover_subdirs(dqm_file, dqm_base):
         """Return direct subdirectory names under dqm_base in the DQM ROOT file."""
@@ -240,17 +247,17 @@ def main(opts):
             val.doPlots(ticlcand, plotterDrawArgs=drawArgs)
 
         plotDict = {
-            hitCalLabel: [plot_hitCal],
-            hitValLabel: [plot_hitVal],
-            layerClustersLabel: [plot_LC],
-            trackstersLabel: [plot_Tst],
-            trackstersWithEdgesLabel: [plot_TstEdges],
-            simLabel: [plot_SC, plot_CP],
-            candidatesLabel: [plotCand],
+            ValidLabels.hitCalLabel: [plot_hitCal],
+            ValidLabels.hitValLabel: [plot_hitVal],
+            ValidLabels.layerClustersLabel: [plot_LC],
+            ValidLabels.trackstersLabel: [plot_Tst],
+            ValidLabels.trackstersWithEdgesLabel: [plot_TstEdges],
+            ValidLabels.simLabel: [plot_SC, plot_CP],
+            ValidLabels.candidatesLabel: [plotCand],
         }
 
-        if allLabel not in collections:
-            for coll in collections:
+        if allLabel not in opts.collections:
+            for coll in opts.collections:
                 for task in plotDict[coll]:
                     task()
         else:
@@ -273,6 +280,10 @@ def main(opts):
 
 
 if __name__ == "__main__":
+    collection_choices = [ValidLabels.allLabel, ValidLabels.hitCalLabel, ValidLabels.hitValLabel, ValidLabels.layerClustersLabel,
+                          ValidLabels.trackstersLabel, ValidLabels.trackstersWithEdgesLabel, ValidLabels.candidatesLabel,
+                          ValidLabels.simLabel]
+    
     parser = argparse.ArgumentParser(description="Create set of HGCal validation plots from one or more DQM files.")
     parser.add_argument("files", metavar="file", type=str, nargs="+",
                         default="DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root",
@@ -293,7 +304,7 @@ if __name__ == "__main__":
                         help="Sample name for HTML page generation (default: CMSSW version)")
     parser.add_argument("--html-validation-name", type=str, default=["TICL Validation", ""], nargs="+",
                         help="Validation name for HTML page generation (enters to <title> element) (default 'TICL Validation')")
-    parser.add_argument("--collection", default=trackstersLabel, type=str,
+    parser.add_argument("--collections", default=trackstersLabel, nargs='+', type=str,
                         help="Choose output plots collections among possible choices: {collection_choices}")
     parser.add_argument("--extended", action="store_true", default=False,
                         help="Include extended set of plots (e.g. bunch of distributions; default off)")
@@ -311,5 +322,9 @@ if __name__ == "__main__":
             parser.error("DQM file %s does not exist" % f)
     if len(opts.files) == 0:
         parser.error("No DQM files specified")
-    else:
-        main(opts)
+
+    for coll in opts.collections:
+        if coll not in collection_choices:
+            raise ValueError(f"Unknown collection '{coll}'. Valid options: {collection_choices}.")
+        
+    main(opts)

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -5,7 +5,7 @@ import argparse
 import datetime
 import ROOT
 
-from Validation.RecoTrack.plotting.validation import SeparateValidation, SimpleValidation, SimpleSample
+from Validation.RecoTrack.plotting.validation import SimpleValidation, SimpleSample
 from Validation.HGCalValidation.HGCalValidator_cff import hgcalValidator
 import Validation.RecoTrack.plotting.plotting as plotting
 
@@ -133,11 +133,8 @@ def main(opts):
             hgcalPlots.hgcVal_dqm = dqm_base
 
         sample = SimpleSample(prefix, opts.html_sample, filenames)
-
-        val = SimpleValidation([sample], out_dir, nProc=opts.jobs)
-        if opts.separate:
-            val = SeparateValidation([sample], out_dir)
-
+        val = SimpleValidation([sample], out_dir, nProc=opts.jobs, separate=opts.separate)
+        
         htmlReport = val.createHtmlReport(
             validationName=f"{opts.html_validation_name[0]} ({prefix})"
         )

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -134,10 +134,11 @@ def main(opts):
 
         sample = SimpleSample(prefix, opts.html_sample, filenames)
         val = SimpleValidation([sample], out_dir, nProc=opts.jobs, separate=opts.separate)
-        
-        htmlReport = val.createHtmlReport(
-            validationName=f"{opts.html_validation_name[0]} ({prefix})"
-        )
+
+        if not opts.no_html and not opts.separate:
+            htmlReport = val.createHtmlReport(
+                validationName=f"{opts.html_validation_name[0]} ({prefix})"
+            )
 
         # Discover which collections exist under this base in the DQM file
         discovered_subdirs = _discover_subdirs(opts.files[0], dqm_base)
@@ -264,7 +265,7 @@ def main(opts):
                 for task in plotDict[label]:
                     task()
 
-        if opts.no_html:
+        if opts.no_html or opts.separate:
             print("Plots created into directory '%s'." % out_dir)
         else:
             htmlReport.write()

--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -840,6 +840,31 @@ class HtmlReport:
             f.write("\n")
         f.close()
 
+
+    @staticmethod
+    def writeTopIndex(output_dir, title, entries):
+        """Create a single top-level index.html linking to per-flavour reports."""
+        index_path = os.path.join(output_dir, "index.html")
+        lines = []
+        lines.append("<!doctype html>")
+        lines.append("<html lang='en'>")
+        lines.append("<head>")
+        lines.append("  <meta charset='utf-8'>")
+        lines.append("  <meta name='viewport' content='width=device-width, initial-scale=1'>")
+        lines.append("  <title>" + title + "</title>")
+        lines.append("  <style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;max-width:900px;margin:2rem auto;padding:0 1rem}ul{line-height:1.8}</style>")
+        lines.append("</head>")
+        lines.append("<body>")
+        lines.append("  <h1>" + title + "</h1>")
+        lines.append("  <ul>")
+        for label, rel_index in entries:
+            lines.append(f"    <li><a href='{rel_index}'>{label}</a></li>")
+        lines.append("  </ul>")
+        lines.append("</body>")
+        lines.append("</html>")
+        with open(index_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+
 class HtmlReportDummy:
     def __init__(self):
         pass

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -2399,13 +2399,12 @@ class PlotGroup(object):
         ly2def = 0.95
 
         ret = []
-
         for plot in self._plots:
             if plot.isEmpty():
                 continue
-
-            canvas = _createCanvas(self._name+"Single", width, height)
-            canvasRatio = _createCanvas(self._name+"SingleRatio", width, int(height*self._ratioFactor))
+            
+            canvas = _createCanvas(self._name+'Single', width, height)
+            canvasRatio = _createCanvas(self._name+'SingleRatio', width, int(height*self._ratioFactor))
 
             # from TDRStyle
             for c in [canvas, canvasRatio]:
@@ -2415,16 +2414,16 @@ class PlotGroup(object):
                 c.SetRightMargin(0.05)
 
             ratioForThisPlot = plot.isRatio(ratio)
-            c = canvas
             if ratioForThisPlot:
                 c = canvasRatio
                 c.cd()
                 self._modifyPadForRatio(c)
+            else:
+                c = canvas
 
             # Draw plot to canvas
             c.cd()
             plot.draw(c, ratioForThisPlot, self._ratioFactor, 1)
-
             if plot._legend:
                 # Setup legend
                 lx1 = lx1def
@@ -2442,12 +2441,14 @@ class PlotGroup(object):
                     lx2 += plot._legendDw
                 if plot._legendDh is not None:
                     ly1 -= plot._legendDh
-
                 c.cd()
                 legend = self._createLegend(plot, legendLabels, lx1, ly1, lx2, ly2, textSize=0.03,
                                             denomUncertainty=(ratioForThisPlot and plot.drawRatioUncertainty))
-
             ret.extend(self._save(c, saveFormat, prefix=prefix, postfix="/"+plot.getName(), single=True, directory=directory))
+
+            del canvas
+            del canvasRatio
+            
         return ret
 
     def _modifyPadForRatio(self, pad):
@@ -2471,7 +2472,7 @@ class PlotGroup(object):
         return l
 
     def _save(self, canvas, saveFormat, prefix=None, postfix=None, single=False, directory=""):
-        # Save the canvas to file and clear
+        """Save the canvas to file and clear."""
         name = self._name
         if not os.path.exists(directory+'/'+name):
             os.makedirs(directory+'/'+name, exist_ok=True)

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -2397,12 +2397,12 @@ class PlotGroup(object):
         lx2def = 0.95
         ly1def = 0.85
         ly2def = 0.95
-
+        
         ret = []
         for plot in self._plots:
             if plot.isEmpty():
                 continue
-            
+
             canvas = _createCanvas(self._name+'Single', width, height)
             canvasRatio = _createCanvas(self._name+'SingleRatio', width, int(height*self._ratioFactor))
 

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import urllib.request
 import multiprocessing
+import shutil
 
 import ROOT
 ROOT.gROOT.SetBatch(True)
@@ -1240,6 +1241,7 @@ class SimpleValidation:
         self._htmlReport = html.HtmlReportDummy()
 
     def createHtmlReport(self, validationName=""):
+        assert not self._separate
         if hasattr(self._htmlReport, "write"):
             raise Exception("HTML report object already created. There is probably some logic error in the calling code.")
         self._htmlReport = html.HtmlReport(validationName, self._newdir)
@@ -1251,7 +1253,8 @@ class SimpleValidation:
         for sample in self._samples:
             self._subdirprefix = sample.label()
             self._labels = sample.legendLabels()
-            self._htmlReport.beginSample(sample)
+            if not self._separate:
+                self._htmlReport.beginSample(sample)
 
             self._openFiles = []
             for f in sample.files():
@@ -1297,7 +1300,7 @@ class SimpleValidation:
                 result = {}
                 self._doPlots(plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, result)
                 proc.append((plotterFolder, dqmSubFolder, None))
-                if len(result) > 0:
+                if len(result) > 0 and not self._separate:
                     self._htmlReport.addPlots(plotterFolder, dqmSubFolder, result)
             else:
                 while len(active_proc) >= plottingProcess:
@@ -1313,7 +1316,7 @@ class SimpleValidation:
         if not single_threaded:
             for i in range(iProc):
                 proc[i][2].join()
-                if len(return_dict[i]) > 0:
+                if len(return_dict[i]) > 0 and not self._separate:
                     self._htmlReport.addPlots(proc[i][0], proc[i][1], return_dict[i])
         
     def _doPlots(self, plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, return_dict):
@@ -1322,8 +1325,9 @@ class SimpleValidation:
         if len(fileList) == 0:
             print("No object found in %s" % plotterFolder.getName())
 
-        for tableCreator in plotterFolder.getTableCreators():
-            self._htmlReport.addTable(tableCreator.create(self._openFiles, self._labels, dqmSubFolder))
+        if not self._separate:
+            for tableCreator in plotterFolder.getTableCreators():
+                self._htmlReport.addTable(tableCreator.create(self._openFiles, self._labels, dqmSubFolder))
 
         dups = _findDuplicates(fileList)
         if len(dups) > 0:
@@ -1331,23 +1335,32 @@ class SimpleValidation:
             print("Typically this is a naming problem in the plotter configuration")
             sys.exit(1)
 
-        downloadables = ['index.php', 'res/jquery-ui.js', 'res/jquery.js', 'res/style.css', 'res/style.js', 'res/theme.css']        
         if self._separate:
+            downloadables = ['index.php',]
+            newdir_parent = newdir[:newdir.rfind("/")]
             linkList = []
             for f in fileList:
                 ridx = f.rfind("/")
-                if f[:ridx] not in linkList and str(f[:ridx]) != str(newdir):
-                    linkList.append(f[:ridx])
-                               
-            for link in linkList:
-                os.makedirs(f'{link}/res', exist_ok=True)
-                for d in downloadables:
-                    if not os.path.exists(f'{link}/{d}'):
-                        urllib.request.urlretrieve(f'https://raw.githubusercontent.com/rovere/php-plots/master/{d}', f'{link}/{d}')
-            
+                subdir = f[:ridx]
+                while subdir != newdir_parent and subdir not in linkList:
+                    linkList.append(subdir)
+                    subdir = subdir[:subdir.rfind("/")]
+             
+            for d in downloadables:
+                downloaded_path = None
+                for link in linkList:
+                    dest = f'{link}/{d}'
+                    if not os.path.exists(dest):
+                        if downloaded_path is None:
+                            downloaded_path = dest
+                            urllib.request.urlretrieve(f'https://gitlab.cern.ch/cms-analysis/general/php-plots/-/raw/master/{d}', downloaded_path)
+                        else:
+                            shutil.copy2(downloaded_path, dest)
+                            
             return_dict[iProc] = list(map(lambda n: n.replace(newdir, newsubdir), linkList))
 
         else:
+            downloadables = ['index.php', 'res/jquery-ui.js', 'res/jquery.js', 'res/style.css', 'res/style.js', 'res/theme.css']        
             os.makedirs(f'{newdir}/res', exist_ok=True)
             for d in downloadables:
                 if not os.path.exists(f'{newdir}/{d}'):

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -1187,37 +1187,51 @@ def _findDuplicates(lst):
 
 def _doPlotsForPlotter(self, plotter, sample, limitSubFoldersOnlyTo=None):
     plottingProcess = self._nProc
-    if plottingProcess<=0: plottingProcess = os.cpu_count()
+    if plottingProcess <= 0: plottingProcess = os.cpu_count()
+
+    single_threaded = (plottingProcess == 1)
+
     plotterInstance = plotter.readDirs(*self._openFiles)
-    manager = multiprocessing.Manager()
-    return_dict = manager.dict()
+
+    if not single_threaded:
+        manager = multiprocessing.Manager()
+        return_dict = manager.dict()
+
     proc = []
-    iProc = 0
     active_proc = []
+    iProc = 0
 
     for plotterFolder, dqmSubFolder in plotterInstance.iterFolders(limitSubFoldersOnlyTo=limitSubFoldersOnlyTo):
         if sample is not None and not _processPlotsForSample(plotterFolder, sample):
             continue
-        newsubdir = self._subdirprefix+plotterFolder.getSelectionName(dqmSubFolder)
+        newsubdir = self._subdirprefix + plotterFolder.getSelectionName(dqmSubFolder)
         newdir = os.path.join(self._newdir, newsubdir)
-        if not os.path.exists(newdir):
-            os.makedirs(newdir, exist_ok=True)
-
+        os.makedirs(newdir, exist_ok=True)
         plotterFolder.create(self._openFiles, self._labels, dqmSubFolder)
-        while len(active_proc)>=plottingProcess:
-          time.sleep(0.1)
-          active_proc = [p for p in active_proc if p.is_alive()]
-        p = multiprocessing.Process(target=self._doPlots, args=(plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, return_dict))
-        proc.append((plotterFolder, dqmSubFolder, p))
-        active_proc.append(p)
-        p.start()
+
+        if single_threaded: # Run directly in the main process for easier debugging
+            result = {}
+            self._doPlots(plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, result)
+            proc.append((plotterFolder, dqmSubFolder, None))
+            if len(result) > 0:
+                self._htmlReport.addPlots(plotterFolder, dqmSubFolder, result)
+        else:
+            while len(active_proc) >= plottingProcess:
+                time.sleep(0.1)
+                active_proc = [p for p in active_proc if p.is_alive()]
+            p = multiprocessing.Process(target=self._doPlots, args=(plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, return_dict))
+            proc.append((plotterFolder, dqmSubFolder, p))
+            active_proc.append(p)
+            p.start()
+
         iProc += 1
 
-    for i in range(iProc):
-        proc[i][2].join()
-        if len(return_dict[i]) > 0:
-            self._htmlReport.addPlots(proc[i][0], proc[i][1], return_dict[i])
-
+    if not single_threaded:
+        for i in range(iProc):
+            proc[i][2].join()
+            if len(return_dict[i]) > 0:
+                self._htmlReport.addPlots(proc[i][0], proc[i][1], return_dict[i])
+                
 class SimpleSample:
     def __init__(self, label, name, fileLegends, pileup=True, customPileupLabel=""):
         self._label = label
@@ -1325,7 +1339,7 @@ class SimpleValidation:
                 if f[:ridx] not in linkList and str(f[:ridx]) != str(newdir):
                     linkList.append(f[:ridx])
                                
-            for link in linkList :
+            for link in linkList:
                 os.makedirs(f'{link}/res', exist_ok=True)
                 for d in downloadables:
                     if not os.path.exists(f'{link}/{d}'):

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -1262,10 +1262,11 @@ class SimpleSample:
         return True
 
 class SimpleValidation:
-    def __init__(self, samples, newdir, nProc=0):
+    def __init__(self, samples, newdir, nProc=0, separate=False):
         self._samples = samples
         self._newdir = newdir
         self._nProc = nProc
+        self._separate = separate
         if not os.path.exists(newdir):
             os.makedirs(newdir)
 
@@ -1294,7 +1295,7 @@ class SimpleValidation:
                     self._openFiles.append(None)
 
             for plotter in plotters:
-                _doPlotsForPlotter(self, plotter, sample, **kwargs)
+                _doPlotsForPlotter(self, plotter, sample, **kwargs) # which in turn launches _doPlots()
 
             for tf in self._openFiles:
                 if tf is not None:
@@ -1316,89 +1317,28 @@ class SimpleValidation:
             print("Typically this is a naming problem in the plotter configuration")
             sys.exit(1)
 
-        if self._plotterDrawArgs.get("separate", False):
-            if not os.path.exists("%s/res"%newdir):
-              os.makedirs("%s/res"%newdir)
-            downloadables = ["index.php", "res/jquery-ui.js", "res/jquery.js", "res/style.css", "res/style.js", "res/theme.css"]
+        downloadables = ['index.php', 'res/jquery-ui.js', 'res/jquery.js', 'res/style.css', 'res/style.js', 'res/theme.css']        
+        if self._separate:
+            linkList = []
+            for f in fileList:
+                ridx = f.rfind("/")
+                if f[:ridx] not in linkList and str(f[:ridx]) != str(newdir):
+                    linkList.append(f[:ridx])
+                               
+            for link in linkList :
+                os.makedirs(f'{link}/res', exist_ok=True)
+                for d in downloadables:
+                    if not os.path.exists(f'{link}/{d}'):
+                        urllib.request.urlretrieve(f'https://raw.githubusercontent.com/rovere/php-plots/master/{d}', f'{link}/{d}')
+            
+            return_dict[iProc] = list(map(lambda n: n.replace(newdir, newsubdir), linkList))
+
+        else:
+            os.makedirs(f'{newdir}/res', exist_ok=True)
             for d in downloadables:
-                if not os.path.exists("%s/%s" % (newdir,d)):
-                    urllib.request.urlretrieve("https://raw.githubusercontent.com/musella/php-plots/master/%s"%d, "%s/%s"%(newdir,d))
+                if not os.path.exists(f'{newdir}/{d}'):
+                    urllib.request.urlretrieve(f'https://raw.githubusercontent.com/musella/php-plots/master/{d}', f'{newdir}/{d}')
 
-        print("Created plots in %s" % newdir)
-        return_dict[iProc] = list(map(lambda n: n.replace(newdir, newsubdir), fileList))
+            return_dict[iProc] = list(map(lambda n: n.replace(newdir, newsubdir), fileList))
 
-class SeparateValidation:
-    #Similar to the SimpleValidation
-    #To be used only if `--separate` option is on
-    def __init__(self, samples, newdir, nProc=0):
-        self._samples = samples
-        self._newdir = newdir
-        self._nProc = nProc
-        if not os.path.exists(newdir):
-            os.makedirs(newdir)
-
-        self._htmlReport = html.HtmlReportDummy()
-
-    def createHtmlReport(self, validationName=""):
-        if hasattr(self._htmlReport, "write"):
-            raise Exception("HTML report object already created. There is probably some logic error in the calling code.")
-        self._htmlReport = html.HtmlReport(validationName, self._newdir)
-        return self._htmlReport
-
-    def doPlots(self, plotters, plotterDrawArgs={}, **kwargs):
-        self._plotterDrawArgs = plotterDrawArgs
-
-        for sample in self._samples:
-            self._subdirprefix = sample.label()
-            self._labels = sample.legendLabels()
-            self._htmlReport.beginSample(sample)
-
-            self._openFiles = []
-            for f in sample.files():
-                if os.path.exists(f):
-                    self._openFiles.append(ROOT.TFile.Open(f))
-                else:
-                    print("File %s not found (from sample %s), ignoring it" % (f, sample.name()))
-                    self._openFiles.append(None)
-
-            for plotter in plotters:
-                _doPlotsForPlotter(self, plotter, sample, **kwargs)
-
-            for tf in self._openFiles:
-                if tf is not None:
-                    tf.Close()
-            self._openFiles = []
-
-    def _doPlots(self, plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, return_dict):
-        fileList = plotterFolder.draw(directory=newdir, **self._plotterDrawArgs)
-
-        # check if plots are produced
-        if len(fileList) == 0:
-            print("No object found in %s" % plotterFolder.getName())
-
-        # check if there are duplicated plot
-        dups = _findDuplicates(fileList)
-        if len(dups) > 0:
-            print("Plotter produced multiple files with names", ", ".join(dups))
-            print("Typically this is a naming problem in the plotter configuration")
-            sys.exit(1)
-
-        linkList = []
-        for f in fileList:
-            if f[:f.rfind("/")] not in linkList :
-                if str(f[:f.rfind("/")]) != str(newdir) :
-                    linkList.append(f[:f.rfind("/")])
-
-        for tableCreator in plotterFolder.getTableCreators():
-            self._htmlReport.addTable(tableCreator.create(self._openFiles, self._labels, dqmSubFolder))
-
-        for link in linkList :
-            if not os.path.exists("%s/res"%link):
-              os.makedirs("%s/res"%link)
-            downloadables = ["index.php", "res/jquery-ui.js", "res/jquery.js", "res/style.css", "res/style.js", "res/theme.css"]
-            for d in downloadables:
-                if not os.path.exists("%s/%s" % (link,d)):
-                    urllib.request.urlretrieve("https://raw.githubusercontent.com/rovere/php-plots/master/%s"%d, "%s/%s"%(link,d))
-
-        print("Created separated plots in %s" % newdir)
-        return_dict[iProc] = list(map(lambda n: n.replace(newdir, newsubdir), linkList))
+        print('Created ' + ('separate' if self._separate else '') + f' plots in {newdir}.')

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -1184,53 +1184,6 @@ def _findDuplicates(lst):
         else:
             found.add(x)
     return list(found2)
-
-def _doPlotsForPlotter(self, plotter, sample, limitSubFoldersOnlyTo=None):
-    plottingProcess = self._nProc
-    if plottingProcess <= 0: plottingProcess = os.cpu_count()
-
-    single_threaded = (plottingProcess == 1)
-
-    plotterInstance = plotter.readDirs(*self._openFiles)
-
-    if not single_threaded:
-        manager = multiprocessing.Manager()
-        return_dict = manager.dict()
-
-    proc = []
-    active_proc = []
-    iProc = 0
-
-    for plotterFolder, dqmSubFolder in plotterInstance.iterFolders(limitSubFoldersOnlyTo=limitSubFoldersOnlyTo):
-        if sample is not None and not _processPlotsForSample(plotterFolder, sample):
-            continue
-        newsubdir = self._subdirprefix + plotterFolder.getSelectionName(dqmSubFolder)
-        newdir = os.path.join(self._newdir, newsubdir)
-        os.makedirs(newdir, exist_ok=True)
-        plotterFolder.create(self._openFiles, self._labels, dqmSubFolder)
-
-        if single_threaded: # Run directly in the main process for easier debugging
-            result = {}
-            self._doPlots(plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, result)
-            proc.append((plotterFolder, dqmSubFolder, None))
-            if len(result) > 0:
-                self._htmlReport.addPlots(plotterFolder, dqmSubFolder, result)
-        else:
-            while len(active_proc) >= plottingProcess:
-                time.sleep(0.1)
-                active_proc = [p for p in active_proc if p.is_alive()]
-            p = multiprocessing.Process(target=self._doPlots, args=(plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, return_dict))
-            proc.append((plotterFolder, dqmSubFolder, p))
-            active_proc.append(p)
-            p.start()
-
-        iProc += 1
-
-    if not single_threaded:
-        for i in range(iProc):
-            proc[i][2].join()
-            if len(return_dict[i]) > 0:
-                self._htmlReport.addPlots(proc[i][0], proc[i][1], return_dict[i])
                 
 class SimpleSample:
     def __init__(self, label, name, fileLegends, pileup=True, customPileupLabel=""):
@@ -1309,13 +1262,60 @@ class SimpleValidation:
                     self._openFiles.append(None)
 
             for plotter in plotters:
-                _doPlotsForPlotter(self, plotter, sample, **kwargs) # which in turn launches _doPlots()
+                self._doPlotsForPlotter(plotter, sample, **kwargs) # which in turn launches _doPlots()
 
             for tf in self._openFiles:
                 if tf is not None:
                     tf.Close()
             self._openFiles = []
 
+    def _doPlotsForPlotter(self, plotter, sample, limitSubFoldersOnlyTo=None):
+        plottingProcess = self._nProc
+        if plottingProcess <= 0: plottingProcess = os.cpu_count()
+     
+        single_threaded = (plottingProcess == 1)
+     
+        plotterInstance = plotter.readDirs(*self._openFiles)
+     
+        if not single_threaded:
+            manager = multiprocessing.Manager()
+            return_dict = manager.dict()
+     
+        proc = []
+        active_proc = []
+        iProc = 0
+     
+        for plotterFolder, dqmSubFolder in plotterInstance.iterFolders(limitSubFoldersOnlyTo=limitSubFoldersOnlyTo):
+            if sample is not None and not _processPlotsForSample(plotterFolder, sample):
+                continue
+            newsubdir = self._subdirprefix + plotterFolder.getSelectionName(dqmSubFolder)
+            newdir = os.path.join(self._newdir, newsubdir)
+            os.makedirs(newdir, exist_ok=True)
+            plotterFolder.create(self._openFiles, self._labels, dqmSubFolder)
+     
+            if single_threaded: # Run directly in the main process for easier debugging
+                result = {}
+                self._doPlots(plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, result)
+                proc.append((plotterFolder, dqmSubFolder, None))
+                if len(result) > 0:
+                    self._htmlReport.addPlots(plotterFolder, dqmSubFolder, result)
+            else:
+                while len(active_proc) >= plottingProcess:
+                    time.sleep(0.1)
+                    active_proc = [p for p in active_proc if p.is_alive()]
+                p = multiprocessing.Process(target=self._doPlots, args=(plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, return_dict))
+                proc.append((plotterFolder, dqmSubFolder, p))
+                active_proc.append(p)
+                p.start()
+     
+            iProc += 1
+     
+        if not single_threaded:
+            for i in range(iProc):
+                proc[i][2].join()
+                if len(return_dict[i]) > 0:
+                    self._htmlReport.addPlots(proc[i][0], proc[i][1], return_dict[i])
+        
     def _doPlots(self, plotterFolder, dqmSubFolder, newsubdir, newdir, iProc, return_dict):
         fileList = plotterFolder.draw(directory=newdir, **self._plotterDrawArgs)
 


### PR DESCRIPTION
The `--separate` option of the `makeHGCalValidationPlots.py` script was crashing. I fixed the "bug" (AFAICT the usage of multiple `TCanvas` with the same name) and took the chance to remove some duplicated code and apply other minor improvements.
The `--separate` version, on top of separating plots to independent canvases, now produces the PNG plots directly into the folder structure, without the `html` wrapping (so partially mimicking what the `--no_html` option is doing). 
The default options were left unchanged.


Tested with and without the `--separate` option:

```
python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root -o /eos/user/b/bfontana/www/SinglePhotonTESTS/HGCALValidation/ --collections tracksters

python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root -o /eos/user/b/bfontana/www/SinglePhotonTESTS/HGCALValidation/ --collections tracksters --separate
```