### PR TITLE
[20.0.X] fix bug in `hltMkFitEventOfHits`, do not use the offline beamspot at HLT

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltMkFitEventOfHits_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltMkFitEventOfHits_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 # MkFitEventOfHits options
 hltMkFitEventOfHits = cms.EDProducer("MkFitEventOfHitsProducer",
-    beamSpot = cms.InputTag("offlineBeamSpot"),
+    beamSpot = cms.InputTag("hltOnlineBeamSpot"),
     mightGet = cms.optional.untracked.vstring,
     pixelHits = cms.InputTag("hltMkFitSiPixelHits"),
     stripHits = cms.InputTag("hltMkFitSiPhase2Hits"),


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/51410

#### PR description:

Title says it all.

#### PR validation:

None, the bot will test

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of backport of https://github.com/cms-sw/cmssw/pull/51410 to be used for the Phase-2 MC production in 20_0_X.
