### PR TITLE
bug fix needed for photos

### DIFF
--- a/GeneratorInterface/Core/src/EmbeddingHepMCFilter.cc
+++ b/GeneratorInterface/Core/src/EmbeddingHepMCFilter.cc
@@ -84,7 +84,7 @@ bool EmbeddingHepMCFilter::filter(const HepMC::GenEvent *evt) {
 
     if (!isHardProc) {
       continue;
-    } else if (pdg_id == tauonPDGID_) {
+    } else if (pdg_id == tauonPDGID_ && (*particle)->status() != 746) {
       reco::Candidate::LorentzVector p4Vis;
       decay_and_sump4Vis((*particle), p4Vis);  // recursive access to final states.
       p4VisPair_.push_back(p4Vis);
@@ -119,6 +119,8 @@ bool EmbeddingHepMCFilter::filter(const HepMC::GenEvent *evt) {
 
 void EmbeddingHepMCFilter::decay_and_sump4Vis(HepMC::GenParticle *particle, reco::Candidate::LorentzVector &p4Vis) {
   bool decaymode_known = false;
+  
+  if (particle->end_vertex() !=0 ) {
   for (HepMC::GenVertex::particle_iterator daughter = particle->end_vertex()->particles_begin(HepMC::children);
        daughter != particle->end_vertex()->particles_end(HepMC::children);
        ++daughter) {
@@ -149,6 +151,7 @@ void EmbeddingHepMCFilter::decay_and_sump4Vis(HepMC::GenParticle *particle, reco
       p4Vis += (reco::Candidate::LorentzVector)(*daughter)->momentum();
     else if (!neutrino)
       decay_and_sump4Vis((*daughter), p4Vis);
+   }
   }
 }
 


### PR DESCRIPTION

backport of https://github.com/cms-sw/cmssw/pull/50915

Two protections added to avoid crashed when using photos ("null vertices of intermediate 746 particles")

PR validation:

Tested on 10k events with cmsDriver.py Configuration/GenProduction/python/SMP-RunIII2024Summer24wmLHEGS-00182-fragment.py --eventcontent RAWSIM,LHE --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM,LHE --conditions 140X_mcRun3_2024_realistic_v26 --beamspot DBrealistic...

This PR has been made to the master branch, 14_0_X and intermediate releases, and recently to 10_6_X as well to produce a 2018 sample for the dedicated DY production needed for the tau polarisation study. Requesting now the backport to intermediate releases as well.