### PR TITLE
[17_0_X] [L1T] Adding a reduced data format: phase2_l1scout for use in the Spring24 MC Campaign (Phase 2)

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -288,6 +288,7 @@ from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_la
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+from Configuration.ProcessModifiers.phase2_l1scout_cff import phase2_l1scout
 from RecoLocalFastTime.Configuration.RecoLocalFastTime_EventContent_cff import *
 from RecoMTD.Configuration.RecoMTD_EventContent_cff import *
 
@@ -1010,6 +1011,8 @@ MINIAODSIMEventContent= cms.PSet(
 )
 MINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputCommands)
 MINIAODSIMEventContent.outputCommands.extend(HLTriggerMINIAODSIM.outputCommands)
+
+phase2_l1scout.toModify(MINIAODSIMEventContent, outputCommands = L1TriggerPhase2L1ScoutMINIAODSIM.outputCommands)
 
 MINIGENEventContent= cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),

--- a/Configuration/ProcessModifiers/python/phase2_l1scout_cff.py
+++ b/Configuration/ProcessModifiers/python/phase2_l1scout_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_l1scout =  cms.Modifier()

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -99,6 +99,84 @@ L1TriggerFEVTDEBUG = cms.PSet(
         'keep LumiSummary_lumiProducer_*_*')
 )
 
+L1TriggerPhase2L1ScoutMINIAODSIM = cms.PSet(
+    outputCommands = cms.untracked.vstring("drop *",
+            # --- GEN
+            "keep *_genParticles_*_*",
+            "keep *_genFilterEfficiencyProducer_*_*",
+            "keep *_generator_*_*",
+            "keep *_externalLHEProducer_*_*",
+            "keep *_ak4GenJetsNoNu_*_*",
+            "keep *_genMetTrue_*_*",
+            # --- Track TPs
+            "keep *_l1tTTTracksFromTrackletEmulation_*_*",
+            "keep *_l1tTTTracksFromExtendedTrackletEmulation_*_*",
+            "keep *_TTTrackAssociatorFromPixelDigis_*_*",
+            "keep *_TTTrackAssociatorFromPixelDigisExtended_*_*",
+            # --- Calo TPs
+            "keep *_simEcalEBTriggerPrimitiveDigis_*_*",
+            "keep *_simHcalTriggerPrimitiveDigis_*_*",
+            "keep *_simCaloStage2Layer1Digis_*_*",
+            "keep *_simCaloStage2Digis_*_*",
+            # --- Muon TPs
+            "keep *_simMuonRPCDigis_*_*",
+            "keep *_simMuonGEMPadDigis_*_*",
+            "keep *_simMuonGEMPadDigiClusters_*_*",
+            "keep *_simDtTriggerPrimitiveDigis_*_*",
+            "keep *_simCscTriggerPrimitiveDigis_*_*",
+            "keep *_simTwinMuxDigis_*_*",
+            "keep *_simBmtfDigis_*_*",
+            "keep *_simKBmtfStubs_*_*",
+            "keep *_simKBmtfDigis_*_*",
+            "keep *_simEmtfDigis_*_*",
+            "keep *_simOmtfDigis_*_*",
+            "keep *_simGmtCaloSumDigis_*_*",
+            "keep *_simGmtStage2Digis_*_*",
+            "keep *_simEmtfShowers_*_*",
+            "keep *_simGmtShowerDigis_*_*",
+            "keep *_simCscTriggerPrimitiveDigisRun3_*_*",
+            "keep *_simMuonME0PadDigis_*_*",
+            "keep *_me0TriggerDigis_*_*",
+            "keep *_simMuonME0PseudoReDigisCoarse_*_*",
+            "keep *_me0RecHitsCoarse_*_*",
+            "keep *_me0TriggerPseudoDigis_*_*",
+            "keep *_me0RecHits_*_*",
+            "keep *_me0Segments_*_*",
+            "keep *_me0TriggerConvertedPseudoDigis_*_*",
+            "keep *_simCscTriggerPrimitiveDigisPhase2_*_*",
+            "keep *_simGtExtFakeStage2Digis_*_*",
+            "keep *_simGtStage2Digis_*_*",
+            "keep *_CalibratedDigis_*_*",
+            "keep *_dtTriggerPhase2PrimitiveDigis_*_*",
+            # --- HGCal TPs
+            "keep l1tHGCalTriggerCellBXVector_l1tHGCalVFEProducer_*_*",
+            "keep l1tHGCalMulticlusterBXVector_l1tHGCalBackEndLayer2Producer_*_*",
+            "keep l1tHGCalTowerBXVector_l1tHGCalTowerProducer_*_*",
+            # --- GCT reconstruction
+            "keep *_l1tEGammaClusterEmuProducer_*_*",
+            "keep *_l1tTowerCalibration_*_*",
+            "keep *_l1tCaloJet_*_*",
+            "keep *_l1tCaloJetHTT_*_*",
+            # --- GTT reconstruction
+            "keep *_l1tVertexFinder_*_*",
+            "keep *_l1tVertexFinderEmulator_*_*",
+            "keep *_l1tTrackJets_*_*",
+            "keep *_l1tTrackJetsExtended_*_*",
+            "keep *_l1tTrackFastJets_*_*",
+            "keep *_l1tTrackerEtMiss_*_*",
+            "keep *_l1tTrackerHTMiss_*_*",
+            "keep *_l1tTrackJetsEmulation_*_*",
+            "keep *_l1tTrackJetsExtendedEmulation_*_*",
+            "keep *_l1tTrackerEmuEtMiss_*_*",
+            "keep *_l1tTrackerEmuHTMiss_*_*",
+            "keep *_l1tTrackerEmuHTMissExtended_*_*",
+            # --- GMT reconstruction
+            "keep *_l1tStubsGmt_*_*",
+            "keep *_l1tKMTFMuonsGmt_*_*",
+            "keep *_l1tFwdMuonsGmt_*_*",
+            "keep *_l1tSAMuonsGmt_*_*",
+    )
+)
 
 def _appendCICADAInformation(obj):
     cicadaDataRegions = [


### PR DESCRIPTION
#### PR description:

Adding in new configuration options providing a reduced data format: phase2_l1scout for use in the Spring24 MC Campaign. 

The idea behind this is to reduce the event size by a factor of ~50 to be able to request more MC statistics for Phase-2 L1 Scouting use.

#### PR validation:

Ran the code locally over ~50 events using Phase2Spring24 MC campaign setup commands. It produces the expected result without crashing. File size goes from ~3 GB to ~100 MB.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/51330

Please let me know which other releases should get a backport of this PR

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->


