### PR TITLE
[WarningFix]:CondCore/CondHDF5ESSource- avoids dead store in zstd dec…

### DIFF
--- a/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
+++ b/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
@@ -229,7 +229,7 @@ std::vector<char> HDF5ProductResolver::decompress_zstd(std::vector<char> compres
       throw cms::Exception("H5CondFailedDecompress")
           << "unexpected payload size before attempting to decompress buffer using zstd";
     }
-    buffer = std::vector<char>(iMemSize);
+    buffer = std::vector<char>(size);
     size = ZSTD_decompress(buffer.data(), buffer.size(), compressedBuffer.data(), compressedBuffer.size());
     if (ZSTD_isError(size)) {
       throw cms::Exception("H5CondFailedDecompress") << "error detected during zstd buffer decompression";

--- a/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
+++ b/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
@@ -222,7 +222,7 @@ std::vector<char> HDF5ProductResolver::decompress_zstd(std::vector<char> compres
     if (size == ZSTD_CONTENTSIZE_UNKNOWN) {
       // decompressed size field is not present, assume iMemSize
       size = iMemSize;
-    } else if (ZSTD_isError(size == ZSTD_CONTENTSIZE_ERROR)) {
+    } else if (size == ZSTD_CONTENTSIZE_ERROR) {
       throw cms::Exception("H5CondFailedDecompress")
           << "error detected before attempting to decompress buffer using zstd";
     } else if (size != iMemSize) {

--- a/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
+++ b/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
@@ -222,7 +222,7 @@ std::vector<char> HDF5ProductResolver::decompress_zstd(std::vector<char> compres
     if (size == ZSTD_CONTENTSIZE_UNKNOWN) {
       // decompressed size field is not present, assume iMemSize
       size = iMemSize;
-    } else if (ZSTD_isError(size)) {
+    } else if (ZSTD_isError(size == ZSTD_CONTENTSIZE_ERROR)) {
       throw cms::Exception("H5CondFailedDecompress")
           << "error detected before attempting to decompress buffer using zstd";
     } else if (size != iMemSize) {


### PR DESCRIPTION
**PR description:**

This PR fixes a clang static analyzer warning in

`CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc`.

The fix is a minimal one-line change that uses `size` when allocating the output buffer:

```cpp
buffer = std::vector<char>(size);
```

This removes the dead store warning while preserving the existing behavior.

**Warning:**

```text
src/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc:224:7:
warning: Value stored to 'size' is never read [deadcode.DeadStores]
```
