### PR TITLE
Mark Hcal ESSources as concurrent capable

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.h
@@ -64,6 +64,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
+  bool isConcurrentFinder() const override { return true; }
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
                       const edm::IOVSyncValue&,
                       edm::ValidityInterval&) override;

--- a/CalibCalorimetry/HcalPlugins/src/HcalTimeSlewEP.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTimeSlewEP.h
@@ -27,6 +27,7 @@ public:
   ReturnType produce(const HcalTimeSlewRecord&);
 
 protected:
+  bool isConcurrentFinder() const override { return true; }
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
                       const edm::IOVSyncValue&,
                       edm::ValidityInterval&) override;


### PR DESCRIPTION
#### PR description:

Modified HcalHardcodeCalibrations and HcalTimeSlewEP as they are used in production configurations.
These are trivially concurrent capable as they only deliver 1 IOV.

#### PR validation:

Code compiles.

associated with https://github.com/cms-sw/cmssw/issues/51171
resolves https://github.com/cms-sw/framework-team/issues/2283