### PR TITLE
[WarningFix]Clang static analyzer thread-safety warning for the globa…

### DIFF
--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRootFile.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRootFile.h
@@ -6,6 +6,8 @@
 #include "TFile.h"
 #include "TTree.h"
 
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaObject.h"
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaResultType.h"
 
@@ -62,6 +64,6 @@ public:
   ClassDefOverride(TEcnaRootFile, 1)  //Root file of CNA
 };
 
-R__EXTERN TEcnaRootFile *gCnaRootFile;
+R__EXTERN TEcnaRootFile *gCnaRootFile CMS_THREAD_SAFE;
 
 #endif

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRead.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRead.cc
@@ -10,8 +10,6 @@
 //  Documentation: see TEcnaRead.h
 //--------------------------------------
 
-R__EXTERN TEcnaRootFile *gCnaRootFile;
-
 ClassImp(TEcnaRead);
 //___________________________________________________________________________
 //

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRootFile.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRootFile.cc
@@ -11,7 +11,7 @@
 //  Documentation: see TEcnaRootFile.h
 //--------------------------------------
 
-TEcnaRootFile *gCnaRootFile = nullptr;
+TEcnaRootFile *gCnaRootFile CMS_THREAD_SAFE = nullptr;
 
 ClassImp(TEcnaRootFile);
 //___________________________________________________________________________

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRun.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRun.cc
@@ -10,8 +10,6 @@
 //  Documentation: see TEcnaRun.h
 //--------------------------------------
 
-R__EXTERN TEcnaRootFile* gCnaRootFile;
-
 ClassImp(TEcnaRun);
 //___________________________________________________________________________
 //


### PR DESCRIPTION

#### PR description:
Fix thread-safety warnings reported by the Clang static analyzer in
`CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos`.

```
The static analyzer reports this global mutable state as potentially unsafe in a multithreaded environment.

This change:
- annotates the intentionally shared global variable with `CMS_THREAD_SAFE`
- removes redundant `R__EXTERN` declarations from source files since the declaration is already provided through `TEcnaRootFile.h`
```
The `CMS_THREAD_SAFE` annotation documents that this global object is intentionally used in a thread-safe context and avoids suppressing the analyzer warning.
After this change, the thread-safety warning for gCnaRootFile is no longer reported by the static analyzer.
[logs](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_20_1_X_2026-07-13-2300/el9_amd64_gcc13/build-logs/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/log.html)


