### PR TITLE
Phase2-hgx367lm Correct a bug in HGCalGeomParameters.cc to make it work correctly for the ColdBox mode of HGCal and the testing code for neighbour finder of HGCal silicon cells -- backport of #51323 and #51324

### DIFF
--- a/Geometry/CaloTopology/test/HGCalNeighbourTester.cc
+++ b/Geometry/CaloTopology/test/HGCalNeighbourTester.cc
@@ -89,19 +89,17 @@ void HGCalNeighbourTester::beginRun(edm::Run const &iRun, edm::EventSetup const 
     edm::LogVerbatim("HGCGeom") << "Loaded HGCalDDConstants for " << nameDetector_;
     detIds_ = geom->getValidDetIds(dets_);
     edm::LogVerbatim("HGCGeom") << "Gets " << detIds_.size() << " valid ID's for detector " << dets_;
-    auto hgc_ = std::make_unique<HGCalNeighbourFinder>(&(geom->topology().dddConstants()));
     for (unsigned int k = 0; k < detIds_.size(); k += nskip_) {
       HGCSiliconDetId id(detIds_[k]);
-      std::vector<unsigned int> ids = hgc_->nearestNeighboursOfDetId(detIds_[k].rawId());
+      std::vector<DetId> ids = geom->topology().neighbors(id);
       edm::LogVerbatim("HGCGeom") << "[" << k << "] Layer " << id.layer() << " Wafer " << id.waferU() << ":"
                                   << id.waferV() << " Cell " << id.cellU() << ":" << id.cellV() << " has " << ids.size()
                                   << " neighbours:";
       unsigned int k1(0);
       for (auto const &idZ : ids) {
         HGCSiliconDetId idx(idZ);
-        edm::LogVerbatim("HGCGeom") << "[" << k1 << "] Layer " << id.layer() << " Wafer " << id.waferU() << ":"
-                                    << id.waferV() << " Cell " << id.cellU() << ":" << id.cellV() << " has "
-                                    << ids.size() << " neighbours:";
+        edm::LogVerbatim("HGCGeom") << "[" << k1 << "] Layer " << idx.layer() << " Wafer " << idx.waferU() << ":"
+                                    << idx.waferV() << " Cell " << idx.cellU() << ":" << idx.cellV();
         ++k1;
       }
     }

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -921,7 +921,7 @@ void HGCalGeomParameters::loadGeometryHexagonModule(const DDCompactView* cpv,
               const DDBox& box = static_cast<DDBox>(sol);
               rout = HGCalParameters::k_ScaleFromDDD * box.halfX();
             }
-            double zp = zvals[std::make_pair(lay, 1)];
+            double zp = (php.coldBoxMode_ == 0) ? zvals[std::make_pair(lay, 1)] : zvals[std::make_pair(lay, zside)];
             HGCalGeomParameters::layerParameters laypar(rin, rout, zp);
             layers[lay] = laypar;
 #ifdef EDM_ML_DEBUG


### PR DESCRIPTION
#### PR description:

Correct a bug in HGCalGeomParameters.cc to make it work correctly for the ColdBox mode of HGCal and the testing code for neighbour finder of HGCal silicon cells -- backport of #51323 and #51324

#### PR validation:

Tested in CMSSW versions 20_1_X

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backports of #51323 and #51324