### PR TITLE
Add `passThrough` option to `RecoTrackSelectorBase` for `ngtScouting` HLT tracks

### DIFF
--- a/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
@@ -18,7 +18,8 @@ class RecoTrackSelectorBase {
 public:
   RecoTrackSelectorBase() {}
   RecoTrackSelectorBase(const edm::ParameterSet& cfg)
-      : ptMin_(cfg.getParameter<double>("ptMin")),
+      : passThrough_(cfg.getParameter<bool>("passThrough")),
+        ptMin_(cfg.getParameter<double>("ptMin")),
         minRapidity_(cfg.getParameter<double>("minRapidity")),
         maxRapidity_(cfg.getParameter<double>("maxRapidity")),
         meanPhi_((cfg.getParameter<double>("minPhi") + cfg.getParameter<double>("maxPhi")) / 2.),
@@ -69,6 +70,8 @@ public:
   }
 
   void init(const edm::Event& event, const edm::EventSetup& es) {
+    if (passThrough_)
+      return;
     edm::Handle<reco::BeamSpot> beamSpot;
     event.getByToken(bsSrcToken_, beamSpot);
     vertex_ = beamSpot->position();
@@ -82,6 +85,7 @@ public:
   }
 
   static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    desc.add<bool>("passThrough", false);
     desc.add<bool>("invertRapidityCut", false);
     desc.add<bool>("usePV", false);
     desc.add<double>("lip", 300.0);
@@ -110,6 +114,9 @@ public:
   bool operator()(const reco::Track& t) const { return (*this)(t, vertex_); }
 
   bool operator()(const reco::Track& t, const reco::Track::Point& vertex) const {
+    if (passThrough_)
+      return true;
+
     bool quality_ok = true;
     if (!quality_.empty()) {
       quality_ok = false;
@@ -160,6 +167,7 @@ public:
   }
 
 private:
+  bool passThrough_;
   double ptMin_;
   double minRapidity_;
   double maxRapidity_;

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
@@ -44,12 +44,16 @@ from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 _hltGeneralTracksNGTScouting = cms.EDProducer("RecoTrackSelector",
                                               src = cms.InputTag('hltPhase2PixelTracks'),
                                               copyExtras = cms.untracked.bool(True),
+                                              passThrough = cms.bool(True),
+                                              usePV = cms.bool(False),
                                               minHit = cms.int32(0),
                                               minLayer = cms.int32(0),
                                               min3DLayer = cms.int32(0),
                                               minPixelHit = cms.int32(0),
                                               ptMin = cms.double(0.0),
                                               maxChi2 = cms.double(10000.0),
+                                              beamSpot = cms.InputTag('hltOnlineBeamSpot'),
+                                              vertexTag = cms.InputTag(''),
                                               tip = cms.double(1e9),
                                               lip = cms.double(1e9),
                                               minRapidity = cms.double(-9.9),
@@ -57,8 +61,7 @@ _hltGeneralTracksNGTScouting = cms.EDProducer("RecoTrackSelector",
                                               minPhi = cms.double(-3.2),
                                               maxPhi = cms.double(3.2),
                                               quality = cms.vstring(),
-                                              algorithm = cms.vstring(),
-                                              )
+                                              algorithm = cms.vstring())
 
 _hltGeneralTracksNGTScoutingLST = hltGeneralTracks.clone(
     MinPT = cms.double(0.9),

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -389,6 +389,7 @@ std::unique_ptr<RecoTrackSelectorBase> MTVHistoProducerAlgoForTracker::makeRecoT
   psetTrack.addParameter("invertRapidityCut", false);
   psetTrack.addParameter("minPhi", -3.2);
   psetTrack.addParameter("maxPhi", 3.2);
+  psetTrack.addParameter("passThrough", false);
   return std::make_unique<RecoTrackSelectorBase>(psetTrack);
 }
 


### PR DESCRIPTION
#### PR description:

This PR fixes a bug introduced at https://github.com/cms-sw/cmssw/pull/51186 and updates the `ngtScouting`-modified Phase-2 HLT general-tracks configuration to make use of it.
The main issue is that the default auto-generated `cfi` consumes the **offline** Beam Spot, see at

https://github.com/cms-sw/cmssw-cfipython/blob/CMSSW_20_1_X/CommonTools/RecoAlgos/RecoTrackSelector.py#L18

and the configuration fragment introduced in  https://github.com/cms-sw/cmssw/pull/51186  didn't override it, thus when limiting the job to use the minimal amount of collections to run HLT the job failed

**1.)** `RecoTrackSelectorBase.h`: adds a `passThrough_` boolean member.
- When `passThrough` is `true`, `init()` skips the beamspot/vertex lookup and `operator()` unconditionally returns `true`, so the selector acts as a no-op filter on the input collection.
- `fillPSetDescription` gains the corresponding `passThrough` parameter (default `false`, preserving existing behavior for all other configurations).
- This completes in cms-sw/cmssw#51186, which introduced a pass-through use of `RecoTrackSelector` to avoid a redundant `TrackCollectionFilterCloner` call in the `ngtScouting` general-tracks configuration.

**2.)** `hltGeneralTracks_cfi.py`: configures `_hltGeneralTracksNGTScouting`'s `RecoTrackSelector` with `passThrough = True` and `usePV = False`, and adds the `beamSpot`/`vertexTag` input tags required by `fillPSetDescription`, so the module builds and runs as a pure pass-through of `hltPhase2PixelTracks` rather than re-applying selection cuts.

#### PR validation:

- Ran the relevant Phase-2 HLT menu workflow with the `ngtScouting` modifier and confirmed `hltGeneralTracks` output is unchanged relative to the pre-existing (non-pass-through) selector behavior.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A — this is a fix/follow-up building on the pass-through approach introduced in cms-sw/cmssw#51186, not a backport of it.

