### PR TITLE
Re-enable unit tests for TkAl offline validation tools for Phase-2

### DIFF
--- a/Alignment/OfflineValidation/bin/Zmumumerge.cc
+++ b/Alignment/OfflineValidation/bin/Zmumumerge.cc
@@ -78,7 +78,7 @@ int merge(int argc, char* argv[]) {
   std::cout << "filesAndLabels: " << filesAndLabels << std::endl;
 
   //And finally fit
-  DiMuonMassProfiles(filesAndLabels, cmslabel, rlabel, autoLimits);
+  DiMuonMassProfiles(filesAndLabels, cmslabel, rlabel, autoLimits, outdir);
 
   return EXIT_SUCCESS;
 }

--- a/Alignment/OfflineValidation/macros/DiMuonMassProfiles.C
+++ b/Alignment/OfflineValidation/macros/DiMuonMassProfiles.C
@@ -623,7 +623,8 @@ void producePlots(const std::vector<diMuonMassBias::histoMap>& inputMap,
                   const std::vector<TString>& labels,
                   const TString& Rlabel,
                   const bool useAutoLimits,
-                  const bool isWidth)
+                  const bool isWidth,
+                  const TString& outdir = "")
 /************************************************/
 {
   int W = 800;
@@ -729,8 +730,8 @@ void producePlots(const std::vector<diMuonMassBias::histoMap>& inputMap,
       outputName.erase(0, pos + 1);
     }
 
-    c->SaveAs(((isWidth ? "width_" : "mean_") + outputName + ".png").c_str());
-    c->SaveAs(((isWidth ? "width_" : "mean_") + outputName + ".pdf").c_str());
+    c->SaveAs(outdir + (isWidth ? "width_" : "mean_") + TString(outputName) + ".png");
+    c->SaveAs(outdir + (isWidth ? "width_" : "mean_") + TString(outputName) + ".pdf");
   }
 }
 
@@ -740,7 +741,8 @@ void produceMaps(const std::vector<diMuonMassBias::histo2DMap>& inputMap,
                  const std::vector<TString>& labels,
                  const TString& Rlabel,
                  const bool useAutoLimits,
-                 const bool isWidth)
+                 const bool isWidth,
+                 const TString& outdir = "")
 /************************************************/
 {
   const auto& sides = getClosestFactors(labels.size());
@@ -840,8 +842,8 @@ void produceMaps(const std::vector<diMuonMassBias::histo2DMap>& inputMap,
       outputName.erase(0, pos + 1);
     }
 
-    c->SaveAs(((isWidth ? "width_" : "mean_") + outputName + ".png").c_str());
-    c->SaveAs(((isWidth ? "width_" : "mean_") + outputName + ".pdf").c_str());
+    c->SaveAs(outdir + (isWidth ? "width_" : "mean_") + TString(outputName) + ".png");
+    c->SaveAs(outdir + (isWidth ? "width_" : "mean_") + TString(outputName) + ".pdf");
   }
 }
 
@@ -849,7 +851,8 @@ void produceMaps(const std::vector<diMuonMassBias::histo2DMap>& inputMap,
 void DiMuonMassProfiles(TString namesandlabels,
                         const TString& CMSlabel = "",
                         const TString& Rlabel = "",
-                        const bool useAutoLimits = false)
+                        const bool useAutoLimits = false,
+                        TString outdir = "")
 /************************************************/
 {
   gStyle->SetOptStat(0);
@@ -870,6 +873,11 @@ void DiMuonMassProfiles(TString namesandlabels,
       std::cout << "Please give file name and legend entry in the following form:\n"
                 << " filename1=legendentry1,filename2=legendentry2\n";
       return;
+    }
+  }
+  if (outdir != "") {
+    if (!outdir.EndsWith("/")) {
+      outdir += "/";
     }
   }
 
@@ -938,13 +946,13 @@ void DiMuonMassProfiles(TString namesandlabels,
                                           "TkTkMassVsPhiPlusInEtaBins/th2d_mass_PhiPlus_backward-backward",
                                           "TkTkMassVsPhiPlusInEtaBins/th2d_mass_PhiPlus_forward-backward"};
 
-  producePlots(v_meanHistos, MEtoHarvest, labels, Rlabel, useAutoLimits, false);
-  producePlots(v_widthHistos, MEtoHarvest, labels, Rlabel, useAutoLimits, true);
+  producePlots(v_meanHistos, MEtoHarvest, labels, Rlabel, useAutoLimits, false, outdir);
+  producePlots(v_widthHistos, MEtoHarvest, labels, Rlabel, useAutoLimits, true, outdir);
 
   std::vector<std::string> MEtoHarvest3D = {"th3d_mass_vs_eta_phi_plus", "th3d_mass_vs_eta_phi_minus"};
 
-  produceMaps(v_meanMaps, MEtoHarvest3D, labels, Rlabel, useAutoLimits, false);
-  produceMaps(v_widthMaps, MEtoHarvest3D, labels, Rlabel, useAutoLimits, true);
+  produceMaps(v_meanMaps, MEtoHarvest3D, labels, Rlabel, useAutoLimits, false, outdir);
+  produceMaps(v_widthMaps, MEtoHarvest3D, labels, Rlabel, useAutoLimits, true, outdir);
 
   // finally close the file
   for (const auto& file : sourceFiles) {

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/DMR_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/DMR_cfg.py
@@ -8,7 +8,9 @@ import json
 import os
 
 ##Define process
-process = cms.Process("OfflineValidator")
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+process = cms.Process("OfflineValidator",_PH2_ERA)
 
 ##Argument parsing
 options = VarParsing()
@@ -83,9 +85,9 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 ##Basic modules
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
-process.load("Configuration.Geometry.GeometryDB_cff")
 process.load('Configuration.StandardSequences.Services_cff')
 process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
 
 ##Track fitting
 import Alignment.CommonAlignment.tools.trackselectionRefitting as trackselRefit
@@ -105,7 +107,7 @@ process.seqTrackselRefit = trackselRefit.getSequence(process,
 #Global tag
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", "auto:phase1_2017_realistic"))
+process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", _PH2_GLOBAL_TAG))
 
 ##Load conditions if wished
 if "conditions" in config["alignment"]:

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/DiMuonV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/DiMuonV_cfg.py
@@ -12,7 +12,9 @@ import os
 ###################################################################
 # Define process
 ###################################################################
-process = cms.Process("DiMuonVertexValidation")
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+process = cms.Process("DiMuonVertexValidation",_PH2_ERA)
 
 ###################################################################
 # Argument parsing
@@ -111,7 +113,7 @@ process.MessageLogger.cout = cms.untracked.PSet(
 # import of standard configurations
 ###################################################################
 process.load('Configuration.StandardSequences.Services_cff')
-process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
 process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
@@ -134,7 +136,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
 # default to remain in sycn with the default input sample
-process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", "125X_mcRun3_2022_realistic_v3"))
+process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", _PH2_GLOBAL_TAG))
 
 ####################################################################
 # Load conditions if wished

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/GenericV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/GenericV_cfg.py
@@ -8,7 +8,9 @@ from FWCore.ParameterSet.VarParsing import VarParsing
 ###################################################################
 # Define process 
 ###################################################################
-process = cms.Process("GenericTrackAndVertexValidation")
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+process = cms.Process("GenericTrackAndVertexValidation",_PH2_ERA)
 
 ###################################################################
 # Argument parsing
@@ -99,7 +101,7 @@ process.MessageLogger.cout.enableStatistics = cms.untracked.bool(True)
 # Basic modules
 ###################################################################
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
-process.load("Configuration.Geometry.GeometryDB_cff")
+process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
 process.load('Configuration.StandardSequences.Services_cff')
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
@@ -116,7 +118,7 @@ process.TrackRefitter.NavigationSchool = ""
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", "auto:phase1_2017_realistic"))
+process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", _PH2_GLOBAL_TAG))
 
 ####################################################################
 # Load conditions if wished

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
@@ -5,8 +5,11 @@ here doing refit of tracks and vertices using latest alignment
 
 # Define the process
 import FWCore.ParameterSet.Config as cms
-from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultData_JetHTRun2018D
-process = cms.Process("JetHTAnalyzer")
+from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_NoPU_AlCa
+
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+process = cms.Process("JetHTAnalyzer",_PH2_ERA)
 
 # Choose whether to run with Monte Carlo or data settings based on command line argument
 import FWCore.ParameterSet.VarParsing as VarParsing
@@ -42,7 +45,7 @@ else:
         configuration = json.load(configFile)
 
 # Read parameters from the configuration file
-useMC = configuration["validation"].get("mc", False)
+useMC = configuration["validation"].get("mc", True)
 printTriggers = configuration["validation"].get("printTriggers", False)
 triggerFilter = str(configuration["validation"].get("triggerFilter", "nothing"))
 iovListFile = str(configuration["validation"].get("iovListFile", "nothing"))
@@ -53,8 +56,8 @@ maxEventsToRun = configuration["validation"].get("maxevents", 1)
 filesPerJob = configuration["validation"].get("filesPerJob", 5)
 runsInFiles = configuration.get("runsInFiles",[])
 
-# The default global tag is suiteble for the unit test file for data
-globalTag = str(configuration["alignment"].get("globaltag", "auto:run2_data"))
+# The default global tag is suiteble for the unit test file for Phase 2 MC
+globalTag = str(configuration["alignment"].get("globaltag", _PH2_GLOBAL_TAG))
 
 # Alignment conditions can be also loaded from a configuration file instead of database
 alignmentFile = str(configuration["validation"].get("TrackerAlignmentRcdFile", "nothing"))
@@ -94,7 +97,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(maxEventsToR
 # Basic modules
 ###################################################################
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
-process.load("Configuration.Geometry.GeometryDB_cff")
+process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
 process.load('Configuration.StandardSequences.Services_cff')
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
@@ -163,14 +166,14 @@ else:
     print(">>>>>>>>>> JetHT_cfg.py: msg%-i: dataset not specified in configuration! Loading default file!")
 
     if useMC:
-        print(">>>>>>>>>> JetHT_cfg.py: msg%-i: Default file for 2018 MC from 170-300 pT hat bin.")
+        print(">>>>>>>>>> JetHT_cfg.py: msg%-i: Default file for Phase 2 MC from RelValQCD_FlatPt_15_3000HS_14.")
         process.source = cms.Source("PoolSource",
-                              fileNames = cms.untracked.vstring('root://xrootd-cms.infn.it//store/mc/RunIIWinter19PFCalibDRPremix/QCD_Pt_170to300_TuneCP5_13TeV_pythia8/ALCARECO/TkAlMinBias-2018Conditions_105X_upgrade2018_realistic_v4-v1/270000/C42688BC-7401-3A41-9008-7CD1CA4B09E1.root')
-                              )
+                                    fileNames = filesDefaultMC_NoPU_AlCa)
     else:
-        print(">>>>>>>>>> JetHT_cfg.py: msg%-i: Default file read from 2018D JetHT dataset.")
+        print(">>>>>>>>>> JetHT_cfg.py: msg%-i: Default file read from <TODO> dataset.")
+        raise FileNotFoundError("No Default Phase 2 data exist yet. Use MC only.")
         process.source = cms.Source("PoolSource",
-                                    fileNames = filesDefaultData_JetHTRun2018D)
+                                    fileNames = "") #FIXME
 
 ####################################################################
 # Global tag

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV.py
@@ -187,7 +187,10 @@ def PV(config, validationDir):
             for iname, singleName in enumerate(config["validations"]["PV"][pvType][trendName]["singles"]):
                 isMC = (len(IOVs[singleName]) == 1 and int(IOVs[singleName][0]) == 1)
                 if isMC:
-                    raise Exception("Trend jobs are not implemented for treating MC.")  
+                    if "doUnitTest" in config["validations"]["PV"][pvType][trendName].keys() and config["validations"]["PV"][pvType][trendName]["doUnitTest"]:
+                        pass
+                    else:    
+                        raise Exception("Trend jobs are not implemented for treating MC.")  
                 if iname == 0: 
                     trendIOVs = IOVs[singleName] 
                 else:

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV_cfg.py
@@ -1,7 +1,7 @@
 
 import FWCore.ParameterSet.Config as cms
 import FWCore.PythonUtilities.LumiList as LumiList
-from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultData_HLTPhys2024I
+from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_NoPU 
 
 from FWCore.ParameterSet.VarParsing import VarParsing
 
@@ -10,7 +10,9 @@ import json
 import os
 
 ##Define process
-process = cms.Process("PrimaryVertexValidation")
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+process = cms.Process("PrimaryVertexValidation",_PH2_ERA)
 
 ##Argument parsing
 options = VarParsing()
@@ -44,9 +46,9 @@ if "dataset" in config["validation"]:
                                 skipEvents = cms.untracked.uint32(0)
                             )
 else:
-    print(">>>>>>>>>> PV_cfg.py: msg%-i: config not specified! Loading default dataset -> filesDefaultData_HLTPhys2024I!")
+    print(">>>>>>>>>> PV_cfg.py: msg%-i: config not specified! Loading default dataset -> filesDefaultMC_NoPU !")
     process.source = cms.Source("PoolSource",
-                                fileNames = filesDefaultData_HLTPhys2024I,
+                                fileNames = filesDefaultMC_NoPU,
                                 skipEvents = cms.untracked.uint32(0)
                             )
 
@@ -95,9 +97,9 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 ##Basic modules
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
-process.load("Configuration.Geometry.GeometryRecoDB_cff") #or process.load("Configuration.Geometry.GeometryDB_cff")?????
 process.load('Configuration.StandardSequences.Services_cff')
 process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
 
 ####################################################################
 # Produce the Transient Track Record in the event
@@ -109,7 +111,7 @@ process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
 ####################################################################
 import Alignment.CommonAlignment.tools.trackselectionRefitting as trackselRefit
 process.seqTrackselRefit = trackselRefit.getSequence(process,
-                                                     config["validation"].get("trackcollection", "ALCARECOTkAlMinBias"),
+                                                     config["validation"].get("trackcollection", "generalTracks"),
                                                      isPVValidation=True,
                                                      TTRHBuilder=config["validation"].get("tthrbuilder", "WithTrackAngle"),
                                                      usePixelQualityFlag=config["validation"].get("usePixelQualityFlag", False),
@@ -124,7 +126,7 @@ process.seqTrackselRefit = trackselRefit.getSequence(process,
 #Global tag
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", "140X_dataRun3_Prompt_v4"))
+process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", _PH2_GLOBAL_TAG))
 
 ##Load conditions if wished
 if "conditions" in config["alignment"]:
@@ -147,15 +149,19 @@ if "conditions" in config["alignment"]:
 ####################################################################
 # Load and Configure event selection
 ####################################################################
-process.primaryVertexFilter = cms.EDFilter("VertexSelector",
-                                           src = cms.InputTag(config["validation"].get("vertexcollection", "offlinePrimaryVertices")),
-                                           cut = cms.string("!isFake && ndof > 4 && abs(z) <= 24 && position.Rho <= 2"),
-                                           filter = cms.bool(True)
-                                           )
+vertex_collection = config["validation"].get("vertexcollection", "offlinePrimaryVertices")
+if vertex_collection != "hltVerticesPFFilter":
+    process.primaryVertexFilter = cms.EDFilter("VertexSelector",
+                                               src = cms.InputTag(vertex_collection),
+                                               cut = cms.string("!isFake && ndof > 4 && abs(z) <= 24 && position.Rho <= 2"),
+                                               filter = cms.bool(True)
+                                               )
+else:
+    process.primaryVertexFilter = cms.EDFilter("HLTBool", result=cms.bool(True))
 
 process.noscraping = cms.EDFilter("FilterOutScraping",
                                   applyfilter = cms.untracked.bool(True),
-                                  src = cms.untracked.InputTag(config["validation"].get("trackcollection", "ALCARECOTkAlMinBias")),
+                                  src = cms.untracked.InputTag(config["validation"].get("trackcollection", "generalTracks")),
                                   debugOn = cms.untracked.bool(False),
                                   numtrack = cms.untracked.uint32(10),
                                   thresh = cms.untracked.double(0.25)
@@ -168,7 +174,7 @@ maxclusters = config["validation"].get("maxclusters", None)
 if(maxclusters is not None):
     import  HLTrigger.special.hltPixelActivityFilter_cfi
     process.multFilter = HLTrigger.special.hltPixelActivityFilter_cfi.hltPixelActivityFilter.clone(
-        inputTag = 'ALCARECOTkAlMinBias',
+        inputTag = cms.InputTag(config["validation"].get("trackcollection", "generalTracks")),
         minClusters = 1,
         maxClusters = maxclusters
     )
@@ -178,16 +184,25 @@ if(maxclusters is not None):
 # Beamspot compatibility check
 ###################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
-process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-    bsFromFile = config["validation"].get("bsFromFile","offlineBeamSpot::RECO"),  # source of the event beamspot (in the ALCARECO files)
-    bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
-    dbFromEvent = True,
-    warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
-    errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
-)
+if vertex_collection != "hltVerticesPFFilter":
+    process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
+        bsFromFile = config["validation"].get("bsFromFile","offlineBeamSpot::RECO"),  # source of the event beamspot (in the ALCARECO files)
+        bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+        dbFromEvent = True,
+        warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
+        errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
+    )
+else:
+    process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
+        bsFromFile = "hltOnlineBeamSpot::HLT",  
+        bsFromDB = "offlineBeamSpot", 
+        dbFromEvent = True,
+        warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
+        errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
+    )
 
 process.load("Alignment.CommonAlignment.filterOutLowPt_cfi")
-process.filterOutLowPt.src = cms.untracked.InputTag(config["validation"].get("trackcollection", "ALCARECOTkAlMinBias"))
+process.filterOutLowPt.src = cms.untracked.InputTag(config["validation"].get("trackcollection", "generalTracks"))
 process.filterOutLowPt.ptmin = cms.untracked.double(config["validation"].get("ptCut", 3.))
 process.filterOutLowPt.runControl = False
 if(isMultipleRuns):
@@ -245,7 +260,7 @@ process.PVValidation = _primaryVertexValidation.clone(
     askFirstLayerHit = False,
     forceBeamSpot = config["validation"].get("forceBeamSpot", False),
     probePt = config["validation"].get("ptCut", 3),
-    probeEta  = config["validation"].get("etaCut", 2.5),
+    probeEta  = config["validation"].get("etaCut", 4),
     minPt  = config["validation"].get("minPt", 1.),
     maxPt  = config["validation"].get("maxPt", 30.),
     doBPix = config["validation"].get("doBPix", True),

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
@@ -9,7 +9,9 @@ from Alignment.OfflineValidation.TkAlAllInOneTool.utils import _byteify
 ###################################################################
 # Define process 
 ###################################################################
-process = cms.Process("PrimaryVertexResolution")
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+process = cms.Process("PrimaryVertexResolution",_PH2_ERA)
 
 ###################################################################
 # Argument parsing
@@ -100,7 +102,7 @@ process.MessageLogger.cout.enableStatistics = cms.untracked.bool(True)
 # Basic modules
 ###################################################################
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
-process.load("Configuration.Geometry.GeometryDB_cff")
+process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
 process.load('Configuration.StandardSequences.Services_cff')
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
@@ -117,7 +119,7 @@ process.TrackRefitter.NavigationSchool = ""
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", "105X_upgrade2018_realistic_v4"))
+process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", _PH2_GLOBAL_TAG))
 
 ####################################################################
 # Load conditions if wished

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
@@ -7,12 +7,14 @@ import FWCore.ParameterSet.Config as cms
 import FWCore.PythonUtilities.LumiList as LumiList
 from FWCore.ParameterSet.VarParsing import VarParsing
 from Alignment.OfflineValidation.TkAlAllInOneTool.utils import _byteify
-from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_DoubleMuonAlCa_string
+from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_DoubleMuon_string
 
 ###################################################################
 # Define process
 ###################################################################
-process = cms.Process("TkAlignmentDiMuonValidation")
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+process = cms.Process("TkAlignmentDiMuonValidation",_PH2_ERA)
 
 ###################################################################
 # Argument parsing
@@ -47,7 +49,7 @@ if "dataset" in config["validation"]:
         for fileName in datafiles.readlines():
             readFiles.append(fileName.replace("\n", ""))
 else:
-    readFiles = filesDefaultMC_DoubleMuonAlCa_string
+    readFiles = filesDefaultMC_DoubleMuon_string
 
 ###################################################################
 # Get good lumi section
@@ -90,7 +92,7 @@ process.options = cms.untracked.PSet(
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 process.load("Configuration.StandardSequences.Services_cff")
-process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
@@ -117,7 +119,7 @@ process.TrackRefitter = process.TrackRefitterP5.clone(
 ###################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", "auto:phase1_2024_realistic"))
+process.GlobalTag = GlobalTag(process.GlobalTag, config["alignment"].get("globaltag", _PH2_GLOBAL_TAG))
 
 ###################################################################
 # Load conditions if wished
@@ -144,13 +146,13 @@ from Alignment.OfflineValidation.diMuonValidation_cfi import diMuonValidation as
 process.DiMuonMassValidation = _diMuonValidation.clone(
     TkTag = 'TrackRefitter',
     # mu mu mass
-    Pair_mass_min   = 60.,
+    Pair_mass_min   = 80.,
     Pair_mass_max   = 120.,
     Pair_mass_nbins = 80,
-    Pair_etaminpos  = -2.4,
-    Pair_etamaxpos  = 2.4,
-    Pair_etaminneg  = -2.4,
-    Pair_etamaxneg  = 2.4,
+    Pair_etaminpos  = -4.,
+    Pair_etamaxpos  = 4.,
+    Pair_etaminneg  = -4.,
+    Pair_etamaxneg  = 4.,
     # cosTheta CS
     Variable_CosThetaCS_xmin  = -1.,
     Variable_CosThetaCS_xmax  =  1.,
@@ -160,12 +162,12 @@ process.DiMuonMassValidation = _diMuonValidation.clone(
     Variable_DeltaEta_xmax  = 4.8,
     Variable_DeltaEta_nbins = 20,
     # EtaMinus
-    Variable_EtaMinus_xmin  = -2.4,
-    Variable_EtaMinus_xmax  =  2.4,
+    Variable_EtaMinus_xmin  = -4.,
+    Variable_EtaMinus_xmax  =  4.,
     Variable_EtaMinus_nbins = 12,
     # EtaPlus
-    Variable_EtaPlus_xmin  = -2.4,
-    Variable_EtaPlus_xmax  =  2.4,
+    Variable_EtaPlus_xmin  = -4.,
+    Variable_EtaPlus_xmax  =  4.,
     Variable_EtaPlus_nbins = 12,
     # Phi CS
     Variable_PhiCS_xmin  = -math.pi/2.,
@@ -199,11 +201,11 @@ if valiMode == "StandAlone":
 ###################################################################
 from RecoVertex.BeamSpotProducer.beamSpotCompatibilityChecker_cfi import beamSpotCompatibilityChecker
 process.BeamSpotChecker = beamSpotCompatibilityChecker.clone(
-    bsFromFile = config["validation"].get("bsFromFile","offlineBeamSpot::RECO"),  # source of the event beamspot (in the ALCARECO files)
-    bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
-    dbFromEvent = True,
-    warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
-    errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
+        bsFromFile = config["validation"].get("bsFromFile","offlineBeamSpot::RECO"),  # source of the event beamspot (in the ALCARECO files)
+        bsFromDB = "offlineBeamSpot::@currentProcess", # source of the DB beamspot (from Global Tag) NOTE: only if dbFromEvent is True!
+        dbFromEvent = True,
+        warningThr = config["validation"].get("bsIncompatibleWarnThresh", 3), # significance threshold to emit a warning message
+        errorThr = config["validation"].get("bsIncompatibleErrThresh", 5),    # significance threshold to abort the job
 )
 
 process.p = cms.Path(process.offlineBeamSpot*

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
@@ -1,16 +1,20 @@
 import FWCore.ParameterSet.Config as cms
 
 filesDefaultMC_IsoMuon = cms.untracked.vstring(
-    '/store/mc/RunIIWinter19PFCalibDR/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/ALCARECO/TkAlMuonIsolated-2018Conditions_ideal_105X_upgrade2018_design_v3-v2/240000/D4F6E0C2-A83C-7144-A375-4667727CD9F0.root'
+    '/store/relval/CMSSW_20_0_0_pre1/RelValQCD_Pt_1800_2400_14/ALCARECO/TkAlMuonIsolated-150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/4b892577-915a-490e-9f66-2269648bf20d.root'
 )
 
 filesDefaultMC_DoubleMuon = cms.untracked.vstring(
     '/store/relval/CMSSW_12_5_0_pre5/RelValZMM_14/GEN-SIM-RECO/125X_mcRun3_2022_realistic_v3-v1/10000/068634c7-e8e2-4e46-a68e-97ebefed4868.root'
 )
 
-filesDefaultMC_DoubleMuon_string = '/store/relval/CMSSW_12_5_0_pre5/RelValZMM_14/GEN-SIM-RECO/125X_mcRun3_2022_realistic_v3-v1/10000/068634c7-e8e2-4e46-a68e-97ebefed4868.root'
+filesDefaultMC_DoubleElectron_string = '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/028e09cc-784b-41ab-a712-511d5bb67724.root'
 
-filesDefaultMC_DoubleMuonAlCa_string = '/store/relval/CMSSW_14_0_0_pre3/RelValZMM_14/ALCARECO/TkAlZMuMu-140X_mcRun3_2024_realistic_v1_STD_2024_noPU-v1/2580000/b91cfb5d-090c-4410-8c9e-ce165f4a4ef4.root'
+filesDefaultMC_DoubleElectron = cms.untracked.vstring(filesDefaultMC_DoubleElectron_string)
+
+filesDefaultMC_DoubleMuon_string = '/store/relval/CMSSW_20_0_0_pre1/RelValZMM_14/GEN-SIM-RECO/PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU-v1/2590000/42c2b496-5687-4872-803f-f0daa1c6b2b9.root'
+
+filesDefaultMC_DoubleMuonAlCa_string = '/store/relval/CMSSW_20_0_0_pre1/RelValZMM_14/ALCARECO/TkAlZMuMu-150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/d42b4f5d-7e50-461a-924c-9e95ad81194b.root'
 
 filesDefaultMC_TTBarPU = cms.untracked.vstring(
     '/store/relval/CMSSW_12_5_0_pre5/RelValTTbar_14TeV/GEN-SIM-RECO/PU_125X_mcRun3_2022_realistic_v3-v1/10000/0136c33f-3ff9-4602-8578-906ae6e0160b.root'
@@ -27,7 +31,7 @@ filesDefaultMC_MinBiasPUPhase2RECO = cms.untracked.vstring(
 )
 
 filesDefaultMC_TTbarPhase2RECO = cms.untracked.vstring(
-    '/store/relval/CMSSW_14_1_0_pre5/RelValTTbar_14TeV/GEN-SIM-RECO/140X_mcRun4_realistic_v4_STD_2026D110_noPU-v1/2580000/b8c9ef5e-9c45-4c47-aae3-4db1304cd66e.root',
+    '/store/relval/CMSSW_20_0_0_pre1/RelValTTbar_14TeV/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/1bf48ba4-bd8e-405e-845d-cfdfbfbed923.root',
 )
 
 filesDefaultData_JetHTRun2018D = cms.untracked.vstring(
@@ -42,8 +46,10 @@ filesDefaultData_JetHTRun2018DHcalIsoTrk = cms.untracked.vstring(
     '/store/data/Run2018D/JetHT/ALCARECO/HcalCalIsoTrkFilter-12Nov2019_UL2018-v3/100000/075A1F1E-20B4-134D-9794-AD764DA6730D.root')
 
 filesDefaultMC_NoPU = cms.untracked.vstring(
-    '/store/mc/RunIIWinter19PFCalibDR/Single_Pion_gun_E_2to200_13TeV_pythia8/GEN-SIM-RECO/2018ConditionsNoPU_105X_upgrade2018_realistic_v4-v1/270000/2BCBEBAB-BA94-B74F-9BFA-04F849A32558.root'
+    '/store/relval/CMSSW_20_0_0_pre1/RelValMinBias_14TeV/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/e084e752-0b18-4f3b-b910-5eadc930ed59.root'
 )
+
+filesDefaultMC_NoPU_AlCa = cms.untracked.vstring('/store/relval/CMSSW_20_0_0_pre1/RelValQCD_FlatPt_15_3000HS_14/ALCARECO/TkAlMinBias-150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/76b13a13-8751-43f8-8c1b-475dfb7f9178.root')
 
 filesDefaultMC_Ideal900GeV = cms.untracked.vstring(
     '/store/relval/CMSSW_12_0_2_patch1/RelValMinBias_14TeV/ALCARECO/TkAlMinBias-120X_mcRun3_2021_realistic_forpp900GeV_IdealTkAlign_v1_IdealTkAlignmentJIRA137-v1/2580000/044c1fa8-9bdf-4c2e-9aa4-00ba966426a2.root'

--- a/Alignment/OfflineValidation/src/CompareAlignments.cc
+++ b/Alignment/OfflineValidation/src/CompareAlignments.cc
@@ -27,7 +27,9 @@ void CompareAlignments::doComparison(TString namesandlabels,
       TFile *currentFile = TFile::Open(aFileLegPair->At(0)->GetName());
       if (currentFile != nullptr && !currentFile->IsZombie()) {
         FileList->Add(currentFile);  // 2
-        if (currentFile->Get("TrackerOfflineValidation/Pixel/P1PXBBarrel_1")) {
+        if (currentFile->Get("TrackerOfflineValidation/Pixel/P2PXBBarrel_1")) {
+          phases.push_back(2);
+        } else if (currentFile->Get("TrackerOfflineValidation/Pixel/P1PXBBarrel_1")) {
           phases.push_back(1);
         } else if (currentFile->Get("TrackerOfflineValidation/Pixel/TPBBarrel_1")) {
           phases.push_back(0);
@@ -85,6 +87,12 @@ void CompareAlignments::doComparison(TString namesandlabels,
   // both phase 0 and 1 together in the vector
   lowestlevels.push_back("P1PXBLadder");
   lowestlevels.push_back("P1PXECPanel");
+
+  // phase 2
+  lowestlevels.push_back("P2PXBLadder");
+  lowestlevels.push_back("P2PXECPanel");
+  lowestlevels.push_back("P2OTBRod");
+  lowestlevels.push_back("P2OTECSide");
 
   MergeRootfile(Target, FileList, LabelList, bigtext);
 }

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -1,54 +1,54 @@
 <environment>
   <test name="validateAlignments" command="testingScripts/validateAlignments.sh"/>
-  <!-- <test name="DMRall" command="testingScripts/test_unitDMR.sh"> COMMENT: reads old format file
+  <test name="DMRall" command="testingScripts/test_unitDMR.sh"> 
     <flags PRE_TEST="validateAlignments"/>
-  </test> -->
-  <!-- <test name="PVall" command="testingScripts/test_unitPV.sh"> COMMENT: reads old format file
+  </test>
+  <test name="PVall" command="testingScripts/test_unitPV.sh"> 
     <flags PRE_TEST="validateAlignments"/>
-  </test> -->
-  <!-- <test name="Zmumuall" command="testingScripts/test_unitZmumu.sh"> COMMENT: reads old format file
+  </test>
+  <test name="Zmumuall" command="testingScripts/test_unitZmumu.sh"> 
     <flags PRE_TEST="validateAlignments"/>
-  </test> -->
-  <!-- <test name="SplitVall" command="testingScripts/test_unitSplitV.sh"> COMMENT: reads old format file
+  </test>
+  <test name="SplitVall" command="testingScripts/test_unitSplitV.sh"> 
     <flags PRE_TEST="validateAlignments"/>
-  </test> -->
-  <!-- <test name="JetHTall" command="testingScripts/test_unitJetHT.sh"> COMMENT: reads old format file
+  </test>
+  <test name="JetHTall" command="testingScripts/test_unitJetHT.sh">
     <flags PRE_TEST="validateAlignments"/>
-  </test> -->
+  </test>
   <test name="GCPall" command="testingScripts/test_unitGCP.sh">
     <flags PRE_TEST="validateAlignments"/>
   </test>
-  <!-- <test name="DiMuonVall" command="testingScripts/test_unitDiMuonV.sh"> COMMENT: reads old format file
+  <test name="DiMuonVall" command="testingScripts/test_unitDiMuonV.sh"> 
     <flags PRE_TEST="validateAlignments"/>
-  </test> -->
+  </test>
   <!-- <test name="MTSall" command="testingScripts/test_unitMTS.sh"> COMMENT: reads old format file
     <flags PRE_TEST="validateAlignments"/>
-  </test>  -->
+  </test> -->
   <test name="PixBaryall" command="testingScripts/test_unitPixBary.sh">
     <flags PRE_TEST="validateAlignments"/>
   </test>
-  <!-- <test name="Genericall" command="testingScripts/test_unitGeneric.sh"> COMMENT: reads old format file
+  <test name="Genericall" command="testingScripts/test_unitGeneric.sh"> 
     <flags PRE_TEST="validateAlignments"/>
-  </test> -->
-  <!-- <test name="PVValidation" command="testingScripts/test_unitPVValidation.sh"/> COMMENT: reads old format file -->
+  </test>
+  <test name="PVValidation" command="testingScripts/test_unitPVValidation.sh"/> 
   <bin file="testTrackAnalyzers.cc" name="testTrackAnalysis">
     <use name="FWCore/TestProcessor"/>
     <use name="catch2"/>
   </bin>
-  <!-- <test name="PrimaryVertex" command="testingScripts/test_unitPrimaryVertex.sh"/> COMMENT: reads old format file -->
-  <!-- <bin file="testPVPlotting.cpp" name="testPVPlotting"> COMMENT: dependent test disabled
+  <test name="PrimaryVertex" command="testingScripts/test_unitPrimaryVertex.sh"/> 
+  <bin file="testPVPlotting.cpp" name="testPVPlotting">
     <flags PRE_TEST="PrimaryVertex"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>
     <use name="rootgraphics"/>
     <use name="Alignment/OfflineValidation"/>
-  </bin> -->
+  </bin>
   <bin file="testTkAlStyle.C" name="testTkAlStyle">
     <use name="rootgraphics"/>
     <use name="Alignment/OfflineValidation"/>
   </bin>
-  <!-- <test name="DiMuonVertex" command="testingScripts/test_unitDiMuonVertex.sh"/> COMMENT: reads old format file -->
-  <!-- <test name="DiElectronVertex" command="testingScripts/test_unitDiElectronVertex.sh"/> COMMENT: reads old format file -->
+  <test name="DiMuonVertex" command="testingScripts/test_unitDiMuonVertex.sh"/> 
+  <test name="DiElectronVertex" command="testingScripts/test_unitDiElectronVertex.sh"/> 
   <test name="SubmitPVrbr" command="testingScripts/test_unitSubmitPVrbr.sh"/>
   <test name="SubmitPVsplit" command="testingScripts/test_unitSubmitPVsplit.sh"/>
   <!-- <test name="EoP" command="testingScripts/test_unitEoP.sh"/> COMMENT: reads old format file -->
@@ -61,13 +61,13 @@
   </bin> -->
   <!-- <test name="Miscellanea" command="testingScripts/test_unitMiscellanea.sh"/> COMMENT: reads old format file -->
   <!-- <test name="ShortTrackValidation" command="testingScripts/test_unitShortTrackValidation.sh"/> COMMENT: reads old format file -->
-  <!-- <test name="SagittaBiasNtuplizer" command="testingScripts/test_unitSagittaBiasNtuplizer.sh"/> COMMENT: reads old format file -->
+  <test name="SagittaBiasNtuplizer" command="testingScripts/test_unitSagittaBiasNtuplizer.sh"/>
   <test name="BeamSpotPlotting" command="testingScripts/test_unitBeamSpotPlotting.sh"/>
-  <!-- <bin file="testanalyzeDiMuonBiases.cpp" name="testDiMuonBiasesPlotting"> COMMENT: dependent test disabled
+  <bin file="testanalyzeDiMuonBiases.cpp" name="testDiMuonBiasesPlotting"> 
     <flags PRE_TEST="SagittaBiasNtuplizer"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>
     <use name="rootgraphics"/>
     <use name="Alignment/OfflineValidation"/>
-  </bin> -->
+  </bin>
 </environment>

--- a/Alignment/OfflineValidation/test/DiElectronVertexValidation_cfg.py
+++ b/Alignment/OfflineValidation/test/DiElectronVertexValidation_cfg.py
@@ -4,7 +4,11 @@ import FWCore.Utilities.FileUtils as FileUtils
 import FWCore.ParameterSet.VarParsing as VarParsing
 import sys
 
+from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_DoubleElectron_string
+
 from Configuration.StandardSequences.Eras import eras
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
 
 ###################################################################
 def best_match(rcd):
@@ -25,13 +29,13 @@ options.register('maxEvents',
                  VarParsing.VarParsing.varType.int,
                  "number of events to process (\"-1\" for all)")
 options.register ('era',
-                  '2022', # default value
+                  'Phase2', # default value
                   VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                   VarParsing.VarParsing.varType.string,         # string, int, or float
                   "CMS running era")
 
 options.register ('GlobalTag',
-                  'auto:phase1_2022_realistic', # default value
+                  _PH2_GLOBAL_TAG, # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
                   "seed number")
@@ -55,7 +59,7 @@ options.register ('myseed',
                   "seed number")
 
 options.register ('myfile',
-                  '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/4a1ae43b-f4b3-4ad9-b86e-a7d9f6fc5c40.root',
+                  filesDefaultMC_DoubleElectron_string,
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
                   "file name")
@@ -100,13 +104,19 @@ elif options.era=='2022':
 elif options.era=='2023':
     print("===> running era 2023")
     process = cms.Process('Analysis',eras.Run3_2023)
+elif options.era=='Phase2':
+    print("===> running era Phase2")
+    process = cms.Process('Analysis', _PH2_ERA)
 else:
     print("unrecognized era %s" % options.era)
     sys.exit(1)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
-process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+if options.era=='Phase2':
+    process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
+else:
+    process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 

--- a/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
+++ b/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
@@ -5,6 +5,8 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 import sys
 
 from Configuration.StandardSequences.Eras import eras
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
 from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_DoubleMuon_string
 
 ###################################################################
@@ -26,13 +28,13 @@ options.register('maxEvents',
                  VarParsing.VarParsing.varType.int,
                  "number of events to process (\"-1\" for all)")
 options.register ('era',
-                  '2022', # default value
+                  'Phase2', # default value
                   VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                   VarParsing.VarParsing.varType.string,         # string, int, or float
                   "CMS running era")
 
 options.register ('GlobalTag',
-                  'auto:phase1_2022_realistic', # default value
+                  _PH2_GLOBAL_TAG, # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
                   "seed number")
@@ -101,6 +103,9 @@ elif options.era=='2022':
 elif options.era=='2023':
     print("===> running era 2023")
     process = cms.Process('Analysis',eras.Run3_2023)
+elif options.era=='Phase2':
+    print("===> running era Phase2")
+    process = cms.Process('Analysis', _PH2_ERA)
 
 ###################################################################
 # Set the process to run multi-threaded
@@ -109,7 +114,10 @@ process.options.numberOfThreads = 8
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
-process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+if options.era=='Phase2':
+    process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
+else:    
+    process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 

--- a/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py
+++ b/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py
@@ -5,6 +5,9 @@ import FWCore.Utilities.FileUtils as FileUtils
 from FWCore.ParameterSet.VarParsing import VarParsing
 from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_DoubleMuon_string
 
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
 options = VarParsing('analysis')
 options.register('scenario', 
                  'null',
@@ -13,7 +16,7 @@ options.register('scenario',
                  "Name of input misalignment scenario")
 
 options.register('globalTag',
-                 "125X_mcRun3_2022_design_v6", # default value
+                 _PH2_GLOBAL_TAG, # default value
                  VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.varType.string, # string, int, or float
                  "name of the input Global Tag")
@@ -53,7 +56,7 @@ if options.scenario not in valid_scenarios:
     print(valid_scenarios)
     exit(1)
 
-process = cms.Process("SagittaBiasNtuplizer")
+process = cms.Process("SagittaBiasNtuplizer",_PH2_ERA)
 
 ###################################################################
 # Set the process to run multi-threaded
@@ -82,7 +85,7 @@ process.MessageLogger.cout = cms.untracked.PSet(
 ###################################################################
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 process.load("Configuration.StandardSequences.Services_cff")
-process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/Alignment/OfflineValidation/test/inspectData_cfg.py
+++ b/Alignment/OfflineValidation/test/inspectData_cfg.py
@@ -2,7 +2,7 @@ import math
 import glob
 import importlib
 import FWCore.ParameterSet.Config as cms
-from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultData_Comissioning2022_Cosmics_string,filesDefaultMC_DoubleMuonPUPhase_string
+from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultData_Comissioning2022_Cosmics_string,filesDefaultMC_DoubleMuonAlCa_string
 
 ###################################################################
 # Setup 'standard' options
@@ -136,7 +136,7 @@ if(options.unitTest):
     ## fixed input for the unit test
     if('D' in options.Detector) :
         # it's for phase-2
-        readFiles.extend([filesDefaultMC_DoubleMuonPUPhase_string])
+        readFiles.extend([filesDefaultMC_DoubleMuonAlCa_string])
     else:
         # it's for phase-1
         readFiles.extend([filesDefaultData_Comissioning2022_Cosmics_string])

--- a/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
@@ -15,8 +15,9 @@ applyExtraConditions = True
 theRefitter = RefitType.COMMON
 _theTrackCollection = "generalTracks" #"ALCARECOTkAlMinBias" unfortunately not yet
 
-from Configuration.Eras.Era_Phase2C22I13M9_cff import Phase2C22I13M9
-process = cms.Process("Demo",Phase2C22I13M9) 
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+process = cms.Process("Demo",_PH2_ERA)
 
 ###################################################################
 # Set the process to run multi-threaded
@@ -81,7 +82,8 @@ process.load('Configuration.StandardSequences.MagneticField_cff')
 # Standard loads
 ###################################################################
 #process.load("Configuration.Geometry.GeometryRecoDB_cff")
-process.load('Configuration.Geometry.GeometryExtendedRun4D121Reco_cff')
+#process.load('Configuration.Geometry.GeometryExtendedRun4D121Reco_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
 
 ####################################################################
 # Get the BeamSpot
@@ -93,7 +95,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG, '')
 
 if allFromGT:
      print("############ testPVValidation_cfg.py: msg%-i: All is taken from GT")

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitDiMuonV.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitDiMuonV.sh
@@ -3,7 +3,7 @@
 function die { echo $1: status $2 ; exit $2; }
 
 echo "TESTING Alignment/DiMuonV single configuration with json..."
-pushd test_yaml/DiMuonV/single/testUnits/unitTestDiMuonVMC/1/
+pushd test_yaml/DiMuonV/single/testUnits/unitTest/1/
 ./cmsRun validation_cfg.py config=validation.json || die "Failure running DiMuonV single configuration with json" $?
 
 echo "TESTING Alignment/DiMuonV single configuration standalone..."

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitJetHT.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitJetHT.sh
@@ -2,8 +2,8 @@
 
 function die { echo $1: status $2 ; exit $2; }
 
-echo "TESTING Alignment/JetHT single configuration with json..."
-pushd test_yaml/JetHT/single/testJob/unitTestJetHT
+echo "TESTING Alignment/JetHT single configuration with json for MC ..."
+pushd test_yaml/JetHT/single/testMC/unitTestJetHTMC
 ./cmsRun validation_cfg.py config=validation.json || die "Failure running JetHT single configuration with json" $?
 
 echo "TESTING Alignment/JetHT single configuration standalone..."
@@ -11,12 +11,12 @@ echo "TESTING Alignment/JetHT single configuration standalone..."
 popd
 
 echo "TESTING JetHT merge step"
-pushd test_yaml/JetHT/merge/testJob/unitTestJetHT
+pushd test_yaml/JetHT/merge/testMC/unitTestJetHTMC
 ./run.sh || die "Failure running JetHT merge step" $?
 popd
 
 echo "TESTING JetHT plotting"
-pushd test_yaml/JetHT/plot/testJob/
+pushd test_yaml/JetHT/plot/testMC/
 ./run.sh || die "Failure running JetHT plotting" $?
 popd
 

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitPV.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitPV.sh
@@ -3,7 +3,7 @@
 function die { echo $1: status $2 ; exit $2; }
 
 echo "TESTING Alignment/PV single configuration with json..."
-pushd test_yaml/PV/single/TestDATA/unitTestPV/317087/
+pushd test_yaml/PV/single/TestMC/unitTest/1/
 ./cmsRun validation_cfg.py config=validation.json || die "Failure running PV single configuration with json" $?
 
 echo "TESTING Alignment/PV single configuration standalone..."
@@ -11,11 +11,11 @@ echo "TESTING Alignment/PV single configuration standalone..."
 popd
 
 echo "TESTING PV merge step"
-pushd test_yaml/PV/merge/TestDATA/317087/
+pushd test_yaml/PV/merge/TestMC/1/
 ./PVmerge validation.json --verbose || die "Failure running PV merge step" $?
 popd
 
 echo "TESTING PV trends"
-pushd test_yaml/PV/trends/TestDATA/
+pushd test_yaml/PV/trends/TestMC/
 ./PVtrends validation.json --verbose || die "Failure running PV trends" $?
 popd

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitPVValidation.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitPVValidation.sh
@@ -2,8 +2,8 @@
 
 function die { echo $1: status $2 ; exit $2; }
 
-echo "TESTING Alignment/OfflineValidation/test/test_all_cfg.py ..."
-cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/test_all_cfg.py || die "Failure running test_all_cfg.py" $?
+#echo "TESTING Alignment/OfflineValidation/test/test_all_cfg.py ..."
+#cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/test_all_cfg.py || die "Failure running test_all_cfg.py" $?
 
 echo "TESTING Alignment/OfflineValidation/test/test_all_Phase2_cfg.py ..."
 cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py || die "Failure running test_all_Phase2_cfg.py" $?

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitPixBary.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitPixBary.sh
@@ -4,25 +4,25 @@ function die { echo $1: status $2 ; exit $2; }
 
 runrange=376370-379254
 
-thistest="Alignment/PixelBarycentre single yaml configuration unitTest (test 1/4)"
+thistest="Alignment/PixelBarycentre single yaml configuration unitTestPhase1 (test 1/4)"
 echo "TESTING $thistest..."
-pushd test_yaml/PixBary/single/testSinglePixBary/unitTest/$runrange
+pushd test_yaml/PixBary/single/testSinglePixBary/unitTestPhase1/$runrange
 ./cmsRun validation_cfg.py config=validation.json || die "Failure running $thistest" $?
 popd
 
-thistest="Alignment/PixelBarycentre single yaml configuration mp3619 (test 2/4)"
+thistest="Alignment/PixelBarycentre single yaml configuration mp3619 Phase1 (test 2/4)"
 echo "TESTING $thistest..."
 pushd test_yaml/PixBary/single/testSinglePixBary/mp3619/$runrange
 ./cmsRun validation_cfg.py config=validation.json || die "Failure running $thistest" $?
 popd
 
-thistest="Alignment/PixelBarycentre extract yaml configuration unitTest (test 3/4)"
+thistest="Alignment/PixelBarycentre extract yaml configuration unitTestPhase1 (test 3/4)"
 echo "TESTING $thistest..."
-pushd test_yaml/PixBary/extract/testExtractPixBary/testSinglePixBary/unitTest/$runrange
+pushd test_yaml/PixBary/extract/testExtractPixBary/testSinglePixBary/unitTestPhase1/$runrange
 ./run.sh || die "Failure running $thistest" $?
 popd
 
-thistest="Alignment/PixelBarycentre extract yaml configuration mp3619 (test 4/4)"
+thistest="Alignment/PixelBarycentre extract yaml configuration mp3619 Phase1 (test 4/4)"
 echo "TESTING $thistest..."
 pushd test_yaml/PixBary/extract/testExtractPixBary/testSinglePixBary/mp3619/$runrange
 ./run.sh || die "Failure running $thistest" $?

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitPrimaryVertex.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitPrimaryVertex.sh
@@ -2,8 +2,8 @@
 
 function die { echo $1: status $2 ; exit $2; }
 
-echo "TESTING Primary Vertex Validation: phase-1 setup ..."
-cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py isPhase2=False maxEvents=100 || die "Failure running testPrimaryVertexRelatedValidations_cfg.py isPhase2=False" $?
+#echo "TESTING Primary Vertex Validation: phase-1 setup ..."
+#cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py isPhase2=False maxEvents=100 || die "Failure running testPrimaryVertexRelatedValidations_cfg.py isPhase2=False" $?
 
 echo "TESTING Primary Vertex Validation: phase-2 setup ..."
 cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py isPhase2=True maxEvents=10 || die "Failure running testPrimaryVertexRelatedValidations_cfg.py isPhase2=True" $?

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitSagittaBiasNtuplizer.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitSagittaBiasNtuplizer.sh
@@ -5,4 +5,4 @@ echo "TESTING SagittaBiasNtuplizer Analyser with RECO input..."
 cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py || die "Failure running SagittaBiasNtuplizer_cfg.py (with RECO input)" $?
 
 echo "TESTING SagittaBiasNtuplizer Analyser with ALCARECO input..."
-cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py globalTag=142X_mcRun3_2025_realistic_v7 fromRECO=False  myfile=/store/relval/CMSSW_15_1_0_pre1/RelValZMM_14/ALCARECO/TkAlDiMuonAndVertex-142X_mcRun3_2025_realistic_v7_STD_RegeneratedGS_2025_noPU-v1/2580000/b5e3fc09-7b77-42b8-9d69-d37e6fcfb5b8.root || die "Failure running SagittaBiasNtuplizer_cfg.py (with ALCARECO input)" $?
+cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py globalTag="auto:phase2_realistic" fromRECO=False  myfile=/store/relval/CMSSW_20_0_0_pre1/RelValZMM_14/ALCARECO/TkAlDiMuonAndVertex-150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/b245c25c-c9cd-4329-b081-38a95f3b6bbe.root || die "Failure running SagittaBiasNtuplizer_cfg.py (with ALCARECO input)" $?

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitZmumu.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitZmumu.sh
@@ -8,7 +8,7 @@ pushd test_yaml/Zmumu/single/testSingleZMM/unitTestZmumuMCreal/1/
 popd
 
 echo "TESTING Alignment/Zmumu single configuration with json..."
-pushd test_yaml/Zmumu/single/testSingleZMM/unitTestZmumuMCdesign/1/
+pushd test_yaml/Zmumu/single/testSingleZMM/unitTestZmumuMCdisplacedBS/1/
 ./cmsRun validation_cfg.py config=validation.json || die "Failure running Zmumu second single configuration with json" $?
 
 echo "TESTING Alignment/Zmumu single configuration standalone..."

--- a/Alignment/OfflineValidation/test/unit_test.json
+++ b/Alignment/OfflineValidation/test/unit_test.json
@@ -5,22 +5,22 @@
     "alignments": {
         "unitTest": {
            "color": "1",
-           "globaltag": "auto:phase1_2018_realistic",
+           "globaltag": "auto:phase2_realistic",
            "style": "2101",
            "title": "unit test"
         },
-        "unitTestPV": {
+        "unitTestZmumuMCreal": {
            "color": "1",
-           "globaltag": "140X_dataRun3_Prompt_v4",
-           "style": "2001",
-           "title": "unit test"
+           "globaltag": "auto:phase2_realistic",
+           "style": "20",
+           "title": "realistic"
         },
-	"unitTestDiMuonVMC": {
-	    "color": "1",
-	    "globaltag": "auto:auto:phase1_2022_realistic",
-	    "style": "2101",
-	    "title": "unit test"
-	},
+	"unitTestZmumuMCdisplacedBS": {
+           "color": "2",
+           "globaltag": "150X_mcRun4_displacedBeamSpot_v1",
+           "style": "21",
+           "title": "displaced BS"
+        },
         "ideal": {
            "color": "1",
            "globaltag": "auto:phase1_2017_design",
@@ -53,7 +53,7 @@
         },
         "unitTestJetHTMC": {
            "color": "1",
-           "globaltag": "auto:phase1_2018_realistic",
+           "globaltag": "auto:phase2_realistic",
            "style": "2101",
            "title": "unit test"
         },
@@ -142,21 +142,21 @@
         },
         "PV": {
              "single": {
-                 "TestDATA": {
-                      "IOV": ["317087"],
-                      "alignments": ["unitTestPV"],
-                      "trackcollection": "ALCARECOTkAlMinBias",
+                 "TestMC": {
+                      "IOV": ["1"],
+                      "alignments": ["unitTest"],
+                      "trackcollection": "generalTracks",
                       "vertexcollection": "offlinePrimaryVertices",
 		      "bsIncompatibleWarnThresh": "100",
         	      "bsIncompatibleErrThresh": "1000",
                       "maxevents": "10",
                       "isda": "true",
-                      "ismc": "false"
+                      "ismc": "true"
                  }
              },
              "merge": {
-                 "TestDATA": {
-                      "singles": ["TestDATA"],
+                 "TestMC": {
+                      "singles": ["TestMC"],
                       "doMaps": "true",
                       "stdResiduals": "true",
                       "autoLimits": "false",
@@ -167,8 +167,8 @@
                  }
              },  
 	     "trends": {
-                 "TestDATA": {
-                      "singles": ["TestDATA"],
+                 "TestMC": {
+                      "singles": ["TestMC"],
                       "doUnitTest": "true"
                  }
              }
@@ -209,6 +209,24 @@
                 }
             }
         },
+        "Zmumu" : {
+            "merge": {
+                "testSingleZMM": {
+                     "singles": ["testSingleZMM"],
+		     "customrighttitle": "UnitTest"
+                }
+            },
+            "single" : {
+                "testSingleZMM" : {
+                    "IOV" : ["1"],
+                    "alignments" : ["unitTestZmumuMCreal","unitTestZmumuMCdisplacedBS"],
+                    "bsIncompatibleWarnThresh": "100",
+                    "bsIncompatibleErrThresh": "1000",
+                    "trackcollection" : "ALCARECOTkAlZMuMu",
+                    "maxevents" : "-1"
+                }
+            }
+        },
 	"DiMuonV" : {
             "merge": {
 		"testUnits": {
@@ -218,7 +236,7 @@
 	    "single" : {
 		"testUnits" : {
 		    "IOV" : ["1"],
-                    "alignments" : ["unitTestDiMuonVMC"],
+                    "alignments" : ["unitTest"],
 		    "bsIncompatibleWarnThresh": "100",
         	    "bsIncompatibleErrThresh": "1000",
                     "trackcollection" : "generalTracks",
@@ -263,14 +281,6 @@
         },
         "JetHT": {
             "single": {
-                "testJob": {
-                    "alignments": ["unitTestJetHT"],
-                    "trackCollection": "ALCARECOTkAlMinBias",
-                    "maxevents": 100,
-                    "iovListFile": "Alignment/OfflineValidation/data/lumiPerRun_Run2.txt",
-		    "bsIncompatibleWarnThresh": "100",
-        	    "bsIncompatibleErrThresh": "1000"
-                },
                 "testMC": {
                     "alignments": ["unitTestJetHTMC"],
                     "trackCollection": "ALCARECOTkAlMinBias",
@@ -281,30 +291,12 @@
                 }
             },
             "merge": {
-                "testJob": {
-                    "singles": ["testJob"],
-                    "alignments": ["unitTestJetHT"]
-                },
                 "testMC": {
                     "singles": ["testMC"],
                     "alignments": ["unitTestJetHTMC"]
                 }
             },
             "plot": {
-                "testJob": {
-                    "merges": ["testJob"],
-                    "alignments": ["unitTestJetHT"],
-                    "jethtplot":{
-                        "drawProfiles": {
-                            "drawDzErrorVsPt": true,
-                            "drawDxyErrorVsPt": true
-                        },
-                        "drawHistograms": {
-                            "drawDz": true,
-                            "drawDxy": true
-                        }
-                    }
-                },
                 "testMC": {
                     "merges": ["testMC"],
                     "alignments": ["unitTestJetHTMC"],

--- a/Alignment/OfflineValidation/test/unit_test.yaml
+++ b/Alignment/OfflineValidation/test/unit_test.yaml
@@ -3,9 +3,14 @@ name: test_yaml
 alignments:
     unitTest:
         color: 1
-        globaltag: auto:phase1_2018_realistic
+        globaltag: auto:phase2_realistic
         style: 2101
         title: unit test
+    unitTestPhase1:
+        color: 1
+        globaltag: auto:phase1_2018_realistic
+        style: 2101
+        title: unit test      
     unitTestPV:
         color: 1
         globaltag: 140X_dataRun3_Prompt_v4
@@ -36,24 +41,19 @@ alignments:
         title: Unit test
     unitTestJetHTMC:
         color: 1
-        globaltag: auto:phase1_2018_realistic
-        style: 2101
-        title: unit test
-    unitTestDiMuonVMC:
-        color: 1
-        globaltag: auto:phase1_2022_realistic
+        globaltag: auto:phase2_realistic
         style: 2101
         title: unit test
     unitTestZmumuMCreal:
         color: 1
-        globaltag: auto:phase1_2024_realistic
+        globaltag: auto:phase2_realistic
         style: 20
         title: realistic
-    unitTestZmumuMCdesign:
+    unitTestZmumuMCdisplacedBS:
         color: 2
-        globaltag: auto:phase1_2024_design
+        globaltag: 150X_mcRun4_displacedBeamSpot_v1
         style: 21
-        title: design
+        title: "displaced BS"
     PromptNewTemplate:
         name: PromptNewTemplate
         color: 1
@@ -138,23 +138,23 @@ validations:
 
     PV:
         single:
-            TestDATA:
+            TestMC:
                 IOV:
-                    - 317087
+                - 1
                 alignments:
-                    - unitTestPV
+                - unitTest
                 maxevents: 10
                 bsIncompatibleWarnThresh: 100
                 bsIncompatibleErrThresh: 1000
-                trackcollection: ALCARECOTkAlMinBias
+                trackcollection: generalTracks
                 vertexcollection: offlinePrimaryVertices
                 isda: true
-                ismc: false                 
+                ismc: true                 
 
         merge:
-            TestDATA:
+            TestMC:
                 singles:
-                - TestDATA
+                - TestMC
                 doMaps: true
                 stdResiduals: true
                 autoLimits: false
@@ -164,9 +164,9 @@ validations:
                 m_dzEtaMax: 50
 
         trends:
-            TestDATA:
+            TestMC:
                 singles:
-                - TestDATA
+                - TestMC
                 doUnitTest: true  
 
     SplitV:
@@ -215,7 +215,7 @@ validations:
                 IOV:
                 - 1
                 alignments:
-                - unitTestDiMuonVMC
+                - unitTest
                 bsIncompatibleWarnThresh: 100
                 bsIncompatibleErrThresh: 1000
                 trackcollection: generalTracks
@@ -233,7 +233,7 @@ validations:
                 - 1
                 alignments:
                 - unitTestZmumuMCreal
-                - unitTestZmumuMCdesign
+                - unitTestZmumuMCdisplacedBS
                 bsIncompatibleWarnThresh: 100
                 bsIncompatibleErrThresh: 1000
                 trackcollection: ALCARECOTkAlZMuMu
@@ -270,15 +270,6 @@ validations:
         doUnitTest: true
     JetHT:
         single:
-            testJob:
-                alignments:
-                - unitTestJetHT
-                trackCollection: ALCARECOTkAlMinBias
-                bsIncompatibleWarnThresh: 100
-                bsIncompatibleErrThresh: 1000
-                maxevents: 100
-                iovListFile: Alignment/OfflineValidation/data/lumiPerRun_Run2.txt
-
             testMC:
                 alignments:
                 - unitTestJetHTMC
@@ -288,29 +279,12 @@ validations:
                 mc: True
                 maxevents: 100
         merge:
-            testJob:
-                singles:
-                - testJob
-                alignments:
-                - unitTestJetHT
             testMC:
                 singles:
                 - testMC
                 alignments:
                 - unitTestJetHTMC
         plot:
-            testJob:
-                merges:
-                - testJob
-                alignments:
-                - unitTestJetHT
-                jethtplot:
-                    drawProfiles:
-                        drawDzErrorVsPt: true
-                        drawDxyErrorVsPt: true
-                    drawHistograms:
-                        drawDz: true
-                        drawDxy: true
             testMC:
                 merges:
                 - testMC
@@ -329,7 +303,7 @@ validations:
                 firstRun: 376370
                 lastRun: 379254
                 alignments:
-                - unitTest
+                - unitTestPhase1
                 - mp3619
         extract:
             testExtractPixBary:


### PR DESCRIPTION
This PR aims on **re-enabling TkAl offline validation unit tests** that were disabled due to the migration of CMSSW master branch to CMSSW_20_Y_Z. As a direct consequence it was not anymore possible to use old-formatted rootfiles. This PR addresses that and adds minor fixes to support validation of TkAl conditions assuming Phase-2 geometry. 

Unit tests:
Pass   79s ... Alignment/OfflineValidation/BeamSpotPlotting
Pass   21s ... Alignment/OfflineValidation/validateAlignments
Pass  233s ... Alignment/OfflineValidation/DMRall
Pass   69s ... Alignment/OfflineValidation/DiElectronVertex
Pass  260s ... Alignment/OfflineValidation/DiMuonVall
Pass   61s ... Alignment/OfflineValidation/DiMuonVertex
Pass  322s ... Alignment/OfflineValidation/GCPall
Pass  113s ... Alignment/OfflineValidation/Genericall
Pass  108s ... Alignment/OfflineValidation/JetHTall
Pass   84s ... Alignment/OfflineValidation/PVValidation
Pass  126s ... Alignment/OfflineValidation/PVall
Pass   34s ... Alignment/OfflineValidation/PixBaryall
Pass   62s ... Alignment/OfflineValidation/PrimaryVertex
Pass  149s ... Alignment/OfflineValidation/SagittaBiasNtuplizer
Pass  124s ... Alignment/OfflineValidation/SplitVall
Pass   59s ... Alignment/OfflineValidation/SubmitPVrbr
Pass  117s ... Alignment/OfflineValidation/SubmitPVsplit
Pass  215s ... Alignment/OfflineValidation/Zmumuall
Pass    4s ... Alignment/OfflineValidation/testDiMuonBiasesPlotting
Pass    4s ... Alignment/OfflineValidation/testPVPlotting
Pass    1s ... Alignment/OfflineValidation/testTkAlStyle
Pass  219s ... Alignment/OfflineValidation/testTrackAnalysis


#### PR validation:

scram b code-checks
scram b runtests 
scram b code-format