### PR TITLE
HLTrigger/Configuration: fix mis-wired L1-seeded TICL Recovery sequence

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTiclTrackstersRecoverySequenceL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTiclTrackstersRecoverySequenceL1Seeded_cfi.py
@@ -3,4 +3,4 @@ import FWCore.ParameterSet.Config as cms
 from ..modules.hltFilteredLayerClustersRecoveryL1Seeded_cfi import *
 from ..modules.hltTiclTrackstersRecoveryL1Seeded_cfi import *
 
-HLTTiclTrackstersRecoverySequence = cms.Sequence(hltFilteredLayerClustersRecovery+hltTiclTrackstersRecovery)
+HLTTiclTrackstersRecoverySequenceL1Seeded = cms.Sequence(hltFilteredLayerClustersRecoveryL1Seeded+hltTiclTrackstersRecoveryL1Seeded)


### PR DESCRIPTION
HLTTiclTrackstersRecoverySequenceL1Seeded_cfi imported the L1-seeded modules but built the sequence from the un-imported unseeded names (NameError on import) and mislabelled the sequence variable. Build it from the imported L1-seeded modules.