### PR TITLE
Fix needed for change in root io protocol root-project/root#22744

### DIFF
--- a/FWStorage/TFileAdaptor/src/TFileAdaptor.cc
+++ b/FWStorage/TFileAdaptor/src/TFileAdaptor.cc
@@ -192,10 +192,12 @@ TFileAdaptor::TFileAdaptor(edm::ParameterSet const& pset, edm::ActivityRegistry&
     addType(mgr, "^dcap:");
   if (!native("gsidcap"))
     addType(mgr, "^gsidcap:");
-  if (!native("root"))
-    addType(mgr, "^root:", 1);  // See comments in addType
-  if (!native("root"))
-    addType(mgr, "^[x]?root:", 1);  // See comments in addType
+  if (!native("root")) {
+    // See comments in addType
+    addType(mgr, "^root:", 1);
+    addType(mgr, "^[x]?root:", 1);
+    addType(mgr, "^[x]?root[s]?:", 1);
+  }
 
   // Make sure the TStorageFactoryFile can be loaded regardless of the header auto-parsing setting
   {

--- a/FWStorage/TFileAdaptor/test/tfileTest.cpp
+++ b/FWStorage/TFileAdaptor/test/tfileTest.cpp
@@ -18,9 +18,18 @@
 
 int main(int argc, char* argv[]) {
   // This list should replicate the addHandler calls in TFileAdaptor
-  std::array<char const*, 10> const protocols = {
-      {"^file:", "^http:", "^http[s]?:", "^ftp:", "^web:", "^dcache:", "^dcap:", "^gsidcap:", "^root:", "^[x]?root:"}};
-  std::array<char const*, 10> const uris{{"file:foo",
+  std::array<char const*, 11> const protocols = {{"^file:",
+                                                  "^http:",
+                                                  "^http[s]?:",
+                                                  "^ftp:",
+                                                  "^web:",
+                                                  "^dcache:",
+                                                  "^dcap:",
+                                                  "^gsidcap:",
+                                                  "^root:",
+                                                  "^[x]?root:",
+                                                  "^[x]?root[s]?:"}};
+  std::array<char const*, 11> const uris{{"file:foo",
                                           "http://foo",
                                           "https://foo",
                                           "ftp://foo",
@@ -29,7 +38,8 @@ int main(int argc, char* argv[]) {
                                           "dcap://foo",
                                           "gsidcap://foo",
                                           "root://foo",
-                                          "xroot://foo"}};
+                                          "xroot://foo",
+                                          "xroots://foo"}};
 
   char const* tStorageFactoryFileFunc = "TStorageFactoryFile(char const*, Option_t*, char const*, Int_t)";
   char const* tStorageFactoryFileFuncNet =


### PR DESCRIPTION
This change is needed to make sure cmssw still uses its TFileAdaptor ( see https://github.com/cms-sw/cmsdist/pull/10706#issuecomment-4892516073 failure after https://github.com/root-project/root/pull/22744 change  in ROOT master and ROOT 6.40).  Root's now register ` TNetXNGFile` for `^[x]?root[s]?:` protocol which override cmssw's `TStorageFactoryFile` to hanle `^root:` or `^[x]?root:`. This PR proposes that before adding CMSSW handlers we make sure to delete any handlers register by ROOT itself.

FYI @Dr15Jones 