### PR TITLE
[WarningFix] Alignment/Geners: remove unnecessary const_cast/static-l…

### DIFF
--- a/Alignment/Geners/interface/binaryIO.hh
+++ b/Alignment/Geners/interface/binaryIO.hh
@@ -75,7 +75,7 @@ namespace gs {
     read_pod(in, &vlen);
     if (vlen) {
       pv->resize(vlen);
-      read_pod_array(in, const_cast<T *>(pv->data()), vlen);
+      read_pod_array(in, &((*pv)[0]), vlen);
     } else
       pv->clear();
   }

--- a/Alignment/Geners/src/BinaryArchiveBase.cc
+++ b/Alignment/Geners/src/BinaryArchiveBase.cc
@@ -236,7 +236,7 @@ namespace gs {
     std::string cmode(modeIn ? modeIn : "");
     if (cmode.empty())
       return true;
-    char *mode = const_cast<char *>(cmode.c_str());
+    char *mode = &cmode[0];
 
     unsigned cnt = 0;
     for (char *opt = strtok(mode, ":"); opt; opt = strtok(nullptr, ":"), ++cnt) {

--- a/Alignment/Geners/src/CStringStream.cc
+++ b/Alignment/Geners/src/CStringStream.cc
@@ -168,7 +168,7 @@ namespace gs {
   }
 
   bool CStringStream::getCompressionModeByName(const char *name, CompressionMode *m) {
-    static const char *names[] = {"n", "z", "b"};
+    static constexpr const char *names[] = {"n", "z", "b"};
     if (!name || !m)
       return false;
     for (unsigned i = 0; i < sizeof(names) / sizeof(names[0]); ++i)


### PR DESCRIPTION
#### PR description:
This PR fixes clang static analyzer warnings in Alignment/Geners without changing the existing logic.
#### Warnings:
```
src/Alignment/Geners/src/CStringStream.cc:171:5:
warning: function 'gs::CStringStream::getCompressionModeByName' accesses or modifies non-const static local variable 'names'. [cms.FunctionChecker]

src/Alignment/Geners/src/CStringStream.cc:171:5:
warning: Non-const variable 'const char *[3] names' is static local or static member data and might be thread-unsafe [threadsafety.StaticLocal]

src/Alignment/Geners/interface/binaryIO.hh:78:26:
warning: const_cast was used, this may result in thread-unsafe code [threadsafety.ConstCast]

src/Alignment/Geners/src/BinaryArchiveBase.cc:239:18:
warning: const_cast was used, this may result in thread-unsafe code [threadsafety.ConstCast]
```