### PR TITLE
Fix tree ownership issue in NanoAODTools

### DIFF
--- a/PhysicsTools/NanoAODTools/README.md
+++ b/PhysicsTools/NanoAODTools/README.md
@@ -9,10 +9,12 @@ It can be used directly from a CMSSW environment, or checked out as a standalone
 
 Originally imported to CMSSW from [cms-nanoAOD/nanoAOD-tools](https://github.com/cms-nanoAOD/nanoAOD-tools) (post-processor functionality only).
 
+A library of **modules to apply corrections using official correctionlib JSONS** is maintained in [cms-cat/nanoAOD-tools-modules](https://github.com/cms-cat/nanoAOD-tools-modules).
+
 ## Usage in CMSSW
 No specific setup is needed.
 
-It is recommended to add external modules (eg correction modules) in separate packages.
+It is recommended to add external modules (in particular correction modules, see above) in separate packages. 
 
 ## Standalone usage (without CMSSW): checkout instructions
 

--- a/PhysicsTools/NanoAODTools/python/postprocessing/framework/output.py
+++ b/PhysicsTools/NanoAODTools/python/postprocessing/framework/output.py
@@ -149,6 +149,7 @@ class FullOutput(OutputTree):
                 '1', "", maxEntries if maxEntries else ROOT.TVirtualTreePlayer.kMaxEntries, firstEntry)
         else:
             outputTree = inputTree.CloneTree(0)
+        ROOT.SetOwnership(outputTree, False)
 
         # enable back all branches in inputTree, then disable for computation
         # the branches as requested in branchSelection
@@ -169,10 +170,12 @@ class FullOutput(OutputTree):
                     # treat content of other trees as if associated to event 0
                     self._otherTrees[kn] = inputFile.Get(
                         kn).CopyTree('1' if firstEntry == 0 else '0')
+                    ROOT.SetOwnership(self._otherTrees[kn], False)
             elif kn in ("LuminosityBlocks", "Runs"):
                 if not jsonFilter:
                     self._otherTrees[kn] = inputFile.Get(
                         kn).CopyTree('1' if firstEntry == 0 else '0')
+                    ROOT.SetOwnership(self._otherTrees[kn], False)
                 elif firstEntry == 0:
                     _isRun = (kn == "Runs")
                     _it = inputFile.Get(kn)
@@ -181,6 +184,7 @@ class FullOutput(OutputTree):
                         if (jsonFilter.filterRunOnly(ev.run) if _isRun else jsonFilter.filterRunLumi(ev.run, ev.luminosityBlock)):
                             _ot.Fill()
                     self._otherTrees[kn] = _ot
+                    ROOT.SetOwnership(self._otherTrees[kn], False)
             elif k.GetClassName() == "TTree":
                 print("Not copying unknown tree %s" % kn)
             else:
@@ -195,7 +199,7 @@ class FullOutput(OutputTree):
             self.outputbranchSelection.selectBranches(self._tree)
         self._tree = self.tree().CopyTree('1', "",
                                           self.maxEntries if self.maxEntries else ROOT.TVirtualTreePlayer.kMaxEntries, 0)
-
+        ROOT.SetOwnership(self._tree, False)
         OutputTree.write(self)
         for t in self._otherTrees.values():
             t.Write()
@@ -208,4 +212,5 @@ class FriendOutput(OutputTree):
         outputFile.cd()
         outputTree = ROOT.TTree(
             treeName, "Friend tree for " + inputTree.GetName())
+        ROOT.SetOwnership(outputTree, False)
         OutputTree.__init__(self, outputFile, outputTree, inputTree)


### PR DESCRIPTION
#### PR description:

Fix an ownership problem that can cause a crash due to a conflict in python and root deletion of objects.
The crash is quite rare and happens at the transition between input files when running several files per job.

Also add a reference to correction module library in the doc.

#### PR validation:

Tested over large processing samples.
