### PR TITLE
Update CUDAService for CUDA 13.x

### DIFF
--- a/HeterogeneousCore/CUDAServices/plugins/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/plugins/CUDAService.cc
@@ -266,8 +266,14 @@ CUDAService::CUDAService(edm::ParameterSet const& config) : verbose_(config.getU
       log << "  streaming multiprocessors: " << std::setw(13) << properties.multiProcessorCount << '\n';
       log << "  CUDA cores: " << std::setw(28)
           << properties.multiProcessorCount * getCudaCoresPerSM(properties.major, properties.minor) << '\n';
-      log << "  single to double performance: " << std::setw(8) << properties.singleToDoublePrecisionPerfRatio
-          << ":1\n";
+      int singleToDoublePrecisionPerfRatio = 0;
+#if CUDART_VERSION < 13000
+      singleToDoublePrecisionPerfRatio = properties.singleToDoublePrecisionPerfRatio;
+#else
+      cudaCheck(
+          cudaDeviceGetAttribute(&singleToDoublePrecisionPerfRatio, cudaDevAttrSingleToDoublePrecisionPerfRatio, i));
+#endif
+      log << "  single to double performance: " << std::setw(8) << singleToDoublePrecisionPerfRatio << ":1\n";
     }
 
     // compute mode
@@ -277,11 +283,18 @@ CUDAService::CUDAService(edm::ParameterSet const& config) : verbose_(config.getU
         "prohibited",                  // cudaComputeModeProhibited
         "exclusive (single process)",  // cudaComputeModeExclusiveProcess
         "unknown"};
+    static constexpr const int cudaComputeModeUnknown = static_cast<int>(std::size(computeModeDescription)) - 1;
     if (verbose_) {
-      log << "  compute mode:" << std::right << std::setw(27)
-          << computeModeDescription[std::min(properties.computeMode,
-                                             static_cast<int>(std::size(computeModeDescription)) - 1)]
-          << '\n';
+      int computeMode = cudaComputeModeUnknown;
+#if CUDART_VERSION < 13000
+      computeMode = properties.computeMode;
+#else
+      cudaCheck(cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode, i));
+#endif
+      if (computeMode < 0 or computeMode >= cudaComputeModeUnknown) {
+        computeMode = cudaComputeModeUnknown;
+      }
+      log << "  compute mode:" << std::right << std::setw(27) << computeModeDescription[computeMode] << '\n';
     }
 
     // TODO if a device is in exclusive use, skip it and remove it from the list, instead of failing with abort()
@@ -327,8 +340,10 @@ CUDAService::CUDAService(edm::ParameterSet const& config) : verbose_(config.getU
           << " directly access managed memory on the device without migration\n";
       log << "  " << (properties.cooperativeLaunch ? "supports" : "does not support")
           << " launching cooperative kernels via cudaLaunchCooperativeKernel()\n";
+#if CUDART_VERSION < 13000
       log << "  " << (properties.cooperativeMultiDeviceLaunch ? "supports" : "does not support")
           << " launching cooperative kernels via cudaLaunchCooperativeKernelMultiDevice()\n";
+#endif
       log << '\n';
     }
 


### PR DESCRIPTION
#### PR description:

CUDA 13 removes some deprecated fields from `cudaDeviceProp`, and replaces most of them with direct calls to `cudaDeviceGetAttribute`.
See https://developer.nvidia.com/blog/whats-new-and-important-in-cuda-toolkit-13-0/#changes_to_cudadeviceprop .

#### PR validation:

Code builds with CUDA 12.x and 13.x.