### PR TITLE
MatrixUtil: For --ibeos wse ibeos-lfn-sort to sort LFNs for selected lumis

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixUtil.py
+++ b/Configuration/PyReleaseValidation/python/MatrixUtil.py
@@ -119,6 +119,7 @@ class InputInfo(object):
         self.skimEvents = skimEvents
 
     def das(self, das_options, dataset):
+        use_ibeos = os.getenv("CMSSW_USE_IBEOS","false")=="true"
         if not self.skimEvents and (len(self.run) != 0 or self.ls):
             queries = self.queries(dataset)
             if len(self.run) != 0:
@@ -126,8 +127,9 @@ class InputInfo(object):
             else:
               lumis = self.lumis()
               commands = []
+              ibeos_sort = " | ibeos-lfn-sort" if use_ibeos else ""
               while queries:
-                    commands.append("dasgoclient %s --query 'lumi,%s' --format json | das-selected-lumis.py %s " % (das_options, queries.pop(), lumis.pop()))
+                    commands.append("dasgoclient %s --query 'lumi,%s' --format json | das-selected-lumis.py %s %s" % (das_options, queries.pop(), lumis.pop(), ibeos_sort))
               command = ";".join(commands)
             command = "({0})".format(command)
         elif not self.skimEvents:
@@ -139,8 +141,7 @@ class InputInfo(object):
             command += " | grep -E -v "
             command += " ".join(["-e '{0}'".format(pattern) for pattern in self.ib_blacklist])
         if not self.skimEvents: ## keep run-lumi sorting
-            from os import getenv
-            if getenv("CMSSW_USE_IBEOS","false")=="true":
+            if use_ibeos:
                 return "export CMSSW_USE_IBEOS=true; " + command
             return command + " | sort -u"
         else:


### PR DESCRIPTION
Currently with `--ibeos` , we do not sort results for `json` formatted das output. This PR proposes to use `ibeos-lfn-sort` utility for `json` results too (when `--ibeos` is enabled)