### PR TITLE
[cmsShow] Fix crash on load of configuration in release CMSSW_20_X

### DIFF
--- a/Fireworks/Core/src/FWEventItemsManager.cc
+++ b/Fireworks/Core/src/FWEventItemsManager.cc
@@ -181,6 +181,34 @@ void FWEventItemsManager::addTo(FWConfiguration& iTo) const {
   }
 }
 
+
+namespace {
+std::string addIoV1Namespace(std::string type)
+{
+    const std::string reco = "reco::";
+    const std::string io_v1 = "io_v1::";
+
+    size_t pos = 0;
+    while ((pos = type.find(reco, pos)) != std::string::npos) {
+
+        // Skip if already reco::io_v1::
+        if (type.compare(pos + reco.size(),
+                        io_v1.size(),
+                        io_v1) != 0)
+        {
+            type.insert(pos + reco.size(), io_v1);
+            pos += reco.size() + io_v1.size();
+        }
+        else {
+            pos += reco.size() + io_v1.size();
+        }
+    }
+
+    return type;
+}
+}
+
+
 /** This is responsible for resetting the status of items from configuration  
   */
 void FWEventItemsManager::setFrom(const FWConfiguration& iFrom) {
@@ -235,6 +263,8 @@ void FWEventItemsManager::setFrom(const FWConfiguration& iFrom) {
 
     unsigned int layer = strtol((*keyValues)[7].second.value().c_str(), nullptr, 10);
 
+    std::string cr_type = addIoV1Namespace(type);
+
     //For older configs assume name is the same as purpose
     std::string purpose(name);
     if (conf.version() > 1)
@@ -256,7 +286,7 @@ void FWEventItemsManager::setFrom(const FWConfiguration& iFrom) {
     }
 
     FWPhysicsObjectDesc desc(name,
-                             TClass::GetClass(type.c_str()),
+                             TClass::GetClass(cr_type.c_str()),
                              purpose,
                              dp,
                              moduleLabel,


### PR DESCRIPTION


#### PR description:
cmsShow crashes when a pre-existing Fireworks configuration is present:
The Fireworks configuration parser attempts to load collections with the reco namespace, and the program crashes when accessing dictionaries within FWItemAccessorFactory.

A workaround for the problem is that CMSSW_20_1_X releases and beyond add the io_v1 namespace in the configuration type at runtime if the io_v1 string is not already added.




#### PR validation:
To test, run cmsShow with configuration from the Fireworks/Core/macros directory and with a data file from the CMSSW_20_X release validation.