### PR TITLE
[UBSAN]BasicTrajectoryState: Initialize surface side for default constructor

### DIFF
--- a/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
+++ b/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
@@ -73,7 +73,11 @@ public:
 
 public:
   // default constructor : to make root happy
-  BasicTrajectoryState() : theLocalParametersValid(false), theValid(false), theWeight(0) {}
+  BasicTrajectoryState()
+      : theLocalParametersValid(false),
+        theValid(false),
+        theSurfaceSide(SurfaceSideDefinition::atCenterOfSurface),
+        theWeight(0) {}
 
   /// construct invalid trajectory state (without parameters)
   explicit BasicTrajectoryState(const SurfaceType& aSurface);


### PR DESCRIPTION
Initialize `BasicTrajectoryState::theSurfaceSide` data member for default constructor too. Thbsi should fix the ubsan runtime error [a]. 

[a] https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/CMSSW_20_1_X_2026-07-06-2300/logs/8a/8aaafefbee0021d520f156d914c5764f/log
```
TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h:66:7: runtime error: load of value 5434, which is not a valid value for type 'SurfaceSide'
    #1 0x153be25d7c3c in BasicSingleTrajectoryState::BasicSingleTrajectoryState(BasicSingleTrajectoryState const&) src/TrackingTools/TrajectoryState/interface/BasicSingleTrajectoryState.h:10
    #2 0x153be25d7c3c in void std::_Construct<BasicSingleTrajectoryState, BasicSingleTrajectoryState const&>(BasicSingleTrajectoryState*, BasicSingleTrajectoryState const&) /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/include/c++/13.4.0/bits/stl_construct.h:119
    #3 0x153be25d7c3c in void std::allocator_traits<std::allocator<void> >::construct<BasicSingleTrajectoryState, BasicSingleTrajectoryState const&>(std::allocator<void>&, BasicSingleTrajectoryState*, BasicSingleTrajectoryState const&) /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/include/c++/13.4.0/bits/alloc_traits.h:661
    #4 0x153be25d7c3c in std::_Sp_counted_ptr_inplace<BasicSingleTrajectoryState, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<BasicSingleTrajectoryState const&>(std::allocator<void>, BasicSingleTrajectoryState const&) /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/include/c++/13.4.0/bits/shared_ptr_base.h:604
    #5 0x153be25d7c3c in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<BasicSingleTrajectoryState, std::allocator<void>, BasicSingleTrajectoryState const&>(BasicSingleTrajectoryState*&, std::_Sp_alloc_shared_tag<std::allocator<void> >, BasicSingleTrajectoryState const&) /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/include/c++/13.4.0/bits/shared_ptr_base.h:971
    #6 0x153be25d7c3c in std::__shared_ptr<BasicSingleTrajectoryState, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void>, BasicSingleTrajectoryState const&>(std::_Sp_alloc_shared_tag<std::allocator<void> >, BasicSingleTrajectoryState const&) /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/include/c++/13.4.0/bits/shared_ptr_base.h:1712
    #7 0x153be25d7c3c in std::shared_ptr<BasicSingleTrajectoryState>::shared_ptr<std::allocator<void>, BasicSingleTrajectoryState const&>(std::_Sp_alloc_shared_tag<std::allocator<void> >, BasicSingleTrajectoryState const&) /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/include/c++/13.4.0/bits/shared_ptr.h:464
    #8 0x153be25d7c3c in std::shared_ptr<BasicSingleTrajectoryState> std::make_shared<BasicSingleTrajectoryState, BasicSingleTrajectoryState const&>(BasicSingleTrajectoryState const&) /data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/gcc/13.4.0-6908cfdf803923e783448096ca4f0923/include/c++/13.4.0/bits/shared_ptr.h:1010
    #9 0x153be25d7c3c in std::shared_ptr<BasicTrajectoryState> BasicTrajectoryState::build<BasicSingleTrajectoryState, BasicSingleTrajectoryState const&>(BasicSingleTrajectoryState const&) src/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h:87
    #10 0x153be25d7c3c in BasicSingleTrajectoryState::clone() const src/TrackingTools/TrajectoryState/interface/BasicSingleTrajectoryState.h:17
    #11 0x153adeb921ba in ProxyBase11<BasicTrajectoryState>::unsharedData() src/TrackingTools/TrajectoryState/interface/ProxyBase11.h:59
    #12 0x153adeb921ba in TrajectoryStateOnSurface::rescaleError(double) src/TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h:82
    #13 0x153adeb921ba in OutsideInMuonSeeder::doLayer(GeometricSearchDet const&, TrajectoryStateOnSurface const&, std::vector<io_v1::TrajectorySeed, std::allocator<io_v1::TrajectorySeed> >&, Propagator const&, Propagator const&, MeasurementTrackerEvent const&) const src/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc:240
    #14 0x153adeb9b262 in OutsideInMuonSeeder::produce(edm::Event&, edm::EventSetup const&) src/RecoTracker/SpecialSeedGenerators/src/OutsideInMuonSeeder.cc:170
    #15 0x153c15b578dd in edm::stream::EDProducerAdaptorBase::doEvent(edm::EventTransitionInfo const&, edm::ActivityRegistry*, edm::ModuleCallingContext const*) src/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc:83
    #16 0x153c159e9a1f in edm::WorkerT<edm::stream::EDProducerAdaptorBase>::implDo(edm::EventTransitionInfo const&, edm::ModuleCallingContext const*) src/FWCore/Framework/src/WorkerT.cc:204
    #17 0x153c1537b2d0 in edm::workerhelper::CallImpl<edm::OccurrenceTraits<edm::EventPrincipal, (edm::TransitionActionType)1> >::call(edm::Worker*, edm::StreamID, edm::EventTransitionInfo const&, edm::ActivityRegistry*, edm::ModuleCallingContext const*, edm::StreamContext const*) src/FWCore/Framework/interface/maker/Worker.h:606

```