### PR TITLE
[Backport] update Sherpack name with SCRAM_ARCH and CMSSW_VERSION

### DIFF
--- a/GeneratorInterface/SherpaInterface/data/MakeSherpaLibs.sh
+++ b/GeneratorInterface/SherpaInterface/data/MakeSherpaLibs.sh
@@ -81,7 +81,7 @@ clean_libs() {
 #    rm *.tex
 #   rm aclocal.m4 ChangeLog depcomp install-sh libtool ltmain.sh missing
     rm aclocal.m4 ChangeLog depcomp install-sh ltmain.sh missing
-    rm AUTHORS COPYING INSTALL NEWS README 
+    rm AUTHORS COPYING INSTALL NEWS README
     rm -rf autom4te.cache
     find ./ -type f -name 'Makefile*' -exec rm -rf {} \;
     find ./ -type d -name '.deps'     -exec rm -rf {} \;
@@ -148,7 +148,7 @@ do
   \?)
     shift `expr $OPTIND - 1`
     if [ "$1" = "--help" ]; then print_help && exit 0;
-    else 
+    else
       echo -n "MakeSherpaLibs: error: unrecognized option "
       if [ $OPTARG != "-" ]; then echo "'-$OPTARG'. try '-h'"
       else echo "'$1'. try '-h'"
@@ -234,15 +234,15 @@ cd ${shrun}
 runfile="Run.dat"
 runcardfile=Run.dat_${prc}
 outflbs=sherpa_${prc}
-cardfile=${outflbs}_cards.tgz             # input card file (master -> libraries)
+cardfile=${outflbs}_cards_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz             # input card file (master -> libraries)
 if [ "${lbo}" = "CRSS" ]; then
-  cardfile=${outflbs}_crdC.tgz
+  cardfile=${outflbs}_crdC_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz
 elif [ "${lbo}" = "EVTS" ]; then
-  cardfile=${outflbs}_crdE.tgz
+  cardfile=${outflbs}_crdE_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz
 fi
-libsfile=${outflbs}_libs.tgz              # output libs
-crssfile=${outflbs}_crss.tgz              # output cross sections
-evtsfile=${outflbs}_evts.tgz              # output events
+libsfile=${outflbs}_libs_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz              # output libs
+crssfile=${outflbs}_crss_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz              # output cross sections
+evtsfile=${outflbs}_evts_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz              # output events
 if [ ! "${cfdc}" = "" ]; then
   cardfile=${cfdc}                        # custom input data card file
   echo " <I> using custom data card file: "${cardfile}
@@ -255,14 +255,14 @@ if [ ! "${cfcr}" = "" ]; then
   crssfile=${cfcr}                        # custom input cross section file
   echo " <I> using custom cross section file: "${crssfile}
 fi
-crdlfile=${outflbs}_crdL.tgz              # output cardfile (-> from library production)
-crdcfile=${outflbs}_crdC.tgz              # output cardfile (-> from cross section calculation)
-crdefile=${outflbs}_crdE.tgz              # output cardfile (-> from event generation)
-loglfile=${outflbs}_logL.tgz              # output messages (-> from library production)
-logcfile=${outflbs}_logC.tgz              # output messages (-> from cross section calculation)
-logefile=${outflbs}_logE.tgz              # output messages (-> from event generation)
+crdlfile=${outflbs}_crdL_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz              # output cardfile (-> from library production)
+crdcfile=${outflbs}_crdC_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz              # output cardfile (-> from cross section calculation)
+crdefile=${outflbs}_crdE_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz              # output cardfile (-> from event generation)
+loglfile=${outflbs}_logL_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz              # output messages (-> from library production)
+logcfile=${outflbs}_logC_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz              # output messages (-> from cross section calculation)
+logefile=${outflbs}_logE_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz              # output messages (-> from event generation)
 #
-gridfile=${outflbs}_migr.tgz              # multiple interactions phase-space grid
+gridfile=${outflbs}_migr_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz              # multiple interactions phase-space grid
 #
 dir1="Process"                            # SHERPA process directory name
 dir2="Result"                             # SHERPA results directory name
@@ -537,7 +537,7 @@ if [ "${lbo}" == "LIBS" ] || [ "${lbo}" == "LBCR" ]; then
       nlines=200
 #      nphbw=`tail -${nlines} ${shrun}/${outflbs}_pass${lbo}.out | grep -c "has been written"`
 #      npasw=`tail -${nlines} ${shrun}/${outflbs}_pass${lbo}.out | grep -c "AMEGIC::Single_Process::WriteLibrary"`
-      npnlc=`tail -${nlines} ${shrun}/${outflbs}_pass${lbo}.out | grep -c "New libraries created. Please compile."` 
+      npnlc=`tail -${nlines} ${shrun}/${outflbs}_pass${lbo}.out | grep -c "New libraries created. Please compile."`
 #      if [ ${nphbw} -gt 0 ] || [ ${npasw} -gt 0 ] || [ ${npnlc} -gt 0 ] ; then
       if [ ${npnlc} -gt 0 ] ; then
         echo " <I> (AMEGIC) detected library writing: "${nphbw}" (HBW), "${npasw}" (ASW), "${npnlc}" (NLC)"
@@ -599,7 +599,7 @@ fi
 
 if [ "${lbo}" == "LBCR" ] || [ "${lbo}" = "CRSS" ]; then
   touch ${crssfile}.tmp
-  find ./${dir2}/ -name '*'     > tmp.lst 
+  find ./${dir2}/ -name '*'     > tmp.lst
   if [ -e Result.db ]; then
     echo Result.db >> tmp.lst
   fi

--- a/GeneratorInterface/SherpaInterface/data/PrepareSherpaLibs.sh
+++ b/GeneratorInterface/SherpaInterface/data/PrepareSherpaLibs.sh
@@ -49,7 +49,9 @@ function build_python_cff() {
   cfffilename=$1  # config file name
   process=$2      # process name
   checksum=$3     # MD5 checksum
-  hepmc_version=$4       # HepMC version (HepMC2 or HepMC3)
+  sherpackfile=$4 # sherpack tar.xz filename
+  hepmc_version=$5       # HepMC version (HepMC2 or HepMC3)
+
   if [ -e ${cfffilename} ]; then rm ${cfffilename}; fi
   touch ${cfffilename}
 
@@ -62,9 +64,9 @@ function build_python_cff() {
   echo "source = cms.Source(\"EmptySource\")"                              >> ${cfffilename}
   echo ""                                                                  >> ${cfffilename}
   if [ $hepmc_version == "HepMC3" ]; then
-      echo "generator = cms.EDFilter(\"SherpaHepMC3GeneratorFilter\","               >> ${cfffilename}
+      echo "generator = cms.EDFilter(\"SherpaHepMC3GeneratorFilter\","     >> ${cfffilename}
   elif [ $hepmc_version == "HepMC2" ]; then
-      echo "generator = cms.EDFilter(\"SherpaGeneratorFilter\","               >> ${cfffilename}
+      echo "generator = cms.EDFilter(\"SherpaGeneratorFilter\","           >> ${cfffilename}
   else
       echo "[ EXIT ]: Unsupported HepMC version: $hepmc_version. Please use HepMC3 or HepMC2."
       exit 1
@@ -73,7 +75,8 @@ function build_python_cff() {
   echo "  filterEfficiency = cms.untracked.double(1.0),"                   >> ${cfffilename}
   echo "  crossSection = cms.untracked.double(-1),"                        >> ${cfffilename}
   echo "  SherpaProcess = cms.string('"${process}"'),"                     >> ${cfffilename}
-  echo "  SherpackLocation = cms.string('./'),"                            >> ${cfffilename}
+  echo "  NewSherpackFormat = cms.bool(True),"                             >> ${cfffilename}
+  echo "  SherpackLocation = cms.string('"${sherpackfile}"'),"             >> ${cfffilename}
   echo "  SherpackChecksum = cms.string('"${checksum}"'),"                 >> ${cfffilename}
   echo "  FetchSherpack = cms.bool(False),"                                >> ${cfffilename}
 ##  if [ "${imode}" = "PROD" ]; then
@@ -247,7 +250,7 @@ HDIR=`pwd`
 # 'guess' SHERPA dataset name
 ip=1
 cproc="XXX"
-for file in `ls sherpa_*_libs.tgz`; do
+for file in `ls sherpa_*_libs_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz`; do
   if [ $ip -eq 1 ]; then
     cproc=`echo $file | awk -F"sherpa_" '{print $2}' | awk -F"_libs" '{print $1}'`
   fi
@@ -350,10 +353,10 @@ echo "  -> HepMC version '"${vhepmc}"'"
 
 
 # set SHERPA data file names
-cardfile=sherpa_${dataset}_crdE.tgz
-libsfile=sherpa_${dataset}_libs.tgz
-crssfile=sherpa_${dataset}_crss.tgz
-gridfile=sherpa_${dataset}_migr.tgz
+cardfile=sherpa_${dataset}_crdE_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz
+libsfile=sherpa_${dataset}_libs_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz
+crssfile=sherpa_${dataset}_crss_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz
+gridfile=sherpa_${dataset}_migr_${SCRAM_ARCH}_${CMSSW_VERSION}.tgz
 if [ ! "${cfdc}" = "" ]; then cardfile=${cfdc}; fi
 if [ ! "${cflb}" = "" ]; then libsfile=${cflb}; fi
 if [ ! "${cfcr}" = "" ]; then crssfile=${cfcr}; fi
@@ -409,23 +412,20 @@ if [ ! "${cfgr}" = "" ]; then gridfile=${cfgr}; fi
 spsummd5=""
 
 ##if [ "${imode}" = "PROD" ] || [ "${imode}" = "LOCAL" ]; then
-  shpamstfile="sherpa_"${dataset}"_MASTER.tgz"
-  shpamstmd5s="sherpa_"${dataset}"_MASTER.md5"
+  shpaxzfile="sherpa_"${dataset}"_MASTER_${SCRAM_ARCH}_${CMSSW_VERSION}.tar.xz"
   shpacfffile="sherpa_"${dataset}"_MASTER_cff.py"
 
   cd ${MYCMSSWSHPA}
 
-  tar -czf ${shpamstfile} *
+  tar -cJpf ${shpaxzfile} *
 ####
-  md5sum ${shpamstfile} > ${shpamstmd5s}
-  spsummd5=`md5sum ${shpamstfile} | cut -f1 -d" "`
+  spsummd5=`md5sum ${shpaxzfile} | cut -f1 -d" "`
 ####
 
 ##  build_python_cff ${imode} ${shpacfffile} ${dataset} ${spsummd5}
-  build_python_cff ${shpacfffile} ${dataset} ${spsummd5} ${vhepmc}
+  build_python_cff ${shpacfffile} ${dataset} ${spsummd5} ${shpaxzfile} ${vhepmc}
 
-  mv ${shpamstfile} $HDIR
-  mv ${shpamstmd5s} $HDIR
+  mv ${shpaxzfile} $HDIR
   mv ${shpacfffile} $HDIR
 
   cd $HDIR
@@ -439,11 +439,10 @@ echo " <I>  "
 echo " <I>  "
 echo " <I>  "
 echo " <I>  generated sherpack:"
-echo " <I>    "${shpamstfile}
+echo " <I>    "${shpaxzfile}
 echo " <I>  generated python fragment:"
 echo " <I>    "${shpacfffile}
-echo " <I>  MD5 checksum file:"
-echo " <I>    "${shpamstmd5s}
+echo " <I>  (MD5 checksum stored inside sherpa_<process>_MASTER_cff.py in associated with the production of sherpack, could also be derived with 'md5sum sherpack' command)"
 echo " <I>  "
 echo " <I>  "
 echo " <I>  "
@@ -463,7 +462,7 @@ echo " <I>    FetchSherpack = cms.bool(true)"
 echo " <I>  "
 echo " <I>  "
 echo " <I>  for a production with CRAB add the sherpack to the list of additional files"
-echo " <I>    additional_input_files = [name of the ..._MASTER.tgz sherpack]"
+echo " <I>    additional_input_files = [name of the ..._MASTER_<SCRAM_ARCH>_<CMSSW_VERSION>.tgz sherpack]"
 echo " <I>  make sure that the sherpack location is"
 echo " <I>    SherpackLocation = cms.string('./')"
 echo " <I>  and make sure that the SherpaInterface does not try to fetch the sherpack"

--- a/GeneratorInterface/SherpaInterface/data/README.md
+++ b/GeneratorInterface/SherpaInterface/data/README.md
@@ -1,0 +1,95 @@
+# SherpaInterface data utilities
+
+## convert_sherpack.sh
+
+Converts a Sherpa sherpack between the **new** (`.tar.xz`) and **old** (`.tgz`) formats,
+and generates the matching `_cff.py` fragment from the `Run.dat` inside the sherpack.
+
+### Formats
+
+| Format | Filename pattern | Used with |
+|--------|-----------------|-----------|
+| new | `sherpa_<PROCESS>_<SCRAM_ARCH>_<CMSSW_VERSION>.tar.xz` | CMSSW ≥ 14 (xz-aware `SherpackFetcher`) |
+| old | `sherpa_<PROCESS>.tgz` | legacy gzip-based `SherpackFetcher` |
+
+### Prerequisites
+
+Run inside a CMSSW environment (`cmsenv`) so that `SCRAM_ARCH` and `CMSSW_VERSION`
+are set. `tar` and `python3` must be available (both are standard in the Singularity image).
+
+```bash
+cd /your/work/dir
+cmsenv
+```
+
+### new → old
+
+Convert a `.tar.xz` sherpack to a `.tgz` and generate its `_cff.py`:
+
+```bash
+convert_sherpack.sh new_to_old sherpa_DY_MASTER_el8_amd64_gcc12_CMSSW_14_0_21.tar.xz
+```
+
+Produces:
+
+| File | Description |
+|------|-------------|
+| `sherpa_DY_MASTER.tgz` | gzip-compressed sherpack |
+| `sherpa_DY_MASTER.md5` | full `md5sum` output line, e.g. `c0f81ea6...  sherpa_DY_MASTER.tgz` |
+| `sherpa_DY_MASTER_cff.py` | CMS config fragment |
+
+In the generated `_cff.py`:
+
+- `SherpackLocation` is set to the **parent directory** of the `.tgz` (i.e. `$(pwd)/`).
+  Update this if you move the `.tgz` to a different location (e.g. `/cvmfs/...`).
+- `SherpackChecksum` is the MD5 hash of the `.tgz`.
+- `FetchSherpack = True` — the old fetcher copies the file from `SherpackLocation`.
+
+### old → new
+
+Convert a `.tgz` sherpack to a `.tar.xz` and generate its `_cff.py`:
+
+```bash
+convert_sherpack.sh old_to_new sherpa_DY_MASTER.tgz
+```
+
+Produces:
+
+| File | Description |
+|------|-------------|
+| `sherpa_DY_MASTER_el8_amd64_gcc12_CMSSW_14_0_21.tar.xz` | xz-compressed sherpack |
+| `sherpa_DY_MASTER_cff.py` | CMS config fragment |
+
+In the generated `_cff.py`:
+
+- `SherpackLocation` is set to the **full absolute path** of the `.tar.xz` (i.e. `$(pwd)/sherpa_...tar.xz`).
+  Update this if you move the file.
+- `SherpackChecksum` is the MD5 hash of the `.tar.xz`.
+- `FetchSherpack = True`.
+
+### Generated _cff.py
+
+The `Run = cms.vstring(...)` block is populated from `Run.dat` found inside the sherpack.
+The `MPI_Cross_Sections` block is always:
+
+```python
+MPI_Cross_Sections = cms.vstring(
+    " MPIs in Sherpa, Model = Amisic:",
+    " semihard xsec = 39.2965 mb,",
+    " non-diffractive xsec = 17.0318 mb with nd factor = 0.3142."
+),
+```
+
+`SherpaProcess` is derived from the filename by stripping the `sherpa_` prefix and
+optional `_MASTER` suffix (e.g. `sherpa_DY_MASTER` → `DY`). Edit it manually if needed.
+
+### After conversion
+
+Always check the generated `_cff.py` and update:
+
+1. `SherpackLocation` — if the sherpack was moved after conversion.
+2. `SherpackChecksum` — must match the MD5 of the file at `SherpackLocation`.
+3. `SherpaProcess` — if the auto-derived name does not match.
+
+The `_GEN.py` that runs under `cmsRun` typically `import`s the `_cff.py`, so changes
+there propagate automatically.

--- a/GeneratorInterface/SherpaInterface/data/convert_sherpack.sh
+++ b/GeneratorInterface/SherpaInterface/data/convert_sherpack.sh
@@ -40,13 +40,14 @@ TMPDIR_WORK=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_WORK"' EXIT
 
 # ── generate_cff ──────────────────────────────────────────────────────────────
-# Args: sherpa_process  sherpack_location  checksum  tmpdir  output_cff
+# Args: sherpa_process  sherpack_location  checksum  tmpdir  output_cff  new_format
 generate_cff() {
     local sherpa_process="$1"
     local sherpack_location="$2"
     local checksum="$3"
     local tmpdir="$4"
     local output_cff="$5"
+    local new_format="$6"
 
     echo "Generating ${output_cff} ..."
 
@@ -61,6 +62,7 @@ generate_cff() {
     CHECKSUM="$checksum" \
     RUN_DAT="${run_dat}" \
     OUTPUT_CFF="$output_cff" \
+    NEW_SHERPACK_FORMAT="$new_format" \
     python3 << 'PYEOF'
 import os
 
@@ -69,6 +71,7 @@ sherpack_location = os.environ['SHERPACK_LOCATION']
 checksum          = os.environ['CHECKSUM']
 run_dat_path      = os.environ.get('RUN_DAT', '')
 output_cff        = os.environ['OUTPUT_CFF']
+new_sherpack_format = os.environ['NEW_SHERPACK_FORMAT']
 
 def read_all_lines(path):
     if not path:
@@ -115,6 +118,7 @@ generator = cms.EDFilter("SherpaGeneratorFilter",
   SherpaProcess = cms.string('%s'),
   SherpackLocation = cms.string('%s'),
   SherpackChecksum = cms.string('%s'),
+  NewSherpackFormat = cms.bool(%s),
   FetchSherpack = cms.bool(True),
   SherpaPath = cms.string('./'),
   SherpaPathPiece = cms.string('./'),
@@ -136,6 +140,7 @@ ProductionFilterSequence = cms.Sequence(generator)
 """
 
 content = template % (sherpa_process, sherpack_location, checksum,
+                      new_sherpack_format,
                       mpi_vstring, run_vstring)
 
 with open(output_cff, 'w') as f:
@@ -199,7 +204,7 @@ if [[ "$MODE" == "new_to_old" ]]; then
     echo "  Saved to: $MD5FILE"
     echo ""
 
-    generate_cff "$SHERPA_PROC" "$SHERPACK_DIR" "$MD5" "$TMPDIR_WORK" "$CFF_PY"
+    generate_cff "$SHERPA_PROC" "$SHERPACK_DIR" "$MD5" "$TMPDIR_WORK" "$CFF_PY" "False"
 
     echo ""
     echo "=========================================================="
@@ -255,7 +260,7 @@ elif [[ "$MODE" == "old_to_new" ]]; then
     echo "  $MD5_LINE"
     echo ""
 
-    generate_cff "$SHERPA_PROC" "$OUTPUT_FULLPATH" "$MD5" "$TMPDIR_WORK" "$CFF_PY"
+    generate_cff "$SHERPA_PROC" "$OUTPUT_FULLPATH" "$MD5" "$TMPDIR_WORK" "$CFF_PY" "True"
 
     echo ""
     echo "=========================================================="

--- a/GeneratorInterface/SherpaInterface/data/convert_sherpack.sh
+++ b/GeneratorInterface/SherpaInterface/data/convert_sherpack.sh
@@ -1,0 +1,277 @@
+#!/bin/bash
+# convert_sherpack.sh
+# Converts Sherpa sherpacks between:
+#   new format: sherpa_<PROCESS>_<SCRAM_ARCH>_<CMSSW_VERSION>.tar.xz
+#   old format: sherpa_<PROCESS>.tgz
+# and generates the corresponding _cff.py from Run.dat / MPI_Cross_Sections
+# inside the sherpack.
+#
+# Usage:
+#   new_to_old:  convert_sherpack.sh new_to_old sherpa_DY_MASTER_el8_amd64_gcc12_CMSSW_14_0_21.tar.xz
+#   old_to_new:  convert_sherpack.sh old_to_new sherpa_DY_MASTER.tgz
+#                (requires SCRAM_ARCH and CMSSW_VERSION set in the environment)
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <mode> <sherpack_file>"
+    echo ""
+    echo "  Modes:"
+    echo "    new_to_old   sherpa_<PROCESS>_<SCRAM_ARCH>_<CMSSW_VERSION>.tar.xz"
+    echo "    old_to_new   sherpa_<PROCESS>.tgz"
+    echo ""
+    echo "For old_to_new, SCRAM_ARCH and CMSSW_VERSION must be set in the environment"
+    echo "(they are set automatically inside a cmsenv shell)."
+    exit 1
+}
+
+die() { echo "Error: $*" >&2; exit 1; }
+
+[ $# -eq 2 ] || usage
+
+MODE="$1"
+INPUT="$2"
+
+[[ "$MODE" == "new_to_old" || "$MODE" == "old_to_new" ]] \
+    || die "Unknown mode '$MODE'. Use 'new_to_old' or 'old_to_new'."
+[ -f "$INPUT" ] || die "File '$INPUT' not found"
+
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+# ── generate_cff ──────────────────────────────────────────────────────────────
+# Args: sherpa_process  sherpack_location  checksum  tmpdir  output_cff
+generate_cff() {
+    local sherpa_process="$1"
+    local sherpack_location="$2"
+    local checksum="$3"
+    local tmpdir="$4"
+    local output_cff="$5"
+
+    echo "Generating ${output_cff} ..."
+
+    local run_dat
+    run_dat=$(find "$tmpdir" -name "Run.dat" | head -1 || true)
+    [ -n "$run_dat" ] || echo "  Warning: Run.dat not found in sherpack — Run vstring will be empty"
+
+    # Pass paths via environment; use single-quoted PYEOF so Python code is
+    # not subject to bash expansion (Run.dat may contain { } * etc.)
+    SHERPA_PROCESS="$sherpa_process" \
+    SHERPACK_LOCATION="$sherpack_location" \
+    CHECKSUM="$checksum" \
+    RUN_DAT="${run_dat}" \
+    OUTPUT_CFF="$output_cff" \
+    python3 << 'PYEOF'
+import os
+
+sherpa_process    = os.environ['SHERPA_PROCESS']
+sherpack_location = os.environ['SHERPACK_LOCATION']
+checksum          = os.environ['CHECKSUM']
+run_dat_path      = os.environ.get('RUN_DAT', '')
+output_cff        = os.environ['OUTPUT_CFF']
+
+def read_all_lines(path):
+    if not path:
+        return []
+    try:
+        with open(path) as f:
+            return [l.rstrip('\n') for l in f]
+    except IOError:
+        return []
+
+run_lines = read_all_lines(run_dat_path)
+
+INDENT = ' ' * 32
+
+# MPI_Cross_Sections is always these fixed 3 lines
+mpi_vstring = (
+    '%s" MPIs in Sherpa, Model = Amisic:",\n'
+    '%s" semihard xsec = 39.2965 mb,",\n'
+    '%s" non-diffractive xsec = 17.0318 mb with nd factor = 0.3142."'
+) % (INDENT, INDENT, INDENT)
+
+def make_vstring(lines, placeholder):
+    if not lines:
+        return '%s" %s"' % (INDENT, placeholder)
+    parts = []
+    for i, line in enumerate(lines):
+        comma = ',' if i < len(lines) - 1 else ''
+        parts.append('%s" %s"%s' % (INDENT, line, comma))
+    return '\n'.join(parts)
+
+run_vstring = make_vstring(run_lines, 'Run.dat not found in sherpack')
+
+# Use %-formatting so Sherpa's { } braces in run_vstring are not misread.
+template = """\
+import FWCore.ParameterSet.Config as cms
+import os
+
+source = cms.Source("EmptySource")
+
+generator = cms.EDFilter("SherpaGeneratorFilter",
+  maxEventsToPrint = cms.int32(0),
+  filterEfficiency = cms.untracked.double(1.0),
+  crossSection = cms.untracked.double(-1),
+  SherpaProcess = cms.string('%s'),
+  SherpackLocation = cms.string('%s'),
+  SherpackChecksum = cms.string('%s'),
+  FetchSherpack = cms.bool(True),
+  SherpaPath = cms.string('./'),
+  SherpaPathPiece = cms.string('./'),
+  SherpaResultDir = cms.string('Result'),
+  SherpaDefaultWeight = cms.double(1.0),
+  SherpaParameters = cms.PSet(parameterSets = cms.vstring(
+                             "MPI_Cross_Sections",
+                             "Run"),
+                              MPI_Cross_Sections = cms.vstring(
+%s
+                                                  ),
+                              Run = cms.vstring(
+%s
+                                                  ),
+                             )
+)
+
+ProductionFilterSequence = cms.Sequence(generator)
+"""
+
+content = template % (sherpa_process, sherpack_location, checksum,
+                      mpi_vstring, run_vstring)
+
+with open(output_cff, 'w') as f:
+    f.write(content)
+PYEOF
+
+    echo "  Generated: ${output_cff}"
+}
+
+# ── new_to_old ────────────────────────────────────────────────────────────────
+if [[ "$MODE" == "new_to_old" ]]; then
+
+    [[ "$INPUT" == *.tar.xz ]] \
+        || die "new_to_old expects a .tar.xz file, got: $INPUT"
+
+    BASENAME=$(basename "${INPUT%.tar.xz}")
+
+    [[ "$BASENAME" == *_CMSSW_* ]] || die "Cannot find _CMSSW_ in filename '$BASENAME'"
+    CMSSW_VERSION="CMSSW_${BASENAME##*_CMSSW_}"
+    STEM="${BASENAME%_${CMSSW_VERSION}}"
+
+    # SCRAM_ARCH: last 3 underscore-separated tokens of the stem
+    PART3="${STEM##*_}";    REST="${STEM%_$PART3}"
+    PART2="${REST##*_}";    REST="${REST%_$PART2}"
+    PART1="${REST##*_}";    PROCESS="${REST%_$PART1}"
+    SCRAM_ARCH="${PART1}_${PART2}_${PART3}"
+
+    # SherpaProcess: strip "sherpa_" prefix and optional "_MASTER" suffix
+    SHERPA_PROC="${PROCESS#sherpa_}"
+    SHERPA_PROC="${SHERPA_PROC%_MASTER}"
+
+    OUTPUT="${PROCESS}.tgz"
+    MD5FILE="${PROCESS}.md5"
+    CFF_PY="${PROCESS}_cff.py"
+
+    # SherpackLocation for old format is the parent directory of the tgz
+    SHERPACK_DIR="$(pwd)/"
+
+    echo "=== new_to_old ==="
+    echo "  Input:            $INPUT"
+    echo "  Output:           $OUTPUT"
+    echo "  CFF:              $CFF_PY"
+    echo "  MD5 file:         $MD5FILE"
+    echo "  SherpaProcess:    $SHERPA_PROC"
+    echo "  SCRAM_ARCH:       $SCRAM_ARCH"
+    echo "  CMSSW_VERSION:    $CMSSW_VERSION"
+    echo "  SherpackLocation: $SHERPACK_DIR"
+    echo ""
+
+    echo "Extracting $INPUT ..."
+    tar -xJf "$INPUT" -C "$TMPDIR_WORK"
+
+    echo "Repacking as $OUTPUT (gzip) ..."
+    tar -czf "$OUTPUT" -C "$TMPDIR_WORK" .
+
+    echo "Computing MD5 checksum ..."
+    MD5_LINE=$(md5sum "$OUTPUT")           # e.g. "c0f81ea6...  sherpa_DY_MASTER.tgz"
+    MD5=$(echo "$MD5_LINE" | awk '{print $1}')
+    echo "$MD5_LINE" > "$MD5FILE"
+    echo "  $MD5_LINE"
+    echo "  Saved to: $MD5FILE"
+    echo ""
+
+    generate_cff "$SHERPA_PROC" "$SHERPACK_DIR" "$MD5" "$TMPDIR_WORK" "$CFF_PY"
+
+    echo ""
+    echo "=========================================================="
+    echo "WARNING: update SherpackLocation and SherpackChecksum"
+    echo "=========================================================="
+    echo "In ${CFF_PY} (or the _GEN.py that imports it):"
+    echo ""
+    echo "  SherpackLocation = cms.string('${SHERPACK_DIR}'),"
+    echo "  SherpackChecksum = cms.string('${MD5}'),"
+    echo ""
+    echo "If you move ${OUTPUT} to a different directory, update"
+    echo "SherpackLocation to that directory's path."
+    echo "Previously pointed to: ${INPUT}"
+    echo "=========================================================="
+
+# ── old_to_new ────────────────────────────────────────────────────────────────
+elif [[ "$MODE" == "old_to_new" ]]; then
+
+    [[ "$INPUT" == *.tgz ]] \
+        || die "old_to_new expects a .tgz file, got: $INPUT"
+
+    SCRAM_ARCH="${SCRAM_ARCH:-}"
+    CMSSW_VERSION="${CMSSW_VERSION:-}"
+    [ -n "$SCRAM_ARCH" ]    || die "SCRAM_ARCH is not set. Run 'cmsenv' first, or: export SCRAM_ARCH=el8_amd64_gcc12"
+    [ -n "$CMSSW_VERSION" ] || die "CMSSW_VERSION is not set. Run 'cmsenv' first, or: export CMSSW_VERSION=CMSSW_14_0_21"
+
+    PROCESS=$(basename "${INPUT%.tgz}")
+    OUTPUT="${PROCESS}_${SCRAM_ARCH}_${CMSSW_VERSION}.tar.xz"
+    OUTPUT_FULLPATH="$(pwd)/${OUTPUT}"
+    CFF_PY="${PROCESS}_cff.py"
+
+    SHERPA_PROC="${PROCESS#sherpa_}"
+    SHERPA_PROC="${SHERPA_PROC%_MASTER}"
+
+    echo "=== old_to_new ==="
+    echo "  Input:            $INPUT"
+    echo "  Output:           $OUTPUT_FULLPATH"
+    echo "  CFF:              $CFF_PY"
+    echo "  SherpaProcess:    $SHERPA_PROC"
+    echo "  SCRAM_ARCH:       $SCRAM_ARCH"
+    echo "  CMSSW_VERSION:    $CMSSW_VERSION"
+    echo ""
+
+    echo "Extracting $INPUT ..."
+    tar -xzf "$INPUT" -C "$TMPDIR_WORK"
+
+    echo "Repacking as $OUTPUT (xz) ..."
+    tar -cJf "$OUTPUT" -C "$TMPDIR_WORK" .
+
+    echo "Computing MD5 checksum ..."
+    MD5_LINE=$(md5sum "$OUTPUT")
+    MD5=$(echo "$MD5_LINE" | awk '{print $1}')
+    echo "  $MD5_LINE"
+    echo ""
+
+    generate_cff "$SHERPA_PROC" "$OUTPUT_FULLPATH" "$MD5" "$TMPDIR_WORK" "$CFF_PY"
+
+    echo ""
+    echo "=========================================================="
+    echo "WARNING: update SherpackLocation and SherpackChecksum"
+    echo "=========================================================="
+    echo "In ${CFF_PY} (or the _GEN.py that imports it):"
+    echo ""
+    echo "  SherpackLocation = cms.string('${OUTPUT_FULLPATH}'),"
+    echo "  SherpackChecksum = cms.string('${MD5}'),"
+    echo ""
+    echo "If you move ${OUTPUT} to a different path, update SherpackLocation."
+    echo "Previously pointed to: ${INPUT}"
+    echo "If SherpaProcess needs editing, check Run.dat in the sherpack."
+    echo "=========================================================="
+
+fi
+
+echo ""
+echo "Done."

--- a/GeneratorInterface/SherpaInterface/interface/SherpackFetcher.h
+++ b/GeneratorInterface/SherpaInterface/interface/SherpackFetcher.h
@@ -30,6 +30,7 @@ namespace spf {
     std::string SherpackLocation;
     std::string SherpackChecksum;
     bool FetchSherpack;
+    bool NewSherpackFormat;
     std::string SherpaPath;
   };
 

--- a/GeneratorInterface/SherpaInterface/src/SherpaHepMC3Hadronizer.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpaHepMC3Hadronizer.cc
@@ -297,7 +297,7 @@ bool SherpaHepMC3Hadronizer::generatePartonsAndHadronize() {
     std::map<std::string, std::size_t> nameToIndex;
     for (std::size_t i = 0; i < weight_list.size(); ++i) {
       nameToIndex[weight_list[i]] = i;
-      std::cout << i << ", " << weight_list[i] << std::endl;
+      // std::cout << i << ", " << weight_list[i] << std::endl;
     }
     // Helper lambda: get weight by name, fall back to index
     auto getWeightByName = [&](const std::string &name, std::size_t fallbackIdx) -> double {
@@ -311,7 +311,7 @@ bool SherpaHepMC3Hadronizer::generatePartonsAndHadronize() {
 
     bool unweighted = false;
     double weight_normalization = -1;
-    std::cout << "EVENT MODE:" << ATOOLS::ToType<int>(ATOOLS::rpa->gen.Variable("EVENT_GENERATION_MODE")) << std::endl;
+    // std::cout << "EVENT MODE:" << ATOOLS::ToType<int>(ATOOLS::rpa->gen.Variable("EVENT_GENERATION_MODE")) << std::endl;
     int EVENT_GENERATION_MODE = ATOOLS::ToType<int>(ATOOLS::rpa->gen.Variable("EVENT_GENERATION_MODE"));
     if ((EVENT_GENERATION_MODE == 1) || (EVENT_GENERATION_MODE == 2)) {
       // EVENT_GENERATION_MODE: 1->Unweighted; 2->PartiallyUnweighted;
@@ -319,7 +319,7 @@ bool SherpaHepMC3Hadronizer::generatePartonsAndHadronize() {
       if (evt->weights().size() > 2) {
         unweighted = true;
         weight_normalization = getWeightByName("WeightNormalisation", 2);
-        std::cout << weight_normalization << std::endl;
+        // std::cout << weight_normalization << std::endl;
       } else {
         throw cms::Exception("SherpaInterface")
             << "Requested unweighted production. Missing normalization weight." << std::endl;
@@ -341,7 +341,7 @@ bool SherpaHepMC3Hadronizer::generatePartonsAndHadronize() {
         auto it = nameToIndex.find(i);
         if (it != nameToIndex.end()) {
           double w = evt->weights()[it->second];
-          std::cout << it->first << ", " << it->second << ", " << w << ", " << weight_normalization << std::endl;
+          // std::cout << it->first << ", " << it->second << ", " << w << ", " << weight_normalization << std::endl;
           newWeights.push_back(unweighted ? w / weight_normalization : w);
         } else {
           throw cms::Exception("SherpaInterface")

--- a/GeneratorInterface/SherpaInterface/src/SherpackFetcher.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpackFetcher.cc
@@ -23,72 +23,148 @@ namespace spf {
       SherpaPath = "";
     else
       SherpaPath = pset.getParameter<std::string>("SherpaPath");
+    if (!pset.exists("NewSherpackFormat"))
+      NewSherpackFormat = false;
+    else
+      NewSherpackFormat = pset.getParameter<bool>("NewSherpackFormat");
   }
 
   int SherpackFetcher::Fetch() {
-    std::string option = "-c";
-    std::string constr = "`cmsGetFnConnect frontier://smallfiles`";
-    std::string sherpack = SherpackLocation + "/sherpa_" + SherpaProcess + "_MASTER.tgz";
-    std::string sherpackunzip = "sherpa_" + SherpaProcess + "_MASTER.tar";
-    std::string path = SherpackLocation + "/" + sherpack;
+    if (NewSherpackFormat) {
+      // New format: SherpackLocation is the full path to a tar.xz file
+      std::string sherpackPath = SherpackLocation;
+      size_t lastSlash = sherpackPath.find_last_of("/\\");
+      std::string sherpack = (lastSlash == std::string::npos) ? sherpackPath : sherpackPath.substr(lastSlash + 1);
 
-    if (FetchSherpack == true) {
-      std::cout << "SherpackFetcher: Trying to fetch the Sherpack " << sherpack << std::endl;
-      int res = -1;
-
-      res = CopyFile(path);
-
-      if (res != 1) {
-        throw cms::Exception("SherpaInterface")
-            << "SherpackFetcher: Fetching of Sherpack did not succeed, terminating" << std::endl;
-        return -1;
-      }
-      std::cout << "SherpackFetcher: Fetching successful" << std::endl;
-    }
-
-    std::ifstream my_file(sherpack.c_str());
-    if (!my_file.good()) {
-      throw cms::Exception("SherpaInterface") << "SherpackFetcher: No Sherpack found: " << sherpack << std::endl;
-      return -2;
-    }
-    my_file.close();
-    std::cout << "SherpackFetcher: Sherpack found" << std::endl;
-
-    if (!SherpackChecksum.empty()) {
-      char md5checksum[33];
-      spu::md5_File(sherpack, md5checksum);
-      for (int k = 0; k < 33; k++) {
-        if (md5checksum[k] != SherpackChecksum[k]) {
+      if (FetchSherpack == true) {
+        std::cout << "SherpackFetcher: Trying to fetch the Sherpack from " << sherpackPath << std::endl;
+        int res = CopyFile(sherpackPath);
+        if (res != 1) {
           throw cms::Exception("SherpaInterface")
-              << "SherpackFetcher: failure, calculated and specified checksums differ!" << std::endl;
-          return -3;
+              << "SherpackFetcher: Fetching of Sherpack did not succeed, terminating" << std::endl;
+          return -1;
         }
+        std::cout << "SherpackFetcher: Fetching successful" << std::endl;
       }
-      std::cout << "SherpackFetcher: Calculated checksum of the Sherpack is " << md5checksum << " and matches"
-                << std::endl;
-    } else {
-      std::cout << "SherpackFetcher: Ignoring Checksum" << std::endl;
-    }
 
-    std::cout << "SherpackFetcher: Trying to unzip the Sherpack" << std::endl;
-    int res = spu::Unzip(sherpack, sherpackunzip);
-    if (res != 0) {
-      throw cms::Exception("SherpaInterface") << "SherpackFetcher: Decompressing failed " << std::endl;
-      return -4;
-    }
-    std::cout << "SherpackFetcher: Decompressing successful " << std::endl;
+      std::ifstream my_file(sherpack.c_str());
+      if (!my_file.good()) {
+        throw cms::Exception("SherpaInterface") << "SherpackFetcher: No Sherpack found at " << sherpack << std::endl;
+        return -2;
+      }
+      my_file.close();
+      std::cout << "SherpackFetcher: Sherpack found" << std::endl;
 
-    FILE *file = fopen(const_cast<char *>(sherpackunzip.c_str()), "r");
-    if (file) {
-      std::cout << "SherpackFetcher: Decompressed Sherpack exists with name " << sherpackunzip
-                << " starting to untar it" << std::endl;
-      spu::Untar(file, SherpaPath.c_str());
+      if (!SherpackChecksum.empty()) {
+        char md5checksum[33];
+        spu::md5_File(sherpack, md5checksum);
+        for (int k = 0; k < 33; k++) {
+          if (md5checksum[k] != SherpackChecksum[k]) {
+            throw cms::Exception("SherpaInterface")
+                << "SherpackFetcher: failure, calculated and specified checksums differ!" << std::endl;
+            return -3;
+          }
+        }
+        std::cout << "SherpackFetcher: Calculated checksum of the Sherpack is " << md5checksum << " and matches"
+                  << std::endl;
+      } else {
+        std::cout << "SherpackFetcher: Ignoring Checksum" << std::endl;
+      }
+
+      const char *envCMSSWVersion = std::getenv("CMSSW_VERSION");
+      const char *envSCRAMArch = std::getenv("SCRAM_ARCH");
+      std::string cmsswVersion = envCMSSWVersion ? envCMSSWVersion : "";
+      std::string scramArch = envSCRAMArch ? envSCRAMArch : "";
+      if (!cmsswVersion.empty() && !scramArch.empty()) {
+        bool versionMatch = (sherpack.find(cmsswVersion) != std::string::npos);
+        bool archMatch = (sherpack.find(scramArch) != std::string::npos);
+        if (versionMatch && archMatch) {
+          std::cout << "SherpackFetcher: CMSSW_VERSION (" << cmsswVersion << ") and SCRAM_ARCH (" << scramArch
+                    << ") match the Sherpack" << std::endl;
+        } else {
+          if (!versionMatch)
+            std::cout << "SherpackFetcher: WARNING - CMSSW_VERSION mismatch: environment has " << cmsswVersion
+                      << " but not found in Sherpack " << sherpack << std::endl;
+          if (!archMatch)
+            std::cout << "SherpackFetcher: WARNING - SCRAM_ARCH mismatch: environment has " << scramArch
+                      << " but not found in Sherpack " << sherpack << std::endl;
+        }
+      } else {
+        std::cout << "SherpackFetcher: CMSSW_VERSION or SCRAM_ARCH not set in environment, skipping compatibility check"
+                  << std::endl;
+      }
+
+      std::cout << "SherpackFetcher: Trying to decompress the Sherpack (tar.xz): " << sherpack << std::endl;
+      std::string tarCmd = "tar -xJf " + sherpack;
+      int res = system(tarCmd.c_str());
+      if (res != 0) {
+        throw cms::Exception("SherpaInterface") << "SherpackFetcher: Decompressing failed " << std::endl;
+        return -4;
+      }
+      std::cout << "SherpackFetcher: Decompressing successful " << std::endl;
+      return 0;
+
     } else {
-      throw cms::Exception("SherpaInterface") << "SherpackFetcher: Could not open decompressed Sherpack" << std::endl;
-      return -5;
+      // Old format: SherpackLocation is a directory containing sherpa_<process>_MASTER.tgz
+      std::string sherpack = SherpackLocation + "/sherpa_" + SherpaProcess + "_MASTER.tgz";
+      std::string sherpackunzip = "sherpa_" + SherpaProcess + "_MASTER.tar";
+      const std::string &path = sherpack;
+
+      if (FetchSherpack == true) {
+        std::cout << "SherpackFetcher: Trying to fetch the Sherpack " << sherpack << std::endl;
+        int res = CopyFile(path);
+        if (res != 1) {
+          throw cms::Exception("SherpaInterface")
+              << "SherpackFetcher: Fetching of Sherpack did not succeed, terminating" << std::endl;
+          return -1;
+        }
+        std::cout << "SherpackFetcher: Fetching successful" << std::endl;
+      }
+
+      std::ifstream my_file(sherpack.c_str());
+      if (!my_file.good()) {
+        throw cms::Exception("SherpaInterface") << "SherpackFetcher: No Sherpack found: " << sherpack << std::endl;
+        return -2;
+      }
+      my_file.close();
+      std::cout << "SherpackFetcher: Sherpack found" << std::endl;
+
+      if (!SherpackChecksum.empty()) {
+        char md5checksum[33];
+        spu::md5_File(sherpack, md5checksum);
+        for (int k = 0; k < 33; k++) {
+          if (md5checksum[k] != SherpackChecksum[k]) {
+            throw cms::Exception("SherpaInterface")
+                << "SherpackFetcher: failure, calculated and specified checksums differ!" << std::endl;
+            return -3;
+          }
+        }
+        std::cout << "SherpackFetcher: Calculated checksum of the Sherpack is " << md5checksum << " and matches"
+                  << std::endl;
+      } else {
+        std::cout << "SherpackFetcher: Ignoring Checksum" << std::endl;
+      }
+
+      std::cout << "SherpackFetcher: Trying to unzip the Sherpack" << std::endl;
+      int res = spu::Unzip(sherpack, sherpackunzip);
+      if (res != 0) {
+        throw cms::Exception("SherpaInterface") << "SherpackFetcher: Decompressing failed " << std::endl;
+        return -4;
+      }
+      std::cout << "SherpackFetcher: Decompressing successful " << std::endl;
+
+      FILE *file = fopen(const_cast<char *>(sherpackunzip.c_str()), "r");
+      if (file) {
+        std::cout << "SherpackFetcher: Decompressed Sherpack exists with name " << sherpackunzip
+                  << " starting to untar it" << std::endl;
+        spu::Untar(file, SherpaPath.c_str());
+      } else {
+        throw cms::Exception("SherpaInterface") << "SherpackFetcher: Could not open decompressed Sherpack" << std::endl;
+        return -5;
+      }
+      fclose(file);
+      return 0;
     }
-    fclose(file);
-    return 0;
   }
 
   int SherpackFetcher::CopyFile(std::string pathstring) {


### PR DESCRIPTION
#### PR description:
Add `CMSSW_VERSION` and `SCRAM_ARCH` to the `Sherpack`, this is a backport of #50955 .
<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to Run3 legacy (17_0_X).

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->
