### PR TITLE
Phase2-hgx367L1 Correct a bug in HGCalGeomParameters.cc to make it work correctly for the ColdBox mode of HGCal

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -921,7 +921,7 @@ void HGCalGeomParameters::loadGeometryHexagonModule(const DDCompactView* cpv,
               const DDBox& box = static_cast<DDBox>(sol);
               rout = HGCalParameters::k_ScaleFromDDD * box.halfX();
             }
-            double zp = zvals[std::make_pair(lay, 1)];
+            double zp = (php.coldBoxMode_ == 0) ? zvals[std::make_pair(lay, 1)] : zvals[std::make_pair(lay, zside)];
             HGCalGeomParameters::layerParameters laypar(rin, rout, zp);
             layers[lay] = laypar;
 #ifdef EDM_ML_DEBUG


### PR DESCRIPTION
#### PR description:

Correct a bug in HGCalGeomParameters.cc to make it work correctly for the ColdBox mode of HGCal

#### PR validation:

Tested by Vadim with his modified version

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to CMSSW_17_0_X and CMSSW_20_0_X