### PR TITLE
Fix LHEEventProduct::pdf_ issue

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -241,9 +241,12 @@
   <version ClassVersion="14" checksum="905719452"/>
   <version ClassVersion="15" checksum="898288635"/>
  </class>
- <ioread sourceClass = "LHEEventProduct" checksum="[395176982]" targetClass="LHEEventProduct" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
+ <ioread sourceClass = "LHEEventProduct" version="[-13]" targetClass="LHEEventProduct" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
    <![CDATA[pdf_.reset(onfile.pdf_.get()); onfile.pdf_.release();]]>
  </ioread> 
+ <ioread sourceClass = "LHEEventProduct" checksum="[395176982]" targetClass="LHEEventProduct" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
+   <![CDATA[pdf_.reset(onfile.pdf_.get()); onfile.pdf_.release();]]>
+ </ioread>
  <ioread sourceClass = "LHEEventProduct" version="[-12]" targetClass="LHEEventProduct" source = "" target="npLO_">
     <![CDATA[npLO_ = -99;]]>
   </ioread> 

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -241,7 +241,7 @@
   <version ClassVersion="14" checksum="905719452"/>
   <version ClassVersion="15" checksum="898288635"/>
  </class>
- <ioread sourceClass = "LHEEventProduct" version="[-13]" targetClass="LHEEventProduct" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
+ <ioread sourceClass = "LHEEventProduct" checksum="[395176982]" targetClass="LHEEventProduct" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
    <![CDATA[pdf_.reset(onfile.pdf_.get()); onfile.pdf_.release();]]>
  </ioread> 
  <ioread sourceClass = "LHEEventProduct" version="[-12]" targetClass="LHEEventProduct" source = "" target="npLO_">


### PR DESCRIPTION
#### PR description:

This PR should fix the `LHEEventProduct::pdf_` conversion error as described in https://github.com/cms-sw/cmssw/issues/49538 .

According to the discussion in this issue, the PR is only intended to fix a reading issue of 10_6_X MiniAOD files in 15_0_X in central production.
Unless there's any plan or need to read 10_6_X MiniAODs in central production with a more recent release, this PR is only needed for 15_0_X.

#### PR validation:

Tested locally opening the following file:
`/store/mc/RunIISummer20UL17MiniAODv2/GluGluToHHTo2B2G_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/PowhegBugFix_106X_mc2017_realistic_v9-v5/110000/FD848079-E570-3449-9CE1-DEB3349DBAEA.root`
Running:
`Events->Scan("LHEEventProduct_externalLHEProducer__GEN.obj")`
doesn't result in any conversion error.