### PR TITLE
[17_0_X] Fix use of unsubtracted jets in tag info producers

### DIFF
--- a/RecoBTag/FeatureTools/plugins/DeepFlavourTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepFlavourTagInfoProducer.cc
@@ -269,11 +269,11 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
     // reco jet reference (use as much as possible)
     const auto& jet = jets->at(jet_n);
     // dynamical casting to pointers, null if not possible
-    const auto* pf_jet = dynamic_cast<const reco::PFJet*>(&jet);
-    const auto* pat_jet = dynamic_cast<const pat::Jet*>(&jet);
     edm::RefToBase<reco::Jet> jet_ref(jets, jet_n);
     const auto& unsubJet =
         (use_unsubjet_map_ && (*unsubjet_map)[jet_ref].isNonnull()) ? *(*unsubjet_map)[jet_ref] : jet;
+    const auto* pf_jet = dynamic_cast<const reco::PFJet*>(&unsubJet);
+    const auto* pat_jet = dynamic_cast<const pat::Jet*>(&unsubJet);
     // TagInfoCollection not in an associative container so search for matchs
     const edm::View<reco::ShallowTagInfo>& taginfos = *shallow_tag_infos;
     edm::Ptr<reco::ShallowTagInfo> match;

--- a/RecoBTag/FeatureTools/plugins/ParticleTransformerAK4TagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/ParticleTransformerAK4TagInfoProducer.cc
@@ -220,11 +220,11 @@ void ParticleTransformerAK4TagInfoProducer::produce(edm::Event& iEvent, const ed
       features.is_filled = false;
     }
     // dynamical casting to pointers, null if not possible
-    const auto* pf_jet = dynamic_cast<const reco::PFJet*>(&jet);
-    const auto* pat_jet = dynamic_cast<const pat::Jet*>(&jet);
     edm::RefToBase<reco::Jet> jet_ref(jets, jet_n);
     const auto& unsubJet =
         (use_unsubjet_map_ && (*unsubjet_map)[jet_ref].isNonnull()) ? *(*unsubjet_map)[jet_ref] : jet;
+    const auto* pf_jet = dynamic_cast<const reco::PFJet*>(&unsubJet);
+    const auto* pat_jet = dynamic_cast<const pat::Jet*>(&unsubJet);
 
     if (features.is_filled) {
       math::XYZVector jet_dir = jet.momentum().Unit();

--- a/RecoBTag/FeatureTools/plugins/UnifiedParticleTransformerAK4TagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/UnifiedParticleTransformerAK4TagInfoProducer.cc
@@ -232,11 +232,11 @@ void UnifiedParticleTransformerAK4TagInfoProducer::produce(edm::Event& iEvent, c
       features.is_filled = false;
     }
     // dynamical casting to pointers, null if not possible
-    const auto* pf_jet = dynamic_cast<const reco::PFJet*>(&jet);
-    const auto* pat_jet = dynamic_cast<const pat::Jet*>(&jet);
     edm::RefToBase<reco::Jet> jet_ref(jets, jet_n);
     const auto& unsubJet =
         (use_unsubjet_map_ && (*unsubjet_map)[jet_ref].isNonnull()) ? *(*unsubjet_map)[jet_ref] : jet;
+    const auto* pf_jet = dynamic_cast<const reco::PFJet*>(&unsubJet);
+    const auto* pat_jet = dynamic_cast<const pat::Jet*>(&unsubJet);
 
     if (features.is_filled) {
       math::XYZVector jet_dir = jet.momentum().Unit();


### PR DESCRIPTION
#### PR description:

This PR fixes a bug present in the use of unsubtracted jets in the tag info producers that causes a crash if used together with puppi.

#### PR validation:

Tested locally

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

To be backported to 14_1_X
