### PR TITLE
Follow-up to MTD reconstruction at HLT

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -760,6 +760,14 @@ phase2_muon.toModify(FEVTDEBUGHLTEventContent,
 phase2_hgcal.toModify(FEVTDEBUGHLTEventContent,
     outputCommands = FEVTDEBUGHLTEventContent.outputCommands + TICL_FEVTHLT.outputCommands)
 
+from Configuration.ProcessModifiers.mtd_at_hlt_cff import mtd_at_hlt
+mtd_at_hlt.toModify(FEVTDEBUGHLTEventContent,
+                    outputCommands = FEVTDEBUGHLTEventContent.outputCommands + RecoLocalFastTimeFEVTHLT.outputCommands + RecoMTDFEVTHLT.outputCommands)
+
+mtd_at_hlt.toModify(FEVTDEBUGHLTEventContent,
+                    outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
+                        'keep *_hltOfflinePrimaryVertices4D_*_*'
+                    ])
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 

--- a/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_EventContent_cff.py
+++ b/RecoLocalFastTime/Configuration/python/RecoLocalFastTime_EventContent_cff.py
@@ -22,3 +22,13 @@ RecoLocalFastTimeFEVT = cms.PSet(
     )
 )
 RecoLocalFastTimeFEVT.outputCommands.extend(RecoLocalFastTimeRECO.outputCommands)
+
+#FEVTHLT content
+RecoLocalFastTimeFEVTHLT = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *_hltMtdRecHits_*_*',
+        'keep *_hltMtdClusters_*_*',
+        'keep *_hltMtdUncalibratedRecHits_*_*',
+        'keep *_hltMtdTrackingRecHits_*_*',
+    )
+)

--- a/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
+++ b/RecoMTD/Configuration/python/RecoMTD_EventContent_cff.py
@@ -21,3 +21,13 @@ RecoMTDFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
 RecoMTDFEVT.outputCommands.extend(RecoMTDRECO.outputCommands)
+
+#FEVTHLT content
+RecoMTDFEVTHLT = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *edmValueMap_hltTrackExtenderWithMTD_*_*',
+        'keep *_hltMtdTrackQualityMVA_*_*',
+        'keep recoTrack*_hltTrackExtenderWithMTD_*_*',
+        'keep TrackingRecHitsOwned_hltTrackExtenderWithMTD_*_*',
+    )
+)

--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorEDProducer.cc
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorEDProducer.cc
@@ -59,27 +59,23 @@ void MtdRecoClusterToSimLayerClusterAssociatorEDProducer::produce(edm::StreamID,
                                                                   edm::Event &iEvent,
                                                                   const edm::EventSetup &iSetup) const {
   using namespace edm;
+  auto theAssociator = iEvent.getHandle(associatorToken_);
+  auto btlRecoClusters = iEvent.getHandle(btlRecoClustersToken_);
+  auto etlRecoClusters = iEvent.getHandle(etlRecoClustersToken_);
+  auto simClusters = iEvent.getHandle(simClustersToken_);
 
-  edm::Handle<reco::MtdRecoClusterToSimLayerClusterAssociator> theAssociator;
-  iEvent.getByToken(associatorToken_, theAssociator);
+  auto r2s = std::make_unique<reco::RecoToSimCollectionMtd>();
+  auto s2r = std::make_unique<reco::SimToRecoCollectionMtd>();
 
-  edm::Handle<FTLClusterCollection> btlRecoClusters;
-  iEvent.getByToken(btlRecoClustersToken_, btlRecoClusters);
-
-  edm::Handle<FTLClusterCollection> etlRecoClusters;
-  iEvent.getByToken(etlRecoClustersToken_, etlRecoClusters);
-
-  edm::Handle<MtdSimLayerClusterCollection> simClusters;
-  iEvent.getByToken(simClustersToken_, simClusters);
-
-  // associate reco clus to sim layer clus
-  reco::RecoToSimCollectionMtd recoToSimColl =
-      theAssociator->associateRecoToSim(btlRecoClusters, etlRecoClusters, simClusters);
-  reco::SimToRecoCollectionMtd simToRecoColl =
-      theAssociator->associateSimToReco(btlRecoClusters, etlRecoClusters, simClusters);
-
-  auto r2s = std::make_unique<reco::RecoToSimCollectionMtd>(recoToSimColl);
-  auto s2r = std::make_unique<reco::SimToRecoCollectionMtd>(simToRecoColl);
+  if (btlRecoClusters.isValid() && etlRecoClusters.isValid()) {
+    // associate reco clus to sim layer clus
+    reco::RecoToSimCollectionMtd recoToSimColl =
+        theAssociator->associateRecoToSim(btlRecoClusters, etlRecoClusters, simClusters);
+    reco::SimToRecoCollectionMtd simToRecoColl =
+        theAssociator->associateSimToReco(btlRecoClusters, etlRecoClusters, simClusters);
+    *r2s = recoToSimColl;
+    *s2r = simToRecoColl;
+  }
 
   iEvent.put(std::move(r2s));
   iEvent.put(std::move(s2r));

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -128,6 +128,7 @@ private:
   const float trackMaxBtlEta_;
   const float trackMinEtlEta_;
   const float trackMaxEtlEta_;
+  const bool skipNonExistingSrc_;
 
   static constexpr double simUnit_ = 1e9;                // sim time in s while reco time in ns
   static constexpr double etacutGEN_ = 4.;               // |eta| < 4;
@@ -514,7 +515,8 @@ MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
       trackMaxPt_(iConfig.getParameter<double>("trackMaximumPt")),
       trackMaxBtlEta_(iConfig.getParameter<double>("trackMaximumBtlEta")),
       trackMinEtlEta_(iConfig.getParameter<double>("trackMinimumEtlEta")),
-      trackMaxEtlEta_(iConfig.getParameter<double>("trackMaximumEtlEta")) {
+      trackMaxEtlEta_(iConfig.getParameter<double>("trackMaximumEtlEta")),
+      skipNonExistingSrc_(iConfig.getParameter<bool>("skipNonExistingSrc")) {
   GenRecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagG"));
   RecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagT"));
 
@@ -568,33 +570,86 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   using namespace geant_units::operators;
   using namespace std;
 
-  auto GenRecTrackHandle = makeValid(iEvent.getHandle(GenRecTrackToken_));
+  const auto& GenRecTrackHandle = iEvent.getHandle(GenRecTrackToken_);
+  const auto& btlRecCluHandle = iEvent.getHandle(btlRecCluToken_);
+  const auto& etlRecCluHandle = iEvent.getHandle(etlRecCluToken_);
 
-  auto btlRecCluHandle = makeValid(iEvent.getHandle(btlRecCluToken_));
-  auto etlRecCluHandle = makeValid(iEvent.getHandle(etlRecCluToken_));
+  if (!GenRecTrackHandle.isValid() || !btlRecCluHandle.isValid() || !etlRecCluHandle.isValid()) {
+    if (skipNonExistingSrc_)
+      return;
+    else
+      throw cms::Exception("Invalid Product")
+          << "Attempted to fill a input collection edm::Handle with an invalid product";
+  }
 
   const auto& tp2SimAssociationMap = iEvent.get(tp2SimAssociationMapToken_);
   const auto& Sim2tpAssociationMap = iEvent.get(Sim2tpAssociationMapToken_);
   const auto& r2sAssociationMap = iEvent.get(r2sAssociationMapToken_);
 
-  const auto& tMtd = iEvent.get(tmtdToken_);
-  const auto& SigmatMtd = iEvent.get(SigmatmtdToken_);
-  const auto& t0Src = iEvent.get(t0SrcToken_);
-  const auto& Sigmat0Src = iEvent.get(Sigmat0SrcToken_);
-  const auto& t0Pid = iEvent.get(t0PidToken_);
-  const auto& Sigmat0Pid = iEvent.get(Sigmat0PidToken_);
-  const auto& t0Safe = iEvent.get(t0SafePidToken_);
-  const auto& Sigmat0Safe = iEvent.get(Sigmat0SafePidToken_);
-  const auto& SigmaTofPi = iEvent.get(SigmaTofPiToken_);
-  const auto& SigmaTofK = iEvent.get(SigmaTofKToken_);
-  const auto& SigmaTofP = iEvent.get(SigmaTofPToken_);
-  const auto& mtdQualMVA = iEvent.get(trackMVAQualToken_);
-  const auto& trackAssoc = iEvent.get(trackAssocToken_);
-  const auto& pathLength = iEvent.get(pathLengthToken_);
-  const auto& btlMatchTimeChi2 = iEvent.get(btlMatchTimeChi2Token_);
-  const auto& etlMatchTimeChi2 = iEvent.get(etlMatchTimeChi2Token_);
-  const auto& btlMatchChi2 = iEvent.get(btlMatchChi2Token_);
-  const auto& outermostHitPosition = iEvent.get(outermostHitPositionToken_);
+  const auto& tMtdHandle = iEvent.getHandle(tmtdToken_);
+  const auto& SigmatMtdHandle = iEvent.getHandle(SigmatmtdToken_);
+  const auto& t0SrcHandle = iEvent.getHandle(t0SrcToken_);
+  const auto& Sigmat0SrcHandle = iEvent.getHandle(Sigmat0SrcToken_);
+  const auto& t0PidHandle = iEvent.getHandle(t0PidToken_);
+  const auto& Sigmat0PidHandle = iEvent.getHandle(Sigmat0PidToken_);
+  const auto& t0SafeHandle = iEvent.getHandle(t0SafePidToken_);
+  const auto& Sigmat0SafeHandle = iEvent.getHandle(Sigmat0SafePidToken_);
+  const auto& SigmaTofPiHandle = iEvent.getHandle(SigmaTofPiToken_);
+  const auto& SigmaTofKHandle = iEvent.getHandle(SigmaTofKToken_);
+  const auto& SigmaTofPHandle = iEvent.getHandle(SigmaTofPToken_);
+  const auto& mtdQualMVAHandle = iEvent.getHandle(trackMVAQualToken_);
+  const auto& trackAssocHandle = iEvent.getHandle(trackAssocToken_);
+  const auto& pathLengthHandle = iEvent.getHandle(pathLengthToken_);
+  const auto& btlMatchTimeChi2Handle = iEvent.getHandle(btlMatchTimeChi2Token_);
+  const auto& etlMatchTimeChi2Handle = iEvent.getHandle(etlMatchTimeChi2Token_);
+  const auto& btlMatchChi2Handle = iEvent.getHandle(btlMatchChi2Token_);
+  const auto& outermostHitPositionHandle = iEvent.getHandle(outermostHitPositionToken_);
+
+  const auto& allValid = {tMtdHandle.isValid(),
+                          SigmatMtdHandle.isValid(),
+                          t0SrcHandle.isValid(),
+                          Sigmat0SrcHandle.isValid(),
+                          t0PidHandle.isValid(),
+                          Sigmat0PidHandle.isValid(),
+                          t0SafeHandle.isValid(),
+                          Sigmat0SafeHandle.isValid(),
+                          SigmaTofPiHandle.isValid(),
+                          SigmaTofKHandle.isValid(),
+                          SigmaTofPHandle.isValid(),
+                          mtdQualMVAHandle.isValid(),
+                          trackAssocHandle.isValid(),
+                          pathLengthHandle.isValid(),
+                          btlMatchTimeChi2Handle.isValid(),
+                          etlMatchTimeChi2Handle.isValid(),
+                          btlMatchChi2Handle.isValid(),
+                          outermostHitPositionHandle.isValid()};
+
+  if (!std::all_of(allValid.begin(), allValid.end(), [](bool v) { return v; })) {
+    if (skipNonExistingSrc_)
+      return;
+    else
+      throw cms::Exception("Invalid Product")
+          << "Attempted to fill a edm::ValueMap edm::Handle with an invalid product";
+  }
+
+  const auto& tMtd = *tMtdHandle;
+  const auto& SigmatMtd = *SigmatMtdHandle;
+  const auto& t0Src = *t0SrcHandle;
+  const auto& Sigmat0Src = *Sigmat0SrcHandle;
+  const auto& t0Pid = *t0PidHandle;
+  const auto& Sigmat0Pid = *Sigmat0PidHandle;
+  const auto& t0Safe = *t0SafeHandle;
+  const auto& Sigmat0Safe = *Sigmat0SafeHandle;
+  const auto& SigmaTofPi = *SigmaTofPiHandle;
+  const auto& SigmaTofK = *SigmaTofKHandle;
+  const auto& SigmaTofP = *SigmaTofPHandle;
+  const auto& mtdQualMVA = *mtdQualMVAHandle;
+  const auto& trackAssoc = *trackAssocHandle;
+  const auto& pathLength = *pathLengthHandle;
+  const auto& btlMatchTimeChi2 = *btlMatchTimeChi2Handle;
+  const auto& etlMatchTimeChi2 = *etlMatchTimeChi2Handle;
+  const auto& btlMatchChi2 = *btlMatchChi2Handle;
+  const auto& outermostHitPosition = *outermostHitPositionHandle;
 
   auto recoToSimH = makeValid(iEvent.getHandle(recoToSimAssociationToken_));
   r2s_ = recoToSimH.product();
@@ -3286,6 +3341,7 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
 
   desc.add<std::string>("folder", "MTD/Tracks");
   desc.add<bool>("optionalPlots", false);
+  desc.add<bool>("skipNonExistingSrc", false);
   desc.add<edm::InputTag>("inputTagG", edm::InputTag("generalTracks"));
   desc.add<edm::InputTag>("inputTagT", edm::InputTag("trackExtenderWithMTD"));
   desc.add<edm::InputTag>("inputTagV", edm::InputTag("offlinePrimaryVertices4D"));

--- a/Validation/MtdValidation/python/hltMtdPostProcessor_cff.py
+++ b/Validation/MtdValidation/python/hltMtdPostProcessor_cff.py
@@ -10,5 +10,5 @@ hltPrimary4DVertexPostProcessor = _Primary4DVertexPostProcessor.clone(
     folder = cms.string('HLT/MTD/Vertices/')
 )
 
-hltMtdValidationPostProcessor = cms.Sequence(#hltMtdTracksPostProcessor +
+hltMtdValidationPostProcessor = cms.Sequence(hltMtdTracksPostProcessor +
                                              hltPrimary4DVertexPostProcessor)

--- a/Validation/MtdValidation/python/hltMtdValidation_cff.py
+++ b/Validation/MtdValidation/python/hltMtdValidation_cff.py
@@ -30,6 +30,7 @@ hltMtdAssociationProducers = cms.Sequence(
 from Validation.MtdValidation.mtdTracksValid_cfi import mtdTracksValid as _mtdTracksValid
 hltMtdTracksValid = _mtdTracksValid.clone(
     folder = cms.string('HLT/MTD/Tracks'),
+    skipNonExistingSrc = cms.bool(True), # at HLT to protect when the products are not available
     inputTagG = cms.InputTag('hltGeneralTracks'),
     inputTagT = cms.InputTag('hltTrackExtenderWithMTD'),
     inputTagV = cms.InputTag('hltOfflinePrimaryVertices4D'),
@@ -89,6 +90,6 @@ hltVertices4DValid =  _vertices4DValid.clone(
     probP = cms.InputTag('hltTofPID', 'probP')
 )
 
-hltMtdRecoValid = cms.Sequence(#hltMtdAssociationProducers +
-                               #hltMtdTracksValid +
+hltMtdRecoValid = cms.Sequence(hltMtdAssociationProducers +
+                               hltMtdTracksValid +
                                hltVertices4DValid)


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to https://github.com/cms-sw/cmssw/pull/51170.
When the `mtd_at_hlt` modifier is active:
- save in the `FEVTDEBUGHLTEventContent` the MTD local and "global" reco products as well as the 4D vertices
- complete the HLT MTD Validation, by enabling both `MtdTracksValidation` and the corresponding harvesting module (after having protected the whole chain against missing products).

#### PR validation:

Run successfully `runTheMatrix.py -l 34434.7522 -t 4 -j 8` and checked that the event products of the step2 file are as expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A