### PR TITLE
complete disabling of MC based TSG integration tests in IBs

### DIFF
--- a/HLTrigger/Configuration/test/runAll.csh
+++ b/HLTrigger/Configuration/test/runAll.csh
@@ -23,24 +23,24 @@ rm -f                           ./runOne.log
 time ./runOne.csh DATA    $1   # >& ./runOne.log
 # & time ./runOne.csh MC  $1   # do not run MC based test in CMSSW_20_0_X
 
-  set N = 0
-  cp -f ./runOne.log ./runOne.tmp  
-  grep -q Finished   ./runOne.tmp
-  set F = $?
+#   set N = 0
+#   cp -f ./runOne.log ./runOne.tmp  
+#   grep -q Finished   ./runOne.tmp
+#   set F = $?
 
-while ( $F )
-  awk "{if (NR>$N) {print}}"  ./runOne.tmp
-  set N = `cat ./runOne.tmp | wc -l`
-  sleep 13
-  cp -f ./runOne.log ./runOne.tmp  
-  grep -q Finished   ./runOne.tmp
-  set F = $?
-end
+# while ( $F )
+#   awk "{if (NR>$N) {print}}"  ./runOne.tmp
+#   set N = `cat ./runOne.tmp | wc -l`
+#   sleep 13
+#   cp -f ./runOne.log ./runOne.tmp  
+#   grep -q Finished   ./runOne.tmp
+#   set F = $?
+# end
 
-wait
+# wait
 
-  awk "{if (NR>$N) {print}}"  ./runOne.log
-  rm -f ./runOne.{log,tmp}
+#   awk "{if (NR>$N) {print}}"  ./runOne.log
+#   rm -f ./runOne.{log,tmp}
 
 echo
 echo "Resulting log files:"


### PR DESCRIPTION
#### PR description:

Address https://github.com/cms-sw/cmssw/pull/51151#discussion_r3386399468 which was missed in https://github.com/cms-sw/cmssw/pull/51141

#### PR validation:

```bash
#!/bin/bash -ex
cd $CMSSW_BASE/src/HLTrigger/Configuration/test/
./runAll.csh IB | tee -a runIB.log 
./examLogs.csh | tee -a examLogs.out
```

runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
