### PR TITLE
Adding GSFtracks Indices in SimTICLCandidate

### DIFF
--- a/DataFormats/HGCalReco/interface/TICLCandidate.h
+++ b/DataFormats/HGCalReco/interface/TICLCandidate.h
@@ -7,6 +7,7 @@
 #include "DataFormats/HGCalReco/interface/Trackster.h"
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "Common.h"
 
@@ -112,6 +113,12 @@ namespace io_v1 {
     inline const std::vector<edm::Ptr<reco::Track>> trackPtrs() const { return trackPtrs_; }
     void addTrackPtr(const edm::Ptr<reco::Track>& trackPtr) { trackPtrs_.push_back(trackPtr); }
 
+    inline const edm::Ptr<reco::GsfTrack> gsftrackPtr(int index = 0) const {
+      return gsfTrackPtrs_.empty() ? edm::Ptr<reco::GsfTrack>() : gsfTrackPtrs_[index];
+    }
+    inline const std::vector<edm::Ptr<reco::GsfTrack>>& gsfTrackPtrs() const { return gsfTrackPtrs_; }
+    void addGsfTrackPtr(const edm::Ptr<reco::GsfTrack>& gsftrackPtr) { gsfTrackPtrs_.push_back(gsftrackPtr); }
+
     inline float rawEnergy() const { return rawEnergy_; }
     void setRawEnergy(float rawEnergy) { rawEnergy_ = rawEnergy; }
 
@@ -145,6 +152,7 @@ namespace io_v1 {
     // and there can be derived classes
     std::vector<edm::Ptr<ticl::Trackster>> tracksters_;
     std::vector<edm::Ptr<reco::Track>> trackPtrs_;
+    std::vector<edm::Ptr<reco::GsfTrack>> gsfTrackPtrs_;
     // Since it contains multiple tracksters, duplicate the probability interface
     std::array<float, 8> idProbabilities_;
 

--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -79,7 +79,9 @@ namespace ticl {
       inline void calculateRawEmPt() { raw_em_pt_ = raw_em_energy_ / std::cosh(barycenter_.eta()); }
       inline void setBarycenter(Vector value) { barycenter_ = value; }
       inline void addTrackIdx(int index) { track_idxs_.push_back(index); }
+      inline void addGSFTrackIdx(int index) { gsftrack_idxs_.push_back(index); }
       int trackIdx(int index = 0) const { return track_idxs_.empty() ? -1 : track_idxs_[index]; }
+      int gsftrackIdx(int index = 0) const { return gsftrack_idxs_.empty() ? -1 : gsftrack_idxs_[index]; }
       inline bool isHadronic(float th = 0.5f) const {
         return id_probability(Trackster::ParticleType::photon) + id_probability(Trackster::ParticleType::electron) < th;
       }
@@ -200,7 +202,7 @@ namespace ticl {
       inline const std::array<float, 8> &id_probabilities() const { return id_probabilities_; }
       inline const float id_probabilities(int index) const { return id_probabilities_[index]; }
       inline const std::vector<int> &trackIdxs() const { return track_idxs_; }
-
+      inline const std::vector<int> &gsftrackIdxs() const { return gsftrack_idxs_; }
       // convenience method to return the ID probability for a certain particle type
       inline float id_probability(ParticleType type) const {
         // probabilities are stored in the same order as defined in the ParticleType enum
@@ -239,6 +241,7 @@ namespace ticl {
       // can be cooked using the previous ProductID and this index.
       int seedIndex_;
       std::vector<int> track_idxs_;
+      std::vector<int> gsftrack_idxs_;
 
       std::array<Vector, 3> eigenvectors_;
       std::array<float, 3> eigenvalues_;

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -1,6 +1,7 @@
 
 <lcgdict>
-  <class name="ticl::io_v1::Trackster" ClassVersion="3">
+  <class name="ticl::io_v1::Trackster" ClassVersion="4">
+    <version ClassVersion="4" checksum="4107442909"/>
     <version ClassVersion="3" checksum="2779314320"/>
   </class>
   <class name="std::vector<ticl::io_v1::Trackster>" />
@@ -58,8 +59,9 @@
   <class name="edm::Wrapper<TICLSeedingRegion>" />
   <class name="edm::Wrapper<std::vector<TICLSeedingRegion> >" />
 
-  <class name="io_v1::TICLCandidate" ClassVersion="3">
-   <version ClassVersion="3" checksum="2436690028"/>
+  <class name="io_v1::TICLCandidate" ClassVersion="4">
+    <version ClassVersion="4" checksum="2330696932"/>
+    <version ClassVersion="3" checksum="2436690028"/>
   </class>
   <class name="std::vector<io_v1::TICLCandidate>" />
   <class name="edm::Wrapper<io_v1::TICLCandidate>" />

--- a/RecoHGCal/TICL/plugins/BuildFile.xml
+++ b/RecoHGCal/TICL/plugins/BuildFile.xml
@@ -34,6 +34,7 @@
 <use name="TrackingTools/Records"/>
 <use name="TrackingTools/TrajectoryState"/>
 <use name="fastjet"/>
+<use name="RecoEgamma/EgammaElectronAlgos"/> 
 <library file="*.cc" name="RecoHGCalTICLPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
@@ -698,16 +698,17 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
 
   std::sort(toKeep.begin(), toKeep.end());
   toKeep.erase(std::unique(toKeep.begin(), toKeep.end()), toKeep.end());
-  TracksterCollection keptFromCP;
-  std::vector<TICLCandidate> keptCandidates;
-  keptFromCP.reserve(toKeep.size());
-  keptCandidates.reserve(toKeep.size());
+  size_t writeIdx = 0;
   for (auto idx : toKeep) {
-    keptFromCP.push_back(std::move((*result_fromCP)[idx]));
-    keptCandidates.push_back(std::move((*result_ticlCandidates)[idx]));
+    if (writeIdx != (size_t)idx) {
+      (*result_fromCP)[writeIdx] = std::move((*result_fromCP)[idx]);
+      (*result_ticlCandidates)[writeIdx] = std::move((*result_ticlCandidates)[idx]);
+    }
+    ++writeIdx;
   }
-  *result_fromCP = std::move(keptFromCP);
-  *result_ticlCandidates = std::move(keptCandidates);
+  result_fromCP->resize(writeIdx);
+  result_ticlCandidates->resize(writeIdx);
+ 
   evt.put(std::move(result_ticlCandidates));
   evt.put(std::move(output_mask));
   evt.put(std::move(result_fromCP), "fromCPs");

--- a/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
@@ -708,7 +708,7 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
   }
   result_fromCP->resize(writeIdx);
   result_ticlCandidates->resize(writeIdx);
- 
+
   evt.put(std::move(result_ticlCandidates));
   evt.put(std::move(output_mask));
   evt.put(std::move(result_fromCP), "fromCPs");

--- a/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
@@ -696,16 +696,18 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
     }
   }
 
-  std::vector<int> all_nums(result_fromCP->size());  // vector containing all caloparticles indexes
-  std::iota(all_nums.begin(), all_nums.end(), 0);    // fill the vector with consecutive numbers starting from 0
-
-  std::vector<int> toRemove;
-  std::set_difference(all_nums.begin(), all_nums.end(), toKeep.begin(), toKeep.end(), std::back_inserter(toRemove));
-  std::sort(toRemove.begin(), toRemove.end(), [](int x, int y) { return x > y; });
-  for (auto const& r : toRemove) {
-    result_fromCP->erase(result_fromCP->begin() + r);
-    result_ticlCandidates->erase(result_ticlCandidates->begin() + r);
+  std::sort(toKeep.begin(), toKeep.end());
+  toKeep.erase(std::unique(toKeep.begin(), toKeep.end()), toKeep.end());
+  TracksterCollection keptFromCP;
+  std::vector<TICLCandidate> keptCandidates;
+  keptFromCP.reserve(toKeep.size());
+  keptCandidates.reserve(toKeep.size());
+  for (auto idx : toKeep) {
+    keptFromCP.push_back(std::move((*result_fromCP)[idx]));
+    keptCandidates.push_back(std::move((*result_ticlCandidates)[idx]));
   }
+  *result_fromCP = std::move(keptFromCP);
+  *result_ticlCandidates = std::move(keptCandidates);
   evt.put(std::move(result_ticlCandidates));
   evt.put(std::move(output_mask));
   evt.put(std::move(result_fromCP), "fromCPs");

--- a/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
@@ -22,6 +22,9 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronTools.h"
+
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h"
 #include "SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociator.h"
@@ -103,9 +106,12 @@ private:
   const edm::EDGetTokenT<std::vector<reco::Track>> recoTracksToken_;
   const StringCutObjectSelector<reco::Track> cutTk_;
 
+  const edm::EDGetTokenT<reco::GsfTrackCollection> gsf_tracks_token_;
+
   const edm::EDGetTokenT<reco::SimToRecoCollection> associatormapStRsToken_;
   const edm::EDGetTokenT<reco::RecoToSimCollection> associatormapRtSsToken_;
   const edm::EDGetTokenT<SimTrackToTPMap> associationSimTrackToTPToken_;
+  const edm::EDGetTokenT<reco::SimToRecoCollection> associatormapGsfStRsToken_;
 };
 
 DEFINE_FWK_MODULE(SimTrackstersProducer);
@@ -132,8 +138,10 @@ SimTrackstersProducer::SimTrackstersProducer(const edm::ParameterSet& ps)
           consumes<std::vector<TrackingParticle>>(ps.getParameter<edm::InputTag>("trackingParticles"))),
       recoTracksToken_(consumes<std::vector<reco::Track>>(ps.getParameter<edm::InputTag>("recoTracks"))),
       cutTk_(ps.getParameter<std::string>("cutTk")),
+      gsf_tracks_token_(consumes<reco::GsfTrackCollection>(ps.getParameter<edm::InputTag>("gsfTracks"))),
       associatormapStRsToken_(consumes(ps.getParameter<edm::InputTag>("tpToTrack"))),
-      associationSimTrackToTPToken_(consumes(ps.getParameter<edm::InputTag>("simTrackToTPMap"))) {
+      associationSimTrackToTPToken_(consumes(ps.getParameter<edm::InputTag>("simTrackToTPMap"))),
+      associatormapGsfStRsToken_(consumes<reco::SimToRecoCollection>(ps.getParameter<edm::InputTag>("tpToGsfTrack"))) {
   produces<TracksterCollection>();
   produces<std::vector<float>>();
   produces<TracksterCollection>("fromCPs");
@@ -162,6 +170,8 @@ void SimTrackstersProducer::fillDescriptions(edm::ConfigurationDescriptions& des
                         "1.48 < abs(eta) < 3.0 && pt > 1. && quality(\"highPurity\") && "
                         "hitPattern().numberOfLostHits(\"MISSING_OUTER_HITS\") < 5");
   desc.add<edm::InputTag>("tpToTrack", edm::InputTag("trackingParticleRecoTrackAsssociation"));
+  desc.add<edm::InputTag>("gsfTracks", edm::InputTag("electronGsfTracks"));
+  desc.add<edm::InputTag>("tpToGsfTrack", edm::InputTag("trackingParticleGsfTrackAssociation"));
 
   desc.add<edm::InputTag>("trackingParticles", edm::InputTag("mix", "MergedTrackTruth"));
 
@@ -311,6 +321,15 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
   evt.getByToken(trackingParticleToken_, trackingParticles_h);
   edm::Handle<std::vector<reco::Track>> recoTracks_h;
   evt.getByToken(recoTracksToken_, recoTracks_h);
+  edm::Handle<reco::GsfTrackCollection> gsf_tracks_h;
+  evt.getByToken(gsf_tracks_token_, gsf_tracks_h);
+
+  const reco::GsfTrackCollection* recoGSFTracksPtr = nullptr;
+  if (!gsf_tracks_h.isValid()) {
+    edm::LogWarning("SimTrackstersProducer") << "Missing GSF track collection.";
+  } else {
+    recoGSFTracksPtr = &(*gsf_tracks_h);
+  }
 
   //TP to reco track map
   const auto TPtoRecoTrackMapHandle = evt.getHandle(associatormapStRsToken_);
@@ -320,6 +339,14 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
     return;
   }
   const auto& TPtoRecoTrackMap = *TPtoRecoTrackMapHandle;
+  const auto TPtoGsfTrackMapHandle = evt.getHandle(associatormapGsfStRsToken_);
+
+  const reco::SimToRecoCollection* TPtoGsfTrackMap = nullptr;
+  if (!TPtoGsfTrackMapHandle.isValid()) {
+    edm::LogWarning("SimTrackstersProducer") << "Missing TP->GsfTrack association.";
+  } else {
+    TPtoGsfTrackMap = &(*TPtoGsfTrackMapHandle);
+  }
 
   const auto& simTrackToTPMap = evt.get(associationSimTrackToTPToken_);
   const auto& recoTracks = *recoTracks_h;
@@ -478,6 +505,50 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
     return trackIdx;
   };
 
+  auto simTrackToGsfTrack = [&](UniqueSimTrackId simTkId) -> std::vector<int> {
+    std::vector<int> gsfTrackIdx;
+    if (!recoGSFTracksPtr || !TPtoGsfTrackMap)
+      return gsfTrackIdx;
+    auto ipos = simTrackToTPMap.mapping.find(simTkId);
+    if (ipos != simTrackToTPMap.mapping.end() && TPtoGsfTrackMap) {
+      auto jpos = TPtoGsfTrackMap->find((ipos->second));
+      if (jpos != TPtoGsfTrackMap->end()) {
+        auto& associatedGsfTracks = jpos->val;
+        if (!associatedGsfTracks.empty()) {
+          int gsfIndex = associatedGsfTracks[0].first.key();
+          // Validate the index is within bounds
+          if (gsfIndex >= 0 && gsfIndex < (int)recoGSFTracksPtr->size()) {
+            gsfTrackIdx.push_back(gsfIndex);
+          } else {
+            edm::LogWarning("SimTrackstersProducer")
+                << "Invalid GSF track index: " << gsfIndex << " (size: " << recoGSFTracksPtr->size() << ")";
+          }
+        }
+      }
+
+      // Also check daughter GSFtracks
+      const auto& tp = (*ipos->second);
+      if (!tp.decayVertices().empty()) {
+        const auto& iTV = tp.decayVertices()[0];
+        for (auto iTP = iTV->daughterTracks_begin(); iTP != iTV->daughterTracks_end(); ++iTP) {
+          if (TPtoGsfTrackMap) {
+            auto kpos = TPtoGsfTrackMap->find((*iTP));
+            if (kpos != TPtoGsfTrackMap->end()) {
+              auto& associatedGsfTracks = kpos->val;
+              if (!associatedGsfTracks.empty()) {
+                int gsfIndex = associatedGsfTracks[0].first.key();
+                if (gsfIndex >= 0 && gsfIndex < (int)recoGSFTracksPtr->size()) {
+                  gsfTrackIdx.push_back(gsfIndex);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return gsfTrackIdx;
+  };
+
   // Set the reco track id to SimTrackstersFromCP
   auto& simTrackstersFromCP = *result_fromCP;
   for (unsigned int i = 0; i < simTrackstersFromCP.size(); ++i) {
@@ -489,6 +560,11 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
     if (not bestAssociatedRecoTracks.empty()) {
       for (auto const trackIndex : bestAssociatedRecoTracks)
         simTrackstersFromCP[i].addTrackIdx(trackIndex);
+    }
+    auto bestAssociatedGsfTracks = simTrackToGsfTrack(simTkIds);
+    if (not bestAssociatedGsfTracks.empty()) {
+      for (auto const gsfIndex : bestAssociatedGsfTracks)
+        simTrackstersFromCP[i].addGSFTrackIdx(gsfIndex);
     }
   }
 
@@ -503,6 +579,11 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
     if (not bestAssociatedRecoTracks.empty()) {
       for (auto const trackIndex : bestAssociatedRecoTracks)
         simTracksters[i].addTrackIdx(trackIndex);
+    }
+    auto bestAssociatedGsfTracks = simTrackToGsfTrack(simTkIds);
+    if (not bestAssociatedGsfTracks.empty()) {
+      for (auto const gsfIndex : bestAssociatedGsfTracks)
+        simTracksters[i].addGSFTrackIdx(gsfIndex);
     }
   }
 
@@ -531,6 +612,13 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
       if (cand.trackPtrs().empty() and not trackIndices.empty() and caloparticles[cp_index].charge() != 0) {
         for (const auto trackIndex : trackIndices) {
           cand.addTrackPtr(edm::Ptr<reco::Track>(recoTracks_h, trackIndex));
+        }
+      }
+      auto gsfTrackIndices = tCP.gsftrackIdxs();
+      if (recoGSFTracksPtr && cand.gsfTrackPtrs().empty() && !gsfTrackIndices.empty() &&
+          caloparticles[cp_index].charge() != 0) {
+        for (const auto gsfIndex : gsfTrackIndices) {
+          cand.addGsfTrackPtr(edm::Ptr<reco::GsfTrack>(gsf_tracks_h, gsfIndex));
         }
       }
       toKeep.push_back(cp_index);

--- a/RecoHGCal/TICL/python/HLTSimTracksters_cff.py
+++ b/RecoHGCal/TICL/python/HLTSimTracksters_cff.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoHGCal.TICL.simTrackstersProducer_cfi import simTrackstersProducer as _simTrackstersProducer
 from RecoHGCal.TICL.filteredLayerClustersProducer_cfi import filteredLayerClustersProducer as _filteredLayerClustersProducer
-from Validation.RecoTrack.associators_cff import hltTrackAssociatorByHits, tpToHLTpixelTrackAssociation
+from Validation.RecoTrack.associators_cff import hltTrackAssociatorByHits, tpToHLTpixelTrackAssociation, tpToHLTgsfTrackAssociation
 from SimGeneral.TrackingAnalysis.simHitTPAssociation_cfi import simHitTPAssocProducer
-
+from SimTracker.TrackAssociation.trackingParticleRecoTrackAsssociation_cfi import trackingParticleRecoTrackAsssociation
 # CA - PATTERN RECOGNITION
 
 hltFilteredLayerClustersSimTracksters = _filteredLayerClustersProducer.clone(
@@ -19,6 +19,10 @@ tpToHltGeneralTrackAssociation = tpToHLTpixelTrackAssociation.clone(
     label_tr = "hltGeneralTracks"
 )
 
+tpHltGsfTrackAssociation = tpToHLTgsfTrackAssociation.clone(
+    label_tr = cms.InputTag("hltEgammaGsfTracksL1Seeded"),
+)
+
 hltTiclSimTracksters = _simTrackstersProducer.clone(
     layerClusterCaloParticleAssociator = cms.InputTag("hltHGCalLayerClusterCaloParticleAssociation"),
     layerClusterSimClusterAssociator = cms.InputTag("hltHGCalLayerClusterSimClusterAssociation"),
@@ -27,8 +31,10 @@ hltTiclSimTracksters = _simTrackstersProducer.clone(
     time_layerclusters = cms.InputTag("hltMergeLayerClusters","timeLayerCluster"),
     simTrackToTPMap = cms.InputTag("simHitTPAssocProducer","simTrackToTP"),
     recoTracks = cms.InputTag("hltGeneralTracks"),
+    gsfTracks  = cms.InputTag("hltEgammaGsfTracksL1Seeded"),
     simclusters = cms.InputTag("mix","MergedCaloTruth"),
     tpToTrack = cms.InputTag("tpToHltGeneralTrackAssociation"),
+    tpToGsfTrack  = cms.InputTag("tpHltGsfTrackAssociation"),
     computeLocalTime = cms.bool(True)
 )
 
@@ -36,6 +42,7 @@ from Validation.Configuration.hltHGCalSimValid_cff import *
 
 hltTiclSimTrackstersTask = cms.Task(hltTrackAssociatorByHits,
                                     tpToHltGeneralTrackAssociation,
+                                    tpHltGsfTrackAssociation,
                                     simHitTPAssocProducer,
                                     hltHgcalAssociatorsTask,
                                     hltFilteredLayerClustersSimTracksters,

--- a/RecoHGCal/TICL/python/SimTracksters_cff.py
+++ b/RecoHGCal/TICL/python/SimTracksters_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoHGCal.TICL.simTrackstersProducer_cfi import simTrackstersProducer as _simTrackstersProducer
 from RecoHGCal.TICL.filteredLayerClustersProducer_cfi import filteredLayerClustersProducer as _filteredLayerClustersProducer
 
-
+from SimTracker.TrackAssociation.trackingParticleRecoTrackAsssociation_cfi import trackingParticleRecoTrackAsssociation
 # CA - PATTERN RECOGNITION
 
 
@@ -13,8 +13,13 @@ filteredLayerClustersSimTracksters = _filteredLayerClustersProducer.clone(
     iteration_label = "ticlSimTracksters"
 )
 
+trackingParticleGsfTrackAssociation = trackingParticleRecoTrackAsssociation.clone(
+    label_tr = "electronGsfTracks",  
+)
+
 ticlSimTracksters = _simTrackstersProducer.clone(
-    computeLocalTime = cms.bool(True)
+    computeLocalTime = cms.bool(True),
+    tpToGsfTrack = cms.InputTag("trackingParticleGsfTrackAssociation"),  
 )
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
@@ -23,7 +28,7 @@ premix_stage2.toModify(ticlSimTracksters,
     caloparticles = "mixData:MergedCaloTruth",
 )
 
-ticlSimTrackstersTask = cms.Task(filteredLayerClustersSimTracksters, ticlSimTracksters)
+ticlSimTrackstersTask = cms.Task(filteredLayerClustersSimTracksters, trackingParticleGsfTrackAssociation, ticlSimTracksters)
 
 # BARREL
 


### PR DESCRIPTION
This PR adds the indices of the matched GSFtracks to the SimTICLCandidate collection. This can be used for validation studies and will also be used by MLPF to define the training targets.