### PR TITLE
Non-concurrent Finder requires only 1 concurrent Record

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -706,13 +706,6 @@ namespace edm {
       auto guard = makeGuard([this]() { actReg_->postEventSetupConfigurationFinalizedSignal_.emit(); });
       espController_->finishConfiguration();
     }
-    if (espController_->hasNonconcurrentFinder() and preallocations_.numberOfThreads() > 1) {
-      throw edm::Exception(edm::errors::Configuration, "Non-concurrent ESSource")
-          << "The EventSetup configuration contains a non-concurrent ESSource. "
-             "This will limit the number of threads allowed in the job to 1. Either \n"
-             " - see if the ESSource can be made conccurent or \n"
-             " - set the numberOfThreads in the configuration to 1.";
-    }
     eventsetup::ESRecordsToProductResolverIndices esRecordsToProductResolverIndices = esp_->recordsToResolverIndices();
 
     actReg_->eventSetupConfigurationSignal_.emit(esRecordsToProductResolverIndices, processContext_);

--- a/FWCore/Framework/src/EventSetupRecordProvider.cc
+++ b/FWCore/Framework/src/EventSetupRecordProvider.cc
@@ -106,6 +106,17 @@ namespace edm {
       }
       if (finder_) {
         hasNonconcurrentFinder_ = !finder_->concurrentFinder();
+        if (hasNonconcurrentFinder_ and nConcurrentIOVs_ > 1) {
+          throw cms::Exception("Configuration")
+              .format(
+                  "EventSetupRecord {} has a nonconcurrent finder and the number of concurrent IOVs is set to {}.\n"
+                  "The number of concurrent IOVs for this record must be set to 1. This may be done by adding the "
+                  "following to the configuration:\n"
+                  "process.options.eventSetup.forceNumberOfConcurrentIOVs.{} = 1'",
+                  key_.name(),
+                  nConcurrentIOVs_,
+                  key_.name());
+        }
       }
 
       //now we get rid of the temporary

--- a/FWCore/Integration/test/eventSetupTest.sh
+++ b/FWCore/Integration/test/eventSetupTest.sh
@@ -16,12 +16,12 @@ cmsRun ${LOCAL_TEST_DIR}/ESProductHostTest_cfg.py || die 'Failed in ESProductHos
 echo testConcurrentIOVs
 cmsRun ${LOCAL_TEST_DIR}/testConcurrentIOVs_cfg.py || die 'Failed in testConcurrentIOVs_cfg.py' $?
 
-echo testConcurrentIOVsLegacy 1 thread
+echo testConcurrentIOVsLegacy 1 concurrent record
 cmsRun ${LOCAL_TEST_DIR}/testConcurrentIOVsLegacy_cfg.py -n 1|| die 'Failed in testConcurrentIOVsLegacy_cfg.py' $?
 
-echo testConcurrentIOVsLegacy 4 threads
-cmsRun ${LOCAL_TEST_DIR}/testConcurrentIOVsLegacy_cfg.py -n 4 &> testConcurrentIOVsLegacy_4threads.txt && die 'Failed in testConcurrentIOVsLegacy_cfg.py, the configuration succeeded while it should have failed' $?
-grep "The EventSetup configuration contains a non-concurrent ESSource" testConcurrentIOVsLegacy_4threads.txt >/dev/null || diecat 'Failed in testConcurrentIOVsLegacy_cfg.py, the configuration failed but in an unexpected way' $? testConcurrentIOVsLegacy_4threads.txt
+echo testConcurrentIOVsLegacy 2 concurrent records
+cmsRun ${LOCAL_TEST_DIR}/testConcurrentIOVsLegacy_cfg.py -n 2 &> testConcurrentIOVsLegacy_2concurrentRecords.txt && die 'Failed in testConcurrentIOVsLegacy_cfg.py, the configuration succeeded while it should have failed' $?
+grep "EventSetupRecord ESTestRecordI has a nonconcurrent finder" testConcurrentIOVsLegacy_2concurrentRecords.txt >/dev/null || diecat 'Failed in testConcurrentIOVsLegacy_cfg.py, the configuration failed but in an unexpected way' $? testConcurrentIOVsLegacy_2concurrentRecords.txt
 
 echo testAllowConcurrentIOVs_cfg
 cmsRun ${LOCAL_TEST_DIR}/testAllowConcurrentIOVs_cfg.py || die 'Failed in testAllowConcurrentIOVs_cfg.py' $?

--- a/FWCore/Integration/test/testConcurrentIOVsLegacy_cfg.py
+++ b/FWCore/Integration/test/testConcurrentIOVsLegacy_cfg.py
@@ -12,7 +12,7 @@ import FWCore.ParameterSet.Config as cms
 import argparse
 
 parser = argparse.ArgumentParser(add_help=False)
-parser.add_argument("-n", type=int, default=4)
+parser.add_argument("-n", type=int, default=2)
 args, _ = parser.parse_known_args()
 
 process = cms.Process("TEST")
@@ -30,12 +30,14 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.options = dict(
-    numberOfThreads = args.n,
+    numberOfThreads = 4,
     numberOfStreams = 4,
     numberOfConcurrentRuns = 1,
     numberOfConcurrentLuminosityBlocks = 4,
     eventSetup = dict(
-        numberOfConcurrentIOVs = 2
+        numberOfConcurrentIOVs = 2,
+        forceNumberOfConcurrentIOVs = dict(
+            ESTestRecordI = args.n,)
     )
 )
 


### PR DESCRIPTION
#### PR description:

If a job contains a non-concurrent Finder then we require that the Record associated with the Finder have only 1 concurrent instance.

This replaces the previous condition which required a single thread if there was a non-concurrent Finder in the job. The replacement is because if we have 1 thread but multiple streams then the condition we were trying to enforce fails.

#### PR validation:

Code compiles. Framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/2321