### PR TITLE
Remove delayed call to EventSetupsController::finishConfiguration

### DIFF
--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -131,8 +131,7 @@ namespace edm {
                                                            WaitingTaskHolder const& taskToStartAfterIOVInit,
                                                            WaitingTaskList& endIOVWaitingTasks,
                                                            std::shared_ptr<const EventSetupImpl>& eventSetupImpl) {
-      finishConfiguration();
-
+      assert(mustFinishConfiguration_ == false);
       bool newEventSetupImpl = false;
       eventSetupImpl.reset();
 
@@ -182,6 +181,7 @@ namespace edm {
     void synchronousEventSetupForInstance(IOVSyncValue const& syncValue,
                                           oneapi::tbb::task_group& iGroup,
                                           eventsetup::EventSetupsController& espController) {
+      espController.finishConfiguration();
       FinalWaitingTask waitUntilIOVInitializationCompletes{iGroup};
 
       // These do nothing ...


### PR DESCRIPTION
#### PR description:

cmsRun has been calling the routine early. Only a few tests were calling the function in a delayed manner.

#### PR validation:

Code compiles, framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/2318
