### PR TITLE
Produce more TkAl ALCARECO flavours in phase-2 by default

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_cff.py
@@ -47,3 +47,6 @@ seqALCARECOTkAlJetHT = cms.Sequence(ALCARECOTkAlJetHTHLT+ALCARECOTkAlJetHTDCSFil
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(ALCARECOTkAlJetHT, etaMin = -4, etaMax = 4)
+phase2_tracker.toModify(ALCARECOTkAlJetHTHLT,
+                        eventSetupPathsKey='',
+                        HLTPaths = ['HLT_*HT*','HLT_*Jet*'])

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_cff.py
@@ -4,7 +4,8 @@ import FWCore.ParameterSet.Config as cms
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 ALCARECOTkAlJetHTHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
     andOr = True, ## choose logical OR between Triggerbits
-    eventSetupPathsKey = 'TkAlJetHTHLT',
+    eventSetupPathsKey = '',
+    HLTPaths = ['HLT_*HT*','HLT_*Jet*'],
     throw = False # tolerate triggers stated above, but not available
     )
 
@@ -47,6 +48,3 @@ seqALCARECOTkAlJetHT = cms.Sequence(ALCARECOTkAlJetHTHLT+ALCARECOTkAlJetHTDCSFil
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(ALCARECOTkAlJetHT, etaMin = -4, etaMax = 4)
-phase2_tracker.toModify(ALCARECOTkAlJetHTHLT,
-                        eventSetupPathsKey='',
-                        HLTPaths = ['HLT_*HT*','HLT_*Jet*'])

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4939,7 +4939,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
     upgradeStepDict['HARVESTGlobalFakeHLT'][k] = merge([{'-s': 'HARVESTING:@phase2ValidationFakeHLT+@phase2FakeHLT+@miniAODValidation+@miniAODDQM'}, upgradeStepDict['HARVEST'][k]])
 
-    upgradeStepDict['ALCA'][k] = {'-s':'ALCA:SiPixelCalSingleMuonLoose+SiPixelCalSingleMuonTight+TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+TkAlDiMuonAndVertex+HcalCalHBHEMuonProducerFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu+SiStripCalMinBias',
+    upgradeStepDict['ALCA'][k] = {'-s':'ALCA:SiPixelCalSingleMuonLoose+SiPixelCalSingleMuonTight+TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+TkAlDiMuonAndVertex+HcalCalHBHEMuonProducerFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu+SiStripCalMinBias+TkAlV0s+TkAlJetHT',
                                       '--conditions':gt,
                                       '--datatier':'ALCARECO',
                                       '-n':'10',
@@ -4947,7 +4947,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--geometry' : geom,
                                       }
 
-    upgradeStepDict['ALCAPhase2'][k] = merge([{'-s':'ALCA:SiPixelCalSingleMuonLoose+SiPixelCalSingleMuonTight+TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+TkAlDiMuonAndVertex+HcalCalHBHEMuonProducerFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu'},upgradeStepDict['ALCA'][k]])
+    upgradeStepDict['ALCAPhase2'][k] = merge([{'-s':'ALCA:SiPixelCalSingleMuonLoose+SiPixelCalSingleMuonTight+TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+TkAlDiMuonAndVertex+HcalCalHBHEMuonProducerFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu+TkAlV0s+TkAlJetHT'},upgradeStepDict['ALCA'][k]])
 
     upgradeStepDict['FastSim'][k]={'-s':'GEN,SIM,RECO,VALIDATION',
                                    '--eventcontent':'FEVTDEBUGHLT,DQM',


### PR DESCRIPTION
#### PR description:

While reviewing https://github.com/cms-sw/cmssw/pull/51307 I noticed that some of the tests rely on `ALCA` flavours that we don't produce in MC, thus it's not possible to test them on Phase 2. 
This PR just adds to the `ALCA` and `ALCAPhase2` steps the ones needed, together with a small change in the trigger selection to avoid crashing at runtime when using phase-2.
- the new trigger bit selection is `['HLT_*HT*','HLT_*Jet*']` which is the same coming from the database `eventSetupPathsKey` (see [payload inspector plot](https://cern.ch/tnrmc))

#### PR validation:

Run `runTheMatrix.py -l 34434.0 -t 4 -j 8 ` and 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

Cc: @TomasKello 
