### PR TITLE
RecoHGCal/TICL: pattern-recognition correctness fixes

### DIFF
--- a/RecoHGCal/TICL/plugins/HGCDoublet.cc
+++ b/RecoHGCal/TICL/plugins/HGCDoublet.cc
@@ -114,7 +114,12 @@ int HGCDoublet::areAligned(double xi,
   auto dot_pointing_sq = dot_pointing * dot_pointing;
   auto mag_pointing_sq = pointingDir.mag2();
   auto minCosPointing_sq = minCosPointing * minCosPointing;
-  bool isWithinLimitsPointing = (dot_pointing_sq > minCosPointing_sq * mag_pointing_sq * mag2sq);
+  // Squaring loses the sign of minCosPointing: a negative/permissive threshold (e.g. -1, meant to
+  // disable the cut) must not become "reject everything", and an anti-pointing doublet
+  // (dot_pointing < 0) must fail the cut for a positive threshold.
+  bool isWithinLimitsPointing =
+      (minCosPointing <= -1.f) ? true
+                               : (dot_pointing > 0.f && dot_pointing_sq > minCosPointing_sq * mag_pointing_sq * mag2sq);
   if (debug) {
     LogDebug("HGCDoublet") << "Pointing direction: " << pointingDir << std::endl;
     LogDebug("HGCDoublet") << "-- Are Aligned -- dot_pointing_sq: " << dot_pointing_sq

--- a/RecoHGCal/TICL/plugins/HGCGraph.cc
+++ b/RecoHGCal/TICL/plugins/HGCGraph.cc
@@ -268,9 +268,13 @@ void HGCGraphT<TILES>::findNtuplets(std::vector<HGCDoublet::HGCntuplet> &foundNt
     allDoublets_[rootDoublet].findNtuplets(
         allDoublets_, tmpNtuplet, seedIndex, outInDFS, outInHops, maxOutInHops, outInToVisit);
     while (!outInToVisit.empty()) {
-      allDoublets_[outInToVisit.back().first].findNtuplets(
-          allDoublets_, tmpNtuplet, seedIndex, outInDFS, outInToVisit.back().second, maxOutInHops, outInToVisit);
+      // pop BEFORE processing: findNtuplets pushes the node's children onto the back of
+      // outInToVisit, so popping after would discard a freshly-queued child instead of the
+      // node just handled (silently dropping backward branches).
+      const auto next = outInToVisit.back();
       outInToVisit.pop_back();
+      allDoublets_[next.first].findNtuplets(
+          allDoublets_, tmpNtuplet, seedIndex, outInDFS, next.second, maxOutInHops, outInToVisit);
     }
 
     if (tmpNtuplet.size() > minClustersPerNtuplet) {

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCLUE3D.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCLUE3D.cc
@@ -614,7 +614,7 @@ void PatternRecognitionbyCLUE3D<TILES>::calculateDistanceToHigher(
       minLayer = std::max(layerId - densitySiblingLayers_[algoId], minLayer);
       maxLayer = std::min(layerId + densitySiblingLayers_[algoId], lastLayerPerSide - 1);
     } else {
-      minLayer = std::max(layerId - densitySiblingLayers_[algoId], lastLayerPerSide + 1);
+      minLayer = std::max(layerId - densitySiblingLayers_[algoId], lastLayerPerSide);
       maxLayer = std::min(layerId + densitySiblingLayers_[algoId], maxLayer);
     }
     constexpr float maxDelta = std::numeric_limits<float>::max();
@@ -699,7 +699,7 @@ int PatternRecognitionbyCLUE3D<TILES>::findAndAssignTracksters(
   const auto &critical_transverse_distance =
       useAbsoluteProjectiveScale_ ? criticalXYDistance_ : criticalEtaPhiDistance_;
   // find cluster seeds and outlier
-  unsigned int maxLayer = (isBarrel_) ? this->rhtools_->lastLayerBarrel() : 2 * this->rhtools_->lastLayer();
+  unsigned int maxLayer = (isBarrel_) ? this->rhtools_->lastLayerBarrel() + 1 : 2 * this->rhtools_->lastLayer();
   for (unsigned int layer = 0; layer < maxLayer; layer++) {
     auto &clustersOnLayer = clusters_[layer];
     unsigned int numberOfClusters = clustersOnLayer.x.size();

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.cc
@@ -99,14 +99,15 @@ void PatternRecognitionbyFastJet<TILES>::makeTracksters(
   constexpr int nPhiBin = TILES::constants_type_t::nPhiBins;
 
   // We need to partition the two sides of the HGCAL detector
-  auto lastLayerPerSide = static_cast<unsigned int>(rhtools->lastLayer(isHFnose)) - 1;
+  auto lastLayerPerSide = static_cast<unsigned int>(rhtools->lastLayer(isHFnose));
   if (isBarrel)
-    lastLayerPerSide = static_cast<unsigned int>(rhtools->lastLayerBarrel()) - 1;
-  unsigned int maxLayer = isBarrel ? lastLayerPerSide + 1 : 2 * lastLayerPerSide - 1;
+    lastLayerPerSide = static_cast<unsigned int>(rhtools->lastLayerBarrel());
+  unsigned int maxLayer = isBarrel ? lastLayerPerSide : 2 * lastLayerPerSide - 1;
   std::vector<fastjet::PseudoJet> fjInputs;
   fjInputs.clear();
   for (unsigned int currentLayer = 0; currentLayer <= maxLayer; ++currentLayer) {
-    if (currentLayer == lastLayerPerSide) {
+    // flush the first endcap before starting the second; the barrel is a single region (no split)
+    if (!isBarrel && currentLayer == lastLayerPerSide) {
       buildJetAndTracksters(fjInputs, result);
     }
     const auto &tileOnLayer = input.tiles[currentLayer];


### PR DESCRIPTION
- CLUE3D: include the last barrel layer in findAndAssignTracksters; fix the +z-endcap floor in calculateDistanceToHigher (was lastLayerPerSide+1, inconsistent with density).
- FastJet: fix the per-side layer count (was lastLayer()-1, dropping endcap layers and flushing across the IP); the barrel is a single region (no mid flush).
- HGCGraph: pop the out-in DFS node before processing (popping after discarded children).
- HGCDoublet: keep the sign of minCosPointing (default -1 no longer rejects all doublets; anti-pointing doublets fail a positive threshold).

