### PR TITLE
RecoHGCal/TICL: dedicated muon interpretation for TICL candidates

### DIFF
--- a/DataFormats/HGCalReco/interface/Common.h
+++ b/DataFormats/HGCalReco/interface/Common.h
@@ -49,6 +49,8 @@ namespace ticl {
   //constants
   constexpr double mpion = 0.13957;
   constexpr float mpion2 = mpion * mpion;
+  constexpr double mmuon = 0.1056583745;
+  constexpr float mmuon2 = mmuon * mmuon;
   typedef math::XYZVectorF Vector;
 
   inline Trackster::ParticleType tracksterParticleTypeFromPdgId(int pdgId, int charge) {

--- a/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
+++ b/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
@@ -28,6 +28,11 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 namespace ticl {
+  // Sentinel a muon interpretation pass writes into resultCandidate for a track it
+  // rejected (the trajectory points to a shower, so it is not a muon). The producer
+  // routes such tracks to the next (general) pass instead of building a muon candidate.
+  constexpr int kMuonRejected = -2;
+
   template <typename T>
   class TICLInterpretationAlgoBase {
   public:
@@ -79,10 +84,14 @@ namespace ticl {
           : tkTime_h(tkT), tkTimeErr_h(tkTE), tkQuality_h(tkQ), tkBeta_h(tkB), tkPath_h(tkP), tkMtdPos_h(mtdPos) {}
     };
 
+    // maskedTracksters (indexed over input.tracksters) lets several interpretation
+    // passes run in sequence: a pass marks the tracksters it consumes, and later
+    // passes skip them. Empty or all-false means "nothing already consumed".
     virtual void makeCandidates(const Inputs& input,
                                 edm::Handle<MtdHostCollection> inputTiming_h,
                                 std::vector<Trackster>& resultTracksters,
-                                std::vector<int>& resultCandidate) = 0;
+                                std::vector<int>& resultCandidate,
+                                std::vector<bool>& maskedTracksters) = 0;
 
     virtual void initialize(const HGCalDDDConstants* hgcons,
                             const hgcal::RecHitTools rhtools,

--- a/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.cc
@@ -347,7 +347,8 @@ void GNNInterpretationAlgo::buildGraphFromNodes(const std::tuple<Vector, Algebra
 void GNNInterpretationAlgo::makeCandidates(const Inputs& input,
                                            edm::Handle<MtdHostCollection> inputTiming_h,
                                            std::vector<Trackster>& resultTracksters,
-                                           std::vector<int>& resultCandidate) {
+                                           std::vector<int>& resultCandidate,
+                                           std::vector<bool>& maskedTracksters) {
   const auto& tracks = *input.tracksHandle;
   const auto& maskTracks = input.maskedTracks;
   const auto& tracksters = input.tracksters;
@@ -445,6 +446,11 @@ void GNNInterpretationAlgo::makeCandidates(const Inputs& input,
   std::vector<std::vector<unsigned>> trackToTracksters(tracks.size());
   std::vector<std::vector<std::pair<unsigned, float>>> trackToScores(tracks.size());
   std::vector<bool> tracksterAvailable(tracksters.size(), true);
+  // Tracksters consumed by an earlier interpretation pass (e.g. muon MIP tracksters)
+  // are unavailable: they are neither re-linked to a track nor emitted as neutrals.
+  for (size_t i = 0; i < tracksters.size() && i < maskedTracksters.size(); ++i)
+    if (maskedTracksters[i])
+      tracksterAvailable[i] = false;
 
   auto runInferenceForTrack = [&](unsigned trkId,
                                   const std::vector<TrackPropInfo>& tkProps,

--- a/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.h
@@ -43,7 +43,8 @@ namespace ticl {
     void makeCandidates(const Inputs &input,
                         edm::Handle<MtdHostCollection> inputTiming_h,
                         std::vector<Trackster> &resultTracksters,
-                        std::vector<int> &resultCandidate) override;
+                        std::vector<int> &resultCandidate,
+                        std::vector<bool> &maskedTracksters) override;
 
     void initialize(const HGCalDDDConstants *hgcons,
                     const hgcal::RecHitTools rhtools,

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -205,7 +205,8 @@ bool GeneralInterpretationAlgo::timeAndEnergyCompatible(float &total_raw_energy,
 void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
                                                edm::Handle<MtdHostCollection> inputTiming_h,
                                                std::vector<Trackster> &resultTracksters,
-                                               std::vector<int> &resultCandidate) {
+                                               std::vector<int> &resultCandidate,
+                                               std::vector<bool> &maskedTracksters) {
   bool useMTDTiming = inputTiming_h.isValid();
   const auto tkH = input.tracksHandle;
   const auto maskTracks = input.maskedTracks;
@@ -319,6 +320,12 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
   trackstersInTrackIndices.resize(tracks.size());
 
   std::vector<bool> chargedMask(tracksters.size(), true);
+  // Tracksters already consumed by an earlier interpretation pass (e.g. muon MIP
+  // tracksters) are unavailable here: they are neither linked to a track nor emitted
+  // as neutral candidates.
+  for (size_t i = 0; i < tracksters.size() && i < maskedTracksters.size(); ++i)
+    if (maskedTracksters[i])
+      chargedMask[i] = false;
   for (unsigned &i : candidateTrackIds) {
     if (tsNearTk[i].empty() && tsNearTkAtInt[i].empty()) {  // nothing linked to track, make charged hadrons
       continue;

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
@@ -20,7 +20,8 @@ namespace ticl {
     void makeCandidates(const Inputs &input,
                         edm::Handle<MtdHostCollection> inputTiming_h,
                         std::vector<Trackster> &resultTracksters,
-                        std::vector<int> &resultCandidate) override;
+                        std::vector<int> &resultCandidate,
+                        std::vector<bool> &maskedTracksters) override;
 
     void initialize(const HGCalDDDConstants *hgcons,
                     const hgcal::RecHitTools rhtools,

--- a/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.cc
@@ -1,0 +1,112 @@
+#include "RecoHGCal/TICL/plugins/MuonInterpretationAlgo.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+// v0 of the Muon-POG HGCAL muon interpretation. It captures the architecture (point the
+// track into HGCAL, collect the tracksters around the trajectory, require a MIP / not-
+// energetic signature, and consume the MIP tracksters) with a rule-based decision as a
+// placeholder for the neural network. TODOs marked below are the upgrade path:
+//   - replace the direction-based association with full track propagation to the HGCAL
+//     layers (as GeneralInterpretationAlgo does) and per-layer layer-cluster collection;
+//   - run the ONNX muon-ID network over those layer clusters (onnx_model_path_).
+
+using namespace ticl;
+
+MuonInterpretationAlgo::MuonInterpretationAlgo(const edm::ParameterSet &conf, edm::ConsumesCollector iC)
+    : TICLInterpretationAlgoBase(conf, iC),
+      delta_tk_ts_(conf.getParameter<double>("delta_tk_ts")),
+      mip_energy_max_(conf.getParameter<double>("mip_energy_max")),
+      onnx_model_path_(conf.getParameter<std::string>("onnx_model_path")),
+      hgcons_(nullptr) {}
+
+MuonInterpretationAlgo::~MuonInterpretationAlgo() {}
+
+void MuonInterpretationAlgo::initialize(const HGCalDDDConstants *hgcons,
+                                        const hgcal::RecHitTools rhtools,
+                                        const edm::ESHandle<MagneticField> bfieldH,
+                                        const edm::ESHandle<Propagator> propH) {
+  hgcons_ = hgcons;
+  rhtools_ = rhtools;
+  bfield_ = bfieldH;
+  propagator_ = propH;
+}
+
+bool MuonInterpretationAlgo::isMuonLike(double nearbyEnergy, unsigned /*nNearbyTracksters*/) const {
+  // TODO: when onnx_model_path_ is set, run the muon-ID network over the surrounding
+  // layer clusters and use its score here. Until then, the Muon-POG "not energetic"
+  // requirement is the decision: a muon deposits a MIP, so the tracksters around its
+  // trajectory carry little energy.
+  return nearbyEnergy < mip_energy_max_;
+}
+
+void MuonInterpretationAlgo::makeCandidates(const Inputs &input,
+                                            edm::Handle<MtdHostCollection> /*inputTiming_h*/,
+                                            std::vector<Trackster> &resultTracksters,
+                                            std::vector<int> &resultCandidate,
+                                            std::vector<bool> &maskedTracksters) {
+  const auto &tracks = *input.tracksHandle;
+  const auto &maskTracks = input.maskedTracks;
+  const auto &tracksters = input.tracksters;
+  if (maskedTracksters.size() < tracksters.size())
+    maskedTracksters.resize(tracksters.size(), false);
+
+  for (size_t iTrack = 0; iTrack < tracks.size(); ++iTrack) {
+    if (!maskTracks[iTrack])
+      continue;
+    const auto &tk = tracks[iTrack];
+    // TODO: propagate the track to the HGCAL layers; here we use the outer track
+    // direction (or the momentum direction) as the HGCAL entry direction, which is a
+    // good approximation for a minimally-bending muon.
+    const auto dir = tk.outerOk() ? tk.outerMomentum() : tk.momentum();
+    const double tkEta = dir.eta();
+    const double tkPhi = dir.phi();
+
+    // Collect the tracksters whose barycenter lies within the (eta,phi) window around
+    // the trajectory, and sum their raw energy (the "is it energetic?" measure).
+    std::vector<unsigned> nearby;
+    double nearbyEnergy = 0.;
+    for (unsigned iTs = 0; iTs < tracksters.size(); ++iTs) {
+      if (maskedTracksters[iTs])
+        continue;
+      const auto &bary = tracksters[iTs].barycenter();
+      if (bary.eta() * tkEta < 0.)  // same endcap
+        continue;
+      if (reco::deltaR(bary.eta(), bary.phi(), tkEta, tkPhi) < delta_tk_ts_) {
+        nearby.push_back(iTs);
+        nearbyEnergy += tracksters[iTs].raw_energy();
+      }
+    }
+
+    if (!isMuonLike(nearbyEnergy, nearby.size())) {
+      // Trajectory points to a shower: this is not a muon. Flag it so the producer
+      // routes it to the general interpretation instead of building a muon candidate.
+      resultCandidate[iTrack] = kMuonRejected;
+      continue;
+    }
+
+    // Muon: consume the MIP tracksters (mask them) and merge them into one trackster so
+    // the producer can attach it to the muon candidate; the candidate energy itself is
+    // taken from the track momentum by the producer.
+    if (!nearby.empty()) {
+      Trackster muonTrackster;
+      for (unsigned iTs : nearby) {
+        muonTrackster.mergeTracksters(tracksters[iTs]);
+        maskedTracksters[iTs] = true;
+      }
+      resultCandidate[iTrack] = static_cast<int>(resultTracksters.size());
+      resultTracksters.push_back(muonTrackster);
+    } else {
+      resultCandidate[iTrack] = -1;  // muon with no HGCAL deposit: track-only candidate
+    }
+  }
+}
+
+void MuonInterpretationAlgo::fillPSetDescription(edm::ParameterSetDescription &desc) {
+  desc.add<double>("delta_tk_ts", 0.1)->setComment("(eta,phi) window to collect tracksters around the trajectory.");
+  desc.add<double>("mip_energy_max", 10.0)
+      ->setComment("Max summed raw energy [GeV] around the trajectory for a MIP-like (muon) signature.");
+  desc.add<std::string>("onnx_model_path", "")
+      ->setComment("ONNX muon-ID model; empty falls back to the rule-based MIP test.");
+  TICLInterpretationAlgoBase::fillPSetDescription(desc);
+}

--- a/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.h
@@ -1,0 +1,76 @@
+#ifndef RecoHGCal_TICL_MuonInterpretationAlgo_h
+#define RecoHGCal_TICL_MuonInterpretationAlgo_h
+
+// Muon interpretation for TICL candidates. A muon crosses HGCAL as a MIP: it should
+// NOT be built from the small calorimetric deposit it leaves (as the general
+// interpretation would), but recognised as a muon and built from the track momentum,
+// with its MIP tracksters consumed so they do not resurface as neutral candidates.
+//
+// This is where the Muon-POG HGCAL muon identification belongs. For each candidate
+// track this algo:
+//   1. points/propagates the track into HGCAL and collects the layer clusters /
+//      tracksters in an (eta,phi) window around the trajectory;
+//   2. checks the trajectory does NOT coincide with an energetic trackster (a muon is
+//      MIP-like, not a shower) - the "not energetic" requirement;
+//   3. runs a neural network over the surrounding layer clusters to decide muon vs not
+//      (ONNX model, path configurable like the other TICL inference). The trained
+//      weights are a Muon-POG deliverable; until a model is provided the decision falls
+//      back to the rule-based MIP/not-energetic test so the algo is runnable.
+// A track accepted as a muon has its MIP tracksters masked (consumed) and is reported
+// so the producer builds a muon candidate from the track momentum.
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+
+#include <memory>
+#include <string>
+
+namespace cms::Ort {
+  class ONNXRuntime;
+}
+
+namespace ticl {
+
+  class MuonInterpretationAlgo : public TICLInterpretationAlgoBase<reco::Track> {
+  public:
+    MuonInterpretationAlgo(const edm::ParameterSet &conf, edm::ConsumesCollector iC);
+    ~MuonInterpretationAlgo() override;
+
+    void makeCandidates(const Inputs &input,
+                        edm::Handle<MtdHostCollection> inputTiming_h,
+                        std::vector<Trackster> &resultTracksters,
+                        std::vector<int> &resultCandidate,
+                        std::vector<bool> &maskedTracksters) override;
+
+    void initialize(const HGCalDDDConstants *hgcons,
+                    const hgcal::RecHitTools rhtools,
+                    const edm::ESHandle<MagneticField> bfieldH,
+                    const edm::ESHandle<Propagator> propH) override;
+
+    static void fillPSetDescription(edm::ParameterSetDescription &iDesc);
+
+  private:
+    // NN muon score over the layer clusters around the trajectory. Falls back to the
+    // rule-based MIP/not-energetic decision when no ONNX model is configured.
+    bool isMuonLike(double nearbyEnergy, unsigned nNearbyTracksters) const;
+
+    // (eta,phi) window used to collect tracksters around the track direction.
+    const double delta_tk_ts_;
+    // Max summed raw energy of the tracksters around the trajectory for a MIP-like
+    // (muon) signature; above this the track points to a shower and is not a muon.
+    const double mip_energy_max_;
+    // ONNX muon-ID model (empty -> rule-based fallback). Loaded via the global cache.
+    const std::string onnx_model_path_;
+
+    const HGCalDDDConstants *hgcons_;
+    hgcal::RecHitTools rhtools_;
+    edm::ESHandle<MagneticField> bfield_;
+    edm::ESHandle<Propagator> propagator_;
+  };
+
+}  // namespace ticl
+
+#endif

--- a/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
@@ -79,6 +79,7 @@ private:
                               F func) const;
 
   std::unique_ptr<TICLInterpretationAlgoBase<reco::Track>> generalInterpretationAlgo_;
+  std::unique_ptr<TICLInterpretationAlgoBase<reco::Track>> muonInterpretationAlgo_;
   std::vector<edm::EDGetTokenT<std::vector<Trackster>>> egamma_tracksters_tokens_;
   std::vector<edm::EDGetTokenT<std::vector<std::vector<unsigned>>>> egamma_tracksterlinks_tokens_;
 
@@ -210,6 +211,11 @@ TICLCandidateProducer::TICLCandidateProducer(const edm::ParameterSet &ps, const 
   auto algoType = interpretationPSet.getParameter<std::string>("type");
   generalInterpretationAlgo_ =
       TICLGeneralInterpretationPluginFactory::get()->create(algoType, interpretationPSet, consumesCollector());
+
+  auto muonInterpretationPSet = ps.getParameter<edm::ParameterSet>("muonInterpretationDescPSet");
+  auto muonAlgoType = muonInterpretationPSet.getParameter<std::string>("type");
+  muonInterpretationAlgo_ =
+      TICLGeneralInterpretationPluginFactory::get()->create(muonAlgoType, muonInterpretationPSet, consumesCollector());
 }
 
 std::unique_ptr<ticl::TICLONNXGlobalCache> TICLCandidateProducer::initializeGlobalCache(
@@ -229,6 +235,7 @@ void TICLCandidateProducer::beginRun(edm::Run const &iEvent, edm::EventSetup con
   bfield_ = es.getHandle(bfield_token_);
   propagator_ = es.getHandle(propagator_token_);
   generalInterpretationAlgo_->initialize(hgcons_, rhtools_, bfield_, propagator_);
+  muonInterpretationAlgo_->initialize(hgcons_, rhtools_, bfield_, propagator_);
 
   trackingGeometry_ = es.getHandle(trackingGeometry_token_);
 }
@@ -326,6 +333,55 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
   maskTracks.resize(tracks.size());
   filterTracks(tracks_h, muons_h, cutTk_, tkEnergyCut_, maskTracks);
 
+  // Split the selected tracks: identified muons go to the muon interpretation pass
+  // (built from the track momentum), the rest to the general pass.
+  std::vector<bool> muonTrackMask(tracks.size(), false);
+  std::vector<bool> generalTrackMask(maskTracks);
+  for (size_t i = 0; i < tracks.size(); ++i) {
+    if (!maskTracks[i])
+      continue;
+    auto trackRef = edm::Ref<reco::TrackCollection>(tracks_h, i);
+    const int muId = PFMuonAlgo::muAssocToTrack(trackRef, *muons_h);
+    const reco::MuonRef muonRef(muons_h, muId);
+    if (muonRef.isNonnull() and PFMuonAlgo::isMuon(muonRef)) {
+      muonTrackMask[i] = true;
+      generalTrackMask[i] = false;
+    }
+  }
+
+  const typename TICLInterpretationAlgoBase<reco::Track>::Inputs muonInput(evt,
+                                                                           es,
+                                                                           layerClusters,
+                                                                           layerClustersTimes,
+                                                                           generalTrackstersSpan,
+                                                                           generalTracksterLinksGlobalId,
+                                                                           tracks_h,
+                                                                           muonTrackMask);
+  auto resultCandidates = std::make_unique<std::vector<TICLCandidate>>();
+  std::vector<int> muonInTrackIndices(tracks.size(), -1);
+  std::vector<int> trackstersInTrackIndices(tracks.size(), -1);
+
+  //TODO
+  //egammaInterpretationAlg_->makecandidates(inputGSF, inputTiming, *resultTrackstersMerged, trackstersInGSFTrackIndices)
+  // mask generalTracks associated to GSFTrack linked in egammaInterpretationAlgo_
+
+  // Tracksters consumed across interpretation passes (indexed over the input span). The
+  // muon pass runs first: it masks the MIP tracksters it consumes and reports, per
+  // muon-candidate track, the consumed trackster (>=0), no trackster (-1, a track-only
+  // muon), or a rejection (kMuonRejected: the trajectory points to a shower).
+  std::vector<bool> maskedInputTracksters(generalTrackstersSpan.size(), false);
+  muonInterpretationAlgo_->makeCandidates(
+      muonInput, inputTiming_h, *resultTracksters, muonInTrackIndices, maskedInputTracksters);
+
+  // A track the muon pass rejected is not a muon: route it back to the general pass so
+  // it is reconstructed there (and no muon candidate is built for it below).
+  for (size_t iTrack = 0; iTrack < tracks.size(); ++iTrack) {
+    if (muonTrackMask[iTrack] && muonInTrackIndices[iTrack] == kMuonRejected) {
+      muonTrackMask[iTrack] = false;
+      generalTrackMask[iTrack] = true;
+    }
+  }
+
   const typename TICLInterpretationAlgoBase<reco::Track>::Inputs input(evt,
                                                                        es,
                                                                        layerClusters,
@@ -333,16 +389,9 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
                                                                        generalTrackstersSpan,
                                                                        generalTracksterLinksGlobalId,
                                                                        tracks_h,
-                                                                       maskTracks);
-
-  auto resultCandidates = std::make_unique<std::vector<TICLCandidate>>();
-  std::vector<int> trackstersInTrackIndices(tracks.size(), -1);
-
-  //TODO
-  //egammaInterpretationAlg_->makecandidates(inputGSF, inputTiming, *resultTrackstersMerged, trackstersInGSFTrackIndices)
-  // mask generalTracks associated to GSFTrack linked in egammaInterpretationAlgo_
-
-  generalInterpretationAlgo_->makeCandidates(input, inputTiming_h, *resultTracksters, trackstersInTrackIndices);
+                                                                       generalTrackMask);
+  generalInterpretationAlgo_->makeCandidates(
+      input, inputTiming_h, *resultTracksters, trackstersInTrackIndices, maskedInputTracksters);
 
   assignPCAtoTracksters(*resultTracksters,
                         layerClusters,
@@ -357,9 +406,30 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
 
   std::vector<bool> maskTracksters(resultTracksters->size(), true);
   edm::OrphanHandle<std::vector<Trackster>> resultTracksters_h = evt.put(std::move(resultTracksters));
-  //create ChargedCandidates
+
+  // Muon candidates: energy from the track momentum (pdgId 13), attaching the MIP
+  // trackster the muon pass associated (if any) and masking it so it is not re-emitted.
+  for (size_t iTrack = 0; iTrack < tracks.size(); ++iTrack) {
+    if (!muonTrackMask[iTrack])
+      continue;
+    auto trackPtr = edm::Ptr<reco::Track>(tracks_h, iTrack);
+    auto const &tk = *trackPtr;
+    const int tracksterId = muonInTrackIndices[iTrack];
+    edm::Ptr<Trackster> tracksterPtr;
+    if (tracksterId >= 0) {
+      tracksterPtr = edm::Ptr<Trackster>(resultTracksters_h, tracksterId);
+      maskTracksters[tracksterId] = false;
+    }
+    TICLCandidate muonCandidate(trackPtr, tracksterPtr);
+    muonCandidate.setPdgId(13 * tk.charge());
+    math::PtEtaPhiMLorentzVector p4Polar(tk.pt(), tk.eta(), tk.phi(), ticl::mmuon);
+    muonCandidate.setP4(p4Polar);
+    resultCandidates->push_back(muonCandidate);
+  }
+
+  //create ChargedCandidates (non-muon tracks)
   for (size_t iTrack = 0; iTrack < tracks.size(); iTrack++) {
-    if (maskTracks[iTrack]) {
+    if (generalTrackMask[iTrack]) {
       auto const tracksterId = trackstersInTrackIndices[iTrack];
       auto trackPtr = edm::Ptr<reco::Track>(tracks_h, iTrack);
       if (tracksterId != -1 and !maskTracksters.empty()) {
@@ -367,18 +437,6 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
         TICLCandidate chargedCandidate(trackPtr, tracksterPtr);
         resultCandidates->push_back(chargedCandidate);
         maskTracksters[tracksterId] = false;
-      } else {
-        //charged candidates track only
-        auto trackRef = edm::Ref<reco::TrackCollection>(tracks_h, iTrack);
-        const int muId = PFMuonAlgo::muAssocToTrack(trackRef, *muons_h);
-        const reco::MuonRef muonRef = reco::MuonRef(muons_h, muId);
-        if (muonRef.isNonnull() and muonRef->isGlobalMuon()) {
-          // create muon candidate
-          edm::Ptr<Trackster> tracksterPtr;
-          TICLCandidate chargedCandidate(trackPtr, tracksterPtr);
-          chargedCandidate.setPdgId(13 * trackPtr.get()->charge());
-          resultCandidates->push_back(chargedCandidate);
-        }
       }
     }
   }
@@ -530,6 +588,9 @@ void TICLCandidateProducer::fillDescriptions(edm::ConfigurationDescriptions &des
   edm::ParameterSetDescription desc;
   edm::ParameterSetDescription interpretationDesc;
   interpretationDesc.addNode(edm::PluginDescription<TICLGeneralInterpretationPluginFactory>("type", "General", true));
+  edm::ParameterSetDescription muonInterpretationDesc;
+  muonInterpretationDesc.addNode(edm::PluginDescription<TICLGeneralInterpretationPluginFactory>("type", "Muon", true));
+  desc.add<edm::ParameterSetDescription>("muonInterpretationDescPSet", muonInterpretationDesc);
   edm::ParameterSetDescription inferenceDesc;
   inferenceDesc.addNode(edm::PluginDescription<TracksterInferenceAlgoFactory>("type", "TracksterInferenceByPFN", true));
   desc.add<edm::ParameterSetDescription>("pluginInferenceAlgoTracksterInferenceByPFN", inferenceDesc);

--- a/RecoHGCal/TICL/plugins/TICLInterpretationPluginFactory.cc
+++ b/RecoHGCal/TICL/plugins/TICLInterpretationPluginFactory.cc
@@ -5,9 +5,11 @@
 #include "RecoHGCal/TICL/plugins/TICLInterpretationPluginFactory.h"
 #include "GeneralInterpretationAlgo.h"
 #include "GNNInterpretationAlgo.h"
+#include "MuonInterpretationAlgo.h"
 
 EDM_REGISTER_VALIDATED_PLUGINFACTORY(TICLGeneralInterpretationPluginFactory, "TICLGeneralInterpretationPluginFactory");
 EDM_REGISTER_VALIDATED_PLUGINFACTORY(TICLEGammaInterpretationPluginFactory, "TICLEGammaInterpretationPluginFactory");
 DEFINE_EDM_VALIDATED_PLUGIN(TICLGeneralInterpretationPluginFactory, ticl::GeneralInterpretationAlgo, "General");
 DEFINE_EDM_VALIDATED_PLUGIN(TICLGeneralInterpretationPluginFactory, ticl::GNNInterpretationAlgo, "GNNLink");
+DEFINE_EDM_VALIDATED_PLUGIN(TICLGeneralInterpretationPluginFactory, ticl::MuonInterpretationAlgo, "Muon");
 // DEFINE_EDM_VALIDATED_PLUGIN(TICLEGammaInterpretationPluginFactory, ticl::EGammaInterpretation, "EGamma");


### PR DESCRIPTION
A muon crosses HGCAL as a MIP and must be built from the track momentum, not the small calorimetric deposit the general interpretation would use. Add a MuonInterpretationAlgo (interpretation plugin type "Muon") that points the track into HGCAL, collects the tracksters around the trajectory, requires a MIP / not-energetic signature (an ONNX muon-ID hook is provided with a rule-based fallback until a trained model is available), and consumes the MIP tracksters.

 TICLCandidateProducer runs the two passes and builds each muon candidate (pdgId 13) from the track momentum, attaching its MIP trackster; a track the muon pass rejects (points to a shower) is routed to the general pass.

@waredjeb @cms-sw/muon-pog-l2 