### PR TITLE
Add customization to skip the duplicated CPU-only HLT reconstruction during MC production

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforMC.py
+++ b/HLTrigger/Configuration/python/customizeHLTforMC.py
@@ -1,8 +1,45 @@
 import FWCore.ParameterSet.Config as cms
 
+def customizeHLT_removeCPUOnlySequences_AlCaPFJet40(process):
+    """
+    Remove AlCa paths from the process to avoid running them twice 
+    (Alpaka and SerialSync, CMSHLT-2461).
+    """
+    path_cpu_only = None
+    path_standard = None
+
+    # Identify target paths (handles potential version suffixes)
+    for path_name in process.paths_():
+        if path_name.startswith('AlCa_PFJet40_CPUOnly_v'):
+            path_cpu_only = path_name
+        elif path_name.startswith('AlCa_PFJet40_v'):
+            path_standard = path_name
+
+    # If CPUOnly path is not present, nothing to modify
+    if not path_cpu_only:
+        return process
+
+    # If standard path is missing, copy fails
+    if not path_standard:
+        print("WARNING: path AlCa_PFJet40_CPUOnly found but not path AlCa_PFJet40, cannot remove it from the process")
+        return process
+
+    # Verify both prescalers exist before replacing
+    has_pre_std = hasattr(process, 'hltPreAlCaPFJet40')
+    has_pre_cpu = hasattr(process, 'hltPreAlCaPFJet40CPUOnly')
+
+    if has_pre_std and has_pre_cpu:
+        new_path = getattr(process, path_standard).copy()
+        new_path.replace(process.hltPreAlCaPFJet40, process.hltPreAlCaPFJet40CPUOnly)
+        setattr(process, path_cpu_only, new_path)
+    else:
+        print("WARNING: path AlCa_PFJet40_CPUOnly found but not hltPreAlCaPFJet40 or hltPreAlCaPFJet40CPUOnly, cannot replace it in the path")
+
+    return process
+
 def customizeHLTforMC(process):
   """adapt the HLT to run on MC, instead of data
   see Configuration/StandardSequences/Reconstruction_Data_cff.py
   which does the opposite, for RECO"""
-
+  process = customizeHLT_removeCPUOnlySequences_AlCaPFJet40(process)
   return process


### PR DESCRIPTION
### PR description

This PR adds the customization function `HLTrigger/Configuration/python/customizeHLTremoveSerialSync.py` which can be used to remove the CPU-only `SerialSync` reconstruction sequence from the HLT menu.

In MC production, this avoids running the HLT particle-flow reconstruction twice: once through the standard Alpaka-based reconstruction and once through the duplicated CPU-only `SerialSync` sequence. In the tested configuration, **this reduces the HLT-step CPU time per event by about 26%, corresponding to about 35% higher throughput.**

### Context

At the beginning of Run 3, when the HLT started using GPUs, TSG create a clone of `AlCa_PFJet40` path named `AlCa_PFJet40_CPUOnly` ([CMSHLT-2461](https://its.cern.ch/jira/browse/CMSHLT-2461)). The purpose was to compare the standard reconstruction with a CPU-only reconstruction and spot possible differences between CPU and GPU results.

The two paths are:

* `AlCa_PFJet40`, which runs the standard Alpaka-based reconstruction on CPU or GPU depending on GPU availability;
* `AlCa_PFJet40_CPUOnly`, which runs the reconstruction using only the CPU.

To implement this comparison, the corresponding reconstruction sequences and modules were duplicated with different names, using the `SerialSync` suffix.

In data taking, both `AlCa_PFJet40` and `AlCa_PFJet40_CPUOnly` are seeded by `L1_ZeroBias`, which is heavily prescaled at L1. As a result, their rate is very small and the timing impact is limited.

In MC production, however, all L1 seeds are emulated without prescales. Therefore, the HLT PFlow reconstruction is effectively run twice for these events:

1. once with the standard Alpaka reconstruction;
2. once with the duplicated CPU-only `SerialSync` reconstruction.

This customization runs the standard sequence, instead of the `SerialSync` sequences, in `AlCa_PFJet40_CPUOnly`, avoiding the duplicated reconstruction and significantly speeding up the HLT step in MC production.

### PR validation

I validated the PR by running the HLT step with:

* CPU only: `--accelerator cpu`;
* 4 threads;
* output removed, to avoid including output-writing time;
* input file:

```text
/eos/cms/store/relval/CMSSW_17_0_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_160X_mcRun3_2026_realistic_v6_STD_2026_RegeneratedGS_PU-v1/2590000/69ac4062-f019-4dcf-959a-98dc730c44e1.root
```

The baseline configuration was produced with:

```bash
cmsDriver.py step2 \
  -s HLT:@relval2026 \
  --process reHLT \
  --conditions auto:phase1_2026_realistic \
  --datatier GEN-SIM-DIGI-RAW \
  -n 500 \
  --eventcontent FEVTDEBUGHLT \
  --geometry DB:Extended \
  --era Run3_2026 \
  --filein file:69ac4062-f019-4dcf-959a-98dc730c44e1.root \
  --nThreads 4 \
  --accelerator cpu \
  --no_exec

echo "process.options.wantSummary = True" >> step2_HLT.py
echo "del process.FEVTDEBUGHLToutput_step" >> step2_HLT.py

cmsRun step2_HLT.py >& logHLT &
```

The baseline timing was:

```text
TimeReport ---------- Event  Summary ---[sec]----
TimeReport       event loop CPU/event = 0.992337
TimeReport      event loop Real/event = 0.278026
TimeReport     sum Streams Real/event = 1.079756
TimeReport efficiency CPU/Real/thread = 0.892307
```

At the same time, I ran the same configuration with the new customization:

```bash
--customise HLTrigger/Configuration/customizeHLTremoveSerialSync.customizeHLTremoveSerialSync
```

obtaining:

```text
TimeReport ---------- Event  Summary ---[sec]----
TimeReport       event loop CPU/event = 0.708285
TimeReport      event loop Real/event = 0.206755
TimeReport     sum Streams Real/event = 0.799066
TimeReport efficiency CPU/Real/thread = 0.856429
```

This corresponds to:

* `sum Streams Real/event`: `1.079756` → `0.799066`, about 26% less stream time per event.

### Backport information

As this change can be used only Run-3 MC, I open this PR only toward 17_0_X. I don't think it can be useful for 20_0_X.
For Phase-2 something similar could be implemented but disabling [DQM_TRKHeterogeneousValidation](https://github.com/cms-sw/cmssw/blob/master/HLTrigger/Configuration/python/HLT_75e33/paths/DQM_TRKHeterogeneousValidation_cfi.py) and [DQM_HGCALHeterogeneousValidation](https://github.com/cms-sw/cmssw/blob/master/HLTrigger/Configuration/python/HLT_75e33/paths/DQM_HGCALHeterogeneousValidation_cfi.py), but it would be a different function.

This customization may be useful for **all** Run 3 CMSSW release cycles, especially in those that will be used to run the HLT step in the MC production (17_0_X only or also other releases depending on the plans of PPD).

As this customization function is very easy,  it should also be possible to apply the customization on the fly in MC production workflows, without requiring it to be present in an official CMSSW release.

@cms-sw/hlt-l2 @cms-sw/heterogeneous-l2 @cms-sw/pdmv-l2 @cms-sw/ppd-l2 