### PR TITLE
do not emit pixel tracks with NaN parameters

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernelsImpl.h
@@ -626,6 +626,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
         for (int i = 0; i < 5; ++i) {
           isNaN |= edm::isNotFinite(tracks_view[it].state()(i));
         }
+        // state(2) is the (finite) inverse pt: an exactly-zero value from a straight-line or
+        // numerically-degenerate fit maps to an infinite momentum in the host local-to-global
+        // transform, so treat it as bad here too and never promote such a track
+        isNaN |= (tracks_view[it].state()(2) == 0.f);
         if (isNaN) {
 #ifdef NTUPLE_DEBUG
           printf("NaN in fit %d size %d chi2 %f\n", it, foundNtuplets->size(it), tracks_view[it].chi2());

--- a/RecoTracker/PixelTrackFitting/plugins/PixelTrackProducerFromSoAAlpaka.cc
+++ b/RecoTracker/PixelTrackFitting/plugins/PixelTrackProducerFromSoAAlpaka.cc
@@ -479,6 +479,15 @@ void PixelTrackProducerFromSoAAlpaka::produce(edm::StreamID streamID,
     GlobalVector pp = gp.momentum();
     math::XYZVector mom(pp.x(), pp.y(), pp.z());
 
+    // A device fit that failed numerically can leave finite SoA parameters that still map to a
+    // non-finite reco trajectory (through transformToPerigeePlane / the local->global transform).
+    // Never emit such a track: drop it and free the edm index reserved above.
+    if (not(std::isfinite(chi2) and std::isfinite(mom.x()) and std::isfinite(mom.y()) and std::isfinite(mom.z()))) {
+      indToEdm[it] = pixelTrack::skippedTrack;
+      --nt;
+      continue;
+    }
+
     auto track = std::make_unique<reco::Track>(chi2, ndof, pos, mom, gp.charge(), CurvilinearTrajectoryError(mo));
 
     // bad and edup not supported as fit not present or not reliable


### PR DESCRIPTION
A numerically-failed device fit can leave finite SoA parameters that still map to a non-finite reco trajectory (via transformToPerigeePlane / the local-to-global transform), producing NaN tracks in the output (observed only on GPU). Skip such tracks in the SoA-to-reco conversion and free the reserved edm index.

