### PR TITLE
Fixes helper templated overloads for `watch{Pre,Post}{Open,Close}OutputFiles()`

### DIFF
--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -444,7 +444,7 @@ namespace edm {
     void watchPreOpenOutputFiles(PreOpenOutputFiles::slot_type const& iSlot) {
       preOpenOutputFilesSignal_.connect(iSlot);
     }
-    AR_WATCH_USING_METHOD_1(watchPreOpenOutputFiles)
+    AR_WATCH_USING_METHOD_0(watchPreOpenOutputFiles)
 
     /// signal is emitted after the framework asks OutputModules to open output files
     typedef signalslot::Signal<void()> PostOpenOutputFiles;
@@ -452,7 +452,7 @@ namespace edm {
     void watchPostOpenOutputFiles(PostOpenOutputFiles::slot_type const& iSlot) {
       postOpenOutputFilesSignal_.connect_front(iSlot);
     }
-    AR_WATCH_USING_METHOD_1(watchPostOpenOutputFiles)
+    AR_WATCH_USING_METHOD_0(watchPostOpenOutputFiles)
 
     /// signal is emitted before the framework asks OutputModules to close output files
     // Note an OutputModule may decide to close and open files by itself, those are not covered by this signal
@@ -461,7 +461,7 @@ namespace edm {
     void watchPreCloseOutputFiles(PreCloseOutputFiles::slot_type const& iSlot) {
       preCloseOutputFilesSignal_.connect(iSlot);
     }
-    AR_WATCH_USING_METHOD_1(watchPreCloseOutputFiles)
+    AR_WATCH_USING_METHOD_0(watchPreCloseOutputFiles)
 
     /// signal is emitted after the framework asks OutputModules to close output files
     typedef signalslot::Signal<void()> PostCloseOutputFiles;
@@ -469,7 +469,7 @@ namespace edm {
     void watchPostCloseOutputFiles(PostCloseOutputFiles::slot_type const& iSlot) {
       postCloseOutputFilesSignal_.connect_front(iSlot);
     }
-    AR_WATCH_USING_METHOD_1(watchPostCloseOutputFiles)
+    AR_WATCH_USING_METHOD_0(watchPostCloseOutputFiles)
 
     typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleBeginStream;
     PreModuleBeginStream preModuleBeginStreamSignal_;


### PR DESCRIPTION
#### PR description:

The macro `AR_WATCH_USING_METHOD_1` was used to declare helper templated overloads for `watch{Pre,Post}{Open,Close}OutputFiles()`, while `AR_WATCH_USING_METHOD_0` should be used as the signal takes no parameters.

#### PR validation:

Before the change, only the base function could be used using this workaround:

```C++
  registry.watchPreOpenOutputFiles(std::bind(&ProfilerService::preOpenOutputFiles, this));
  registry.watchPostOpenOutputFiles(std::bind(&ProfilerService::postOpenOutputFiles, this));
  registry.watchPreCloseOutputFiles(std::bind(&ProfilerService::preCloseOutputFiles, this));
  registry.watchPostCloseOutputFiles(std::bind(&ProfilerService::postCloseOutputFiles, this));
```

After the change, the templated overloads work, like for other signals:

```C++
registry.watchPreOpenOutputFiles(this, &ProfilerService ::preOpenOutputFiles);
registry.watchPostOpenOutputFiles(this, &ProfilerService ::postOpenOutputFiles);
registry.watchPreCloseOutputFiles(this, &ProfilerService ::preCloseOutputFiles);
registry.watchPostCloseOutputFiles(this, &ProfilerService ::postCloseOutputFiles);
```
