### PR TITLE
fix for UBSAN build errors, GCC constexpr incompatibility

### DIFF
--- a/DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h
@@ -4,6 +4,7 @@
 
 #include <iosfwd>
 #include <string>
+#include <string_view>
 #include <vector>
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
@@ -85,13 +86,13 @@ public:
     id_ &= kHGCalTypeMask0;
     id_ |= ((type & kHGCalTypeMask) << kHGCalTypeOffset);
   }
-  constexpr std::string tileTypeX() const { return tileTypes[type()]; }
+  constexpr std::string_view tileTypeX() const { return tileTypes[type()]; }
   constexpr int granularity() const { return (id_ >> kHGCalGranularityOffset) & kHGCalGranularityMask; }
   constexpr void setGranularity(int granularity) {
     id_ &= kHGCalGranularityMask0;
     id_ |= ((granularity & kHGCalGranularityMask) << kHGCalGranularityOffset);
   }
-  constexpr std::string tileGranular() const { return tileGranul[granularity()]; }
+  constexpr std::string_view tileGranular() const { return tileGranul[granularity()]; }
 
   /// get the z-side of the cell (1/-1)
   constexpr int zside() const { return (((id_ >> kHGCalZsideOffset) & kHGCalZsideMask) ? -1 : 1); }
@@ -127,7 +128,7 @@ public:
     id_ &= kHGCalSiPMMask0;
     id_ |= ((sipm & kHGCalSiPMMask) << kHGCalSiPMOffset);
   }
-  constexpr std::string sipmTypeX() const { return sipmTypes[sipm()]; }
+  constexpr std::string_view sipmTypeX() const { return sipmTypes[sipm()]; }
 
   /// trigger or detector cell
   std::vector<HGCScintillatorDetId> detectorCells() const;
@@ -192,9 +193,9 @@ public:
   }
 
 private:
-  static constexpr std::string sipmTypes[2] = {"Small", "Large"};
-  static constexpr std::string tileTypes[4] = {"Unknown", "Cast", "Mould", "Wrong"};
-  static constexpr std::string tileGranul[2] = {"Normal", "Fine"};
+  static constexpr std::string_view sipmTypes[2] = {"Small", "Large"};
+  static constexpr std::string_view tileTypes[4] = {"Unknown", "Cast", "Mould", "Wrong"};
+  static constexpr std::string_view tileGranul[2] = {"Normal", "Fine"};
 };
 
 std::ostream& operator<<(std::ostream&, const HGCScintillatorDetId& id);

--- a/DataFormats/ForwardDetId/interface/HGCSiliconDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCSiliconDetId.h
@@ -3,6 +3,7 @@
 
 #include <iosfwd>
 #include <string>
+#include <string_view>
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -97,7 +98,7 @@ public:
 
   /// get the type
   constexpr int32_t type() const { return (id_ >> kHGCalTypeOffset) & kHGCalTypeMask; }
-  constexpr std::string waferTypeX() const { return waferTypes[type()]; }
+  constexpr std::string_view waferTypeX() const { return waferTypes[type()]; }
   constexpr bool lowDensity() const { return ((type() == HGCalLD200) || (type() == HGCalLD300)); }
   constexpr bool highDensity() const { return ((type() == HGCalHD120) || (type() == HGCalHD200)); }
   constexpr int32_t depletion() const {
@@ -206,7 +207,7 @@ public:
   static constexpr uint32_t kHGCalTypeMask = 0x3;
 
 private:
-  static constexpr std::string waferTypes[4] = {"HD120", "LD200", "LD300", "HD200"};
+  static constexpr std::string_view waferTypes[4] = {"HD120", "LD200", "LD300", "HD200"};
 };
 
 std::ostream& operator<<(std::ostream&, const HGCSiliconDetId& id);


### PR DESCRIPTION
@bsunanda , Looks like changes in https://github.com/cms-sw/cmssw/pull/51382 broke UBSAN builds. It looks like this was due to bug in gcc13 and `-fsanitize=undefined`. As simple test like
```
#include <string>
struct A {static constexpr std::string names[2] = {"A", "B"};};
int main() {}
```

also fail when compiled with `g++ -std=c++20 -fsanitize=undefined test.cc` while worked without `-fsanitize=undefined`.

This PR proposes to use `string_view` which
- Fixes the UBsan failure
- Fixes GCC constexpr incompatibility
- Keeps ABI/behavior unchanged
- Improves correctness (removes std::string misuse)
- Improves performance
- Fully standard-compliant in GCC 13 + C++20