### PR TITLE
Provide configuration descriptions to MTD local reconstruction modules

### DIFF
--- a/RecoLocalFastTime/FTLCommonAlgos/interface/MTDRecHitAlgoBase.h
+++ b/RecoLocalFastTime/FTLCommonAlgos/interface/MTDRecHitAlgoBase.h
@@ -8,6 +8,7 @@
   */
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/FTLRecHit/interface/FTLRecHit.h"

--- a/RecoLocalFastTime/FTLCommonAlgos/interface/MTDUncalibratedRecHitAlgoBase.h
+++ b/RecoLocalFastTime/FTLCommonAlgos/interface/MTDUncalibratedRecHitAlgoBase.h
@@ -2,6 +2,7 @@
 #define RecoLocalFastTime_FTLCommonAlgos_MTDUncalibratedRecHitRecAlgoBase_HH
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/FTLDigi/interface/FTLDigiCollections.h"

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/BTLUncalibRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/BTLUncalibRecHitAlgo.cc
@@ -1,46 +1,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDUncalibratedRecHitAlgoBase.h"
 #include "RecoLocalFastTime/FTLClusterizer/interface/BTLRecHitsErrorEstimatorIM.h"
 
-#include "CommonTools/Utils/interface/FormulaEvaluator.h"
-
-class BTLUncalibRecHitAlgo : public BTLUncalibratedRecHitAlgoBase {
-public:
-  /// Constructor
-  BTLUncalibRecHitAlgo(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : MTDUncalibratedRecHitAlgoBase<BTLDataFrame>(conf, sumes),
-        invLightSpeedLYSO_(conf.getParameter<double>("invLightSpeedLYSO")),
-        c_LYSO_(1. / invLightSpeedLYSO_),
-        npeToADC_(conf.getParameter<std::vector<double>>("npeToADC")),
-        npePerMeV_(conf.getParameter<double>("npePerMeV")),
-        invADCPerMeV_(1. / (npeToADC_[1] * npePerMeV_)),
-        npeSaturationCorr_(conf.getParameter<std::vector<double>>("npeSaturationCorrection")),
-        tdc_to_ns_(conf.getParameter<double>("tdcLSB_ns")),
-        timeError_(conf.getParameter<std::string>("timeResolutionInNs")),
-        timeWalkCorr_(conf.getParameter<std::string>("timeWalkCorrection")) {}
-
-  /// Destructor
-  ~BTLUncalibRecHitAlgo() override {}
-
-  /// get event and eventsetup information
-  void getEvent(const edm::Event&) final {}
-  void getEventSetup(const edm::EventSetup&) final {}
-
-  /// make the rec hit
-  FTLUncalibratedRecHit makeRecHit(const BTLDataFrame& dataFrame) const final;
-
-private:
-  const double invLightSpeedLYSO_;
-  const double c_LYSO_;
-  const std::vector<double> npeToADC_;
-  const double npePerMeV_;
-  const double invADCPerMeV_;
-  const std::vector<double> npeSaturationCorr_;
-  const double tdc_to_ns_;
-  const reco::FormulaEvaluator timeError_;
-  const reco::FormulaEvaluator timeWalkCorr_;
-};
+#include "BTLUncalibRecHitAlgo.h"
 
 FTLUncalibratedRecHit BTLUncalibRecHitAlgo::makeRecHit(const BTLDataFrame& dataFrame) const {
   // The reconstructed amplitudes and times of the right and left hits are saved in a std::pair
@@ -119,5 +80,12 @@ FTLUncalibratedRecHit BTLUncalibRecHitAlgo::makeRecHit(const BTLDataFrame& dataF
       dataFrame.id(), dataFrame.row(), dataFrame.column(), amplitude, time, timeError, position, positionError, flag);
 }
 
-#include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_EDM_PLUGIN(BTLUncalibratedRecHitAlgoFactory, BTLUncalibRecHitAlgo, "BTLUncalibRecHitAlgo");
+void BTLUncalibRecHitAlgo::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<double>("invLightSpeedLYSO");
+  desc.add<std::vector<double>>("npeToADC");
+  desc.add<double>("npePerMeV");
+  desc.add<std::vector<double>>("npeSaturationCorrection");
+  desc.add<double>("tdcLSB_ns");
+  desc.add<std::string>("timeResolutionInNs");
+  desc.add<std::string>("timeWalkCorrection");
+}

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/BTLUncalibRecHitAlgo.h
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/BTLUncalibRecHitAlgo.h
@@ -1,0 +1,42 @@
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+#include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDUncalibratedRecHitAlgoBase.h"
+
+class BTLUncalibRecHitAlgo : public BTLUncalibratedRecHitAlgoBase {
+public:
+  /// Constructor
+  BTLUncalibRecHitAlgo(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : MTDUncalibratedRecHitAlgoBase<BTLDataFrame>(conf, sumes),
+        invLightSpeedLYSO_(conf.getParameter<double>("invLightSpeedLYSO")),
+        c_LYSO_(1. / invLightSpeedLYSO_),
+        npeToADC_(conf.getParameter<std::vector<double>>("npeToADC")),
+        npePerMeV_(conf.getParameter<double>("npePerMeV")),
+        invADCPerMeV_(1. / (npeToADC_[1] * npePerMeV_)),
+        npeSaturationCorr_(conf.getParameter<std::vector<double>>("npeSaturationCorrection")),
+        tdc_to_ns_(conf.getParameter<double>("tdcLSB_ns")),
+        timeError_(conf.getParameter<std::string>("timeResolutionInNs")),
+        timeWalkCorr_(conf.getParameter<std::string>("timeWalkCorrection")) {}
+
+  /// Destructor
+  ~BTLUncalibRecHitAlgo() override {}
+
+  /// get event and eventsetup information
+  void getEvent(const edm::Event&) final {}
+  void getEventSetup(const edm::EventSetup&) final {}
+
+  /// make the rec hit
+  FTLUncalibratedRecHit makeRecHit(const BTLDataFrame& dataFrame) const final;
+
+  /// Fill parameter descriptions for validation
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
+private:
+  const double invLightSpeedLYSO_;
+  const double c_LYSO_;
+  const std::vector<double> npeToADC_;
+  const double npePerMeV_;
+  const double invADCPerMeV_;
+  const std::vector<double> npeSaturationCorr_;
+  const double tdc_to_ns_;
+  const reco::FormulaEvaluator timeError_;
+  const reco::FormulaEvaluator timeWalkCorr_;
+};

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
@@ -1,43 +1,6 @@
-#include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDUncalibratedRecHitAlgoBase.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "CommonTools/Utils/interface/FormulaEvaluator.h"
-
-class ETLUncalibRecHitAlgo : public ETLUncalibratedRecHitAlgoBase {
-public:
-  /// Constructor
-  ETLUncalibRecHitAlgo(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
-      : MTDUncalibratedRecHitAlgoBase<ETLDataFrame>(conf, sumes),
-        adcNBits_(conf.getParameter<uint32_t>("adcNbits")),
-        adcSaturation_(conf.getParameter<double>("adcSaturation")),
-        adcLSB_(adcSaturation_ / (1 << adcNBits_)),
-        toaLSBToNS_(conf.getParameter<double>("toaLSB_ns")),
-        timeError_(conf.getParameter<std::string>("timeResolutionInNs")),
-        timeCorr_p0_(conf.getParameter<double>("timeCorr_p0")),
-        timeCorr_p1_(conf.getParameter<double>("timeCorr_p1")),
-        timeCorr_p2_(conf.getParameter<double>("timeCorr_p2")),
-        timeCorr_p3_(conf.getParameter<double>("timeCorr_p3")) {}
-  /// Destructor
-  ~ETLUncalibRecHitAlgo() override {}
-
-  /// get event and eventsetup information
-  void getEvent(const edm::Event&) final {}
-  void getEventSetup(const edm::EventSetup&) final {}
-
-  /// make the rec hit
-  FTLUncalibratedRecHit makeRecHit(const ETLDataFrame& dataFrame) const final;
-
-private:
-  const uint32_t adcNBits_;
-  const double adcSaturation_;
-  const double adcLSB_;
-  const double toaLSBToNS_;
-  const reco::FormulaEvaluator timeError_;
-  const double timeCorr_p0_;
-  const double timeCorr_p1_;
-  const double timeCorr_p2_;
-  const double timeCorr_p3_;
-};
+#include "ETLUncalibRecHitAlgo.h"
 
 FTLUncalibratedRecHit ETLUncalibRecHitAlgo::makeRecHit(const ETLDataFrame& dataFrame) const {
   constexpr int iSample = 2;  //only in-time sample
@@ -83,5 +46,14 @@ FTLUncalibratedRecHit ETLUncalibRecHitAlgo::makeRecHit(const ETLDataFrame& dataF
                                -1.f,
                                flag);
 }
-#include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_EDM_PLUGIN(ETLUncalibratedRecHitAlgoFactory, ETLUncalibRecHitAlgo, "ETLUncalibRecHitAlgo");
+
+void ETLUncalibRecHitAlgo::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<uint32_t>("adcNbits");
+  desc.add<double>("adcSaturation");
+  desc.add<double>("toaLSB_ns");
+  desc.add<std::string>("timeResolutionInNs");
+  desc.add<double>("timeCorr_p0");
+  desc.add<double>("timeCorr_p1");
+  desc.add<double>("timeCorr_p2");
+  desc.add<double>("timeCorr_p3");
+}

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.h
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.h
@@ -1,0 +1,41 @@
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+#include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDUncalibratedRecHitAlgoBase.h"
+
+class ETLUncalibRecHitAlgo : public ETLUncalibratedRecHitAlgoBase {
+public:
+  /// Constructor
+  ETLUncalibRecHitAlgo(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : MTDUncalibratedRecHitAlgoBase<ETLDataFrame>(conf, sumes),
+        adcNBits_(conf.getParameter<uint32_t>("adcNbits")),
+        adcSaturation_(conf.getParameter<double>("adcSaturation")),
+        adcLSB_(adcSaturation_ / (1 << adcNBits_)),
+        toaLSBToNS_(conf.getParameter<double>("toaLSB_ns")),
+        timeError_(conf.getParameter<std::string>("timeResolutionInNs")),
+        timeCorr_p0_(conf.getParameter<double>("timeCorr_p0")),
+        timeCorr_p1_(conf.getParameter<double>("timeCorr_p1")),
+        timeCorr_p2_(conf.getParameter<double>("timeCorr_p2")),
+        timeCorr_p3_(conf.getParameter<double>("timeCorr_p3")) {}
+  /// Destructor
+  ~ETLUncalibRecHitAlgo() override {}
+
+  /// get event and eventsetup information
+  void getEvent(const edm::Event&) final {}
+  void getEventSetup(const edm::EventSetup&) final {}
+
+  /// make the rec hit
+  FTLUncalibratedRecHit makeRecHit(const ETLDataFrame& dataFrame) const final;
+
+  /// Fill parameter descriptions for validation
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
+private:
+  const uint32_t adcNBits_;
+  const double adcSaturation_;
+  const double adcLSB_;
+  const double toaLSBToNS_;
+  const reco::FormulaEvaluator timeError_;
+  const double timeCorr_p0_;
+  const double timeCorr_p1_;
+  const double timeCorr_p2_;
+  const double timeCorr_p3_;
+};

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
@@ -1,28 +1,6 @@
-#include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDRecHitAlgoBase.h"
-
 #include "RecoLocalFastTime/Records/interface/MTDTimeCalibRecord.h"
 #include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDTimeCalib.h"
-
-class MTDRecHitAlgo : public MTDRecHitAlgoBase {
-public:
-  /// Constructor
-  MTDRecHitAlgo(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes);
-
-  /// Destructor
-  ~MTDRecHitAlgo() override {}
-
-  /// get event and eventsetup information
-  void getEvent(const edm::Event&) final {}
-  void getEventSetup(const edm::EventSetup&) final;
-
-  /// make the rec hit
-  FTLRecHit makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32_t& flags) const final;
-
-private:
-  double thresholdToKeep_, calibration_;
-  const MTDTimeCalib* time_calib_;
-  edm::ESGetToken<MTDTimeCalib, MTDTimeCalibRecord> tcToken_;
-};
+#include "MTDRecHitAlgo.h"
 
 MTDRecHitAlgo::MTDRecHitAlgo(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
     : MTDRecHitAlgoBase(conf, sumes),
@@ -95,5 +73,7 @@ FTLRecHit MTDRecHitAlgo::makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32
   return rh;
 }
 
-#include "FWCore/Framework/interface/MakerMacros.h"
-DEFINE_EDM_PLUGIN(MTDRecHitAlgoFactory, MTDRecHitAlgo, "MTDRecHitAlgo");
+void MTDRecHitAlgo::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add<double>("thresholdToKeep", 1.0)->setComment("Threshold below which rechits are killed");
+  desc.add<double>("calibrationConstant", 1.0)->setComment("Energy calibration factor");
+}

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.h
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.h
@@ -1,0 +1,27 @@
+#include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDRecHitAlgoBase.h"
+#include "RecoLocalFastTime/Records/interface/MTDTimeCalibRecord.h"
+#include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDTimeCalib.h"
+
+class MTDRecHitAlgo : public MTDRecHitAlgoBase {
+public:
+  /// Constructor
+  MTDRecHitAlgo(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes);
+
+  /// Destructor
+  ~MTDRecHitAlgo() override {}
+
+  /// get event and eventsetup information
+  void getEvent(const edm::Event&) final {}
+  void getEventSetup(const edm::EventSetup&) final;
+
+  /// make the rec hit
+  FTLRecHit makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32_t& flags) const final;
+
+  /// Fill parameter descriptions for validation
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
+private:
+  double thresholdToKeep_, calibration_;
+  const MTDTimeCalib* time_calib_;
+  edm::ESGetToken<MTDTimeCalib, MTDTimeCalibRecord> tcToken_;
+};

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/SealModules.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/SealModules.cc
@@ -1,0 +1,3 @@
+#include "MTDRecHitAlgo.h"
+#include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
+DEFINE_EDM_VALIDATED_PLUGIN(MTDRecHitAlgoFactory, MTDRecHitAlgo, "MTDRecHitAlgo");

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/SealModules.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/SealModules.cc
@@ -1,3 +1,7 @@
+#include "BTLUncalibRecHitAlgo.h"
+#include "ETLUncalibRecHitAlgo.h"
 #include "MTDRecHitAlgo.h"
 #include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
+DEFINE_EDM_VALIDATED_PLUGIN(BTLUncalibratedRecHitAlgoFactory, BTLUncalibRecHitAlgo, "BTLUncalibRecHitAlgo");
+DEFINE_EDM_VALIDATED_PLUGIN(ETLUncalibratedRecHitAlgoFactory, ETLUncalibRecHitAlgo, "ETLUncalibRecHitAlgo");
 DEFINE_EDM_VALIDATED_PLUGIN(MTDRecHitAlgoFactory, MTDRecHitAlgo, "MTDRecHitAlgo");

--- a/RecoLocalFastTime/FTLCommonAlgos/src/MTDRecHitAlgoBase.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/src/MTDRecHitAlgoBase.cc
@@ -1,3 +1,3 @@
 #include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDRecHitAlgoBase.h"
-
-EDM_REGISTER_PLUGINFACTORY(MTDRecHitAlgoFactory, "MTDRecHitAlgoFactory");
+#include "FWCore/ParameterSet/interface/ValidatedPluginFactoryMacros.h"
+EDM_REGISTER_VALIDATED_PLUGINFACTORY(MTDRecHitAlgoFactory, "MTDRecHitAlgoFactory");

--- a/RecoLocalFastTime/FTLCommonAlgos/src/MTDUncalibratedRecHitAlgoBase.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/src/MTDUncalibratedRecHitAlgoBase.cc
@@ -1,4 +1,4 @@
 #include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDUncalibratedRecHitAlgoBase.h"
-
-EDM_REGISTER_PLUGINFACTORY(BTLUncalibratedRecHitAlgoFactory, "BTLUncalibratedRecHitAlgoFactory");
-EDM_REGISTER_PLUGINFACTORY(ETLUncalibratedRecHitAlgoFactory, "ETLUncalibratedRecHitAlgoFactory");
+#include "FWCore/ParameterSet/interface/ValidatedPluginFactoryMacros.h"
+EDM_REGISTER_VALIDATED_PLUGINFACTORY(BTLUncalibratedRecHitAlgoFactory, "BTLUncalibratedRecHitAlgoFactory");
+EDM_REGISTER_VALIDATED_PLUGINFACTORY(ETLUncalibratedRecHitAlgoFactory, "ETLUncalibratedRecHitAlgoFactory");

--- a/RecoLocalFastTime/FTLRecProducers/plugins/MTDRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/MTDRecHitProducer.cc
@@ -2,7 +2,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/PluginDescription.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FTLDigi/interface/FTLDigiCollections.h"
 #include "DataFormats/FTLRecHit/interface/FTLRecHitCollections.h"
@@ -22,8 +23,9 @@
 class MTDRecHitProducer : public edm::stream::EDProducer<> {
 public:
   explicit MTDRecHitProducer(const edm::ParameterSet& ps);
-  ~MTDRecHitProducer() override;
+  ~MTDRecHitProducer() override = default;
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   const edm::EDGetTokenT<FTLUncalibratedRecHitCollection> ftlbURecHits_;  // collection of barrel digis
@@ -35,7 +37,7 @@ private:
   std::unique_ptr<MTDRecHitAlgoBase> barrel_, endcap_;
 
   const MTDGeometry* geom_;
-  edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> mtdgeoToken_;
+  const edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> mtdgeoToken_;
 };
 
 MTDRecHitProducer::MTDRecHitProducer(const edm::ParameterSet& ps)
@@ -44,13 +46,12 @@ MTDRecHitProducer::MTDRecHitProducer(const edm::ParameterSet& ps)
       ftleURecHits_(
           consumes<FTLUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("endcapUncalibratedRecHits"))),
       ftlbInstance_(ps.getParameter<std::string>("BarrelHitsName")),
-      ftleInstance_(ps.getParameter<std::string>("EndcapHitsName")) {
+      ftleInstance_(ps.getParameter<std::string>("EndcapHitsName")),
+      mtdgeoToken_(esConsumes<MTDGeometry, MTDDigiGeometryRecord>()) {
   produces<FTLRecHitCollection>(ftlbInstance_);
   produces<FTLRecHitCollection>(ftleInstance_);
 
   auto sumes = consumesCollector();
-  mtdgeoToken_ = esConsumes<MTDGeometry, MTDDigiGeometryRecord>();
-
   const edm::ParameterSet& barrel = ps.getParameterSet("barrel");
   const std::string& barrelAlgo = barrel.getParameter<std::string>("algoName");
   barrel_ = MTDRecHitAlgoFactory::get()->create(barrelAlgo, barrel, sumes);
@@ -59,8 +60,6 @@ MTDRecHitProducer::MTDRecHitProducer(const edm::ParameterSet& ps)
   const std::string& endcapAlgo = endcap.getParameter<std::string>("algoName");
   endcap_ = MTDRecHitAlgoFactory::get()->create(endcapAlgo, endcap, sumes);
 }
-
-MTDRecHitProducer::~MTDRecHitProducer() {}
 
 void MTDRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   auto geom = es.getTransientHandle(mtdgeoToken_);
@@ -108,6 +107,25 @@ void MTDRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   // put the collection of recunstructed hits in the event
   evt.put(std::move(barrelRechits), ftlbInstance_);
   evt.put(std::move(endcapRechits), ftleInstance_);
+}
+
+void MTDRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("barrelUncalibratedRecHits", edm::InputTag("mtdUncalibratedRecHits:FTLBarrel"));
+  desc.add<edm::InputTag>("endcapUncalibratedRecHits", edm::InputTag("mtdUncalibratedRecHits:FTLEndcap"));
+  desc.add<std::string>("BarrelHitsName", "FTLBarrel");
+  desc.add<std::string>("EndcapHitsName", "FTLEndcap");
+
+  edm::ParameterSetDescription barrelDesc;
+  barrelDesc.addNode(edm::PluginDescription<MTDRecHitAlgoFactory>("algoName", true));
+  desc.add<edm::ParameterSetDescription>("barrel", barrelDesc);
+
+  edm::ParameterSetDescription endcapDesc;
+  endcapDesc.addNode(edm::PluginDescription<MTDRecHitAlgoFactory>("algoName", true));
+  desc.add<edm::ParameterSetDescription>("endcap", endcapDesc);
+
+  descriptions.addWithDefaultLabel(desc);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoLocalFastTime/FTLRecProducers/plugins/MTDUncalibratedRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/MTDUncalibratedRecHitProducer.cc
@@ -6,6 +6,9 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FTLDigi/interface/FTLDigiCollections.h"
 #include "DataFormats/FTLRecHit/interface/FTLRecHitCollections.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/PluginDescription.h"
 
 #include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDUncalibratedRecHitAlgoBase.h"
 
@@ -14,8 +17,9 @@
 class MTDUncalibratedRecHitProducer : public edm::stream::EDProducer<> {
 public:
   explicit MTDUncalibratedRecHitProducer(const edm::ParameterSet& ps);
-  ~MTDUncalibratedRecHitProducer() override;
+  ~MTDUncalibratedRecHitProducer() override = default;
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   const edm::EDGetTokenT<BTLDigiCollection> ftlbDigis_;  // collection of BTL digis
@@ -48,8 +52,6 @@ MTDUncalibratedRecHitProducer::MTDUncalibratedRecHitProducer(const edm::Paramete
   endcap_ = std::unique_ptr<ETLUncalibratedRecHitAlgoBase>{
       ETLUncalibratedRecHitAlgoFactory::get()->create(endcapAlgo, endcap, sumes)};
 }
-
-MTDUncalibratedRecHitProducer::~MTDUncalibratedRecHitProducer() {}
 
 void MTDUncalibratedRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   // tranparently get things from event setup
@@ -88,6 +90,25 @@ void MTDUncalibratedRecHitProducer::produce(edm::Event& evt, const edm::EventSet
   // put the collection of recunstructed hits in the event
   evt.put(std::move(barrelRechits), ftlbInstance_);
   evt.put(std::move(endcapRechits), ftleInstance_);
+}
+
+void MTDUncalibratedRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("barrelDigis", edm::InputTag("mix", "FTLBarrel"));
+  desc.add<edm::InputTag>("endcapDigis", edm::InputTag("mix", "FTEndcap"));
+
+  desc.add<std::string>("BarrelHitsName", "FTLBarrel");
+  desc.add<std::string>("EndcapHitsName", "FTLEndcap");
+
+  edm::ParameterSetDescription barrelDesc;
+  barrelDesc.addNode(edm::PluginDescription<BTLUncalibratedRecHitAlgoFactory>("algoName", true));
+  desc.add<edm::ParameterSetDescription>("barrel", barrelDesc);
+
+  edm::ParameterSetDescription endcapDesc;
+  endcapDesc.addNode(edm::PluginDescription<ETLUncalibratedRecHitAlgoFactory>("algoName", true));
+  desc.add<edm::ParameterSetDescription>("endcap", endcapDesc);
+
+  descriptions.addWithDefaultLabel(desc);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"


### PR DESCRIPTION
#### PR description:

The goal of this PR is to update `MTDUncalibratedRecHitProducer` and `MTDRecHitProducer` in order to make them fully suitable for the HLT usage, by adding a `fillDescriptions` method.
As these module make use of plugin factories, additional changes following the line of [these instructions](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideConfigurationValidationAndHelp#A_Plugin_Module_Using_Another_He) were added.
The missing configuration validation was spotted thanks to [this script](https://raw.githubusercontent.com/mmusich/hltScripts/refs/heads/master/confDBparseChecks/testConfDBParsing_Phase2.py) run on `CMSSW_20_1_X_2026-06-21-0000`.

#### PR validation:

I've run successfully: 
- `runTheMatrix.py -l 34434.7522 -t 4 -j 8 -i all --ibeos` in `CMSSW_20_1_X_2026-06-21-0000`. (as introduced at https://github.com/cms-sw/cmssw/pull/51170)
- The script [`testConfDBParsing_Phase2.py`](https://raw.githubusercontent.com/mmusich/hltScripts/refs/heads/master/confDBparseChecks/testConfDBParsing_Phase2.py) does not flag any other MTD modules. The others are long-standing and already reported at https://github.com/cms-sw/cmssw/issues/47275.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.