### PR TITLE
Pass LHE initiator information to Pythia8

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
@@ -59,6 +59,11 @@ bool LHAupLesHouches::setEvent(int inProcId) {
   if (!hepeup.NUP)
     return false;
 
+  // Pass the hard-process initiator flavours and momentum fractions to
+  // Pythia, matching its native LHAupLHEF implementation.
+  const lhef::HEPRUP &heprup = *runInfo->getHEPRUP();
+  setIdX(hepeup.IDUP[0], hepeup.IDUP[1], hepeup.PUP[0][3] / heprup.EBMUP.first, hepeup.PUP[1][3] / heprup.EBMUP.second);
+
   setProcess(hepeup.IDPRUP, hepeup.XWGTUP, hepeup.SCALUP, hepeup.AQEDUP, hepeup.AQCDUP);
 
   const std::vector<float> &scales = event->scales();


### PR DESCRIPTION
#### PR description:

This PR passes the hard-process initiator flavours and longitudinal
momentum fractions from `LHAupLesHouches` to Pythia through
`LHAup::setIdX()`.

Pythia's native `LHAupLHEF` reader provides this information, but the
CMSSW `LHAupLesHouches` adapter currently does not. Consequently,
Pythia modules that consume the initiator IDs and momentum fractions
cannot correctly process externally supplied LHE events.

This was observed when using the Pythia 8.3 photoproduction module with
external photon-initiated LHE events:

- `Photon:ProcessType = 4`
- `PDF:beamA2gamma = on`
- `PDF:beamB2gamma = on`
- `Photon:sampleQ2 = on`

Without `setIdX()`, the incoming-particle IDs and momentum fractions are
not available to the photoproduction module, and Pythia fails to process
the events. With this change, external photon-initiated events are
processed correctly and Pythia generates the transverse recoil of the
intact protons.

The values passed to `setIdX()` are derived from information already
present in `HEPEUP` and `HEPRUP`. This reproduces the behaviour of
Pythia's native LHE reader and is expected to be transparent to standard
external-LHE workflows.

There are no additional CMSSW PR dependencies.

Relevant Pythia documentation:
- [Photoproduction](https://pythia.org/latest-manual/Photoproduction.html)
- [Pythia update history](https://pythia.org/history/)

#### PR validation:

- Successfully compiled `GeneratorInterface/Pythia8Interface` in a
  CMSSW_17_0_X and 16_1_X development areas.
- Validated the equivalent modification in CMSSW_15_0_2 using Pythia
  8.311 and external gamma-gamma to tau-tau LHE events.
- Processed 5000 external LHE events with
  `Photon:sampleQ2 = on`.
- Pythia successfully processed 4988 of 5000 events, corresponding to
  a matching acceptance of 99.8%.
- Verified that accepted events contain two intact final-state protons
  with nonzero transverse momentum.
- A standalone Pythia 8.311 test using the same LHE interface and
  settings gave consistent behaviour.

This is not a backport. After the master PR is merged, backports are
intended for the maintained CMSSW_17_0_X, CMSSW_16_1_X, CMSSW_16_0_X, CMSSW_15_1_X  and
CMSSW_15_0_X release cycles, which use Pythia versions supporting
intermediate photon-virtuality sampling for external events (Py≥8.310).
