### PR TITLE
Make GPU pixel clustering and CA fishbone reproducible

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
@@ -3,14 +3,13 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <limits>
 
 #include <alpaka/alpaka.hpp>
 
 #include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
 #include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersSoA.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoA.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/prefixScan.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/warpsize.h"
 #include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelClusterThresholds.h"
 
 //#define GPU_DEBUG
@@ -45,6 +44,11 @@ namespace pixelClustering {
       auto& charge = alpaka::declareSharedVar<int32_t[maxNumClustersPerModules], __COUNTER__>(acc);
       auto& ok = alpaka::declareSharedVar<uint8_t[maxNumClustersPerModules], __COUNTER__>(acc);
       auto& newclusId = alpaka::declareSharedVar<uint16_t[maxNumClustersPerModules], __COUNTER__>(acc);
+      // per-cluster minimum packed pixel coordinate (row << 16 | col): a physical, run-independent
+      // key that is unique within the module (a pixel belongs to exactly one cluster), used to
+      // renumber the clusters deterministically (see below)
+      auto& minPix = alpaka::declareSharedVar<uint32_t[maxNumClustersPerModules], __COUNTER__>(acc);
+      auto& nOk = alpaka::declareSharedVar<uint32_t, __COUNTER__>(acc);
 
       constexpr int startBPIX2 = TrackerTraits::layerStart[1];
 
@@ -109,7 +113,10 @@ namespace pixelClustering {
         ALPAKA_ASSERT_ACC(nclus <= maxNumClustersPerModules);
         for (auto i : cms::alpakatools::independent_group_elements(acc, nclus)) {
           charge[i] = 0;
+          minPix[i] = std::numeric_limits<uint32_t>::max();
         }
+        if (cms::alpakatools::once_per_block(acc))
+          nOk = 0;
         alpaka::syncBlockThreads(acc);
 
         for (auto i : cms::alpakatools::independent_group_elements(acc, firstPixel, numElements)) {
@@ -121,66 +128,45 @@ namespace pixelClustering {
                             &charge[digi_view[i].clus()],
                             static_cast<int32_t>(digi_view[i].adc()),
                             alpaka::hierarchy::Threads{});
+          alpaka::atomicMin(acc,
+                            &minPix[digi_view[i].clus()],
+                            (uint32_t(digi_view[i].xx()) << 16) | digi_view[i].yy(),
+                            alpaka::hierarchy::Threads{});
         }
         alpaka::syncBlockThreads(acc);
 
         auto chargeCut = clusterThresholds.getThresholdForLayerOnCondition(thisModuleId < startBPIX2);
 
-        bool good = true;
         for (auto i : cms::alpakatools::independent_group_elements(acc, nclus)) {
-          newclusId[i] = ok[i] = (charge[i] >= chargeCut) ? 1 : 0;
-          if (0 == ok[i])
-            good = false;
+          ok[i] = (charge[i] >= chargeCut) ? 1 : 0;
+          if (ok[i])
+            alpaka::atomicAdd(acc, &nOk, 1u, alpaka::hierarchy::Threads{});
 #ifdef GPU_DEBUG
-          printf("Cutting pix %d in module %d newId %d ok? %d charge %d cut %d -> good %d \n",
-                 i,
-                 thisModuleId,
-                 newclusId[i],
-                 ok[i],
-                 charge[i],
-                 chargeCut,
-                 good);
+          printf("Cutting pix %d in module %d ok? %d charge %d cut %d\n", i, thisModuleId, ok[i], charge[i], chargeCut);
 #endif
         }
-        // if all clusters are above threshold, do nothing
-        if (alpaka::syncBlockThreadsPredicate<alpaka::BlockAnd>(acc, good))
-          continue;
+        alpaka::syncBlockThreads(acc);
 
-        // renumber
-        // FIXME move this logic inside a single prefixscan() function ?
-        if constexpr (cms::alpakatools::requires_single_thread_per_block_v<TAcc>) {
-          // for a single-threaded accelerator, use a simple loop
-          for (uint32_t i = 1; i < nclus; ++i) {
-            newclusId[i] += newclusId[i - 1];
-          }
-        } else {
-          // for a multi-threaded accelerator, use an iterative block-based prefix scan
-          constexpr int warpSize = cms::alpakatools::warpSize;
-          // FIXME this value should come from cms::alpakatools::blockPrefixScan itself
-          constexpr uint32_t maxThreads = warpSize * warpSize;
-
-          auto& ws = alpaka::declareSharedVar<uint16_t[warpSize], __COUNTER__>(acc);
-          auto minClust = std::min(nclus, maxThreads);
-
-          // process the first maxThreads elements
-          cms::alpakatools::blockPrefixScan(acc, newclusId, minClust, ws);
-
-          // if there may be more than maxThreads elements, repeat the prefix scan and update the intermediat sums
-          if constexpr (maxNumClustersPerModules > maxThreads) {
-            for (uint32_t offset = maxThreads; offset < nclus; offset += maxThreads) {
-              cms::alpakatools::blockPrefixScan(acc, newclusId + offset, nclus - offset, ws);
-              for (uint32_t i : cms::alpakatools::independent_group_elements(acc, offset, nclus)) {
-                uint32_t prevBlockEnd = (i / maxThreads) * maxThreads - 1;
-                newclusId[i] += newclusId[prevBlockEnd];
-              }
-              alpaka::syncBlockThreads(acc);
-            }
-          }
+        // Renumber the surviving clusters by ascending minimum pixel coordinate.
+        // The clusters are labelled by FindClus in atomic (run-dependent) order, and the cluster id
+        // determines the position of the corresponding RecHit in the hit SoA: renumbering by a
+        // physical key makes the cluster ids - and everything built on top of them - reproducible
+        // run-to-run and across backends. The key is unique within the module, so the ranks form a
+        // permutation of [0, nOk). The O(nclus^2) rank-by-counting is cheap: at PU200 a module has
+        // ~45 clusters on average and less than ~200 at the 99.9% quantile.
+        for (auto i : cms::alpakatools::independent_group_elements(acc, nclus)) {
+          if (!ok[i])
+            continue;
+          auto const key = minPix[i];
+          uint16_t rank = 0;
+          for (uint32_t j = 0; j < nclus; ++j)
+            rank += (ok[j] && (minPix[j] < key)) ? 1 : 0;
+          newclusId[i] = rank;
+          ALPAKA_ASSERT_ACC(rank < nOk);
         }
+        alpaka::syncBlockThreads(acc);
 
-        ALPAKA_ASSERT_ACC(nclus >= newclusId[nclus - 1]);
-
-        clus_view[thisModuleId].clusInModule() = newclusId[nclus - 1];
+        clus_view[thisModuleId].clusInModule() = nOk;
 
         // reassign id
         for (auto i : cms::alpakatools::independent_group_elements(acc, firstPixel, numElements)) {
@@ -191,7 +177,7 @@ namespace pixelClustering {
           if (0 == ok[digi_view[i].clus()])
             digi_view[i].moduleId() = digi_view[i].clus() = invalidModuleId;
           else
-            digi_view[i].clus() = newclusId[digi_view[i].clus()] - 1;
+            digi_view[i].clus() = newclusId[digi_view[i].clus()];
         }
 
         // done

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CACell.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CACell.h
@@ -112,16 +112,18 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
     ALPAKA_FN_ACC ALPAKA_FN_INLINE void setFishbone(Acc2D const& acc, hindex_type id, float z, const HitsConstView& hh) {
-      // make it deterministic: use the farther apart (in z)
+      // make it deterministic: use the farther apart (in z), breaking exact ties by the hit id so
+      // that concurrent updates converge to the same winner independently of their order
       auto old = theFishboneId_;
-      while (
-          old !=
-          alpaka::atomicCas(
-              acc,
-              &theFishboneId_,
-              old,
-              (invalidHitId == old || std::abs(z - theInnerZ_) > std::abs(hh[old].zGlobal() - theInnerZ_)) ? id : old,
-              alpaka::hierarchy::Blocks{}))
+      while (old != alpaka::atomicCas(
+                        acc,
+                        &theFishboneId_,
+                        old,
+                        (invalidHitId == old || std::abs(z - theInnerZ_) > std::abs(hh[old].zGlobal() - theInnerZ_) ||
+                         (std::abs(z - theInnerZ_) == std::abs(hh[old].zGlobal() - theInnerZ_) && id < old))
+                            ? id
+                            : old,
+                        alpaka::hierarchy::Blocks{}))
         old = theFishboneId_;
     }
 

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAFishbone.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAFishbone.h
@@ -64,16 +64,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caPixelDoublets {
           //printf("cell0 = %d ci = %d\n",bin[0],bin[ic]);
           unsigned int otherCell = bin[ic];
           auto& ci = cells[otherCell];
-          //	printf("xo = %.2f yo = %.2f zo = %.2f xi = %.2f yi = %.2f zi = %.2f \n",xo,yo,zo,ci.inner_x(hh),ci.inner_y(hh),ci.inner_z(hh));
           if (ci.unused())
             continue;  // for triplets equivalent to next
           if (checkTrack && cellTracksHisto->size(otherCell) == 0)
             continue;
-
-          float x1 = (ci.inner_x(hh) - xo);
-          float y1 = (ci.inner_y(hh) - yo);
-          float z1 = (ci.inner_z(hh) - zo);
-          float n1 = x1 * x1 + y1 * y1 + z1 * z1;
 
           for (auto jc = ic + 1; jc < size; ++jc) {
             unsigned int nextCell = bin[jc];
@@ -82,102 +76,101 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caPixelDoublets {
               continue;
             if (checkTrack && cellTracksHisto->size(nextCell) == 0)
               continue;
-#ifdef GPU_DEBUG
-            printf("xx = %.2f yo = %.2f zo = %.2f xi = %.2f yi = %.2f zi = %.2f xj = %.2f yj = %.2f zj = %.2f\n",
-                   xo,
-                   yo,
-                   zo,
-                   ci.inner_x(hh),
-                   ci.inner_y(hh),
-                   ci.inner_z(hh),
-                   cj.inner_x(hh),
-                   cj.inner_y(hh),
-                   cj.inner_z(hh));
-#endif
 
             if (ci.inner_detIndex(hh) == cj.inner_detIndex(hh))
               continue;
 
-            float x2 = (cj.inner_x(hh) - xo);
-            float y2 = (cj.inner_y(hh) - yo);
-            float z2 = (cj.inner_z(hh) - zo);
+            // Evaluate every pair in a canonical orientation, fixed by the (reproducible) inner hit
+            // ids rather than by the (run-dependent) order of the two cells in the hit's cell list.
+            // The two distances are computed by different floating point expressions, so for
+            // borderline pairs both the alignment decision and the choice of the victim could
+            // otherwise flip with the orientation, making the set of killed cells not reproducible
+            // run-to-run.
+            bool swap = ci.inner_hit_id() > cj.inner_hit_id();
+            auto& ca = swap ? cj : ci;
+            auto& cb = swap ? ci : cj;
+
+            float x1 = (ca.inner_x(hh) - xo);
+            float y1 = (ca.inner_y(hh) - yo);
+            float z1 = (ca.inner_z(hh) - zo);
+            float n1 = x1 * x1 + y1 * y1 + z1 * z1;
+
+            float x2 = (cb.inner_x(hh) - xo);
+            float y2 = (cb.inner_y(hh) - yo);
+            float z2 = (cb.inner_z(hh) - zo);
             float n2 = x2 * x2 + y2 * y2 + z2 * z2;
 
             auto cos12 = x1 * x2 + y1 * y2 + z1 * z2;
+#ifdef GPU_DEBUG
+            printf("xo = %.2f yo = %.2f zo = %.2f xa = %.2f ya = %.2f za = %.2f xb = %.2f yb = %.2f zb = %.2f\n",
+                   xo,
+                   yo,
+                   zo,
+                   ca.inner_x(hh),
+                   ca.inner_y(hh),
+                   ca.inner_z(hh),
+                   cb.inner_x(hh),
+                   cb.inner_y(hh),
+                   cb.inner_z(hh));
+#endif
 
             if (cos12 * cos12 >= 0.99999f * (n1 * n2)) {
               // alligned:  kill farthest (prefer consecutive layers)
               // if same layer prefer farthest (longer level arm) and make space for intermediate hit
-              bool sameLayer = int(ci.layerPairId()) == int(cj.layerPairId());
+              bool sameLayer = int(ca.layerPairId()) == int(cb.layerPairId());
               if (n1 > n2) {
                 if (sameLayer) {
-                  cj.kill();  // closest
-                  ci.setFishbone(acc, cj.inner_hit_id(), cj.inner_z(hh), hh);
+                  cb.kill();  // closest
+                  ca.setFishbone(acc, cb.inner_hit_id(), cb.inner_z(hh), hh);
 #ifdef GPU_DEBUG
-                  printf(
-                      "n1>n2 lic = %d ljc = %d dic = %.2f djc = %.2f cell %d kill %d cos = %.7f n1 = %.3f n2 = %.3f "
-                      "same\n",
-                      int(ci.layerPairId()),
-                      int(cj.layerPairId()),
-                      ci.inner_detIndex(hh),
-                      cj.inner_detIndex(hh),
-                      bin[ic],
-                      bin[jc],
-                      cos12 * cos12 / (n1 * n2),
-                      n1,
-                      n2);
+                  printf("n1>n2 la = %d lb = %d da = %.2f db = %.2f cos = %.7f n1 = %.3f n2 = %.3f same\n",
+                         int(ca.layerPairId()),
+                         int(cb.layerPairId()),
+                         ca.inner_detIndex(hh),
+                         cb.inner_detIndex(hh),
+                         cos12 * cos12 / (n1 * n2),
+                         n1,
+                         n2);
 #endif
                 } else {
-                  ci.kill();  // farthest
+                  ca.kill();  // farthest
 #ifdef GPU_DEBUG
-                  printf(
-                      "n1>n2 lic = %d ljc = %d dic = %.2f djc = %.2f cell %d kill %d cos = %.7f n1 = %.3f n2 = %.3f "
-                      "diff\n",
-                      int(ci.layerPairId()),
-                      int(cj.layerPairId()),
-                      ci.inner_detIndex(hh),
-                      cj.inner_detIndex(hh),
-                      bin[jc],
-                      bin[ic],
-                      cos12 * cos12 / (n1 * n2),
-                      n1,
-                      n2);
+                  printf("n1>n2 la = %d lb = %d da = %.2f db = %.2f cos = %.7f n1 = %.3f n2 = %.3f diff\n",
+                         int(ca.layerPairId()),
+                         int(cb.layerPairId()),
+                         ca.inner_detIndex(hh),
+                         cb.inner_detIndex(hh),
+                         cos12 * cos12 / (n1 * n2),
+                         n1,
+                         n2);
 #endif
                   // break;  // removed to improve reproducibility, keep it for reference and tests
                 }
               } else {
                 if (!sameLayer) {
-                  cj.kill();  // farthest
+                  cb.kill();  // farthest
 #ifdef GPU_DEBUG
-                  printf(
-                      "n2>n1 lic = %d ljc = %d dic = %.2f djc = %.2f cell %d kill %d cos = %.7f n1 = %.3f n2 = %.3f "
-                      "diff\n",
-                      int(ci.layerPairId()),
-                      int(cj.layerPairId()),
-                      ci.inner_detIndex(hh),
-                      cj.inner_detIndex(hh),
-                      bin[ic],
-                      bin[jc],
-                      cos12 * cos12 / (n1 * n2),
-                      n1,
-                      n2);
+                  printf("n2>n1 la = %d lb = %d da = %.2f db = %.2f cos = %.7f n1 = %.3f n2 = %.3f diff\n",
+                         int(ca.layerPairId()),
+                         int(cb.layerPairId()),
+                         ca.inner_detIndex(hh),
+                         cb.inner_detIndex(hh),
+                         cos12 * cos12 / (n1 * n2),
+                         n1,
+                         n2);
 #endif
                 } else {
-                  ci.kill();  // closest
-                  cj.setFishbone(acc, ci.inner_hit_id(), ci.inner_z(hh), hh);
+                  ca.kill();  // closest
+                  cb.setFishbone(acc, ca.inner_hit_id(), ca.inner_z(hh), hh);
 #ifdef GPU_DEBUG
-                  printf(
-                      "n2>n1 lic = %d ljc = %d dic = %.2f djc = %.2f cell %d kill %d cos = %.7f n1 = %.3f n2 = %.3f "
-                      "same\n",
-                      int(ci.layerPairId()),
-                      int(cj.layerPairId()),
-                      ci.inner_detIndex(hh),
-                      cj.inner_detIndex(hh),
-                      bin[jc],
-                      bin[ic],
-                      cos12 * cos12 / (n1 * n2),
-                      n1,
-                      n2);
+                  printf("n2>n1 la = %d lb = %d da = %.2f db = %.2f cos = %.7f n1 = %.3f n2 = %.3f same\n",
+                         int(ca.layerPairId()),
+                         int(cb.layerPairId()),
+                         ca.inner_detIndex(hh),
+                         cb.inner_detIndex(hh),
+                         cos12 * cos12 / (n1 * n2),
+                         n1,
+                         n2);
 #endif
                   // break;  // removed to improve reproducibility, keep it for reference and tests
                 }


### PR DESCRIPTION
The cluster ids within a module are assigned in atomic arrival order, making the pixel hit SoA ordering non-reproducible run-to-run on GPU, and everything built on top of it (doublets, ntuplets, tracks) with it. The fishbone also evaluates cell pairs in that run-dependent order, flipping borderline alignment and victim decisions.
This PR renumbers the clusters deterministically by their minimum pixel coordinate, evaluate every fishbone pair in a canonical orientation fixed by the inner hit ids, and break exact ties in the fishbone hit selection by the hit id.

With  deterministic-pixel-clustering-and-ca, the ntulpets finding chain is bit-reproducible run-to-run. Then https://github.com/cms-sw/cmssw/pull/51085  order-independent duplicate removal should complete full GPU reproducibility


