### PR TITLE
Mark PPSPixelTopologyESSource as concurrent capable

### DIFF
--- a/CalibPPS/ESProducers/plugins/PPSPixelTopologyESSource.cc
+++ b/CalibPPS/ESProducers/plugins/PPSPixelTopologyESSource.cc
@@ -65,6 +65,7 @@ protected:
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
                       const edm::IOVSyncValue&,
                       edm::ValidityInterval&) override;
+  bool isConcurrentFinder() const override { return true; }
 };
 
 //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
#### PR description:

This is already trivally concurrent as it only allows 1 IOV.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2284

associated with https://github.com/cms-sw/cmssw/issues/51171