### PR TITLE
Fix: remove unused Eigen variables in RecoTracker package

### DIFF
--- a/RecoTracker/PixelTrackFitting/interface/RiemannFit.h
+++ b/RecoTracker/PixelTrackFitting/interface/RiemannFit.h
@@ -593,7 +593,6 @@ namespace riemannFit {
 #endif
       {
         Eigen::Matrix<double, 1, 1> cm;
-        Eigen::Matrix<double, 1, 1> cm2;
         cm = mc.transpose() * vMat * mc;
         const double tempC2 = cm(0, 0);
         Matrix2Nd<N> tempVcsMat;
@@ -727,7 +726,6 @@ namespace riemannFit {
         Eigen::Matrix<double, 1, 1> cm1;
         Eigen::Matrix<double, 1, 1> cm3;
         cm1 = (vVec.transpose() * c0Mat * vVec);
-        //      cm2 = (c0Mat.cwiseProduct(t0)).sum();
         cm3 = (r0.transpose() * t0 * r0);
         // Workaround to get things working in GPU
         const double tempC = cm1(0, 0) + (c0Mat.cwiseProduct(t0)).sum() + cm3(0, 0);

--- a/RecoTracker/PixelTrackFitting/test/PixelTrackFits.cc
+++ b/RecoTracker/PixelTrackFitting/test/PixelTrackFits.cc
@@ -336,7 +336,6 @@ void test_helix_fit(bool getcin) {
   const double B_field = 3.8 * c_speed / pow(10, 9) / 100;
   Matrix<double, 6, 1> gen_par;
   Vector5d true_par;
-  Vector5d err;
   generator.seed(1);
   std::cout << std::setprecision(6);
   cout << "_________________________________________________________________________\n";


### PR DESCRIPTION
#### PR description:

Eigen 3.5.0/5.0.0 made fixed size matrices and arrays [trivially_default_constructible](https://gitlab.com/libeigen/eigen/-/merge_requests/1696). This uncovered two unused Eigen::Vector/Matrix variables in RecoTracker/PixelTrackFitting.
