### PR TITLE
[10_6_X] Add dictionaries for types that were causing header parsing

### DIFF
--- a/DataFormats/CSCDigi/src/classes_def.xml
+++ b/DataFormats/CSCDigi/src/classes_def.xml
@@ -103,6 +103,9 @@
    <class name="std::pair<CSCDetId,std::vector<CSCALCTStatusDigi> >"/>
    <class name="std::pair<CSCDetId,std::vector<CSCCLCTPreTrigger> >"/>
 
+   <class name="std::__pair_base<CSCDetId,std::vector<CSCWireDigi> >"/> <!-- this was visible in header parsing -->
+   <class name="std::__pair_base<CSCDetId,std::vector<CSCStripDigi> >"/> <!-- this was visible in header parsing -->
+   <class name="std::__pair_base<CSCDetId,std::vector<CSCComparatorDigi> >"/> <!-- this was visible in header parsing -->
 
    <class name="MuonDigiCollection<CSCDetId,CSCWireDigi>"/>
    <class name="MuonDigiCollection<CSCDetId,CSCRPCDigi>"/>

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -5,6 +5,7 @@
  <version ClassVersion="11" checksum="1310457745"/>
 </class>
 <class name="std::vector<GEMDigi>"/>
+<class name="std::pair<GEMDetId,std::vector<GEMDigi> >"/>
 <class name="std::map<GEMDetId,std::vector<GEMDigi> >"/>
 <class name="MuonDigiCollection<GEMDetId,GEMDigi>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMDigi> >" splitLevel="0"/> 
@@ -14,6 +15,7 @@
  <version ClassVersion="12" checksum="3838591655"/>
 </class>
 <class name="std::vector<GEMPadDigi>"/>
+<class name="std::pair<GEMDetId,std::vector<GEMPadDigi> >"/>
 <class name="std::map<GEMDetId,std::vector<GEMPadDigi> >"/>
 <class name="MuonDigiCollection<GEMDetId,GEMPadDigi>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMPadDigi> >" splitLevel="0"/> 
@@ -22,6 +24,7 @@
  <version ClassVersion="10" checksum="2569340006"/>
 </class>
 <class name="std::vector<GEMPadDigiCluster>"/>
+<class name="std::pair<GEMDetId,std::vector<GEMPadDigiCluster> >"/>
 <class name="std::map<GEMDetId,std::vector<GEMPadDigiCluster> >"/>
 <class name="MuonDigiCollection<GEMDetId,GEMPadDigiCluster>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMPadDigiCluster> >" splitLevel="0"/> 

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -56,12 +56,14 @@
  <class name="edm::ProductRegistry::Transients" ClassVersion="0"/>
  <class name="std::map<edm::BranchKey,edm::BranchDescription>"/>
  <class name="std::pair<edm::BranchKey,edm::BranchDescription>"/>
+ <class name="std::__pair_base<edm::BranchKey,edm::BranchDescription>"/> <!-- this was visible in header parsing -->
  <class name="edm::BranchKey" ClassVersion="10">
   <version ClassVersion="10" checksum="3014148246"/>
  </class>
  <class name="std::set<edm::BranchID>"/>
  <class name="std::map<edm::BranchID, std::set<edm::BranchID> >"/>
  <class name="std::pair<edm::BranchID, std::set<edm::BranchID> >"/>
+ <class name="std::__pair_base<edm::BranchID, std::set<edm::BranchID> >"/> <!-- this was visible in header parsing -->
  <class name="std::vector<edm::BranchID>"/>
  <class name="std::vector<edm::ProductID>"/>
  <class name="edm::VecArray<edm::ProductID, 2>"/>
@@ -156,6 +158,7 @@
  <class name="std::vector<std::vector<edm::ParameterSetID > >"/>
  <class name="std::map<edm::ParameterSetID,edm::ParameterSetBlob>"/>
  <class name="std::pair<edm::ParameterSetID,edm::ParameterSetBlob>"/>
+ <class name="std::__pair_base<edm::ParameterSetID,edm::ParameterSetBlob>"/> <!-- this was visible in header parsing -->
  <class name="edm::ProcessConfigurationID"/>
  <class name="std::vector<edm::ProcessConfigurationID>"/>
  <class name="edm::ParentageID"/>

--- a/DataFormats/RPCDigi/src/classes_def.xml
+++ b/DataFormats/RPCDigi/src/classes_def.xml
@@ -5,6 +5,7 @@
 <class name="std::vector<RPCDigi>"/>
 <class name="std::map<RPCDetId,std::vector<RPCDigi> >"/>
 <class name="std::pair<RPCDetId,std::vector<RPCDigi> >"/>
+<class name="std::__pair_base<RPCDetId,std::vector<RPCDigi> >"/> <!-- this was visible in header parsing -->
 <class name="MuonDigiCollection<RPCDetId,RPCDigi>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<RPCDetId,RPCDigi>>" splitLevel="0"/> 
 

--- a/SimDataFormats/DigiSimLinks/src/classes_def.xml
+++ b/SimDataFormats/DigiSimLinks/src/classes_def.xml
@@ -3,6 +3,8 @@
  <version ClassVersion="10" checksum="1414990067"/>
 </class>
 <class name="std::vector<DTDigiSimLink>"/>
+<class name="std::__pair_base<DTLayerId,std::vector<DTDigiSimLink> >"/> <!-- this was visible in header parsing -->
+<class name="std::pair<DTLayerId,std::vector<DTDigiSimLink> >"/>
 <class name="std::map<DTLayerId,std::vector<DTDigiSimLink> >"/>
 <class name="MuonDigiCollection<DTLayerId,DTDigiSimLink>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<DTLayerId,DTDigiSimLink>>" splitLevel="0"/> 


### PR DESCRIPTION
#### PR description:

The stack traces in https://github.com/cms-sw/cmssw/issues/51060 indicated ROOT doing header parsing during the problematic section of the application. I ran the test job (with a ROOT debug build) through gdb and put a breakpoint for `ExecAutoParse()`, and added dictionaries for types shown in the stack traces of the breakpoint.

Resolves https://github.com/cms-sw/framework-team/issues/2280

#### PR validation:

Code compiles. The test job from https://github.com/cms-sw/cmssw/issues/51060 did not show hits in a breakpoint for `ExecAutoParse()` for data format types.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, and not to be forward-ported either. There is enough ROOT version specific behavior here that this is a targeted workaround for 10_6_X.