### PR TITLE
Mark SiPhase2BadStripConfigurableFakeESSource as concurrent

### DIFF
--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2BadStripConfigurableFakeESSource.cc
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2BadStripConfigurableFakeESSource.cc
@@ -55,6 +55,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
+  bool isConcurrentFinder() const override { return true; }
   std::map<unsigned short, unsigned short> clusterizeBadChannels(
       const std::vector<Phase2TrackerDigi::PackedDigiType>& maskedChannels);
 


### PR DESCRIPTION

#### PR description:

This is trivially concurrent as an ESSource as it only provides 1 IOV.

#### PR validation:

resolves https://github.com/cms-sw/framework-team/issues/2286
