### PR TITLE
[170X] Drop unused Geometry/CommonDetUnit package

### DIFF
--- a/Geometry/CommonDetUnit/BuildFile.xml
+++ b/Geometry/CommonDetUnit/BuildFile.xml
@@ -1,1 +1,0 @@
-<use name="Geometry/CommonTopologies"/>

--- a/Geometry/CommonDetUnit/interface/DetSorting.h
+++ b/Geometry/CommonDetUnit/interface/DetSorting.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonTopologies/interface/DetSorting.h"

--- a/Geometry/CommonDetUnit/interface/DoubleSensGeomDet.h
+++ b/Geometry/CommonDetUnit/interface/DoubleSensGeomDet.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonTopologies/interface/DoubleSensGeomDet.h"

--- a/Geometry/CommonDetUnit/interface/GeomDet.h
+++ b/Geometry/CommonDetUnit/interface/GeomDet.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonTopologies/interface/GeomDet.h"

--- a/Geometry/CommonDetUnit/interface/GeomDetEnumerators.h
+++ b/Geometry/CommonDetUnit/interface/GeomDetEnumerators.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonTopologies/interface/GeomDetEnumerators.h"

--- a/Geometry/CommonDetUnit/interface/GeomDetType.h
+++ b/Geometry/CommonDetUnit/interface/GeomDetType.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonTopologies/interface/GeomDetType.h"

--- a/Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h
+++ b/Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"

--- a/Geometry/CommonDetUnit/interface/GluedGeomDet.h
+++ b/Geometry/CommonDetUnit/interface/GluedGeomDet.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonTopologies/interface/GluedGeomDet.h"

--- a/Geometry/CommonDetUnit/interface/MTDGeomDet.h
+++ b/Geometry/CommonDetUnit/interface/MTDGeomDet.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonTopologies/interface/MTDGeomDet.h"

--- a/Geometry/CommonDetUnit/interface/PixelGeomDetType.h
+++ b/Geometry/CommonDetUnit/interface/PixelGeomDetType.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonTopologies/interface/PixelGeomDetType.h"

--- a/Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h
+++ b/Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonTopologies/interface/PixelGeomDetUnit.h"

--- a/Geometry/CommonDetUnit/interface/StackGeomDet.h
+++ b/Geometry/CommonDetUnit/interface/StackGeomDet.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonTopologies/interface/StackGeomDet.h"

--- a/Geometry/CommonDetUnit/interface/TrackerGeomDet.h
+++ b/Geometry/CommonDetUnit/interface/TrackerGeomDet.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonTopologies/interface/TrackerGeomDet.h"

--- a/Geometry/CommonDetUnit/interface/TrackingGeometry.h
+++ b/Geometry/CommonDetUnit/interface/TrackingGeometry.h
@@ -1,1 +1,0 @@
-#include "Geometry/CommonTopologies/interface/TrackingGeometry.h"


### PR DESCRIPTION
backport of #51183

Following up https://github.com/cms-sw/cmssw/issues/28415, this PR now drops Geometry/CommonDetUnit .
