### PR TITLE
RecoHGCal/TICL: avoid NaN energies in PF and superclustering

### DIFF
--- a/RecoHGCal/TICL/plugins/EGammaSuperclusterProducer.cc
+++ b/RecoHGCal/TICL/plugins/EGammaSuperclusterProducer.cc
@@ -138,8 +138,8 @@ void EGammaSuperclusterProducer::produce(edm::Event& iEvent, const edm::EventSet
     assert(!superclusterLink.empty());
 
     reco::CaloClusterPtrVector trackstersEMInSupercluster;
-    float max_eta = std::numeric_limits<float>::min();
-    float max_phi = std::numeric_limits<float>::min();
+    float max_eta = std::numeric_limits<float>::lowest();
+    float max_phi = std::numeric_limits<float>::lowest();
     float min_eta = std::numeric_limits<float>::max();
     float min_phi = std::numeric_limits<float>::max();
     for (unsigned int tsInSc_id : superclusterLink) {

--- a/RecoHGCal/TICL/plugins/PFTICLProducer.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducer.cc
@@ -92,7 +92,7 @@ void PFTICLProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
       total_raw_energy += t->raw_energy();
       total_em_raw_energy += t->raw_em_energy();
     }
-    float ecal_energy_fraction = total_em_raw_energy / total_raw_energy;
+    float ecal_energy_fraction = (total_raw_energy > 0.f) ? (total_em_raw_energy / total_raw_energy) : 0.f;
     float ecal_energy = energy_from_regression_ ? ticl_cand.p4().energy() * ecal_energy_fraction
                                                 : ticl_cand.rawEnergy() * ecal_energy_fraction;
     float hcal_energy =

--- a/RecoHGCal/TICL/plugins/TracksterP4FromEnergySumPlugin.cc
+++ b/RecoHGCal/TICL/plugins/TracksterP4FromEnergySumPlugin.cc
@@ -80,7 +80,7 @@ namespace ticl {
     }
     std::transform(
         std::begin(barycentre), std::end(barycentre), std::begin(barycentre), [&energy](double val) -> double {
-          return energy >= 0. ? val / energy : val;
+          return energy > 0. ? val / energy : val;
         });
 
     math::XYZVector direction(barycentre[0] - vertex.x(), barycentre[1] - vertex.y(), barycentre[2] - vertex.z());


### PR DESCRIPTION
- PFTICLProducer: guard the EM/total energy fraction when a candidate has no tracksters (track-only/global-muon) -> no NaN ECAL energy on the PFCandidate.
- EGammaSuperclusterProducer: initialise the running maxima with numeric_limits::lowest() instead of ::min(), which corrupted etaWidth/phiWidth regression features.
- TracksterP4FromEnergySumPlugin: guard the barycentre/energy division (> 0, not >= 0).

