### PR TITLE
re-activate Phase2 HLT timing script, using samples produced in `CMSSW_20_0_0_pre1`

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
+++ b/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
@@ -11,7 +11,7 @@ set -o pipefail
 ############################
 
 FOLDER_FILES="/data/user/${USER}/"
-DATASET="/RelValTTbar_14TeV/CMSSW_15_1_0_pre3-PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v1/GEN-SIM-DIGI-RAW"
+DATASET="/RelValTTbar_14TeV/CMSSW_20_0_0_pre1-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU-v1/GEN-SIM-DIGI-RAW"
 
 EVENTS=1000
 THREADS=4
@@ -151,8 +151,8 @@ run_cmsdriver() {
 		 -s ${menu} \
 		 --processName=${process} \
 		 --conditions auto:phase2_realistic_T35 \
-		 --geometry ExtendedRun4D110 \
-		 --era Phase2C17I13M9 \
+		 --geometry ExtendedRun4D121 \
+		 --era Phase2C22I13M9 \
 		 --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
 		 --eventcontent FEVTDEBUGHLT \
 		 --filein="${ALL_FILES}" \
@@ -385,25 +385,6 @@ run_ngt_scouting() {
 ############################
 
 main() {
-    # create fake input files
-    touch Phase2Timing_resources.json
-    touch Phase2Timing_resources_NGT.json
-    touch Phase2Timing_resources_OnCPU.json
-
-    mkdir -p logs.Phase2_L1P2GT_HLT
-    mkdir -p logs.Phase2_L1P2GT_HLT_OnCPU
-    mkdir -p logs.NGTScouting_L1P2GT_HLT
-    
-    touch logs.Phase2_L1P2GT_HLT/cpu_memory.csv       
-    touch logs.Phase2_L1P2GT_HLT/gpu_memory.csv       
-    touch logs.Phase2_L1P2GT_HLT/gpu_usage.csv        
-    touch logs.Phase2_L1P2GT_HLT_OnCPU/cpu_memory.csv 
-    touch logs.NGTScouting_L1P2GT_HLT/cpu_memory.csv  
-    touch logs.NGTScouting_L1P2GT_HLT/gpu_memory.csv  
-    touch logs.NGTScouting_L1P2GT_HLT/gpu_usage.csv   
-    
-    exit 0 # temporarily until we have samples in CMSSW_20_0_X
-    
     fetch_files
     build_input_file_string
 


### PR DESCRIPTION
#### PR description:

As samples are ready, roll back part of https://github.com/cms-sw/cmssw/pull/51141.

#### PR validation:

None. It will be tested by the bot.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It will be backported to CMSSW_20_0_X
