### PR TITLE
RecoHGCal/TICL: linking and inference fixes

### DIFF
--- a/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.cc
@@ -145,7 +145,9 @@ void GNNInterpretationAlgo::constructNodeFromWindow(
     float delta2,
     unsigned trackstersSize,
     std::vector<ticl::Node>& graph) {
-  const float delta = 0.5f * delta2;
+  // delta2 carries the configured linear deltaR window (del_tk_ts_); build the eta/phi search box
+  // with the full window and cut on the squared distance below, matching the General algo.
+  const float delta = delta2;
 
   for (const auto& [seedPos, seedIdx, _] : seeding) {
     const float seedEta = seedPos.Eta();
@@ -173,7 +175,7 @@ void GNNInterpretationAlgo::constructNodeFromWindow(
 
           const float sep2 =
               reco::deltaR2(tracksterPropPoints[tsIdx].Eta(), tracksterPropPoints[tsIdx].Phi(), seedEta, seedPhi);
-          if (sep2 < delta2) {
+          if (sep2 < delta * delta) {
             node.addOuterNeighbour(tsIdx);
           }
         }

--- a/RecoHGCal/TICL/plugins/LinkingAlgoByDirectionGeometric.cc
+++ b/RecoHGCal/TICL/plugins/LinkingAlgoByDirectionGeometric.cc
@@ -4,6 +4,7 @@
 
 #include "DataFormats/GeometrySurface/interface/BoundDisk.h"
 #include "DataFormats/HGCalReco/interface/Common.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -105,8 +106,9 @@ void LinkingAlgoByDirectionGeometric::findTrackstersInWindow(
         const auto &in_tile = tile[tile.globalBin(eta_i, (phi_i % TileConstants::nPhiBins))];
         for (const unsigned &t_i : in_tile) {
           // calculate actual distances of tracksters to the seed for a more accurate cut
-          auto sep2 = (tracksterPropPoints[t_i].Eta() - seed_eta) * (tracksterPropPoints[t_i].Eta() - seed_eta) +
-                      (tracksterPropPoints[t_i].Phi() - seed_phi) * (tracksterPropPoints[t_i].Phi() - seed_phi);
+          const auto dphi = reco::deltaPhi(tracksterPropPoints[t_i].Phi(), seed_phi);
+          auto sep2 =
+              (tracksterPropPoints[t_i].Eta() - seed_eta) * (tracksterPropPoints[t_i].Eta() - seed_eta) + dphi * dphi;
           if (sep2 < delta2) {
             in_delta.push_back(t_i);
             distances2.push_back(sep2);

--- a/RecoHGCal/TICL/plugins/TracksterInferenceByDNN.cc
+++ b/RecoHGCal/TICL/plugins/TracksterInferenceByDNN.cc
@@ -21,7 +21,7 @@ namespace ticl {
         eidNClusters_(conf.getParameter<int>("eid_n_clusters")),
         doPID_(conf.getParameter<int>("doPID")),
         doRegression_(conf.getParameter<int>("doRegression")),
-        miniBatchSize_(conf.getUntrackedParameter<int>("miniBatchSize", 256)) {
+        miniBatchSize_(conf.getUntrackedParameter<int>("miniBatchSize", 64)) {
     const std::string pidModel = conf.getParameter<std::string>("onnxPIDModelPath");
     const std::string energyModel = conf.getParameter<std::string>("onnxEnergyModelPath");
 
@@ -108,6 +108,9 @@ namespace ticl {
         for (int k : clusterIndices) {
           const unsigned int v = ts.vertices(k);
           auto const& cl = layerClusters[v];
+          if (rhtools.isBarrel(cl.seed())) {  // keep the tensor consistent with the selection loop
+            continue;
+          }
 
           const int j = rhtools.getLayerWithOffset(cl.hitsAndFractions()[0].first) - 1;
           if (j < 0 || j >= eidNLayers_) {

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.cc
@@ -480,7 +480,8 @@ void TracksterLinkingbySkeletons::linkTracksters(
           auto const &tracksterOut = tracksters[n];
           auto const &skeletonOut = skeletons[n];
           auto const deltaphi = reco::deltaPhi(trackster.barycenter().phi(), tracksterOut.barycenter().phi());
-          if (abs(trackster.barycenter().eta() - tracksterOut.barycenter().eta()) <= window && deltaphi <= window) {
+          if (abs(trackster.barycenter().eta() - tracksterOut.barycenter().eta()) <= window &&
+              std::abs(deltaphi) <= window) {
             bool isInGood = isGoodTrackster(trackster, skeleton, min_num_lcs_, min_trackster_energy_, pca_quality_th_);
             bool isOutGood =
                 isGoodTrackster(tracksterOut, skeletonOut, min_num_lcs_, min_trackster_energy_, pca_quality_th_);

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -191,11 +191,11 @@ void TrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
       const typename PatternRecognitionAlgoBaseT<TICLLayerTilesBarrel>::Inputs inputBarrel(
           evt, es, layerClusters, inputClusterMask, layerClustersTimes, layer_clusters_barrel_tiles, seeding_regions);
 
-      if (inferenceAlgo_) {
-        inferenceAlgo_->runInference(layerClusters, *initialResult, rhtools_);
-      }
-
       myAlgoBarrel_->makeTracksters(inputBarrel, *result, seedToTrackstersAssociation);
+
+      if (inferenceAlgo_) {
+        inferenceAlgo_->runInference(layerClusters, *result, rhtools_);
+      }
     } else {
       const auto& tiles = evt.get(layer_clusters_tiles_token_);
       const typename PatternRecognitionAlgoBaseT<TICLLayerTiles>::Inputs input(


### PR DESCRIPTION
- TracksterLinkingbySkeletons: use abs(deltaPhi) in the phi window (was signed).
- LinkingAlgoByDirectionGeometric: wrap the phi difference (reco::deltaPhi) in the cut.
- GNNInterpretationAlgo: make the search window and squared distance cut consistent.
- TracksterInferenceByDNN: skip barrel clusters in the tensor fill (consistent with the selection loop); fix the miniBatchSize default (64).
- TrackstersProducer: run barrel inference on the produced tracksters, not the empty initialResult.

