### PR TITLE
LST: set T5 occupancy threshold at 100K

### DIFF
--- a/RecoTracker/LSTCore/interface/alpaka/Common.h
+++ b/RecoTracker/LSTCore/interface/alpaka/Common.h
@@ -44,6 +44,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   HOST_DEVICE_CONSTANT float kWidthPS = 0.01;
   HOST_DEVICE_CONSTANT float kPt_betaMax = 7.0;
   HOST_DEVICE_CONSTANT int kNTripletThreshold = 1000;
+  HOST_DEVICE_CONSTANT int kNQuintupletThreshold = 100000;
   HOST_DEVICE_CONSTANT int kLogicalOTLayers = 11;  // logical OT layers are 1..11
   HOST_DEVICE_CONSTANT auto kMaxPLSHitBitsInHitsSoA = ::lst::kMaxPLSHitBitsInHitsSoA;
 

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -2153,6 +2153,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
         if (dynamic_count == 0)
           continue;
+        if (dynamic_count > kNQuintupletThreshold)
+          dynamic_count = kNQuintupletThreshold;
 
         int nEligibleT5Modules = alpaka::atomicAdd(acc, &nEligibleT5Modulesx, 1, alpaka::hierarchy::Threads{});
         int nTotQ = alpaka::atomicAdd(acc, &nTotalQuintupletsx, dynamic_count, alpaka::hierarchy::Threads{});

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -1871,6 +1871,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
             // Match inner Sg and Outer Sg
             int mIdx = alpaka::atomicAdd(acc, &matchCount, 1, alpaka::hierarchy::Threads{});
+            if (mIdx >= ranges.quintupletModuleOccupancy()[lowerModule1])
+              continue;
             unsigned int quintupletIndex = ranges.quintupletModuleIndices()[lowerModule1] + mIdx;
 
 #ifdef WARNINGS
@@ -1900,7 +1902,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
         }
 
         // Step 2: Parallel processing of triplet pairs
-        for (int i = flatThreadIdxXY; i < matchCount; i += flatThreadExtent) {
+        const int stage2Bound = matchCount < ranges.quintupletModuleOccupancy()[lowerModule1]
+                                    ? matchCount
+                                    : ranges.quintupletModuleOccupancy()[lowerModule1];
+        for (int i = flatThreadIdxXY; i < stage2Bound; i += flatThreadExtent) {
           unsigned int quintupletIndex = ranges.quintupletModuleIndices()[lowerModule1] + i;
           int innerTripletIndex = quintuplets.preAllocatedTripletIndices()[quintupletIndex][0];
           int outerTripletIndex = quintuplets.preAllocatedTripletIndices()[quintupletIndex][1];


### PR DESCRIPTION
This is an interim measure to address the very extreme tail event(s) such as seen the phase-2 170pre2 relval QCD 2TeV jet events in https://github.com/cms-sw/cmssw/issues/51245#issuecomment-4808609161

a somewhat rounded upper limit of 100K is placed on the maximum number of T5s (per module [accounting unit]).
- Not seen in 200 ttbar PU200 events (the max here is close to/below 50K).
- happens in about 3% of QCD 2 TeV dijet events (200 events initially made from 16_1_X relval)

The slow event seen in the relval ([tarball](https://eoscmsweb.cern.ch/eos/cms/store/logs/prod/recent/PRODUCTION/pdmvserv_RVCMSSW_17_0_0_pre2QCD_Pt_1800_2400_14__STD_D121_RegeneratedGS_PU_260622_144822_6445/DigiTriggerPU_Run4D121PU/vocms0259.cern.ch-1156829-0-log.tar.gz) used to reproduce) 
- original pre2: was killed after it took over 44 hours in the production job. I reproduced it locally (the event didn't complete as of this message; more than 24 hours since the start; running on CPU). 
- After the fix that long event completes in about 40 mins on CPU backend. Reducing the T5 cap to 50K reduces the processing time to just about 30 mins; to avoid reproducibility issues due to going over the cap in ttbar the cap is kept at 100K.

Tests on 1K events show minimal differences in physics (tracking running on GPU, some non-reproducibility expected)
- ttbar events <img width="599" height="409" alt="image" src="https://github.com/user-attachments/assets/dcacfe3e-f3e6-4898-9372-e1dac49dc4e9" />
- QCD 2TeV events <img width="603" height="405" alt="image" src="https://github.com/user-attachments/assets/a3505fb6-d999-4159-8143-00c240fd72c3" />

(all HLT MTV plots for [QCD](https://uaf-10.t2.ucsd.edu/~mmasciov/MIC/Phase2/June2026/hltMTV_qcd-pT1800to2400-PU200_t5truncation/plots_hlt.html) and [ttbar](https://uaf-10.t2.ucsd.edu/~mmasciov/MIC/Phase2/June2026/hltMTV_ttPU200_t5truncation/plots_hlt.html))