### PR TITLE
Protect isMergeable() from types with no dictionary

### DIFF
--- a/DataFormats/Common/src/setIsMergeable.cc
+++ b/DataFormats/Common/src/setIsMergeable.cc
@@ -19,7 +19,7 @@ namespace edm {
     // was already set.
     // Set it only for branches that are present
     if (desc.present() and (desc.branchType() == InRun or desc.branchType() == InLumi)) {
-      if (!desc.isMergeable()) {
+      if (!desc.isMergeable() && !desc.wrappedType().invalidTypeInfo()) {
         TClass* wrapperBaseTClass = TypeWithDict::byName("edm::WrapperBase").getClass();
         TClass* tClass = desc.wrappedType().getClass();
         void* p = tClass->New();


### PR DESCRIPTION
#### PR description:

Reading pre-20xx files in 20xx can segfault in the check for mergable run and lumi products in the case where there is no dictionary for the product being checked.  Sample stack trace:
```
#4  0x0000000000000000 in ?? ()
#5  0x000015496a7cc53f in edm::setIsMergeable(edm::BranchDescription&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02946/el8_amd64_gcc13/cms/cmssw/CMSSW_20_1_X_2026-06-15-1100/lib/el8_amd64_gcc13/libDataFormatsCommon.so
#6  0x00001549185ae2fc in edm::RootFile::RootFile(edm::RootFile::FileOptions&&, edm::InputType, edm::RootFile::ProcessingOptions&&, edm::RootTree::Options&&, edm::RootFile::ProductChoices&&, edm::RootFile::CrossFileInfo&&, unsigned int, edm::ProcessHistoryRegistry&, std::vector<edm::Hash<2>, std::allocator<edm::Hash<2> > >&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02946/el8_amd64_gcc13/cms/cmssw/CMSSW_20_1_X_2026-06-15-1100/lib/el8_amd64_gcc13/pluginIOPoolInput.so
#7  0x00001549185cf14b in edm::RootPrimaryFileSequence::makeRootFile(std::shared_ptr<edm::InputFile>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02946/el8_amd64_gcc13/cms/cmssw/CMSSW_20_1_X_2026-06-15-1100/lib/el8_amd64_gcc13/pluginIOPoolInput.so
```

Background in https://github.com/cms-sw/cmssw/pull/51199#issuecomment-4716633287.

Job failure in this case is expected, since #50968 breaks backward compatibility.  However, the job should not segfault.

#### PR validation:

With this PR, sample failing jobs fail with a proper exception:
```
----- Begin Fatal Exception 16-Jun-2026 12:13:20 EDT-----------------------
An exception of category 'DictionaryNotFound' occurred while
   [0] Constructing the EventProcessor
Exception Message:
No Dictionary for class: 'GenEventInfoProduct'
----- End Fatal Exception -------------------------------------------------
```
A limited matrix run (in progress) has found no problems introduced by this PR.

Resolves https://github.com/cms-sw/framework-team/issues/2301
