### PR TITLE
re-organization of HGCal local reconstruction HLT products, add unseeded EGamma GSF tracks to FEVTHLT

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -734,10 +734,9 @@ from Configuration.ProcessModifiers.hltPhase2LegacyTracking_cff import hltPhase2
 
 phase2_common.toModify(FEVTDEBUGHLTEventContent,
                        outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
-                           'keep *_hltHGCalRecHit_*_*',
-                           'keep *_hltMergeLayerClusters*_*_*',
                            'keep *_hltParticleFlowRecHit*_*_*',
                            'keep *_hltEgammaGsfTracksL1Seeded_*_*',
+                           'keep *_hltEgammaGsfTracksUnseeded_*_*',
                            'keep *_hltPFMET_*_*',
                            'keep *_hltPFPuppiMET_*_*',
                            'keep *_hltPFPuppiMETTypeOne_*_*',
@@ -768,6 +767,9 @@ mtd_at_hlt.toModify(FEVTDEBUGHLTEventContent,
                     outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
                         'keep *_hltOfflinePrimaryVertices4D_*_*'
                     ])
+
+phase2_hgcal.toModify(FEVTDEBUGHLTEventContent,
+    outputCommands = FEVTDEBUGHLTEventContent.outputCommands + HGCAL_FEVTHLT.outputCommands)
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 

--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -49,9 +49,9 @@ TICL_FEVT.outputCommands.extend(TICL_RECO.outputCommands)
 TICL_FEVTHLT = cms.PSet(
     outputCommands = cms.untracked.vstring(
             ['keep *_hltPfTICL_*_*',
-            'keep *_hltTiclTrackstersCLUE3D*_*_*',
-            'keep *_hltTiclTracksterLinks*_*_*',
-            'keep *_hltTiclCandidate_*_*']
+             'keep *_hltTiclTrackstersCLUE3D*_*_*',
+             'keep *_hltTiclTracksterLinks*_*_*',
+             'keep *_hltTiclCandidate_*_*']
     )
 )
 TICL_FEVTHLT.outputCommands.extend(TICL_FEVT.outputCommands)

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContent_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContent_cff.py
@@ -76,3 +76,11 @@ RecoLocalCaloFEVT.outputCommands.extend(RecoLocalCaloRECO.outputCommands)
 RecoLocalCaloFEVT.outputCommands.extend(ecalLocalRecoFEVT.outputCommands)
 phase2_hgcal.toModify( RecoLocalCaloFEVT, 
     outputCommands = RecoLocalCaloFEVT.outputCommands + ['keep *_HGCalUncalibRecHit_*_*'])
+
+#HGCAL FEVTHLT content
+HGCAL_FEVTHLT = cms.PSet(
+    outputCommands = cms.untracked.vstring(
+        'keep *_hltHGCalRecHit_*_*',
+        'keep *_hltMergeLayerClusters*_*_*'
+    )
+)


### PR DESCRIPTION
#### PR description:

Minor re-organization of the Phase-2 FEVTDEBUGHLT event content:
- move the HGCal local reconstruction products definition into the `RecoLocalCalo/Configuration` package
- add `hltEgammaGsfTracksUnseeded`  to the event content, as I noticed it's empty in production relvals DQM, since `CMSSW_16_0_0_pre1` see e.g.: https://cern.ch/nvw2l

#### PR validation:

Run successfully `runTheMatrix.py -l ph2_hlt` and checked that the output of the step2 files have the desired change in the event content.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
