### PR TITLE
MTD reconstruction and validation: fix FTLHit methods, add optional test printouts in Validation code

### DIFF
--- a/DataFormats/FTLRecHit/interface/FTLCluster.h
+++ b/DataFormats/FTLRecHit/interface/FTLCluster.h
@@ -29,9 +29,9 @@ namespace io_v1 {
           : x_(hit_x), y_(hit_y), energy_(hit_energy), time_(hit_time), time_error_(hit_time_error) {}
       constexpr uint16_t x() { return x_; }
       constexpr uint16_t y() { return y_; }
-      constexpr uint16_t energy() { return energy_; }
-      constexpr uint16_t time() { return time_; }
-      constexpr uint16_t time_error() { return time_error_; }
+      constexpr float energy() { return energy_; }
+      constexpr float time() { return time_; }
+      constexpr float time_error() { return time_error_; }
 
     private:
       uint16_t x_;  //row

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -339,9 +339,9 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 #ifdef EDM_ML_DEBUG
   for (const auto& hits : *mtdTrkHitHandle) {
     if (MTDDetId(hits.id()).mtdSubDetector() == MTDDetId::MTDType::BTL) {
-      LogDebug("BtlLocalRecoValidation") << "MTD cluster DetId " << hits.id() << " # cluster " << hits.size();
+      LogTrace("BtlLocalRecoValidation") << "MTD cluster DetId " << hits.id() << " # cluster " << hits.size();
       for (const auto& hit : hits) {
-        LogDebug("BtlLocalRecoValidation")
+        LogTrace("BtlLocalRecoValidation")
             << "MTD_TRH: " << hit.localPosition().x() << "," << hit.localPosition().y() << " : "
             << hit.localPositionError().xx() << "," << hit.localPositionError().yy() << " : " << hit.time() << " : "
             << hit.timeError();
@@ -429,7 +429,7 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     meHitTvsZ_->Fill(global_point.z(), recHit.time());
 
     // Resolution histograms
-    LogDebug("BtlLocalRecoValidation") << "RecoHit DetId= " << detId.rawId()
+    LogTrace("BtlLocalRecoValidation") << "RecoHit DetId= " << detId.rawId()
                                        << " sim hits in id= " << m_btlSimHits.count(detId.rawId());
     if (m_btlSimHits.count(detId.rawId()) == 1 && m_btlSimHits[detId.rawId()].energy > hitMinEnergy_) {
       float longpos_res = recHit.position() - convertMmToCm(m_btlSimHits[detId.rawId()].x);
@@ -456,7 +456,7 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       meTPullvsE_->Fill(m_btlSimHits[detId.rawId()].energy, time_res / recHit.timeError());
     } else if (m_btlSimHits.count(detId.rawId()) == 0) {
       n_reco_btl_nosimhit++;
-      LogDebug("BtlLocalRecoValidation") << "BTL rec hit with no corresponding sim hit in crystal, DetId= "
+      LogTrace("BtlLocalRecoValidation") << "BTL rec hit with no corresponding sim hit in crystal, DetId= "
                                          << detId.rawId() << " geoId= " << geoId.rawId() << " ene= " << recHit.energy()
                                          << " time= " << recHit.time();
     }
@@ -488,6 +488,9 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
             << "GeographicalID: " << std::hex << cluId << " is invalid!" << std::dec << std::endl;
       }
       n_clus_btl++;
+      LogTrace("BtlLocalRecoValidation") << "Cluster DetId " << cluId.rawId() << " size = " << cluster.size()
+                                         << " min/max row = " << cluster.minHitRow() << " " << cluster.maxHitRow()
+                                         << " min/max col = " << cluster.minHitCol() << " " << cluster.maxHitCol();
 
       const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(genericDet->topology());
       const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
@@ -517,10 +520,20 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
       if (optionalPlots_) {
         for (int ihit = 0; ihit < cluster.size(); ++ihit) {
+          auto thisHit = cluster.hit(ihit);
+          LogTrace("BtlLocalRecoValidation")
+              << "Cluster hit " << ihit << " row/col = " << thisHit.x() << " " << thisHit.y()
+              << " time = " << thisHit.time() << " timeError = " << thisHit.time_error()
+              << " energy = " << thisHit.energy();
           int hit_row = cluster.minHitRow() + cluster.hitOffset()[ihit * 2];
           int hit_col = cluster.minHitCol() + cluster.hitOffset()[ihit * 2 + 1];
+          if (hit_row != thisHit.x() || hit_col != thisHit.y()) {
+            edm::LogWarning("BtlLocalRecoValidation")
+                << "Index in cluster memory not consistent, row/col = " << hit_row << " " << hit_col;
+          }
 
           // Match the RECO hit to the corresponding SIM hit
+          bool found(false);
           for (const auto& recHit : *btlRecHitsHandle) {
             BTLDetId hitId(recHit.id().rawId());
 
@@ -552,9 +565,14 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
             cluEneSIM += m_btlSimHits[recHit.id().rawId()].energy;
             cluTimeSIM += m_btlSimHits[recHit.id().rawId()].time * m_btlSimHits[recHit.id().rawId()].energy;
 
+            found = true;
             break;
 
           }  // recHit loop
+          if (!found) {
+            edm::LogWarning("BtlLocalRecoValidation")
+                << "Cluster " << cluster.id().rawId() << " hit " << ihit << " Matching recHit not found!";
+          }
 
         }  // ihit loop
       }
@@ -885,7 +903,7 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       hit_amplitude /= nHits;
       hit_time /= nHits;
 
-      LogDebug("BtlLocalRecoValidation") << "#unc " << nHits << " A/T " << hit_amplitude << " " << hit_time;
+      LogTrace("BtlLocalRecoValidation") << "#unc " << nHits << " A/T " << hit_amplitude << " " << hit_time;
       if (nHits == 0.) {
         edm::LogWarning("BtlLocalRecoValidation") << "Empty uncalibrated hit in DetId " << detId;
         continue;

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -209,9 +209,9 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 #ifdef EDM_ML_DEBUG
   for (const auto& hits : *mtdTrkHitHandle) {
     if (MTDDetId(hits.id()).mtdSubDetector() == MTDDetId::MTDType::ETL) {
-      LogDebug("EtlLocalRecoValidation") << "MTD cluster DetId " << hits.id() << " # cluster " << hits.size();
+      LogTrace("EtlLocalRecoValidation") << "MTD cluster DetId " << hits.id() << " # cluster " << hits.size();
       for (const auto& hit : hits) {
-        LogDebug("EtlLocalRecoValidation")
+        LogTrace("EtlLocalRecoValidation")
             << "MTD_TRH: " << hit.localPosition().x() << "," << hit.localPosition().y() << " : "
             << hit.localPositionError().xx() << "," << hit.localPositionError().yy() << " : " << hit.time() << " : "
             << hit.timeError();
@@ -369,6 +369,9 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         throw cms::Exception("EtlLocalRecoValidation")
             << "GeographicalID: " << std::hex << cluId << " is invalid!" << std::dec << std::endl;
       }
+      LogTrace("EtlLocalRecoValidation") << "Cluster DetId " << cluId.rawId() << " size = " << cluster.size()
+                                         << " min/max row = " << cluster.minHitRow() << " " << cluster.maxHitRow()
+                                         << " min/max col = " << cluster.minHitCol() << " " << cluster.maxHitCol();
 
       MTDClusterParameterEstimator::ReturnType tuple = cpe.getParameters(cluster, *genericDet);
 
@@ -395,7 +398,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       }
 
       index++;
-      LogDebug("EtlLocalRecoValidation") << "Cluster # " << index << " DetId " << cluId.rawId() << " idet " << idet;
+      LogTrace("EtlLocalRecoValidation") << "Cluster # " << index << " DetId " << cluId.rawId() << " idet " << idet;
 
       meCluTime_[idet]->Fill(cluster.time());
       meCluTimeError_[idet]->Fill(cluster.timeError());
@@ -417,10 +420,20 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
       if (optionalPlots_) {
         for (int ihit = 0; ihit < cluster.size(); ++ihit) {
+          auto thisHit = cluster.hit(ihit);
+          LogTrace("EtlLocalRecoValidation")
+              << "Cluster hit " << ihit << " row/col = " << thisHit.x() << " " << thisHit.y()
+              << " time = " << thisHit.time() << " timeError = " << thisHit.time_error()
+              << " energy = " << thisHit.energy();
           int hit_row = cluster.minHitRow() + cluster.hitOffset()[ihit * 2];
           int hit_col = cluster.minHitCol() + cluster.hitOffset()[ihit * 2 + 1];
+          if (hit_row != thisHit.x() || hit_col != thisHit.y()) {
+            edm::LogWarning("EtlLocalRecoValidation")
+                << "Index in cluster memory not consistent, row/col = " << hit_row << " " << hit_col;
+          }
 
           // Match the RECO hit to the corresponding SIM hit
+          bool found(false);
           for (const auto& recHit : *etlRecHitsHandle) {
             ETLDetId detId(recHit.id().rawId());
 
@@ -461,9 +474,14 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
             cluEneSIM += m_etlSimHits[idet][pixelId].energy;
             cluTimeSIM += m_etlSimHits[idet][pixelId].time * m_etlSimHits[idet][pixelId].energy;
 
+            found = true;
             break;
 
           }  // recHit loop
+          if (!found) {
+            edm::LogWarning("EtlLocalRecoValidation")
+                << "Cluster " << cluster.id().rawId() << " hit " << ihit << " Matching recHit not found!";
+          }
 
         }  // ihit loop
       }
@@ -480,7 +498,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         }
       }
       if (!matchClu) {
-        edm::LogWarning("BtlLocalRecoValidation")
+        edm::LogWarning("EtlLocalRecoValidation")
             << "No valid TrackingRecHit corresponding to cluster, detId = " << detIdObject.rawId();
       }
 


### PR DESCRIPTION
#### PR description:

Preparatory work to MTD clustering updates. This PR:

- fixes the type of methods in the ```FTLHit``` class part of ```FTLCluster```;
- adds some optional debugging printout to the ```Validation/MtdValidation``` local reco classes.

#### PR validation:

Tested on wf 34434.0.