### PR TITLE
Add HIN Run3 Mini2Mini relvals

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -597,6 +597,12 @@ workflows[144.903] = ['',['RunUPC2025','RECONANODR3_2026_UPC','HARVESTDPROMPTR3'
 workflows[144.201] = ['',['HydjetQ_B12_5362GeV_2026','DIGIHI2026','SKIMHIFORWARDRUN3_2026','HARVESTHI2026']]
 workflows[144.202] = ['',['HydjetQ_MinBias_5362GeV_2026','DIGIHI2026','RAWPRIMESIMHI26','SKIMHIPHYSICSRAWPRIMERUN3_2026','HARVESTHI2026S4']]
 
+## run3 MINI2MINI (HI RawPrime data)
+workflows[141.401] = ['',['RunHI2023MAOD','MAOD2MAODHI23']]
+workflows[142.401] = ['',['RunHI2024MAOD','MAOD2MAODHI24']]
+workflows[143.401] = ['',['RunHI2025MAOD','MAOD2MAODHI25']]
+workflows[144.401] = ['',['RunHI2026MAOD','MAOD2MAODHI26']]
+
 ## special HLT scouting workflow (with hardcoded private input file from ScoutingPFMonitor skimmed to remove all events without scouting)
 workflows[145.415] = ['',['HLTDR3_ScoutingPFMonitor_2024','RECONANORUN3_ScoutingPFMonitor_reHLT_2024','HARVESTRUN3_ScoutingPFMonitor_2024']]
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -656,6 +656,14 @@ steps['RunUPC2025']={'INPUT':InputInfo(dataSet='/HIForward0/HIRun2025A-v1/RAW',l
 RunHI2023={375491: [[100, 100]]}
 steps['RunHIPhysicsRawPrime2023A']={'INPUT':InputInfo(dataSet='/HIPhysicsRawPrime0/HIRun2023A-v1/RAW',label='HI2023A',events=100000,location='STD', ls=RunHI2023)}
 
+steps['RunHI2023MAOD']={'INPUT':InputInfo(dataSet='/HIPhysicsRawPrime0/HIRun2023A-PromptReco-v2/MINIAOD',label='HI2023A',events=100000,location='STD',ls=RunHI2023)}
+
+steps['RunHI2024MAOD']={'INPUT':InputInfo(dataSet='/HIPhysicsRawPrime0/HIRun2024B-PromptReco-v2/MINIAOD',label='HI2024B',events=1000,location='STD',ls={388468 : [[89, 89]]})}
+
+steps['RunHI2025MAOD']={'INPUT':InputInfo(dataSet='/HIPhysicsRawPrime0/HIRun2025A-PbPbEW-PromptReco-v1/MINIAOD',label='HI2025A',events=1000,location='STD',ls={399499 : [[55, 55]]})}
+
+steps['RunHI2026MAOD']={'INPUT':InputInfo(dataSet='/HIPhysicsRawPrime0/HIRun2026A-PbPbEW-PromptReco-v1/MINIAOD',label='HI2026A',events=1000,location='STD',ls={404339 : [[55, 55]]})}
+
 steps['RunHLTMonitor2024I']={'INPUT':InputInfo(dataSet='/HLTMonitor/Run2024I-Express-v2/FEVTHLTALL',label='2024I',events=100000,location='STD', ls={386801: [[32, 111]]})}
 
 ####################################################################################################################################
@@ -2562,6 +2570,18 @@ steps['REMINIAODHID18']={ '--scenario':'pp',
                           '-n':'100'
 }
 
+steps['MAOD2MAODHI23']={ '--scenario':'pp',
+                         '--conditions':'auto:run3_data_prompt',
+                         '-s':'PAT:Configuration/StandardSequences/REMINI_HIN_cff.patAlgosToolsTask,SKIM:PbPbEW',
+                         '--datatier':'MINIAOD',
+                         '--eventcontent':'MINIAOD',
+                         '--era':'Run3_pp_on_PbPb_2023',
+                         '--data':'',
+                         '--processName':'M2M',
+                         '-n':'100' }
+steps['MAOD2MAODHI24']=merge([{'--era':'Run3_pp_on_PbPb_2024'},steps['MAOD2MAODHI23']])
+steps['MAOD2MAODHI25']=merge([{'--era':'Run3_pp_on_PbPb_2025'},steps['MAOD2MAODHI23']])
+steps['MAOD2MAODHI26']=merge([{'--era':'Run3_pp_on_PbPb_2026'},steps['MAOD2MAODHI23']])
 
 steps['RECOHID22APPROXCLUSTERS']=merge([{ '--scenario':'pp',
                                           '--conditions':'auto:run3_data_prompt',

--- a/Configuration/StandardSequences/python/REMINI_HIN_cff.py
+++ b/Configuration/StandardSequences/python/REMINI_HIN_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+patAlgosToolsTask = cms.Task()
+
+from PhysicsTools.PatAlgos.slimming.miniAODFromMiniAOD_HIN_tools import miniAODFromMiniAOD_customizeAllData as miniAOD_customizeAllData
+from PhysicsTools.PatAlgos.slimming.miniAODFromMiniAOD_HIN_tools import miniAODFromMiniAOD_customizeAllMC as miniAOD_customizeAllMC
+

--- a/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_HIN_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_HIN_tools.py
@@ -1,0 +1,104 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.PatAlgos.tools.helpers  import getPatAlgosToolsTask, addToProcessAndTask
+
+def miniAODFromMiniAOD_customizeCommon(process):
+
+    task = getPatAlgosToolsTask(process)
+    cols = []
+
+    ###########################################################################
+    # Update egamma regression
+    ###########################################################################
+    def _updateEGRegression(process):
+        from RecoEgamma.EgammaTools.regressionModifier_cfi import regressionModifier
+        for obj in ['Electron','Photon']:
+            setattr(process,f'slimmed{obj}s',cms.EDProducer(f"Modified{obj}Producer",
+                src = cms.InputTag(f'slimmed{obj}s::@skipCurrentProcess'),
+                modifierConfig = cms.PSet(modifications = cms.VPSet(regressionModifier))
+            ))
+            task.add(getattr(process,f'slimmed{obj}s'))
+            cols.append(f'slimmed{obj}s')
+
+    from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+    pp_on_PbPb_run3.toModify(process, _updateEGRegression)
+
+    ###########################################################################
+    # Add secondary vertex
+    ###########################################################################
+    def _addSecondaryVertex(process,n=''):
+        process.load('TrackingTools.TransientTrack.TransientTrackBuilder_cfi')
+        import RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff as _sv
+        if n == 'Negative':
+            import RecoVertex.AdaptiveVertexFinder.inclusiveNegativeVertexing_cff as _sv
+        for mod in [f'inclusiveCandidate{n}VertexFinder',f'candidate{n}VertexArbitrator']:
+            setattr(process,mod,getattr(_sv,mod).clone(
+                tracks = "packedPFCandidates",
+                primaryVertices = "offlineSlimmedPrimaryVertices"
+            ))
+        getattr(process,f'inclusiveCandidate{n}VertexFinder').minHits = 10
+        getattr(process,f'inclusiveCandidate{n}VertexFinder').minPt = 1.0
+        setattr(process,f'candidate{n}VertexMerger',getattr(_sv,f'candidate{n}VertexMerger').clone())
+        setattr(process,f'slimmed{n}SecondaryVertices',getattr(_sv,f'inclusiveCandidate{n}SecondaryVertices').clone())
+        for mod in [f'inclusiveCandidate{n}VertexFinder',f'candidate{n}VertexMerger',
+                    f'candidate{n}VertexArbitrator',f'slimmed{n}SecondaryVertices']:
+            task.add(getattr(process,mod))
+        cols.append(f'slimmed{n}SecondaryVertices')
+
+    def _addNegativeSecondaryVertex(process):
+        return _addSecondaryVertex(process,n='Negative')
+
+    from Configuration.Eras.Modifier_pp_on_PbPb_run3_2023_cff import pp_on_PbPb_run3_2023
+    from Configuration.Eras.Modifier_pp_on_PbPb_run3_2024_cff import pp_on_PbPb_run3_2024
+    (pp_on_PbPb_run3_2023 | pp_on_PbPb_run3_2024).toModify(process, _addSecondaryVertex)
+    pp_on_PbPb_run3.toModify(process, _addNegativeSecondaryVertex)
+
+    ###########################################################################
+    # Add centrality
+    ###########################################################################
+    def _addCentrality(process):
+        process.load("RecoHI.HiCentralityAlgos.CentralityBin_cfi")
+        process.centralityBin.Centrality = "hiCentrality"
+        process.centralityBin.centralityVariable = "HFtowers"
+        task.add(process.centralityBin)
+        cols.append('centralityBin')
+
+    pp_on_PbPb_run3.toModify(process, _addCentrality)
+
+    ###########################################################################
+    # Define output collections
+    ###########################################################################
+    outputCommands = []
+    for new_collection_to_keep in cols:
+        new_collection_to_keep += '_*' if not '_' in new_collection_to_keep else ''
+        outputCommands += [
+            f'drop *_{new_collection_to_keep}_*',
+            f'keep *_{new_collection_to_keep}_{process.name_()}']
+
+    mini_output = None
+    for out_name in process.outputModules_().keys():
+        if out_name.startswith('MINIAOD'):
+            mini_output = getattr(process, out_name)
+            break
+    if mini_output:
+        mini_output.outputCommands += outputCommands
+
+    if hasattr(process,'SKIMStreamPbPbEW'):
+        process.SKIMStreamPbPbEW.outputCommands += outputCommands
+
+    return process
+
+def miniAODFromMiniAOD_customizeData(process):
+    return process
+
+def miniAODFromMiniAOD_customizeMC(process):
+    return process
+
+def miniAODFromMiniAOD_customizeAllData(process):
+    process = miniAODFromMiniAOD_customizeData(process)
+    process = miniAODFromMiniAOD_customizeCommon(process)
+    return process
+
+def miniAODFromMiniAOD_customizeAllMC(process):
+    process = miniAODFromMiniAOD_customizeMC(process)
+    process = miniAODFromMiniAOD_customizeCommon(process)
+    return process


### PR DESCRIPTION
#### PR description:

This PR adds a Mini2Mini workflow for Run3 PbPb RawPrime data that includes:
- Update of the egamma regression optimized on PbPb
- Secondary vertex for 2023 and 2024 PbPb
- Negative secondary vertex for b-tag calibration
- Update of centrality bin

In addition, this PR adds a set of relvals that runs on MiniAOD data defined as:
- 141.401 : relval run on 2023 PbPb MiniAOD
- 142.401 : relval run on 2024 PbPb MiniAOD
- 143.401 : relval run on 2025 PbPb MiniAOD
- 144.401 : relval run on 2026 PbPb MiniAOD

that runs both the Mini2Mini and the PbPbEW skim steps.

@mandrenguyen 

#### PR validation:

Tested with workflows:
141.401,142.401,143.401,144.401

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 16_1_X