### PR TITLE
Add scouting to Phase-2 HLT menu

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/paths/DST_NGTScouting_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/DST_NGTScouting_cfi.py
@@ -1,0 +1,80 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltAK4PFJetsForTaus_cfi import *
+from ..modules.hltL1GTAcceptFilter_cfi import *
+from ..modules.hltFixedGridRhoFastjetAllCaloForEGamma_cfi import *
+from ..modules.hltL1SeedsForPuppiMETFilter_cfi import *
+from ..modules.hltPFPuppiHT_cfi import *
+from ..modules.hltPFPuppiMETTypeOne140_cfi import *
+from ..modules.hltPFPuppiMETTypeOneCorrector_cfi import *
+from ..modules.hltPFPuppiMETTypeOne_cfi import *
+from ..modules.hltPFPuppiMHT140_cfi import *
+from ..modules.hltPFPuppiMHT_cfi import *
+from ..modules.hltParticleFlowClusterECALUncorrectedUnseeded_cfi import *
+from ..modules.hltParticleFlowClusterECALUnseeded_cfi import *
+from ..modules.hltParticleFlowRecHitECALUnseeded_cfi import *
+from ..modules.hltPhase2L3MuonCandidates_cfi import *
+from ..modules.hltEgammaEleL1TrkIsoUnseeded_cfi import *
+from ..modules.hltEgammaClusterShapeUnseeded_cfi import *
+from ..modules.hltEgammaR9Unseeded_cfi import *
+from ..modules.hltEgammaEcalPFClusterIsoUnseeded_cfi import *
+from ..modules.hltEgammaEleGsfTrackIsoUnseeded_cfi import *
+from ..modules.hltEgammaHcalPFClusterIsoUnseeded_cfi import *
+from ..sequences.HLTAK4PFJetsReconstruction_cfi import *
+from ..sequences.HLTAK4PFPuppiJetsReconstruction_cfi import *
+from ..sequences.HLTBeginSequence_cfi import *
+from ..sequences.HLTBtagDeepCSVSequencePFPuppi_cfi import *
+from ..sequences.HLTBtagDeepFlavourSequencePFPuppi_cfi import *
+from ..sequences.HLTEndSequence_cfi import *
+from ..sequences.HLTHPSDeepTauPFTauSequence_cfi import *
+from ..sequences.HLTTICLLocalRecoSequence_cfi import *
+from ..sequences.HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi import *
+from ..sequences.HLTLocalrecoSequence_cfi import *
+from ..sequences.HLTMuonsSequence_cfi import *
+from ..sequences.HLTPFPuppiMETReconstruction_cfi import *
+from ..sequences.HLTPFTauHPS_cfi import *
+from ..sequences.HLTParticleFlowSequence_cfi import *
+from ..sequences.HLTElePixelMatchUnseededSequence_cfi import *
+from ..sequences.HLTGsfElectronUnseededSequence_cfi import *
+from ..sequences.HLTPhase2L3MuonGeneralTracksSequence_cfi import *
+from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
+from ..sequences.HLTRawToDigiSequence_cfi import *
+from ..sequences.HLTTrackingSequence_cfi import *
+from ..sequences.HLTEndSequence_cfi import *
+
+DST_NGTScouting = cms.Path(
+    HLTBeginSequence
+    + hltL1GTAcceptFilter
+    + HLTRawToDigiSequence
+    + HLTLocalrecoSequence
+    + HLTTICLLocalRecoSequence
+    + HLTTrackingSequence
+    + HLTMuonsSequence
+    + HLTParticleFlowSequence
+    + hltParticleFlowRecHitECALUnseeded
+    + hltParticleFlowClusterECALUncorrectedUnseeded
+    + hltParticleFlowClusterECALUnseeded
+    + HLTHgcalTiclPFClusteringForEgammaUnseededSequence
+    + HLTPFClusteringForEgammaUnseededSequence
+    + hltFixedGridRhoFastjetAllCaloForEGamma
+    + HLTElePixelMatchUnseededSequence
+    + HLTGsfElectronUnseededSequence
+    + hltEgammaEleL1TrkIsoUnseeded
+    + hltEgammaClusterShapeUnseeded
+    + hltEgammaR9Unseeded
+    + hltEgammaEcalPFClusterIsoUnseeded
+    + hltEgammaEleGsfTrackIsoUnseeded
+    + hltEgammaHcalPFClusterIsoUnseeded
+    + hltPhase2L3MuonCandidates
+    + HLTPhase2L3MuonGeneralTracksSequence
+    + HLTAK4PFJetsReconstruction
+    + hltAK4PFJetsForTaus
+    + HLTPFTauHPS
+    + HLTHPSDeepTauPFTauSequence
+    + HLTAK4PFPuppiJetsReconstruction
+    + hltPFPuppiHT
+    + hltPFPuppiMHT
+    + HLTBtagDeepCSVSequencePFPuppi
+    + HLTBtagDeepFlavourSequencePFPuppi
+    + HLTEndSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -102,6 +102,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltChi2EstimatorForR
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltKFSmootherForRefitInsideOut_cfi")
 
 ### Paths
+fragment.load("HLTrigger/Configuration/HLT_75e33/paths/DST_PFScouting_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Diphoton30_23_IsoCaloId_L1Seeded_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Diphoton30_23_IsoCaloId_Unseeded_cfi")
@@ -283,6 +284,8 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/services/ThroughputService_cfi"
 
 fragment.schedule = cms.Schedule(*[
 
+    fragment.DST_PFScouting,
+   
     fragment.HLT_AK4PFPuppiJet520,
     fragment.HLT_PFPuppiHT1070,
     fragment.HLT_PFPuppiMETTypeOne140_PFPuppiMHT140,

--- a/HLTrigger/Configuration/python/HLT_NGTScouting_cff.py
+++ b/HLTrigger/Configuration/python/HLT_NGTScouting_cff.py
@@ -106,7 +106,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltChi2EstimatorForR
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltKFSmootherForRefitInsideOut_cfi")
 
 ### Paths
-fragment.load("HLTrigger/Configuration/HLT_75e33/paths/DST_PFScouting_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/paths/DST_NGTScouting_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLTAnalyzerEndpath_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLTriggerFinalPath_cfi")
 
@@ -245,7 +245,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/services/FastTimerService_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/services/ThroughputService_cfi")
 
 fragment.schedule = cms.Schedule(*[
-    fragment.DST_PFScouting,
+    fragment.DST_NGTScouting,
     fragment.HLTriggerFinalPath,
     fragment.HLTAnalyzerEndpath,
 ])

--- a/Validation/HLTrigger/python/HLTGenValidation_cff.py
+++ b/Validation/HLTrigger/python/HLTGenValidation_cff.py
@@ -586,7 +586,7 @@ hltGenValSourceLabels = [
 for label in hltGenValSourceLabels:
     if label in globals():
         ngtScouting.toModify(globals()[label],
-                             hltPathsToCheck = ['DST_PFScouting'])
+                             hltPathsToCheck = ['DST_NGTScouting'])
 
 from RecoMET.Configuration.RecoGenMET_cff import genMetCalo,genMetTrue
 from RecoMET.Configuration.GenMETParticles_cff import genCandidatesForMET, genParticlesForMETAllVisible


### PR DESCRIPTION
#### PR description:

As discussed at the TSG coordination meetings [[1]](https://indico.cern.ch/event/1695113/) and [[2]](https://indico.cern.ch/event/1692122/), here a PR to add scouting to the Phase-2 HLT menu.
As this scouting will reconstruct almost all HLT objects in all events, it will be added only to `HLT_75e33_cff.py`, and not to `HLT_75e33_timing_cff.py`.
Note that in `HLT_75e33_cff.py` we are already reconstructing tracks and unseeded electrons in all events or so (see `MC_TRK` and `MC_Ele5_Open_Unseeded`), so I do not expect a big increase in timing of step2 due to this PR

#### PR validation:

I ran 
```
cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:@relvalRun4 --conditions auto:phase2_realistic_T35 --datatier GEN-SIM-DIGI-RAW -n 10 --eventcontent FEVTDEBUGHLT --geometry ExtendedRun4D121 --era Phase2C22I13M9 --filein file:/eos/cms/store/relval/CMSSW_20_0_0_pre1/RelValTTbar_14TeV/GEN-SIM/150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU-v1/2590000/7dad7759-584f-4f99-8fdc-cdc531cebf4c.root
```

in `CMSSW_20_0_0_pre1` with and without the changes. I checked that after the change the trigger bit `DST_PFScouting` appeared

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport requested (as the 20_0_X production is supposed to start very soon)
