### PR TITLE
Fix SciTag values

### DIFF
--- a/FWStorage/Catalog/test/InputFileCatalog_t.cpp
+++ b/FWStorage/Catalog/test/InputFileCatalog_t.cpp
@@ -59,17 +59,17 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWStorage/Catalog]") {
 
       SECTION("Catalog 0") {
         CHECK(catalog.physicalFileNames(configuredFileNames[0])[0] ==
-              "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196664");
+              "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=206");
         CHECK(catalog.physicalFileNames(configuredFileNames[1])[0] == "file:/foo/bar");
-        CHECK(catalog.physicalFileNames(configuredFileNames[2])[0] == "root://foobar?scitag.flow=196664");
+        CHECK(catalog.physicalFileNames(configuredFileNames[2])[0] == "root://foobar?scitag.flow=206");
       }
       SECTION("Catalog 1") {
         CHECK(catalog.physicalFileNames(configuredFileNames[0])[1] ==
-              "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=196664");
+              "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=206");
       }
       SECTION("Catalog 2") {
         CHECK(catalog.physicalFileNames(configuredFileNames[0])[2] ==
-              "root://host.domain//pnfs/cms/store/foo/bar?scitag.flow=196664");
+              "root://host.domain//pnfs/cms/store/foo/bar?scitag.flow=206");
       }
     }
 
@@ -79,30 +79,30 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWStorage/Catalog]") {
       REQUIRE(catalog.physicalFileNames(2).size() == 1);
 
       SECTION("Catalog 0") {
-        CHECK(catalog.physicalFileNames(0)[0] == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196664");
+        CHECK(catalog.physicalFileNames(0)[0] == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=206");
         CHECK(catalog.physicalFileNames(1)[0] == "file:/foo/bar");
-        CHECK(catalog.physicalFileNames(2)[0] == "root://foobar?scitag.flow=196664");
+        CHECK(catalog.physicalFileNames(2)[0] == "root://foobar?scitag.flow=206");
       }
       SECTION("Catalog 1") {
         CHECK(catalog.physicalFileNames(0)[1] ==
-              "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=196664");
+              "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=206");
       }
       SECTION("Catalog 2") {
-        CHECK(catalog.physicalFileNames(0)[2] == "root://host.domain//pnfs/cms/store/foo/bar?scitag.flow=196664");
+        CHECK(catalog.physicalFileNames(0)[2] == "root://host.domain//pnfs/cms/store/foo/bar?scitag.flow=206");
       }
     }
 
     SECTION("allPFNsFromFirstCatalog") {
       auto const pfns = catalog.allPFNsFromFirstCatalog();
       REQUIRE(pfns.size() == 3);
-      CHECK(pfns[0] == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196664");
+      CHECK(pfns[0] == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=206");
       CHECK(pfns[1] == "file:/foo/bar");
-      CHECK(pfns[2] == "root://foobar?scitag.flow=196664");
+      CHECK(pfns[2] == "root://foobar?scitag.flow=206");
     }
 
     SECTION("firstPFNFromFirstCatalog") {
       auto const pfn = catalog.firstPFNFromFirstCatalog();
-      CHECK(pfn == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196664");
+      CHECK(pfn == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=206");
     }
   }
 
@@ -121,16 +121,16 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWStorage/Catalog]") {
       SECTION("Embedded Catalog 0") {
         CHECK(catalog.physicalFileNames(configuredFileNames[0])[0] == "file:/foo/bar");
         CHECK(catalog.physicalFileNames(configuredFileNames[1])[0] ==
-              "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196700");
-        CHECK(catalog.physicalFileNames(configuredFileNames[2])[0] == "root://foobar?scitag.flow=196700");
+              "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=215");
+        CHECK(catalog.physicalFileNames(configuredFileNames[2])[0] == "root://foobar?scitag.flow=215");
       }
       SECTION("Embedded Catalog 1") {
         CHECK(catalog.physicalFileNames(configuredFileNames[1])[1] ==
-              "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=196700");
+              "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=215");
       }
       SECTION("Embedded Catalog 2") {
         CHECK(catalog.physicalFileNames(configuredFileNames[1])[2] ==
-              "root://host.domain//pnfs/cms/store/foo/bar?scitag.flow=196700");
+              "root://host.domain//pnfs/cms/store/foo/bar?scitag.flow=215");
       }
     }
   }
@@ -146,7 +146,7 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWStorage/Catalog]") {
     REQUIRE(configuredFileNames.size() == 3);
 
     CHECK(catalog.physicalFileNames(configuredFileNames[1])[0] ==
-          "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196704");
+          "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=216");
   }
 
   SECTION("Behavior of 'Undefined' category") {
@@ -183,17 +183,17 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWStorage/Catalog]") {
       REQUIRE(catalog.physicalFileNames(configuredFileNames[2]).size() == 1);
 
       CHECK(catalog.physicalFileNames(configuredFileNames[0])[0] ==
-            "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=196664");
+            "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=206");
       CHECK(catalog.physicalFileNames(configuredFileNames[1])[0] == "file:/foo/bar");
-      CHECK(catalog.physicalFileNames(configuredFileNames[2])[0] == "root://foobar?scitag.flow=196664");
+      CHECK(catalog.physicalFileNames(configuredFileNames[2])[0] == "root://foobar?scitag.flow=206");
     }
 
     SECTION("allPFNsFromFirstCatalog") {
       auto const pfns = catalog.allPFNsFromFirstCatalog();
       REQUIRE(pfns.size() == 3);
-      CHECK(pfns[0] == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=196664");
+      CHECK(pfns[0] == "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=206");
       CHECK(pfns[1] == "file:/foo/bar");
-      CHECK(pfns[2] == "root://foobar?scitag.flow=196664");
+      CHECK(pfns[2] == "root://foobar?scitag.flow=206");
     }
   }
 
@@ -217,18 +217,18 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWStorage/Catalog]") {
 
       SECTION("Catalog 0") {
         CHECK(catalog.physicalFileNames(configuredFileNames[0])[0] ==
-              "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196664");
+              "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=206");
         CHECK(catalog.physicalFileNames(configuredFileNames[1])[0] == "/tmp/foo/bar");
-        CHECK(catalog.physicalFileNames(configuredFileNames[2])[0] == "root://foobar?scitag.flow=196664");
+        CHECK(catalog.physicalFileNames(configuredFileNames[2])[0] == "root://foobar?scitag.flow=206");
       }
       SECTION("Catalog 1") {
         CHECK(catalog.physicalFileNames(configuredFileNames[0])[1] ==
-              "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=196664");
+              "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/foo/bar?scitag.flow=206");
         CHECK(catalog.physicalFileNames(configuredFileNames[1])[1] == "/tmp/foo/bar");
       }
       SECTION("Catalog 2") {
         CHECK(catalog.physicalFileNames(configuredFileNames[0])[2] ==
-              "root://host.domain//pnfs/cms/store/foo/bar?scitag.flow=196664");
+              "root://host.domain//pnfs/cms/store/foo/bar?scitag.flow=206");
         CHECK(catalog.physicalFileNames(configuredFileNames[1])[2] == "/tmp/foo/bar");
       }
     }
@@ -237,9 +237,9 @@ TEST_CASE("InputFileCatalog with Rucio data catalog", "[FWStorage/Catalog]") {
       SECTION("Catalog 0") {
         auto const pfns = catalog.allPFNsFromFirstCatalog();
         REQUIRE(pfns.size() == 3);
-        CHECK(pfns[0] == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=196664");
+        CHECK(pfns[0] == "root://cmsxrootd.fnal.gov/store/foo/bar?scitag.flow=206");
         CHECK(pfns[1] == "/tmp/foo/bar");
-        CHECK(pfns[2] == "root://foobar?scitag.flow=196664");
+        CHECK(pfns[2] == "root://foobar?scitag.flow=206");
       }
     }
   }

--- a/FWStorage/Catalog/test/TestScitagConfig.h
+++ b/FWStorage/Catalog/test/TestScitagConfig.h
@@ -13,7 +13,7 @@ namespace edmtest::catalog {
 
   class TestScitagConfig : public edm::StorageURLModifier {
   public:
-    TestScitagConfig() : testSuffixes_{"?scitag.flow=196664", "?scitag.flow=196700", "?scitag.flow=196704"} {}
+    TestScitagConfig() : testSuffixes_{"?scitag.flow=206", "?scitag.flow=215", "?scitag.flow=216"} {}
 
     void modify(edm::SciTagCategory sciTagCategory, std::string& url) const override {
       if (url.starts_with("root:")) {

--- a/FWStorage/Services/plugins/ScitagConfig.cc
+++ b/FWStorage/Services/plugins/ScitagConfig.cc
@@ -66,8 +66,8 @@ namespace {
   constexpr char const* const kXRootPrefix = "root:";
   // These are the values assigned to CMS.
   // Values outside this range are used by other organizations.
-  constexpr int kCMSSciTagRangeStart = 196612;
-  constexpr int kCMSSciTagRangeEnd = 196860;
+  constexpr int kCMSSciTagRangeStart = 193;
+  constexpr int kCMSSciTagRangeEnd = 216;
 }  // namespace
 
 namespace edm {
@@ -135,15 +135,15 @@ namespace edm {
       ParameterSetDescription desc;
 
       ParameterSetDescription analysisDesc;
-      analysisDesc.addUntracked<unsigned int>("primarySciTag", 196664);
-      analysisDesc.addUntracked<unsigned int>("embeddedSciTag", 196700);
-      analysisDesc.addUntracked<unsigned int>("preMixedPileupSciTag", 196704);
+      analysisDesc.addUntracked<unsigned int>("primarySciTag", 206);
+      analysisDesc.addUntracked<unsigned int>("embeddedSciTag", 215);
+      analysisDesc.addUntracked<unsigned int>("preMixedPileupSciTag", 216);
       desc.addUntracked<ParameterSetDescription>("analysis", analysisDesc);
 
       ParameterSetDescription productionDesc;
-      productionDesc.addUntracked<unsigned int>("primarySciTag", 196656);
-      productionDesc.addUntracked<unsigned int>("embeddedSciTag", 196700);
-      productionDesc.addUntracked<unsigned int>("preMixedPileupSciTag", 196704);
+      productionDesc.addUntracked<unsigned int>("primarySciTag", 204);
+      productionDesc.addUntracked<unsigned int>("embeddedSciTag", 215);
+      productionDesc.addUntracked<unsigned int>("preMixedPileupSciTag", 216);
       desc.addUntracked<ParameterSetDescription>("production", productionDesc);
 
       desc.addUntracked<bool>("enable", true);

--- a/FWStorage/Services/test/test_catch2_ScitagConfig.cc
+++ b/FWStorage/Services/test/test_catch2_ScitagConfig.cc
@@ -36,15 +36,15 @@ TEST_CASE("Test ScitagConfig", "[scitagconfig]") {
 
     std::string pfn1 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::Primary, pfn1);
-    CHECK(pfn1 == "root://example.com//store/data/file.root?scitag.flow=196664");
+    CHECK(pfn1 == "root://example.com//store/data/file.root?scitag.flow=206");
 
     std::string pfn2 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::Embedded, pfn2);
-    CHECK(pfn2 == "root://example.com//store/data/file.root?scitag.flow=196700");
+    CHECK(pfn2 == "root://example.com//store/data/file.root?scitag.flow=215");
 
     std::string pfn3 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::PreMixedPileup, pfn3);
-    CHECK(pfn3 == "root://example.com//store/data/file.root?scitag.flow=196704");
+    CHECK(pfn3 == "root://example.com//store/data/file.root?scitag.flow=216");
   }
 
   SECTION("scitagconfig default parameters except production case") {
@@ -59,15 +59,15 @@ TEST_CASE("Test ScitagConfig", "[scitagconfig]") {
 
     std::string pfn1 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::Primary, pfn1);
-    CHECK(pfn1 == "root://example.com//store/data/file.root?scitag.flow=196656");
+    CHECK(pfn1 == "root://example.com//store/data/file.root?scitag.flow=204");
 
     std::string pfn2 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::Embedded, pfn2);
-    CHECK(pfn2 == "root://example.com//store/data/file.root?scitag.flow=196700");
+    CHECK(pfn2 == "root://example.com//store/data/file.root?scitag.flow=215");
 
     std::string pfn3 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::PreMixedPileup, pfn3);
-    CHECK(pfn3 == "root://example.com//store/data/file.root?scitag.flow=196704");
+    CHECK(pfn3 == "root://example.com//store/data/file.root?scitag.flow=216");
   }
 
   SECTION("scitagconfig analysis case") {
@@ -75,9 +75,9 @@ TEST_CASE("Test ScitagConfig", "[scitagconfig]") {
     pset.addUntrackedParameter<bool>("enable", true);
     pset.addUntrackedParameter<bool>("productionCase", false);
     edm::ParameterSet analysisPSet;
-    analysisPSet.addUntrackedParameter<unsigned int>("primarySciTag", 196612);
-    analysisPSet.addUntrackedParameter<unsigned int>("embeddedSciTag", 196860);
-    analysisPSet.addUntrackedParameter<unsigned int>("preMixedPileupSciTag", 196705);
+    analysisPSet.addUntrackedParameter<unsigned int>("primarySciTag", 193);
+    analysisPSet.addUntrackedParameter<unsigned int>("embeddedSciTag", 216);
+    analysisPSet.addUntrackedParameter<unsigned int>("preMixedPileupSciTag", 203);
     pset.addUntrackedParameter<edm::ParameterSet>("analysis", analysisPSet);
     edm::ParameterSet productionPSet;
     productionPSet.addUntrackedParameter<unsigned int>("primarySciTag", 396656);
@@ -93,15 +93,15 @@ TEST_CASE("Test ScitagConfig", "[scitagconfig]") {
 
     std::string pfn1 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::Primary, pfn1);
-    CHECK(pfn1 == "root://example.com//store/data/file.root?scitag.flow=196612");
+    CHECK(pfn1 == "root://example.com//store/data/file.root?scitag.flow=193");
 
     std::string pfn2 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::Embedded, pfn2);
-    CHECK(pfn2 == "root://example.com//store/data/file.root?scitag.flow=196860");
+    CHECK(pfn2 == "root://example.com//store/data/file.root?scitag.flow=216");
 
     std::string pfn3 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::PreMixedPileup, pfn3);
-    CHECK(pfn3 == "root://example.com//store/data/file.root?scitag.flow=196705");
+    CHECK(pfn3 == "root://example.com//store/data/file.root?scitag.flow=203");
 
     std::string pfn4 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::Undefined, pfn4);
@@ -117,7 +117,7 @@ TEST_CASE("Test ScitagConfig", "[scitagconfig]") {
 
     std::string pfn7 = "root://example.com//store/data/file.root?eos.app=cmst0";
     scitagConfig->modify(edm::SciTagCategory::Primary, pfn7);
-    CHECK(pfn7 == "root://example.com//store/data/file.root?eos.app=cmst0&scitag.flow=196612");
+    CHECK(pfn7 == "root://example.com//store/data/file.root?eos.app=cmst0&scitag.flow=193");
 
     std::string pfn8 = "root://example.com//store/data/file.root?eos.app=cmst0";
     CHECK_THROWS(scitagConfig->modify(static_cast<edm::SciTagCategory>(4), pfn8));
@@ -127,9 +127,9 @@ TEST_CASE("Test ScitagConfig", "[scitagconfig]") {
     edm::ParameterSet pset = defaultPSet;
     pset.addUntrackedParameter<bool>("productionCase", true);
     edm::ParameterSet productionPSet;
-    productionPSet.addUntrackedParameter<unsigned int>("primarySciTag", 196656);
-    productionPSet.addUntrackedParameter<unsigned int>("embeddedSciTag", 196702);
-    productionPSet.addUntrackedParameter<unsigned int>("preMixedPileupSciTag", 196706);
+    productionPSet.addUntrackedParameter<unsigned int>("primarySciTag", 204);
+    productionPSet.addUntrackedParameter<unsigned int>("embeddedSciTag", 194);
+    productionPSet.addUntrackedParameter<unsigned int>("preMixedPileupSciTag", 215);
     pset.addUntrackedParameter<edm::ParameterSet>("production", productionPSet);
 
     std::vector<edm::ParameterSet> psets = {pset};
@@ -140,15 +140,15 @@ TEST_CASE("Test ScitagConfig", "[scitagconfig]") {
 
     std::string pfn1 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::Primary, pfn1);
-    CHECK(pfn1 == "root://example.com//store/data/file.root?scitag.flow=196656");
+    CHECK(pfn1 == "root://example.com//store/data/file.root?scitag.flow=204");
 
     std::string pfn2 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::Embedded, pfn2);
-    CHECK(pfn2 == "root://example.com//store/data/file.root?scitag.flow=196702");
+    CHECK(pfn2 == "root://example.com//store/data/file.root?scitag.flow=194");
 
     std::string pfn3 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::PreMixedPileup, pfn3);
-    CHECK(pfn3 == "root://example.com//store/data/file.root?scitag.flow=196706");
+    CHECK(pfn3 == "root://example.com//store/data/file.root?scitag.flow=215");
 
     std::string pfn4 = "root://example.com//store/data/file.root";
     scitagConfig->modify(edm::SciTagCategory::Undefined, pfn4);
@@ -164,7 +164,7 @@ TEST_CASE("Test ScitagConfig", "[scitagconfig]") {
 
     std::string pfn7 = "root://example.com//store/data/file.root?eos.app=cmst0";
     scitagConfig->modify(edm::SciTagCategory::Primary, pfn7);
-    CHECK(pfn7 == "root://example.com//store/data/file.root?eos.app=cmst0&scitag.flow=196656");
+    CHECK(pfn7 == "root://example.com//store/data/file.root?eos.app=cmst0&scitag.flow=204");
   }
 
   SECTION("scitagconfig enable is false") {
@@ -186,7 +186,7 @@ TEST_CASE("Test ScitagConfig", "[scitagconfig]") {
     edm::ParameterSet pset = defaultPSet;
 
     edm::ParameterSet analysisPSet;
-    analysisPSet.addUntrackedParameter<unsigned int>("primarySciTag", 196611);
+    analysisPSet.addUntrackedParameter<unsigned int>("primarySciTag", 192);
     pset.addUntrackedParameter<edm::ParameterSet>("analysis", analysisPSet);
 
     std::vector<edm::ParameterSet> psets = {pset};
@@ -197,7 +197,7 @@ TEST_CASE("Test ScitagConfig", "[scitagconfig]") {
     edm::ParameterSet pset = defaultPSet;
 
     edm::ParameterSet analysisPSet;
-    analysisPSet.addUntrackedParameter<unsigned int>("embeddedSciTag", 196861);
+    analysisPSet.addUntrackedParameter<unsigned int>("embeddedSciTag", 217);
     pset.addUntrackedParameter<edm::ParameterSet>("analysis", analysisPSet);
 
     std::vector<edm::ParameterSet> psets = {pset};

--- a/FWStorage/Services/test/test_sitelocalconfig_catalog_cfg.py
+++ b/FWStorage/Services/test/test_sitelocalconfig_catalog_cfg.py
@@ -9,12 +9,12 @@ process.tester = cms.EDAnalyzer("SiteLocalConfigServiceCatalogTester",
         cms.untracked.PSet(
             file = cms.untracked.string("/store/a/b.root"),
             catalogIndex = cms.untracked.uint32(0),
-            expectResult = cms.untracked.string("root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/a/b.root?scitag.flow=196664")
+            expectResult = cms.untracked.string("root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/a/b.root?scitag.flow=206")
         ),
         cms.untracked.PSet(
             file = cms.untracked.string("/store/a/b.root"),
             catalogIndex = cms.untracked.uint32(1),
-            expectResult = cms.untracked.string("root://xrootd-cms.infn.it//store/a/b.root?scitag.flow=196664")
+            expectResult = cms.untracked.string("root://xrootd-cms.infn.it//store/a/b.root?scitag.flow=206")
         ),
     )
 )


### PR DESCRIPTION
#### PR description:

The SciTag values added in https://github.com/cms-sw/cmssw/pull/49740 (following https://github.com/cms-sw/cmssw/issues/47517) turned out to be wrong, see https://github.com/cms-sw/cmssw/issues/51227. This PR updates the SciTag values to those in https://github.com/cms-sw/cmssw/issues/51227#issuecomment-4719038601.

Resolves https://github.com/cms-sw/framework-team/issues/2300

#### PR validation:

Unit tests run.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported down to 16_0_X.