### PR TITLE
Remove unnecessary use of imp

### DIFF
--- a/Alignment/HIPAlignmentAlgorithm/scripts/batchHippy.py
+++ b/Alignment/HIPAlignmentAlgorithm/scripts/batchHippy.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import sys
-import imp
 import copy
 import os
 import shutil

--- a/Calibration/EcalAlCaRecoProducers/test/alcaSkimming.py
+++ b/Calibration/EcalAlCaRecoProducers/test/alcaSkimming.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 import subprocess
 import copy

--- a/Geometry/CMSCommonData/test/dd4hep/runlegacy.py
+++ b/Geometry/CMSCommonData/test/dd4hep/runlegacy.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 process = cms.Process("HcalParametersTest")

--- a/Geometry/CaloTopology/test/testHcalTopology_cfg.py
+++ b/Geometry/CaloTopology/test/testHcalTopology_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Geometry/ForwardCommonData/test/g4OverlapCheckHFNoseDD4hep_cfg.py
+++ b/Geometry/ForwardCommonData/test/g4OverlapCheckHFNoseDD4hep_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Geometry/ForwardCommonData/test/g4OverlapCheckHFNoseDDD_cfg.py
+++ b/Geometry/ForwardCommonData/test/g4OverlapCheckHFNoseDDD_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Geometry/ForwardGeometry/test/testZdcGeometry_cfg.py
+++ b/Geometry/ForwardGeometry/test/testZdcGeometry_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Geometry/ForwardGeometry/test/testZdcTopology_cfg.py
+++ b/Geometry/ForwardGeometry/test/testZdcTopology_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Geometry/HGCalTBCommonData/test/python/dumpTBModuleDDD_cfg.py
+++ b/Geometry/HGCalTBCommonData/test/python/dumpTBModuleDDD_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Geometry/HGCalTBCommonData/test/python/testHGCalTBNumbering_cfg.py
+++ b/Geometry/HGCalTBCommonData/test/python/testHGCalTBNumbering_cfg.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 

--- a/Geometry/HcalCommonData/test/python/dumpGeometryDD4hep_cfg.py
+++ b/Geometry/HcalCommonData/test/python/dumpGeometryDD4hep_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Geometry/HcalCommonData/test/python/dumpGeometryDDD_cfg.py
+++ b/Geometry/HcalCommonData/test/python/dumpGeometryDDD_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Geometry/HcalCommonData/test/python/runHcalParametersFromDD4hepAnalyzer_cfg.py
+++ b/Geometry/HcalCommonData/test/python/runHcalParametersFromDD4hepAnalyzer_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Geometry/HcalCommonData/test/python/runHcalParametersFromDDDAnalyzer_cfg.py
+++ b/Geometry/HcalCommonData/test/python/runHcalParametersFromDDDAnalyzer_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Geometry/HcalCommonData/test/python/runHcalSimNumberingDDDTester_cfg.py
+++ b/Geometry/HcalCommonData/test/python/runHcalSimNumberingDDDTester_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Geometry/HcalCommonData/test/python/testHitRelabeller_cfg.py
+++ b/Geometry/HcalCommonData/test/python/testHitRelabeller_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Geometry/TrackerCommonData/test/python/run21flat.py
+++ b/Geometry/TrackerCommonData/test/python/run21flat.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
-import os, sys, imp, re
+import os, sys, re
 
 from Configuration.Eras.Era_Run3_cff import Run3
 process = cms.Process('SIM',Run3)

--- a/Validation/HGCalValidation/scripts/testHGCalDigi_cfg.py
+++ b/Validation/HGCalValidation/scripts/testHGCalDigi_cfg.py
@@ -11,7 +11,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re, random
+import os, sys, re, random
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Validation/HGCalValidation/scripts/testHGCalMTRecoStudy_cfg.py
+++ b/Validation/HGCalValidation/scripts/testHGCalMTRecoStudy_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Validation/HGCalValidation/scripts/testHGCalReco_cfg.py
+++ b/Validation/HGCalValidation/scripts/testHGCalReco_cfg.py
@@ -9,7 +9,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re, random
+import os, sys, re, random
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Validation/HGCalValidation/scripts/testHGCalSimSingleMuonPt100_cfg.py
+++ b/Validation/HGCalValidation/scripts/testHGCalSimSingleMuonPt100_cfg.py
@@ -7,7 +7,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re, random
+import os, sys, re, random
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Validation/HGCalValidation/scripts/testHGCalSimTTBar_cfg.py
+++ b/Validation/HGCalValidation/scripts/testHGCalSimTTBar_cfg.py
@@ -7,7 +7,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re, random
+import os, sys, re, random
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Validation/HGCalValidation/test/python/protoValid_cfg.py
+++ b/Validation/HGCalValidation/test/python/protoValid_cfg.py
@@ -10,7 +10,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ############################################################


### PR DESCRIPTION
#### PR description:

Most remaining uses of the deprecated `imp` module are not necessary (apparently a set of imports was frequently copy/pasted without the imported libraries actually being used). This PR removes them, making progress on #46113.

#### PR validation:

`python3 $FILE` runs. No `imp.` calls are found in any of these files.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Can be backported to 17_0_X if requested.