### PR TITLE
Fix customiseTrackingNtuple.extendedContent to correctly pick up OOT particles

### DIFF
--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -179,7 +179,7 @@ def customiseTrackingNtupleHLT(process):
     return process
 
 def extendedContent(process):
-    process.trackingParticlesIntime.intimeOnly = True
+    process.trackingParticlesIntime.intimeOnly = False
     shTags = [process.simHitTPAssocProducer.simHitSrc]
     if _usePileupSimHits(process):
         shTags += [process.crossingFramePSimHitToPSimHits.src]


### PR DESCRIPTION
It looks like I introduced a bug in #48881 in the [extendedContent diffs](https://github.com/cms-sw/cmssw/pull/48881/changes#diff-cbca4c9ceb271ca0c39da18a8667c342b35a7952a751be02390a6820acc89fcaR195-R204)
The code changes there were intentionally meant to pick up out-of-time pileup, but one component was missing.

This PR is a fix (tested on a somewhat random PU200 setup)
- the symptoms without a fix is a crash with `std::exception was thrown.  unordered_map::at`, which can happen after a few events.

@bdanzi @VourMa I think you mentioned some setup not working with the `extendedContent` possibly related to this; I can't recall if you found another work-around.