### PR TITLE
[20.0.X] first implementation of `TrigObjP4FlatTableProducer`

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -663,7 +663,8 @@ from Configuration.PyReleaseValidation.relval_Run4 import prefixDet
 
 # Phase-2 HLT NANO workflows
 _wfn = WFN(3000)
-workflows[_wfn()]  = _upgrade_workflows[prefixDet+34.759]  # HLT75e33 + NANO
-workflows[_wfn()]  = _upgrade_workflows[prefixDet+34.7591] # HLT75e33 + NANO (including validation)
-workflows[_wfn()]  = _upgrade_workflows[prefixDet+34.772]  # NGTScouting + NANO
-workflows[_wfn()]  = _upgrade_workflows[prefixDet+34.773]  # NGTScouting + NANO (including validation)
+workflows[_wfn()]  = _upgrade_workflows[prefixDet+34.759]  # HLT75e33 + HLT NANO
+workflows[_wfn()]  = _upgrade_workflows[prefixDet+34.7591] # HLT75e33 + HLT NANO (including validation)
+workflows[_wfn()]  = _upgrade_workflows[prefixDet+34.772]  # NGTScouting + HLT NANO
+workflows[_wfn()]  = _upgrade_workflows[prefixDet+34.773]  # NGTScouting + HLT NANO (including validation)
+workflows[_wfn()]  = _upgrade_workflows[prefixDet+34.774]  # NGTScouting + HLT NANO (including validation) + L1 NANO

--- a/HLTrigger/NGTScouting/plugins/BuildFile.xml
+++ b/HLTrigger/NGTScouting/plugins/BuildFile.xml
@@ -8,11 +8,12 @@
 <use name="DataFormats/Scouting"/>
 <use name="DataFormats/StdDictionaries"/>
 <use name="DataFormats/VertexReco"/>
-<use name="SimDataFormats/CaloAnalysis"/>
 <use name="FWCore/Common"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
+<use name="HLTrigger/HLTcore"/>
 <use name="PhysicsTools/NanoAOD"/>
 <use name="RecoVertex/VertexTools"/>
+<use name="SimDataFormats/CaloAnalysis"/>
 <use name="boost"/>

--- a/HLTrigger/NGTScouting/plugins/TrigObjP4FlatTableProducer.cc
+++ b/HLTrigger/NGTScouting/plugins/TrigObjP4FlatTableProducer.cc
@@ -1,0 +1,287 @@
+// NanoAOD FlatTable producer for HLT trigger objects.
+//
+// The set of objects saved as table rows is the deduplicated union of:
+//   (a) all objects passing the last save-tags filter of every path in pathNames
+//   (b) all objects passing any filter listed in extraFilters
+//
+// Per-row columns:
+//   pt, eta, phi, mass   - four-momentum
+//   id                   - trigger object type id (TriggerTypeDefs.h)
+//   <pathName>           - bool: object passes the last filter of that path
+//
+// Path name branch sanitisation: ':' and '/' are replaced with '_'.
+
+// user includes
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "DataFormats/HLTReco/interface/TriggerObject.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+
+// standard includes
+#include <algorithm>
+#include <string>
+#include <vector>
+#include <unordered_set>
+
+class TrigObjP4FlatTableProducer : public edm::global::EDProducer<edm::RunCache<HLTConfigProvider>> {
+public:
+  explicit TrigObjP4FlatTableProducer(const edm::ParameterSet&);
+  ~TrigObjP4FlatTableProducer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  // RunCache interface - one HLTConfigProvider initialised per run, thread-safely
+  std::shared_ptr<HLTConfigProvider> globalBeginRun(const edm::Run&, const edm::EventSetup&) const override;
+  void globalEndRun(const edm::Run&, const edm::EventSetup&) const override {}
+
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+private:
+  // Return the (sorted, unique) set of TriggerObjectCollection indices for
+  // objects that pass filterLabel.  Returns empty if the filter is not found.
+  static std::vector<trigger::size_type> indicesPassingFilter(const trigger::TriggerEvent& trigEvent,
+                                                              const std::string& filterLabel,
+                                                              const std::string& processName);
+
+  // Sanitise a path/filter name into a valid ROOT branch name.
+  static std::string toBranchName(std::string name);
+
+  // ---------- config ----------
+  const edm::InputTag trigEventTag_;
+  const edm::EDGetTokenT<trigger::TriggerEvent> trigEventToken_;
+  const std::string tableName_;
+  const std::vector<std::string> pathNames_;     // HLT paths  -> last-filter seeds + bool columns
+  const std::vector<std::string> extraFilters_;  // extra filters -> additional seed objects
+};
+
+// ---------------------------------------------------------------------------
+// constructor
+// ---------------------------------------------------------------------------
+TrigObjP4FlatTableProducer::TrigObjP4FlatTableProducer(const edm::ParameterSet& ps)
+    : trigEventTag_(ps.getParameter<edm::InputTag>("triggerEvent")),
+      trigEventToken_(consumes<trigger::TriggerEvent>(trigEventTag_)),
+      tableName_(ps.getParameter<std::string>("tableName")),
+      pathNames_(ps.getParameter<std::vector<std::string>>("pathNames")),
+      extraFilters_(ps.getParameter<std::vector<std::string>>("extraFilters")) {
+  produces<nanoaod::FlatTable>();
+}
+
+// ---------------------------------------------------------------------------
+// RunCache
+// ---------------------------------------------------------------------------
+std::shared_ptr<HLTConfigProvider> TrigObjP4FlatTableProducer::globalBeginRun(const edm::Run& run,
+                                                                              const edm::EventSetup& setup) const {
+  auto hltConfig = std::make_shared<HLTConfigProvider>();
+  bool changed = false;
+  if (!hltConfig->init(run, setup, trigEventTag_.process(), changed))
+    edm::LogWarning("TrigObjP4FlatTableProducer")
+        << "HLTConfigProvider::init() failed for process " << trigEventTag_.process();
+  return hltConfig;
+}
+
+// ---------------------------------------------------------------------------
+// helper – indices of objects passing a filter
+// ---------------------------------------------------------------------------
+std::vector<trigger::size_type> TrigObjP4FlatTableProducer::indicesPassingFilter(const trigger::TriggerEvent& trigEvent,
+                                                                                 const std::string& filterLabel,
+                                                                                 const std::string& processName) {
+  for (size_t ifilt = 0; ifilt < trigEvent.sizeFilters(); ++ifilt) {
+    std::string fullname = trigEvent.filterTag(ifilt).label();  // just label part
+    //const trigger::size_type filterIdx = trigEvent.filterIndex(edm::InputTag(filterLabel, "", processName).encode());
+    if (fullname == filterLabel) {
+      if (ifilt >= trigEvent.sizeFilters())
+        return {};
+      const trigger::Keys& keys = trigEvent.filterKeys(ifilt);
+      return {keys.begin(), keys.end()};  // already sorted by TriggerEvent
+    }
+  }
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// helper - sanitise name -> ROOT branch name
+// ---------------------------------------------------------------------------
+std::string TrigObjP4FlatTableProducer::toBranchName(std::string name) {
+  for (char& c : name)
+    if (c == ':' || c == '/' || c == '-' || c == '.')
+      c = '_';
+  return name;
+}
+
+// ---------------------------------------------------------------------------
+// produce
+// ---------------------------------------------------------------------------
+void TrigObjP4FlatTableProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup&) const {
+  const auto& trigEvent = iEvent.get(trigEventToken_);
+  const auto& hltConfig = *runCache(iEvent.getRun().index());
+  const std::string& proc = trigEventTag_.process();
+  const trigger::TriggerObjectCollection& allObjs = trigEvent.getObjects();
+
+  // -----------------------------------------------------------------------
+  // Step 1 - resolve the last save-tags filter for every requested path.
+  //          We store it so we can reuse it for the boolean flag columns.
+  // -----------------------------------------------------------------------
+  struct PathInfo {
+    std::string name;        // original path name
+    std::string lastFilter;  // last save-tags filter (empty if path unknown)
+  };
+  std::vector<PathInfo> pathInfos;
+  pathInfos.reserve(pathNames_.size());
+
+  for (const std::string& path : pathNames_) {
+    PathInfo pi;
+    pi.name = path;
+    const unsigned int pathIdx = hltConfig.triggerIndex(path);
+    if (pathIdx < hltConfig.size()) {
+      const auto& saveTags = hltConfig.saveTagsModules(pathIdx);
+      if (!saveTags.empty()) {
+        pi.lastFilter = saveTags.back();
+      } else {
+        edm::LogInfo("TrigObjP4FlatTableProducer") << "Path " << path << " has no save-tags modules - skipped as seed";
+      }
+    } else {
+      edm::LogInfo("TrigObjP4FlatTableProducer") << "Path " << path << " not found in HLT menu - skipped as seed";
+    }
+    pathInfos.push_back(std::move(pi));
+  }
+
+  // -----------------------------------------------------------------------
+  // Step 2 - build the union of seeding object indices:
+  //          - last filter of every known path
+  //          - every filter in extraFilters_
+  // Use an ordered set so the final table is deterministically ordered by
+  // object index (same ordering as TriggerObjectCollection).
+  // -----------------------------------------------------------------------
+  std::unordered_set<trigger::size_type> seedSet;
+
+  for (const PathInfo& pi : pathInfos) {
+    LogTrace("TrigObjP4FlatTableProducer") << "path: " << pi.name << " filter: " << pi.lastFilter << std::endl;
+    if (pi.lastFilter.empty()) {
+      continue;
+    }
+    for (auto idx : indicesPassingFilter(trigEvent, pi.lastFilter, proc)) {
+      seedSet.insert(idx);
+    }
+  }
+
+  for (const std::string& filter : extraFilters_) {
+    for (auto idx : indicesPassingFilter(trigEvent, filter, proc))
+      seedSet.insert(idx);
+  }
+
+  // Sort to give stable row ordering
+  std::vector<trigger::size_type> rowIndices(seedSet.begin(), seedSet.end());
+  std::sort(rowIndices.begin(), rowIndices.end());
+  const size_t nObj = rowIndices.size();
+
+  LogTrace("TrigObjP4FlatTableProducer") << "nObj=" << nObj << " allObjs.size()=" << allObjs.size() << std::endl;
+
+  // -----------------------------------------------------------------------
+  // Step 3 - fill kinematic columns
+  // -----------------------------------------------------------------------
+  std::vector<float> pt(nObj), eta(nObj), phi(nObj), mass(nObj);
+  std::vector<int> id(nObj);
+
+  for (size_t i = 0; i < nObj; ++i) {
+    LogTrace("TrigObjP4FlatTableProducer") << "Processing object " << i << " with rowIndices[" << i << "]" << std::endl;
+
+    const trigger::TriggerObject& obj = allObjs[rowIndices[i]];
+    pt[i] = obj.pt();
+    eta[i] = obj.eta();
+    phi[i] = obj.phi();
+    mass[i] = obj.mass();
+    id[i] = obj.id();
+
+    LogTrace("TrigObjP4FlatTableProducer") << "  -> pt=" << pt[i] << ", eta=" << eta[i] << ", phi=" << phi[i]
+                                           << ", mass=" << mass[i] << ", id=" << id[i] << std::endl;
+  }
+
+  // -----------------------------------------------------------------------
+  // Step 4 - per-path boolean flags:
+  //          for each row, did this object pass the last filter of the path?
+  // -----------------------------------------------------------------------
+  // Pre-index the row positions for O(1) lookup when filling flags
+  std::unordered_map<trigger::size_type, size_t> rowPosition;
+  rowPosition.reserve(nObj);
+  for (size_t i = 0; i < nObj; ++i)
+    rowPosition[rowIndices[i]] = i;
+
+  struct PathFlag {
+    std::string branchName;
+    std::string docString;
+    std::vector<bool> fired;
+  };
+  std::vector<PathFlag> pathFlags;
+  pathFlags.reserve(pathInfos.size());
+
+  for (const PathInfo& pi : pathInfos) {
+    PathFlag pf;
+    pf.branchName = toBranchName(pi.name);
+    pf.docString = "object passes last filter of path " + pi.name;
+    pf.fired.assign(nObj, false);
+
+    if (!pi.lastFilter.empty()) {
+      for (auto objIdx : indicesPassingFilter(trigEvent, pi.lastFilter, proc)) {
+        auto it = rowPosition.find(objIdx);
+        if (it != rowPosition.end())
+          pf.fired[it->second] = true;
+      }
+    }
+    pathFlags.push_back(std::move(pf));
+  }
+
+  // -----------------------------------------------------------------------
+  // Step 5 - assemble FlatTable
+  // -----------------------------------------------------------------------
+  auto table = std::make_unique<nanoaod::FlatTable>(nObj, tableName_, false, false);
+
+  table->addColumn<float>("pt", pt, "trigger object pT [GeV]");
+  table->addColumn<float>("eta", eta, "trigger object eta");
+  table->addColumn<float>("phi", phi, "trigger object phi [rad]");
+  table->addColumn<float>("mass", mass, "trigger object mass [GeV]");
+  table->addColumn<int>("id",
+                        id,
+                        "trigger object type id – see DataFormats/HLTReco/interface/TriggerTypeDefs.h "
+                        "(e.g. 81=photon, 82=electron, 83=muon, 84=tau, 85=jet, 86=bjet, 87=MET, 0=other)");
+
+  for (const PathFlag& pf : pathFlags)
+    table->addColumn<bool>(pf.branchName, pf.fired, pf.docString);
+
+  iEvent.put(std::move(table));
+}
+
+// ---------------------------------------------------------------------------
+// fillDescriptions
+// ---------------------------------------------------------------------------
+void TrigObjP4FlatTableProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment(
+      "Produces a nanoAOD FlatTable of HLT trigger objects. "
+      "The row set is the union of objects passing the last save-tags filter "
+      "of every path in pathNames and every filter in extraFilters.");
+
+  desc.add<edm::InputTag>("triggerEvent", edm::InputTag("hltTriggerSummaryAOD", "", "HLT"))
+      ->setComment("TriggerEvent summary product");
+  desc.add<std::string>("tableName", "TrigObj")->setComment("nanoAOD table name");
+  desc.add<std::vector<std::string>>("pathNames", {})
+      ->setComment(
+          "HLT paths: their last save-tags filter seeds the object set "
+          "and each path gets a per-object bool column");
+  desc.add<std::vector<std::string>>("extraFilters", {})
+      ->setComment(
+          "Additional HLT filter labels whose passing objects are included "
+          "in the table (no extra bool column is added for these)");
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+DEFINE_FWK_MODULE(TrigObjP4FlatTableProducer);

--- a/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
+++ b/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
@@ -26,6 +26,7 @@ from HLTrigger.NGTScouting.hltTICLCandidates_cfi import *
 from HLTrigger.NGTScouting.hltTICLSuperClusters_cfi import *
 from HLTrigger.NGTScouting.hltLayerClusters_cfi import * 
 from HLTrigger.NGTScouting.hltSums_cfi import *
+from HLTrigger.NGTScouting.hltTriggerObjects_cff import *
 from HLTrigger.NGTScouting.hltTriggerAcceptFilter_cfi import hltTriggerAcceptFilter,dstTriggerAcceptFilter
 
 ######################################
@@ -55,7 +56,8 @@ NanoGenTables = cms.Sequence(
 
 # Store hlt objects for NGT scouting
 NanoHltTables = cms.Sequence(
-    hltVertexTable
+    hltTriggerObjP4Table
+    + hltVertexTable
     + hltSecondaryVertexTable
     + hltPixelVertexTable
     + hltGeneralTrackTable

--- a/HLTrigger/NGTScouting/python/hltTriggerObjects_cff.py
+++ b/HLTrigger/NGTScouting/python/hltTriggerObjects_cff.py
@@ -1,0 +1,65 @@
+import FWCore.ParameterSet.Config as cms
+
+# ---------------------------------------------------------------------------
+# Example configuration for T
+#
+# Drop this fragment into your nanoAOD customisation function and add
+# trigObjFlatTable to your output commands / schedule.
+# ---------------------------------------------------------------------------
+
+hltTriggerObjP4Table = cms.EDProducer(
+    "TrigObjP4FlatTableProducer",
+
+    # TriggerEvent summary from HLT (process name must match your HLT menu).
+    triggerEvent=cms.InputTag("hltTriggerSummaryAOD", "", "@currentProcess"),
+
+    # Name of the output branch group in the nanoAOD file.
+    tableName=cms.string("TriggerObject"),
+
+    # HLT paths for which:
+    #   (1) the last save-tags filter seeds the object set (objects passing it
+    #       are included as rows of the table), AND
+    #   (2) a per-row bool column named after the path is added.
+    # Branch names are the path strings with ':', '/', '-', '.' replaced by '_'.
+    pathNames=cms.vstring(
+        "HLT_AK4PFPuppiJet520",
+        "HLT_PFPuppiHT1070",
+        "HLT_PFPuppiMETTypeOne140_PFPuppiMHT140",
+        "HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_2p4",
+        "HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepFlavour_2p4",
+        "HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepFlavour_2p4",
+        "HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4",
+        "HLT_Mu50_FromL1TkMuon",
+        "HLT_IsoMu24_FromL1TkMuon",
+        "HLT_Mu37_Mu27_FromL1TkMuon",
+        "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon",
+        "HLT_TriMu_10_5_5_DZ_FromL1TkMuon",
+        "HLT_Ele32_WPTight_Unseeded",
+        "HLT_Ele26_WP70_Unseeded",
+        "HLT_Photon108EB_TightID_TightIso_Unseeded",
+        "HLT_Photon187_Unseeded",
+        "HLT_DoubleEle25_CaloIdL_PMS2_Unseeded",
+        "HLT_Diphoton30_23_IsoCaloId_Unseeded",
+        "HLT_Ele32_WPTight_L1Seeded",
+        "HLT_Ele115_NonIso_L1Seeded",
+        "HLT_Ele26_WP70_L1Seeded",
+        "HLT_Photon108EB_TightID_TightIso_L1Seeded",
+        "HLT_Photon187_L1Seeded",
+        "HLT_DoubleEle25_CaloIdL_PMS2_L1Seeded",
+        "HLT_DoubleEle23_12_Iso_L1Seeded",
+        "HLT_Diphoton30_23_IsoCaloId_L1Seeded",
+        "HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1",
+        "HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1",
+        "HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1",
+        "HLT_Ele30_WPTight_L1Seeded_LooseDeepTauPFTauHPS30_eta2p1_CrossL1"
+    ),
+
+    # Extra HLT filter labels whose passing objects are also included in the
+    # table rows (union with the path seeds above, deduplicated).
+    # No additional bool column is created for these - they only extend coverage.
+    # Useful for intermediate filters, L1-seeded objects, or cross-trigger seeds.
+    extraFilters=cms.vstring(
+        # e.g. "hltEGL1SingleEGOrFilter",
+        # e.g. "hltEle32WPTightGsfTrackIsoFilter",
+    ),
+)

--- a/HLTrigger/NGTScouting/test/testProduceNanoHLT.sh
+++ b/HLTrigger/NGTScouting/test/testProduceNanoHLT.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -ex
+
+LOCALPATH='/eos/cms/store/relval/CMSSW_20_0_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU-v1/2590000/'
+echo "Input source: |${LOCALPATH}|"
+LOCALFILES=$(ls -1 ${LOCALPATH})
+ALL_FILES=""
+for f in ${LOCALFILES[@]}; do
+    ALL_FILES+="file:${LOCALPATH}/${f},"
+done
+
+# Remove the last character
+ALL_FILES="${ALL_FILES%?}"
+echo "Discovered files: $ALL_FILES"
+
+cmsDriver.py step2 -s L1P2GT,HLT:75e33_timing,NANO:@Phase2HLT \
+             --conditions auto:phase2_realistic_T35 \
+             --datatier NANOAODSIM \
+             -n 100 \
+             --eventcontent NANOAODSIM \
+             --geometry ExtendedRun4D110 \
+             --era Phase2C17I13M9 \
+             --filein $ALL_FILES \
+             --nThreads 1 \
+             --process HLTX \
+             --no_exec \
+             --inputCommands='keep *, drop *_hlt*_*_HLT, drop trigger*_*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT'
+
+cat <<@EOF >> step2_L1P2GT_HLT_NANO.py
+process.NanoHltTables = cms.Sequence(process.hltTriggerObjP4Table)
+@EOF
+
+cmsRun step2_L1P2GT_HLT_NANO.py > step2.log  2>&1


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/51376

#### PR description:


The goal of this PR is to implement `TrigObjP4FlatTableProducer`: a first implementation of  a NanoAOD FlatTable producer for HLT trigger objects.
The set of objects saved as table rows is the deduplicated union of:
- (a) all objects passing the last save-tags filter of every path in `pathNames`
-  (b) all objects passing any filter listed in `extraFilters`

Per-row columns:
- `pt`, `eta`, `phi`, `mass`   (- four-momentum)
- `id`                   - trigger object type id (`TriggerTypeDefs.h`)
-  `<pathName>`           - bool: object passes the last filter of that path

This module w.r.t. the existing implementation at [PhysicsTools/NanoAOD](https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/plugins/TriggerObjectTableProducer.cc) doesn't depend on the `TriggerResults`  in the event and it 's not reliant on the `PAT` step of `cmssw`.

#### PR validation:

Run the provided script in the PR [testProduceNanoHLT.sh](https://github.com/mmusich/cmssw/blob/e803ecc8ec10352c1a746f1da9190345519380ea/HLTrigger/NGTScouting/test/testProduceNanoHLT.sh) and inspected the resulting nanoAOD output file.
I inspected the file and the output is available at:
- [Size report](https://marcomusich.web.cern.ch/display/TrigObjP4FlatTableProducer/SizeReport.html)
- [EventContent](https://marcomusich.web.cern.ch/display/TrigObjP4FlatTableProducer/EventContent.html)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/51376 to CMSSW_20_0_X. It might be useful to have if we try to produce HLT nanos in the 20.0.X 2026 Phase-2 MC production