### PR TITLE
RecoHGCal/TICL: coding-rules compliance 

### DIFF
--- a/RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h
+++ b/RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h
@@ -1,8 +1,8 @@
 // Author: Felice Pantaleo - felice.pantaleo@cern.ch
 // Date: 09/2018
 
-#ifndef RecoHGCal_TICL_PatternRecognitionAlgoBase_H__
-#define RecoHGCal_TICL_PatternRecognitionAlgoBase_H__
+#ifndef RecoHGCal_TICL_PatternRecognitionAlgoBase_h
+#define RecoHGCal_TICL_PatternRecognitionAlgoBase_h
 
 #include <memory>
 #include <vector>

--- a/RecoHGCal/TICL/interface/SuperclusteringDNNInputs.h
+++ b/RecoHGCal/TICL/interface/SuperclusteringDNNInputs.h
@@ -11,8 +11,8 @@
 // Date: 02/2026
 //
 
-#ifndef __RecoHGCal_TICL_SuperclusteringDNNInputs_H__
-#define __RecoHGCal_TICL_SuperclusteringDNNInputs_H__
+#ifndef RecoHGCal_TICL_SuperclusteringDNNInputs_h
+#define RecoHGCal_TICL_SuperclusteringDNNInputs_h
 
 #include "DataFormats/HGCalReco/interface/TracksterFwd.h"
 #include <vector>

--- a/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
+++ b/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_PatternRecognitionAlgoBase_H__
-#define RecoHGCal_TICL_PatternRecognitionAlgoBase_H__
+#ifndef RecoHGCal_TICL_TICLInterpretationAlgoBase_h
+#define RecoHGCal_TICL_TICLInterpretationAlgoBase_h
 
 #include <memory>
 #include <vector>

--- a/RecoHGCal/TICL/interface/TracksterInferenceAlgoBase.h
+++ b/RecoHGCal/TICL/interface/TracksterInferenceAlgoBase.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_TracksterInferenceAlgo_H__
-#define RecoHGCal_TICL_TracksterInferenceAlgo_H__
+#ifndef RecoHGCal_TICL_TracksterInferenceAlgoBase_h
+#define RecoHGCal_TICL_TracksterInferenceAlgoBase_h
 
 #include <vector>
 

--- a/RecoHGCal/TICL/interface/TracksterInferenceAlgoFactory.h
+++ b/RecoHGCal/TICL/interface/TracksterInferenceAlgoFactory.h
@@ -1,8 +1,8 @@
 // Author: Felice Pantaleo - felice.pantaleo@cern.ch
 // Date: 07/2024
 
-#ifndef RecoHGCal_TICL_TracksterInferenceAlgoFactory_H__
-#define RecoHGCal_TICL_TracksterInferenceAlgoFactory_H__
+#ifndef RecoHGCal_TICL_TracksterInferenceAlgoFactory_h
+#define RecoHGCal_TICL_TracksterInferenceAlgoFactory_h
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoHGCal/TICL/interface/TracksterInferenceByCNN.h
+++ b/RecoHGCal/TICL/interface/TracksterInferenceByCNN.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_interface_TracksterInferenceByCNN_h
-#define RecoHGCal_TICL_interface_TracksterInferenceByCNN_h
+#ifndef RecoHGCal_TICL_TracksterInferenceByCNN_h
+#define RecoHGCal_TICL_TracksterInferenceByCNN_h
 
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 #include "RecoHGCal/TICL/interface/TICLONNXGlobalCache.h"

--- a/RecoHGCal/TICL/interface/TracksterInferenceByDNN.h
+++ b/RecoHGCal/TICL/interface/TracksterInferenceByDNN.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_TracksterInferenceByDNN_H__
-#define RecoHGCal_TICL_TracksterInferenceByDNN_H__
+#ifndef RecoHGCal_TICL_TracksterInferenceByDNN_h
+#define RecoHGCal_TICL_TracksterInferenceByDNN_h
 
 #include <string>
 #include <vector>
@@ -45,4 +45,4 @@ namespace ticl {
 
 }  // namespace ticl
 
-#endif  // RecoHGCal_TICL_TracksterInferenceByDNN_H__
+#endif  // RecoHGCal_TICL_TracksterInferenceByDNN_h

--- a/RecoHGCal/TICL/interface/TracksterInferenceByPFN.h
+++ b/RecoHGCal/TICL/interface/TracksterInferenceByPFN.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_TracksterInferenceByPFN_H__
-#define RecoHGCal_TICL_TracksterInferenceByPFN_H__
+#ifndef RecoHGCal_TICL_TracksterInferenceByPFN_h
+#define RecoHGCal_TICL_TracksterInferenceByPFN_h
 
 #include <vector>
 
@@ -44,4 +44,4 @@ namespace ticl {
 
 }  // namespace ticl
 
-#endif  // RecoHGCal_TICL_TracksterInferenceByPFN_H__
+#endif  // RecoHGCal_TICL_TracksterInferenceByPFN_h

--- a/RecoHGCal/TICL/interface/TracksterLinkingAlgoBase.h
+++ b/RecoHGCal/TICL/interface/TracksterLinkingAlgoBase.h
@@ -1,8 +1,8 @@
 // Author: Felice Pantaleo - felice.pantaleo@cern.ch
 // Date: 09/2018
 
-#ifndef RecoHGCal_TICL_PatternRecognitionAlgoBase_H__
-#define RecoHGCal_TICL_PatternRecognitionAlgoBase_H__
+#ifndef RecoHGCal_TICL_TracksterLinkingAlgoBase_h
+#define RecoHGCal_TICL_TracksterLinkingAlgoBase_h
 
 #include <memory>
 #include <vector>

--- a/RecoHGCal/TICL/interface/TracksterMomentumPluginBase.h
+++ b/RecoHGCal/TICL/interface/TracksterMomentumPluginBase.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_TracksterMomentumPluginBase_H__
-#define RecoHGCal_TICL_TracksterMomentumPluginBase_H__
+#ifndef RecoHGCal_TICL_TracksterMomentumPluginBase_h
+#define RecoHGCal_TICL_TracksterMomentumPluginBase_h
 
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"

--- a/RecoHGCal/TICL/interface/TracksterTrackPluginBase.h
+++ b/RecoHGCal/TICL/interface/TracksterTrackPluginBase.h
@@ -1,7 +1,7 @@
 // Base class for plugins that set the track reference(s) in the Trackster -> TICLCandidate conversion.
 
-#ifndef RecoHGCal_TICL_TracksterTrackPluginBase_H__
-#define RecoHGCal_TICL_TracksterTrackPluginBase_H__
+#ifndef RecoHGCal_TICL_TracksterTrackPluginBase_h
+#define RecoHGCal_TICL_TracksterTrackPluginBase_h
 
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"

--- a/RecoHGCal/TICL/plugins/ClusterFilterBase.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterBase.h
@@ -1,8 +1,8 @@
 // Author: Felice Pantaleo, Marco Rovere - felice.pantaleo@cern.ch, marco.rovere@cern.ch
 // Date: 09/2018
 
-#ifndef RecoHGCal_TICL_ClusterFilterBase_H__
-#define RecoHGCal_TICL_ClusterFilterBase_H__
+#ifndef RecoHGCal_TICL_ClusterFilterBase_h
+#define RecoHGCal_TICL_ClusterFilterBase_h
 
 #include "DataFormats/HGCalReco/interface/Common.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"

--- a/RecoHGCal/TICL/plugins/ClusterFilterByAlgo.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterByAlgo.h
@@ -1,8 +1,8 @@
 // Author: Marco Rovere - marco.rovere@cern.ch
 // Date: 11/2018
 
-#ifndef RecoHGCal_TICL_ClusterFilterByAlgo_H__
-#define RecoHGCal_TICL_ClusterFilterByAlgo_H__
+#ifndef RecoHGCal_TICL_ClusterFilterByAlgo_h
+#define RecoHGCal_TICL_ClusterFilterByAlgo_h
 
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "ClusterFilterBase.h"

--- a/RecoHGCal/TICL/plugins/ClusterFilterByAlgoAndSize.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterByAlgoAndSize.h
@@ -1,8 +1,8 @@
 // Authors: Marco Rovere - marco.rovere@cern.ch, Felice Pantaleo - felice.pantaleo@cern.ch
 // Date: 11/2018
 
-#ifndef RecoHGCal_TICL_ClusterFilterByAlgoAndSize_H__
-#define RecoHGCal_TICL_ClusterFilterByAlgoAndSize_H__
+#ifndef RecoHGCal_TICL_ClusterFilterByAlgoAndSize_h
+#define RecoHGCal_TICL_ClusterFilterByAlgoAndSize_h
 
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "ClusterFilterBase.h"

--- a/RecoHGCal/TICL/plugins/ClusterFilterByAlgoAndSizeAndLayerRange.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterByAlgoAndSizeAndLayerRange.h
@@ -1,8 +1,8 @@
 // Authors: Marco Rovere - marco.rovere@cern.ch, Felice Pantaleo - felice.pantaleo@cern.ch
 // Date: 09/2020
 
-#ifndef RecoHGCal_TICL_ClusterFilterByAlgoAndSizeAndLayerRange_H__
-#define RecoHGCal_TICL_ClusterFilterByAlgoAndSizeAndLayerRange_H__
+#ifndef RecoHGCal_TICL_ClusterFilterByAlgoAndSizeAndLayerRange_h
+#define RecoHGCal_TICL_ClusterFilterByAlgoAndSizeAndLayerRange_h
 
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "ClusterFilterBase.h"

--- a/RecoHGCal/TICL/plugins/ClusterFilterBySize.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterBySize.h
@@ -1,8 +1,8 @@
 // Author: Marco Rovere - marco.rovere@cern.ch
 // Date: 11/2018
 
-#ifndef RecoHGCal_TICL_ClusterFilterBySize_H__
-#define RecoHGCal_TICL_ClusterFilterBySize_H__
+#ifndef RecoHGCal_TICL_ClusterFilterBySize_h
+#define RecoHGCal_TICL_ClusterFilterBySize_h
 
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "ClusterFilterBase.h"

--- a/RecoHGCal/TICL/plugins/ClusterFilterFactory.h
+++ b/RecoHGCal/TICL/plugins/ClusterFilterFactory.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_ClusterFilterFactory_H
-#define RecoHGCal_TICL_ClusterFilterFactory_H
+#ifndef RecoHGCal_TICL_ClusterFilterFactory_h
+#define RecoHGCal_TICL_ClusterFilterFactory_h
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"

--- a/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_GNNInterpretationAlgo_H_
-#define RecoHGCal_TICL_GNNInterpretationAlgo_H_
+#ifndef RecoHGCal_TICL_GNNInterpretationAlgo_h
+#define RecoHGCal_TICL_GNNInterpretationAlgo_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_GeneralInterpretationAlgo_H_
-#define RecoHGCal_TICL_GeneralInterpretationAlgo_H_
+#ifndef RecoHGCal_TICL_GeneralInterpretationAlgo_h
+#define RecoHGCal_TICL_GeneralInterpretationAlgo_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/RecoHGCal/TICL/plugins/HGCDoublet.h
+++ b/RecoHGCal/TICL/plugins/HGCDoublet.h
@@ -1,8 +1,8 @@
 // Author: Felice Pantaleo,Marco Rovere - felice.pantaleo@cern.ch, marco.rovere@cern.ch
 // Date: 11/2018
 
-#ifndef __RecoHGCal_TICL_HGCDoublet_H__
-#define __RecoHGCal_TICL_HGCDoublet_H__
+#ifndef RecoHGCal_TICL_HGCDoublet_h
+#define RecoHGCal_TICL_HGCDoublet_h
 
 #include <cmath>
 #include <vector>

--- a/RecoHGCal/TICL/plugins/HGCGraph.h
+++ b/RecoHGCal/TICL/plugins/HGCGraph.h
@@ -1,8 +1,8 @@
 // Author: Felice Pantaleo - felice.pantaleo@cern.ch
 // Date: 11/2018
 
-#ifndef __RecoHGCal_TICL_HGCGraph_H__
-#define __RecoHGCal_TICL_HGCGraph_H__
+#ifndef RecoHGCal_TICL_HGCGraph_h
+#define RecoHGCal_TICL_HGCGraph_h
 
 #include <vector>
 

--- a/RecoHGCal/TICL/plugins/LinkingAlgoBase.h
+++ b/RecoHGCal/TICL/plugins/LinkingAlgoBase.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_LinkingAlgoBase_H__
-#define RecoHGCal_TICL_LinkingAlgoBase_H__
+#ifndef RecoHGCal_TICL_LinkingAlgoBase_h
+#define RecoHGCal_TICL_LinkingAlgoBase_h
 
 #include <vector>
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"

--- a/RecoHGCal/TICL/plugins/LinkingAlgoByDirectionGeometric.h
+++ b/RecoHGCal/TICL/plugins/LinkingAlgoByDirectionGeometric.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_LinkingAlgoByDirectionGeometric_H__
-#define RecoHGCal_TICL_LinkingAlgoByDirectionGeometric_H__
+#ifndef RecoHGCal_TICL_LinkingAlgoByDirectionGeometric_h
+#define RecoHGCal_TICL_LinkingAlgoByDirectionGeometric_h
 
 #include <memory>
 #include <array>

--- a/RecoHGCal/TICL/plugins/LinkingAlgoFactory.h
+++ b/RecoHGCal/TICL/plugins/LinkingAlgoFactory.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCAL_TICL_LinkingAlgoFactory_h
-#define RecoHGCAL_TICL_LinkingAlgoFactory_h
+#ifndef RecoHGCal_TICL_LinkingAlgoFactory_h
+#define RecoHGCal_TICL_LinkingAlgoFactory_h
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"

--- a/RecoHGCal/TICL/plugins/PatternRecognitionPluginFactory.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionPluginFactory.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_PatternRecognitionPluginFactory_H
-#define RecoHGCal_TICL_PatternRecognitionPluginFactory_H
+#ifndef RecoHGCal_TICL_PatternRecognitionPluginFactory_h
+#define RecoHGCal_TICL_PatternRecognitionPluginFactory_h
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -1,8 +1,8 @@
 // Author: Felice Pantaleo,Marco Rovere - felice.pantaleo@cern.ch, marco.rovere@cern.ch
 // Date: 09/2018
 
-#ifndef __RecoHGCal_TICL_PRbyCA_H__
-#define __RecoHGCal_TICL_PRbyCA_H__
+#ifndef RecoHGCal_TICL_PatternRecognitionbyCA_h
+#define RecoHGCal_TICL_PatternRecognitionbyCA_h
 #include <memory>  // unique_ptr
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h"

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCLUE3D.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCLUE3D.h
@@ -1,8 +1,8 @@
 // Author: Marco Rovere - marco.rovere@cern.ch
 // Date: 04/2021
 
-#ifndef __RecoHGCal_TICL_PRbyCLUE3D_H__
-#define __RecoHGCal_TICL_PRbyCLUE3D_H__
+#ifndef RecoHGCal_TICL_PatternRecognitionbyCLUE3D_h
+#define RecoHGCal_TICL_PatternRecognitionbyCLUE3D_h
 #include <memory>  // unique_ptr
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h"

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.h
@@ -1,8 +1,8 @@
 // Author: Marco Rovere - marco.rovere@cern.ch
 // Date: 10/2021
 
-#ifndef __RecoHGCal_TICL_PRbyFASTJET_H__
-#define __RecoHGCal_TICL_PRbyFASTJET_H__
+#ifndef RecoHGCal_TICL_PatternRecognitionbyFastJet_h
+#define RecoHGCal_TICL_PatternRecognitionbyFastJet_h
 #include <memory>  // unique_ptr
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h"

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyRecovery.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyRecovery.h
@@ -1,8 +1,8 @@
 // Author: Felice Pantaleo - felice.pantaleo@cern.ch
 // Date: 05/2024
 
-#ifndef __RecoHGCal_TICL_PatternRecognitionbyRecovery_H__
-#define __RecoHGCal_TICL_PatternRecognitionbyRecovery_H__
+#ifndef RecoHGCal_TICL_PatternRecognitionbyRecovery_h
+#define RecoHGCal_TICL_PatternRecognitionbyRecovery_h
 #include <memory>  // unique_ptr
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "RecoHGCal/TICL/interface/PatternRecognitionAlgoBase.h"
@@ -33,4 +33,4 @@ namespace ticl {
 
 }  // namespace ticl
 
-#endif  // __RecoHGCal_TICL_PatternRecognitionbyRecovery_H__
+#endif  // RecoHGCal_TICL_PatternRecognitionbyRecovery_h

--- a/RecoHGCal/TICL/plugins/SeedingRegionAlgoBase.h
+++ b/RecoHGCal/TICL/plugins/SeedingRegionAlgoBase.h
@@ -2,8 +2,8 @@
 // Emails: felice.pantaleo@cern.ch, marco.rovere@cern.ch
 // Date: 06/2019
 
-#ifndef RecoHGCal_TICL_SeedingRegionAlgoBase_H__
-#define RecoHGCal_TICL_SeedingRegionAlgoBase_H__
+#ifndef RecoHGCal_TICL_SeedingRegionAlgoBase_h
+#define RecoHGCal_TICL_SeedingRegionAlgoBase_h
 
 #include <memory>
 #include <vector>

--- a/RecoHGCal/TICL/plugins/SeedingRegionAlgoFactory.h
+++ b/RecoHGCal/TICL/plugins/SeedingRegionAlgoFactory.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCAL_TICL_SeedingRegionAlgoFactory_h
-#define RecoHGCAL_TICL_SeedingRegionAlgoFactory_h
+#ifndef RecoHGCal_TICL_SeedingRegionAlgoFactory_h
+#define RecoHGCal_TICL_SeedingRegionAlgoFactory_h
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"

--- a/RecoHGCal/TICL/plugins/SeedingRegionGlobal.h
+++ b/RecoHGCal/TICL/plugins/SeedingRegionGlobal.h
@@ -1,8 +1,8 @@
 // Author: Felice Pantaleo,Marco Rovere - felice.pantaleo@cern.ch, marco.rovere@cern.ch
 // Date: 09/2018
 
-#ifndef __RecoHGCal_TICL_SeedingRegionGlobal_H__
-#define __RecoHGCal_TICL_SeedingRegionGlobal_H__
+#ifndef RecoHGCal_TICL_SeedingRegionGlobal_h
+#define RecoHGCal_TICL_SeedingRegionGlobal_h
 #include <memory>  // unique_ptr
 #include <string>
 #include "RecoHGCal/TICL/plugins/SeedingRegionAlgoBase.h"

--- a/RecoHGCal/TICL/plugins/TICLGraph.h
+++ b/RecoHGCal/TICL/plugins/TICLGraph.h
@@ -1,5 +1,5 @@
-#ifndef DataFormats_HGCalReco_TICLGraph_h
-#define DataFormats_HGCalReco_TICLGraph_h
+#ifndef RecoHGCal_TICL_TICLGraph_h
+#define RecoHGCal_TICL_TICLGraph_h
 
 #include "DataFormats/HGCalReco/interface/Trackster.h"
 #include "DataFormats/TrackReco/interface/Track.h"

--- a/RecoHGCal/TICL/plugins/TICLInterpretationPluginFactory.h
+++ b/RecoHGCal/TICL/plugins/TICLInterpretationPluginFactory.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_TICLInterpretationPluginFactory_H
-#define RecoHGCal_TICL_TICLInterpretationPluginFactory_H
+#ifndef RecoHGCal_TICL_TICLInterpretationPluginFactory_h
+#define RecoHGCal_TICL_TICLInterpretationPluginFactory_h
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoHGCal/TICL/plugins/TracksterLinkingPluginFactory.h
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingPluginFactory.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_TracksterLinkingPluginFactory_H
-#define RecoHGCal_TICL_TracksterLinkingPluginFactory_H
+#ifndef RecoHGCal_TICL_TracksterLinkingPluginFactory_h
+#define RecoHGCal_TICL_TracksterLinkingPluginFactory_h
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoHGCal/TICL/plugins/TracksterLinkingRecovery.h
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingRecovery.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_TracksterLinkingRecovery_H
-#define RecoHGCal_TICL_TracksterLinkingRecovery_H
+#ifndef RecoHGCal_TICL_TracksterLinkingRecovery_h
+#define RecoHGCal_TICL_TracksterLinkingRecovery_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbyFastJet.h
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbyFastJet.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_TracksterLinkingAlgoByFastJet_H
-#define RecoHGCal_TICL_TracksterLinkingAlgoByFastJet_H
+#ifndef RecoHGCal_TICL_TracksterLinkingbyFastJet_h
+#define RecoHGCal_TICL_TracksterLinkingbyFastJet_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.h
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySkeletons.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_TracksterLinkingAlgoBySkeletons_H
-#define RecoHGCal_TICL_TracksterLinkingAlgoBySkeletons_H
+#ifndef RecoHGCal_TICL_TracksterLinkingbySkeletons_h
+#define RecoHGCal_TICL_TracksterLinkingbySkeletons_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySuperClusteringDNN.h
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySuperClusteringDNN.h
@@ -1,5 +1,5 @@
-#ifndef RecoHGCal_TICL_TracksterLinkingSuperClustering_H
-#define RecoHGCal_TICL_TracksterLinkingSuperClustering_H
+#ifndef RecoHGCal_TICL_TracksterLinkingbySuperClusteringDNN_h
+#define RecoHGCal_TICL_TracksterLinkingbySuperClusteringDNN_h
 /*
 TICL plugin for electron superclustering in HGCAL using a DNN. 
 DNN designed and trained by Alessandro Tarabini.

--- a/RecoHGCal/TICL/plugins/TracksterLinkingbySuperClusteringMustache.h
+++ b/RecoHGCal/TICL/plugins/TracksterLinkingbySuperClusteringMustache.h
@@ -4,8 +4,8 @@ Authors : Theo Cuisset <theo.cuisset@cern.ch>, Shamik Ghosh <shamik.ghosh@cern.c
 Date : 06/2024
 */
 
-#ifndef RecoHGCal_TICL_TracksterLinkingSuperClusteringMustache_H
-#define RecoHGCal_TICL_TracksterLinkingSuperClusteringMustache_H
+#ifndef RecoHGCal_TICL_TracksterLinkingbySuperClusteringMustache_h
+#define RecoHGCal_TICL_TracksterLinkingbySuperClusteringMustache_h
 
 #include <vector>
 

--- a/RecoHGCal/TICL/plugins/TracksterLinksProducer.cc
+++ b/RecoHGCal/TICL/plugins/TracksterLinksProducer.cc
@@ -178,9 +178,9 @@ void TracksterLinksProducer::beginRun(edm::Run const &iEvent, edm::EventSetup co
 };
 
 void TracksterLinksProducer::dumpTrackster(const Trackster &t) const {
-  auto e_over_h = (t.raw_em_pt() / ((t.raw_pt() - t.raw_em_pt()) != 0. ? (t.raw_pt() - t.raw_em_pt()) : 1.));
   LogDebug("TracksterLinksProducer")
-      << "\nTrackster raw_pt: " << t.raw_pt() << " raw_em_pt: " << t.raw_em_pt() << " eoh: " << e_over_h
+      << "\nTrackster raw_pt: " << t.raw_pt() << " raw_em_pt: " << t.raw_em_pt()
+      << " eoh: " << (t.raw_em_pt() / ((t.raw_pt() - t.raw_em_pt()) != 0. ? (t.raw_pt() - t.raw_em_pt()) : 1.))
       << " barycenter: " << t.barycenter() << " eta,phi (baricenter): " << t.barycenter().eta() << ", "
       << t.barycenter().phi() << " eta,phi (eigen): " << t.eigenvectors(0).eta() << ", " << t.eigenvectors(0).phi()
       << " pt(eigen): " << std::sqrt(t.eigenvectors(0).Unit().perp2()) * t.raw_energy() << " seedID: " << t.seedID()

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.h
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.h
@@ -1,5 +1,5 @@
-#ifndef RECOHGCAL_TICL_TRACKSTERSPCA_H
-#define RECOHGCAL_TICL_TRACKSTERSPCA_H
+#ifndef RecoHGCal_TICL_TrackstersPCA_h
+#define RecoHGCal_TICL_TrackstersPCA_h
 
 #include "DataFormats/HGCalReco/interface/Trackster.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"

--- a/RecoHGCal/TICL/test/TiclDebugger.cc
+++ b/RecoHGCal/TICL/test/TiclDebugger.cc
@@ -77,7 +77,7 @@ TiclDebugger::TiclDebugger(const edm::ParameterSet& iConfig)
 TiclDebugger::~TiclDebugger() {}
 
 void TiclDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  static const char* particle_kind[] = {"gam", "e", "mu", "pi0", "h", "h0", "?", "!"};
+  static const char* const particle_kind[] = {"gam", "e", "mu", "pi0", "h", "h0", "?", "!"};
   using namespace edm;
   using std::begin;
   using std::end;


### PR DESCRIPTION
Findings from cmsCodeRulesChecker, clang-format, scram b code-checks and the LLVM static analyzer (scram b checker) on the package.

Include guards (TCR-1): three headers shared the guard RecoHGCal_TICL_PatternRecognitionAlgoBase_H__ (PatternRecognitionAlgoBase.h, TICLInterpretationAlgoBase.h, TracksterLinkingAlgoBase.h) -- a real bug, since a translation unit including two of them silently dropped the second body. Other guards used reserved double-underscore forms (..._H__, leading __...), wrong package casing (RecoHGCAL_/RECOHGCAL_), or a foreign-package guard (TICLGraph.h used DataFormats_HGCalReco_TICLGraph_h). Normalised all 41 to the canonical RecoHGCal_TICL_<File>_h; guards are now unique and free of reserved __.

