### PR TITLE
accept the --pileup_input filelist:... also if not DATAMIX is specified

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -707,6 +707,8 @@ class ConfigBuilder(object):
 			if self._options.pileup_input:
 				if self._options.pileup_input.startswith('dbs:') or self._options.pileup_input.startswith('das:'):
 					mixingDict['F']=filesFromDASQuery('file dataset = %s'%(self._options.pileup_input[4:],),self._options.pileup_dasoption)[0]
+                                elif self._options.pileup_input.startswith('filelist:'):
+                                        mixingDict['F']=(filesFromList(self._options.pileup_input[9:]))[0]
 				else:
 					mixingDict['F']=self._options.pileup_input.split(',')
 			specialization=defineMixing(mixingDict)


### PR DESCRIPTION
#### PR description:

that option to provide `--pileup_input filelist:<path to a file>` is available in 8.1 and after, but is missing in 8.0 and prevents some production using old releases  #51179 

#### PR validation:

this command
`cmsDriver.py Configuration/GenProduction/python/HIN-pPb816Spring16GS-00223-fragment.py --eventcontent RAWSIM --pileup HiMixGEN --customise Configuration/StandardSequences/SimWithCastor_cff.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions 80X_mcRun2_pA_v4 --beamspot MatchPbPBoost --step GEN,SIM --scenario HeavyIons --era Run2_2016_pA --python_filename HIN-pPb816Spring16GS-00223_1_cfg.py --fileout file:HIN-pPb816Spring16GS-00223.root --number 160 --number_out 160 --pileup_input "filelist:/cvmfs/cms.cern.ch/offcomp-prod/premixPUlist/d8652afafee2e83edebf88a446b3ba53.txt" --no_exec --mc`

now functions properly in CMSSW_8_0_X_2026-06-07-0000

## backport 

this is somewhat a backport of https://github.com/cms-sw/cmssw/commit/81c7eaa7116a8bdfab21f6661b5a382324bd93db 