### PR TITLE
[17_0_X] Prevent the MPI modules from throwing upon race conditions or hanging at the end of a run

### DIFF
--- a/HeterogeneousCore/MPICore/interface/MPIChannel.h
+++ b/HeterogeneousCore/MPICore/interface/MPIChannel.h
@@ -4,6 +4,7 @@
 // C++ standard library headers
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -34,18 +35,18 @@ public:
   MPIChannel& operator=(MPIChannel const& other) = delete;
 
   MPIChannel(MPIChannel&& other) : comm_(other.comm_), request_(other.request_), dest_(other.dest_) {
-    ChannelStatus status = kInvalid;
-    other.status_.exchange(status, std::memory_order::acq_rel);
-    status_.store(status, std::memory_order::acq_rel);
+    ChannelStatus state = kInvalid;
+    other.state_.exchange(state, std::memory_order::acq_rel);
+    state_.store(state, std::memory_order::acq_rel);
     other.comm_ = MPI_COMM_NULL;
     other.request_ = MPI_REQUEST_NULL;
     other.dest_ = MPI_UNDEFINED;
   }
 
   MPIChannel& operator=(MPIChannel&& other) {
-    ChannelStatus status = kInvalid;
-    other.status_.exchange(status, std::memory_order::acq_rel);
-    status_.store(status, std::memory_order::acq_rel);
+    ChannelStatus state = kInvalid;
+    other.state_.exchange(state, std::memory_order::acq_rel);
+    state_.store(state, std::memory_order::acq_rel);
     comm_ = other.comm_;
     request_ = other.request_;
     dest_ = other.dest_;
@@ -226,9 +227,13 @@ private:
 
   int slot_ = -1;
 
-  // Note: the status_ flag is accessed atomically because it can be written to and read from by
+  // Note: the state_ flag is accessed atomically because it can be written to and read from by
   // different threads.
-  std::atomic<ChannelStatus> status_ = kInvalid;
+  std::atomic<ChannelStatus> state_ = kInvalid;
+
+  // Mutex to guard state_ transitions and MPI operations modifying request_
+  // in ready() and wait().
+  std::mutex mutex_;
 };
 
 #endif  // HeterogeneousCore_MPICore_interface_MPIChannel_h

--- a/HeterogeneousCore/MPICore/src/MPIChannel.cc
+++ b/HeterogeneousCore/MPICore/src/MPIChannel.cc
@@ -155,6 +155,11 @@ void MPIChannel::wait() {
 
 // close the underlying communicator and reset the MPIChannel to an invalid state
 void MPIChannel::reset() {
+  // Complete any pending MPI_Request
+  if (request_ != MPI_REQUEST_NULL) {
+    MPI_Wait(&request_, MPI_STATUS_IGNORE);
+    assert(request_ == MPI_REQUEST_NULL);
+  }
   // This is a blocking collective operation.
   MPI_Comm_disconnect(&comm_);
   dest_ = MPI_UNDEFINED;

--- a/HeterogeneousCore/MPICore/src/MPIChannel.cc
+++ b/HeterogeneousCore/MPICore/src/MPIChannel.cc
@@ -1,7 +1,9 @@
 // C++ standard library headers
+#include <atomic>
 #include <cassert>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <string>
 
 // ROOT headers
@@ -40,7 +42,7 @@ std::unique_ptr<MPIChannel> MPIChannel::duplicate(int slot) const {
   MPI_Comm newcomm;
   MPI_Comm_dup(comm_, &newcomm);
   auto channel = std::make_unique<MPIChannel>(newcomm, dest_);
-  channel->status_.store(kReady, std::memory_order_release);
+  channel->state_.store(kReady, std::memory_order_release);
   channel->slot_ = slot;
   LogDebug("MPI") << "channel " << slot << " transitioned to kReady";
   return channel;
@@ -48,47 +50,63 @@ std::unique_ptr<MPIChannel> MPIChannel::duplicate(int slot) const {
 
 // mark the channel as busy
 void MPIChannel::acquire() {
-  auto status = status_.load(std::memory_order_acquire);
-  if (status != kReady) {
+  auto state = state_.load(std::memory_order_acquire);
+  if (state != kReady) {
     throw cms::Exception("MPI") << "MPIChannel " << slot_ << " is in an invalide state";
   }
   assert(request_ == MPI_REQUEST_NULL);
-  status_.store(kBusy, std::memory_order_release);
+  state_.store(kBusy, std::memory_order_release);
   LogDebug("MPI") << "channel " << slot_ << " transitioned to kBusy";
 }
 
 // make sure both processes have completed processing the event that was transmitted
 // Note: this is a non-blocking collective operation.
 void MPIChannel::sync() {
-  auto status = status_.load(std::memory_order_acquire);
-  if (status != kBusy) {
+  auto state = state_.load(std::memory_order_acquire);
+  if (state != kBusy) {
     throw cms::Exception("MPI") << "MPIChannel " << slot_ << " is in an invalide state";
   }
   assert(request_ == MPI_REQUEST_NULL);
   MPI_Ibarrier(comm_, &request_);
   assert(request_ != MPI_REQUEST_NULL);
-  status_.store(kSync, std::memory_order_release);
+  state_.store(kSync, std::memory_order_release);
+  state_.notify_one();
   LogDebug("MPI") << "channel " << slot_ << " transitioned to kSync";
 }
 
 // check whether this channel can be used to transmit a new event
 bool MPIChannel::ready() {
-  auto status = status_.load(std::memory_order_acquire);
-  if (status == kInvalid) {
+  auto state = state_.load(std::memory_order_acquire);
+  if (state == kInvalid) {
     throw cms::Exception("MPI") << "MPIChannel " << slot_ << " is in an invalide state";
-  } else if (status == kReady) {
+  } else if (state == kReady) {
     return true;
-  } else if (status == kBusy) {
+  } else if (state == kBusy) {
     return false;
-  } else if (status == kSync) {
+  } else if (state == kSync) {
+    // Guard the MPI_Test and the state_.store() below with a mutex. If some
+    // other thread is currently in wait() on this channel and owns the mutex,
+    // return false to indicate that this channel is not yet ready.
+    std::unique_lock lock(mutex_, std::try_to_lock);
+    if (!lock) {
+      return false;
+    }
+    // reload state_, since at this point it could have been changed by wait().
+    state = state_.load(std::memory_order_acquire);
+    if (state == kReady) {
+      return true;
+    } else if (state != kSync) {
+      return false;
+    }
     int flag = 0;
     assert(request_ != MPI_REQUEST_NULL);
-    // TODO check status and return value
+    // TODO check state and return value
     MPI_Test(&request_, &flag, MPI_STATUS_IGNORE);
     if (flag) {
       // if the barrier was reached, MPI_Test resets the request object to MPI_REQUEST_NULL
       assert(request_ == MPI_REQUEST_NULL);
-      status_.store(kReady, std::memory_order_release);
+      state_.store(kReady, std::memory_order_release);
+      state_.notify_one();
       LogDebug("MPI") << "channel " << slot_ << " transitioned to kReady";
       return true;
     } else {
@@ -102,23 +120,35 @@ bool MPIChannel::ready() {
 
 // wait until this channel can be used to transmit a new event
 void MPIChannel::wait() {
-  auto status = status_.load(std::memory_order_acquire);
-  if (status == kInvalid) {
+  auto state = state_.load(std::memory_order_acquire);
+
+  state_.wait(kBusy, std::memory_order_acquire);
+  state = state_.load(std::memory_order_acquire);
+
+  if (state == kInvalid) {
     throw cms::Exception("MPI") << "MPIChannel " << slot_ << " is in an invalide state";
-  } else if (status == kReady) {
+  } else if (state == kReady) {
     return;
-  } else if (status == kBusy) {
-    throw cms::Exception("MPI") << "MPIChannel::wait() cannot resolve a kBusy status";
-    return;
-  } else if (status == kSync) {
-    assert(request_ != MPI_REQUEST_NULL);
-    // TODO check status and return value
-    MPI_Wait(&request_, MPI_STATUS_IGNORE);
-    // if the barrier was reached, MPI_Test resets the request object to MPI_REQUEST_NULL
-    assert(request_ == MPI_REQUEST_NULL);
-    status_.store(kReady, std::memory_order_release);
-    LogDebug("MPI") << "channel " << slot_ << " transitioned to kReady";
-    return;
+  } else if (state == kSync) {
+    std::lock_guard lock(mutex_);
+    // reload state_, since at this point it could have been changed by ready().
+    state = state_.load(std::memory_order_acquire);
+    if (state == kReady) {
+      return;
+    } else if (state == kSync) {
+      assert(request_ != MPI_REQUEST_NULL);
+      // TODO check state and return value
+      MPI_Wait(&request_, MPI_STATUS_IGNORE);
+      // if the barrier was reached, MPI_Wait resets the request object to MPI_REQUEST_NULL
+      assert(request_ == MPI_REQUEST_NULL);
+      state_.store(kReady, std::memory_order_release);
+      state_.notify_one();
+      LogDebug("MPI") << "channel " << slot_ << " transitioned to kReady";
+      return;
+    }
+    // kSync cannot transition to any state other than kReady
+  } else {
+    throw cms::Exception("MPI") << "MPIChannel " << slot_ << " is in an unexpected invalid state";
   }
   __builtin_unreachable();
 }


### PR DESCRIPTION
#### PR description:
Backport of #50889.

This backport is being opened so that the changes introduced by #50889 can be included in the MPI-related tests on the Run 3 HLT setup.

#### PR validation:
Unit tests pass