### PR TITLE
[LST standalone] Bump CUDA compute capability to 8.0

### DIFF
--- a/RecoTracker/LSTCore/standalone/LST/Makefile
+++ b/RecoTracker/LSTCore/standalone/LST/Makefile
@@ -41,7 +41,7 @@ LIBS=$(LIB_CPU) $(LIB_CUDA) $(LIB_ROCM)
 #
 
 # Different architectures to optimize for
-GENCODE_CUDA := -gencode arch=compute_70,code=[sm_70,compute_70] -gencode arch=compute_89,code=[sm_89,compute_89]
+GENCODE_CUDA := -gencode arch=compute_80,code=[sm_80,compute_80] -gencode arch=compute_89,code=[sm_89,compute_89] -gencode arch=compute_90,code=[sm_90,compute_90]
 
 CXX                  = g++
 CXXFLAGS_CPU         = -march=native -mtune=native -Ofast -fno-reciprocal-math -fopenmp-simd -g -Wall -Woverloaded-virtual -fPIC -fopenmp -I..


### PR DESCRIPTION
Since CMSSW moved to CUDA 13 in https://github.com/cms-sw/cmsdist/pull/10617, compute capability 7.0 is no longer supported. This caused LST standalone to start failing to compile. This PR bumps the target compute capability to 8.0 (while keeping the existing 8.9), since those reflect the compute capabilities available in our test machines.