### PR TITLE
Minor adjustments for `ngtScouting`-modified ph2 HLT menus

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltAk4CaloJetsForTrk_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltAk4CaloJetsForTrk_cfi.py
@@ -31,3 +31,7 @@ hltAk4CaloJetsForTrk = cms.EDProducer("FastjetJetProducer",
     useDeterministicSeed = cms.bool(True),
     voronoiRfact = cms.double(-0.9)
 )
+
+from Configuration.ProcessModifiers.ngtScouting_cff import ngtScouting
+ngtScouting.toModify(hltAk4CaloJetsForTrk,
+                     srcPVs = "hltPhase2PixelVertices")

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
@@ -40,7 +40,26 @@ hltPhase2LegacyTracking.toReplaceWith(hltGeneralTracks, _hltGeneralTracksLegacy)
 
 from Configuration.ProcessModifiers.ngtScouting_cff import ngtScouting
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-from ..modules.hltPhase2PixelTracks_cfi import *
+
+_hltGeneralTracksNGTScouting = cms.EDProducer("RecoTrackSelector",
+                                              src = cms.InputTag('hltPhase2PixelTracks'),
+                                              copyExtras = cms.untracked.bool(True),
+                                              minHit = cms.int32(0),
+                                              minLayer = cms.int32(0),
+                                              min3DLayer = cms.int32(0),
+                                              minPixelHit = cms.int32(0),
+                                              ptMin = cms.double(0.0),
+                                              maxChi2 = cms.double(10000.0),
+                                              tip = cms.double(1e9),
+                                              lip = cms.double(1e9),
+                                              minRapidity = cms.double(-9.9),
+                                              maxRapidity = cms.double(9.9),
+                                              minPhi = cms.double(-3.2),
+                                              maxPhi = cms.double(3.2),
+                                              quality = cms.vstring(),
+                                              algorithm = cms.vstring(),
+                                              )
+
 _hltGeneralTracksNGTScoutingLST = hltGeneralTracks.clone(
     MinPT = cms.double(0.9),
     TrackProducers = ["hltPhase2PixelTracks", "hltInitialStepTracksT4T5TCLST"],
@@ -50,6 +69,5 @@ _hltGeneralTracksNGTScoutingLST = hltGeneralTracks.clone(
     setsToMerge = {0: dict(pQual=True, tLists=[0,1])}
 )
 
-(ngtScouting & ~trackingLST).toReplaceWith(hltGeneralTracks, hltPhase2PixelTracks)
-
+(ngtScouting & ~trackingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksNGTScouting)
 (ngtScouting & trackingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksNGTScoutingLST)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepPVSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepPVSequence_cfi.py
@@ -4,4 +4,9 @@ from ..modules.hltAk4CaloJetsForTrk_cfi import *
 from ..modules.hltFirstStepPrimaryVerticesUnsorted_cfi import *
 from ..modules.hltPhase2TowerMakerForAll_cfi import *
 
-HLTInitialStepPVSequence = cms.Sequence(hltFirstStepPrimaryVerticesUnsorted+hltPhase2TowerMakerForAll+hltAk4CaloJetsForTrk)
+HLTInitialStepPVSequence = cms.Sequence(hltFirstStepPrimaryVerticesUnsorted+
+                                        hltPhase2TowerMakerForAll+
+                                        hltAk4CaloJetsForTrk)
+
+from Configuration.ProcessModifiers.ngtScouting_cff import ngtScouting
+ngtScouting.toReplaceWith(HLTInitialStepPVSequence,HLTInitialStepPVSequence.copyAndExclude([hltFirstStepPrimaryVerticesUnsorted]))


### PR DESCRIPTION
#### PR description:

This PR packages two minor optimizations related to the usage of the `ngtScouting` modifier in the phase-2 menu.

----
**1.)** The first (commit 13695f81eb36051a723712637ad9bc1653291710) is about the fact that when the `ngtScouting` modifier is active, the module `hltFirstStepPrimaryVerticesUnsorted` is currently being fed with a not existing collection

https://github.com/cms-sw/cmssw/blob/dddbe6b78c7be5aded1be8dfdca57403c6f75aee/HLTrigger/Configuration/python/HLT_75e33/modules/hltFirstStepPrimaryVerticesUnsorted_cfi.py#L28

and `hltInitialStepTracks` is not executed when the `ngtScouting` modifier is active.

https://github.com/cms-sw/cmssw/blob/dddbe6b78c7be5aded1be8dfdca57403c6f75aee/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py#L96-L105

https://github.com/cms-sw/cmssw/blob/dddbe6b78c7be5aded1be8dfdca57403c6f75aee/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTrackingSequence_cfi.py#L44

this basically makes `PrimaryVertexProducer` to fall-back to the Beam Spot

https://github.com/cms-sw/cmssw/blob/dddbe6b78c7be5aded1be8dfdca57403c6f75aee/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc#L197-L198

as the collection `hltPhase2PixelVertices` exists also in the `ngtScouting`-gated scenarios we can do better and use that instead.
The overall effect is tiny and the physics validation is available at [this link](https://marcomusich.web.cern.ch/NGT/3.1.1/TestSkipFirstPVIter/ValidationWRTReconstructableSim/hltOfflinePrimaryVertices/).

----
**2.)** The second (commit a706cc1cf783fa6ef288021bc0db48fdfbc23f58) pertains to the in flight replacement of the hlt general tracks with pixel tracks using `ngtScouting`. This avoids a second (useless) call to the `TrackCollectionFilterCloner` by replacing it with a pass-through of the pixel tracks, profiting of the existing `RecoTrackSelector` module.
This will allow to further reduce the timing cost when https://github.com/cms-sw/cmssw/pull/51042 is merged (at that point the `hltGeneralTracks` for the `ngtScouting` modifier would become a more expensive `PixelTrackProducerFromSoAAlpaka`).

#### PR validation:

I've run successfully with this branch: `runTheMatrix.py -l ph2_hlt`.
Additionally I've benchmarked the new resulting configuration and found no substantial difference:

<img width="1525" height="669" alt="image" src="https://github.com/user-attachments/assets/07b75331-ea86-4ff3-9a11-0d68913d9ef6" />

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A