### PR TITLE
Include reduced ProcessingHistory ID to `DiagStreamerFile` checks

### DIFF
--- a/IOPool/Streamer/bin/BuildFile.xml
+++ b/IOPool/Streamer/bin/BuildFile.xml
@@ -1,5 +1,6 @@
 <environment>
   <bin file="DiagStreamerFile.cpp">
+    <use name="DataFormats/Streamer"/>
     <use name="FWCore/Utilities"/>
     <use name="IOPool/Streamer"/>
   </bin>

--- a/IOPool/Streamer/bin/DiagStreamerFile.cpp
+++ b/IOPool/Streamer/bin/DiagStreamerFile.cpp
@@ -21,8 +21,10 @@
 
 */
 
+#include "DataFormats/Streamer/interface/StreamedProducts.h"
 #include "FWCore/Utilities/interface/Adler32Calculator.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "IOPool/Streamer/interface/ClassFiller.h"
 #include "IOPool/Streamer/interface/DumpTools.h"
 #include "IOPool/Streamer/interface/EventMessage.h"
 #include "IOPool/Streamer/interface/InitMessage.h"
@@ -31,20 +33,28 @@
 #include "IOPool/Streamer/interface/StreamerOutputFile.h"
 #include "IOPool/Streamer/interface/uncompress.h"
 
+#include "TBufferFile.h"
+
 #include <iostream>
 #include <map>
 #include <memory>
+#include <optional>
 
 using namespace edm::streamer;
 
 namespace {
   bool compares_bad(EventMsgView const* eview1, EventMsgView const* eview2);
-  bool uncompressBuffer(unsigned char const* inputBuffer,
-                        unsigned int inputSize,
-                        std::vector<unsigned char>& outputBuffer,
-                        unsigned int expectedFullSize);
+
+  // Upon success returns the number of uncompressed bytes (the outputBuffer.size() can be larger)
+  // Upon failure returns nullopt
+  std::optional<unsigned int> uncompressBuffer(unsigned char const* inputBuffer,
+                                               unsigned int inputSize,
+                                               std::vector<unsigned char>& outputBuffer,
+                                               unsigned int expectedFullSize);
   bool test_chksum(EventMsgView const* eview);
-  bool test_uncompress(EventMsgView const* eview, std::vector<unsigned char>& dest);
+  std::optional<unsigned int> test_uncompress(EventMsgView const* eview, std::vector<unsigned char>& dest);
+  std::unique_ptr<edm::SendEvent> getSendEvent(std::vector<unsigned char>& uncompressed, unsigned int uncompressedSize);
+  bool test_ProcessHistoryID(edm::ProcessHistoryID const& id1, edm::SendEvent const& sendEvent2);
   void readfile(std::string filename, std::string outfile);
   void help();
 }  // namespace
@@ -81,6 +91,7 @@ namespace {
     uint32 num_badevents(0);
     uint32 num_baduncompress(0);
     uint32 num_badchksum(0);
+    uint32 num_badhistoryid(0);
     uint32 num_goodevents(0);
     uint32 num_duplevents(0);
     std::vector<unsigned char> compress_buffer(7000000);
@@ -108,7 +119,8 @@ namespace {
       std::cout << "\n\n-------------EVENT Messages-------------------" << std::endl;
 
       bool first_event(true);
-      std::unique_ptr<EventMsgView> firstEvtView(nullptr);
+      std::unique_ptr<EventMsgView> firstEvtView;
+      std::optional<edm::ProcessHistoryID> firstProcessHistoryID;
       std::vector<unsigned char> savebuf(0);
       EventMsgView const* eview(nullptr);
       seenEventMap.clear();
@@ -132,8 +144,6 @@ namespace {
                     << " seen " << seenEventMap[eview->event()] << " times" << std::endl;
         }
         if (first_event) {
-          std::cout << "----------dumping first EVENT-----------" << std::endl;
-          dumpEventView(eview);
           first_event = false;
           unsigned char* src = (unsigned char*)eview->startAddress();
           unsigned int srcSize = eview->size();
@@ -145,23 +155,31 @@ namespace {
             std::cout << "checksum error for count " << num_events << " event number " << eview->event()
                       << " from host name " << eview->hostName() << std::endl;
             ++num_badchksum;
-            std::cout << "----------dumping bad checksum EVENT-----------" << std::endl;
             dumpEventView(eview);
             good_event = false;
           }
-          if (!test_uncompress(eview, compress_buffer)) {
+          auto uncompressedSize = test_uncompress(eview, compress_buffer);
+          if (!uncompressedSize.has_value()) {
             std::cout << "uncompress error for count " << num_events << " event number " << firstEvtView->event()
                       << std::endl;
             ++num_baduncompress;
-            std::cout << "----------dumping bad uncompress EVENT-----------" << std::endl;
             dumpEventView(firstEvtView.get());
             good_event = false;
           }
+          std::unique_ptr<edm::SendEvent> firstSendEvent;
+          if (good_event) {
+            firstSendEvent = getSendEvent(compress_buffer, *uncompressedSize);
+            if (firstSendEvent) {
+              auto history = firstSendEvent->processHistory();
+              history.reduce();
+              firstProcessHistoryID = history.id();
+            }
+          }
+          std::cout << "----------dumping first EVENT-----------" << std::endl;
+          dumpEventView(eview, firstSendEvent.get());
         } else {
           if (compares_bad(firstEvtView.get(), eview)) {
-            std::cout << "Bad event at count " << num_events << " dumping event " << std::endl
-                      << "----------dumping bad EVENT-----------" << std::endl;
-            dumpEventView(eview);
+            std::cout << "Bad event at count " << num_events << " dumping event " << std::endl;
             ++num_badevents;
             good_event = false;
           }
@@ -169,16 +187,27 @@ namespace {
             std::cout << "checksum error for count " << num_events << " event number " << eview->event()
                       << " from host name " << eview->hostName() << std::endl;
             ++num_badchksum;
-            std::cout << "----------dumping bad checksum EVENT-----------" << std::endl;
-            dumpEventView(eview);
             good_event = false;
           }
-          if (!test_uncompress(eview, compress_buffer)) {
+          auto uncompressedSize = test_uncompress(eview, compress_buffer);
+          if (!uncompressedSize.has_value()) {
             std::cout << "uncompress error for count " << num_events << " event number " << eview->event() << std::endl;
             ++num_baduncompress;
-            std::cout << "----------dumping bad uncompress EVENT-----------" << std::endl;
-            dumpEventView(eview);
             good_event = false;
+          }
+          std::unique_ptr<edm::SendEvent> sendEvent;
+          if (uncompressedSize.has_value()) {
+            sendEvent = getSendEvent(compress_buffer, *uncompressedSize);
+            if (firstProcessHistoryID.has_value() and not test_ProcessHistoryID(*firstProcessHistoryID, *sendEvent)) {
+              std::cout << "ProcessHistoryID error for count " << num_events << " event number "
+                        << firstEvtView->event() << std::endl;
+              ++num_badhistoryid;
+              good_event = false;
+            }
+          }
+          if (not good_event) {
+            std::cout << "----------dumping bad EVENT-----------" << std::endl;
+            dumpEventView(eview, sendEvent.get());
           }
         }
         if (good_event) {
@@ -204,7 +233,8 @@ namespace {
                 << "and " << num_badevents << " events with bad headers" << std::endl
                 << "and " << num_badchksum << " events with bad check sum" << std::endl
                 << "and " << num_baduncompress << " events with bad uncompress" << std::endl
-                << "and " << num_duplevents << " duplicated event Id" << std::endl;
+                << "and " << num_duplevents << " duplicated event Id" << std::endl
+                << "and " << num_badhistoryid << " events with incompatible reduced ProcessHistoryID" << std::endl;
 
       if (output) {
         std::cout << "Wrote " << num_goodevents << " good events " << std::endl;
@@ -269,7 +299,7 @@ namespace {
   }
 
   //==========================================================================
-  bool test_uncompress(EventMsgView const* eview, std::vector<unsigned char>& dest) {
+  std::optional<unsigned int> test_uncompress(EventMsgView const* eview, std::vector<unsigned char>& dest) {
     unsigned long origsize = eview->origDataSize();
     if (origsize != 0 && origsize != 78) {
       // compressed
@@ -277,21 +307,40 @@ namespace {
           static_cast<unsigned char const*>(eview->eventData()), eview->eventLength(), dest, origsize);
     } else {
       // uncompressed anyway
-      return false;
+      // need to copy for the test_ProcessHistoryID test
+      dest.resize(eview->eventLength());
+      unsigned char* pos = dest.data();
+      unsigned char const* from = static_cast<unsigned char const*>(eview->eventData());
+      std::copy(from, from + eview->eventLength(), pos);
+      return dest.size();
     }
   }
 
   //==========================================================================
-  bool uncompressBuffer(unsigned char const* inputBuffer,
-                        unsigned int inputSize,
-                        std::vector<unsigned char>& outputBuffer,
-                        unsigned int expectedFullSize) {
+  std::optional<unsigned int> uncompressBuffer(unsigned char const* inputBuffer,
+                                               unsigned int inputSize,
+                                               std::vector<unsigned char>& outputBuffer,
+                                               unsigned int expectedFullSize) {
     try {
-      edm::streamer::uncompress::uncompressBuffer(inputBuffer, inputSize, outputBuffer, expectedFullSize);
+      return edm::streamer::uncompress::uncompressBuffer(inputBuffer, inputSize, outputBuffer, expectedFullSize);
     } catch (cms::Exception& e) {
       std::cout << "Problem with uncompress: " << e.what() << std::endl;
-      return false;
+      return {};
     }
-    return true;
+  }
+
+  //==========================================================================
+  std::unique_ptr<edm::SendEvent> getSendEvent(std::vector<unsigned char>& uncompressed,
+                                               unsigned int uncompressedSize) {
+    TBufferFile buf(TBuffer::kRead, 1024 * 1024);
+    buf.SetBuffer(uncompressed.data(), uncompressedSize, kFALSE);
+    return std::unique_ptr<edm::SendEvent>(
+        reinterpret_cast<edm::SendEvent*>(buf.ReadObjectAny(getTClass(typeid(edm::SendEvent)))));
+  }
+
+  bool test_ProcessHistoryID(edm::ProcessHistoryID const& id1, edm::SendEvent const& sendEvent2) {
+    auto history2 = sendEvent2.processHistory();
+    history2.reduce();
+    return id1 == history2.id();
   }
 }  // namespace

--- a/IOPool/Streamer/bin/DiagStreamerFile.cpp
+++ b/IOPool/Streamer/bin/DiagStreamerFile.cpp
@@ -55,7 +55,7 @@ namespace {
   std::optional<unsigned int> test_uncompress(EventMsgView const* eview, std::vector<unsigned char>& dest);
   std::unique_ptr<edm::SendEvent> getSendEvent(std::vector<unsigned char>& uncompressed, unsigned int uncompressedSize);
   bool test_ProcessHistoryID(edm::ProcessHistoryID const& id1, edm::SendEvent const& sendEvent2);
-  void readfile(std::string filename, std::string outfile);
+  int readfile(std::string filename, std::string outfile);
   void help();
 }  // namespace
 //==========================================================================
@@ -72,10 +72,10 @@ int main(int argc, char* argv[]) {
     outfile = argv[2];
   }
 
-  readfile(streamfile, outfile);
+  auto const ret = readfile(streamfile, outfile);
   std::cout << "\n\nDiagStreamerFile TEST DONE\n" << std::endl;
 
-  return 0;
+  return ret;
 }
 
 namespace {
@@ -85,7 +85,7 @@ namespace {
               << " [output_file_name]" << std::endl;
   }
   //==========================================================================
-  void readfile(std::string filename, std::string outfile) {
+  int readfile(std::string filename, std::string outfile) {
     uint32 num_metadata(0);
     uint32 num_events(0);
     uint32 num_badevents(0);
@@ -247,7 +247,9 @@ namespace {
                 << "and " << num_badchksum << " events with bad check sum" << std::endl
                 << "and " << num_baduncompress << " events with bad uncompress" << std::endl
                 << "and " << num_duplevents << " duplicated event Id" << std::endl;
+      return EXIT_FAILURE;
     }
+    return EXIT_SUCCESS;
   }
 
   //==========================================================================

--- a/IOPool/Streamer/interface/DumpTools.h
+++ b/IOPool/Streamer/interface/DumpTools.h
@@ -5,6 +5,7 @@
     Messages on screen.
 */
 
+#include "DataFormats/Streamer/interface/StreamedProducts.h"
 #include "IOPool/Streamer/interface/MsgTools.h"
 #include "IOPool/Streamer/interface/InitMessage.h"
 #include "IOPool/Streamer/interface/EventMessage.h"
@@ -17,7 +18,7 @@ namespace edm::streamer {
   void dumpInit(uint8* buf);
   void printBits(unsigned char c);
   void dumpEventHeader(const EventMsgView* eview);
-  void dumpEventView(const EventMsgView* eview);
+  void dumpEventView(const EventMsgView* eview, const SendEvent* sendEvent = nullptr);
   void dumpEventIndex(const EventMsgView* eview);
   void dumpEvent(uint8* buf);
   void dumpFRDEventView(const FRDEventMsgView* fview);

--- a/IOPool/Streamer/src/DumpTools.cc
+++ b/IOPool/Streamer/src/DumpTools.cc
@@ -182,13 +182,18 @@ namespace edm::streamer {
     std::cout.flush();
   }
 
-  void dumpEventView(const EventMsgView* eview) {
+  void dumpEventView(const EventMsgView* eview, const SendEvent* sendEvent) {
     dumpEventHeader(eview);
     //const uint8* edata = eview->eventData();
     //std::cout << "\nevent data=\n(";
     //std::copy(&edata[0],&edata[0]+eview->eventLength(),
     //     std::ostream_iterator<char>(std::cout,""));
     //std::cout << ")\n";
+    if (sendEvent) {
+      auto history = sendEvent->processHistory();
+      history.reduce();
+      std::cout << "\nReduced ProcessHistory ID=" << history.id() << "\n";
+    }
     std::cout.flush();
   }
 

--- a/IOPool/Streamer/test/BuildFile.xml
+++ b/IOPool/Streamer/test/BuildFile.xml
@@ -35,6 +35,8 @@
   <test name="TestIOPoolStreamerReducedProcessHistoryVersion" command="run_TestReducedProcessHistoryVersion.sh"/>
   <test name="TestIOPoolStreamerReducedProcessHistoryHardwareResources" command="run_TestReducedProcessHistoryHardwareResources.sh"/>
 
+  <test name="TestIOPoolStreamerDiagStreamerFile" command="run_TestDiagStreamerFile.sh"/>
+
   <library file="StreamThingProducer.cc" name="StreamThingProducer">
     <flags EDM_PLUGIN="1"/>
     <use name="DataFormats/TestObjects"/>

--- a/IOPool/Streamer/test/run_TestDiagStreamerFile.sh
+++ b/IOPool/Streamer/test/run_TestDiagStreamerFile.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+function die { echo -e "Failure $1: status $2" ; exit $2 ; }
+function runSuccess {
+    echo "cmsRun $@"
+    cmsRun $@ || die "cmsRun $*" $?
+    echo
+}
+
+VERSION_ARR=(${CMSSW_VERSION//_/ })
+VERSION1="${VERSION_ARR[0]}_${VERSION_ARR[1]}_${VERSION_ARR[2]}_0"
+VERSION2="${VERSION_ARR[0]}_${VERSION_ARR[1]}_${VERSION_ARR[2]}_1"
+VERSION3="${VERSION_ARR[0]}_${VERSION_ARR[1]}_$((${VERSION_ARR[2]}+1))_0"
+
+# Check compression algorithms
+for COMP in "UNCOMPRESSED" "ZLIB" "LZMA" "ZSTD"; do
+    runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistoryCreate_cfg.py --compression ${COMP} --output compression_${COMP}.dat
+    DiagStreamerFile compression_${COMP}.dat > compression_${COMP}_diag.txt || die "DiagStreamerFile compression_${COMP}.dat failed, last 10 lines:\n $(tail -n 10 compression_${COMP}_diag.txt)" $?
+    grep -q "and 10 events" compression_${COMP}_diag.txt || die "compression_${COMP}_diag.txt had incorrect event count" $?
+done
+
+
+# Check that changing the patch version does not lead to new lumi or run
+runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistoryCreate_cfg.py --version ${VERSION1} --firstEvent 1 --output version1.dat
+runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistoryCreate_cfg.py --version ${VERSION2} --firstEvent 101 --output version2.dat
+
+CatStreamerFiles merged.dat version1.dat version2.dat
+DiagStreamerFile merged.dat > merged_diag.txt 2>&1 || die "DiagStreamerFile merged.dat failed, last 10 lines:\n $(tail -n 10 merged_diag.txt)" $?
+grep -q "read 2 metadata records" merged_diag.txt || die "merged_diag.txt had incorrect metadata record count" $?
+grep -q "and 20 events" merged_diag.txt || die "merged_diag.txt had incorrect event count" $?
+grep -q "and 0 events with bad headers" merged_diag.txt || die "merged_diag.txt had incorrect bad headers count" $?
+grep -q "and 0 events with bad check sum" merged_diag.txt || die "merged_diag.txt had incorrect bad check sum count" $?
+grep -q "and 0 duplicated event Id" merged_diag.txt || die "merged_diag.txt had incorrect duplicated event count" $?
+
+# Check that changing the minor version leads to new lumi
+runSuccess ${SCRAM_TEST_PATH}/testReducedProcessHistoryCreate_cfg.py --version ${VERSION3} --firstEvent 201 --output version3.dat
+
+CatStreamerFiles merged3.dat version1.dat version3.dat
+DiagStreamerFile merged3.dat > merged3_diag.txt 2>&1 || die "DiagStreamerFile merged3.dat failed, last 10 lines:\n $(tail -n 10 merged3_diag.txt)" $?
+grep -q "ProcessHistoryID error for count 11" merged3_diag.txt || die "merged3_diag.txt did not have ProcessHistoryID error for count 11" $?
+grep -q "ProcessHistoryID error for count 20" merged3_diag.txt || die "merged3_diag.txt did not have ProcessHistoryID error for count 20" $?
+NUM=$(grep -c "ProcessHistoryID error" merged3_diag.txt)
+if [ "$NUM" != "10" ]; then
+    die "merged3_diag.txt had unexpected number $NUM of ProcessHistoryID errors, expected 10" 1
+fi
+grep -q "and 10 events with incompatible reduced ProcessHistoryID" merged3_diag.txt || die "merged3_diag.txt had incorrect 'incompatible reduced ProcessHistoryID' count" $?

--- a/IOPool/Streamer/test/testReducedProcessHistoryCreate_cfg.py
+++ b/IOPool/Streamer/test/testReducedProcessHistoryCreate_cfg.py
@@ -7,6 +7,7 @@ parser.add_argument("--accelerators", type=str, nargs='+', help="Propagated to p
 parser.add_argument("--firstEvent", default=1, type=int, help="Number of first event")
 parser.add_argument("--lumi", default=1, type=int, help="LuminosityBlock number")
 parser.add_argument("--output", type=str, help="Output file name")
+parser.add_argument("--compression", type=str, default=None, help="Specify compression algorithm")
 
 args = parser.parse_args()
 
@@ -38,6 +39,8 @@ from IOPool.Streamer.modules import EventStreamFileWriter
 process.out = EventStreamFileWriter(
     fileName = args.output
 )
+if args.compression:
+    process.out.compression_algorithm = args.compression
 
 from FWCore.Framework.modules import IntProducer
 process.intProducer = IntProducer(ivalue = 42)


### PR DESCRIPTION
#### PR description:

This PR is motivated by the investigation in https://github.com/cms-sw/cmssw/issues/50960. At the cost of having to deserialize the `SendEvent`, this PR checks that the reduced ProcessingHistoryID is the same in all the events of a file (which is an assumption/requirement of the streamer file format). This PR also adds a test for the `DiagStreamerFile`.

Resolves https://github.com/cms-sw/framework-team/issues/2230

#### PR validation:

Unit test runs

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 17_0_X