### PR TITLE
Add generic emulator wrapper for NGJet

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/L1TSC4NGJetID.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/L1TSC4NGJetID.h
@@ -14,6 +14,8 @@
 
 namespace L1TSC4NGJet {
 
+  typedef ap_fixed<64, 32,AP_RND,AP_SAT,0> inputtype;
+
   template <class t>
   t candidate_mass(l1ct::PuppiObj puppicand) {
     // Define lookup table
@@ -43,39 +45,49 @@ namespace L1TSC4NGJet {
 class L1TSC4NGJetID {
 public:
   L1TSC4NGJetID(const std::shared_ptr<hls4mlEmulator::Model> model, int iNParticles, bool debug);
-
-  typedef ap_fixed<24, 12, AP_RND, AP_SAT, 0> inputtype;
-  typedef std::array<ap_ufixed<24, 12, AP_RND, AP_SAT, 0>, 8> classtype;
-  typedef std::array<ap_fixed<16, 6>, 1> regressiontype;
-  typedef std::pair<regressiontype, classtype> pairtype;
+  
+  static const int N_candidates = 16; 
+  static const int N_candidate_features = 21; 
+  static const int N_candidate_inputs = N_candidates * N_candidate_features;
+  static const int N_jet_inputs = 2; 
+  static const int N_class_outputs = 8;
+  static const int N_regression_outputs = 1;
 
   // Intermediate output type to allow full precision multiplication of jet pt by the ratio
   typedef ap_ufixed<22, 12, AP_TRN, AP_SAT> output_regression_type;
   // Intermediate output type for classification score to be loaded into jet word
-  typedef std::array<l1ct::jet_tag_score_t, 8> output_class_type;
-  typedef std::pair<regressiontype, output_class_type> outputpairtype;
-  void setNNVectorVar();
+  typedef std::array<l1ct::jet_tag_score_t, N_class_outputs> output_class_type;
+  typedef std::pair<std::array<output_regression_type,N_regression_outputs>, output_class_type> outputpairtype;
+
+  void setVectors();
   outputpairtype EvaluateNNFixed();
   outputpairtype computeFixed(const l1t::PFJet &iJet);
 
 private:
-  std::vector<inputtype> NNvectorVar_;
-  int fNParticles_;
-  std::unique_ptr<inputtype[]> fPt_;
-  std::unique_ptr<inputtype[]> fPt_rel_;
-  std::unique_ptr<inputtype[]> fDEta_;
-  std::unique_ptr<inputtype[]> fDPhi_;
-  std::unique_ptr<inputtype[]> fPt_log_;
-  std::unique_ptr<inputtype[]> fMass_;
-  std::unique_ptr<inputtype[]> fZ0_;
-  std::unique_ptr<inputtype[]> fDxy_;
-  std::unique_ptr<inputtype[]> fIs_filled_;
-  std::unique_ptr<inputtype[]> fPuppi_weight_;
-  std::unique_ptr<inputtype[]> fEmID_;
-  std::unique_ptr<inputtype[]> fQuality_;
+  std::vector<L1TSC4NGJet::inputtype> candidate_vector_;
+  std::vector<L1TSC4NGJet::inputtype> jet_vector_;
 
-  std::unique_ptr<inputtype[]> fCharge_;
-  std::unique_ptr<inputtype[]> fId_;
+  int fNParticles_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fPt_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fPt_rel_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fDEta_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fDPhi_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fPt_log_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fMass_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fZ0_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fDxy_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fIs_filled_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fPuppi_weight_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fEmID_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fQuality_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fEta_;
+
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fCharge_;
+  std::unique_ptr<L1TSC4NGJet::inputtype[]> fId_;
+  
+  L1TSC4NGJet::inputtype fJetPt_;
+  L1TSC4NGJet::inputtype fJetEta_;
+
   std::shared_ptr<hls4mlEmulator::Model> modelRef_;
 
   bool isDebugEnabled_;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/L1TSC4NGJetID.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/L1TSC4NGJetID.h
@@ -14,7 +14,7 @@
 
 namespace L1TSC4NGJet {
 
-  typedef ap_fixed<64, 32,AP_RND,AP_SAT,0> inputtype;
+  typedef ap_fixed<64, 32, AP_RND, AP_SAT, 0> inputtype;
 
   template <class t>
   t candidate_mass(l1ct::PuppiObj puppicand) {
@@ -45,11 +45,11 @@ namespace L1TSC4NGJet {
 class L1TSC4NGJetID {
 public:
   L1TSC4NGJetID(const std::shared_ptr<hls4mlEmulator::Model> model, int iNParticles, bool debug);
-  
-  static const int N_candidates = 16; 
-  static const int N_candidate_features = 21; 
+
+  static const int N_candidates = 16;
+  static const int N_candidate_features = 21;
   static const int N_candidate_inputs = N_candidates * N_candidate_features;
-  static const int N_jet_inputs = 2; 
+  static const int N_jet_inputs = 2;
   static const int N_class_outputs = 8;
   static const int N_regression_outputs = 1;
 
@@ -57,7 +57,7 @@ public:
   typedef ap_ufixed<22, 12, AP_TRN, AP_SAT> output_regression_type;
   // Intermediate output type for classification score to be loaded into jet word
   typedef std::array<l1ct::jet_tag_score_t, N_class_outputs> output_class_type;
-  typedef std::pair<std::array<output_regression_type,N_regression_outputs>, output_class_type> outputpairtype;
+  typedef std::pair<std::array<output_regression_type, N_regression_outputs>, output_class_type> outputpairtype;
 
   void setVectors();
   outputpairtype EvaluateNNFixed();
@@ -84,7 +84,7 @@ private:
 
   std::unique_ptr<L1TSC4NGJet::inputtype[]> fCharge_;
   std::unique_ptr<L1TSC4NGJet::inputtype[]> fId_;
-  
+
   L1TSC4NGJet::inputtype fJetPt_;
   L1TSC4NGJet::inputtype fJetEta_;
 

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TSC4NGJetProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TSC4NGJetProducer.cc
@@ -152,7 +152,7 @@ void L1TSC4NGJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<bool>("returnRawPt", false);
   desc.add<std::string>("correctorFile", "");
   desc.add<std::string>("correctorDir", "");
-  desc.add<std::string>("l1tSC4NGJetModelPath", std::string("L1TSC4NGJetModel_v1_0_1"));
+  desc.add<std::string>("l1tSC4NGJetModelPath", std::string("L1TSC4NGJetModel_v2_0_0"));
   desc.add<int>("maxJets", 16);
   desc.add<int>("nParticles", 16);
   desc.add<double>("minPt", 10);

--- a/L1Trigger/Phase2L1ParticleFlow/src/L1TSC4NGJet.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/L1TSC4NGJet.cc
@@ -3,9 +3,23 @@
 #include "L1Trigger/Phase2L1ParticleFlow/interface/common/log.h"
 #include <algorithm>
 
+using namespace L1TSC4NGJet;
+
+  struct ModelInputs {
+        inputtype* candidate_inputs;
+        inputtype* jet_inputs;
+        int total_candidate_inputs;
+        int total_jet_inputs;
+  };
+
+  struct ModelOutputs {
+        inputtype* jet_class_output;
+        inputtype* jet_regression_output;
+  };
+
 L1TSC4NGJetID::L1TSC4NGJetID(const std::shared_ptr<hls4mlEmulator::Model> model, int iNParticles, bool debug)
     : modelRef_(model) {
-  NNvectorVar_.clear();
+  candidate_vector_.clear();
   fNParticles_ = iNParticles;
   isDebugEnabled_ = debug;
 
@@ -21,13 +35,18 @@ L1TSC4NGJetID::L1TSC4NGJetID(const std::shared_ptr<hls4mlEmulator::Model> model,
   fPuppi_weight_ = std::make_unique<inputtype[]>(fNParticles_);
   fEmID_ = std::make_unique<inputtype[]>(fNParticles_);
   fQuality_ = std::make_unique<inputtype[]>(fNParticles_);
+  fEta_ = std::make_unique<inputtype[]>(fNParticles_);
 
   fId_ = std::make_unique<inputtype[]>(fNParticles_);
   fCharge_ = std::make_unique<inputtype[]>(fNParticles_);
+
+  fJetPt_ = 0;
+  fJetEta_ = 0;
 }
 
-void L1TSC4NGJetID::setNNVectorVar() {
-  NNvectorVar_.clear();
+void L1TSC4NGJetID::setVectors() {
+  candidate_vector_.clear();
+  jet_vector_.clear();
   if (isDebugEnabled_) {
     LogDebug("L1TSC4NGJetID") << "\n ===== Input Vector =====" << std::endl;
   }
@@ -36,131 +55,168 @@ void L1TSC4NGJetID::setNNVectorVar() {
     bool filled = fIs_filled_.get()[i0] == 1;
     inputtype null_value = 0;
 
-    NNvectorVar_.push_back(filled ? fPt_.get()[i0] : null_value);      // pt
-    NNvectorVar_.push_back(filled ? fPt_rel_.get()[i0] : null_value);  // pT as a fraction of jet pT
-    NNvectorVar_.push_back(filled ? fPt_log_.get()[i0] : null_value);  // pt log
-    NNvectorVar_.push_back(filled ? fDEta_.get()[i0] : null_value);    // dEta from jet axis
-    NNvectorVar_.push_back(filled ? fDPhi_.get()[i0] : null_value);    // dPhi from jet axis
-    NNvectorVar_.push_back(filled ? fMass_.get()[i0] : null_value);    // Mass
-    NNvectorVar_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::PHOTON) : null_value);    // Photon
-    NNvectorVar_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::ELEPLUS) : null_value);   // Positron
-    NNvectorVar_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::ELEMINUS) : null_value);  // Electron
-    NNvectorVar_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::MUPLUS) : null_value);    // Anti-muon
-    NNvectorVar_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::MUMINUS) : null_value);   // Muon
-    NNvectorVar_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::HADZERO) : null_value);
-    NNvectorVar_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::HADPLUS) : null_value);   // Anti-Pion
-    NNvectorVar_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::HADMINUS) : null_value);  // Pion
-    NNvectorVar_.push_back(filled ? fZ0_.get()[i0] : null_value);                                           // z0
-    NNvectorVar_.push_back(filled ? fDxy_.get()[i0] : null_value);                                          // dxy
-    NNvectorVar_.push_back(filled ? fIs_filled_.get()[i0] : null_value);                                    // isfilled
-    NNvectorVar_.push_back(filled ? fPuppi_weight_.get()[i0] : null_value);  // puppi weight
-    NNvectorVar_.push_back(filled ? fEmID_.get()[i0] : null_value);          // emID
-    NNvectorVar_.push_back(filled ? fQuality_.get()[i0] : null_value);       // quality
+    candidate_vector_.push_back(filled ? fPt_.get()[i0] : null_value);      // pt
+    candidate_vector_.push_back(filled ? fPt_rel_.get()[i0] : null_value);  // pT as a fraction of jet pT
+    candidate_vector_.push_back(filled ? fPt_log_.get()[i0] : null_value);  // pt log
+    candidate_vector_.push_back(filled ? fDEta_.get()[i0] : null_value);    // dEta from jet axis
+    candidate_vector_.push_back(filled ? fDPhi_.get()[i0] : null_value);    // dPhi from jet axis
+    candidate_vector_.push_back(filled ? fMass_.get()[i0] : null_value);    // Mass
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::PHOTON) : null_value);    // Photon
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::ELEPLUS) : null_value);   // Positron
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::ELEMINUS) : null_value);  // Electron
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::MUPLUS) : null_value);    // Anti-muon
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::MUMINUS) : null_value);   // Muon
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::HADZERO) : null_value);
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::HADPLUS) : null_value);   // Anti-Pion
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::HADMINUS) : null_value);  // Pion
+    candidate_vector_.push_back(filled ? fZ0_.get()[i0] : null_value);                                           // z0
+    candidate_vector_.push_back(filled ? fDxy_.get()[i0] : null_value);                                          // dxy
+    candidate_vector_.push_back(filled ? fIs_filled_.get()[i0] : null_value);                                    // isfilled
+    candidate_vector_.push_back(filled ? fPuppi_weight_.get()[i0] : null_value);  // puppi weight
+    candidate_vector_.push_back(filled ? fEmID_.get()[i0] : null_value);          // emID
+    candidate_vector_.push_back(filled ? fQuality_.get()[i0] : null_value);       // quality
+    candidate_vector_.push_back(filled ? fEta_.get()[i0] : null_value); // eta
 
     if (isDebugEnabled_) {
       LogDebug("L1TSC4NGJetID") << "Particle: " << i0 << "\n"
-                                << "pT: " << NNvectorVar_[i0 * 20]
+                                << "pT: " << candidate_vector_[i0 * N_candidate_features]
                                 << " | "
                                    "pT rel: "
-                                << NNvectorVar_[i0 * 20 + 1]
+                                << candidate_vector_[i0 * N_candidate_features + 1]
                                 << " | "
                                    "pT log: "
-                                << NNvectorVar_[i0 * 20 + 2]
+                                << candidate_vector_[i0 * N_candidate_features + 2]
                                 << " | "
                                    "dEta: "
-                                << NNvectorVar_[i0 * 20 + 3]
+                                << candidate_vector_[i0 * N_candidate_features + 3]
                                 << " | "
                                    "dPhi: "
-                                << NNvectorVar_[i0 * 20 + 4]
+                                << candidate_vector_[i0 * N_candidate_features + 4]
                                 << " | "
                                    "mass: "
-                                << NNvectorVar_[i0 * 20 + 5]
+                                << candidate_vector_[i0 * N_candidate_features + 5]
                                 << " | "
                                    "photon ID: "
-                                << NNvectorVar_[i0 * 20 + 6]
+                                << candidate_vector_[i0 * N_candidate_features + 6]
                                 << " | "
                                    "electron + ID: "
-                                << NNvectorVar_[i0 * 20 + 7]
+                                << candidate_vector_[i0 * N_candidate_features + 7]
                                 << " | "
                                    "electron - ID: "
-                                << NNvectorVar_[i0 * 20 + 8]
+                                << candidate_vector_[i0 * N_candidate_features + 8]
                                 << " | "
                                    "muon + ID: "
-                                << NNvectorVar_[i0 * 20 + 9]
+                                << candidate_vector_[i0 * N_candidate_features + 9]
                                 << " | "
                                    "muon - ID: "
-                                << NNvectorVar_[i0 * 20 + 10]
+                                << candidate_vector_[i0 * N_candidate_features + 10]
                                 << " | "
                                    "neutral hadron ID: "
-                                << NNvectorVar_[i0 * 20 + 11]
+                                << candidate_vector_[i0 * N_candidate_features + 11]
                                 << " | "
                                    "hadron + ID: "
-                                << NNvectorVar_[i0 * 20 + 12]
+                                << candidate_vector_[i0 * N_candidate_features + 12]
                                 << " | "
                                    "hadron - ID: "
-                                << NNvectorVar_[i0 * 20 + 13]
+                                << candidate_vector_[i0 * N_candidate_features + 13]
                                 << " | "
                                    "z0: "
-                                << NNvectorVar_[i0 * 20 + 14]
+                                << candidate_vector_[i0 * N_candidate_features + 14]
                                 << " | "
                                    "sqrt Dxy: "
-                                << NNvectorVar_[i0 * 20 + 15]
+                                << candidate_vector_[i0 * N_candidate_features + 15]
                                 << " | "
                                    "is filled: "
-                                << NNvectorVar_[i0 * 20 + 16]
+                                << candidate_vector_[i0 * N_candidate_features + 16]
                                 << " | "
                                    "puppi weight: "
-                                << NNvectorVar_[i0 * 20 + 17]
+                                << candidate_vector_[i0 * N_candidate_features + 17]
                                 << " | "
                                    "ElectroMagnetic ID: "
-                                << NNvectorVar_[i0 * 20 + 18]
+                                << candidate_vector_[i0 * N_candidate_features + 18]
                                 << " | "
                                    "Track Quality: "
-                                << NNvectorVar_[i0 * 20 + 19] << " | "
-                                << "===========" << std::endl;
+                                << candidate_vector_[i0 * N_candidate_features + 19]
+                                << " | "
+				   "Eta: "
+				<< candidate_vector_[i0 * N_candidate_features + 20] << " | "
+				<< "===========" << std::endl;
     }
   }
+  // After the particle loop
+  jet_vector_.push_back(fJetPt_);
+  jet_vector_.push_back(fJetEta_);
 }
 
 L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::EvaluateNNFixed() {
-  const int NInputs = 320;
-  classtype classresult;
-  regressiontype regressionresult;
 
   inputtype fillzero = 0.0;
 
-  inputtype modelInput[NInputs] = {};  // Do something
-  std::fill(modelInput, modelInput + NInputs, fillzero);
+   // Define Candidate inputs and fill fully with 0s. Allows for case when N_candidate_inputs > candidate_vector_.size(). 
+  inputtype modelCandidateInput[N_candidate_inputs] = {};  
+  std::fill(modelCandidateInput, modelCandidateInput + N_candidate_inputs, fillzero);
 
-  for (unsigned int i = 0; i < NNvectorVar_.size(); i++) {
-    modelInput[i] = NNvectorVar_[i];
+  // Fill the candidate inputs from the pre calculated NNvectorVar
+  for (unsigned int i = 0; i < candidate_vector_.size(); i++) {
+    modelCandidateInput[i] = candidate_vector_[i];
   }
 
-  pairtype modelResult;
+  // Define Jet inputs and fill fully with 0s.
+  inputtype modelJetInput[N_jet_inputs] = {};  
+  std::fill(modelJetInput, modelJetInput + N_jet_inputs, fillzero);
+  for (unsigned int i = 0; i < jet_vector_.size(); i++) {
+    modelJetInput[i] = jet_vector_[i];
+  }
 
-  modelRef_->prepare_input(modelInput);
+  // Define input struct
+  ModelInputs modelInputStruct;
+  // Load candidate and jet inputs 
+  modelInputStruct.candidate_inputs = modelCandidateInput;
+  modelInputStruct.jet_inputs = modelJetInput;
+  modelInputStruct.total_candidate_inputs = N_candidate_features;
+  modelInputStruct.total_jet_inputs = N_jet_inputs;
+
+  // Define output struct
+  ModelOutputs modelOutputStruct;
+  
+  // Define and load output with zeros ready for replacement from the model
+  inputtype modelClassOutput[N_class_outputs] = {}; 
+  inputtype modelRegressionOutput[N_regression_outputs] = {};  
+  std::fill(modelClassOutput, modelClassOutput + N_class_outputs, fillzero);
+  std::fill(modelRegressionOutput, modelRegressionOutput + N_regression_outputs, fillzero);
+
+  // Load class and regression outputs 
+  modelOutputStruct.jet_class_output = modelClassOutput;
+  modelOutputStruct.jet_regression_output = modelRegressionOutput;
+
+  // Run the inference
+  modelRef_->prepare_input(modelInputStruct);
   modelRef_->predict();
-  modelRef_->read_result(&modelResult);
+  modelRef_->read_result(&modelOutputStruct);
 
   outputpairtype modelResult_forOutput;
   if (isDebugEnabled_) {
     LogDebug("L1TSC4NGJetID") << "\n ===== Jet ID Output Score =====" << std::endl;
   }
-  for (unsigned int i = 0; i < 8; i++) {
+  for (unsigned int i = 0; i < N_class_outputs; i++) {
     // Cast model output to jet tag score datatype
-    modelResult_forOutput.second[i] = l1ct::jet_tag_score_t(modelResult.second[i]);
+    modelResult_forOutput.second[i] = l1ct::jet_tag_score_t(modelOutputStruct.jet_class_output[i]);
     if (isDebugEnabled_) {
-      LogDebug("L1TSC4NGJetID") << l1ct::JetTagClassHandler::tagClassesDefault_[i] << " : " << modelResult.second[i]
+      LogDebug("L1TSC4NGJetID") << l1ct::JetTagClassHandler::tagClassesDefault_[i] << " : " << modelOutputStruct.jet_class_output[i]
                                 << " Cast to Jet Class type: " << modelResult_forOutput.second[i] << std::endl;
     }
   }
-  // Cast model output to transient regression score for jet pt multiplication
-  modelResult_forOutput.first[0] = output_regression_type(modelResult.first[0]);
-  if (isDebugEnabled_) {
-    LogDebug("L1TSC4NGJetID") << "\n ===== Jet pT Correction Output ===== \n"
-                              << modelResult.first[0] << " Cast to Jet pT type: " << modelResult_forOutput.first[0]
-                              << std::endl;
-  }
+  
+  for (unsigned int i = 0; i < N_regression_outputs; i++) {
+      // Cast model output to transient regression score for jet pt multiplication
+      modelResult_forOutput.first[i] = modelOutputStruct.jet_regression_output[i];
+      if (isDebugEnabled_) {
+         LogDebug("L1TSC4NGJetID") << "\n ===== Jet pT Correction Output ===== \n"
+                                    << modelOutputStruct.jet_regression_output[i] << " Cast to Jet pT type: " << modelResult_forOutput.first[i]
+                                    << std::endl;
+      }
+   }
+
   return modelResult_forOutput;
 }  //end EvaluateNNFixed
 
@@ -178,6 +234,7 @@ L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::computeFixed(const l1t::PFJet &iJet
     fPuppi_weight_.get()[i0] = 0;
     fEmID_.get()[i0] = 0;
     fQuality_.get()[i0] = 0;
+    fEta_.get()[i0] = 0;
 
     fId_.get()[i0] = 0;
     fCharge_.get()[i0] = 0;
@@ -192,6 +249,11 @@ L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::computeFixed(const l1t::PFJet &iJet
   inputtype jet_pt_ = inputtype(ctJet.hwPt);
   inputtype jet_eta_ = inputtype(ctJet.hwEta);
   inputtype jet_phi_ = inputtype(ctJet.hwPhi);
+  
+  // Fill jet level features
+  fJetPt_ = jet_pt_;
+  fJetEta_ = jet_eta_;
+
 
   for (unsigned int i0 = 0; i0 < iParts.size(); i0++) {
     if (i0 >= (unsigned int)fNParticles_)
@@ -200,7 +262,7 @@ L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::computeFixed(const l1t::PFJet &iJet
     fPt_.get()[i0] = inputtype(puppicand.hwPt);
 
     constexpr int INV_LUT_SIZE = 1024;
-    inputtype inv_jet_pt = l1ct::invert_with_shift<l1ct::pt_t, inputtype, INV_LUT_SIZE>(jet_pt_);
+    inputtype inv_jet_pt = l1ct::invert_with_shift<l1ct::pt_t, l1ct::pt_t, INV_LUT_SIZE>(jet_pt_);
 
     fPt_rel_.get()[i0] = inputtype(puppicand.hwPt) * inv_jet_pt;
 
@@ -218,11 +280,16 @@ L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::computeFixed(const l1t::PFJet &iJet
     fDPhi_.get()[i0] = dphiw;
 
     constexpr int LOG_LUT_SIZE = 256;
-    inputtype log_pt = l1ct::log_with_shift<l1ct::pt_t, inputtype, LOG_LUT_SIZE>(puppicand.hwPt);
+    inputtype log_pt = l1ct::log_with_shift<l1ct::pt_t, l1ct::pt_t, LOG_LUT_SIZE>(puppicand.hwPt);
     fPt_log_.get()[i0] = log_pt;
 
     inputtype massCand = L1TSC4NGJet::candidate_mass<inputtype>(puppicand);
     fMass_.get()[i0] = inputtype(massCand);
+
+    inputtype const_eta = inputtype(puppicand.hwEta);
+    fEta_.get()[i0] = (const_eta < 0)
+      ? inputtype(-const_eta)
+      : inputtype(const_eta);
 
     fZ0_.get()[i0] = puppicand.hwId.charged() ? inputtype(puppicand.hwZ0()) : inputtype(0);
     fDxy_.get()[i0] = puppicand.hwId.charged() ? inputtype(puppicand.hwDxy()) : inputtype(0);
@@ -234,6 +301,6 @@ L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::computeFixed(const l1t::PFJet &iJet
     fCharge_.get()[i0] = inputtype(puppicand.hwId.charged());
     fId_.get()[i0] = inputtype(puppicand.hwId.bits);
   }
-  setNNVectorVar();
+  setVectors();
   return EvaluateNNFixed();
 }

--- a/L1Trigger/Phase2L1ParticleFlow/src/L1TSC4NGJet.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/L1TSC4NGJet.cc
@@ -5,17 +5,17 @@
 
 using namespace L1TSC4NGJet;
 
-  struct ModelInputs {
-        inputtype* candidate_inputs;
-        inputtype* jet_inputs;
-        int total_candidate_inputs;
-        int total_jet_inputs;
-  };
+struct ModelInputs {
+  inputtype* candidate_inputs;
+  inputtype* jet_inputs;
+  int total_candidate_inputs;
+  int total_jet_inputs;
+};
 
-  struct ModelOutputs {
-        inputtype* jet_class_output;
-        inputtype* jet_regression_output;
-  };
+struct ModelOutputs {
+  inputtype* jet_class_output;
+  inputtype* jet_regression_output;
+};
 
 L1TSC4NGJetID::L1TSC4NGJetID(const std::shared_ptr<hls4mlEmulator::Model> model, int iNParticles, bool debug)
     : modelRef_(model) {
@@ -61,21 +61,25 @@ void L1TSC4NGJetID::setVectors() {
     candidate_vector_.push_back(filled ? fDEta_.get()[i0] : null_value);    // dEta from jet axis
     candidate_vector_.push_back(filled ? fDPhi_.get()[i0] : null_value);    // dPhi from jet axis
     candidate_vector_.push_back(filled ? fMass_.get()[i0] : null_value);    // Mass
-    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::PHOTON) : null_value);    // Photon
-    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::ELEPLUS) : null_value);   // Positron
-    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::ELEMINUS) : null_value);  // Electron
-    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::MUPLUS) : null_value);    // Anti-muon
-    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::MUMINUS) : null_value);   // Muon
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::PHOTON) : null_value);  // Photon
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::ELEPLUS)
+                                       : null_value);  // Positron
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::ELEMINUS)
+                                       : null_value);  // Electron
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::MUPLUS)
+                                       : null_value);  // Anti-muon
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::MUMINUS) : null_value);  // Muon
     candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::HADZERO) : null_value);
-    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::HADPLUS) : null_value);   // Anti-Pion
+    candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::HADPLUS)
+                                       : null_value);  // Anti-Pion
     candidate_vector_.push_back(filled ? inputtype(fId_.get()[i0] == l1ct::ParticleID::HADMINUS) : null_value);  // Pion
     candidate_vector_.push_back(filled ? fZ0_.get()[i0] : null_value);                                           // z0
     candidate_vector_.push_back(filled ? fDxy_.get()[i0] : null_value);                                          // dxy
-    candidate_vector_.push_back(filled ? fIs_filled_.get()[i0] : null_value);                                    // isfilled
+    candidate_vector_.push_back(filled ? fIs_filled_.get()[i0] : null_value);     // isfilled
     candidate_vector_.push_back(filled ? fPuppi_weight_.get()[i0] : null_value);  // puppi weight
     candidate_vector_.push_back(filled ? fEmID_.get()[i0] : null_value);          // emID
     candidate_vector_.push_back(filled ? fQuality_.get()[i0] : null_value);       // quality
-    candidate_vector_.push_back(filled ? fEta_.get()[i0] : null_value); // eta
+    candidate_vector_.push_back(filled ? fEta_.get()[i0] : null_value);           // eta
 
     if (isDebugEnabled_) {
       LogDebug("L1TSC4NGJetID") << "Particle: " << i0 << "\n"
@@ -138,9 +142,9 @@ void L1TSC4NGJetID::setVectors() {
                                    "Track Quality: "
                                 << candidate_vector_[i0 * N_candidate_features + 19]
                                 << " | "
-				   "Eta: "
-				<< candidate_vector_[i0 * N_candidate_features + 20] << " | "
-				<< "===========" << std::endl;
+                                   "Eta: "
+                                << candidate_vector_[i0 * N_candidate_features + 20] << " | "
+                                << "===========" << std::endl;
     }
   }
   // After the particle loop
@@ -149,11 +153,10 @@ void L1TSC4NGJetID::setVectors() {
 }
 
 L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::EvaluateNNFixed() {
-
   inputtype fillzero = 0.0;
 
-   // Define Candidate inputs and fill fully with 0s. Allows for case when N_candidate_inputs > candidate_vector_.size(). 
-  inputtype modelCandidateInput[N_candidate_inputs] = {};  
+  // Define Candidate inputs and fill fully with 0s. Allows for case when N_candidate_inputs > candidate_vector_.size().
+  inputtype modelCandidateInput[N_candidate_inputs] = {};
   std::fill(modelCandidateInput, modelCandidateInput + N_candidate_inputs, fillzero);
 
   // Fill the candidate inputs from the pre calculated NNvectorVar
@@ -162,7 +165,7 @@ L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::EvaluateNNFixed() {
   }
 
   // Define Jet inputs and fill fully with 0s.
-  inputtype modelJetInput[N_jet_inputs] = {};  
+  inputtype modelJetInput[N_jet_inputs] = {};
   std::fill(modelJetInput, modelJetInput + N_jet_inputs, fillzero);
   for (unsigned int i = 0; i < jet_vector_.size(); i++) {
     modelJetInput[i] = jet_vector_[i];
@@ -170,7 +173,7 @@ L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::EvaluateNNFixed() {
 
   // Define input struct
   ModelInputs modelInputStruct;
-  // Load candidate and jet inputs 
+  // Load candidate and jet inputs
   modelInputStruct.candidate_inputs = modelCandidateInput;
   modelInputStruct.jet_inputs = modelJetInput;
   modelInputStruct.total_candidate_inputs = N_candidate_features;
@@ -178,14 +181,14 @@ L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::EvaluateNNFixed() {
 
   // Define output struct
   ModelOutputs modelOutputStruct;
-  
+
   // Define and load output with zeros ready for replacement from the model
-  inputtype modelClassOutput[N_class_outputs] = {}; 
-  inputtype modelRegressionOutput[N_regression_outputs] = {};  
+  inputtype modelClassOutput[N_class_outputs] = {};
+  inputtype modelRegressionOutput[N_regression_outputs] = {};
   std::fill(modelClassOutput, modelClassOutput + N_class_outputs, fillzero);
   std::fill(modelRegressionOutput, modelRegressionOutput + N_regression_outputs, fillzero);
 
-  // Load class and regression outputs 
+  // Load class and regression outputs
   modelOutputStruct.jet_class_output = modelClassOutput;
   modelOutputStruct.jet_regression_output = modelRegressionOutput;
 
@@ -202,25 +205,26 @@ L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::EvaluateNNFixed() {
     // Cast model output to jet tag score datatype
     modelResult_forOutput.second[i] = l1ct::jet_tag_score_t(modelOutputStruct.jet_class_output[i]);
     if (isDebugEnabled_) {
-      LogDebug("L1TSC4NGJetID") << l1ct::JetTagClassHandler::tagClassesDefault_[i] << " : " << modelOutputStruct.jet_class_output[i]
+      LogDebug("L1TSC4NGJetID") << l1ct::JetTagClassHandler::tagClassesDefault_[i] << " : "
+                                << modelOutputStruct.jet_class_output[i]
                                 << " Cast to Jet Class type: " << modelResult_forOutput.second[i] << std::endl;
     }
   }
-  
+
   for (unsigned int i = 0; i < N_regression_outputs; i++) {
-      // Cast model output to transient regression score for jet pt multiplication
-      modelResult_forOutput.first[i] = modelOutputStruct.jet_regression_output[i];
-      if (isDebugEnabled_) {
-         LogDebug("L1TSC4NGJetID") << "\n ===== Jet pT Correction Output ===== \n"
-                                    << modelOutputStruct.jet_regression_output[i] << " Cast to Jet pT type: " << modelResult_forOutput.first[i]
-                                    << std::endl;
-      }
-   }
+    // Cast model output to transient regression score for jet pt multiplication
+    modelResult_forOutput.first[i] = modelOutputStruct.jet_regression_output[i];
+    if (isDebugEnabled_) {
+      LogDebug("L1TSC4NGJetID") << "\n ===== Jet pT Correction Output ===== \n"
+                                << modelOutputStruct.jet_regression_output[i]
+                                << " Cast to Jet pT type: " << modelResult_forOutput.first[i] << std::endl;
+    }
+  }
 
   return modelResult_forOutput;
 }  //end EvaluateNNFixed
 
-L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::computeFixed(const l1t::PFJet &iJet) {
+L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::computeFixed(const l1t::PFJet& iJet) {
   for (int i0 = 0; i0 < fNParticles_; i0++) {
     fPt_rel_.get()[i0] = 0;
     fPt_.get()[i0] = 0;
@@ -249,11 +253,10 @@ L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::computeFixed(const l1t::PFJet &iJet
   inputtype jet_pt_ = inputtype(ctJet.hwPt);
   inputtype jet_eta_ = inputtype(ctJet.hwEta);
   inputtype jet_phi_ = inputtype(ctJet.hwPhi);
-  
+
   // Fill jet level features
   fJetPt_ = jet_pt_;
   fJetEta_ = jet_eta_;
-
 
   for (unsigned int i0 = 0; i0 < iParts.size(); i0++) {
     if (i0 >= (unsigned int)fNParticles_)
@@ -287,9 +290,7 @@ L1TSC4NGJetID::outputpairtype L1TSC4NGJetID::computeFixed(const l1t::PFJet &iJet
     fMass_.get()[i0] = inputtype(massCand);
 
     inputtype const_eta = inputtype(puppicand.hwEta);
-    fEta_.get()[i0] = (const_eta < 0)
-      ? inputtype(-const_eta)
-      : inputtype(const_eta);
+    fEta_.get()[i0] = (const_eta < 0) ? inputtype(-const_eta) : inputtype(const_eta);
 
     fZ0_.get()[i0] = puppicand.hwId.charged() ? inputtype(puppicand.hwZ0()) : inputtype(0);
     fDxy_.get()[i0] = puppicand.hwId.charged() ? inputtype(puppicand.hwDxy()) : inputtype(0);


### PR DESCRIPTION
#### PR description:

This PR updates the Phase 2 L1TNGJet model wrapper to be more generic. Major changes include:
 - Removal of specific datatype input and output arrays and replacement with input and output structs that take any number of input and output arrays with a generic input type. The selection of these features is done inside the model emulator itself
 - Additional constants for number of inputs and outputs 
 - Splitting of NNVectorVar into Candidate vectors and Jet vectors
 - Additional processing of the input and output structs, filling them with 0s and passing to the model

This PR needs to be merged alongside [this](https://github.com/cms-sw/cmsdist/pull/10667) cms-dist PR as it will cause bad any cast errors without this update

This PR does not change model performance, the cms-dist PR updates the emulator model wrapper only and not the model  itself, outputs of the model are expected to remain constant

#### PR validation:

This PR is verified in this pipeline with specific plots measuring emulator / hls4ml matching [here](https://cms-l1t-jet-tagger.web.cern.ch/TrainTagger/branches/generic-emulator-update/baseline_5param_extended_trk/latest/plots/emulation/)

Code check and formats are applied
