### PR TITLE
Update GenProton NanoAOD acceptance for Run 3

### DIFF
--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -49,7 +49,13 @@ if singleRPProtons: protonTablesTask.add(singleRPTable)
 
 # GEN-level signal/PU protons collection
 genProtonTable = _genproton.clone(
-    cut = cms.string('(pdgId == 2212) && (abs(pz) > 5200) && (abs(pz) < 6467.5)') # xi in [0.015, 0.2]
+    cut = cms.string('(pdgId == 2212) && (abs(pz) > 5200.0) && (abs(pz) < 6435.0)') # Run 2 xi in [0.01, 0.2]
+)
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(
+    genProtonTable,
+    cut = '(pdgId == 2212) && (abs(pz) > 5440) && (abs(pz) < 6732)' # Run 3, xi in [0.01, 0.2]
 )
 
 genProtonTablesTask = cms.Task(genProtonTable)


### PR DESCRIPTION
#### PR description:

This PR updates the generator-level proton selection used for the NanoAOD
`GenProton` table.

The selection is expressed as a proton longitudinal momentum window
corresponding to a fixed proton fractional momentum loss acceptance. This PR
standardizes the acceptance to xi in [0.01, 0.2] and uses beam-energy-dependent pz windows:
```text
Run 2, E_beam = 6500 GeV:
6500 * (1 - 0.2) = 5200 GeV
6500 * (1 - 0.01) = 6435 GeV

Run 3, E_beam = 6800 GeV:
6800 * (1 - 0.2) = 5440 GeV
6800 * (1 - 0.01) = 6732 GeV
```

The default selection is updated to the Run 2 xi in [0.01, 0.2] window, and
a run3_common era modifier is added to use the corresponding Run 3 window
when running with a Run 3 era.
This affects only the generator-level proton table content in NanoAOD.
There are no additional CMSSW PR dependencies.

#### PR validation:

- Successfully compiled PhysicsTools/NanoAOD

- Produced a local Run 3 NanoAOD test configuration with `--era Run3_2024` and verified that the `run3_common` era modifier changes the `GenProton` selection to the Run 3 beam-energy window


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport. Backports should be made for Run 3 NanoAOD
production release cycles if needed.

watchers: @forthommel