### PR TITLE
[NGT] Bug fix for tau prevalidation sequence in Run2 workflow

### DIFF
--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -46,7 +46,6 @@ from DQMOffline.Trigger.EgHLTOfflineSource_cfi import *
 
 # online dqm:
 from DQMOffline.Trigger.HLTMonTau_cfi import *
-from PhysicsTools.JetMCAlgos.TauGenJetsDecayModeSelectorAllHadrons_cfi import *
 
 # additional producer sequence prior to hltvalidation
 # to evacuate producers/filters from the EndPath
@@ -57,7 +56,6 @@ hltassociation = cms.Sequence(
     +ExoticaValidationProdSeq
     +hltMultiTrackValidationGsfTracks
     +hltJetPreValidSeq
-    +tauGenJetsSelectorAllHadrons
     )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
@@ -76,6 +74,9 @@ _phase2_hltassociation += hltTrackerphase2ValidationSource
 
 # Add HGCal SimTracksters
 _phase2_hltassociation += hltTiclSimTrackstersSeq
+
+# Add gentau reference for validation
+_phase2_hltassociation += tauPreValidSeq
 
 # Apply the modification
 phase2_common.toReplaceWith(hltassociation, _phase2_hltassociation)

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -155,6 +155,7 @@ globalPrevalidationJetMETOnly = cms.Sequence(
 
 globalPrevalidationTaus = cms.Sequence(
     # produceDenoms
+    tauPreValidSeq
 )
 
 globalValidationTaus = cms.Sequence(

--- a/Validation/RecoTau/python/RecoTauValidation_cff.py
+++ b/Validation/RecoTau/python/RecoTauValidation_cff.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+from PhysicsTools.JetMCAlgos.TauGenJetsDecayModeSelectorAllHadrons_cfi import *
+tauPreValidSeq = cms.Sequence(tauGenJetsSelectorAllHadrons)
+
 from Validation.RecoTau.TauValidator import TauValidator as _TauValidator
 
 # recoTauValidation = _TauValidator(


### PR DESCRIPTION
#### PR description:

This PR fixes a failure observed in workflow `1311.0`, caused by missing products needed to build the generator-level tau collection used in the new tau validation strategy introduced in #51092. 

The issue manifests as a `ProductNotFound` exception during the prevalidation_step, when the module `tauGenJetsSelectorAllHadrons` attempts to access the `tauGenJets` collection:
```
----- Begin Fatal Exception 11-Jun-2026 05:53:51 CEST-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 2 stream: 3
   [1] Running path 'prevalidation_step'
   [2] Calling method for module TauGenJetDecayModeSelector/'tauGenJetsSelectorAllHadrons'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: std::vector<reco::io_v1::GenJet>
Looking for module label: tauGenJets
Looking for productInstanceName: 
----- End Fatal Exception -------------------------------------------------
```
The cause is the missing `tauGenJets` collection, which is not produced in the Run-2 validation workflow. The `tauGenJetsSelectorAllHadrons` sequence is now restricted to Phase-2 workflows only, where the necessary inputs are available. This restores correct behavior of the tau validation, including the DQM plots introduced in #51092.

#### PR validation:

The fix has been validated in:
- Affected Run-2 workflow: `1311.0` (now runs without errors)
- Phase-2 workflow: `34434.0` (tau validation behaves as expected)

It has also been tested on TenTau RelVal samples using the following commands:
- Tau Validation (HLT only):
```
cmsDriver.py step2 -s L1P2GT,HLT:75e33,VALIDATION:@hltValidation -n -1 --nThreads 0 \
 --conditions auto:phase2_realistic_T35 --datatier GEN-SIM-DIGI-RAW,DQMIO \
 --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 --eventcontent FEVTDEBUGHLT,DQMIO \
 --geometry ExtendedRun4D110 --era Phase2C17I13M9 --hltProcess HLTX --processName HLTX \
 --filein file:/eos/cms/store/relval/CMSSW_20_0_0_pre1/RelValTenTau_15_500/GEN-SIM-DIGI-RAW/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/390470c8-1a6f-4259-8e96-561dde76396b.root --fileout file:step2.root \
 --inputCommands="keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT"
```
```
cmsDriver.py step3 -s HARVESTING:@hltValidation -n -1 \
 --conditions auto:phase2_realistic_T35 --mc --geometry ExtendedRun4D110 --era Phase2C17I13M9 \
 --filetype DQM --scenario pp --hltProcess HLTX --filein file:step2_inDQM.root --fileout file:step3.root
```
- Tau Validation (HLT + RECO):
```
cmsDriver.py step3 -s RAW2DIGI,RECO,RECOSIM,PAT,VALIDATION:@phase2Validation -n 10 \
 --conditions auto:phase2_realistic_T35 --geometry ExtendedRun4D110 --era Phase2C17I13M9 \
 --datatier DQMIO --eventcontent DQM \
 --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
 --customise_command "process.globalValidationHCAL = cms.Sequence(process.hcalSimHitsValidationSequence + process.hcalSimHitStudy)" \
 --filein file:/eos/cms/store/relval/CMSSW_20_0_0_pre1/RelValTenTau_15_500/GEN-SIM-DIGI-RAW/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/390470c8-1a6f-4259-8e96-561dde76396b.root \
 --fileout file:step3.root 
```
```
cmsDriver.py step4 -s HARVESTING:@phase2Validation -n -1 \
 --conditions auto:phase2_realistic_T35 --mc --geometry ExtendedRun4D110 --era Phase2C17I13M9 \
 --filetype DQM --scenario pp --hltProcess HLTX --filein file:step3.root --fileout file:step4.root
```