### PR TITLE
DQM/Physics: clang warning fixes for unused variables

### DIFF
--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
@@ -440,8 +440,6 @@ namespace SingleTopTChannelLepton {
     unsigned int mMult = 0, mTight = 0, mTightId = 0;
 
     edm::Handle<edm::View<reco::Muon>> muons;
-    edm::View<reco::Muon>::const_iterator muon;
-    //reco::MuonRef muon;
     reco::Muon mu;
 
     if (!event.getByToken(muons_, muons))

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
@@ -506,8 +506,6 @@ namespace SingleTopTChannelLepton_miniAOD {
 
     pat::Muon mu;
 
-    edm::View<pat::Muon>::const_iterator muonit;
-
     if (!event.getByToken(muons_, muons))
       return;
 

--- a/DQM/Physics/src/TopDiLeptonOfflineDQM.cc
+++ b/DQM/Physics/src/TopDiLeptonOfflineDQM.cc
@@ -324,7 +324,6 @@ namespace TopDiLeptonOffline {
     std::vector<const reco::PFCandidate*> isoMuons;
 
     edm::Handle<edm::View<reco::PFCandidate>> muons;
-    edm::View<reco::PFCandidate>::const_iterator muonit;
 
     if (!event.getByToken(muons_, muons))
       return;

--- a/DQM/Physics/src/TopSingleLeptonDQM.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM.cc
@@ -455,7 +455,6 @@ namespace TopSingleLepton {
     unsigned int mMult = 0, mTight = 0, mTightId = 0;
 
     edm::Handle<edm::View<reco::Muon>> muons;
-    edm::View<reco::Muon>::const_iterator muonit;
 
     if (!event.getByToken(muons_, muons))
       return;

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
@@ -489,7 +489,6 @@ namespace TopSingleLepton_miniAOD {
     unsigned int mMult = 0, mTight = 0, mTightId = 0;
 
     edm::Handle<edm::View<pat::Muon>> muons;
-    edm::View<pat::Muon>::const_iterator muonit;
 
     if (!event.getByToken(muons_, muons))
       return;


### PR DESCRIPTION
This PR fixes build warnings generated by clang about unused variables [a]

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc13/CMSSW_20_1_CLANG_X_2026-06-21-2300/DQM/Physics
```
[src/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc:443](https://github.com/cms-sw/cmssw/blob/CMSSW_20_1_CLANG_X_2026-06-21-2300/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc#L443):43: warning: unused variable 'muon' [-Wunused-variable]
   443 |     edm::View<reco::Muon>::const_iterator muon;
      |                                           ^~~~
[src/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc:509](https://github.com/cms-sw/cmssw/blob/CMSSW_20_1_CLANG_X_2026-06-21-2300/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc#L509):42: warning: unused variable 'muonit' [-Wunused-variable]
   509 |     edm::View<pat::Muon>::const_iterator muonit;
      |                                          ^~~~~~
[src/DQM/Physics/src/TopDiLeptonOfflineDQM.cc:327](https://github.com/cms-sw/cmssw/blob/CMSSW_20_1_CLANG_X_2026-06-21-2300/DQM/Physics/src/TopDiLeptonOfflineDQM.cc#L327):50: warning: unused variable 'muonit' [-Wunused-variable]
   327 |     edm::View<reco::PFCandidate>::const_iterator muonit;
      |                                                  ^~~~~~
[src/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc:492](https://github.com/cms-sw/cmssw/blob/CMSSW_20_1_CLANG_X_2026-06-21-2300/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc#L492):42: warning: unused variable 'muonit' [-Wunused-variable]
   492 |     edm::View<pat::Muon>::const_iterator muonit;
      |                                          ^~~~~~
[src/DQM/Physics/src/TopSingleLeptonDQM.cc:458](https://github.com/cms-sw/cmssw/blob/CMSSW_20_1_CLANG_X_2026-06-21-2300/DQM/Physics/src/TopSingleLeptonDQM.cc#L458):43: warning: unused variable 'muonit' [-Wunused-variable]
   458 |     edm::View<reco::Muon>::const_iterator muonit;
```
