### PR TITLE
Make CalibPPS ESSources concurrent capable

### DIFF
--- a/CalibPPS/ESProducers/interface/CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon.h
+++ b/CalibPPS/ESProducers/interface/CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon.h
@@ -21,8 +21,12 @@ public:
   ~CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon();
 
   CTPPSRPAlignmentCorrectionsDataSequence acsMeasured, acsReal, acsMisaligned;
-  CTPPSRPAlignmentCorrectionsData acMeasured, acReal, acMisaligned;
 
+  static const CTPPSRPAlignmentCorrectionsData *dataFor(edm::IOVSyncValue const &,
+                                                        CTPPSRPAlignmentCorrectionsDataSequence const &);
+  static edm::ValidityInterval intervalFor(edm::IOVSyncValue const &,
+                                           CTPPSRPAlignmentCorrectionsDataSequence const &,
+                                           bool verbosity);
   unsigned int verbosity;
 
   static edm::EventID previousLS(const edm::EventID &src);

--- a/CalibPPS/ESProducers/plugins/CTPPSLHCInfoESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSLHCInfoESSource.cc
@@ -23,18 +23,17 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &);
 
 private:
+  bool isConcurrentFinder() const override { return true; }
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
                       const edm::IOVSyncValue &,
                       edm::ValidityInterval &) override;
 
-  std::string m_label;
+  const std::string m_label;
 
-  edm::EventRange m_validityRange;
-  double m_beamEnergy;
-  double m_betaStar;
-  double m_xangle;
-
-  bool m_insideValidityRange;
+  const edm::EventRange m_validityRange;
+  const double m_beamEnergy;
+  const double m_betaStar;
+  const double m_xangle;
 };
 
 //----------------------------------------------------------------------------------------------------
@@ -45,8 +44,7 @@ CTPPSLHCInfoESSource::CTPPSLHCInfoESSource(const edm::ParameterSet &conf)
       m_validityRange(conf.getParameter<edm::EventRange>("validityRange")),
       m_beamEnergy(conf.getParameter<double>("beamEnergy")),
       m_betaStar(conf.getParameter<double>("betaStar")),
-      m_xangle(conf.getParameter<double>("xangle")),
-      m_insideValidityRange(false) {
+      m_xangle(conf.getParameter<double>("xangle")) {
   setWhatProduced(this, m_label);
   findingRecord<LHCInfoRcd>();
 }
@@ -73,12 +71,9 @@ void CTPPSLHCInfoESSource::setIntervalFor(const edm::eventsetup::EventSetupRecor
                                           const edm::IOVSyncValue &iosv,
                                           edm::ValidityInterval &oValidity) {
   if (edm::contains(m_validityRange, iosv.eventID())) {
-    m_insideValidityRange = true;
     oValidity = edm::ValidityInterval(edm::IOVSyncValue(m_validityRange.startEventID()),
                                       edm::IOVSyncValue(m_validityRange.endEventID()));
   } else {
-    m_insideValidityRange = false;
-
     if (iosv.eventID() < m_validityRange.startEventID()) {
       edm::RunNumber_t run = m_validityRange.startEventID().run();
       edm::LuminosityBlockNumber_t lb = m_validityRange.startEventID().luminosityBlock();
@@ -99,10 +94,10 @@ void CTPPSLHCInfoESSource::setIntervalFor(const edm::eventsetup::EventSetupRecor
 
 //----------------------------------------------------------------------------------------------------
 
-edm::ESProducts<std::unique_ptr<LHCInfo>> CTPPSLHCInfoESSource::produce(const LHCInfoRcd &) {
+edm::ESProducts<std::unique_ptr<LHCInfo>> CTPPSLHCInfoESSource::produce(const LHCInfoRcd &iRcd) {
   auto output = std::make_unique<LHCInfo>();
 
-  if (m_insideValidityRange) {
+  if (edm::contains(m_validityRange, iRcd.validityInterval().first().eventID())) {
     output->setEnergy(m_beamEnergy);
     output->setBetaStar(m_betaStar);
     output->setCrossingAngle(m_xangle);

--- a/CalibPPS/ESProducers/plugins/CTPPSOpticalFunctionsESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSOpticalFunctionsESSource.cc
@@ -10,6 +10,7 @@
 #include "CondFormats/PPSObjects/interface/LHCOpticalFunctionsSetCollection.h"
 #include "CondFormats/DataRecord/interface/CTPPSOpticsRcd.h"
 
+#include <optional>
 //----------------------------------------------------------------------------------------------------
 
 /**
@@ -24,6 +25,8 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &);
 
 private:
+  bool isConcurrentFinder() const override { return true; }
+  std::optional<unsigned int> findEntryFor(const edm::IOVSyncValue &) const;
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
                       const edm::IOVSyncValue &,
                       edm::ValidityInterval &) override;
@@ -47,16 +50,13 @@ private:
   };
 
   std::vector<Entry> m_entries;
-
-  bool m_currentEntryValid;
-  unsigned int m_currentEntry;
 };
 
 //----------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------
 
 CTPPSOpticalFunctionsESSource::CTPPSOpticalFunctionsESSource(const edm::ParameterSet &conf)
-    : m_label(conf.getParameter<std::string>("label")), m_currentEntryValid(false), m_currentEntry(0) {
+    : m_label(conf.getParameter<std::string>("label")) {
   for (const auto &entry_pset : conf.getParameter<std::vector<edm::ParameterSet>>("configuration")) {
     edm::EventRange validityRange = entry_pset.getParameter<edm::EventRange>("validityRange");
 
@@ -81,26 +81,30 @@ CTPPSOpticalFunctionsESSource::CTPPSOpticalFunctionsESSource(const edm::Paramete
 
 //----------------------------------------------------------------------------------------------------
 
-void CTPPSOpticalFunctionsESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &key,
-                                                   const edm::IOVSyncValue &iosv,
-                                                   edm::ValidityInterval &oValidity) {
+std::optional<unsigned int> CTPPSOpticalFunctionsESSource::findEntryFor(const edm::IOVSyncValue &iosv) const {
   for (unsigned int idx = 0; idx < m_entries.size(); ++idx) {
     const auto &entry = m_entries[idx];
 
     // is within an entry ?
     if (edm::contains(entry.m_validityRange, iosv.eventID())) {
-      m_currentEntryValid = true;
-      m_currentEntry = idx;
-      oValidity = edm::ValidityInterval(edm::IOVSyncValue(entry.m_validityRange.startEventID()),
-                                        edm::IOVSyncValue(entry.m_validityRange.endEventID()));
-      return;
+      return idx;
     }
+  }
+  return std::nullopt;
+}
+
+void CTPPSOpticalFunctionsESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &key,
+                                                   const edm::IOVSyncValue &iosv,
+                                                   edm::ValidityInterval &oValidity) {
+  const auto findEntry = findEntryFor(iosv);
+  if (findEntry) {
+    auto const &entry = m_entries[*findEntry];
+    oValidity = edm::ValidityInterval(edm::IOVSyncValue(entry.m_validityRange.startEventID()),
+                                      edm::IOVSyncValue(entry.m_validityRange.endEventID()));
+    return;
   }
 
   // not within any entry
-  m_currentEntryValid = false;
-  m_currentEntry = 0;
-
   edm::LogInfo("") << "No configuration entry found for event " << iosv.eventID()
                    << ", no optical functions will be available.";
 
@@ -111,13 +115,14 @@ void CTPPSOpticalFunctionsESSource::setIntervalFor(const edm::eventsetup::EventS
 
 //----------------------------------------------------------------------------------------------------
 
-std::unique_ptr<LHCOpticalFunctionsSetCollection> CTPPSOpticalFunctionsESSource::produce(const CTPPSOpticsRcd &) {
+std::unique_ptr<LHCOpticalFunctionsSetCollection> CTPPSOpticalFunctionsESSource::produce(const CTPPSOpticsRcd &iRcd) {
   // prepare output, empty by default
   auto output = std::make_unique<LHCOpticalFunctionsSetCollection>();
 
+  auto const findEntry = findEntryFor(iRcd.validityInterval().first());
   // fill the output
-  if (m_currentEntryValid) {
-    const auto &entry = m_entries[m_currentEntry];
+  if (findEntry) {
+    const auto &entry = m_entries[*findEntry];
 
     for (const auto &fi : entry.m_fileInfo) {
       std::unordered_map<unsigned int, LHCOpticalFunctionsSet> xa_data;

--- a/CalibPPS/ESProducers/plugins/CTPPSPixelDAQMappingESSourceXML.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSPixelDAQMappingESSourceXML.cc
@@ -36,6 +36,7 @@
 
 #include <memory>
 #include <sstream>
+#include <optional>
 
 //#define DEBUG 1
 
@@ -87,12 +88,6 @@ private:
 
   vector<ConfigBlock> configuration;
 
-  /// index of the current block in 'configuration' array
-  unsigned int currentBlock;
-
-  /// flag whether the 'currentBlock' index is valid
-  bool currentBlockValid;
-
   /// enumeration of XML node types
   enum NodeType { nUnknown, nSkip, nTop, nArm, nRPStation, nRPPot, nRPixPlane, nROC, nPixel };
 
@@ -140,7 +135,10 @@ private:
     return ((type == nArm) || (type == nRPStation) || (type == nRPPot) || (type == nRPixPlane) || (type == nROC));
   }
 
-protected:
+  bool isConcurrentFinder() const override { return false; }
+
+  std::optional<unsigned int> findBlockFor(const edm::IOVSyncValue &) const;
+
   /// sets infinite validity of this data
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
                       const edm::IOVSyncValue &,
@@ -170,9 +168,7 @@ static const unsigned int offsetROCinDetId = 13;
 
 CTPPSPixelDAQMappingESSourceXML::CTPPSPixelDAQMappingESSourceXML(const edm::ParameterSet &conf)
     : verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0)),
-      subSystemName(conf.getUntrackedParameter<string>("subSystem")),
-      currentBlock(0),
-      currentBlockValid(false) {
+      subSystemName(conf.getUntrackedParameter<string>("subSystem")) {
   for (const auto &it : conf.getParameter<vector<ParameterSet>>("configuration")) {
     ConfigBlock b;
     b.validityRange = it.getParameter<EventRange>("validityRange");
@@ -190,6 +186,21 @@ CTPPSPixelDAQMappingESSourceXML::CTPPSPixelDAQMappingESSourceXML(const edm::Para
   LogVerbatim("CTPPSPixelDAQMappingESSourceXML") << " Inside  CTPPSPixelDAQMappingESSourceXML";
 }
 
+std::optional<unsigned int> CTPPSPixelDAQMappingESSourceXML::findBlockFor(const edm::IOVSyncValue &iosv) const {
+  for (unsigned int idx = 0; idx < configuration.size(); ++idx) {
+    const auto &bl = configuration[idx];
+
+    EventID startEventID = bl.validityRange.startEventID();
+    if (startEventID == EventID(1, 0, 1))
+      startEventID = EventID(1, 0, 0);
+
+    if (startEventID <= iosv.eventID() && iosv.eventID() <= bl.validityRange.endEventID()) {
+      return idx;
+    }
+  }
+  return std::nullopt;
+}
+
 void CTPPSPixelDAQMappingESSourceXML::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &key,
                                                      const edm::IOVSyncValue &iosv,
                                                      edm::ValidityInterval &oValidity) {
@@ -199,33 +210,25 @@ void CTPPSPixelDAQMappingESSourceXML::setIntervalFor(const edm::eventsetup::Even
   LogVerbatim("CTPPSPixelDAQMappingESSourceXML")
       << "    run=" << iosv.eventID().run() << ", event=" << iosv.eventID().event();
 
-  currentBlockValid = false;
-  for (unsigned int idx = 0; idx < configuration.size(); ++idx) {
-    const auto &bl = configuration[idx];
-
+  auto findBlock = findBlockFor(iosv);
+  if (findBlock) {
+    auto const &bl = configuration[*findBlock];
     EventID startEventID = bl.validityRange.startEventID();
-    if (startEventID == EventID(1, 0, 1))
+    if (startEventID == EventID(1, 0, 1)) {
       startEventID = EventID(1, 0, 0);
-
-    if (startEventID <= iosv.eventID() && iosv.eventID() <= bl.validityRange.endEventID()) {
-      currentBlockValid = true;
-      currentBlock = idx;
-
-      const IOVSyncValue begin(startEventID);
-      const IOVSyncValue end(bl.validityRange.endEventID());
-      oValidity = ValidityInterval(begin, end);
-
-      LogVerbatim("CTPPSPixelDAQMappingESSourceXML") << "    block found: index=" << currentBlock << ", interval=("
-                                                     << startEventID << " - " << bl.validityRange.endEventID() << ")";
-
-      return;
     }
+    const IOVSyncValue begin(startEventID);
+    const IOVSyncValue end(bl.validityRange.endEventID());
+    oValidity = ValidityInterval(begin, end);
+
+    LogVerbatim("CTPPSPixelDAQMappingESSourceXML")
+        << "    block found: index=" << *findBlock << ", interval=(" << startEventID << " - " << end.eventID() << ")";
+
+    return;
   }
 
-  if (!currentBlockValid) {
-    throw cms::Exception("CTPPSPixelDAQMappingESSourceXML::setIntervalFor")
-        << "No configuration for event " << iosv.eventID();
-  }
+  throw cms::Exception("CTPPSPixelDAQMappingESSourceXML::setIntervalFor")
+      << "No configuration for event " << iosv.eventID();
 }
 
 CTPPSPixelDAQMappingESSourceXML::~CTPPSPixelDAQMappingESSourceXML() {}
@@ -236,8 +239,10 @@ string CTPPSPixelDAQMappingESSourceXML::CompleteFileName(const string &fn) {
 }
 
 std::unique_ptr<CTPPSPixelDAQMapping> CTPPSPixelDAQMappingESSourceXML::produceCTPPSPixelDAQMapping(
-    const CTPPSPixelDAQMappingRcd &) {
-  assert(currentBlockValid);
+    const CTPPSPixelDAQMappingRcd &iRcd) {
+  auto findBlock = findBlockFor(iRcd.validityInterval().first());
+  assert(findBlock);
+  const auto currentBlock = *findBlock;
 
   auto mapping = std::make_unique<CTPPSPixelDAQMapping>();
   auto mask = std::make_unique<CTPPSPixelAnalysisMask>();
@@ -262,8 +267,10 @@ std::unique_ptr<CTPPSPixelDAQMapping> CTPPSPixelDAQMappingESSourceXML::produceCT
 }
 
 std::unique_ptr<CTPPSPixelAnalysisMask> CTPPSPixelDAQMappingESSourceXML::produceCTPPSPixelAnalysisMask(
-    const CTPPSPixelAnalysisMaskRcd &) {
-  assert(currentBlockValid);
+    const CTPPSPixelAnalysisMaskRcd &iRcd) {
+  auto findBlock = findBlockFor(iRcd.validityInterval().first());
+  assert(findBlock);
+  const auto currentBlock = *findBlock;
 
   auto mapping = std::make_unique<CTPPSPixelDAQMapping>();
   auto mask = std::make_unique<CTPPSPixelAnalysisMask>();

--- a/CalibPPS/ESProducers/plugins/CTPPSRPAlignmentCorrectionsDataESSourceXML.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSRPAlignmentCorrectionsDataESSourceXML.cc
@@ -42,12 +42,14 @@ public:
   ~CTPPSRPAlignmentCorrectionsDataESSourceXML() override;
 
 protected:
-  std::unique_ptr<CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon> ctppsRPAlignmentCorrectionsDataESSourceXMLCommon;
+  std::unique_ptr<CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon const>
+      ctppsRPAlignmentCorrectionsDataESSourceXMLCommon;
 
   std::unique_ptr<CTPPSRPAlignmentCorrectionsData> produceMeasured(const CTPPSRPAlignmentCorrectionsDataRcd &);
   std::unique_ptr<CTPPSRPAlignmentCorrectionsData> produceReal(const RPRealAlignmentRecord &);
   std::unique_ptr<CTPPSRPAlignmentCorrectionsData> produceMisaligned(const RPMisalignedAlignmentRecord &);
 
+  bool isConcurrentFinder() const override { return true; }
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
                       const edm::IOVSyncValue &,
                       edm::ValidityInterval &) override;
@@ -75,23 +77,36 @@ CTPPSRPAlignmentCorrectionsDataESSourceXML::~CTPPSRPAlignmentCorrectionsDataESSo
 
 std::unique_ptr<CTPPSRPAlignmentCorrectionsData> CTPPSRPAlignmentCorrectionsDataESSourceXML::produceMeasured(
     const CTPPSRPAlignmentCorrectionsDataRcd &iRecord) {
-  return std::make_unique<CTPPSRPAlignmentCorrectionsData>(
-      ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->acMeasured);
+  auto data = CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon::dataFor(
+      iRecord.validityInterval().first(), ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->acsMeasured);
+  if (data) {
+    return std::make_unique<CTPPSRPAlignmentCorrectionsData>(*data);
+  }
+  return std::make_unique<CTPPSRPAlignmentCorrectionsData>();
 }
 
 //----------------------------------------------------------------------------------------------------
 
 std::unique_ptr<CTPPSRPAlignmentCorrectionsData> CTPPSRPAlignmentCorrectionsDataESSourceXML::produceReal(
     const RPRealAlignmentRecord &iRecord) {
-  return std::make_unique<CTPPSRPAlignmentCorrectionsData>(ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->acReal);
+  auto data = CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon::dataFor(
+      iRecord.validityInterval().first(), ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->acsReal);
+  if (data) {
+    return std::make_unique<CTPPSRPAlignmentCorrectionsData>(*data);
+  }
+  return std::make_unique<CTPPSRPAlignmentCorrectionsData>();
 }
 
 //----------------------------------------------------------------------------------------------------
 
 std::unique_ptr<CTPPSRPAlignmentCorrectionsData> CTPPSRPAlignmentCorrectionsDataESSourceXML::produceMisaligned(
     const RPMisalignedAlignmentRecord &iRecord) {
-  return std::make_unique<CTPPSRPAlignmentCorrectionsData>(
-      ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->acMisaligned);
+  auto data = CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon::dataFor(
+      iRecord.validityInterval().first(), ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->acsMisaligned);
+  if (data) {
+    return std::make_unique<CTPPSRPAlignmentCorrectionsData>(*data);
+  }
+  return std::make_unique<CTPPSRPAlignmentCorrectionsData>();
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -110,79 +125,30 @@ void CTPPSRPAlignmentCorrectionsDataESSourceXML::setIntervalFor(const edm::event
   }
 
   // // determine what sequence and corrections should be used
-  CTPPSRPAlignmentCorrectionsDataSequence *p_seq = nullptr;
-  CTPPSRPAlignmentCorrectionsData *p_corr = nullptr;
+  CTPPSRPAlignmentCorrectionsDataSequence const *p_seq = nullptr;
 
+  bool knownRecord = false;
   if (strcmp(key.name(), "CTPPSRPAlignmentCorrectionsDataRcd") == 0) {
     p_seq = &(ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->acsMeasured);
-    p_corr = &(ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->acMeasured);
+    knownRecord = true;
   }
 
   if (strcmp(key.name(), "RPRealAlignmentRecord") == 0) {
     p_seq = &(ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->acsReal);
-    p_corr = &(ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->acReal);
+    knownRecord = true;
   }
 
   if (strcmp(key.name(), "RPMisalignedAlignmentRecord") == 0) {
     p_seq = &(ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->acsMisaligned);
-    p_corr = &(ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->acMisaligned);
+    knownRecord = true;
   }
 
-  if (p_corr == nullptr)
+  if (not knownRecord)
     throw cms::Exception("CTPPSRPAlignmentCorrectionsDataESSourceXML::setIntervalFor")
         << "Unknown record " << key.name();
 
-  // // find the corresponding interval
-  bool next_exists = false;
-  const edm::EventID &event_curr = iosv.eventID();
-  edm::EventID event_next_start(edm::EventID::maxRunNumber(), edm::EventID::maxLuminosityBlockNumber(), 1);
-
-  for (const auto &it : *p_seq) {
-    const auto &it_event_first = it.first.first().eventID();
-    const auto &it_event_last = it.first.last().eventID();
-
-    bool it_contained_lo = ((it_event_first.run() < event_curr.run()) ||
-                            ((it_event_first.run() == event_curr.run()) &&
-                             (it_event_first.luminosityBlock() <= event_curr.luminosityBlock())));
-
-    bool it_contained_up = ((it_event_last.run() > event_curr.run()) ||
-                            ((it_event_last.run() == event_curr.run()) &&
-                             (it_event_last.luminosityBlock() >= event_curr.luminosityBlock())));
-
-    if (it_contained_lo && it_contained_up) {
-      valInt = it.first;
-      *p_corr = it.second;
-
-      if (ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->verbosity) {
-        LogInfo("PPS") << "    setting validity interval ["
-                       << CTPPSRPAlignmentCorrectionsMethods::iovValueToString(valInt.first()) << ", "
-                       << CTPPSRPAlignmentCorrectionsMethods::iovValueToString(valInt.last()) << "]";
-      }
-
-      return;
-    }
-
-    bool it_in_future = ((it_event_first.run() > event_curr.run()) ||
-                         ((it_event_first.run() == event_curr.run() &&
-                           (it_event_first.luminosityBlock() > event_curr.luminosityBlock()))));
-
-    if (it_in_future) {
-      next_exists = true;
-      if (event_next_start > it_event_first)
-        event_next_start = it_event_first;
-    }
-  }
-
-  // no interval found, set empty corrections
-  *p_corr = CTPPSRPAlignmentCorrectionsData();
-
-  if (!next_exists) {
-    valInt = ValidityInterval(iosv, iosv.endOfTime());
-  } else {
-    const EventID &event_last = ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->previousLS(event_next_start);
-    valInt = ValidityInterval(iosv, IOVSyncValue(event_last));
-  }
-
+  valInt = CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon::intervalFor(
+      iosv, *p_seq, ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->verbosity);
   if (ctppsRPAlignmentCorrectionsDataESSourceXMLCommon->verbosity) {
     LogInfo("PPS") << "    setting validity interval ["
                    << CTPPSRPAlignmentCorrectionsMethods::iovValueToString(valInt.first()) << ", "

--- a/CalibPPS/ESProducers/plugins/PPSAssociationCutsESSource.cc
+++ b/CalibPPS/ESProducers/plugins/PPSAssociationCutsESSource.cc
@@ -19,6 +19,7 @@
 #include "CondFormats/PPSObjects/interface/PPSAssociationCuts.h"
 #include "CondFormats/DataRecord/interface/PPSAssociationCutsRcd.h"
 #include <vector>
+#include <optional>
 
 using namespace std;
 
@@ -33,11 +34,14 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &);
 
 protected:
+  bool isConcurrentFinder() const override { return true; }
+
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
                       const edm::IOVSyncValue &,
                       edm::ValidityInterval &) override;
 
 private:
+  std::optional<unsigned int> associationCutIndexFor(const edm::IOVSyncValue &) const;
   static edm::ParameterSetDescription getIOVDefaultParameters();
   bool currentAssociationCutValid_;
   unsigned int currentAssociationCutIdx_;
@@ -59,22 +63,25 @@ PPSAssociationCutsESSource::PPSAssociationCutsESSource(const edm::ParameterSet &
 
 //----------------------------------------------------------------------------------------------------
 
-void PPSAssociationCutsESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &key,
-                                                const edm::IOVSyncValue &iosv,
-                                                edm::ValidityInterval &oValidity) {
+std::optional<unsigned int> PPSAssociationCutsESSource::associationCutIndexFor(const edm::IOVSyncValue &iosv) const {
   for (unsigned int idx = 0; idx < ppsAssociationCuts_.size(); ++idx) {
     // is within an entry ?
     if (edm::contains(validityRanges_[idx], iosv.eventID())) {
-      currentAssociationCutValid_ = true;
-      currentAssociationCutIdx_ = idx;
-      oValidity = edm::ValidityInterval(edm::IOVSyncValue(validityRanges_[idx].startEventID()),
-                                        edm::IOVSyncValue(validityRanges_[idx].endEventID()));
-      return;
+      return idx;
     }
   }
+  return std::nullopt;
+}
 
-  currentAssociationCutValid_ = false;
-  currentAssociationCutIdx_ = 0;
+void PPSAssociationCutsESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &key,
+                                                const edm::IOVSyncValue &iosv,
+                                                edm::ValidityInterval &oValidity) {
+  auto cutIdx = associationCutIndexFor(iosv);
+  if (cutIdx) {
+    oValidity = edm::ValidityInterval(edm::IOVSyncValue(validityRanges_[*cutIdx].startEventID()),
+                                      edm::IOVSyncValue(validityRanges_[*cutIdx].endEventID()));
+    return;
+  }
 
   edm::LogInfo("PPSAssociationCutsESSource")
       << ">> PPSAssociationCutsESSource::setIntervalFor(" << key.name() << ")\n"
@@ -87,11 +94,13 @@ void PPSAssociationCutsESSource::setIntervalFor(const edm::eventsetup::EventSetu
 
 //----------------------------------------------------------------------------------------------------
 
-std::shared_ptr<PPSAssociationCuts> PPSAssociationCutsESSource::produce(const PPSAssociationCutsRcd &) {
+std::shared_ptr<PPSAssociationCuts> PPSAssociationCutsESSource::produce(const PPSAssociationCutsRcd &iRcd) {
   auto output = std::make_shared<PPSAssociationCuts>();
 
-  if (currentAssociationCutValid_) {
-    const auto &associationCut = ppsAssociationCuts_[currentAssociationCutIdx_];
+  auto cutIdx = associationCutIndexFor(iRcd.validityInterval().first());
+
+  if (cutIdx) {
+    const auto &associationCut = ppsAssociationCuts_[*cutIdx];
     output = associationCut;
   }
 

--- a/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
@@ -42,6 +42,7 @@
 
 #include <memory>
 #include <sstream>
+#include <optional>
 
 //#define DEBUG 1
 
@@ -92,6 +93,7 @@ public:
   edm::ESProducts<std::unique_ptr<TotemDAQMapping>, std::unique_ptr<TotemAnalysisMask>> produce(const TotemReadoutRcd &);
 
 private:
+  std::optional<unsigned int> findBlockFor(edm::IOVSyncValue const &) const;
   unsigned int verbosity;
 
   /// label of the CTPPS sub-system
@@ -118,12 +120,6 @@ private:
   };
 
   vector<ConfigBlock> configuration;
-
-  /// index of the current block in 'configuration' array
-  unsigned int currentBlock;
-
-  /// flag whether the 'currentBlock' index is valid
-  bool currentBlockValid;
 
   /// enumeration of XML node types
   enum NodeType {
@@ -232,6 +228,8 @@ private:
   bool CommonNode(NodeType type) { return ((type == nChip) || (type == nArm)); }
 
 protected:
+  bool isConcurrentFinder() const override { return true; }
+
   /// sets infinite validity of this data
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
                       const edm::IOVSyncValue &,
@@ -280,9 +278,7 @@ TotemDAQMappingESSourceXML::TotemDAQMappingESSourceXML(const edm::ParameterSet &
     : verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0)),
       subSystemName(conf.getUntrackedParameter<string>("subSystem")),
       sampicSubDetId(conf.getParameter<unsigned int>("sampicSubDetId")),
-      packedPayload(conf.getParameter<bool>("multipleChannelsPerPayload")),
-      currentBlock(0),
-      currentBlockValid(false) {
+      packedPayload(conf.getParameter<bool>("multipleChannelsPerPayload")) {
   for (const auto &it : conf.getParameter<vector<ParameterSet>>("configuration")) {
     ConfigBlock b;
     b.validityRange = it.getParameter<EventRange>("validityRange");
@@ -305,7 +301,23 @@ void TotemDAQMappingESSourceXML::setIntervalFor(const edm::eventsetup::EventSetu
   LogVerbatim("TotemDAQMappingESSourceXML")
       << "    run=" << iosv.eventID().run() << ", event=" << iosv.eventID().event();
 
-  currentBlockValid = false;
+  auto currentBlock = findBlockFor(iosv);
+  if (currentBlock) {
+    edm::EventRange range = configuration[*currentBlock].validityRange;
+
+    const IOVSyncValue begin(range.startEventID());
+    const IOVSyncValue end(range.endEventID());
+    oValidity = edm::ValidityInterval(begin, end);
+
+    LogVerbatim("TotemDAQMappingESSourceXML") << "    block found: index=" << *currentBlock << ", interval=("
+                                              << range.startEventID() << " - " << range.endEventID() << ")";
+
+  } else {
+    throw cms::Exception("TotemDAQMappingESSourceXML::setIntervalFor")
+        << "No configuration for event " << iosv.eventID();
+  }
+}
+std::optional<unsigned int> TotemDAQMappingESSourceXML::findBlockFor(const edm::IOVSyncValue &iosv) const {
   for (unsigned int idx = 0; idx < configuration.size(); ++idx) {
     const auto &bl = configuration[idx];
 
@@ -318,24 +330,10 @@ void TotemDAQMappingESSourceXML::setIntervalFor(const edm::eventsetup::EventSetu
       range = edm::EventRange(edm::EventID(range.startEventID().run(), 0, 0), range.endEventID());
 
     if (edm::contains(range, iosv.eventID())) {
-      currentBlockValid = true;
-      currentBlock = idx;
-
-      const IOVSyncValue begin(range.startEventID());
-      const IOVSyncValue end(range.endEventID());
-      oValidity = edm::ValidityInterval(begin, end);
-
-      LogVerbatim("TotemDAQMappingESSourceXML") << "    block found: index=" << currentBlock << ", interval=("
-                                                << range.startEventID() << " - " << range.endEventID() << ")";
-
-      return;
+      return idx;
     }
   }
-
-  if (!currentBlockValid) {
-    throw cms::Exception("TotemDAQMappingESSourceXML::setIntervalFor")
-        << "No configuration for event " << iosv.eventID();
-  }
+  return std::nullopt;
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -353,8 +351,10 @@ string TotemDAQMappingESSourceXML::CompleteFileName(const string &fn) {
 static inline std::string to_string(const XMLCh *ch) { return XERCES_CPP_NAMESPACE_QUALIFIER XMLString::transcode(ch); }
 
 edm::ESProducts<std::unique_ptr<TotemDAQMapping>, std::unique_ptr<TotemAnalysisMask>>
-TotemDAQMappingESSourceXML::produce(const TotemReadoutRcd &) {
-  assert(currentBlockValid);
+TotemDAQMappingESSourceXML::produce(const TotemReadoutRcd &iRcd) {
+  auto findBlock = findBlockFor(iRcd.validityInterval().first());
+  assert(findBlock);
+  auto currentBlock = *findBlock;
 
   auto mapping = std::make_unique<TotemDAQMapping>();
   auto mask = std::make_unique<TotemAnalysisMask>();

--- a/CalibPPS/ESProducers/src/CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon.cc
+++ b/CalibPPS/ESProducers/src/CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon.cc
@@ -144,3 +144,75 @@ edm::EventID CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon::nextLS(const edm:
 
   return edm::EventID(src.run(), src.luminosityBlock() + 1, src.event());
 }
+
+//----------------------------------------------------------------------------------------------------
+const CTPPSRPAlignmentCorrectionsData *CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon::dataFor(
+    edm::IOVSyncValue const &iosv, CTPPSRPAlignmentCorrectionsDataSequence const &seq) {
+  const edm::EventID &event_curr = iosv.eventID();
+
+  for (const auto &it : seq) {
+    const auto &it_event_first = it.first.first().eventID();
+    const auto &it_event_last = it.first.last().eventID();
+
+    bool it_contained_lo = ((it_event_first.run() < event_curr.run()) ||
+                            ((it_event_first.run() == event_curr.run()) &&
+                             (it_event_first.luminosityBlock() <= event_curr.luminosityBlock())));
+
+    bool it_contained_up = ((it_event_last.run() > event_curr.run()) ||
+                            ((it_event_last.run() == event_curr.run()) &&
+                             (it_event_last.luminosityBlock() >= event_curr.luminosityBlock())));
+
+    if (it_contained_lo && it_contained_up) {
+      return &it.second;
+    }
+  }
+  return nullptr;
+}
+//----------------------------------------------------------------------------------------------------
+edm::ValidityInterval CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon::intervalFor(
+    edm::IOVSyncValue const &iosv, CTPPSRPAlignmentCorrectionsDataSequence const &seq, bool verbosity) {
+  // // find the corresponding interval
+  bool next_exists = false;
+  const edm::EventID &event_curr = iosv.eventID();
+  edm::EventID event_next_start(edm::EventID::maxRunNumber(), edm::EventID::maxLuminosityBlockNumber(), 1);
+
+  for (const auto &it : seq) {
+    const auto &it_event_first = it.first.first().eventID();
+    const auto &it_event_last = it.first.last().eventID();
+
+    bool it_contained_lo = ((it_event_first.run() < event_curr.run()) ||
+                            ((it_event_first.run() == event_curr.run()) &&
+                             (it_event_first.luminosityBlock() <= event_curr.luminosityBlock())));
+
+    bool it_contained_up = ((it_event_last.run() > event_curr.run()) ||
+                            ((it_event_last.run() == event_curr.run()) &&
+                             (it_event_last.luminosityBlock() >= event_curr.luminosityBlock())));
+
+    if (it_contained_lo && it_contained_up) {
+      auto valInt = it.first;
+
+      if (verbosity) {
+        edm::LogInfo("PPS") << "    setting validity interval ["
+                            << CTPPSRPAlignmentCorrectionsMethods::iovValueToString(valInt.first()) << ", "
+                            << CTPPSRPAlignmentCorrectionsMethods::iovValueToString(valInt.last()) << "]";
+      }
+      return valInt;
+    }
+
+    bool it_in_future = ((it_event_first.run() > event_curr.run()) ||
+                         ((it_event_first.run() == event_curr.run() &&
+                           (it_event_first.luminosityBlock() > event_curr.luminosityBlock()))));
+
+    if (it_in_future) {
+      next_exists = true;
+      if (event_next_start > it_event_first)
+        event_next_start = it_event_first;
+    }
+  }
+
+  if (!next_exists) {
+    return edm::ValidityInterval(iosv, iosv.endOfTime());
+  }
+  const edm::EventID &event_last = previousLS(event_next_start);
+  return edm::ValidityInterval(iosv, edm::IOVSyncValue(event_last));
+}

--- a/CalibPPS/ESProducers/test/BuildFile.xml
+++ b/CalibPPS/ESProducers/test/BuildFile.xml
@@ -1,3 +1,5 @@
 <bin name="alignment_xml_io_test" file="alignment_xml_io_test.cc">
+  <use name="CalibPPS/ESProducers"/>
   <use name="Geometry/VeryForwardGeometryBuilder"/>
+  <use name="catch2"/>
 </bin>

--- a/CalibPPS/ESProducers/test/alignment_xml_io_test.cc
+++ b/CalibPPS/ESProducers/test/alignment_xml_io_test.cc
@@ -8,9 +8,13 @@
 #include "DataFormats/CTPPSDetId/interface/CTPPSPixelDetId.h"
 #include "DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h"
 
+#include "CalibPPS/ESProducers/interface/CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon.h"
+
+#include <catch2/catch_all.hpp>
+
 //----------------------------------------------------------------------------------------------------
 
-int CompareCorrections(const CTPPSRPAlignmentCorrectionData &c1, const CTPPSRPAlignmentCorrectionData c2) {
+int CompareCorrections(const CTPPSRPAlignmentCorrectionData& c1, const CTPPSRPAlignmentCorrectionData c2) {
   if (c1.getShX() != c2.getShX())
     return 2;
   if (c1.getShY() != c2.getShY())
@@ -30,7 +34,7 @@ int CompareCorrections(const CTPPSRPAlignmentCorrectionData &c1, const CTPPSRPAl
 
 //----------------------------------------------------------------------------------------------------
 
-int main() {
+TEST_CASE("CTPPSRPAlignmentCorrectionsDataSequence", "[CTPPSRPAlignmentCorrectionsDataSequence]") {
   // build sample alignment data
   CTPPSRPAlignmentCorrectionsData ad;
 
@@ -62,39 +66,83 @@ int main() {
   CTPPSRPAlignmentCorrectionsMethods::writeToXML(
       ads, "alignment_xml_io_test.xml", false, false, true, true, true, true);
 
-  // load alignment data from XML file
-  const CTPPSRPAlignmentCorrectionsDataSequence &adsl =
-      CTPPSRPAlignmentCorrectionsMethods::loadFromXML("alignment_xml_io_test.xml");
+  SECTION("from XML") {
+    // load alignment data from XML file
+    const CTPPSRPAlignmentCorrectionsDataSequence& adsl =
+        CTPPSRPAlignmentCorrectionsMethods::loadFromXML("alignment_xml_io_test.xml");
 
-  // there should be exactly one element in the sequence
-  if (adsl.size() != 1)
-    return 1;
+    // there should be exactly one element in the sequence
+    REQUIRE(adsl.size() == 1);
 
-  // check loaded iov
-  const auto &iovl = adsl.begin()->first;
-  if (iovl.first() != edm::IOVSyncValue::beginOfTime() || iovl.last().eventID().run() != event_end.run() ||
-      iovl.last().eventID().luminosityBlock() != event_end.luminosityBlock())
-    return 2;
+    SECTION("check loaded iov") {
+      const auto& iovl = adsl.begin()->first;
+      REQUIRE(iovl.first() == edm::IOVSyncValue::beginOfTime());
+      REQUIRE(iovl.last().eventID().run() == event_end.run());
+      REQUIRE(iovl.last().eventID().luminosityBlock() == event_end.luminosityBlock());
+    }
+    SECTION("compare build and loaded data for 1 RP") {
+      unsigned int id = TotemRPDetId(1, 0, 3);
+      const CTPPSRPAlignmentCorrectionData& a = ad.getRPCorrection(id);
+      const CTPPSRPAlignmentCorrectionData& al = adsl.begin()->second.getRPCorrection(id);
 
-  // compare build and loaded data for 1 RP
-  {
-    unsigned int id = TotemRPDetId(1, 0, 3);
-    const CTPPSRPAlignmentCorrectionData &a = ad.getRPCorrection(id);
-    const CTPPSRPAlignmentCorrectionData &al = adsl.begin()->second.getRPCorrection(id);
+      REQUIRE(CompareCorrections(a, al) == 0);
+    }
 
-    if (CompareCorrections(a, al) != 0)
-      return 3;
+    SECTION("compare build and loaded data for 1 sensor") {
+      unsigned int id = TotemRPDetId(1, 0, 3, 2);
+      const CTPPSRPAlignmentCorrectionData& a = ad.getSensorCorrection(id);
+      const CTPPSRPAlignmentCorrectionData& al = adsl.begin()->second.getSensorCorrection(id);
+
+      REQUIRE(CompareCorrections(a, al) == 0);
+    }
   }
+}
 
-  // compare build and loaded data for 1 sensor
-  {
-    unsigned int id = TotemRPDetId(1, 0, 3, 2);
-    const CTPPSRPAlignmentCorrectionData &a = ad.getSensorCorrection(id);
-    const CTPPSRPAlignmentCorrectionData &al = adsl.begin()->second.getSensorCorrection(id);
-
-    if (CompareCorrections(a, al) != 0)
-      return 4;
+namespace edm {
+  //These are helpful if a REQUIRE clause fails and it prints the values
+  std::ostream& operator<<(std::ostream& ost, edm::IOVSyncValue const& sv) {
+    ost << " { " << sv.eventID() << " } ";
+    return ost;
   }
+  std::ostream& operator<<(std::ostream& ost, edm::ValidityInterval const& iov) {
+    ost << "( " << iov.first() << ", " << iov.last() << " )";
+    return ost;
+  }
+}  // namespace edm
 
-  return 0;
+TEST_CASE("CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon", "[CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon]") {
+  CTPPSRPAlignmentCorrectionsData ad;
+
+  ad.addRPCorrection(TotemRPDetId(1, 0, 3),
+                     CTPPSRPAlignmentCorrectionData(1., 2., 3., 1e-3, 2e-3, 3e-3));  // silicon RP
+  ad.addSensorCorrection(TotemRPDetId(1, 0, 3, 2),
+                         CTPPSRPAlignmentCorrectionData(4., 5., 6., 4e-3, 5e-3, 6e-3));  // silicon plane
+
+  auto iov = [](edm::EventID const& begin, edm::EventID const& end) {
+    return edm::ValidityInterval{edm::IOVSyncValue{begin}, edm::IOVSyncValue{end}};
+  };
+
+  CTPPSRPAlignmentCorrectionsDataSequence ads;
+  ads.insert(iov({2, 1, 0}, {2, 100, 0}), ad);
+  ads.insert(iov({3, 1, 0}, {3, 100, 0}), ad);
+
+  using common = CTPPSRPAlignmentCorrectionsDataESSourceXMLCommon;
+  SECTION("Test IOV handling") {
+    REQUIRE(edm::ValidityInterval{edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue{edm::EventID{2, 0, 0}}} ==
+            common::intervalFor(edm::IOVSyncValue::beginOfTime(), ads, false));
+    REQUIRE(iov({2, 1, 0}, {2, 100, 0}) == common::intervalFor(edm::IOVSyncValue{edm::EventID{2, 1, 0}}, ads, false));
+    REQUIRE(iov({2, 1, 0}, {2, 100, 0}) == common::intervalFor(edm::IOVSyncValue{edm::EventID{2, 20, 0}}, ads, false));
+    REQUIRE(iov({2, 200, 0}, {3, 0, 0}) == common::intervalFor(edm::IOVSyncValue{edm::EventID{2, 200, 0}}, ads, false));
+    REQUIRE(iov({3, 1, 0}, {3, 100, 0}) == common::intervalFor(edm::IOVSyncValue{edm::EventID{3, 1, 0}}, ads, false));
+    REQUIRE(edm::ValidityInterval{edm::IOVSyncValue::endOfTime(), edm::IOVSyncValue::endOfTime()} ==
+            common::intervalFor(edm::IOVSyncValue::endOfTime(), ads, false));
+  }
+  SECTION("Test data IOV handling") {
+    REQUIRE(nullptr == common::dataFor(edm::IOVSyncValue::beginOfTime(), ads));
+    REQUIRE(nullptr != common::dataFor(edm::IOVSyncValue{edm::EventID{2, 1, 0}}, ads));
+    REQUIRE(nullptr != common::dataFor(edm::IOVSyncValue{edm::EventID{2, 20, 0}}, ads));
+    REQUIRE(nullptr == common::dataFor(edm::IOVSyncValue{edm::EventID{2, 200, 0}}, ads));
+    REQUIRE(nullptr != common::dataFor(edm::IOVSyncValue{edm::EventID{3, 1, 0}}, ads));
+    REQUIRE(nullptr == common::dataFor(edm::IOVSyncValue::endOfTime(), ads));
+  }
 }


### PR DESCRIPTION
#### PR description:

The produce methods no longer directly depend on calls to setIntervalFor.

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2299