### PR TITLE
remove `CaloTriggerPrimitives_cff` import from `L1TCaloLayer1Summary_cff`

### DIFF
--- a/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cff.py
+++ b/DQM/L1TMonitor/python/L1TCaloLayer1Summary_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from L1Trigger.Configuration.CaloTriggerPrimitives_cff import *
 from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Summary_cfi import *
 from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Digis_cfi import *
 from DQM.L1TMonitor.L1TCaloLayer1Summary_cfi import *


### PR DESCRIPTION
#### PR description:

This PR removes from `L1TCaloLayer1Summary_cff` the unnecessary import of `CaloTriggerPrimitives_cff`.

That import statement was introduced in #45605 (as part of a bug). That update was reverted in #46482 (fixing the bug), but in that PR the removal of the import statement was missed.

Loosely related to #48976.

Merely technical, no changes expected.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
