### PR TITLE
Store SiPixelDigi collections in AlCaRecos that store pixel clusters

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlGlobalCosmicsInCollisions_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlGlobalCosmicsInCollisions_Output_cff.py
@@ -25,8 +25,7 @@ OutALCARECOMuAlGlobalCosmicsInCollisions_noDrop = cms.PSet(
 	'keep DcsStatuss_scalersRawToDigi_*_*',
 	'keep Si*Cluster*_si*Clusters_*_*', # for cosmics keep original clusters
 	'keep siStripDigis_DetIdCollection_*_*',
-	'keep recoMuons_muons1Leg_*_*', # save muons as timing info is needed for BP corrections in deconvolution
-    )
+	'keep recoMuons_muons1Leg_*_*') # save muons as timing info is needed for BP corrections in deconvolution
 )
 
 import copy

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlGlobalCosmics_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlGlobalCosmics_Output_cff.py
@@ -28,8 +28,7 @@ OutALCARECOMuAlGlobalCosmics_noDrop = cms.PSet(
 	'keep DcsStatuss_scalersRawToDigi_*_*',
 	'keep Si*Cluster*_si*Clusters_*_*', # for cosmics keep original clusters
 	'keep siStripDigis_DetIdCollection_*_*',
-	'keep recoMuons_muons1Leg_*_*', # save muons as timing info is needed for BP corrections in deconvolution
-    )
+	'keep recoMuons_muons1Leg_*_*') # save muons as timing info is needed for BP corrections in deconvolution
 )
 
 import copy

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlBeamHalo_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlBeamHalo_Output_cff.py
@@ -14,7 +14,8 @@ OutALCARECOTkAlBeamHalo_noDrop = cms.PSet(
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
-        'keep DcsStatuss_scalersRawToDigi_*_*')
+        'keep DcsStatuss_scalersRawToDigi_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlCosmics0T_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlCosmics0T_Output_cff.py
@@ -25,7 +25,8 @@ OutALCARECOTkAlCosmics0T_noDrop = cms.PSet(
         #'keep Si*Cluster*_si*Clusters_*_*', # for cosmics keep original clusters
         'keep SiPixelCluster*_siPixelClusters_*_*',
         'keep SiStripCluster*_siStripClusters_*_*',
-        'keep recoMuons_muons1Leg_*_*') # save muons as timing info is needed for BP corrections in deconvolution
+        'keep recoMuons_muons1Leg_*_*', # save muons as timing info is needed for BP corrections in deconvolution
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 import copy

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlCosmicsInCollisions_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlCosmicsInCollisions_Output_cff.py
@@ -19,7 +19,8 @@ OutALCARECOTkAlCosmicsInCollisions_noDrop = cms.PSet(
         #'keep Si*Cluster*_si*Clusters_*_*', # for cosmics keep original clusters
         'keep SiPixelCluster*_siPixelClusters_*_*', # for cosmics keep original clusters
         'keep SiStripCluster*_siStripClusters_*_*', # for cosmics keep original clusters
-        'keep recoMuons_muons1Leg_*_*') # save muons as timing info is needed for BP corrections in deconvolution
+        'keep recoMuons_muons1Leg_*_*', # save muons as timing info is needed for BP corrections in deconvolution
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 import copy

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlCosmics_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlCosmics_Output_cff.py
@@ -22,7 +22,8 @@ OutALCARECOTkAlCosmics_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep Si*Cluster*_si*Clusters_*_*', # for cosmics keep original clusters
-        'keep recoMuons_muons1Leg_*_*') # save muons as timing info is needed for BP corrections in deconvolution
+        'keep recoMuons_muons1Leg_*_*', # save muons as timing info is needed for BP corrections in deconvolution
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 import copy

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_Output_cff.py
@@ -21,7 +21,8 @@ OutALCARECOTkAlDiMuonAndVertex_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep *_offlinePrimaryVertices_*_*',
-        'keep *_offlineBeamSpot_*_*')
+        'keep *_offlineBeamSpot_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # add branches for MC truth evaluation

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracksZMuMu_Output_cff.py
@@ -18,9 +18,10 @@ OutALCARECOTkAlHLTTracksZMuMu_noDrop = cms.PSet(
         'keep recoTrackExtras_ALCARECOTkAlHLTPixelZMuMuVertexTracks_*_*',
         'keep TrackingRecHitsOwned_ALCARECOTkAlHLTPixelZMuMuVertexTracks_*_*',
         'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlHLTPixelZMuMuVertexTracks_*_*',
-	'keep *_hltVerticesPFFilter_*_*',
+	    'keep *_hltVerticesPFFilter_*_*',
         'keep *_hltOnlineBeamSpot_*_*',
-        'keep DCSRecord_onlineMetaDataDigis_*_*'
+        'keep DCSRecord_onlineMetaDataDigis_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*'
     )
 )
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlHLTTracks_Output_cff.py
@@ -16,7 +16,8 @@ OutALCARECOTkAlHLTTracks_noDrop = cms.PSet(
         'keep *_hltPixelVertices_*_*',
         'keep *_hltVerticesPFFilter_*_*',
         'keep *_hltOnlineBeamSpot_*_*',
-        'keep DCSRecord_onlineMetaDataDigis_*_*'
+        'keep DCSRecord_onlineMetaDataDigis_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*'
     )
 )
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_Output_cff.py
@@ -16,7 +16,8 @@ OutALCARECOTkAlJetHT_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep *_offlinePrimaryVertices_*_*',
-        'keep *_offlineBeamSpot_*_*')
+        'keep *_offlineBeamSpot_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_Output_cff.py
@@ -15,7 +15,8 @@ OutALCARECOTkAlJpsiMuMuHI_noDrop = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
-	'keep *_hiSelectedVertex_*_*')
+	    'keep *_hiSelectedVertex_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_Output_cff.py
@@ -15,7 +15,8 @@ OutALCARECOTkAlJpsiMuMu_noDrop = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
-	'keep *_offlinePrimaryVertices_*_*')
+	    'keep *_offlinePrimaryVertices_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # add branches for MC truth evaluation

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBiasHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBiasHI_Output_cff.py
@@ -16,7 +16,8 @@ OutALCARECOTkAlMinBiasHI_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep *_hiSelectedVertex_*_*',
-        'keep *_offlineBeamSpot_*_*')
+        'keep *_offlineBeamSpot_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_Output_cff.py
@@ -16,7 +16,8 @@ OutALCARECOTkAlMinBias_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep *_offlinePrimaryVertices_*_*',
-        'keep *_offlineBeamSpot_*_*')
+        'keep *_offlineBeamSpot_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_Output_cff.py
@@ -15,7 +15,8 @@ OutALCARECOTkAlMuonIsolatedHI_noDrop = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
-	'keep *_hiSelectedVertex_*_*')
+	    'keep *_hiSelectedVertex_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedPA_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedPA_Output_cff.py
@@ -15,7 +15,8 @@ OutALCARECOTkAlMuonIsolatedPA_noDrop = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
-	'keep *_offlinePrimaryVertices_*_*')
+	    'keep *_offlinePrimaryVertices_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 import copy

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolated_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolated_Output_cff.py
@@ -15,7 +15,8 @@ OutALCARECOTkAlMuonIsolated_noDrop = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
-	'keep *_offlinePrimaryVertices_*_*')
+	    'keep *_offlinePrimaryVertices_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_Output_cff.py
@@ -15,7 +15,8 @@ OutALCARECOTkAlUpsilonMuMuHI_noDrop = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
-	'keep *_hiSelectedVertex_*_*')
+	    'keep *_hiSelectedVertex_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuPA_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuPA_Output_cff.py
@@ -15,7 +15,8 @@ OutALCARECOTkAlUpsilonMuMuPA_noDrop = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
-	'keep *_offlinePrimaryVertices_*_*')
+	    'keep *_offlinePrimaryVertices_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_Output_cff.py
@@ -15,7 +15,8 @@ OutALCARECOTkAlUpsilonMuMu_noDrop = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
-	'keep *_offlinePrimaryVertices_*_*')
+	    'keep *_offlinePrimaryVertices_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # add branches for MC truth evaluation

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlV0s_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlV0s_Output_cff.py
@@ -23,7 +23,8 @@ OutALCARECOTkAlV0s_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep *_offlinePrimaryVertices_*_*',
-        'keep *_offlineBeamSpot_*_*')
+        'keep *_offlineBeamSpot_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlWMuNu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlWMuNu_Output_cff.py
@@ -15,7 +15,8 @@ OutALCARECOTkAlWMuNu_noDrop = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
-	'keep *_offlinePrimaryVertices_*_*')
+	    'keep *_offlinePrimaryVertices_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_Output_cff.py
@@ -15,7 +15,8 @@ OutALCARECOTkAlZMuMuHI_noDrop = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
-	'keep *_hiSelectedVertex_*_*')
+	    'keep *_hiSelectedVertex_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_Output_cff.py
@@ -15,7 +15,8 @@ OutALCARECOTkAlZMuMuPA_noDrop = cms.PSet(
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
-	'keep *_offlinePrimaryVertices_*_*')
+	    'keep *_offlinePrimaryVertices_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # in Run3, SCAL digis replaced by onlineMetaDataDigis

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
@@ -16,7 +16,8 @@ OutALCARECOTkAlZMuMu_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep *_offlinePrimaryVertices_*_*',
-        'keep *_offlineBeamSpot_*_*')
+        'keep *_offlineBeamSpot_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*')
 )
 
 # add branches for MC truth evaluation

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_Output_cff.py
@@ -7,7 +7,8 @@ OutALCARECOSiPixelCalCosmics_noDrop = cms.PSet(
     outputCommands = cms.untracked.vstring(
         'keep *_ALCARECOSiPixelCalCosmics_*_*',
         'keep *_muons__*',
-        'keep *_*riggerResults_*_HLT'
+        'keep *_*riggerResults_*_HLT',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*'
     )
 )
 import copy

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonLoose_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonLoose_Output_cff.py
@@ -8,7 +8,8 @@ OutALCARECOSiPixelCalSingleMuonLoose_noDrop = cms.PSet(
       'keep *_ALCARECOSiPixelCalSingleMuonLoose_*_*',
       'keep *_muons__*',
       'keep *_offlinePrimaryVertices_*_*',
-      'keep *_*riggerResults_*_HLT'
+      'keep *_*riggerResults_*_HLT',
+      'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*'
      )
 )
 

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_Output_cff.py
@@ -11,7 +11,8 @@ OutALCARECOSiPixelCalSingleMuonTight_noDrop = cms.PSet(
         'keep *_*riggerResults_*_HLT',
         'keep *_*closebyPixelClusters*_*_*',
         'keep *_*trackDistances*_*_*',
-        'keep PileupSummaryInfos_addPileupInfo_*_*'
+        'keep PileupSummaryInfos_addPileupInfo_*_*',
+        'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*'
      )
 )
 OutALCARECOSiPixelCalSingleMuonTight=OutALCARECOSiPixelCalSingleMuonTight_noDrop.clone()

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuon_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuon_Output_cff.py
@@ -8,7 +8,8 @@ OutALCARECOSiPixelCalSingleMuon_noDrop = cms.PSet(
       'keep *_ALCARECOSiPixelCalSingleMuon_*_*',
       'keep *_muons__*',
       'keep *_offlinePrimaryVertices_*_*',
-      'keep *_*riggerResults_*_HLT'
+      'keep *_*riggerResults_*_HLT',
+      'keep PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*'
      )
 )
 


### PR DESCRIPTION
#### PR description:

This PR addresses issue https://github.com/cms-sw/cmssw/issues/51320. It adds `PixelFEDChanneledmNewDetSetVector_siPixelDigis_*_*` collection to select ALCARECO flavours, allowing pixel FedErrors to be properly handled when refitting.

#### PR validation:

Two test `ALCARECOSiPixelCalSingleMuonTight` files are generated from a Muon0 RAW-RECO file ([cfg](https://github.com/mroguljic/cmssw/blob/debug_inactive_pixel/Debug/DebugInactivePixel/test/generate_muon_alcareco.py)), with and without this PR. The `edmEventSize` below shows all the collections in `ALCARECOSiPixelCalSingleMuonTight` and their sizes. The branch added with this PR starts with `SiPixelClusteredmNewDetSetVector`

```
File alcareco_with_pr.root Events 178
Branch Name | Average Uncompressed Size (Bytes/Event) | Average Compressed Size (Bytes/Event) 
recoMuons_muons__RECO. 17670.3 7932.45
recoVertexs_offlinePrimaryVertices__RECO. 34341.6 4721.78
EventProductProvenance 4370.24 3309.89
recoVertexsedmAssociation_offlinePrimaryVertices__RECO. 4202.94 1146.16
PixelFEDChanneledmNewDetSetVector_siPixelDigis__RECO. 11176.9 524.719
recoTrackExtras_ALCARECOSiPixelCalSingleMuonTight__ALCARECO. 522.466 410.438
SiStripClusteredmNewDetSetVector_ALCARECOSiPixelCalSingleMuonTight__ALCARECO. 655.787 381.657
recoTracks_ALCARECOSiPixelCalSingleMuonTight__ALCARECO. 618.781 357.893
intedmValueMap_offlinePrimaryVertices__RECO. 4086.74 353.697
SiPixelClusteredmNewDetSetVector_ALCARECOSiPixelCalSingleMuonTight__ALCARECO. 407.809 272.225
SiPixelClusteredmNewDetSetVector_closebyPixelClusters__ALCARECO. 400.534 262.579
floatedmValueMap_offlinePrimaryVertices__RECO. 245.371 189.051
TrackingRecHitsOwned_ALCARECOSiPixelCalSingleMuonTight__ALCARECO. 1226.07 176.758
Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOSiPixelCalSingleMuonTight__ALCARECO. 176.163 132.719
edmTriggerResults_TriggerResults__HLT. 2051.36 124.534
EventAuxiliary 129.281 64.1236
EventSelections 103.287 24.6404
floatsedmValueMap_trackDistances__ALCARECO. 73.3371 22.0562
BranchListIndexes 25.6573 5.47191
```

A check was made by refitting the tracks in the two test files using the following [cfg](https://github.com/mroguljic/cmssw/blob/debug_inactive_pixel/Debug/DebugInactivePixel/test/DebugInactivePixel_cfg.py), changing the `inputFileName` for ALCARECO. The cfg runs the following [EDAnalyzer](https://github.com/mroguljic/cmssw/blob/debug_inactive_pixel/Debug/DebugInactivePixel/src/DebugInactivePixel.cc) which prints the hit stored and refit hit patterns. The number of REFIT VALID / MISSING / INACTIVE tracking hits without PR ([txt file](https://github.com/mroguljic/cmssw/blob/debug_inactive_pixel/Debug/DebugInactivePixel/test/ALCARECO_central.txt)) is 123 / 48 / 19 vs with PR ([txt file](https://github.com/mroguljic/cmssw/blob/debug_inactive_pixel/Debug/DebugInactivePixel/test/ALCARECO_with_pr.txt)) 123 / 20 / 47. For completness, before refit, the numbers for "STORED" are 124 / 10 / 27.


`runTheMatrix` tests finished with 
```
42 37 36 31 22 1 1 1 1 1 1 tests passed, 12 4 0 0 0 0 0 0 0 0 0 failed
```
The failures seem to come from test files (temporarily?) not being available for reading. Presumably, the failures are not related to the PR.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 17.0.X, 16.1.X, 16.0.X.