### PR TITLE
Fix incorrect loop and memory leak in Phase 2 SIM code

### DIFF
--- a/SimG4Core/Application/interface/Phase2SteppingAction.h
+++ b/SimG4Core/Application/interface/Phase2SteppingAction.h
@@ -42,7 +42,7 @@ private:
   const G4VPhysicalVolume* calo{nullptr};
   const G4VPhysicalVolume* btl{nullptr};
   const CMSSteppingVerbose* steppingVerbose;
-  Phase2TrackFilter* filter;
+  std::unique_ptr<Phase2TrackFilter> filter;
   double theCriticalEnergyForVacuum;
   double theCriticalDensity;
   double maxTrackTime;

--- a/SimG4Core/Application/src/Phase2SteppingAction.cc
+++ b/SimG4Core/Application/src/Phase2SteppingAction.cc
@@ -39,7 +39,7 @@ Phase2SteppingAction::Phase2SteppingAction(
   cms2ZDCName_ = p.getParameter<std::string>("CMS2ZDCName");
   doFineCalo_ = (p.getParameter<bool>("DoFineCalo"));
 
-  filter = new Phase2TrackFilter(pstack, sv);
+  filter = std::make_unique<Phase2TrackFilter>(pstack, sv);
 
   edm::LogVerbatim("SimG4CoreApplication")
       << "Phase2SteppingAction:: KillBeamPipe = " << killBeamPipe

--- a/SimG4Core/Application/src/Phase2SteppingAction.cc
+++ b/SimG4Core/Application/src/Phase2SteppingAction.cc
@@ -107,14 +107,16 @@ void Phase2SteppingAction::UserSteppingAction(const G4Step* aStep) {
     auto step = const_cast<G4Step*>(aStep);
     auto sec = step->GetfSecondary();
     std::size_t n0 = sec->size() - nn;
-    for (std::size_t i = n0; i < sec->size(); ++i) {
-      auto track = (*sec)[i];
+    auto secit = sec->begin() + n0;
+    while (secit != sec->end()) {
+      auto track = *secit;
       if (nullptr != track) {
         auto status = filter->ClassifyNewTrack(track);
         if (status == fKill) {
           step->AddTotalEnergyDeposit(track->GetKineticEnergy());
-          sec->erase(sec->begin() + i);
-          delete track;
+          secit = sec->erase(secit);
+        } else {
+          ++secit;
         }
       }
     }


### PR DESCRIPTION
#### PR description:

Fixes two issues in #50798:
1. Memory leak from `new` -> replaced with `unique_ptr`
2. Deleting vector entries in a for loop over the vector entries is unsafe/inconsistent. Replaced with a while loop using iterators.

The latter issue seems to have contributed to #51239. (I am not marking this as a full resolution yet because my local tests only reproduce changes in the barrel, while the central validation campaign also saw changes in the HF.)

#### PR validation:

Ran workflow 34434.0 and checked ieta distribution of HCAL hits. See https://github.com/cms-sw/cmssw/issues/51239#issuecomment-4794185148

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will be backported to 20_0 and 17_0
