### PR TITLE
(Backport) PF validation on-the-fly update, MLPF support

### DIFF
--- a/Validation/RecoParticleFlow/Makefile
+++ b/Validation/RecoParticleFlow/Makefile
@@ -1,19 +1,24 @@
 TMPDIR=test/tmp
 RELVALCMD=${CMSSW_BASE}/src/Validation/RecoParticleFlow/test/run_relval.sh
 DQM_MC=DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO
+PHASE ?= phase1
+PHASE_Label :=
+ifeq ($(PHASE),phase2)
+   PHASE_Label := _phase2
+endif
 
 conf:
-	cd ${TMPDIR} && ${RELVALCMD} conf reco 0
+	cd ${TMPDIR} && ${RELVALCMD} conf reco 0 ${PHASE}
 
 dumpconf:
-	cd ${TMPDIR}/conf && python3 -c 'import step3; print(step3.process.dumpPython())' > step3_dump.py
-	cp ${TMPDIR}/conf/step3.py test/crab/
-	cp ${TMPDIR}/conf/step3_dump.py test/crab/
+	cd ${TMPDIR}/conf && python3 -c 'import step3${PHASE_Label} as step3; print(step3.process.dumpPython())' > step3${PHASE_Label}_dump.py
+	cp ${TMPDIR}/conf/step3${PHASE_Label}.py test/crab/
+	cp ${TMPDIR}/conf/step3${PHASE_Label}_dump.py test/crab/
 
 QCD: QCD_reco QCD_dqm
 
 QCD_reco:
-	cd ${TMPDIR} && ${RELVALCMD} QCD reco 0
+	cd ${TMPDIR} && ${RELVALCMD} QCD reco 0 ${PHASE}
 
 #Need to expand the CMSSW python3 configuration
 QCD_dumpconf:
@@ -21,46 +26,46 @@ QCD_dumpconf:
 	cp ${TMPDIR}/QCD/step3_dump.py crab/
 
 QCDPU_reco:
-	cd ${TMPDIR} && ${RELVALCMD} QCDPU reco 0
+	cd ${TMPDIR} && ${RELVALCMD} QCDPU reco 0 ${PHASE}
 
 ZMMPU_reco:
-	cd ${TMPDIR} && ${RELVALCMD} ZMMPU reco 0
+	cd ${TMPDIR} && ${RELVALCMD} ZMMPU reco 0 ${PHASE}
 
 ZEEPU_reco:
-	cd ${TMPDIR} && ${RELVALCMD} ZEEPU reco 0
+	cd ${TMPDIR} && ${RELVALCMD} ZEEPU reco 0 ${PHASE}
 
 TenTauPU_reco:
-	cd ${TMPDIR} && ${RELVALCMD} TenTauPU reco 0
+	cd ${TMPDIR} && ${RELVALCMD} TenTauPU reco 0 ${PHASE}
 
 NuGunPU_reco:
-	cd ${TMPDIR} && ${RELVALCMD} NuGunPU reco 0
+	cd ${TMPDIR} && ${RELVALCMD} NuGunPU reco 0 ${PHASE}
 
 #dqm: QCD_dqm QCDPU_dqm ZMM_dqm MinBias_dqm SN_dqm
 dqm: QCD_dqm QCDPU_dqm NuGunPU_dqm
 
 QCD_dqm:
 	rm -f ${TMPDIR}/QCD/DQM*.root
-	cd ${TMPDIR} && ${RELVALCMD} QCD dqm 0
+	cd ${TMPDIR} && ${RELVALCMD} QCD dqm 0 ${PHASE}
 
 QCDPU_dqm:
 	rm -f ${TMPDIR}/QCDPU/DQM*.root
-	cd ${TMPDIR} && ${RELVALCMD} QCDPU dqm 0
+	cd ${TMPDIR} && ${RELVALCMD} QCDPU dqm 0 ${PHASE}
 
 ZMMPU_dqm:
 	rm -f ${TMPDIR}/ZMMPU/DQM*.root
-	cd ${TMPDIR} && ${RELVALCMD} ZMMPU dqm 0
+	cd ${TMPDIR} && ${RELVALCMD} ZMMPU dqm 0 ${PHASE}
 
 ZEEPU_dqm:
 	rm -f ${TMPDIR}/ZEEPU/DQM*.root
-	cd ${TMPDIR} && ${RELVALCMD} ZEEPU dqm 0
+	cd ${TMPDIR} && ${RELVALCMD} ZEEPU dqm 0 ${PHASE}
 
 TenTauPU_dqm:
 	rm -f ${TMPDIR}/TenTauPU/DQM*.root
-	cd ${TMPDIR} && ${RELVALCMD} TenTauPU dqm 0
+	cd ${TMPDIR} && ${RELVALCMD} TenTauPU dqm 0 ${PHASE}
 
 NuGunPU_dqm:
 	rm -f ${TMPDIR}/NuGunPU/DQM*.root
-	cd ${TMPDIR} && ${RELVALCMD} NuGunPU dqm 0
+	cd ${TMPDIR} && ${RELVALCMD} NuGunPU dqm 0 ${PHASE}
 
 .PHONY: plots # Enable re-running plots
 

--- a/Validation/RecoParticleFlow/README.md
+++ b/Validation/RecoParticleFlow/README.md
@@ -9,9 +9,9 @@ for lxplus with SLC8 (used for Run3 CMSSW releases)
 
 ~~~
 ssh -X username@lxplus8.cern.ch
-export SCRAM_ARCH=el8_amd64_gcc10
-cmsrel CMSSW_13_3_0_pre3
-cd CMSSW_13_3_0_pre3
+export SCRAM_ARCH=el8_amd64_gcc13
+cmsrel CMSSW_17_0_0_pre1
+cd CMSSW_17_0_0_pre1
 cmsenv
 ~~~
 
@@ -37,6 +37,10 @@ Create input file lists under test/tmp/das_cache
 ~~~
 cd test; python3 datasets.py; cd ..
 ~~~
+or
+~~~
+cd test; python3 datasets.py --phase phase2; cd ..
+~~~
 
 Proceed to RECO step, about 30 minutes
 
@@ -48,14 +52,28 @@ ERA in test/run_relval.sh when trying other era, before trying the above command
 Note 2: the execution will fail if the destination directory (test/tmp/QCD etc.)
 already exists. Rename or remove existing conflicting directories from test/tmp.
 
+Note 3: by default, PHASE=phase1 (traditional/default pf for Run 3).
+
 ~~~
 make QCD_reco
+~~~
+or
+~~~
+make QCD_reco PHASE=phase1-mlpf
+~~~
+or
+~~~
+make QCD_reco PHASE=phase2
 ~~~
 
 Now let's do the DQM step that takes a few minutes
 
 ~~~
 make QCD_dqm
+~~~
+or
+~~~
+make QCD_dqm PHASE=phase2
 ~~~
 
 Repeat for QCDPU & NuGunPU (make QCDPU_reco, make QCDPU_dqm etc.) or use CRAB
@@ -104,7 +122,7 @@ In this case the URL for the directory is 'http://cern.ch/foo/plots', where 'foo
 (This requires that your personal cern web page cern.ch/username is enabled)
 
 
-# Running via condor
+# Running via condor (outdated)
 
 Make sure datasets.py is already parsed above and there are input file lists under ${CMSSW_BASE}/src/Validation/RecoParticleFlow/test/tmp/das_cache. This is written assuming that you are running condor jobs on CERN lxplus, although with some modifications, the setup can be used with condor of other clusters.
 
@@ -127,6 +145,19 @@ The reco step can also be run via Crab. Prepare CRAB scripts:
 ~~~
 make conf
 make dumpconf
+~~~
+or
+~~~
+make conf PHASE=phase1-mlpf
+make dumpconf PHASE=phase1
+~~~
+or
+~~~
+make conf PHASE=phase2
+make dumpconf PHASE=phase2
+~~~
+then
+~~~
 cd test/crab
 ~~~
 
@@ -145,6 +176,10 @@ Modify the "samples" -list there for changing datasets to process.
 ~~~
 python3 multicrab.py
 ~~~
+or
+~~~
+python3 multicrab_phase2.py
+~~~
 
 Once the jobs are done, move the step3_inMINIAODSIM root files
 from your GRID destination directory to test/tmp/QCD (etc) directory and proceed
@@ -161,35 +196,35 @@ Take note that the CMSSW python3 configuration for running the RECO sequence is 
 # Running DQM steps from existing MINIAOD samples
 
 ~~~
-# For example (default for 2021):
-#CONDITIONS=auto:phase1_2018_realistic ERA=Run2_2018 # for 2018 scenarios
-CONDITIONS=auto:phase1_2022_realistic ERA=Run3 # for run 3
-#CONDITIONS=auto:phase2_realistic ERA=Phase2C9 # for phase2
-#Running with 2 threads allows to use more memory on grid
-NTHREADS=2 TMPDIR=tmp
-
-cd $CMSSW_BASE/src/Validation/RecoParticleFlow
-make -p tmp/QCD; cd tmp/QCD
+cd $CMSSW_BASE/src/Validation/RecoParticleFlow/test/crab
+mkdir -p tmp/QCD; cd tmp/QCD
 #(or
-make -p tmp/QCDPU; cd tmp/QCDPU
-make -p tmp/NuGunPU; cd tmp/NuGunPU
+mkdir -p tmp/QCDPU; cd tmp/QCDPU
+mkdir -p tmp/NuGunPU; cd tmp/NuGunPU
 #)
 ~~~
 
 # Make a text file for input files. For example:
 
 ~~~
-dasgoclient --query="file dataset=/RelValQCD_FlatPt_15_3000HS_14/CMSSW_11_0_0_patch1-110X_mcRun3_2021_realistic_v6-v1/MINIAODSIM" > step3_filelist.txt
+dasgoclient --query="file dataset=/RelValQCD_FlatPt_15_3000HS_14/CMSSW_11_0_0_patch1-110X_mcRun3_2021_realistic_v6-v1/MINIAODSIM" | sed 's/^/file:/' > step3_filelist.txt
 #(or
-dasgoclient --query="file dataset=/RelValQCD_Pt15To7000_Flat_14TeV/CMSSW_11_0_0-110X_mcRun4_realistic_v2_2026D49noPU-v1/MINIAODSIM" > step3_filelist.txt
+dasgoclient --query="file dataset=/RelValQCD_Pt15To7000_Flat_14TeV/CMSSW_11_0_0-110X_mcRun4_realistic_v2_2026D49noPU-v1/MINIAODSIM" | sed 's/^/file:/' > step3_filelist.txt
 or using the list of files from your crab output areas.
 #)
 cat step3_filelist.txt
-
-cmsDriver.py step5 --conditions $CONDITIONS -s DQM:@pfDQM --datatier DQMIO --nThreads $NTHREADS --era $ERA --eventcontent DQM --filein filelist:step3_filelist.txt --fileout file:step5.root -n -1 >& step5.log &
 ~~~
 
-# After step5 is completed:
+and run DQM modules and produce DQM root files (so-called step5 & 6):
 ~~~
-cmsDriver.py step6 --conditions $CONDITIONS -s HARVESTING:@pfDQM --era $ERA --filetype DQM --filein file:step5.root --fileout file:step6.root >& step6.log &
+$CMSSW_BASE/src/Validation/RecoParticleFlow/test/run_relval.sh [QCD|QCDPU|ZEEPU|ZMMPU|TenTauPU|NuGunPU] dqm2 0 [phase1|phase2]
 ~~~
+
+# Make plots
+
+~~~
+cd $CMSSW_BASE/src/Validation/RecoParticleFlow/test/crab
+rm -Rf plots
+python3 $CMSSW_BASE/src/Validation/RecoParticleFlow/test/compare.py \
+    --sample FlatQCD_noPU:tmp/QCD/DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root:tmp/QCD/DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root \
+    --doResponsePlots --doMETPlots --doPFCandPlots

--- a/Validation/RecoParticleFlow/test/crab/multicrab.py
+++ b/Validation/RecoParticleFlow/test/crab/multicrab.py
@@ -2,7 +2,11 @@ from CRABAPI.RawCommand import crabCommand
 from CRABClient.UserUtilities import config
 from copy import deepcopy
 import os
- 
+import json
+
+with open("../datasets.json") as f:
+    dataset_configs = json.load(f)
+
 def submit(config):
     res = crabCommand('submit', config = config)
     #save crab config for the future
@@ -10,12 +14,10 @@ def submit(config):
         fi.write(config.pythonise_())
 
 samples = [
-    ("/RelValQCD_FlatPt_15_3000HS_14/CMSSW_12_1_0_pre2-121X_mcRun3_2021_realistic_v1-v1/GEN-SIM-DIGI-RAW", "QCD_noPU2"),
-    ("/RelValQCD_FlatPt_15_3000HS_14/CMSSW_12_1_0_pre2-PU_121X_mcRun3_2021_realistic_v1-v1/GEN-SIM-DIGI-RAW", "QCD_PU"),
-    ("/RelValZEE_14/CMSSW_12_1_0_pre2-PU_121X_mcRun3_2021_realistic_v1-v1/GEN-SIM-DIGI-RAW", "ZEE_PU"),
-    ("/RelValZMM_14/CMSSW_12_1_0_pre2-PU_121X_mcRun3_2021_realistic_v1-v1/GEN-SIM-DIGI-RAW", "ZMM_PU"),
-    ("/RelValTenTau_15_500/CMSSW_12_1_0_pre2-PU_121X_mcRun3_2021_realistic_v1-v1/GEN-SIM-DIGI-RAW", "TenTau_PU"),
-    ("/RelValNuGun/CMSSW_12_1_0_pre2-PU_121X_mcRun3_2021_realistic_v1-v1/GEN-SIM-DIGI-RAW", "NuGun_PU"),
+    (d["path"], d["name"])
+    for d in dataset_configs
+    #if d["name"] in ["QCD_noPU"] # submit only QCD_noPU
+    if d["name"] in ["QCD_noPU", "QCD_PU"] # submit only QCD_noPU & QCD_PU
 ]
 
 if __name__ == "__main__":
@@ -38,16 +40,17 @@ if __name__ == "__main__":
         conf.JobType.numCores = 8
         
         conf.Data.inputDataset = dataset
-        conf.Data.splitting = 'LumiBased'
-        conf.Data.unitsPerJob = 10
+        conf.Data.splitting = 'FileBased'
+        conf.Data.unitsPerJob = 1
         #conf.Data.totalUnits = 50
         conf.Data.publication = False
         conf.Data.outputDatasetTag = 'pfvalidation'
-        conf.Data.ignoreLocality = True
+        #conf.Data.ignoreLocality = True
         
         # Where the output files will be transmitted to
         conf.Site.storageSite = 'T3_US_Baylor'
         #conf.Site.storageSite = 'T2_US_Caltech'
         #conf.Site.whitelist = ["T2_US_Caltech", "T2_CH_CERN"]
+        #conf.Site.whitelist = ["T3_US_Baylor"]
         
         submit(conf) 

--- a/Validation/RecoParticleFlow/test/crab/multicrab_phase2.py
+++ b/Validation/RecoParticleFlow/test/crab/multicrab_phase2.py
@@ -2,7 +2,11 @@ from CRABAPI.RawCommand import crabCommand
 from CRABClient.UserUtilities import config
 from copy import deepcopy
 import os
- 
+import json
+
+with open("../datasets_phase2.json") as f:
+    dataset_configs = json.load(f)
+
 def submit(config):
     res = crabCommand('submit', config = config)
     #save crab config for the future
@@ -10,44 +14,41 @@ def submit(config):
         fi.write(config.pythonise_())
 
 samples = [
-    ("/RelValQCD_Pt15To7000_Flat_14/CMSSW_11_3_0_pre1-113X_mcRun4_realistic_v1_2026D49noPU_rsb-v1/GEN-SIM-DIGI-RAW", "QCD_noPU_phase2"),
-    ("/RelValQCD_Pt15To7000_Flat_14/CMSSW_11_3_0_pre1-PU_113X_mcRun4_realistic_v1_2026D49PU200-v1/GEN-SIM-DIGI-RAW", "QCD_PU_phase2"),
-    ("/RelValZEE_14/CMSSW_11_3_0_pre1-PU_113X_mcRun4_realistic_v1_2026D49PU200-v1/GEN-SIM-DIGI-RAW", "ZEE_PU_phase2"),
-    ("/RelValZMM_14/CMSSW_11_3_0_pre1-PU_113X_mcRun4_realistic_v1_2026D49PU200-v1/GEN-SIM-DIGI-RAW", "ZMM_PU_phase2"),
-    ("/RelValTenTau_15_500_Eta3p1/CMSSW_11_3_0_pre1-PU_113X_mcRun4_realistic_v1_2026D49PU200-v1/GEN-SIM-DIGI-RAW", "TenTau_PU_phase2"),
-    ("/RelValNuGun/CMSSW_11_3_0_pre1-PU_113X_mcRun4_realistic_v1_2026D49PU200-v1/GEN-SIM-DIGI-RAW", "NuGun_PU_phase2"),
+    (d["path"], d["name"])
+    for d in dataset_configs
+    if d["name"] in ["QCD_noPU", "QCD_PU"] # submit only QCD_noPU QCD_PU
 ]
 
 if __name__ == "__main__":
     for dataset, name in samples:
 
-        if os.path.isfile("step3_dump.pyc"):
-            os.remove("step3_dump.pyc")
- 
+        if os.path.isfile("step3_phase2_dump.pyc"):
+            os.remove("step3_phase2_dump.pyc")
+
         conf = config()
-        
+
         conf.General.requestName = name
         conf.General.transferLogs = True
-        conf.General.workArea = 'crab_projects'
+        conf.General.workArea = 'crab_projects_phase2'
         conf.JobType.pluginName = 'Analysis'
-        conf.JobType.psetName = 'step3_dump.py'
+        conf.JobType.psetName = 'step3_phase2_dump.py'
         conf.JobType.maxJobRuntimeMin = 8*60
         conf.JobType.allowUndistributedCMSSW = True
         conf.JobType.outputFiles = ["step3_inMINIAODSIM.root"]
         conf.JobType.maxMemoryMB = 20000
         conf.JobType.numCores = 8
-        
+
         conf.Data.inputDataset = dataset
-        conf.Data.splitting = 'LumiBased'
-        conf.Data.unitsPerJob = 5
+        conf.Data.splitting = 'FileBased'
+        conf.Data.unitsPerJob = 1
         #conf.Data.totalUnits = 50
         conf.Data.publication = False
         conf.Data.outputDatasetTag = 'pfvalidation'
         #conf.Data.ignoreLocality = True
-        
+
         # Where the output files will be transmitted to
         conf.Site.storageSite = 'T3_US_Baylor'
         #conf.Site.storageSite = 'T2_US_Caltech'
         #conf.Site.whitelist = ["T2_US_Caltech", "T2_CH_CERN"]
-        
-        submit(conf) 
+
+        submit(conf)

--- a/Validation/RecoParticleFlow/test/datasets.json
+++ b/Validation/RecoParticleFlow/test/datasets.json
@@ -1,0 +1,26 @@
+[
+  {
+    "path": "/RelValQCD_FlatPt_15_3000HS_14/CMSSW_16_1_0_pre4-160X_mcRun3_2026_realistic_v6_STD_RegeneratedGS_2026_noPU_20260420_140837-v3/GEN-SIM-DIGI-RAW",
+    "name": "QCD_noPU"
+  },
+  {
+    "path": "/RelValQCD_FlatPt_15_3000HS_14/CMSSW_16_1_0_pre4-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260321_092751-v2/GEN-SIM-DIGI-RAW",
+    "name": "QCD_PU"
+  },
+  {
+    "path": "/RelValZEE_14/CMSSW_16_1_0_pre4-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260321_092751-v2/GEN-SIM-DIGI-RAW",
+    "name": "ZEE_PU"
+  },
+  {
+    "path": "/RelValZMM_14/CMSSW_16_1_0_pre4-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260321_092751-v2/GEN-SIM-DIGI-RAW",
+    "name": "ZMM_PU"
+  },
+  {
+    "path": "/RelValTenTau_15_500/CMSSW_16_1_0_pre4-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260321_092751-v2/GEN-SIM-DIGI-RAW",
+    "name": "TenTau_PU"
+  },
+  {
+    "path": "/RelValNuGun/CMSSW_16_1_0_pre4-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260321_092751-v2/GEN-SIM-DIGI-RAW",
+    "name": "NuGun_PU"
+  }
+]

--- a/Validation/RecoParticleFlow/test/datasets.json
+++ b/Validation/RecoParticleFlow/test/datasets.json
@@ -1,26 +1,26 @@
 [
   {
-    "path": "/RelValQCD_FlatPt_15_3000HS_14/CMSSW_16_1_0_pre4-160X_mcRun3_2026_realistic_v6_STD_RegeneratedGS_2026_noPU_20260420_140837-v3/GEN-SIM-DIGI-RAW",
+    "path": "/RelValQCD_FlatPt_15_3000HS_14/CMSSW_17_0_0_pre1-160X_mcRun3_2026_realistic_v6_STD_RegeneratedGS_2026_noPU_20260519_170947-v2/GEN-SIM-DIGI-RAW",
     "name": "QCD_noPU"
   },
   {
-    "path": "/RelValQCD_FlatPt_15_3000HS_14/CMSSW_16_1_0_pre4-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260321_092751-v2/GEN-SIM-DIGI-RAW",
+    "path": "/RelValQCD_FlatPt_15_3000HS_14/CMSSW_17_0_0_pre1-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260519_170938-v2/GEN-SIM-DIGI-RAW",
     "name": "QCD_PU"
   },
   {
-    "path": "/RelValZEE_14/CMSSW_16_1_0_pre4-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260321_092751-v2/GEN-SIM-DIGI-RAW",
+    "path": "/RelValZEE_14/CMSSW_17_0_0_pre1-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260519_170938-v2/GEN-SIM-DIGI-RAW",
     "name": "ZEE_PU"
   },
   {
-    "path": "/RelValZMM_14/CMSSW_16_1_0_pre4-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260321_092751-v2/GEN-SIM-DIGI-RAW",
+    "path": "/RelValZMM_14/CMSSW_17_0_0_pre1-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260519_170938-v2/GEN-SIM-DIGI-RAW",
     "name": "ZMM_PU"
   },
   {
-    "path": "/RelValTenTau_15_500/CMSSW_16_1_0_pre4-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260321_092751-v2/GEN-SIM-DIGI-RAW",
+    "path": "/RelValTenTau_15_500/CMSSW_17_0_0_pre1-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260519_170938-v2/GEN-SIM-DIGI-RAW",
     "name": "TenTau_PU"
   },
   {
-    "path": "/RelValNuGun/CMSSW_16_1_0_pre4-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260321_092751-v2/GEN-SIM-DIGI-RAW",
+    "path": "/RelValNuGun/CMSSW_17_0_0_pre1-PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU_20260519_170938-v2/GEN-SIM-DIGI-RAW",
     "name": "NuGun_PU"
   }
 ]

--- a/Validation/RecoParticleFlow/test/datasets.py
+++ b/Validation/RecoParticleFlow/test/datasets.py
@@ -22,6 +22,15 @@ import optparse
 import shlex
 import os
 
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--phase",
+    choices=["phase1", "phase2"],
+    default="phase1"
+)
+
+args = parser.parse_args()
+
 LOG_MODULE_NAME = logging.getLogger(__name__)
 
 class Dataset:
@@ -123,19 +132,21 @@ class Dataset:
 
 if __name__ == "__main__":
 
+    json_file = {
+        "phase1": "datasets.json",
+        "phase2": "datasets_phase2.json"
+    }[args.phase]
+
+    with open(json_file) as f:
+        dataset_configs = json.load(f)
+
     #prefix = ""
     prefix = "root://cmsxrootd.fnal.gov//"
     #prefix = "root://xrootd-cms.infn.it//"
     tmpdir = "tmp"
     datasets = [
-        Dataset("/RelValQCD_FlatPt_15_3000HS_14/CMSSW_13_3_0_pre3-132X_mcRun3_2023_realistic_v4-v1/GEN-SIM-DIGI-RAW", "QCD_noPU", prefix, None, False, tmpdir),
-        Dataset("/RelValQCD_FlatPt_15_3000HS_14/CMSSW_12_1_0_pre2-PU_121X_mcRun3_2021_realistic_v1-v1/GEN-SIM-DIGI-RAW", "QCD_PU", prefix, None, False, tmpdir),
-        Dataset("/RelValZEE_14/CMSSW_12_1_0_pre2-PU_121X_mcRun3_2021_realistic_v1-v1/GEN-SIM-DIGI-RAW", "ZEE_PU", prefix, None, False, tmpdir),
-        Dataset("/RelValZMM_14/CMSSW_12_1_0_pre2-PU_121X_mcRun3_2021_realistic_v1-v1/GEN-SIM-DIGI-RAW", "ZMM_PU", prefix, None, False, tmpdir),
-        Dataset("/RelValTenTau_15_500/CMSSW_12_1_0_pre2-PU_121X_mcRun3_2021_realistic_v1-v1/GEN-SIM-DIGI-RAW", "TenTau_PU", prefix, None, False, tmpdir),
-        Dataset("/RelValNuGun/CMSSW_12_1_0_pre2-PU_121X_mcRun3_2021_realistic_v1-v1/GEN-SIM-DIGI-RAW", "NuGun_PU", prefix, None, False, tmpdir)]
+    Dataset(d["path"], d["name"], prefix, None, False, tmpdir)
+    for d in dataset_configs
+    ]
     for ds in datasets:
         ds.cache_das_filenames()
-
-
-

--- a/Validation/RecoParticleFlow/test/datasets.sh
+++ b/Validation/RecoParticleFlow/test/datasets.sh
@@ -1,0 +1,16 @@
+
+RELEASE=CMSSW_17_0_0_pre1
+
+dasgoclient --query="dataset=/RelValQCD_FlatPt_15_3000HS_14/${RELEASE}*mcRun3*noPU*/GEN-SIM-DIGI-RAW"
+dasgoclient --query="dataset=/RelValQCD_FlatPt_15_3000HS_14/${RELEASE}*mcRun3*PU*/GEN-SIM-DIGI-RAW" | grep -v noPU
+dasgoclient --query="dataset=/RelValZEE_14/${RELEASE}*mcRun3*PU*/GEN-SIM-DIGI-RAW" | grep -v noPU
+dasgoclient --query="dataset=/RelValZMM_14/${RELEASE}*mcRun3*PU*/GEN-SIM-DIGI-RAW" | grep -v noPU
+dasgoclient --query="dataset=/RelValTenTau_15_500/${RELEASE}*mcRun3*PU*/GEN-SIM-DIGI-RAW" | grep -v noPU
+dasgoclient --query="dataset=/RelValNuGun/${RELEASE}*mcRun3*PU*/GEN-SIM-DIGI-RAW" | grep -v noPU
+
+dasgoclient --query="dataset=/RelValQCD_FlatPt_15_3000HS_14/${RELEASE}*mcRun4*noPU*/GEN-SIM-DIGI-RAW"
+dasgoclient --query="dataset=/RelValQCD_FlatPt_15_3000HS_14/${RELEASE}*mcRun4*PU*/GEN-SIM-DIGI-RAW" | grep -v noPU
+dasgoclient --query="dataset=/RelValZEE_14/${RELEASE}*mcRun4*PU*/GEN-SIM-DIGI-RAW" | grep -v noPU
+dasgoclient --query="dataset=/RelValZMM_14/${RELEASE}*mcRun4*PU*/GEN-SIM-DIGI-RAW" | grep -v noPU
+dasgoclient --query="dataset=/RelValTenTau_15_500/${RELEASE}*mcRun4*PU*/GEN-SIM-DIGI-RAW" | grep -v noPU
+dasgoclient --query="dataset=/RelValNuGun/${RELEASE}*mcRun4*PU*/GEN-SIM-DIGI-RAW" | grep -v noPU

--- a/Validation/RecoParticleFlow/test/datasets_phase2.json
+++ b/Validation/RecoParticleFlow/test/datasets_phase2.json
@@ -1,26 +1,26 @@
 [
   {
-    "path": "/RelValQCD_FlatPt_15_3000HS_14/CMSSW_16_1_0_pre4-150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU_20260420_140846-v1/GEN-SIM-DIGI-RAW",
+    "path": "/RelValQCD_FlatPt_15_3000HS_14/CMSSW_17_0_0_pre1-150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/GEN-SIM-DIGI-RAW",
     "name": "QCD_noPU"
   },
   {
-    "path": "/RelValQCD_FlatPt_15_3000HS_14/CMSSW_16_1_0_pre4-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU_20260505_140840-v1/GEN-SIM-DIGI-RAW",
+    "path": "/RelValQCD_FlatPt_15_3000HS_14/CMSSW_17_0_0_pre1-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU-v1/GEN-SIM-DIGI-RAW",
     "name": "QCD_PU"
   },
   {
-    "path": "/RelValZEE_14/CMSSW_16_1_0_pre4-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU_20260505_140840-v1/GEN-SIM-DIGI-RAW",
+    "path": "/RelValZEE_14/CMSSW_17_0_0_pre1-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU-v1/GEN-SIM-DIGI-RAW",
     "name": "ZEE_PU"
   },
   {
-    "path": "/RelValZMM_14/CMSSW_16_1_0_pre4-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU_20260505_140840-v1/GEN-SIM-DIGI-RAW",
+    "path": "/RelValZMM_14/CMSSW_17_0_0_pre1-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU-v1/GEN-SIM-DIGI-RAW",
     "name": "ZMM_PU"
   },
   {
-    "path": "/RelValNuGun/CMSSW_16_1_0_pre4-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU_20260505_140840-v1/GEN-SIM-DIGI-RAW",
+    "path": "/RelValTenTau_15_500/CMSSW_17_0_0_pre1-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU-v1/GEN-SIM-DIGI-RAW",
     "name": "TenTau_PU"
   },
   {
-    "path": "/RelValNuGun/CMSSW_16_1_0_pre4-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU_20260420_140840-v2/GEN-SIM-DIGI-RAW",
+    "path": "/RelValNuGun/CMSSW_17_0_0_pre1-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU-v1/GEN-SIM-DIGI-RAW",
     "name": "NuGun_PU"
   }
 ]

--- a/Validation/RecoParticleFlow/test/datasets_phase2.json
+++ b/Validation/RecoParticleFlow/test/datasets_phase2.json
@@ -1,0 +1,26 @@
+[
+  {
+    "path": "/RelValQCD_FlatPt_15_3000HS_14/CMSSW_16_1_0_pre4-150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU_20260420_140846-v1/GEN-SIM-DIGI-RAW",
+    "name": "QCD_noPU"
+  },
+  {
+    "path": "/RelValQCD_FlatPt_15_3000HS_14/CMSSW_16_1_0_pre4-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU_20260505_140840-v1/GEN-SIM-DIGI-RAW",
+    "name": "QCD_PU"
+  },
+  {
+    "path": "/RelValZEE_14/CMSSW_16_1_0_pre4-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU_20260505_140840-v1/GEN-SIM-DIGI-RAW",
+    "name": "ZEE_PU"
+  },
+  {
+    "path": "/RelValZMM_14/CMSSW_16_1_0_pre4-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU_20260505_140840-v1/GEN-SIM-DIGI-RAW",
+    "name": "ZMM_PU"
+  },
+  {
+    "path": "/RelValNuGun/CMSSW_16_1_0_pre4-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU_20260505_140840-v1/GEN-SIM-DIGI-RAW",
+    "name": "TenTau_PU"
+  },
+  {
+    "path": "/RelValNuGun/CMSSW_16_1_0_pre4-PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU_20260420_140840-v2/GEN-SIM-DIGI-RAW",
+    "name": "NuGun_PU"
+  }
+]

--- a/Validation/RecoParticleFlow/test/run_relval.sh
+++ b/Validation/RecoParticleFlow/test/run_relval.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #Script to run RECO and DQM sequences on existing files using cmsDriver.py
-#More background information: 
+#More background information:
 #https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCmsDriver
 #https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookDataFormats
 
@@ -18,22 +18,42 @@ if [ -z "$PERJOB" ]; then
     PERJOB=200
 fi
 
-#
-#set default conditions - run3 2021
-CONDITIONS=auto:phase1_2022_realistic ERA=Run3 GEOM=DB.Extended CUSTOM=
-#
-#conditions - 2018
-#CONDITIONS=auto:phase1_2018_realistic ERA=Run2_2018 GEOM=DB.Extended CUSTOM=
-#
-#conditions - phase2
-#CONDITIONS=auto:phase2_realistic_T15 ERA=Phase2C9 GEOM=Extended2026D49 CUSTOM="--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000"
+PHASE=$4
+case "${PHASE}" in
+    phase1)
+        CONDITIONS="auto:phase1_2026_realistic"
+        ERA="Run3"
+        GEOM="DB:Extended"
+        CUSTOM=""
+	PHASE_Label=""
+        ;;
+    phase1-mlpf)
+        CONDITIONS="auto:phase1_2026_realistic"
+        ERA="Run3"
+        GEOM="DB:Extended"
+        CUSTOM="--procModifiers mlpf"
+	PHASE_Label=""
+        ;;
+    phase2)
+        CONDITIONS="auto:phase2_realistic_T35"
+        ERA="Phase2C22I13M9"
+        GEOM="ExtendedRun4D121"
+        CUSTOM="--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000"
+	PHASE_Label="_phase2"
+        ;;
+esac
+
+echo "CONDITIONS=${CONDITIONS}"
+echo "ERA=${ERA}"
+echo "GEOM=${GEOM}"
+echo "CUSTOM=${CUSTOM}"
 
 #Running with 2 threads allows to use more memory on grid
 NTHREADS=8
 
 #Argument parsing
-if [ "$#" -ne 3 ]; then
-    echo "Must pass exactly 3 arguments: run_relval.sh [QCD|QCDPU|ZEEPU|ZMMPU|TenTauPU|NuGunPU] [reco|dqm] [njob]"
+if [ "$#" -ne 4 ]; then
+    echo "Must pass exactly 4 arguments: run_relval.sh [QCD|QCDPU|ZEEPU|ZMMPU|TenTauPU|NuGunPU] [reco|dqm|dqm2] [njob] [phase1|phase2|phase1-mlpf]"
     exit 0
 fi
 
@@ -79,7 +99,7 @@ elif [ "$1" == "TenTauPU" ]; then
 elif [ "$1" == "NuGunPU" ]; then
     INPUT_FILELIST=${CMSSW_BASE}/src/Validation/RecoParticleFlow/test/tmp/das_cache/NuGun_PU.txt
     NAME=NuGunPU
-elif [ "$1" == "conf" ]; then  # special switch for creating conf file, 
+elif [ "$1" == "conf" ]; then  # special switch for creating conf file,
     INPUT_FILELIST=${CMSSW_BASE}/src/Validation/RecoParticleFlow/test/tmp/das_cache/NuGun_PU.txt # dummy
     NAME=conf
 else
@@ -92,8 +112,10 @@ if [ "$2" == "reco" ]; then
     STEP="RECO"
 elif [ "$2" == "dqm" ]; then
     STEP="DQM"
+elif [ "$2" == "dqm2" ]; then
+    STEP="DQM2"
 else
-    echo "Argument 2 must be [reco|dqm] but was $2"
+    echo "Argument 2 must be [reco|dqm|dqm2] but was $2"
     exit 1
 fi
 
@@ -104,6 +126,8 @@ SKIPEVENTS=$(($NJOB * $PERJOB))
 echo $INPUT_FILELIST $NAME $STEP $SKIPEVENTS
 #env
 
+echo $GEOM $$CONDITIONS
+
 if [ $STEP == "RECO" ]; then
 
     if [ $NAME == "conf" ]; then
@@ -113,10 +137,10 @@ if [ $STEP == "RECO" ]; then
 	FILENAME=`sed -n "${NJOB}p" $INPUT_FILELIST`
 	echo "FILENAME="$FILENAME
 
-	cmsDriver.py step3 --conditions $CONDITIONS -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT --datatier MINIAODSIM --nThreads $NTHREADS -n 100 --era $ERA --eventcontent MINIAODSIM --geometry=$GEOM --filein step2.root --fileout file:step3_inMINIAODSIM.root --no_exec --python_filename=step3.py $CUSTOM
-	
+	cmsDriver.py step3 --conditions $CONDITIONS -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT --datatier MINIAODSIM --nThreads $NTHREADS -n 100 --era $ERA --eventcontent MINIAODSIM --geometry $GEOM --filein step2.root --fileout file:step3_inMINIAODSIM.root --no_exec --python_filename=step3${PHASE_Label}.py $CUSTOM
+
     else
-	
+
 	#Start of workflow
 	echo "Making subdirectory $NAME"
 
@@ -131,29 +155,39 @@ if [ $STEP == "RECO" ]; then
 	FILENAME=`sed -n "${NJOB}p" $INPUT_FILELIST`
 	echo "FILENAME="$FILENAME
 	#Run the actual CMS reco with particle flow.
-	echo "Running step RECO" 
-	cmsDriver.py step3 --conditions $CONDITIONS -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT --datatier MINIAODSIM --nThreads $NTHREADS -n 100 --era $ERA --eventcontent MINIAODSIM --geometry=$GEOM --filein $FILENAME --fileout file:step3_inMINIAODSIM.root $CUSTOM | tee step3.log  2>&1
-   
+	echo "Running step RECO"
+	cmsDriver.py step3 --conditions $CONDITIONS -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT --datatier MINIAODSIM --nThreads $NTHREADS -n 100 --era $ERA --eventcontent MINIAODSIM --geometry $GEOM --filein $FILENAME --fileout file:step3_inMINIAODSIM.root  --python_filename=step3${PHASE_Label}.py $CUSTOM | tee step3.log  2>&1
+
 	#NanoAOD
 	#On lxplus, this step takes about 1 minute / 1000 events
 	#Can be skipped if doing DQM directly from RECO
 	#cmsDriver.py step4 --conditions $CONDITIONS -s NANO --datatier NANOAODSIM --nThreads $NTHREADS -n $N --era $ERA --eventcontent NANOAODSIM --filein file:step3_inMINIAODSIM.root --fileout file:step4.root > step4.log 2>&1
 
     fi
-	
+
 elif [ $STEP == "DQM" ]; then
-    echo "Running step DQM" 
+    echo "Running step DQM"
 
     cd $NAME
-    
+
     #get all the filenames and make them into a python-compatible list of strings
     #STEP3FNS=`ls -1 step3*MINIAODSIM*.root | sed 's/^/"file:/;s/$/",/' | tr '\n' ' '`
     du step3*MINIAODSIM*.root | grep -v "^0" | awk '{print $2}' | sed 's/^/file:/' > step3_filelist.txt
-    cat step3_filelist.txt 
+    cat step3_filelist.txt
 
     #Run the DQM sequences (PF DQM only)
     #override the filenames here as cmsDriver does not allow multiple input files and there is no easy way to merge EDM files
     cmsDriver.py step5 --conditions $CONDITIONS -s DQM:@pfDQM --datatier DQMIO --nThreads $NTHREADS --era $ERA --eventcontent DQM --filein filelist:step3_filelist.txt --fileout file:step5.root -n 100 2>&1 | tee step5.log
+
+    #Harvesting converts the histograms stored in TTrees to be stored in folders by run etc
+    cmsDriver.py step6 --conditions $CONDITIONS -s HARVESTING:@pfDQM --era $ERA --filetype DQM --filein file:step5.root --fileout file:step6.root 2>&1 | tee step6.log
+
+elif [ $STEP == "DQM2" ]; then
+    echo "Running step DQM"
+
+    #Run the DQM sequences (PF DQM only)
+    #override the filenames here as cmsDriver does not allow multiple input files and there is no easy way to merge EDM files
+    cmsDriver.py step5 --conditions $CONDITIONS -s DQM:@pfDQM --datatier DQMIO --nThreads $NTHREADS --era $ERA --eventcontent DQM --filein filelist:step3_filelist.txt --fileout file:step5.root -n -1 2>&1 | tee step5.log
 
     #Harvesting converts the histograms stored in TTrees to be stored in folders by run etc
     cmsDriver.py step6 --conditions $CONDITIONS -s HARVESTING:@pfDQM --era $ERA --filetype DQM --filein file:step5.root --fileout file:step6.root 2>&1 | tee step6.log

--- a/Validation/RecoParticleFlow/test/run_relval.sh
+++ b/Validation/RecoParticleFlow/test/run_relval.sh
@@ -41,6 +41,10 @@ case "${PHASE}" in
         CUSTOM="--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000"
 	PHASE_Label="_phase2"
         ;;
+    *)
+        echo "Error: Unknown PHASE='${PHASE}'. Must be one of: phase1, phase1-mlpf, phase2"
+        exit 1
+        ;;
 esac
 
 echo "CONDITIONS=${CONDITIONS}"
@@ -126,7 +130,7 @@ SKIPEVENTS=$(($NJOB * $PERJOB))
 echo $INPUT_FILELIST $NAME $STEP $SKIPEVENTS
 #env
 
-echo $GEOM $$CONDITIONS
+echo $GEOM $CONDITIONS
 
 if [ $STEP == "RECO" ]; then
 


### PR DESCRIPTION
#### PR description:

Updating the PF validation "on-the-fly" workflow for a more recent release. Also, we added an option to run MLPF. This update was discussed in:
https://indico.cern.ch/event/1689603/#12-report-from-pf-validation
https://indico.cern.ch/event/1697002/#10-pf-mlpf-validations

#### PR validation:

Some plots from the updated workflow are in:
https://hep.baylor.edu/hatake/PFval2/CMSSW_17_0_0_pre1/plots/

This is the backport of https://github.com/cms-sw/cmssw/pull/51202