### PR TITLE
Phase2-hgx368F Protect RecHitTools in RecoLocalCalo/HGCalRecAlgos for HFNose detIDs

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/RecHitTools.cc
@@ -513,6 +513,12 @@ int RecHitTools::getCellType(const DetId& id) const {
   int layerType = -1;
   if (isScint) {
     layerType = CE_H_Tile_HD;
+  } else if (isNose) {
+    if (isEELayer) {
+      layerType = CE_E_120_HD;
+    } else {
+      layerType = CE_H_120_Fine_HD;
+    }
   } else {
     HGCSiliconDetId siHid(id);
     auto type = siHid.type();


### PR DESCRIPTION
#### PR description:

Protect RecHitTools in RecoLocalCalo/HGCalRecAlgos for HFNose detIDs

#### PR validation:

Tested for 32034.0 which was crashing earlier.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to CMSSW_20_0_X and CMSSW_17_0_X