### PR TITLE
Update GenProton NanoAOD acceptance for Run 3 [15_0_X]

### DIFF
--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -49,7 +49,13 @@ if singleRPProtons: protonTablesTask.add(singleRPTable)
 
 # GEN-level signal/PU protons collection
 genProtonTable = _genproton.clone(
-    cut = cms.string('(pdgId == 2212) && (abs(pz) > 5200) && (abs(pz) < 6467.5)') # xi in [0.015, 0.2]
+    cut = cms.string('(pdgId == 2212) && (abs(pz) > 5200.0) && (abs(pz) < 6435.0)') # Run 2 xi in [0.01, 0.2]
+)
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(
+    genProtonTable,
+    cut = '(pdgId == 2212) && (abs(pz) > 5440) && (abs(pz) < 6732)' # Run 3, xi in [0.01, 0.2]
 )
 
 genProtonTablesTask = cms.Task(genProtonTable)


### PR DESCRIPTION
backport of #51283.

The change updates the generator-level proton selection used for the NanoAOD GenProton table to a standardized xi in [0.01, 0.2] acceptance, with the corresponding Run 3 beam-energy window applied through 
un3_common.

No additional code changes are introduced relative to #51283.

#### PR validation:

- Backport is identical to #51283
- Target branch carries the same pre-fix PhysicsTools/NanoAOD/python/protons_cff.py content as the original branch before merge
- Original PR validation in #51283 compiled PhysicsTools/NanoAOD and verified that 
un3_common switches the GenProton selection to the Run 3 beam-energy window with --era Run3_2024

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #51283, needed for Run 3 NanoAOD production release cycles on $(System.Collections.Hashtable.base).

watchers: @forthommel