### PR TITLE
Corrected template parameters for Alpaka PF MD Clusterizer Epilogue kernels  

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizer.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizer.dev.cc
@@ -64,6 +64,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
     constexpr bool enable_multiblock_prologue = !std::is_same_v<Device, alpaka::DevCpu>;
     constexpr bool enable_multiblock_epilogue = !std::is_same_v<Device, alpaka::DevCpu>;
 
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+    constexpr bool is_cooperative = std::is_same_v<Device, alpaka::DevCudaRt>;
+#else
+    constexpr bool is_cooperative = false;
+#endif
+
     const unsigned int wExtend = alpaka::getPreferredWarpSize(alpaka::getDev(queue));
 
     // For ROCm/CUDA backends, this should be a multiple of warp extent,
@@ -255,7 +261,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
 
         alpaka::exec<Acc1D>(queue,
                             ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                            ECLCCFinalizeEpilogueKernel<max_w_items>{},
+                            ECLCCFinalizeEpilogueKernel<max_w_items, is_cooperative>{},
                             outPFCluster.view(),
                             outPFRecHitFracs.view(),
                             epilogueArgs.view(),
@@ -276,7 +282,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
 
         alpaka::exec<Acc1D>(queue,
                             ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                            ECLCCFinalizeEpilogueKernel<max_w_items>{},
+                            ECLCCFinalizeEpilogueKernel<max_w_items, is_cooperative>{},
                             outPFCluster.view(),
                             outPFRecHitFracs.view(),
                             epilogueArgs.view(),
@@ -296,7 +302,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
 
         alpaka::exec<Acc1D>(queue,
                             ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                            ECLCCFinalizeEpilogueKernel<max_w_items>{},
+                            ECLCCFinalizeEpilogueKernel<max_w_items, is_cooperative>{},
                             outPFCluster.view(),
                             outPFRecHitFracs.view(),
                             epilogueArgs.view(),
@@ -324,13 +330,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
                             pfRecHitFracs.view(),
                             pfRecHit.view());
       } else {
-        constexpr bool cooperative_work = true;
         // ECL-CC epilogue:
         if (threadsPerBlock <= 256) {
           constexpr unsigned int max_w_items = 8;
           alpaka::exec<Acc1D>(queue,
                               ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                              ECLCCEpilogueKernel<max_w_items, cooperative_work>{},
+                              ECLCCEpilogueKernel<max_w_items, is_cooperative>{},
                               outPFCluster.view(),
                               outPFRecHitFracs.view(),
                               mdpfCCLabels.view(),
@@ -342,7 +347,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
           constexpr unsigned int max_w_items = 16;
           alpaka::exec<Acc1D>(queue,
                               ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                              ECLCCEpilogueKernel<max_w_items, cooperative_work>{},
+                              ECLCCEpilogueKernel<max_w_items, is_cooperative>{},
                               outPFCluster.view(),
                               outPFRecHitFracs.view(),
                               mdpfCCLabels.view(),
@@ -353,7 +358,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::eclcc {
           constexpr unsigned int max_w_items = 32;
           alpaka::exec<Acc1D>(queue,
                               ::cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock),
-                              ECLCCEpilogueKernel<max_w_items, cooperative_work>{},
+                              ECLCCEpilogueKernel<max_w_items, is_cooperative>{},
                               outPFCluster.view(),
                               outPFRecHitFracs.view(),
                               mdpfCCLabels.view(),

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizerHelper.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthClusterizerHelper.h
@@ -165,12 +165,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     if constexpr (all) {
       const unsigned int high_lane_idx = w_extent - 1;
 
-      // send last lane value (total tile offset) to lane idx = low_lane_idx:
-      const warp::warp_mask_t active_mask = 1 | get_lane_mask(high_lane_idx);
-      const unsigned int tmp = warp::shfl_mask(acc, active_mask, local_offset, high_lane_idx, w_extent);
+      if (lane_idx == 0 || lane_idx == high_lane_idx) {
+        // send last lane value (total tile offset) to lane idx = low_lane_idx:
+        const warp::warp_mask_t active_mask = static_cast<warp::warp_mask_t>(1) | get_lane_mask(high_lane_idx);
+        const std::uint32_t tmp = warp::shfl_mask(acc, active_mask, local_offset, high_lane_idx, w_extent);
 
-      if (lane_idx == 0)
-        local_offset = tmp;  //lane 0 keeps full (inclusive for the last lane) sum
+        if (lane_idx == 0)
+          local_offset = tmp;  //lane 0 keeps full (inclusive for the last lane) sum, nop for high_lane_idx
+      }
     }
     return lane_idx == 0 ? local_offset : local_offset - val;  //we return exclusive sum!
   }

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogue.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCEpilogue.h
@@ -130,7 +130,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
   };
 
-  template <unsigned int max_w_items = 32, bool is_cooperative = false>
+  template <unsigned int max_w_items = 32, bool is_cooperative = true>
   class ECLCCEpilogueKernel {
   public:
     ALPAKA_FN_ACC void operator()(

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCFinalizeEpilogue.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFMultiDepthECLCCFinalizeEpilogue.h
@@ -52,7 +52,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
  * @param pfRecHit            Input PF rec hit device collection.
  */
 
-  template <unsigned int max_w_items = 32, bool is_cooperative = false>
+  template <unsigned int max_w_items = 32, bool is_cooperative = true>
   class ECLCCFinalizeEpilogueKernel {
   public:
     ALPAKA_FN_ACC void operator()(


### PR DESCRIPTION
This PR changes the default value of the `is_cooperative` option to `true` for the CUDA backend.
The ROCm backend keeps the previous default value unchanged.

The CUDA backend showed instability in non-cooperative mode under heavy GPU load with a large number of concurrent streams. Enabling cooperative mode by default improves stability for CUDA Epilogue compute kernels while preserving the existing ROCm behavior.

The original issue: https://github.com/cms-sw/cmssw/issues/50858

