### PR TITLE
Clamp the CLUE3D cluster radius variance at zero

### DIFF
--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCLUE3D.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCLUE3D.cc
@@ -233,8 +233,12 @@ void PatternRecognitionbyCLUE3D<TILES>::makeTracksters(
     // radius. On the other hand, while averaging the x and y radius, we would
     // end up dividing by 2. Hence we omit the value here and in the average
     // below, too.
-    float radius_x = sqrt((sum_sqr_x - (sum_x * sum_x) * invClsize) * invClsize);
-    float radius_y = sqrt((sum_sqr_y - (sum_y * sum_y) * invClsize) * invClsize);
+    // Clamp the variance at zero: for point-like multi-cell clusters the
+    // difference can cancel slightly below zero in floating point, and the
+    // sqrt of a negative value yields a NaN radius whose comparisons are
+    // all false downstream (seed and density decisions).
+    float radius_x = sqrt(std::max(0.f, (sum_sqr_x - (sum_x * sum_x) * invClsize) * invClsize));
+    float radius_y = sqrt(std::max(0.f, (sum_sqr_y - (sum_y * sum_y) * invClsize) * invClsize));
     if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > VerbosityLevel::Advanced) {
       edm::LogVerbatim("PatternRecognitionbyCLUE3D")
           << "cluster rx: " << std::setw(5) << radius_x << ", ry: " << std::setw(5) << radius_y


### PR DESCRIPTION
The per-axis radius estimate is a variance over the cluster cells, computed in float against the stored log-weighted cluster position. For clusters whose cells all share one coordinate (e.g. a vertical column of hexagonal silicon cells, about 2500 per TTbar PU200 event) the true variance along that axis is zero and the one-pass formula subtracts two equal rounding residues, landing below zero about half the time; the sqrt then yields a NaN radius whose comparisons are silently false in the seed and density decisions.