### PR TITLE
Fix wrong signal tagging in HDF5ProductResolver

### DIFF
--- a/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
+++ b/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
@@ -83,7 +83,7 @@ void HDF5ProductResolver::prefetchAsyncImpl(edm::WaitingTaskHolder iTask,
           CMS_SA_ALLOW try {
             edm::ESModuleCallingContext context(providerDescription(),
                                                 reinterpret_cast<std::uintptr_t>(this),
-                                                edm::ESModuleCallingContext::State::kRunning,
+                                                edm::ESModuleCallingContext::State::kPrefetching,
                                                 iParent);
             iRecord.activityRegistry()->preESModuleSignal_.emit(iRecord.key(), context);
             struct EndGuard {


### PR DESCRIPTION
Switches activity registry signal parameter from running to prefetching. This prevents having 2 running ranges at the same time, fixing clashes when profiling with signals.

#### PR description:

This PR simply changes a parameter value in context variable used exclusively for signal parameters.
The impact is hence very limited.

#### PR validation:

When developing an NVTX/ROCTX profiler, it turned out the [activity registry signal emission in HDF5ProductResolver::prefetchAsyncImpl](https://github.com/cms-sw/cmssw/blob/master/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc#L86) clashed with the [one from the base resolver](https://github.com/cms-sw/cmssw/blob/master/FWCore/Framework/src/ESSourceProductResolverBase.cc#L43). Changing the tag from running to prefetching resolves the clash. This is a purely technical fix for profiling.

