### PR TITLE
Correct compatible det propagation in `setSecondHitPattern`

### DIFF
--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -287,10 +287,10 @@ void TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj,
         }  //end loop over layers
       };  // end lambda
 
-  localProp->setPropagationDirection(oppositeToMomentum);
+  localProp->setPropagationDirection(dirForInnerLayers);
   loopOverLayer(innerCompLayers, innerTSOS);
 
-  localProp->setPropagationDirection(alongMomentum);
+  localProp->setPropagationDirection(dirForOuterLayers);
   outIn = !outIn;  // if inOut should mark missing_outer
   loopOverLayer(outerCompLayers, outerTSOS);
 }


### PR DESCRIPTION
#### PR description:

This is a followup to https://github.com/cms-sw/cmssw/pull/51379. That PR resolved cases where some hits in inactive modules would end up incorrectly marked as missing when refitting tracks. Even after this fix, refitted tracks in muon ALCARECOs would end up with more missing / inactive L1 hit patterns than what is stored in the reco step. The affected stored reco tracks had no L1 hit patterns at all.

The tracks associated with this behavior come from `muonSeededStepOutIn` tracking step. In setSecondHitPattern(), the outIn-aware dirForInnerLayers / dirForOuterLayers are correctly used for the compatibleLayers() topological search, but the following compatibleDets() geometric check hardcodes oppositeToMomentum / alongMomentum instead of reusing them. For OutIn tracks this searches for a compatible module in the wrong physical direction, so compatibleDets() comes back empty and nothing gets appended to the HitPattern.

This only affects secondary hit patterns bookkeeping. The track parameters are not affected so no significant changes in reconstruction are expected.

#### PR validation:

Tested by printing L1 hit patterns of stored, and refitted ALCARECO muon tracks before and after the changes

Before change: 
  ```
  STORED (PixelBarrel layer 1, total 161):
    VALID         124
    MISSING        10
    INACTIVE       27

  REFIT (PixelBarrel layer 1, total 190):
    VALID         123
    MISSING        20
    INACTIVE       47
```

After change:
```
STORED (PixelBarrel layer 1, total 190):
  VALID         124
  MISSING        19
  INACTIVE       47

 REFIT (PixelBarrel layer 1, total 190):
  VALID         123
  MISSING        20
  INACTIVE       47
```
The one differing hit is traced to TrackRefitter needing Fitter='muonSeededFittingSmootherWithOutliersRejectionAndRK' to match muonSeededTracksOutIn's own fitter.

EDIT: 
Backports are
[20.0.X](https://github.com/cms-sw/cmssw/pull/51485) (includes https://github.com/cms-sw/cmssw/pull/51379 backport as well), [17.0.X](https://github.com/cms-sw/cmssw/pull/51496), [16.1.X](https://github.com/cms-sw/cmssw/pull/51497), and [16.0.X](https://github.com/cms-sw/cmssw/pull/51498) 
