### PR TITLE
[WarningFix]: Alignment/OfflineValidation- Fix static thread-safety w…

### DIFF
--- a/Alignment/OfflineValidation/bin/JetHtPlotConfiguration.cc
+++ b/Alignment/OfflineValidation/bin/JetHtPlotConfiguration.cc
@@ -1535,7 +1535,7 @@ const char* JetHtPlotConfiguration::iovListForSlides() const { return fIovListFo
 
 // Expand environmental variables updating the input string
 void JetHtPlotConfiguration::autoExpandEnvironmentVariables(std::string& text) const {
-  static std::regex env("\\$\\{?([^}\\/]+)\\}?\\/");
+  static const std::regex env("\\$\\{?([^}\\/]+)\\}?\\/");
   std::smatch match;
   while (std::regex_search(text, match, env)) {
     const char* s = getenv(match[1].str().c_str());

--- a/Alignment/OfflineValidation/interface/TkAlStyle.h
+++ b/Alignment/OfflineValidation/interface/TkAlStyle.h
@@ -17,6 +17,7 @@
 #ifndef ALIGNMENT_OFFLINEVALIDATION_TKAL_STYLE_H
 #define ALIGNMENT_OFFLINEVALIDATION_TKAL_STYLE_H
 
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "TColor.h"
 #include "TError.h"
 #include "TLegend.h"
@@ -98,9 +99,9 @@ public:
   static TPaveText* customTitle(const TString& txt) { return title(txt); }
   static TPaveText* customRightTitle(const TString& txt) { return righttitle(txt); }
 
-  static TString legendheader;
-  static TString legendoptions;
-  static double textSize;
+  CMS_THREAD_SAFE static TString legendheader;
+  CMS_THREAD_SAFE static TString legendoptions;
+  CMS_THREAD_SAFE static double textSize;
   // Returns a TLegend object that fits into the top-right corner
   // of the current pad. Its width, relative to the pad size (without
   // margins), can be specified. Its height is optimized for nEntries
@@ -186,12 +187,12 @@ public:
   static double lineHeight() { return lineHeight_; }
 
 private:
-  static PublicationStatus publicationStatus_;
-  static Era era_;
-  static TString customTitle_;
-  static TString customRightTitle_;
-  static double lineHeight_;
-  static double margin_;
+  CMS_THREAD_SAFE static PublicationStatus publicationStatus_;
+  CMS_THREAD_SAFE static Era era_;
+  CMS_THREAD_SAFE static TString customTitle_;
+  CMS_THREAD_SAFE static TString customRightTitle_;
+  CMS_THREAD_SAFE static double lineHeight_;
+  CMS_THREAD_SAFE static double margin_;
 
   // creates a title
   static TString applyCMS(const TString& txt);

--- a/Alignment/OfflineValidation/macros/CMS_lumi.h
+++ b/Alignment/OfflineValidation/macros/CMS_lumi.h
@@ -1,6 +1,7 @@
 #ifndef _ALIGNMENT_OFFLINEVALIDATION_CMS_LUMI_H_
 #define _ALIGNMENT_OFFLINEVALIDATION_CMS_LUMI_H_
 
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "TPad.h"
 #include "TLatex.h"
 #include "TLine.h"
@@ -11,35 +12,35 @@
 // Global variables
 //
 
-TString cmsText = "CMS";
-float cmsTextFont = 61;  // default is helvetic-bold
+CMS_THREAD_SAFE TString cmsText = "CMS";
+CMS_THREAD_SAFE float cmsTextFont = 61;  // default is helvetic-bold
 
-bool writeExtraText = false;
-TString extraText = "Preliminary";
-float extraTextFont = 52;  // default is helvetica-italics
+CMS_THREAD_SAFE bool writeExtraText = false;
+CMS_THREAD_SAFE TString extraText = "Preliminary";
+CMS_THREAD_SAFE float extraTextFont = 52;  // default is helvetica-italics
 
 // text sizes and text offsets with respect to the top frame
 // in unit of the top margin size
-float lumiTextSize = 0.6;
-float lumiTextOffset = 0.2;
-float cmsTextSize = 0.75;
-float cmsTextOffset = 0.1;  // only used in outOfFrame version
+CMS_THREAD_SAFE float lumiTextSize = 0.6;
+CMS_THREAD_SAFE float lumiTextOffset = 0.2;
+CMS_THREAD_SAFE float cmsTextSize = 0.75;
+CMS_THREAD_SAFE float cmsTextOffset = 0.1;  // only used in outOfFrame version
 
-float relPosX = 0.045;
-float relPosY = 0.035;
-float relExtraDY = 1.2;
+CMS_THREAD_SAFE float relPosX = 0.045;
+CMS_THREAD_SAFE float relPosY = 0.035;
+CMS_THREAD_SAFE float relExtraDY = 1.2;
 
 // ratio of "CMS" and extra text size
-float extraOverCmsTextSize = 0.76;
+CMS_THREAD_SAFE float extraOverCmsTextSize = 0.76;
 
-TString lumi_13TeV = "20.1 fb^{-1}";
-TString lumi_8TeV = "19.7 fb^{-1}";
-TString lumi_7TeV = "5.1 fb^{-1}";
-TString lumi_0p9TeV = "";
-TString lumi_13p6TeV = "";
-TString lumi_sqrtS = "";
-bool writeExraLumi = false;
-bool drawLogo = false;
+CMS_THREAD_SAFE TString lumi_13TeV = "20.1 fb^{-1}";
+CMS_THREAD_SAFE TString lumi_8TeV = "19.7 fb^{-1}";
+CMS_THREAD_SAFE TString lumi_7TeV = "5.1 fb^{-1}";
+CMS_THREAD_SAFE TString lumi_0p9TeV = "";
+CMS_THREAD_SAFE TString lumi_13p6TeV = "";
+CMS_THREAD_SAFE TString lumi_sqrtS = "";
+CMS_THREAD_SAFE bool writeExraLumi = false;
+CMS_THREAD_SAFE bool drawLogo = false;
 
 void CMS_lumi(TPad* pad, int iPeriod = 3, int iPosX = 10, TString RLabel = "");
 

--- a/Alignment/OfflineValidation/macros/DiMuonMassProfiles.C
+++ b/Alignment/OfflineValidation/macros/DiMuonMassProfiles.C
@@ -34,18 +34,18 @@
 #include "Alignment/OfflineValidation/macros/CMS_lumi.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
 
-bool debugMode_{false};
-Int_t def_markers[9] = {kFullSquare,
-                        kFullCircle,
-                        kFullTriangleDown,
-                        kOpenSquare,
-                        kDot,
-                        kOpenCircle,
-                        kFullTriangleDown,
-                        kFullTriangleUp,
-                        kOpenTriangleDown};
+constexpr bool debugMode_{false};
+constexpr Int_t def_markers[9] = {kFullSquare,
+                                  kFullCircle,
+                                  kFullTriangleDown,
+                                  kOpenSquare,
+                                  kDot,
+                                  kOpenCircle,
+                                  kFullTriangleDown,
+                                  kFullTriangleUp,
+                                  kOpenTriangleDown};
 
-Int_t def_colors[9] = {kBlack, kRed, kBlue, kMagenta, kGreen, kCyan, kViolet, kOrange, kGreen + 2};
+constexpr Int_t def_colors[9] = {kBlack, kRed, kBlue, kMagenta, kGreen, kCyan, kViolet, kOrange, kGreen + 2};
 
 namespace diMuonMassBias {
 

--- a/Alignment/OfflineValidation/macros/FitPVResolution.C
+++ b/Alignment/OfflineValidation/macros/FitPVResolution.C
@@ -115,16 +115,16 @@ namespace statmode {
   using fitParams = std::pair<std::pair<double, double>, std::pair<double, double> >;
 }
 
-Int_t def_markers[9] = {kFullSquare,
-                        kFullCircle,
-                        kFullTriangleDown,
-                        kOpenSquare,
-                        kDot,
-                        kOpenCircle,
-                        kFullTriangleDown,
-                        kFullTriangleUp,
-                        kOpenTriangleDown};
-Int_t def_colors[9] = {kBlack, kRed, kBlue, kMagenta, kGreen, kCyan, kViolet, kOrange, kGreen + 2};
+constexpr Int_t def_markers[9] = {kFullSquare,
+                                  kFullCircle,
+                                  kFullTriangleDown,
+                                  kOpenSquare,
+                                  kDot,
+                                  kOpenCircle,
+                                  kFullTriangleDown,
+                                  kFullTriangleUp,
+                                  kOpenTriangleDown};
+constexpr Int_t def_colors[9] = {kBlack, kRed, kBlue, kMagenta, kGreen, kCyan, kViolet, kOrange, kGreen + 2};
 
 // auxilliary functions
 void setPVResolStyle();

--- a/Alignment/OfflineValidation/macros/loopAndPlot.C
+++ b/Alignment/OfflineValidation/macros/loopAndPlot.C
@@ -26,7 +26,7 @@ TFile *sourceFile1, *sourceFile2;
 
 // multi-file case
 std::vector<TFile *> sourceFiles;
-Int_t def_colors[9] = {kBlack, kBlue, kRed, kMagenta, kGreen, kCyan, kViolet, kOrange, kGreen + 2};
+constexpr Int_t def_colors[9] = {kBlack, kBlue, kRed, kMagenta, kGreen, kCyan, kViolet, kOrange, kGreen + 2};
 
 std::pair<Double_t, Double_t> getExtrema(TObjArray *array);
 template <typename T>

--- a/Alignment/OfflineValidation/macros/makeArrowPlots.C
+++ b/Alignment/OfflineValidation/macros/makeArrowPlots.C
@@ -10,7 +10,7 @@
 #include "TFrame.h"
 #include "TString.h"
 
-double arrowSize = 0.0095;
+constexpr double arrowSize = 0.0095;
 float y_, x_, z_, phi_, r_, dphi_, dr_, dx_, dz_, dy_;
 int level_, sublevel_;
 char outputDir_[292];

--- a/Alignment/OfflineValidation/macros/trackSplitPlot.h
+++ b/Alignment/OfflineValidation/macros/trackSplitPlot.h
@@ -47,7 +47,7 @@ Double_t increaseby = .1;
 
 TString xvariables[xsize] = {"", "pt", "eta", "phi", "dz", "dxy", "theta", "qoverpt"};
 TString yvariables[ysize] = {"pt", "pt", "eta", "phi", "dz", "dxy", "theta", "qoverpt", ""};
-Bool_t relativearray[ysize] = {true, false, false, false, false, false, false, false, false};
+constexpr Bool_t relativearray[ysize] = {true, false, false, false, false, false, false, false, false};
 
 TList *stufftodelete = new TList();
 

--- a/Alignment/OfflineValidation/src/CompareAlignments.cc
+++ b/Alignment/OfflineValidation/src/CompareAlignments.cc
@@ -95,7 +95,7 @@ void CompareAlignments::MergeRootfile(TDirectory *target, TList *sourcelist, TLi
     return;
   }
 
-  TString path((char *)strstr(target->GetPath(), ":"));
+  TString path(std::strstr(target->GetPath(), ":"));
   path.Remove(0, 2);
 
   TFile *first_source = (TFile *)sourcelist->First();

--- a/Alignment/OfflineValidation/src/PlotAlignmentValidation.cc
+++ b/Alignment/OfflineValidation/src/PlotAlignmentValidation.cc
@@ -750,7 +750,7 @@ void PlotAlignmentValidation::plotDMR(const std::string& variable,
 
   // This boolean array tells for which detector modules to plot split DMR plots
   // They are plotted for BPIX, FPIX, TIB and TOB
-  static bool plotSplitsFor[6] = {true, true, true, false, true, false};
+  static constexpr bool plotSplitsFor[6] = {true, true, true, false, true, false};
 
   DMRPlotInfo plotinfo;
 


### PR DESCRIPTION
#### PR description:

The fixes are limited to:
- thread-safety annotations for intentional ROOT plotting global state,
- immutable lookup/configuration tables,
- const-correctness improvements,
- removal of an unnecessary const-removing cast.

No functional changes are introduced.

#### Warnings:

```cpp
Warnings:

Alignment/OfflineValidation/interface/TkAlStyle.h

warning: Variable 'TkAlStyle::legendheader' is non-const and globally accessible, may not be thread-safe [threadsafety.StaticLocal]

warning: Variable 'TkAlStyle::legendoptions' is non-const and globally accessible, may not be thread-safe [threadsafety.StaticLocal]

warning: Variable 'TkAlStyle::textSize' is non-const and globally accessible, may not be thread-safe [threadsafety.StaticLocal]

warning: Variable 'TkAlStyle::publicationStatus_' is non-const and globally accessible, may not be thread-safe [threadsafety.StaticLocal]

warning: Variable 'TkAlStyle::era_' is non-const and globally accessible, may not be thread-safe [threadsafety.StaticLocal]

warning: Variable 'TkAlStyle::customTitle_' is non-const and globally accessible, may not be thread-safe [threadsafety.StaticLocal]

warning: Variable 'TkAlStyle::customRightTitle_' is non-const and globally accessible, may not be thread-safe [threadsafety.StaticLocal]

warning: Variable 'TkAlStyle::lineHeight_' is non-const and globally accessible, may not be thread-safe [threadsafety.StaticLocal]

warning: Variable 'TkAlStyle::margin_' is non-const and globally accessible, may not be thread-safe [threadsafety.StaticLocal]


Alignment/OfflineValidation/macros/CMS_lumi.h

warning: Variables 'cmsText', 'cmsTextFont', 'writeExtraText', 'extraText',
'extraTextFont', 'lumiTextSize', 'lumiTextOffset', 'cmsTextSize',
'cmsTextOffset', 'relPosX', 'relPosY', 'relExtraDY',
'extraOverCmsTextSize', 'lumi_13TeV', 'lumi_8TeV', 'lumi_7TeV',
'lumi_0p9TeV', 'lumi_13p6TeV', 'lumi_sqrtS',
'writeExraLumi', and 'drawLogo'
are non-const global variables and may not be thread-safe
[threadsafety.GlobalStatic]


Alignment/OfflineValidation/src/PlotAlignmentValidation.cc

warning: Variable 'plotSplitsFor' is non-const and globally accessible,
may not be thread-safe [threadsafety.StaticLocal]


Alignment/OfflineValidation/macros/DiMuonMassProfiles.C

warning: Variable 'debugMode_' is non-const and globally accessible,
may not be thread-safe [threadsafety.GlobalStatic]

warning: Variable 'def_markers' is non-const and globally accessible,
may not be thread-safe [threadsafety.GlobalStatic]

warning: Variable 'def_colors' is non-const and globally accessible,
may not be thread-safe [threadsafety.GlobalStatic]


Alignment/OfflineValidation/macros/FitPVResolution.C

warning: Variable 'def_markers' is non-const and globally accessible,
may not be thread-safe [threadsafety.GlobalStatic]

warning: Variable 'def_colors' is non-const and globally accessible,
may not be thread-safe [threadsafety.GlobalStatic]


Alignment/OfflineValidation/macros/loopAndPlot.C

warning: Variable 'def_colors' is non-const and globally accessible,
may not be thread-safe [threadsafety.GlobalStatic]


Alignment/OfflineValidation/macros/makeArrowPlots.C

warning: Variable 'arrowSize' is non-const and globally accessible,
may not be thread-safe [threadsafety.GlobalStatic]


Alignment/OfflineValidation/macros/trackSplitPlot.h

warning: Variable 'relativearray' is non-const and globally accessible,
may not be thread-safe [threadsafety.GlobalStatic]


Alignment/OfflineValidation/src/CompareAlignments.cc

warning: const qualifier was removed via a cast
[threadsafety.ConstCastAway]
```

#### Impact:
```
TkAlStyle                     : 167 warnings
CMS_lumi                      :  21 warnings
PlotAlignmentValidation       :   2 warnings
DiMuonMassProfiles            :   3 warnings
FitPVResolution               :   2 warnings
loopAndPlot                   :   1 warning
makeArrowPlots                :   2 warnings
trackSplitPlot                :   1 warning
JetHtPlotConfiguration        :   2 warnings
CompareAlignments             :   1 warning
------------------------------------------------
Total                         : ~202 warnings fixed
```