### PR TITLE
Split CLUE distance parameters

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersEEL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersEEL1Seeded_cfi.py
@@ -11,7 +11,19 @@ hltHgcalLayerClustersEEL1Seeded = cms.EDProducer("HGCalLayerClusterProducer",
             1.3,
             1.3,
             1.3,
-            0.0315
+            1.3
+        ),
+        deltao = cms.vdouble(
+            2.6,
+            2.6,
+            2.6,
+            2.6
+        ),
+        deltas = cms.vdouble(
+            1.3,
+            1.3,
+            1.3,
+            1.3
         ),
         deltasi_index_regemfac = cms.int32(3),
         dependSensor = cms.bool(True),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersEE_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersEE_cfi.py
@@ -11,7 +11,19 @@ hltHgcalLayerClustersEE = cms.EDProducer("HGCalLayerClusterProducer",
             1.3,
             1.3,
             1.3,
-            0.0315
+            1.3
+        ),
+        deltao = cms.vdouble(
+            2.6,
+            2.6,
+            2.6,
+            2.6
+        ),
+        deltas = cms.vdouble(
+            1.3,
+            1.3,
+            1.3,
+            1.3
         ),
         deltasi_index_regemfac = cms.int32(3),
         dependSensor = cms.bool(True),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersHSciL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersHSciL1Seeded_cfi.py
@@ -7,10 +7,26 @@ hltHgcalLayerClustersHSciL1Seeded = cms.EDProducer("HGCalLayerClusterProducer",
     nHitsTime = cms.uint32(3),
     plugin = cms.PSet(
         dEdXweights = HGCAL_reco_constants.dEdXweights,
+        # Scintillator tiles use (eta, phi) coordinates, so the critical/seed/outlier
+        # distances need the scintillator scale (the silicon-scale defaults are used by
+        # the EE/FH instances). deltao = 0.063 reproduces the previous effective outlier
+        # distance (outlierDeltaFactor = 2.0) x (scint critical distance = 0.0315).
         deltac = cms.vdouble(
-            1.3,
-            1.3,
-            1.3,
+            0.0315,
+            0.0315,
+            0.0315,
+            0.0315
+        ),
+        deltao = cms.vdouble(
+            0.063,
+            0.063,
+            0.063,
+            0.063
+        ),
+        deltas = cms.vdouble(
+            0.0315,
+            0.0315,
+            0.0315,
             0.0315
         ),
         deltasi_index_regemfac = cms.int32(3),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersHSci_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersHSci_cfi.py
@@ -7,10 +7,26 @@ hltHgcalLayerClustersHSci = cms.EDProducer("HGCalLayerClusterProducer",
     nHitsTime = cms.uint32(3),
     plugin = cms.PSet(
         dEdXweights = HGCAL_reco_constants.dEdXweights,
+        # Scintillator tiles use (eta, phi) coordinates, so the critical/seed/outlier
+        # distances need the scintillator scale (the silicon-scale defaults are used by
+        # the EE/FH instances). deltao = 0.063 reproduces the previous effective outlier
+        # distance (outlierDeltaFactor = 2.0) x (scint critical distance = 0.0315).
         deltac = cms.vdouble(
-            1.3,
-            1.3,
-            1.3,
+            0.0315,
+            0.0315,
+            0.0315,
+            0.0315
+        ),
+        deltao = cms.vdouble(
+            0.063,
+            0.063,
+            0.063,
+            0.063
+        ),
+        deltas = cms.vdouble(
+            0.0315,
+            0.0315,
+            0.0315,
             0.0315
         ),
         deltasi_index_regemfac = cms.int32(3),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersHSiL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersHSiL1Seeded_cfi.py
@@ -11,7 +11,19 @@ hltHgcalLayerClustersHSiL1Seeded = cms.EDProducer("HGCalLayerClusterProducer",
             1.3,
             1.3,
             1.3,
-            0.0315
+            1.3
+        ),
+        deltao = cms.vdouble(
+            2.6,
+            2.6,
+            2.6,
+            2.6
+        ),
+        deltas = cms.vdouble(
+            1.3,
+            1.3,
+            1.3,
+            1.3
         ),
         deltasi_index_regemfac = cms.int32(3),
         dependSensor = cms.bool(True),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersHSi_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersHSi_cfi.py
@@ -11,7 +11,19 @@ hltHgcalLayerClustersHSi = cms.EDProducer("HGCalLayerClusterProducer",
             1.3,
             1.3,
             1.3,
-            0.0315
+            1.3
+        ),
+        deltao = cms.vdouble(
+            2.6,
+            2.6,
+            2.6,
+            2.6
+        ),
+        deltas = cms.vdouble(
+            1.3,
+            1.3,
+            1.3,
+            1.3
         ),
         deltasi_index_regemfac = cms.int32(3),
         dependSensor = cms.bool(True),

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -64,6 +64,7 @@ namespace hgcal {
     unsigned int getLayer(const DetId&) const;
     unsigned int getLayerWithOffset(const DetId&) const;
     int getCellType(const DetId& id) const;
+    int getSensorGroup(const DetId& id) const;
     std::pair<int, int> getWafer(const DetId&) const;
     std::pair<int, int> getCell(const DetId&) const;
 
@@ -118,6 +119,28 @@ namespace hgcal {
     int geometryType_;
     int bhMaxIphi_;
   };
+
+  enum SensorType {
+    CE_E_200_LD = 0,
+    CE_E_300_LD = 1,
+    CE_E_120_HD = 2,
+    CE_E_200_HD = 3,
+    CE_H_200_Fine_LD = 4,
+    CE_H_300_Fine_LD = 5,
+    CE_H_120_Fine_HD = 6,
+    CE_H_200_Fine_HD = 7,
+    CE_H_200_Coarse_LD = 8,
+    CE_H_300_Coarse_LD = 9,
+    CE_H_120_Coarse_HD = 10,
+    CE_H_200_Coarse_HD = 11,
+    CE_H_Tile_HD = 12,
+    CE_H_Tile_LD_c = 13,
+    CE_H_Tile_LD_m = 14,
+    EnumSize = 15
+  };
+
+  enum SensorGroup { CEE_LD = 0, CEE_HD = 1, CEH_LD = 2, CEH_HD = 3, UNKNOWN };
+
 }  // namespace hgcal
 
 #endif

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -79,17 +79,6 @@ namespace {
     return ddd;
   }
 
-  enum CellType {
-    CE_E_120 = 0,
-    CE_E_200 = 1,
-    CE_E_300 = 2,
-    CE_H_120 = 3,
-    CE_H_200 = 4,
-    CE_H_300 = 5,
-    CE_H_SCINT = 6,
-    EnumSize = 7
-  };
-
 }  // namespace
 
 void RecHitTools::setGeometry(const CaloGeometry& geom) {
@@ -485,30 +474,77 @@ int RecHitTools::getCellType(const DetId& id) const {
   auto isNose = geomNose ? true : false;
   auto isEELayer = (layer_number <= lastLayerEE(isNose));
   auto isScint = isScintillator(id);
+  HGCalDetId hid(id);
+  auto geom = getSubdetectorGeometry(hid);
+  auto ddd = get_ddd(geom, hid);
+  const int waferType = ddd->waferTypeT(hid.waferType());
   int layerType = -1;
-
   if (isScint) {
-    layerType = CE_H_SCINT;
-  }
-  if (isEELayer) {
-    if (thickness == 0) {
-      layerType = CE_E_120;
-    } else if (thickness == 1) {
-      layerType = CE_E_200;
-    } else if (thickness == 2) {
-      layerType = CE_E_300;
-    }
+    layerType = CE_H_Tile_HD;
   } else {
-    if (thickness == 0) {
-      layerType = CE_H_120;
-    } else if (thickness == 1) {
-      layerType = CE_H_200;
-    } else if (thickness == 2) {
-      layerType = CE_H_300;
+    HGCSiliconDetId siHid(id);
+    auto type = siHid.type();
+    if (isEELayer) {
+      if (type == HGCSiliconDetId::HGCalLD200) {
+        layerType = CE_E_200_LD;
+      } else if (type == HGCSiliconDetId::HGCalLD300) {
+        layerType = CE_E_300_LD;
+      } else if (type == HGCSiliconDetId::HGCalHD120) {
+        layerType = CE_E_120_HD;
+      } else {
+        layerType = CE_E_200_HD;
+      }
+    } else {
+      if (waferType == 1) {
+        if (type == HGCSiliconDetId::HGCalLD200) {
+          layerType = CE_H_200_Fine_LD;
+        } else if (type == HGCSiliconDetId::HGCalLD300) {
+          layerType = CE_H_300_Fine_LD;
+        } else if (type == HGCSiliconDetId::HGCalHD120) {
+          layerType = CE_H_120_Fine_HD;
+        } else {
+          layerType = CE_H_200_Fine_HD;
+        }
+      } else {
+        if (type == HGCSiliconDetId::HGCalLD200) {
+          layerType = CE_H_200_Coarse_LD;
+        } else if (type == HGCSiliconDetId::HGCalLD300) {
+          layerType = CE_H_300_Coarse_LD;
+        } else if (type == HGCSiliconDetId::HGCalHD120) {
+          layerType = CE_H_120_Coarse_HD;
+        } else {
+          layerType = CE_H_200_Coarse_HD;
+        }
+      }
     }
   }
   assert(layerType != -1);
   return layerType;
+}
+
+int RecHitTools::getSensorGroup(const DetId& id) const {
+  int cellType = getCellType(id);
+  switch (cellType) {
+    case CE_E_200_LD:
+    case CE_E_300_LD:
+      return CEE_LD;
+    case CE_E_120_HD:
+    case CE_E_200_HD:
+      return CEE_HD;
+    case CE_H_200_Fine_LD:
+    case CE_H_300_Fine_LD:
+    case CE_H_200_Coarse_LD:
+    case CE_H_300_Coarse_LD:
+      return CEH_LD;
+    case CE_H_120_Fine_HD:
+    case CE_H_200_Fine_HD:
+    case CE_H_120_Coarse_HD:
+    case CE_H_200_Coarse_HD:
+    case CE_H_Tile_HD:
+      return CEH_HD;
+    default:
+      return UNKNOWN;
+  }
 }
 
 bool RecHitTools::isSilicon(const DetId& id) const {

--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -468,7 +468,6 @@ bool RecHitTools::isHalfCell(const DetId& id) const {
 int RecHitTools::getCellType(const DetId& id) const {
   checkGeometry();
   auto layer_number = getLayerWithOffset(id);
-  auto thickness = getSiThickIndex(id);
   auto geomNose =
       static_cast<const HGCalGeometry*>(geom_->getSubdetectorGeometry(DetId::Forward, ForwardSubdetector::HFNose));
   auto isNose = geomNose ? true : false;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -1,5 +1,6 @@
 #include "RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
 // Geometry
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
@@ -39,6 +40,7 @@ void HGCalCLUEAlgoT<T, STRATEGY>::populate(const HGCRecHitCollection& hits) {
   for (unsigned int i = 0; i < hits.size(); ++i) {
     const HGCRecHit& hgrh = hits[i];
     DetId detid = hgrh.detid();
+    auto cellType = rhtools_.getSensorGroup(detid);
     unsigned int layerOnSide = (rhtools_.getLayerWithOffset(detid) - 1);
 
     // set sigmaNoise default value 1 to use kappa value directly in case of
@@ -64,6 +66,7 @@ void HGCalCLUEAlgoT<T, STRATEGY>::populate(const HGCRecHitCollection& hits) {
     const GlobalPoint position(rhtools_.getPosition(detid));
     int offset = ((rhtools_.zside(detid) + 1) >> 1) * maxlayer_;
     int layer = layerOnSide + offset;
+    cells_[layer].cellType.emplace_back(cellType);
     // setting the layer position only once per layer
     if (cells_[layer].layerDim3 == std::numeric_limits<float>::infinity())
       cells_[layer].layerDim3 = position.z();
@@ -91,6 +94,7 @@ void HGCalCLUEAlgoT<T, STRATEGY>::prepareDataStructures(unsigned int l) {
   cells_[l].clusterIndex.resize(cellsSize, -1);
   cells_[l].followers.resize(cellsSize);
   cells_[l].isSeed.resize(cellsSize, false);
+  cells_[l].cellType.resize(cellsSize, -1);
 }
 
 // Create a vector of Hexels associated to one cluster from a collection of
@@ -107,27 +111,16 @@ void HGCalCLUEAlgoT<T, STRATEGY>::makeClusters() {
       lt.clear();
       lt.fill(cells_[i].dim1, cells_[i].dim2);
 
-      float delta;
-      if constexpr (std::is_same_v<STRATEGY, HGCalSiliconStrategy>) {
-        // maximum search distance (critical distance) for local density calculation
-        float delta_c;
-        if (i % maxlayer_ < lastLayerEE_)
-          delta_c = vecDeltas_[0];
-        else if (i % maxlayer_ < (firstLayerBH_ - 1))
-          delta_c = vecDeltas_[1];
-        else
-          delta_c = vecDeltas_[2];
-        delta = delta_c;
-      } else {
-        float delta_r = vecDeltas_[3];
-        delta = delta_r;
-      }
       LogDebug("HGCalCLUEAlgo") << "maxlayer: " << maxlayer_ << " lastLayerEE: " << lastLayerEE_
                                 << " firstLayerBH: " << firstLayerBH_ << "\n";
 
-      calculateLocalDensity(lt, i, delta);
-      calculateDistanceToHigher(lt, i, delta);
-      numberOfClustersPerLayer_[i] = findAndAssignClusters(i, delta);
+      // The critical distance for the local-density calculation (vecDeltasC_), the
+      // seed-promotion distance (vecDeltasSeed_) and the outlier distance (vecDeltasO_)
+      // are three independent, per-sensor-group parameters; each function looks up
+      // the relevant value per cell via its cellType (sensor group).
+      calculateLocalDensity(lt, i, vecDeltasC_);
+      calculateDistanceToHigher(lt, i, vecDeltasO_);
+      numberOfClustersPerLayer_[i] = findAndAssignClusters(i, vecDeltasSeed_, vecDeltasO_);
     });
   });
 #if DEBUG_CLUSTERS_ALPAKA
@@ -262,11 +255,12 @@ std::vector<reco::BasicCluster> HGCalCLUEAlgoT<T, STRATEGY>::getClusters(bool) {
 template <typename T, typename STRATEGY>
 void HGCalCLUEAlgoT<T, STRATEGY>::calculateLocalDensity(const T& lt,
                                                         const unsigned int layerId,
-                                                        float delta,
+                                                        const std::vector<double>& deltas_c,
                                                         HGCalSiliconStrategy strategy) {
   auto& cellsOnLayer = cells_[layerId];
   unsigned int numberOfCells = cellsOnLayer.detid.size();
   for (unsigned int i = 0; i < numberOfCells; i++) {
+    const float delta = deltas_c[cellsOnLayer.cellType[i]];
     std::array<int, 4> search_box = lt.searchBox(cellsOnLayer.dim1[i] - delta,
                                                  cellsOnLayer.dim1[i] + delta,
                                                  cellsOnLayer.dim2[i] - delta,
@@ -293,11 +287,12 @@ void HGCalCLUEAlgoT<T, STRATEGY>::calculateLocalDensity(const T& lt,
 template <typename T, typename STRATEGY>
 void HGCalCLUEAlgoT<T, STRATEGY>::calculateLocalDensity(const T& lt,
                                                         const unsigned int layerId,
-                                                        float delta,
+                                                        const std::vector<double>& deltas_c,
                                                         HGCalScintillatorStrategy strategy) {
   auto& cellsOnLayer = cells_[layerId];
   unsigned int numberOfCells = cellsOnLayer.detid.size();
   for (unsigned int i = 0; i < numberOfCells; i++) {
+    const float delta = deltas_c[cellsOnLayer.cellType[i]];
     std::array<int, 4> search_box = lt.searchBox(cellsOnLayer.dim1[i] - delta,
                                                  cellsOnLayer.dim1[i] + delta,
                                                  cellsOnLayer.dim2[i] - delta,
@@ -358,30 +353,36 @@ void HGCalCLUEAlgoT<T, STRATEGY>::calculateLocalDensity(const T& lt,
   }
 }
 template <typename T, typename STRATEGY>
-void HGCalCLUEAlgoT<T, STRATEGY>::calculateLocalDensity(const T& lt, const unsigned int layerId, float delta) {
+void HGCalCLUEAlgoT<T, STRATEGY>::calculateLocalDensity(const T& lt,
+                                                        const unsigned int layerId,
+                                                        const std::vector<double>& deltas_c) {
   if constexpr (std::is_same_v<STRATEGY, HGCalSiliconStrategy>) {
-    calculateLocalDensity(lt, layerId, delta, HGCalSiliconStrategy());
+    calculateLocalDensity(lt, layerId, deltas_c, HGCalSiliconStrategy());
   } else {
-    calculateLocalDensity(lt, layerId, delta, HGCalScintillatorStrategy());
+    calculateLocalDensity(lt, layerId, deltas_c, HGCalScintillatorStrategy());
   }
 }
 
 template <typename T, typename STRATEGY>
-void HGCalCLUEAlgoT<T, STRATEGY>::calculateDistanceToHigher(const T& lt, const unsigned int layerId, float delta) {
+void HGCalCLUEAlgoT<T, STRATEGY>::calculateDistanceToHigher(const T& lt,
+                                                            const unsigned int layerId,
+                                                            const std::vector<double>& deltas_o) {
   auto& cellsOnLayer = cells_[layerId];
   unsigned int numberOfCells = cellsOnLayer.detid.size();
 
   for (unsigned int i = 0; i < numberOfCells; i++) {
     // initialize delta and nearest higher for i
+    //
+    auto const cellType = cellsOnLayer.cellType[i];
+    auto const delta = deltas_o[cellType];
     float maxDelta = std::numeric_limits<float>::max();
     float i_delta = maxDelta;
     int i_nearestHigher = -1;
     float rho_max = 0.f;
-    auto range = outlierDeltaFactor_ * delta;
-    std::array<int, 4> search_box = lt.searchBox(cellsOnLayer.dim1[i] - range,
-                                                 cellsOnLayer.dim1[i] + range,
-                                                 cellsOnLayer.dim2[i] - range,
-                                                 cellsOnLayer.dim2[i] + range);
+    std::array<int, 4> search_box = lt.searchBox(cellsOnLayer.dim1[i] - delta,
+                                                 cellsOnLayer.dim1[i] + delta,
+                                                 cellsOnLayer.dim2[i] - delta,
+                                                 cellsOnLayer.dim2[i] + delta);
     // loop over all bins in the search box
     for (int dim1Bin = search_box[0]; dim1Bin < search_box[1] + 1; ++dim1Bin) {
       for (int dim2Bin = search_box[2]; dim2Bin < search_box[3] + 1; ++dim2Bin) {
@@ -417,7 +418,7 @@ void HGCalCLUEAlgoT<T, STRATEGY>::calculateDistanceToHigher(const T& lt, const u
       cellsOnLayer.delta[i] = std::sqrt(i_delta);
       cellsOnLayer.nearestHigher[i] = i_nearestHigher;
     } else {
-      // otherwise delta is guaranteed to be larger outlierDeltaFactor_*delta_c
+      // otherwise delta is guaranteed to be larger than the outlier distance delta_o
       // we can safely maximize delta to be maxDelta
       cellsOnLayer.delta[i] = maxDelta;
       cellsOnLayer.nearestHigher[i] = -1;
@@ -432,7 +433,9 @@ void HGCalCLUEAlgoT<T, STRATEGY>::calculateDistanceToHigher(const T& lt, const u
 }
 
 template <typename T, typename STRATEGY>
-int HGCalCLUEAlgoT<T, STRATEGY>::findAndAssignClusters(const unsigned int layerId, float delta) {
+int HGCalCLUEAlgoT<T, STRATEGY>::findAndAssignClusters(const unsigned int layerId,
+                                                       const std::vector<double>& deltas_seed,
+                                                       const std::vector<double>& deltas_o) {
   // this is called once per layer and endcap...
   // so when filling the cluster temporary vector of Hexels we resize each time
   // by the number  of clusters found. This is always equal to the number of
@@ -443,11 +446,14 @@ int HGCalCLUEAlgoT<T, STRATEGY>::findAndAssignClusters(const unsigned int layerI
   std::vector<int> localStack;
   // find cluster seeds and outlier
   for (unsigned int i = 0; i < numberOfCells; i++) {
+    auto const cellType = cellsOnLayer.cellType[i];
+    auto const delta_seed = deltas_seed[cellType];
+    auto const delta_o = deltas_o[cellType];
     float rho_c = kappa_ * cellsOnLayer.sigmaNoise[i];
     // initialize clusterIndex
     cellsOnLayer.clusterIndex[i] = -1;
-    bool isSeed = (cellsOnLayer.delta[i] > delta) && (cellsOnLayer.rho[i] >= rho_c);
-    bool isOutlier = (cellsOnLayer.delta[i] > outlierDeltaFactor_ * delta) && (cellsOnLayer.rho[i] < rho_c);
+    bool isSeed = (cellsOnLayer.delta[i] > delta_seed) && (cellsOnLayer.rho[i] >= rho_c);
+    bool isOutlier = (cellsOnLayer.delta[i] > delta_o) && (cellsOnLayer.rho[i] < rho_c);
     if (isSeed) {
       cellsOnLayer.clusterIndex[i] = nClustersOnLayer;
       cellsOnLayer.isSeed[i] = true;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -39,7 +39,9 @@ public:
       : HGCalClusteringAlgoBase(
             (HGCalClusteringAlgoBase::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity", 3),
             reco::CaloCluster::undefined),
-        vecDeltas_(ps.getParameter<std::vector<double>>("deltac")),
+        vecDeltasC_(ps.getParameter<std::vector<double>>("deltac")),
+        vecDeltasSeed_(ps.getParameter<std::vector<double>>("deltas")),
+        vecDeltasO_(ps.getParameter<std::vector<double>>("deltao")),
         kappa_(ps.getParameter<double>("kappa")),
         ecut_(ps.getParameter<double>("ecut")),
         dependSensor_(ps.getParameter<bool>("dependSensor")),
@@ -93,12 +95,29 @@ public:
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
     iDesc.add<std::vector<double>>("thresholdW0", {2.9, 2.9, 2.9, 2.9});
     iDesc.add<double>("positionDeltaRho2", 1.69);
+    // critical distance for the local-density calculation, per sensor group
     iDesc.add<std::vector<double>>("deltac",
                                    {
-                                       1.3,
-                                       1.3,
-                                       1.3,
-                                       0.0315,  // for scintillator
+                                       1.3,  //CE_E-LD
+                                       1.3,  //CE_E-HD
+                                       1.3,  //CE_H-LD
+                                       1.3,  //CE_H-HD
+                                   });
+    // seed-promotion distance, per sensor group (independent from deltac)
+    iDesc.add<std::vector<double>>("deltas",
+                                   {
+                                       1.3,  //CE_E-LD
+                                       1.3,  //CE_E-HD
+                                       1.3,  //CE_H-LD
+                                       1.3,  //CE_H-HD
+                                   });
+    // outlier distance, per sensor group
+    iDesc.add<std::vector<double>>("deltao",
+                                   {
+                                       2.6,  //CE_E-LD
+                                       2.6,  //CE_E-HD
+                                       2.6,  //CE_H-LD
+                                       2.6,  //CE_H-HD
                                    });
     iDesc.add<bool>("dependSensor", true);
     iDesc.add<double>("ecut", 3.0);
@@ -129,8 +148,13 @@ public:
   typedef math::XYZPoint Point;
 
 private:
-  // The two parameters used to identify clusters
-  std::vector<double> vecDeltas_;
+  // The distance parameters used to identify clusters, all indexed per sensor group:
+  // vecDeltasC_   -> critical distance for the local-density calculation
+  // vecDeltasSeed_-> seed-promotion distance (independent from vecDeltasC_)
+  // vecDeltasO_   -> outlier distance
+  std::vector<double> vecDeltasC_;
+  std::vector<double> vecDeltasSeed_;
+  std::vector<double> vecDeltasO_;
   double kappa_;
 
   // The hit energy cutoff
@@ -158,8 +182,6 @@ private:
   // initialization bool
   bool initialized_;
 
-  float outlierDeltaFactor_ = 2.f;
-
   struct CellsOnLayer {
     std::vector<DetId> detid;
     std::vector<float> dim1;
@@ -172,6 +194,7 @@ private:
     std::vector<int> nearestHigher;
     std::vector<int> clusterIndex;
     std::vector<float> sigmaNoise;
+    std::vector<int> cellType;
     std::vector<std::vector<int>> followers;
     std::vector<bool> isSeed;
     float layerDim3 = std::numeric_limits<float>::infinity();
@@ -186,6 +209,7 @@ private:
       nearestHigher.clear();
       clusterIndex.clear();
       sigmaNoise.clear();
+      cellType.clear();
       followers.clear();
       isSeed.clear();
     }
@@ -200,6 +224,7 @@ private:
       nearestHigher.shrink_to_fit();
       clusterIndex.shrink_to_fit();
       sigmaNoise.shrink_to_fit();
+      cellType.shrink_to_fit();
       followers.shrink_to_fit();
       isSeed.shrink_to_fit();
     }
@@ -228,15 +253,21 @@ private:
   }
 
   void prepareDataStructures(const unsigned int layerId);
-  void calculateLocalDensity(const TILE& lt, const unsigned int layerId,
-                             float delta);  // return max density
-  void calculateLocalDensity(const TILE& lt, const unsigned int layerId, float delta, HGCalSiliconStrategy strategy);
   void calculateLocalDensity(const TILE& lt,
                              const unsigned int layerId,
-                             float delta,
+                             const std::vector<double>& deltas_c);  // return max density
+  void calculateLocalDensity(const TILE& lt,
+                             const unsigned int layerId,
+                             const std::vector<double>& deltas_c,
+                             HGCalSiliconStrategy strategy);
+  void calculateLocalDensity(const TILE& lt,
+                             const unsigned int layerId,
+                             const std::vector<double>& deltas_c,
                              HGCalScintillatorStrategy strategy);
-  void calculateDistanceToHigher(const TILE& lt, const unsigned int layerId, float delta);
-  int findAndAssignClusters(const unsigned int layerId, float delta);
+  void calculateDistanceToHigher(const TILE& lt, const unsigned int layerId, const std::vector<double>& deltas_o);
+  int findAndAssignClusters(const unsigned int layerId,
+                            const std::vector<double>& deltas_seed,
+                            const std::vector<double>& deltas_o);
 };
 
 // explicit template instantiation

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
@@ -51,6 +51,14 @@ hgcalLayerClustersHSci = hgcalLayerClusters_.clone(
     detector = 'BH',
     recHits = "HGCalRecHit:HGCHEBRecHits",
     plugin = dict(
+        # Scintillator tiles use (eta, phi) coordinates, so the critical/seed/outlier
+        # distances need the scintillator scale (the default deltac/deltas/deltao are
+        # the silicon-scale values used by the EE/FH/HFNose instances).
+        # deltao = 0.063 reproduces the previous effective outlier distance
+        # (outlierDeltaFactor = 2.0) x (scint critical distance = 0.0315).
+        deltac = [0.0315, 0.0315, 0.0315, 0.0315],
+        deltas = [0.0315, 0.0315, 0.0315, 0.0315],
+        deltao = [0.063, 0.063, 0.063, 0.063],
         dEdXweights = HGCalRecHit.layerWeights.value(),
         #With the introduction of 7 regional factors (6 for silicon plus 1 for scintillator),
         #we extend fcPerMip (along with noises below) so that it is guaranteed that they have 6 entries.


### PR DESCRIPTION
This PR splits the CLUE distance parameters into three independent parameters and allows to configure them depending on the sensor type of the considered cell.

  - deltac: critical distance for the local-density calculation
  - deltas: seed-promotion distance
  - deltao: outlier distance

  - RecHitTools: reworked `CellType`  enum into a more detailed SensorType, and added `getSensorGroup()` which maps each cell to one of four groups (CEE_LD, CEE_HD, CEH_LD, CEH_HD). 
  - Offline and HLT LayerClusters configuration updated accordingly

This PR is purely technical, no physics changes should be expected


@felicepantaleo @AuroraPerego @rovere @sbaldu @pfs @LukaLambrecht @MaxMarriottClarke   fyi