### PR TITLE
[TrackerGeometry]Fix nvcc warings: type qualifier on return type is meaningless

### DIFF
--- a/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
+++ b/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
@@ -75,7 +75,7 @@ public:
   const TrackerGeomDet* idToDetUnit(DetId) const override;
   const TrackerGeomDet* idToDet(DetId) const override;
 
-  const GeomDetEnumerators::SubDetector geomDetSubDetector(int subdet) const;
+  GeomDetEnumerators::SubDetector geomDetSubDetector(int subdet) const;
   unsigned int numberOfLayers(int subdet) const;
   bool isThere(GeomDetEnumerators::SubDetector subdet) const;
 

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -200,7 +200,7 @@ const TrackerGeomDet* TrackerGeometry::idToDet(DetId s) const {
   }
 }
 
-const GeomDetEnumerators::SubDetector TrackerGeometry::geomDetSubDetector(int subdet) const {
+GeomDetEnumerators::SubDetector TrackerGeometry::geomDetSubDetector(int subdet) const {
   if (subdet >= 1 && subdet <= 6) {
     return theSubDetTypeMap[subdet - 1];
   } else {


### PR DESCRIPTION
With `cuda 13.3.0` , we now get build warnings [a]. Looks like `const GeomDetEnumerators::SubDetector geomDetSubDetector(int subdet) const;` is returning an `enum` by value so nvcc complain that return qualifier  `const` is meaningless in this case. 

The Proposes to drop the `const` return qualifier  

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc13/CMSSW_20_1_X_2026-06-18-2300/RecoTracker/LSTCore
```
[src/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h(78)](https://github.com/cms-sw/cmssw/blob/CMSSW_20_1_X_2026-06-18-2300/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h#L78): warning #815-D: type qualifier on return type is meaningless
     const GeomDetEnumerators::SubDetector geomDetSubDetector(int subdet) const;
```