### PR TITLE
[WarningFix]:CalibCalorimetry/EcalTrivialCondModules-Check fgets() re…

### DIFF
--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc
@@ -28,6 +28,14 @@
 
 using namespace edm;
 
+namespace {
+  void checkedFgets(char* line, int size, FILE* file, const std::string& filename) {
+    if (fgets(line, size, file) == nullptr) {
+      throw cms::Exception("FileReadError") << "Unexpected end of file while reading " << filename;
+    }
+  }
+}  // namespace
+
 EcalTrivialConditionRetriever::EcalTrivialConditionRetriever(const edm::ParameterSet& ps) {
   std::string dataPath_ =
       ps.getUntrackedParameter<std::string>("dataPath", "CalibCalorimetry/EcalTrivialCondModules/data/");
@@ -2757,26 +2765,26 @@ std::unique_ptr<EcalIntercalibConstants> EcalTrivialConditionRetriever::getInter
 
     char line[256];
     std::ostringstream str;
-    fgets(line, 255, inpFile);
+    checkedFgets(line, 255, inpFile, intercalibConstantsFile_);
     int sm_number = atoi(line);
     str << "sm: " << sm_number;
 
-    fgets(line, 255, inpFile);
+    checkedFgets(line, 255, inpFile, intercalibConstantsFile_);
     //int nevents=atoi (line) ; // not necessary here just for online conddb
 
-    fgets(line, 255, inpFile);
+    checkedFgets(line, 255, inpFile, intercalibConstantsFile_);
     std::string gen_tag = line;
     str << "gen tag: " << gen_tag;  // should I use this?
 
-    fgets(line, 255, inpFile);
+    checkedFgets(line, 255, inpFile, intercalibConstantsFile_);
     std::string cali_method = line;
     str << "cali method: " << cali_method << std::endl;  // not important
 
-    fgets(line, 255, inpFile);
+    checkedFgets(line, 255, inpFile, intercalibConstantsFile_);
     std::string cali_version = line;
     str << "cali version: " << cali_version << std::endl;  // not important
 
-    fgets(line, 255, inpFile);
+    checkedFgets(line, 255, inpFile, intercalibConstantsFile_);
     std::string cali_type = line;
     str << "cali type: " << cali_type;  // not important
 
@@ -2980,26 +2988,26 @@ std::unique_ptr<EcalIntercalibErrors> EcalTrivialConditionRetriever::getIntercal
 
   char line[256];
   std::ostringstream str;
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, intercalibErrorsFile_);
   int sm_number = atoi(line);
   str << "sm: " << sm_number;
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, intercalibErrorsFile_);
   //int nevents=atoi (line) ; // not necessary here just for online conddb
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, intercalibErrorsFile_);
   std::string gen_tag = line;
   str << "gen tag: " << gen_tag;  // should I use this?
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, intercalibErrorsFile_);
   std::string cali_method = line;
   str << "cali method: " << cali_method << std::endl;  // not important
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, intercalibErrorsFile_);
   std::string cali_version = line;
   str << "cali version: " << cali_version << std::endl;  // not important
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, intercalibErrorsFile_);
   std::string cali_type = line;
   str << "cali type: " << cali_type;  // not important
 
@@ -3086,26 +3094,26 @@ std::unique_ptr<EcalTimeCalibConstants> EcalTrivialConditionRetriever::getTimeCa
 
   char line[256];
   std::ostringstream str;
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, timeCalibConstantsFile_);
   int sm_number = atoi(line);
   str << "sm: " << sm_number;
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, timeCalibConstantsFile_);
   //int nevents=atoi (line) ; // not necessary here just for online conddb
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, timeCalibConstantsFile_);
   std::string gen_tag = line;
   str << "gen tag: " << gen_tag;  // should I use this?
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, timeCalibConstantsFile_);
   std::string cali_method = line;
   str << "cali method: " << cali_method << std::endl;  // not important
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, timeCalibConstantsFile_);
   std::string cali_version = line;
   str << "cali version: " << cali_version << std::endl;  // not important
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, timeCalibConstantsFile_);
   std::string cali_type = line;
   str << "cali type: " << cali_type;  // not important
 
@@ -3190,26 +3198,26 @@ std::unique_ptr<EcalTimeCalibErrors> EcalTrivialConditionRetriever::getTimeCalib
 
   char line[256];
   std::ostringstream str;
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, timeCalibErrorsFile_);
   int sm_number = atoi(line);
   str << "sm: " << sm_number;
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, timeCalibErrorsFile_);
   //int nevents=atoi (line) ; // not necessary here just for online conddb
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, timeCalibErrorsFile_);
   std::string gen_tag = line;
   str << "gen tag: " << gen_tag;  // should I use this?
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, timeCalibErrorsFile_);
   std::string cali_method = line;
   str << "cali method: " << cali_method << std::endl;  // not important
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, timeCalibErrorsFile_);
   std::string cali_version = line;
   str << "cali version: " << cali_version << std::endl;  // not important
 
-  fgets(line, 255, inpFile);
+  checkedFgets(line, 255, inpFile, timeCalibErrorsFile_);
   std::string cali_type = line;
   str << "cali type: " << cali_type;  // not important
 


### PR DESCRIPTION
#### PR description:
This PR fixes static analyzer warnings in CalibCalorimetry/EcalTrivialCondModules.

The affected code reads calibration file headers using repeated fgets() calls and then immediately consumes the buffer contents. If the input file is truncated or malformed, fgets() can fail and the code may continue using invalid/stale data.

Changes:
- Add a small checkedFgets() helper.
- Check all calibration header reads before using the buffer.
- Throw a cms::Exception on unexpected EOF.

#### Warnings: 
```cpp
[src/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc:2764](https://github.com/cms-sw/cmssw/blob/CMSSW_20_1_X_2026-06-11-2300/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc#L2764):5: warning: File position of the stream might be 'indeterminate' after a failed operation. Can cause undefined behavior [unix.Stream]
  2764 |     fgets(line, 255, inpFile);[src/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc:2764](https://github.com/cms-sw/cmssw/blob/CMSSW_20_1_X_2026-06-11-2300/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc#L2764):5: warning: File position of the stream might be 'indeterminate' after a failed operation. Can cause undefined behavior [unix.Stream]

``` 
```cpp
[src/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc:2764](https://github.com/cms-sw/cmssw/blob/CMSSW_20_1_X_2026-06-11-2300/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc#L2764):5: warning: Read function called when stream is in EOF state. Function has no effect [unix.Stream]
  2764 |     fgets(line, 255, inpFile);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~[src/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc:2764](https://github.com/cms-sw/cmssw/blob/CMSSW_20_1_X_2026-06-11-2300/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc#L2764):5: warning: Read function called when stream is in EOF state. Function has no effect [unix.Stream]
      |     ^~~~~~~~~~~~
```