### PR TITLE
Mark XMLIdealGeometryESSource as concurrent capable

### DIFF
--- a/GeometryReaders/XMLIdealGeometryESSource/interface/XMLIdealGeometryESSource.h
+++ b/GeometryReaders/XMLIdealGeometryESSource/interface/XMLIdealGeometryESSource.h
@@ -24,6 +24,7 @@ public:
   std::unique_ptr<DDCompactView> produce();
 
 protected:
+  bool isConcurrentFinder() const override { return true; }
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
                       const edm::IOVSyncValue &,
                       edm::ValidityInterval &) override;


### PR DESCRIPTION

#### PR description:

The IOV part of the ESSource is trivially concurrent capable as it provides only 1 IOV. The producer part is not concurrent capable because of XML parsing. That part is protected via a shared resource specification.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2287