### PR TITLE
non concurrent ESSources may only be in 1 thread jobs

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -706,6 +706,13 @@ namespace edm {
       auto guard = makeGuard([this]() { actReg_->postEventSetupConfigurationFinalizedSignal_.emit(); });
       espController_->finishConfiguration();
     }
+    if (espController_->hasNonconcurrentFinder() and preallocations_.numberOfThreads() > 1) {
+      throw edm::Exception(edm::errors::Configuration, "Non-concurrent ESSource")
+          << "The EventSetup configuration contains a non-concurrent ESSource. "
+             "This will limit the number of threads allowed in the job to 1. Either \n"
+             " - see if the ESSource can be made conccurent or \n"
+             " - set the numberOfThreads in the configuration to 1.";
+    }
     eventsetup::ESRecordsToProductResolverIndices esRecordsToProductResolverIndices = esp_->recordsToResolverIndices();
 
     actReg_->eventSetupConfigurationSignal_.emit(esRecordsToProductResolverIndices, processContext_);

--- a/FWCore/Framework/test/stubs/DummyLooper.cc
+++ b/FWCore/Framework/test/stubs/DummyLooper.cc
@@ -42,13 +42,15 @@ public:
 
   ReturnType produce(const DummyRecord&);
 
-  void startingNewLoop(unsigned int) {}
-  Status duringLoop(const edm::Event&, const edm::EventSetup&) { return issueStop_ ? kStop : kContinue; }
-  Status endOfLoop(const edm::EventSetup&, unsigned int) {
+  void startingNewLoop(unsigned int) final {}
+  Status duringLoop(const edm::Event&, const edm::EventSetup&) final { return issueStop_ ? kStop : kContinue; }
+  Status endOfLoop(const edm::EventSetup&, unsigned int) final {
     (data_->value_)++;
     ++counter_;
     return counter_ == 2 ? kStop : kContinue;
   }
+
+  bool isConcurrentFinder() const final { return true; }
 
 private:
   // ----------member data ---------------------------

--- a/FWCore/Integration/test/eventSetupTest.sh
+++ b/FWCore/Integration/test/eventSetupTest.sh
@@ -16,8 +16,12 @@ cmsRun ${LOCAL_TEST_DIR}/ESProductHostTest_cfg.py || die 'Failed in ESProductHos
 echo testConcurrentIOVs
 cmsRun ${LOCAL_TEST_DIR}/testConcurrentIOVs_cfg.py || die 'Failed in testConcurrentIOVs_cfg.py' $?
 
-echo testConcurrentIOVsLegacy
-cmsRun ${LOCAL_TEST_DIR}/testConcurrentIOVsLegacy_cfg.py || die 'Failed in testConcurrentIOVsLegacy_cfg.py' $?
+echo testConcurrentIOVsLegacy 1 thread
+cmsRun ${LOCAL_TEST_DIR}/testConcurrentIOVsLegacy_cfg.py -n 1|| die 'Failed in testConcurrentIOVsLegacy_cfg.py' $?
+
+echo testConcurrentIOVsLegacy 4 threads
+cmsRun ${LOCAL_TEST_DIR}/testConcurrentIOVsLegacy_cfg.py -n 4 &> testConcurrentIOVsLegacy_4threads.txt && die 'Failed in testConcurrentIOVsLegacy_cfg.py, the configuration succeeded while it should have failed' $?
+grep "The EventSetup configuration contains a non-concurrent ESSource" testConcurrentIOVsLegacy_4threads.txt >/dev/null || diecat 'Failed in testConcurrentIOVsLegacy_cfg.py, the configuration failed but in an unexpected way' $? testConcurrentIOVsLegacy_4threads.txt
 
 echo testAllowConcurrentIOVs_cfg
 cmsRun ${LOCAL_TEST_DIR}/testAllowConcurrentIOVs_cfg.py || die 'Failed in testAllowConcurrentIOVs_cfg.py' $?

--- a/FWCore/Integration/test/testConcurrentIOVsLegacy_cfg.py
+++ b/FWCore/Integration/test/testConcurrentIOVsLegacy_cfg.py
@@ -9,6 +9,11 @@
 # records found by that ESSource.
 
 import FWCore.ParameterSet.Config as cms
+import argparse
+
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("-n", type=int, default=4)
+args, _ = parser.parse_known_args()
 
 process = cms.Process("TEST")
 
@@ -25,7 +30,7 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.options = dict(
-    numberOfThreads = 4,
+    numberOfThreads = args.n,
     numberOfStreams = 4,
     numberOfConcurrentRuns = 1,
     numberOfConcurrentLuminosityBlocks = 4,


### PR DESCRIPTION

#### PR description:

If an ESSource that is marked as non-concurrent is in a job, that job may only use 1 thread.

This is part of work to simplify the EventSetup scheduling system.

#### PR validation:

Framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/2317