### PR TITLE
Make Lumi ESSources concurrent capable

### DIFF
--- a/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.cc
@@ -65,9 +65,9 @@ DIPLumiProducer::DIPLumiProducer(const edm::ParameterSet& iConfig)
   m_cachesize = iConfig.getUntrackedParameter<unsigned int>("ncacheEntries", 3);
 }
 
-DIPLumiProducer::ReturnSummaryType DIPLumiProducer::produceSummary(const DIPLuminosityRcd&) {
-  unsigned int currentrun = m_pcurrentTime->eventID().run();
-  unsigned int currentls = m_pcurrentTime->luminosityBlockNumber();
+DIPLumiProducer::ReturnSummaryType DIPLumiProducer::produceSummary(const DIPLuminosityRcd& iRcd) {
+  const unsigned int currentrun = iRcd.validityInterval().first().eventID().run();
+  const unsigned int currentls = iRcd.validityInterval().first().luminosityBlockNumber();
   if (currentls == 0 || currentls == 4294967295) {
     return std::make_shared<const DIPLumiSummary>();
   }
@@ -97,9 +97,9 @@ DIPLumiProducer::ReturnSummaryType DIPLumiProducer::produceSummary(const DIPLumi
   }
   return m_summaryresult;
 }
-DIPLumiProducer::ReturnDetailType DIPLumiProducer::produceDetail(const DIPLuminosityRcd&) {
-  unsigned int currentrun = m_pcurrentTime->eventID().run();
-  unsigned int currentls = m_pcurrentTime->luminosityBlockNumber();
+DIPLumiProducer::ReturnDetailType DIPLumiProducer::produceDetail(const DIPLuminosityRcd& iRcd) {
+  const unsigned int currentrun = iRcd.validityInterval().first().eventID().run();
+  const unsigned int currentls = iRcd.validityInterval().first().luminosityBlockNumber();
   if (currentls == 0 || currentls == 4294967295) {
     return std::make_shared<const DIPLumiDetail>();
   }
@@ -133,7 +133,6 @@ DIPLumiProducer::ReturnDetailType DIPLumiProducer::produceDetail(const DIPLumino
 void DIPLumiProducer::setIntervalFor(const edm::eventsetup::EventSetupRecordKey& iKey,
                                      const edm::IOVSyncValue& iTime,
                                      edm::ValidityInterval& oValidity) {
-  m_pcurrentTime = &iTime;
   oValidity.setFirst(iTime);
   oValidity.setLast(iTime);
 }

--- a/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.h
+++ b/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.h
@@ -26,7 +26,7 @@ public:
   ReturnSummaryType produceSummary(const DIPLuminosityRcd&);
   typedef std::shared_ptr<const DIPLumiDetail> ReturnDetailType;
   ReturnDetailType produceDetail(const DIPLuminosityRcd&);
-  ~DIPLumiProducer() final;
+  ~DIPLumiProducer() override;
 
 protected:
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,

--- a/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.h
+++ b/RecoLuminosity/LumiProducer/plugins/DIPLumiProducer.h
@@ -26,12 +26,13 @@ public:
   ReturnSummaryType produceSummary(const DIPLuminosityRcd&);
   typedef std::shared_ptr<const DIPLumiDetail> ReturnDetailType;
   ReturnDetailType produceDetail(const DIPLuminosityRcd&);
-  ~DIPLumiProducer() override;
+  ~DIPLumiProducer() final;
 
 protected:
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
                       const edm::IOVSyncValue&,
-                      edm::ValidityInterval&) override;
+                      edm::ValidityInterval&) final;
+  bool isConcurrentFinder() const final { return true; }
 
 private:
   unsigned int maxavailableLSforRun(coral::ISchema& schema, const std::string& tablename, unsigned int runnumber);
@@ -46,7 +47,6 @@ private:
   unsigned int m_cachesize;
   std::shared_ptr<const DIPLumiSummary> m_summaryresult;
   std::shared_ptr<const DIPLumiDetail> m_detailresult;
-  const edm::IOVSyncValue* m_pcurrentTime;
 
 private:
   void fillsummarycache(unsigned int runnumber, unsigned int startlsnum);

--- a/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
@@ -255,15 +255,14 @@ void LumiCorrectionSource::fillparamcache(unsigned int runnumber) {
       reloadAuth();
     }
   }
-  coral::ConnectionService* mydbservice = new coral::ConnectionService;
+  coral::ConnectionService mydbservice;
   if (!m_globaltag.empty()) {
-    coral::ISessionProxy* gsession = mydbservice->connect(m_connectStr, coral::ReadOnly);
+    std::unique_ptr<coral::ISessionProxy> gsession{mydbservice.connect(m_connectStr, coral::ReadOnly)};
     gsession->transaction().start(true);
     parseGlobaltagForLumi(gsession->nominalSchema(), m_globaltag);
     gsession->transaction().commit();
-    delete gsession;
   }
-  coral::ISessionProxy* session = mydbservice->connect(m_connectStr, coral::ReadOnly);
+  std::unique_ptr<coral::ISessionProxy> session{mydbservice.connect(m_connectStr, coral::ReadOnly)};
   coral::ITypeConverter& tconverter = session->typeConverter();
   tconverter.setCppTypeForSqlType(std::string("float"), std::string("FLOAT(63)"));
   tconverter.setCppTypeForSqlType(std::string("unsigned int"), std::string("NUMBER(10)"));
@@ -286,8 +285,6 @@ void LumiCorrectionSource::fillparamcache(unsigned int runnumber) {
       std::shared_ptr<const LumiCorrectionParam> const_result = std::move(result);
       m_paramcache.insert(std::make_pair(runnumber, const_result));
       session->transaction().commit();
-      delete session;
-      delete mydbservice;
       return;
     }
 
@@ -297,7 +294,7 @@ void LumiCorrectionSource::fillparamcache(unsigned int runnumber) {
     std::string conditionStr("DATA_ID=:dataid");
     coral::AttributeList lumiparamOutput;
     lumiparamOutput.extend("NCOLLIDINGBUNCHES", typeid(unsigned int));
-    coral::IQuery* lumiparamQuery = schema.newQuery();
+    std::unique_ptr<coral::IQuery> lumiparamQuery{schema.newQuery()};
     lumiparamQuery->addToTableList(std::string("LUMIDATA"));
     lumiparamQuery->setCondition(conditionStr, lumidataBindVariables);
     lumiparamQuery->addToOutputList("NCOLLIDINGBUNCHES");
@@ -311,7 +308,7 @@ void LumiCorrectionSource::fillparamcache(unsigned int runnumber) {
       }
       result->setNBX(ncollidingbx);
     }
-    delete lumiparamQuery;
+    lumiparamQuery.reset();
     lumi::NormDML normdml;
     unsigned long long normid = 0;
     std::map<std::string, unsigned long long> normidmap;
@@ -344,12 +341,8 @@ void LumiCorrectionSource::fillparamcache(unsigned int runnumber) {
     session->transaction().commit();
   } catch (const coral::Exception& er) {
     session->transaction().rollback();
-    delete session;
-    delete mydbservice;
     throw cms::Exception("DatabaseError ") << er.what();
   }
-  delete session;
-  delete mydbservice;
 }
 void LumiCorrectionSource::parseGlobaltagForLumi(coral::ISchema& schema, const std::string& globaltag) {
   /**select i.pfn,i.tagname from TAGINVENTORY_TABLE i,TAGTREE_TABLE_GLOBALTAG v from i.tagid=v.tagid and i.recordname='LumiCorrectionParamRcd' **/

--- a/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
@@ -203,8 +203,9 @@ LumiCorrectionSource::LumiCorrectionSource(const edm::ParameterSet& iConfig)
   }
 }
 
-LumiCorrectionSource::ReturnParamType LumiCorrectionSource::produceLumiCorrectionParam(const LumiCorrectionParamRcd&) {
-  unsigned int currentrun = m_pcurrentTime->eventID().run();
+LumiCorrectionSource::ReturnParamType LumiCorrectionSource::produceLumiCorrectionParam(
+    const LumiCorrectionParamRcd& iRcd) {
+  const unsigned int currentrun = iRcd.validityInterval().first().eventID().run();
   if (currentrun == 0 || currentrun == 4294967295) {
     return std::make_shared<const LumiCorrectionParam>();
   }
@@ -228,7 +229,6 @@ LumiCorrectionSource::ReturnParamType LumiCorrectionSource::produceLumiCorrectio
 void LumiCorrectionSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey& iKey,
                                           const edm::IOVSyncValue& iTime,
                                           edm::ValidityInterval& oValidity) {
-  m_pcurrentTime = &iTime;
   oValidity.setFirst(iTime);
   oValidity.setLast(iTime);
 }

--- a/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.h
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.h
@@ -27,7 +27,7 @@ public:
   LumiCorrectionSource(const edm::ParameterSet&);
   typedef std::shared_ptr<const LumiCorrectionParam> ReturnParamType;
   ReturnParamType produceLumiCorrectionParam(const LumiCorrectionParamRcd&);
-  ~LumiCorrectionSource() final;
+  ~LumiCorrectionSource() override;
 
 protected:
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,

--- a/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.h
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.h
@@ -27,12 +27,13 @@ public:
   LumiCorrectionSource(const edm::ParameterSet&);
   typedef std::shared_ptr<const LumiCorrectionParam> ReturnParamType;
   ReturnParamType produceLumiCorrectionParam(const LumiCorrectionParamRcd&);
-  ~LumiCorrectionSource() override;
+  ~LumiCorrectionSource() final;
 
 protected:
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
                       const edm::IOVSyncValue&,
-                      edm::ValidityInterval&) override;
+                      edm::ValidityInterval&) final;
+  bool isConcurrentFinder() const final { return true; }
 
 private:
   std::string translateFrontierConnect(const std::string& connectStr);
@@ -50,11 +51,9 @@ private:
   std::string m_normtag;
   std::string m_siteconfpath;
   std::map<unsigned int, std::shared_ptr<const LumiCorrectionParam> > m_paramcache;
-  bool m_isNullRun;  //if lumi data exist for this run
   unsigned int m_paramcachedrun;
   unsigned int m_cachesize;
   std::shared_ptr<const LumiCorrectionParam> m_paramresult;
-  const edm::IOVSyncValue* m_pcurrentTime;
 
 private:
   void fillparamcache(unsigned int runnumber);


### PR DESCRIPTION
#### PR description:

- removed requirement that setIntervalFor can not be called again before a call to produce.
- improved memory handling in LumiCorrectionSource

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2298