### PR TITLE
Remove customizeHLTFor51053 function call in HLT

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -37,12 +37,6 @@ def customiseForOffline(process):
 
     return process
 
-def customizeHLTFor51053(process):
-    for module in producers_by_type(process, "MuonIdProducer"):
-        if not hasattr(module, "isPhase2"):
-            module.isPhase2 = cms.bool(False)
-
-    return process
 
 def replace_all_pixel_seed_inputtags(process):
     import FWCore.ParameterSet.Config as cms
@@ -215,6 +209,5 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # process = customiseFor12718(process)
 
     # process = customizeHLTfor49436(process)
-    process = customizeHLTFor51053(process)
-
+    
     return process


### PR DESCRIPTION
#### PR description:

Removed the customizeHLTFor51053 function call (introduced in https://github.com/cms-sw/cmssw/pull/51053) from the process customization, as being un-needed: the fillDescriptions default of isPhase2 is FALSE.

#### PR validation:

TSG tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport needed.
