### PR TITLE
 More unit tests fixes for TkAl offline validation tools for Phase-2

### DIFF
--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -381,7 +381,21 @@ def getSequence(process, collection,
 
         if g4Refitting:
             customlog("Here we must include geopro first")
-            process.load('Configuration.StandardSequences.GeometryDB_cff')
+
+            def _loadGeometryPhase2(process):
+                customlog("Phase2 era detected, loading Phase2 geometry")
+                process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
+
+            from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+            loadPhase2geom = phase2_common.makeProcessModifier(_loadGeometryPhase2)
+
+            def _loadGeometryRun3(process):
+                customlog("Non-Phase2 era, loading standard geometry")
+                process.load('Configuration.StandardSequences.GeometryDB_cff')
+
+            from Configuration.Eras.Modifier_run3_common_cff import run3_common
+            loadRun3geom = run3_common.makeProcessModifier(_loadGeometryRun3)
+
             process.load("TrackPropagation.Geant4e.geantRefit_cff")
             modules.append(getattr(process,"geopro"))
 

--- a/Alignment/OfflineValidation/interface/OfflineValidationUtils.h
+++ b/Alignment/OfflineValidation/interface/OfflineValidationUtils.h
@@ -1,0 +1,83 @@
+#ifndef Alignment_OfflineValidation_Utils_h
+#define Alignment_OfflineValidation_Utils_h
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
+#include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
+#include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+namespace alignment {
+  namespace offlineValidationUtils {
+    //*************************************************************
+    static bool isHit2D(const TrackingRecHit &hit, const TrackerGeometry *geom, const SiPixelPI::phase &thePhase)
+    //*************************************************************
+    {
+      // helper functionals
+      auto isPinPS = [&](DetId detId) {
+        // Select only P-hits from the OT barrel
+        return (geom->getDetectorType(detId) == TrackerGeometry::ModuleType::Ph2PSP);
+      };
+
+      auto isPixel = [&](DetId detId) {
+        auto subId = detId.subdetId();
+        return (subId == PixelSubdetector::PixelBarrel || subId == PixelSubdetector::PixelEndcap);
+      };
+
+      bool countStereoHitAs2D_ = true;
+      // we count SiStrip stereo modules as 2D if selected via countStereoHitAs2D_
+      // (since they provide theta information)
+      if (!hit.isValid() ||
+          (hit.dimension() < 2 && !countStereoHitAs2D_ && !dynamic_cast<const SiStripRecHit1D *>(&hit))) {
+        return false;  // real RecHit1D - but SiStripRecHit1D depends on countStereoHitAs2D_
+      } else {
+        const DetId detId(hit.geographicalId());
+        if (detId.det() == DetId::Tracker) {
+          if (isPixel(detId)) {
+            return true;  // pixel is always 2D
+          } else {
+            if (thePhase == SiPixelPI::phase::two) {
+              // if the hit is phase-2
+              if (isPinPS(detId))
+                return true;
+              else
+                return false;
+            } else {
+              // should be SiStrip now
+              const SiStripDetId stripId(detId);
+              if (stripId.stereo())
+                return countStereoHitAs2D_;  // stereo modules
+              else if (dynamic_cast<const SiStripRecHit1D *>(&hit) || dynamic_cast<const SiStripRecHit2D *>(&hit))
+                return false;  // rphi modules hit
+              //the following two are not used any more since ages...
+              else if (dynamic_cast<const SiStripMatchedRecHit2D *>(&hit))
+                return true;  // matched is 2D
+              else if (dynamic_cast<const ProjectedSiStripRecHit2D *>(&hit)) {
+                const ProjectedSiStripRecHit2D *pH = static_cast<const ProjectedSiStripRecHit2D *>(&hit);
+                return (countStereoHitAs2D_ && isHit2D(pH->originalHit(), geom, thePhase));  // depends on original...
+              } else {
+                edm::LogError("UnknownType") << "alignment::offlineValidationUtils::isHit2D"
+                                             << "Tracker hit not in pixel, neither SiStripRecHit[12]D nor "
+                                             << "SiStripMatchedRecHit2D nor ProjectedSiStripRecHit2D.";
+                return false;
+              }
+            }
+          }
+        } else {  // not tracker??
+          edm::LogWarning("DetectorMismatch") << "alignment::offlineValidationUtils::isHit2D"
+                                              << "Hit not in tracker with 'official' dimension >=2.";
+          return true;  // dimension() >= 2 so accept that...
+        }
+      }
+      // never reached...
+    }
+  }  // namespace offlineValidationUtils
+}  // namespace alignment
+
+#endif  // Alignment_OfflineValidation_Utils_h

--- a/Alignment/OfflineValidation/plugins/DMRChecker.cc
+++ b/Alignment/OfflineValidation/plugins/DMRChecker.cc
@@ -118,8 +118,6 @@
 using namespace std;
 using namespace edm;
 
-const int kBPIX = PixelSubdetector::PixelBarrel;
-const int kFPIX = PixelSubdetector::PixelEndcap;
 constexpr float cmToUm = 10000.;
 
 /**

--- a/Alignment/OfflineValidation/plugins/DMRChecker.cc
+++ b/Alignment/OfflineValidation/plugins/DMRChecker.cc
@@ -49,6 +49,7 @@
 
 // user system includes
 
+#include "Alignment/OfflineValidation/interface/OfflineValidationUtils.h"
 #include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
 #include "CommonTools/TrackerMap/interface/TrackerMap.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
@@ -76,7 +77,6 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackReco/interface/HitPattern.h"
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -85,11 +85,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackResiduals.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -555,8 +551,9 @@ private:
       unsigned int nHit2D = 0;
       int h_index = 0;
       for (trackingRecHit_iterator iHit = track.recHitsBegin(); iHit != track.recHitsEnd(); ++iHit, ++h_index) {
-        if (this->isHit2D(**iHit))
+        if (alignment::offlineValidationUtils::isHit2D(**iHit, trackerGeometry_, phase_)) {
           ++nHit2D;
+        }
 
         double resX = residuals.residualX(h_index);
         double resY = residuals.residualY(h_index);
@@ -1877,49 +1874,6 @@ private:
                        1 - gPad->GetTopMargin() + 0.01,
                        (PixelRegions::IDlabels.at(index) + " " + toAppend).c_str());
     }
-  }
-
-  //*************************************************************
-  // check if the hit is 2D
-  //*************************************************************
-  bool isHit2D(const TrackingRecHit &hit) {
-    bool countStereoHitAs2D_ = true;
-    // we count SiStrip stereo modules as 2D if selected via countStereoHitAs2D_
-    // (since they provide theta information)
-    if (!hit.isValid() ||
-        (hit.dimension() < 2 && !countStereoHitAs2D_ && !dynamic_cast<const SiStripRecHit1D *>(&hit))) {
-      return false;  // real RecHit1D - but SiStripRecHit1D depends on countStereoHitAs2D_
-    } else {
-      const DetId detId(hit.geographicalId());
-      if (detId.det() == DetId::Tracker) {
-        if (detId.subdetId() == kBPIX || detId.subdetId() == kFPIX) {
-          return true;  // pixel is always 2D
-        } else {        // should be SiStrip now
-          const SiStripDetId stripId(detId);
-          if (stripId.stereo())
-            return countStereoHitAs2D_;  // stereo modules
-          else if (dynamic_cast<const SiStripRecHit1D *>(&hit) || dynamic_cast<const SiStripRecHit2D *>(&hit))
-            return false;  // rphi modules hit
-          //the following two are not used any more since ages...
-          else if (dynamic_cast<const SiStripMatchedRecHit2D *>(&hit))
-            return true;  // matched is 2D
-          else if (dynamic_cast<const ProjectedSiStripRecHit2D *>(&hit)) {
-            const ProjectedSiStripRecHit2D *pH = static_cast<const ProjectedSiStripRecHit2D *>(&hit);
-            return (countStereoHitAs2D_ && this->isHit2D(pH->originalHit()));  // depends on original...
-          } else {
-            edm::LogError("UnknownType") << "@SUB=DMRChecker::isHit2D"
-                                         << "Tracker hit not in pixel, neither SiStripRecHit[12]D nor "
-                                         << "SiStripMatchedRecHit2D nor ProjectedSiStripRecHit2D.";
-            return false;
-          }
-        }
-      } else {  // not tracker??
-        edm::LogWarning("DetectorMismatch") << "@SUB=DMRChecker::isHit2D"
-                                            << "Hit not in tracker with 'official' dimension >=2.";
-        return true;  // dimension() >= 2 so accept that...
-      }
-    }
-    // never reached...
   }
 
   //*************************************************************

--- a/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
@@ -370,7 +370,7 @@ private:
       unsigned int nHit2D = 0;
       std::bitset<16> rocsToMask;
       for (auto iHit = track->recHitsBegin(); iHit != track->recHitsEnd(); ++iHit) {
-        if (this->isHit2D(**iHit)) {
+        if (this->isHit2D(**iHit, theGeometry)) {
           ++nHit2D;
         }
         // rest the ROCs for the map
@@ -1162,9 +1162,20 @@ private:
   }
 
   //*************************************************************
-  bool isHit2D(const TrackingRecHit &hit)
+  bool isHit2D(const TrackingRecHit &hit, const TrackerGeometry *geom)
   //*************************************************************
   {
+    // helper functionals
+    auto isPinPS = [&](DetId detId) {
+      // Select only P-hits from the OT barrel
+      return (geom->getDetectorType(detId) == TrackerGeometry::ModuleType::Ph2PSP);
+    };
+
+    auto isPixel = [&](DetId detId) {
+      auto subId = detId.subdetId();
+      return (subId == PixelSubdetector::PixelBarrel || subId == PixelSubdetector::PixelEndcap);
+    };
+
     bool countStereoHitAs2D_ = true;
     // we count SiStrip stereo modules as 2D if selected via countStereoHitAs2D_
     // (since they provide theta information)
@@ -1174,25 +1185,34 @@ private:
     } else {
       const DetId detId(hit.geographicalId());
       if (detId.det() == DetId::Tracker) {
-        if (detId.subdetId() == kBPIX || detId.subdetId() == kFPIX) {
+        if (isPixel(detId)) {
           return true;  // pixel is always 2D
-        } else {        // should be SiStrip now
-          const SiStripDetId stripId(detId);
-          if (stripId.stereo())
-            return countStereoHitAs2D_;  // stereo modules
-          else if (dynamic_cast<const SiStripRecHit1D *>(&hit) || dynamic_cast<const SiStripRecHit2D *>(&hit))
-            return false;  // rphi modules hit
-          //the following two are not used any more since ages...
-          else if (dynamic_cast<const SiStripMatchedRecHit2D *>(&hit))
-            return true;  // matched is 2D
-          else if (dynamic_cast<const ProjectedSiStripRecHit2D *>(&hit)) {
-            const ProjectedSiStripRecHit2D *pH = static_cast<const ProjectedSiStripRecHit2D *>(&hit);
-            return (countStereoHitAs2D_ && this->isHit2D(pH->originalHit()));  // depends on original...
+        } else {
+          if (phase_ == SiPixelPI::phase::two) {
+            // if the hit is phase-2
+            if (isPinPS(detId))
+              return true;
+            else
+              return false;
           } else {
-            edm::LogError("UnknownType") << "@SUB=GeneralPurposeTrackAnalyzer::isHit2D"
-                                         << "Tracker hit not in pixel, neither SiStripRecHit[12]D nor "
-                                         << "SiStripMatchedRecHit2D nor ProjectedSiStripRecHit2D.";
-            return false;
+            // should be SiStrip now
+            const SiStripDetId stripId(detId);
+            if (stripId.stereo())
+              return countStereoHitAs2D_;  // stereo modules
+            else if (dynamic_cast<const SiStripRecHit1D *>(&hit) || dynamic_cast<const SiStripRecHit2D *>(&hit))
+              return false;  // rphi modules hit
+            //the following two are not used any more since ages...
+            else if (dynamic_cast<const SiStripMatchedRecHit2D *>(&hit))
+              return true;  // matched is 2D
+            else if (dynamic_cast<const ProjectedSiStripRecHit2D *>(&hit)) {
+              const ProjectedSiStripRecHit2D *pH = static_cast<const ProjectedSiStripRecHit2D *>(&hit);
+              return (countStereoHitAs2D_ && this->isHit2D(pH->originalHit(), geom));  // depends on original...
+            } else {
+              edm::LogError("UnknownType") << "@SUB=GeneralPurposeTrackAnalyzer::isHit2D"
+                                           << "Tracker hit not in pixel, neither SiStripRecHit[12]D nor "
+                                           << "SiStripMatchedRecHit2D nor ProjectedSiStripRecHit2D.";
+              return false;
+            }
           }
         }
       } else {  // not tracker??

--- a/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
@@ -75,9 +75,6 @@
 // toggle to enable debugging
 #define DEBUG 0
 
-const int kBPIX = PixelSubdetector::PixelBarrel;
-const int kFPIX = PixelSubdetector::PixelEndcap;
-
 class GeneralPurposeTrackAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   GeneralPurposeTrackAnalyzer(const edm::ParameterSet &pset)

--- a/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
@@ -32,9 +32,9 @@
 #include <boost/range/adaptor/indexed.hpp>
 
 // user include files
+#include "Alignment/OfflineValidation/interface/OfflineValidationUtils.h"
 #include "CommonTools/TrackerMap/interface/TrackerMap.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
@@ -48,18 +48,10 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/GeometrySurface/interface/LocalError.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
-#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/TrackReco/interface/HitPattern.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -370,7 +362,7 @@ private:
       unsigned int nHit2D = 0;
       std::bitset<16> rocsToMask;
       for (auto iHit = track->recHitsBegin(); iHit != track->recHitsEnd(); ++iHit) {
-        if (this->isHit2D(**iHit, theGeometry)) {
+        if (alignment::offlineValidationUtils::isHit2D(**iHit, theGeometry, phase_)) {
           ++nHit2D;
         }
         // rest the ROCs for the map
@@ -1159,69 +1151,6 @@ private:
       pixelrocsmap_->drawMaps(cRocs, "Pixel on-track clusters occupancy");
       cRocs.SaveAs("Phase1PixelROCMaps_fullROCs.png");
     }
-  }
-
-  //*************************************************************
-  bool isHit2D(const TrackingRecHit &hit, const TrackerGeometry *geom)
-  //*************************************************************
-  {
-    // helper functionals
-    auto isPinPS = [&](DetId detId) {
-      // Select only P-hits from the OT barrel
-      return (geom->getDetectorType(detId) == TrackerGeometry::ModuleType::Ph2PSP);
-    };
-
-    auto isPixel = [&](DetId detId) {
-      auto subId = detId.subdetId();
-      return (subId == PixelSubdetector::PixelBarrel || subId == PixelSubdetector::PixelEndcap);
-    };
-
-    bool countStereoHitAs2D_ = true;
-    // we count SiStrip stereo modules as 2D if selected via countStereoHitAs2D_
-    // (since they provide theta information)
-    if (!hit.isValid() ||
-        (hit.dimension() < 2 && !countStereoHitAs2D_ && !dynamic_cast<const SiStripRecHit1D *>(&hit))) {
-      return false;  // real RecHit1D - but SiStripRecHit1D depends on countStereoHitAs2D_
-    } else {
-      const DetId detId(hit.geographicalId());
-      if (detId.det() == DetId::Tracker) {
-        if (isPixel(detId)) {
-          return true;  // pixel is always 2D
-        } else {
-          if (phase_ == SiPixelPI::phase::two) {
-            // if the hit is phase-2
-            if (isPinPS(detId))
-              return true;
-            else
-              return false;
-          } else {
-            // should be SiStrip now
-            const SiStripDetId stripId(detId);
-            if (stripId.stereo())
-              return countStereoHitAs2D_;  // stereo modules
-            else if (dynamic_cast<const SiStripRecHit1D *>(&hit) || dynamic_cast<const SiStripRecHit2D *>(&hit))
-              return false;  // rphi modules hit
-            //the following two are not used any more since ages...
-            else if (dynamic_cast<const SiStripMatchedRecHit2D *>(&hit))
-              return true;  // matched is 2D
-            else if (dynamic_cast<const ProjectedSiStripRecHit2D *>(&hit)) {
-              const ProjectedSiStripRecHit2D *pH = static_cast<const ProjectedSiStripRecHit2D *>(&hit);
-              return (countStereoHitAs2D_ && this->isHit2D(pH->originalHit(), geom));  // depends on original...
-            } else {
-              edm::LogError("UnknownType") << "@SUB=GeneralPurposeTrackAnalyzer::isHit2D"
-                                           << "Tracker hit not in pixel, neither SiStripRecHit[12]D nor "
-                                           << "SiStripMatchedRecHit2D nor ProjectedSiStripRecHit2D.";
-              return false;
-            }
-          }
-        }
-      } else {  // not tracker??
-        edm::LogWarning("DetectorMismatch") << "@SUB=GeneralPurposeTrackAnalyzer::isHit2D"
-                                            << "Hit not in tracker with 'official' dimension >=2.";
-        return true;  // dimension() >= 2 so accept that...
-      }
-    }
-    // never reached...
   }
 };
 

--- a/Alignment/OfflineValidation/plugins/ShortenedTrackValidation.cc
+++ b/Alignment/OfflineValidation/plugins/ShortenedTrackValidation.cc
@@ -54,9 +54,6 @@
 #define CREATE_HIST_2D(varname, nbins, first, last, fs) \
   fs.make<TH2D>(#varname, #varname, nbins, first, last, nbins, first, last)
 
-const int kBPIX = PixelSubdetector::PixelBarrel;
-const int kFPIX = PixelSubdetector::PixelEndcap;
-
 class ShortenedTrackValidation : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
   class trackingMon {
   public:

--- a/Alignment/OfflineValidation/plugins/ShortenedTrackValidation.cc
+++ b/Alignment/OfflineValidation/plugins/ShortenedTrackValidation.cc
@@ -30,6 +30,7 @@
 #include <fmt/printf.h>
 
 // user includes
+#include "Alignment/OfflineValidation/interface/OfflineValidationUtils.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
@@ -45,6 +46,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/transform.h"  // for edm::vector_transform
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #define CREATE_HIST_1D(varname, nbins, first, last, fs) fs.make<TH1D>(#varname, #varname, nbins, first, last)
 
@@ -54,7 +57,7 @@
 const int kBPIX = PixelSubdetector::PixelBarrel;
 const int kFPIX = PixelSubdetector::PixelEndcap;
 
-class ShortenedTrackValidation : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+class ShortenedTrackValidation : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
   class trackingMon {
   public:
     trackingMon() {}
@@ -115,42 +118,10 @@ class ShortenedTrackValidation : public edm::one::EDAnalyzer<edm::one::SharedRes
     }
 
     //____________________________________________________________
-    static bool isHit2D(const TrackingRecHit &hit) {
-      if (hit.dimension() < 2) {
-        return false;  // some (muon...) stuff really has RecHit1D
-      } else {
-        const DetId detId(hit.geographicalId());
-        if (detId.det() == DetId::Tracker) {
-          if (detId.subdetId() == kBPIX || detId.subdetId() == kFPIX) {
-            return true;  // pixel is always 2D
-          } else {        // should be SiStrip now
-            if (dynamic_cast<const SiStripRecHit2D *>(&hit))
-              return false;  // normal hit
-            else if (dynamic_cast<const SiStripMatchedRecHit2D *>(&hit))
-              return true;  // matched is 2D
-            else if (dynamic_cast<const ProjectedSiStripRecHit2D *>(&hit))
-              return false;  // crazy hit...
-            else {
-              edm::LogError("UnknownType") << "@SUB=CalibrationTrackSelector::isHit2D"
-                                           << "Tracker hit not in pixel and neither SiStripRecHit2D nor "
-                                           << "SiStripMatchedRecHit2D nor ProjectedSiStripRecHit2D.";
-              return false;
-            }
-          }
-        } else {  // not tracker??
-          edm::LogWarning("DetectorMismatch") << "@SUB=CalibrationTrackSelector::isHit2D"
-                                              << "Hit not in tracker with 'official' dimension >=2.";
-          return true;  // dimension() >= 2 so accept that...
-        }
-      }
-      // never reached...
-    }
-
-    //____________________________________________________________
-    unsigned int count2DHits(const reco::Track &track) {
+    unsigned int count2DHits(const reco::Track &track, const TrackerGeometry *geom, const SiPixelPI::phase &thePhase) {
       unsigned int nHit2D = 0;
       for (auto iHit = track.recHitsBegin(); iHit != track.recHitsEnd(); ++iHit) {
-        if (isHit2D(**iHit)) {
+        if (alignment::offlineValidationUtils::isHit2D(**iHit, geom, thePhase)) {
           ++nHit2D;
         }
       }
@@ -158,7 +129,11 @@ class ShortenedTrackValidation : public edm::one::EDAnalyzer<edm::one::SharedRes
     }
 
     //____________________________________________________________
-    void fill(const reco::Track &track, const reco::BeamSpot &beamSpot, const reco::Vertex &pvtx) {
+    void fill(const reco::Track &track,
+              const reco::BeamSpot &beamSpot,
+              const reco::Vertex &pvtx,
+              const TrackerGeometry *geom,
+              const SiPixelPI::phase &thePhase) {
       h_chi2ndof->Fill(track.normalizedChi2());
       h_trkQuality->Fill(trackQual(track));
       h_trkAlgo->Fill(static_cast<float>(track.algo()));
@@ -166,7 +141,7 @@ class ShortenedTrackValidation : public edm::one::EDAnalyzer<edm::one::SharedRes
       h_P->Fill(track.p());
       h_Pt->Fill(track.pt());
       h_nHit->Fill(track.numberOfValidHits());
-      h_nHit2D->Fill(count2DHits(track));
+      h_nHit2D->Fill(count2DHits(track, geom, thePhase));
       h_Charge->Fill(track.charge());
       h_QoverP->Fill(track.qoverp());
       h_QoverPZoom->Fill(track.qoverp());
@@ -319,7 +294,9 @@ private:
   template <typename T, typename... Args>
   T *book(const TFileDirectory &dir, const Args &...args) const;
   void beginJob() override;
+  void beginRun(edm::Run const &iRun, edm::EventSetup const &iSetup) override;
   void analyze(edm::Event const &iEvent, edm::EventSetup const &iSetup) override;
+  void endRun(edm::Run const &, edm::EventSetup const &) override {}
 
   // ----------member data ---------------------------
   edm::Service<TFileService> fs_;
@@ -339,6 +316,10 @@ private:
   const std::vector<edm::EDGetTokenT<std::vector<reco::Track>>> tracksRerecoToken_;
   const edm::EDGetTokenT<reco::BeamSpot> beamspotToken_;
   const edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
+
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  SiPixelPI::phase phase_;
+  const TrackerGeometry *trackerGeometry_;
 
   // monitoring histograms
   std::vector<TH1F *> histsPtRatioAll_;
@@ -377,7 +358,8 @@ ShortenedTrackValidation::ShortenedTrackValidation(const edm::ParameterSet &ps)
       tracksRerecoToken_(edm::vector_transform(
           tracksRerecoTag_, [this](edm::InputTag const &tag) { return consumes<std::vector<reco::Track>>(tag); })),
       beamspotToken_(consumes<reco::BeamSpot>(BeamSpotTag_)),
-      vertexToken_(consumes<reco::VertexCollection>(VerticesTag_)) {
+      vertexToken_(consumes<reco::VertexCollection>(VerticesTag_)),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()) {
   usesResource(TFileService::kSharedResource);
   histsPtRatioAll_.clear();
   histsPtDiffAll_.clear();
@@ -403,6 +385,18 @@ template <typename T, typename... Args>
 T *ShortenedTrackValidation::book(const TFileDirectory &dir, const Args &...args) const {
   T *t = dir.make<T>(args...);
   return t;
+}
+
+void ShortenedTrackValidation::beginRun(edm::Run const &iRun, edm::EventSetup const &iSetup) {
+  trackerGeometry_ = &iSetup.getData(geomToken_);
+  if (trackerGeometry_->isThere(GeomDetEnumerators::P2PXB) || trackerGeometry_->isThere(GeomDetEnumerators::P2PXEC)) {
+    phase_ = SiPixelPI::phase::two;
+  } else if (trackerGeometry_->isThere(GeomDetEnumerators::P1PXB) ||
+             trackerGeometry_->isThere(GeomDetEnumerators::P1PXEC)) {
+    phase_ = SiPixelPI::phase::one;
+  } else {
+    phase_ = SiPixelPI::phase::zero;
+  }
 }
 
 //__________________________________________________________________________________
@@ -549,7 +543,7 @@ void ShortenedTrackValidation::analyze(edm::Event const &iEvent, edm::EventSetup
     }
 
     // fill the original track properties monitoring
-    originalTrack.fill(track, beamSpot, pvtx);
+    originalTrack.fill(track, beamSpot, pvtx, trackerGeometry_, phase_);
 
     TLorentzVector tvec;
     tvec.SetPtEtaPhiM(track.pt(), track.eta(), track.phi(), muMass);

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
@@ -7,7 +7,7 @@ import FWCore.ParameterSet.Config as cms
 import FWCore.PythonUtilities.LumiList as LumiList
 from FWCore.ParameterSet.VarParsing import VarParsing
 from Alignment.OfflineValidation.TkAlAllInOneTool.utils import _byteify
-from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_DoubleMuon_string
+from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_DoubleMuonAlCa_string
 
 ###################################################################
 # Define process
@@ -49,7 +49,7 @@ if "dataset" in config["validation"]:
         for fileName in datafiles.readlines():
             readFiles.append(fileName.replace("\n", ""))
 else:
-    readFiles = filesDefaultMC_DoubleMuon_string
+    readFiles = filesDefaultMC_DoubleMuonAlCa_string
 
 ###################################################################
 # Get good lumi section

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -51,16 +51,17 @@
   <test name="DiElectronVertex" command="testingScripts/test_unitDiElectronVertex.sh"/> 
   <test name="SubmitPVrbr" command="testingScripts/test_unitSubmitPVrbr.sh"/>
   <test name="SubmitPVsplit" command="testingScripts/test_unitSubmitPVsplit.sh"/>
-  <!-- <test name="EoP" command="testingScripts/test_unitEoP.sh"/> COMMENT: reads old format file -->
-  <!-- <bin file="testEoPPlotting.cpp" name="testEoPPlotting">
+  <test name="EoP" command="testingScripts/test_unitEoP.sh"/>
+  <bin file="testEoPPlotting.cpp" name="testEoPPlotting">
     <flags PRE_TEST="EoP"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>
     <use name="rootgraphics"/>
     <use name="Alignment/OfflineValidation"/>
-  </bin> -->
-  <!-- <test name="Miscellanea" command="testingScripts/test_unitMiscellanea.sh"/> COMMENT: reads old format file -->
-  <!-- <test name="ShortTrackValidation" command="testingScripts/test_unitShortTrackValidation.sh"/> COMMENT: reads old format file -->
+  </bin>
+  <!-- COMMENT: reads old format file: needs more work when cosmics samples are available -->
+  <test name="Miscellanea" command="testingScripts/test_unitMiscellanea.sh"/>
+  <test name="ShortTrackValidation" command="testingScripts/test_unitShortTrackValidation.sh"/>
   <test name="SagittaBiasNtuplizer" command="testingScripts/test_unitSagittaBiasNtuplizer.sh"/>
   <test name="BeamSpotPlotting" command="testingScripts/test_unitBeamSpotPlotting.sh"/>
   <bin file="testanalyzeDiMuonBiases.cpp" name="testDiMuonBiasesPlotting"> 

--- a/Alignment/OfflineValidation/test/eopElecTreeWriter_cfg.py
+++ b/Alignment/OfflineValidation/test/eopElecTreeWriter_cfg.py
@@ -12,6 +12,10 @@ else :
     exit
     
 import FWCore.ParameterSet.VarParsing as VarParsing
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
+
 options = VarParsing.VarParsing("analysis")
 
 options.register ('outputRootFile',
@@ -21,7 +25,7 @@ options.register ('outputRootFile',
                   "output root file")
 
 options.register ('GlobalTag',
-                  'auto:phase1_2022_realistic',
+                  _PH2_GLOBAL_TAG,
                   VarParsing.VarParsing.multiplicity.singleton,  # singleton or list
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "Global Tag to be used")
@@ -32,9 +36,9 @@ print( "conditionGT       : ", options.GlobalTag)
 print( "outputFile        : ", options.outputRootFile)
 print( "maxEvents         : ", options.maxEvents)
 
+
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Era_Run3_cff import Run3
-process = cms.Process("EnergyOverMomentumTree",Run3)
+process = cms.Process("EnergyOverMomentumTree", _PH2_ERA)
     
 #process.Tracer = cms.Service("Tracer")
 
@@ -49,15 +53,16 @@ process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False))
 # define input files
 process.source = cms.Source("PoolSource",
                             fileNames = cms.untracked.vstring(
-                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/4a1ae43b-f4b3-4ad9-b86e-a7d9f6fc5c40.root',
-                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/33565608-3cac-47fe-a1fc-aef60f866b3a.root',
-                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/87fa96e1-925f-4cd3-878d-98a735737e55.root',
-                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/ea3a1cc8-720f-4392-9f0b-bd04d7f236a8.root',
-                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/3b3e7330-6174-43f3-8a49-c12eeae4d7f2.root',
-                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/ddc48c68-781c-485b-887e-4fcd6f0e0772.root',
-                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/a366a7ca-b71c-457a-8b64-09040f5b5819.root',
-                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/4758604c-b0c1-4e09-a0d4-38dd0da16789.root',
-                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/48985150-6f47-4a7f-b09f-b6301b7ec6ff.root'))
+                                '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/028e09cc-784b-41ab-a712-511d5bb67724.root',
+                                '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/b1273478-d951-4915-b888-c5e73d49f39c.root',
+                                '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/649c30e1-8ec6-4e31-9f17-4c1dd1f6409d.root',
+                                '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/fd8de856-99a9-477c-bb0d-cd572582b004.root',
+                                '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/5aa81899-8d7d-46c9-8636-667de1facc9a.root',
+                                '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/af539472-e507-4896-bc6b-c9795e2def16.root',
+                                '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/0abaf7aa-c2ec-4bcb-96f1-d22d5c7bd937.root',
+                                '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/053a2340-040a-4be4-b335-7f546f24bab6.root',
+                                '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/cf187c8c-96e7-4949-9a75-67d4b7696cf8.root',
+                                '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/0c2bfdc1-278c-4e60-8fa1-2ef58cc3a35b.root'))
                         
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(options.maxEvents)
@@ -76,8 +81,7 @@ process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cf
 ###################################################################
 # Standard loads
 ###################################################################
-from Configuration.Geometry.GeometryRecoDB_cff import *
-process.load("Configuration.Geometry.GeometryRecoDB_cff")
+process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
 
 ####################################################################
 # Get the BeamSpot
@@ -93,6 +97,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, options.GlobalTag, '')
 
 # choose geometry
 if MISALIGN:
+    # TO-DO develop the Phase-2 version of these scenarios!
     print( "MISALIGN")
     from CondCore.CondDB.CondDB_cfi import CondDB
     CondDB.connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")

--- a/Alignment/OfflineValidation/test/testG4Refitter_cfg.py
+++ b/Alignment/OfflineValidation/test/testG4Refitter_cfg.py
@@ -3,9 +3,11 @@ import sys
 from enum import Enum
 import FWCore.ParameterSet.VarParsing as VarParsing
 from Configuration.StandardSequences.Eras import eras
-from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_TTBarPU 
+from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_TTbarPhase2RECO
 
-process = cms.Process("Demo") 
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+process = cms.Process("Demo",_PH2_ERA)
 
 options = VarParsing.VarParsing ()
 options.register('maxEvents',
@@ -19,7 +21,7 @@ options.parseArguments()
 # Event source and run selection
 ###################################################################
 process.source = cms.Source("PoolSource",
-                            fileNames = filesDefaultMC_TTBarPU,
+                            fileNames = filesDefaultMC_TTbarPhase2RECO,
                             duplicateCheckMode = cms.untracked.string('checkAllFilesOpened')
                             )
 
@@ -57,7 +59,7 @@ process.load('Configuration.StandardSequences.MagneticField_cff')
 ###################################################################
 # Standard loads
 ###################################################################
-process.load("Configuration.Geometry.GeometryRecoDB_cff")
+process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
 
 ####################################################################
 # Get the BeamSpot
@@ -69,7 +71,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG, '')
 
 ####################################################################
 # Load and Configure event selection

--- a/Alignment/OfflineValidation/test/testShortenedTrackValidation_cfg.py
+++ b/Alignment/OfflineValidation/test/testShortenedTrackValidation_cfg.py
@@ -2,22 +2,25 @@ import FWCore.ParameterSet.Config as cms
 import FWCore.Utilities.FileUtils as FileUtils
 from FWCore.ParameterSet.VarParsing import VarParsing
 
+import Configuration.Geometry.defaultPhase2ConditionsEra_cff as _settings
+_PH2_GLOBAL_TAG, _PH2_ERA = _settings.get_era_and_conditions(_settings.DEFAULT_VERSION)
+
 options = VarParsing('analysis')
 options.register('scenario', 
-                 '0',
+                 'null',
                  VarParsing.multiplicity.singleton,
                  VarParsing.varType.string,
                  "Name of input misalignment scenario")
 options.parseArguments()
 
-valid_scenarios = ['-10e-6','-8e-6','-6e-6','-4e-6','-2e-6','0','2e-6','4e-6','6e-6','8e-6','10e-6']
+valid_scenarios = ['null', '-10e-6','-8e-6','-6e-6','-4e-6','-2e-6','0','2e-6','4e-6','6e-6','8e-6','10e-6']
 
 if options.scenario not in valid_scenarios:
     print("Error: Invalid scenario specified. Please choose from the following list: ")
     print(valid_scenarios)
     exit(1)
 
-process = cms.Process("TrackingResolution")
+process = cms.Process("TrackingResolution",_PH2_ERA)
 
 #####################################################################
 # import of standard configurations
@@ -27,7 +30,7 @@ process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 100000
 process.load('Configuration.EventContent.EventContent_cff')
-process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4DefaultReco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
@@ -41,7 +44,8 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 #####################################################################
 process.load("RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi") 
 process.MeasurementTrackerEvent.pixelClusterProducer = "ALCARECOTkAlDiMuon"
-process.MeasurementTrackerEvent.stripClusterProducer = "ALCARECOTkAlDiMuon"
+process.MeasurementTrackerEvent.stripClusterProducer = ""
+process.MeasurementTrackerEvent.Phase2TrackerCluster1DProducer = "ALCARECOTkAlDiMuon"
 process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
 process.MeasurementTrackerEvent.inactiveStripDetectorLabels = cms.VInputTag()
 
@@ -54,8 +58,8 @@ process.maxEvents = cms.untracked.PSet(
 #####################################################################
 # filelist = FileUtils.loadListFromFile("listOfFiles_idealMC_TkAlDiMuonAndVertex.txt")
 # readFiles = cms.untracked.vstring( *filelist)
-# events taken from /DYJetsToMuMu_M-50_TuneCP5_13p6TeV-madgraphMLM-pythia8/Run3Winter23Reco-TkAlDiMuonAndVertex-TRKDesignNoPU_AlcaRecoTRKMu_designGaussSigmaZ4cm_125X_mcRun3_2022_design_v6-v1/ALCARECO
-readFiles = cms.untracked.vstring('/store/mc/Run3Winter23Reco/DYJetsToMuMu_M-50_TuneCP5_13p6TeV-madgraphMLM-pythia8/ALCARECO/TkAlDiMuonAndVertex-TRKDesignNoPU_AlcaRecoTRKMu_designGaussSigmaZ4cm_125X_mcRun3_2022_design_v6-v1/60000/d3af17a5-2409-4551-9c3d-00deb2f3f64f.root')
+# events taken from /RelValZMM_14/CMSSW_20_0_0_pre1-TkAlDiMuonAndVertex-150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/ALCARECO
+readFiles = cms.untracked.vstring('/store/relval/CMSSW_20_0_0_pre1/RelValZMM_14/ALCARECO/TkAlDiMuonAndVertex-150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/b245c25c-c9cd-4329-b081-38a95f3b6bbe.root')
 process.source = cms.Source("PoolSource",fileNames = readFiles)
 
 process.options = cms.untracked.PSet()
@@ -70,11 +74,12 @@ process.TFileService = cms.Service("TFileService",
 # Other statements
 #####################################################################
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, "125X_mcRun3_2022_design_v6", '')
+process.GlobalTag = GlobalTag(process.GlobalTag, _PH2_GLOBAL_TAG, '')
 if (options.scenario=='null'):
     print("null scenario, do nothing")
     pass
 else:
+    # TO-DO develop the Phase-2 version of these scenarios!
     process.GlobalTag.toGet = cms.VPSet(cms.PSet(connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS"),
                                                  record = cms.string('TrackerAlignmentRcd'),
                                                  tag = cms.string("LayerRotation_"+options.scenario)))

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitEoP.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitEoP.sh
@@ -1,8 +1,9 @@
 #! /bin/bash
 function die { echo $1: status $2 ; exit $2; }
 
-echo -e "\n\nTESTING eopTreeWriter (Pion Analysis) ..."
-cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py unitTest=True maxEvents=100 || die "Failure running eopTreeWriter" $?
+### TO DO: the alcareco needs to be produced with the Phase-2 geometry
+#echo -e "\n\nTESTING eopTreeWriter (Pion Analysis) ..."
+#cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py unitTest=True maxEvents=100 || die "Failure running eopTreeWriter" $?
 
 echo -e "\n\nTESTING eopElecTreeWriter (Electron Analysis) ..."
-cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/eopElecTreeWriter_cfg.py maxEvents=100 || die "Failure running eopElecTreeWriter" $?
+cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/eopElecTreeWriter_cfg.py maxEvents=1000 || die "Failure running eopElecTreeWriter" $?

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitMiscellanea.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitMiscellanea.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 function die { echo $1: status $2 ; exit $2; }
 
-echo "TESTING inspect ALCARECO data ..."
-cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/inspectData_cfg.py unitTest=True isCosmics=True trackCollection=ALCARECOTkAlCosmicsCTF0T || die "Failure running inspectData_cfg.py" $?
+#echo "TESTING inspect ALCARECO data ..."  (needs Phase-2 cosmics samples)
+#cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/inspectData_cfg.py unitTest=True isCosmics=True trackCollection=ALCARECOTkAlCosmicsCTF0T || die "Failure running inspectData_cfg.py" $?
 
 echo "TESTING inspect Phase2 ALCARECO data ..."
 cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/inspectData_cfg.py unitTest=True isCosmics=False globalTag='' trackCollection=ALCARECOTkAlZMuMu isDiMuonData=True Detector='Run4D110' || die "Failure running inspectData_cfg.py on Phase-2 input" $?
@@ -13,8 +13,8 @@ cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/testG4Refitter_cfg.py 
 echo "TESTING Pixel BaryCenter Analyser ..."
 cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/python/TkAlAllInOneTool/PixelBaryCentreAnalyzer_cfg.py unitTest=True || die "Failure running PixelBaryCentreAnalyzer_cfg.py" $?
 
-echo "TESTING CosmicTrackSplitting Analyser ..."
-cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/testSplitterValidation_cfg.py unitTest=True || die "Failure running testSplitterValidation_cfg.py" $?
+#echo "TESTING CosmicTrackSplitting Analyser ..." (needs Phase-2 cosmics samples)
+#cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/testSplitterValidation_cfg.py unitTest=True || die "Failure running testSplitterValidation_cfg.py" $?
 
-echo "TESTING TkAlV0sAnalyzer Analyser ..."
-cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/TkAlV0sAnalyzer_cfg.py unitTest=True || die "Failure running TkAlV0sAnalyzer_cfg.py" $?
+#echo "TESTING TkAlV0sAnalyzer Analyser ..."   (needs Phase-2 TkAlV0s samples)
+#cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/TkAlV0sAnalyzer_cfg.py unitTest=True || die "Failure running TkAlV0sAnalyzer_cfg.py" $?


### PR DESCRIPTION
#### PR description:

After https://github.com/cms-sw/cmssw/pull/51307 was merged, I see that in the re-enabled tests there are a few issues:
- in test `Genericall` there is a lot of warning messages of the type [log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el9_amd64_gcc13/CMSSW_20_1_X_2026-06-28-2300/unitTestLogs/Alignment/OfflineValidation#/14322)

```
%MSG-e UnknownType:  GeneralPurposeTrackAnalyzer:trackanalysis  GeneralPurposeTrackAnalyzer::isHit2D() 29-Jun-2026 01:25:36 CEST  Run: 1 Event: 87901
Tracker hit not in pixel, neither SiStripRecHit[12]D nor SiStripMatchedRecHit2D nor ProjectedSiStripRecHit2D.
%MSG
```
- in test `Zmumuall` there is repeatedly:

```
%MSG-e TrackRefitter:  TrackRefitter:TrackRefitter 29-Jun-2026 01:06:45 CEST  Run: 1 Event: 5001
could not get the reco::TrackCollection.ALCARECOTkAlZMuMu
%MSG
```

The first is due to the fact that the function `isHit2D` is not equipped to manage the 2D Outer Tracker tracking rechits in the PS modules. This is fixed in 2adb95c3926ce5cd3eeb0023537179da08b9fb22. I profit of this PR to move the function (which is common to a few plugins in this package) into a dedicated header files and use it (commits c9d126b47d6ab40827ca169dbe21dad2f3f238c4 and e7ca415fd129d005997d3702369518b1cd9cbe22).
The second is due to the wrong input data to be used (the test needs the `ALCARECO` and not `RECO` data-tier). This is addressed at commit a37ad5baca5dd2c7a847821760089fade15b7402.
Finally I use this PR to re-activate some more tests (where possible) that were missed at https://github.com/cms-sw/cmssw/pull/51307 (commit a37ad5baca5dd2c7a847821760089fade15b7402).

#### PR validation:

`scram b runtests` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

Cc: @TomasKello 