### PR TITLE
NanoAOD: introduce `NanoAODOutputModuleBase`

### DIFF
--- a/L1TriggerScouting/NanoAOD/plugins/OrbitNanoAODOutputModule.cc
+++ b/L1TriggerScouting/NanoAOD/plugins/OrbitNanoAODOutputModule.cc
@@ -195,6 +195,8 @@ void OrbitNanoAODOutputModule::writeRunTree(edm::RunForOutput const& iRun) {
 
 void OrbitNanoAODOutputModule::initTables() {
   m_tables.clear();
+  m_selbxs.clear();
+
   auto const& keeps = keptProducts();
   for (auto const& keep : keeps[edm::InEvent]) {
     if (keep.first->className() == "l1ScoutingRun3::OrbitFlatTable")

--- a/L1TriggerScouting/NanoAOD/plugins/OrbitNanoAODOutputModule.cc
+++ b/L1TriggerScouting/NanoAOD/plugins/OrbitNanoAODOutputModule.cc
@@ -10,70 +10,38 @@
 //
 // Author original version: Giovanni Petrucciani
 //        adapted by Patin Inkaew
+//
+#include <vector>
 
-// system include files
-#include <algorithm>
-#include <memory>
+#include "oneapi/tbb/task_arena.h"
 
-#include "Compression.h"
-#include "TFile.h"
-#include "TObjString.h"
-#include "TROOT.h"
-#include "TTree.h"
-#include <string>
-
-// user include files
-#include "FWCore/Framework/interface/one/OutputModule.h"
-#include "FWCore/Framework/interface/RunForOutput.h"
-#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
-#include "FWCore/Framework/interface/EventForOutput.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/JobReport.h"
-#include "FWCore/Utilities/interface/GlobalIdentifier.h"
-#include "FWCore/Utilities/interface/Digest.h"
-#include "IOPool/Provenance/interface/CommonProvenanceFiller.h"
-#include "DataFormats/Provenance/interface/BranchType.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
-#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
-#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/NanoAOD/interface/OrbitFlatTable.h"
+#include "DataFormats/Provenance/interface/EventAuxiliary.h"
+#include "DataFormats/Provenance/interface/LuminosityBlockID.h"
+#include "DataFormats/Provenance/interface/RunID.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "PhysicsTools/NanoAOD/interface/NanoAODOutputModuleBase.h"
 
 #include "OrbitTableOutputBranches.h"
 #include "SelectedBxTableOutputBranches.h"
 
-#include "oneapi/tbb/task_arena.h"
-
-class OrbitNanoAODOutputModule : public edm::one::OutputModule<> {
+class OrbitNanoAODOutputModule : public NanoAODOutputModuleBase {
 public:
   OrbitNanoAODOutputModule(edm::ParameterSet const& pset);
-  ~OrbitNanoAODOutputModule() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void write(edm::EventForOutput const& e) override;
-  void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
-  void writeRun(edm::RunForOutput const&) override;
-  bool isFileOpen() const override;
-  void openFile(edm::FileBlock const&) override;
-  void reallyCloseFile() override;
+  void writeEventTree(edm::EventForOutput const& iEvent) override;
+  void writeLuminosityBlockTree(edm::LuminosityBlockForOutput const& iLumi) override;
+  void writeRunTree(edm::RunForOutput const& iRun) override;
 
-  std::string m_fileName;
-  std::string m_logicalFileName;
-  int m_compressionLevel;
-  int m_eventsSinceFlush{0};
-  std::string m_compressionAlgorithm;
-  bool m_skipEmptyBXs;
-  bool m_writeProvenance;
-  bool m_fakeName;  //crab workaround, remove after crab is fixed
-  int m_autoFlush;
-  edm::ProcessHistoryRegistry m_processHistoryRegistry;
-  edm::JobReport::Token m_jrToken;
-  std::unique_ptr<TFile> m_file;
-  std::unique_ptr<TTree> m_tree, m_lumiTree, m_runTree, m_metaDataTree, m_parameterSetsTree;
-
-  static constexpr int m_firstFlush{1000};
+  void initTables() override;
+  void initEventTree(TTree& tree) override { m_commonEventBranches.branch(tree); }
+  void initLuminosityBlockTree(TTree& tree) override { m_commonLumiBranches.branch(tree); }
+  void initRunTree(TTree& tree) override { m_commonRunBranches.branch(tree); }
 
   class CommonEventBranches {
   public:
@@ -83,19 +51,19 @@ private:
       tree.Branch("bunchCrossing", &m_bunchCrossing, "bunchCrossing/i");
       tree.Branch("orbitNumber", &m_orbitNumber, "orbitNumber/i");
     }
-    void fill(const edm::EventAuxiliary& aux) {
+    void fill(edm::EventAuxiliary const& aux) {
       m_run = aux.id().run();
       m_luminosityBlock = aux.id().luminosityBlock();
       m_orbitNumber = aux.id().event();  // in L1Scouting, one processing event is one orbit
     }
-    void setBx(unsigned bx) { m_bunchCrossing = bx; }
+    void setBx(unsigned int const bx) { m_bunchCrossing = bx; }
 
   private:
     UInt_t m_run;
     UInt_t m_luminosityBlock;
     UInt_t m_bunchCrossing;
     UInt_t m_orbitNumber;
-  } m_commonBranches;
+  } m_commonEventBranches;
 
   class CommonLumiBranches {
   public:
@@ -104,7 +72,7 @@ private:
       tree.Branch("luminosityBlock", &m_luminosityBlock, "luminosityBlock/i");
       tree.Branch("nOrbits", &m_orbits, "nOrbits/i");
     }
-    void fill(const edm::LuminosityBlockID& id, unsigned int nOrbits) {
+    void fill(edm::LuminosityBlockID const& id, unsigned int const nOrbits) {
       m_run = id.run();
       m_luminosityBlock = id.value();
       m_orbits = nOrbits;
@@ -119,119 +87,66 @@ private:
   class CommonRunBranches {
   public:
     void branch(TTree& tree) { tree.Branch("run", &m_run, "run/i"); }
-    void fill(const edm::RunID& id) { m_run = id.run(); }
+    void fill(edm::RunID const& id) { m_run = id.run(); }
 
   private:
     UInt_t m_run;
   } m_commonRunBranches;
 
+  bool const m_skipEmptyBXs;
+
   std::vector<OrbitTableOutputBranches> m_tables;
   std::vector<SelectedBxTableOutputBranches> m_selbxs;
   unsigned int m_nOrbits;
 
-  std::vector<std::pair<std::string, edm::EDGetToken>> m_nanoMetadata;
-
-  edm::EDGetTokenT<std::vector<unsigned>> m_bxMaskToken;
-  std::vector<unsigned> allBXs_;
+  edm::EDGetTokenT<std::vector<unsigned int>> m_bxMaskToken;
+  std::vector<unsigned int> allBXs_;
 };
 
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
 OrbitNanoAODOutputModule::OrbitNanoAODOutputModule(edm::ParameterSet const& pset)
     : edm::one::OutputModuleBase::OutputModuleBase(pset),
-      edm::one::OutputModule<>(pset),
-      m_fileName(pset.getUntrackedParameter<std::string>("fileName")),
-      m_logicalFileName(pset.getUntrackedParameter<std::string>("logicalFileName")),
-      m_compressionLevel(pset.getUntrackedParameter<int>("compressionLevel")),
-      m_compressionAlgorithm(pset.getUntrackedParameter<std::string>("compressionAlgorithm")),
+      NanoAODOutputModuleBase(pset),
       m_skipEmptyBXs(pset.getParameter<bool>("skipEmptyBXs")),
-      m_writeProvenance(pset.getUntrackedParameter<bool>("saveProvenance", true)),
-      m_fakeName(pset.getUntrackedParameter<bool>("fakeNameForCrab", false)),
-      m_autoFlush(pset.getUntrackedParameter<int>("autoFlush", -10000000)),
-      m_processHistoryRegistry(),
       m_nOrbits(0) {
-  edm::InputTag bxMask = pset.getParameter<edm::InputTag>("selectedBx");
+  auto const& bxMask = pset.getParameter<edm::InputTag>("selectedBx");
   if (!bxMask.label().empty()) {
-    m_bxMaskToken = consumes<std::vector<unsigned>>(bxMask);
+    m_bxMaskToken = consumes(bxMask);
   } else {
     allBXs_.resize(l1ScoutingRun3::OrbitFlatTable::NBX);
-    for (unsigned int i = 0; i < l1ScoutingRun3::OrbitFlatTable::NBX; ++i) {
+    for (auto i = 0u; i < l1ScoutingRun3::OrbitFlatTable::NBX; ++i) {
       allBXs_[i] = i + 1;
     }
   }
 }
 
-OrbitNanoAODOutputModule::~OrbitNanoAODOutputModule() {}
+void OrbitNanoAODOutputModule::writeEventTree(edm::EventForOutput const& iEvent) {
+  ++m_nOrbits;
 
-void OrbitNanoAODOutputModule::write(edm::EventForOutput const& iEvent) {
-  //Get data from 'e' and write it to the file
-  edm::Service<edm::JobReport> jr;
-  jr->eventWrittenToFile(m_jrToken, iEvent.id().run(), iEvent.id().event());
-  m_nOrbits++;
+  m_commonEventBranches.fill(iEvent.eventAuxiliary());
 
-  if (m_autoFlush) {
-    int64_t events = m_tree->GetEntriesFast();
-    if (events == m_firstFlush) {
-      m_tree->FlushBaskets();
-      float maxMemory;
-      if (m_autoFlush > 0) {
-        // Estimate the memory we'll be using at the first full flush by
-        // linearly scaling the number of events.
-        float percentClusterDone = m_firstFlush / static_cast<float>(m_autoFlush);
-        maxMemory = static_cast<float>(m_tree->GetTotBytes()) / percentClusterDone;
-      } else if (m_tree->GetZipBytes() == 0) {
-        maxMemory = 100 * 1024 * 1024;  // Degenerate case of no information in the tree; arbitrary value
-      } else {
-        // Estimate the memory we'll be using by scaling the current compression ratio.
-        float cxnRatio = m_tree->GetTotBytes() / static_cast<float>(m_tree->GetZipBytes());
-        maxMemory = -m_autoFlush * cxnRatio;
-        float percentBytesDone = -m_tree->GetZipBytes() / static_cast<float>(m_autoFlush);
-        m_autoFlush = m_firstFlush / percentBytesDone;
-      }
-      //std::cout << "OptimizeBaskets: total bytes " << m_tree->GetTotBytes() << std::endl;
-      //std::cout << "OptimizeBaskets: zip bytes " << m_tree->GetZipBytes() << std::endl;
-      //std::cout << "OptimizeBaskets: autoFlush " << m_autoFlush << std::endl;
-      //std::cout << "OptimizeBaskets: maxMemory " << static_cast<uint32_t>(maxMemory) << std::endl;
-      //m_tree->OptimizeBaskets(static_cast<uint32_t>(maxMemory), 1, "d");
-      m_tree->OptimizeBaskets(static_cast<uint32_t>(maxMemory), 1, "");
-    }
-    if (m_eventsSinceFlush == m_autoFlush) {
-      m_tree->FlushBaskets();
-      m_eventsSinceFlush = 0;
-    }
-    m_eventsSinceFlush++;
-  }
-
-  m_commonBranches.fill(iEvent.eventAuxiliary());
   // fill all tables, starting from main tables and then doing extension tables
-  for (unsigned int extensions = 0; extensions <= 1; ++extensions) {
+  for (auto extensions = 0u; extensions <= 1; ++extensions) {
     for (auto& t : m_tables) {
-      t.beginFill(iEvent, *m_tree, extensions);
+      t.beginFill(iEvent, *m_eventTree, extensions);
     }
   }
+
   // get m_table, read parameters, book branches, etc.
   for (auto& t : m_selbxs) {
-    t.beginFill(iEvent, *m_tree);
+    t.beginFill(iEvent, *m_eventTree);
   }
-  // get a lust of selected BXs to be filled
-  const std::vector<unsigned>* selbx = &allBXs_;
-  if (!m_bxMaskToken.isUninitialized()) {
+
+  // get vector of selected BXs to be filled
+  auto const* selbx = &allBXs_;
+  if (not m_bxMaskToken.isUninitialized()) {
     edm::Handle<std::vector<unsigned>> handle;
     iEvent.getByToken(m_bxMaskToken, handle);
     selbx = &*handle;
   }
+
   // convert from orbit as event to collision as event
   tbb::this_task_arena::isolate([&] {
-    for (unsigned bx : *selbx) {
+    for (auto const bx : *selbx) {
       if (m_skipEmptyBXs) {
         bool empty = true;
         for (auto& t : m_tables) {
@@ -245,84 +160,43 @@ void OrbitNanoAODOutputModule::write(edm::EventForOutput const& iEvent) {
         }
       }
 
-      m_commonBranches.setBx(bx);
+      m_commonEventBranches.setBx(bx);
       for (auto& t : m_tables) {
         t.fillBx(bx);
       }
       for (auto& t : m_selbxs) {
         t.fillBx(bx);
       }
-      m_tree->Fill();
+      m_eventTree->Fill();
     }  // bx loop
   });
 
-  // set m_table to nullptr
+  // set entries of m_tables and m_selbxs to nullptr
   for (auto& t : m_tables) {
     t.endFill();
   }
   for (auto& t : m_selbxs) {
     t.endFill();
   }
-  m_processHistoryRegistry.registerProcessHistory(iEvent.processHistory());
 }
 
-void OrbitNanoAODOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput const& iLumi) {
-  edm::Service<edm::JobReport> jr;
-  jr->reportLumiSection(m_jrToken, iLumi.id().run(), iLumi.id().value());
-
+void OrbitNanoAODOutputModule::writeLuminosityBlockTree(edm::LuminosityBlockForOutput const& iLumi) {
   m_commonLumiBranches.fill(iLumi.id(), m_nOrbits);
+  m_nOrbits = 0;
 
   tbb::this_task_arena::isolate([&] { m_lumiTree->Fill(); });
-
-  m_processHistoryRegistry.registerProcessHistory(iLumi.processHistory());
-
-  m_nOrbits = 0;
 }
 
-void OrbitNanoAODOutputModule::writeRun(edm::RunForOutput const& iRun) {
-  edm::Service<edm::JobReport> jr;
-  jr->reportRunNumber(m_jrToken, iRun.id().run());
-
+void OrbitNanoAODOutputModule::writeRunTree(edm::RunForOutput const& iRun) {
   m_commonRunBranches.fill(iRun.id());
 
   tbb::this_task_arena::isolate([&] { m_runTree->Fill(); });
-
-  m_processHistoryRegistry.registerProcessHistory(iRun.processHistory());
 }
 
-bool OrbitNanoAODOutputModule::isFileOpen() const { return nullptr != m_file.get(); }
-
-void OrbitNanoAODOutputModule::openFile(edm::FileBlock const&) {
-  m_file = std::make_unique<TFile>(m_fileName.c_str(), "RECREATE", "", m_compressionLevel);
-  edm::Service<edm::JobReport> jr;
-  cms::Digest branchHash;
-  m_jrToken = jr->outputFileOpened(m_fileName,
-                                   m_logicalFileName,
-                                   std::string(),
-                                   m_fakeName ? "PoolOutputModule" : "OrbitNanoAODOutputModule",
-                                   description().moduleLabel(),
-                                   edm::createGlobalIdentifier(),
-                                   std::string(),
-                                   branchHash.digest().toString(),
-                                   std::vector<std::string>());
-
-  if (m_compressionAlgorithm == std::string("ZLIB")) {
-    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZLIB);
-  } else if (m_compressionAlgorithm == std::string("LZMA")) {
-    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZMA);
-  } else if (m_compressionAlgorithm == std::string("ZSTD")) {
-    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZSTD);
-  } else if (m_compressionAlgorithm == std::string("LZ4")) {
-    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZ4);
-  } else {
-    throw cms::Exception("Configuration")
-        << "OrbitNanoAODOutputModule configured with unknown compression algorithm '" << m_compressionAlgorithm << "'\n"
-        << "Allowed compression algorithms are ZLIB, LZMA, ZSTD, and LZ4\n";
-  }
-  /* Setup file structure here */
+void OrbitNanoAODOutputModule::initTables() {
   m_tables.clear();
-  const auto& keeps = keptProducts();
-  for (const auto& keep : keeps[edm::InEvent]) {
+  auto const& keeps = keptProducts();
+  for (auto const& keep : keeps[edm::InEvent]) {
     if (keep.first->className() == "l1ScoutingRun3::OrbitFlatTable")
       m_tables.emplace_back(keep.first, keep.second);
     else if (keep.first->className() == "std::vector<unsigned int>")
@@ -330,87 +204,20 @@ void OrbitNanoAODOutputModule::openFile(edm::FileBlock const&) {
     else
       throw cms::Exception("Configuration", "OrbitNanoAODOutputModule cannot handle class " + keep.first->className());
   }
-
-  // create the trees
-  m_tree = std::make_unique<TTree>("Events", "Events");
-  m_tree->SetAutoSave(0);
-  m_tree->SetAutoFlush(0);
-  m_commonBranches.branch(*m_tree);
-
-  m_lumiTree = std::make_unique<TTree>("LuminosityBlocks", "LuminosityBlocks");
-  m_lumiTree->SetAutoSave(0);
-  m_commonLumiBranches.branch(*m_lumiTree);
-
-  m_runTree = std::make_unique<TTree>("Runs", "Runs");
-  m_runTree->SetAutoSave(0);
-  m_commonRunBranches.branch(*m_runTree);
-
-  if (m_writeProvenance) {
-    m_metaDataTree = std::make_unique<TTree>(edm::poolNames::metaDataTreeName().c_str(), "Job metadata");
-    m_metaDataTree->SetAutoSave(0);
-    m_parameterSetsTree = std::make_unique<TTree>(edm::poolNames::parameterSetsTreeName().c_str(), "Parameter sets");
-    m_parameterSetsTree->SetAutoSave(0);
-  }
-}
-void OrbitNanoAODOutputModule::reallyCloseFile() {
-  if (m_writeProvenance) {
-    int basketSize = 16384;  // fixme configurable?
-    edm::fillParameterSetBranch(m_parameterSetsTree.get(), basketSize);
-    edm::fillProcessHistoryBranch(m_metaDataTree.get(), basketSize, m_processHistoryRegistry);
-    if (m_metaDataTree->GetNbranches() != 0) {
-      m_metaDataTree->SetEntries(-1);
-    }
-    if (m_parameterSetsTree->GetNbranches() != 0) {
-      m_parameterSetsTree->SetEntries(-1);
-    }
-  }
-  m_file->Write();
-  m_file->Close();
-  m_file.reset();
-  m_tree.release();               // apparently root has ownership
-  m_lumiTree.release();           //
-  m_runTree.release();            //
-  m_metaDataTree.release();       //
-  m_parameterSetsTree.release();  //
-  edm::Service<edm::JobReport> jr;
-  jr->outputFileClosed(m_jrToken);
 }
 
 void OrbitNanoAODOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
 
-  desc.addUntracked<std::string>("fileName");
-  desc.addUntracked<std::string>("logicalFileName", "");
+  NanoAODOutputModuleBase::fillDescription(desc);
 
-  desc.addUntracked<int>("compressionLevel", 9)->setComment("ROOT compression level of output file.");
-  desc.addUntracked<std::string>("compressionAlgorithm", "ZLIB")
-      ->setComment("Algorithm used to compress data in the ROOT output file, allowed values are ZLIB and LZMA");
+  edm::one::OutputModule<>::fillDescription(desc, {"drop *", "keep l1ScoutingRun3OrbitFlatTable_*Table_*_*"});
+
   desc.add<bool>("skipEmptyBXs", false)->setComment("Skip BXs where all input collections are empty");
-  desc.addUntracked<bool>("saveProvenance", true)
-      ->setComment("Save process provenance information, e.g. for edmProvDump");
-  desc.addUntracked<bool>("fakeNameForCrab", false)
-      ->setComment(
-          "Change the OutputModule name in the fwk job report to fake PoolOutputModule. This is needed to run on "
-          "crab "
-          "(and publish) till crab is fixed");
-  desc.addUntracked<int>("autoFlush", -10000000)->setComment("Autoflush parameter for ROOT file");
-
-  //replace with whatever you want to get from the EDM by default
-  const std::vector<std::string> keep = {"drop *", "keep l1ScoutingRun3OrbitFlatTable_*Table_*_*"};
-  edm::one::OutputModule<>::fillDescription(desc, keep);
-
-  //Used by Workflow management for their own meta data
-  edm::ParameterSetDescription dataSet;
-  dataSet.setAllowAnything();
-  desc.addUntracked<edm::ParameterSetDescription>("dataset", dataSet)
-      ->setComment("PSet is only used by Data Operations and not by this module.");
-
-  edm::ParameterSetDescription branchSet;
-  branchSet.setAllowAnything();
-  desc.add<edm::ParameterSetDescription>("branches", branchSet);
-
   desc.add<edm::InputTag>("selectedBx", edm::InputTag())->setComment("selected Bx (1-3564)");
+
   descriptions.addDefault(desc);
 }
 
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(OrbitNanoAODOutputModule);

--- a/L1TriggerScouting/NanoAOD/plugins/OrbitTableOutputBranches.h
+++ b/L1TriggerScouting/NanoAOD/plugins/OrbitTableOutputBranches.h
@@ -9,6 +9,7 @@
 #include "DataFormats/Provenance/interface/ProductDescription.h"
 #include "FWCore/Framework/interface/OccurrenceForOutput.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 class OrbitTableOutputBranches {
 public:

--- a/PhysicsTools/NanoAOD/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/BuildFile.xml
@@ -1,15 +1,16 @@
-<use name="DataFormats/Common"/>
-<use name="DataFormats/NanoAOD"/>
-<use name="Utilities/General"/>
-<use name="boost"/>
-<use name="FWCore/Utilities"/>
-<use name="FWCore/Common"/>
-<use name="DataFormats/StdDictionaries"/>
-<use name="DataFormats/Candidate"/>
-<use name="DataFormats/PatCandidates"/>
 <use name="CommonTools/Utils"/>
-<use name="CommonTools/UtilAlgos"/>
-<use name="CommonTools/CandAlgos"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/L1Trigger"/>
+<use name="DataFormats/NanoAOD"/>
+<use name="DataFormats/Provenance"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/ServiceRegistry"/>
+<use name="FWCore/Utilities"/>
+<use name="IOPool/Provenance"/>
+<use name="SimDataFormats/Associations"/>
+<use name="Utilities/General"/>
 <export>
   <lib name="1"/>
 </export>

--- a/PhysicsTools/NanoAOD/interface/DisTauTagScaling.h
+++ b/PhysicsTools/NanoAOD/interface/DisTauTagScaling.h
@@ -1,3 +1,10 @@
+#include <cmath>
+#include <limits>
+#include <map>
+#include <string>
+#include <tuple>
+#include <vector>
+
 namespace scaling {
   struct PfCand {
     inline static const std::vector<std::vector<float>> mean = {{0, 0},

--- a/PhysicsTools/NanoAOD/interface/NanoAODOutputModuleBase.h
+++ b/PhysicsTools/NanoAOD/interface/NanoAODOutputModuleBase.h
@@ -1,0 +1,96 @@
+// -*- C++ -*-
+//
+// Package:     PhysicsTools/NanoAODOutput
+// Class  :     NanoAODOutputModuleBase
+//
+// Implementation:
+//     Base class for OutputModules that create
+//     flat NanoAOD ntuples based on ROOT's TTree
+//
+// Original Author:  Christopher Jones
+//         Created:  Mon, 07 Aug 2017 14:21:41 GMT
+//
+#ifndef PhysicsTools_NanoAOD_NanoAODOutputModuleBase_h
+#define PhysicsTools_NanoAOD_NanoAODOutputModuleBase_h
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "FWCore/Framework/interface/one/OutputModule.h"
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
+#include "FWCore/Framework/interface/RunForOutput.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/MessageLogger/interface/JobReport.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
+
+class NanoAODOutputModuleBase : public edm::one::OutputModule<> {
+public:
+  explicit NanoAODOutputModuleBase(edm::ParameterSet const& pset);
+  ~NanoAODOutputModuleBase() override = default;
+
+  static void fillDescription(edm::ParameterSetDescription& desc);
+
+private:
+  void write(edm::EventForOutput const& iEvent) override;
+  void writeLuminosityBlock(edm::LuminosityBlockForOutput const& iLumi) override;
+  void writeRun(edm::RunForOutput const& iRun) override;
+
+  bool isFileOpen() const override;
+  void openFile(edm::FileBlock const& iFile) override;
+  void reallyCloseFile() override;
+
+  // The three functions below are called inside
+  // write(iEvent), writeLuminosityBlock(iLumi) and writeRun(iRun), respectively.
+  // They must include all the calls needed to fill
+  // the corresponding TTree for a given Event/Lumi/Run.
+  // The write(iEvent), writeLuminosityBlock(iLumi) and writeRun(iRun) functions
+  // handle the information for the framework's JobReport and ProcessHistoryRegistry,
+  // as well as auto-flushing for the Event's TTree (if enabled),
+  // and the three functions below do the rest.
+  virtual void writeEventTree(edm::EventForOutput const& iEvent) = 0;
+  virtual void writeLuminosityBlockTree(edm::LuminosityBlockForOutput const& iLumi) = 0;
+  virtual void writeRunTree(edm::RunForOutput const& iRun) = 0;
+
+  // initTables: called in openFile(iFile), and used to
+  // fill the vectors of table output branches.
+  virtual void initTables() = 0;
+
+  // The three functions below are called inside openFile(iFile)
+  // after the Event, Lumi, and Run TTrees have been created.
+  // The argument of each function corresponds to the relevant TTree
+  // (*m_eventTree for initEventTree, *m_lumiTree for initLuminosityBlockTree,
+  // and *m_runTree for initRunTree).
+  // These functions contain the calls needed to link branches to the relevant TTree.
+  virtual void initEventTree(TTree& tree) = 0;
+  virtual void initLuminosityBlockTree(TTree& tree) = 0;
+  virtual void initRunTree(TTree& tree) = 0;
+
+  std::string m_fileName;
+  std::string m_logicalFileName;
+  int m_compressionLevel;
+  int m_eventsSinceFlush{0};
+  std::string m_compressionAlgorithm;
+  bool m_writeProvenance;
+  bool m_fakeName;  //crab workaround, remove after crab is fixed
+  int m_autoFlush;
+  edm::ProcessHistoryRegistry m_processHistoryRegistry;
+  edm::JobReport::Token m_jrToken;
+  std::unique_ptr<TTree> m_metaDataTree;
+  std::unique_ptr<TTree> m_parameterSetsTree;
+
+  static constexpr int kFirstFlush{1000};
+  static constexpr const char* kFakeOutputModuleType{"PoolOutputModule"};
+
+protected:
+  std::unique_ptr<TFile> m_file;
+  std::unique_ptr<TTree> m_eventTree;
+  std::unique_ptr<TTree> m_lumiTree;
+  std::unique_ptr<TTree> m_runTree;
+};
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -31,6 +31,7 @@
 <use name="Geometry/CSCGeometry"/>
 <use name="IOPool/Provenance"/>
 <use name="MagneticField/Records"/>
+<use name="PhysicsTools/NanoAOD"/>
 <use name="PhysicsTools/PatAlgos"/>
 <use name="PhysicsTools/RecoUtils"/>
 <use name="RecoVertex/KalmanVertexFit"/>

--- a/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
@@ -9,74 +9,46 @@
 // Original Author:  Christopher Jones
 //         Created:  Mon, 07 Aug 2017 14:21:41 GMT
 //
-
-// system include files
 #include <algorithm>
 #include <memory>
-
-#include "Compression.h"
-#include "TFile.h"
-#include "TObjString.h"
-#include "TROOT.h"
-#include "TTree.h"
 #include <string>
+#include <utility>
+#include <vector>
 
-// user include files
-#include "FWCore/Framework/interface/one/OutputModule.h"
-#include "FWCore/Framework/interface/RunForOutput.h"
-#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
-#include "FWCore/Framework/interface/EventForOutput.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/JobReport.h"
-#include "FWCore/Utilities/interface/GlobalIdentifier.h"
-#include "FWCore/Utilities/interface/Digest.h"
-#include "IOPool/Provenance/interface/CommonProvenanceFiller.h"
-#include "DataFormats/Provenance/interface/BranchType.h"
-#include "DataFormats/Provenance/interface/ProductDescription.h"
-#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
-#include "DataFormats/NanoAOD/interface/FlatTable.h"
-#include "DataFormats/NanoAOD/interface/UniqueString.h"
-#include "PhysicsTools/NanoAOD/plugins/TableOutputBranches.h"
-#include "PhysicsTools/NanoAOD/plugins/LumiOutputBranches.h"
-#include "PhysicsTools/NanoAOD/plugins/TriggerOutputBranches.h"
-#include "PhysicsTools/NanoAOD/plugins/EventStringOutputBranches.h"
-#include "PhysicsTools/NanoAOD/plugins/SummaryTableOutputBranches.h"
-
-#include <iostream>
+#include "TObjString.h"
 
 #include "oneapi/tbb/task_arena.h"
 
-class NanoAODOutputModule : public edm::one::OutputModule<> {
+#include "DataFormats/NanoAOD/interface/UniqueString.h"
+#include "DataFormats/Provenance/interface/EventAuxiliary.h"
+#include "DataFormats/Provenance/interface/LuminosityBlockID.h"
+#include "DataFormats/Provenance/interface/RunID.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "PhysicsTools/NanoAOD/interface/NanoAODOutputModuleBase.h"
+
+#include "EventStringOutputBranches.h"
+#include "LumiOutputBranches.h"
+#include "TableOutputBranches.h"
+#include "TriggerOutputBranches.h"
+#include "SummaryTableOutputBranches.h"
+
+class NanoAODOutputModule : public NanoAODOutputModuleBase {
 public:
-  NanoAODOutputModule(edm::ParameterSet const& pset);
-  ~NanoAODOutputModule() override;
+  explicit NanoAODOutputModule(edm::ParameterSet const& pset);
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void write(edm::EventForOutput const& e) override;
-  void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
-  void writeRun(edm::RunForOutput const&) override;
-  bool isFileOpen() const override;
-  void openFile(edm::FileBlock const&) override;
-  void reallyCloseFile() override;
+  void writeEventTree(edm::EventForOutput const& iEvent) override;
+  void writeLuminosityBlockTree(edm::LuminosityBlockForOutput const& iLumi) override;
+  void writeRunTree(edm::RunForOutput const& iRun) override;
 
-  std::string m_fileName;
-  std::string m_logicalFileName;
-  int m_compressionLevel;
-  int m_eventsSinceFlush{0};
-  std::string m_compressionAlgorithm;
-  bool m_writeProvenance;
-  bool m_fakeName;  //crab workaround, remove after crab is fixed
-  int m_autoFlush;
-  edm::ProcessHistoryRegistry m_processHistoryRegistry;
-  edm::JobReport::Token m_jrToken;
-  std::unique_ptr<TFile> m_file;
-  std::unique_ptr<TTree> m_tree, m_lumiTree, m_runTree, m_metaDataTree, m_parameterSetsTree;
-
-  static constexpr int m_firstFlush{1000};
+  void initTables() override;
+  void initEventTree(TTree& tree) override { m_commonEventBranches.branch(tree); }
+  void initLuminosityBlockTree(TTree& tree) override { m_commonLumiBranches.branch(tree); }
+  void initRunTree(TTree& tree) override { m_commonRunBranches.branch(tree); }
 
   class CommonEventBranches {
   public:
@@ -87,7 +59,7 @@ private:
       tree.Branch("bunchCrossing", &m_bunchCrossing, "bunchCrossing/i");
       tree.Branch("orbitNumber", &m_orbitNumber, "orbitNumber/i");
     }
-    void fill(const edm::EventAuxiliary& aux) {
+    void fill(edm::EventAuxiliary const& aux) {
       m_run = aux.id().run();
       m_luminosityBlock = aux.id().luminosityBlock();
       m_event = aux.id().event();
@@ -101,7 +73,7 @@ private:
     ULong64_t m_event;
     UInt_t m_bunchCrossing;
     UInt_t m_orbitNumber;
-  } m_commonBranches;
+  } m_commonEventBranches;
 
   class CommonLumiBranches {
   public:
@@ -109,7 +81,7 @@ private:
       tree.Branch("run", &m_run, "run/i");
       tree.Branch("luminosityBlock", &m_luminosityBlock, "luminosityBlock/i");
     }
-    void fill(const edm::LuminosityBlockID& id) {
+    void fill(edm::LuminosityBlockID const& id) {
       m_run = id.run();
       m_luminosityBlock = id.value();
     }
@@ -122,7 +94,7 @@ private:
   class CommonRunBranches {
   public:
     void branch(TTree& tree) { tree.Branch("run", &m_run, "run/i"); }
-    void fill(const edm::RunID& id) { m_run = id.run(); }
+    void fill(edm::RunID const& id) { m_run = id.run(); }
 
   private:
     UInt_t m_run;
@@ -141,78 +113,19 @@ private:
   std::vector<std::pair<std::string, edm::EDGetToken>> m_nanoMetadata;
 };
 
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
 NanoAODOutputModule::NanoAODOutputModule(edm::ParameterSet const& pset)
-    : edm::one::OutputModuleBase::OutputModuleBase(pset),
-      edm::one::OutputModule<>(pset),
-      m_fileName(pset.getUntrackedParameter<std::string>("fileName")),
-      m_logicalFileName(pset.getUntrackedParameter<std::string>("logicalFileName")),
-      m_compressionLevel(pset.getUntrackedParameter<int>("compressionLevel")),
-      m_compressionAlgorithm(pset.getUntrackedParameter<std::string>("compressionAlgorithm")),
-      m_writeProvenance(pset.getUntrackedParameter<bool>("saveProvenance", true)),
-      m_fakeName(pset.getUntrackedParameter<bool>("fakeNameForCrab", false)),
-      m_autoFlush(pset.getUntrackedParameter<int>("autoFlush", -10000000)),
-      m_processHistoryRegistry() {}
+    : edm::one::OutputModuleBase::OutputModuleBase(pset), NanoAODOutputModuleBase(pset) {}
 
-NanoAODOutputModule::~NanoAODOutputModule() {}
-
-void NanoAODOutputModule::write(edm::EventForOutput const& iEvent) {
-  //Get data from 'e' and write it to the file
-  edm::Service<edm::JobReport> jr;
-  jr->eventWrittenToFile(m_jrToken, iEvent.id().run(), iEvent.id().event());
-
-  if (m_autoFlush) {
-    int64_t events = m_tree->GetEntriesFast();
-    if (events == m_firstFlush) {
-      m_tree->FlushBaskets();
-      float maxMemory;
-      if (m_autoFlush > 0) {
-        // Estimate the memory we'll be using at the first full flush by
-        // linearly scaling the number of events.
-        float percentClusterDone = m_firstFlush / static_cast<float>(m_autoFlush);
-        maxMemory = static_cast<float>(m_tree->GetTotBytes()) / percentClusterDone;
-      } else if (m_tree->GetZipBytes() == 0) {
-        maxMemory = 100 * 1024 * 1024;  // Degenerate case of no information in the tree; arbitrary value
-      } else {
-        // Estimate the memory we'll be using by scaling the current compression ratio.
-        float cxnRatio = m_tree->GetTotBytes() / static_cast<float>(m_tree->GetZipBytes());
-        maxMemory = -m_autoFlush * cxnRatio;
-        float percentBytesDone = -m_tree->GetZipBytes() / static_cast<float>(m_autoFlush);
-        m_autoFlush = m_firstFlush / percentBytesDone;
-      }
-      //std::cout << "OptimizeBaskets: total bytes " << m_tree->GetTotBytes() << std::endl;
-      //std::cout << "OptimizeBaskets: zip bytes " << m_tree->GetZipBytes() << std::endl;
-      //std::cout << "OptimizeBaskets: autoFlush " << m_autoFlush << std::endl;
-      //std::cout << "OptimizeBaskets: maxMemory " << static_cast<uint32_t>(maxMemory) << std::endl;
-      //m_tree->OptimizeBaskets(static_cast<uint32_t>(maxMemory), 1, "d");
-      m_tree->OptimizeBaskets(static_cast<uint32_t>(maxMemory), 1, "");
-    }
-    if (m_eventsSinceFlush == m_autoFlush) {
-      m_tree->FlushBaskets();
-      m_eventsSinceFlush = 0;
-    }
-    m_eventsSinceFlush++;
-  }
-
-  m_commonBranches.fill(iEvent.eventAuxiliary());
+void NanoAODOutputModule::writeEventTree(edm::EventForOutput const& iEvent) {
+  m_commonEventBranches.fill(iEvent.eventAuxiliary());
   // fill all tables, starting from main tables and then doing extension tables
   for (unsigned int extensions = 0; extensions <= 1; ++extensions) {
     for (auto& t : m_tables)
-      t.fill(iEvent, *m_tree, extensions);
+      t.fill(iEvent, *m_eventTree, extensions);
   }
   if (!m_triggers_areSorted) {  // sort triggers/flags in inverse processHistory order, to save without any special label the most recent ones
     std::vector<std::string> pnames;
-    for (auto& p : iEvent.processHistory())
+    for (auto const& p : iEvent.processHistory())
       pnames.push_back(p.processName());
     std::sort(m_triggers.begin(), m_triggers.end(), [pnames](TriggerOutputBranches& a, TriggerOutputBranches& b) {
       return ((std::find(pnames.begin(), pnames.end(), a.processName()) - pnames.begin()) >
@@ -222,50 +135,45 @@ void NanoAODOutputModule::write(edm::EventForOutput const& iEvent) {
   }
   // fill triggers
   for (auto& t : m_triggers)
-    t.fill(iEvent, *m_tree);
+    t.fill(iEvent, *m_eventTree);
   // fill event branches
   for (auto& t : m_evstrings)
-    t.fill(iEvent, *m_tree);
-  tbb::this_task_arena::isolate([&] { m_tree->Fill(); });
+    t.fill(iEvent, *m_eventTree);
 
-  m_processHistoryRegistry.registerProcessHistory(iEvent.processHistory());
+  tbb::this_task_arena::isolate([&] { m_eventTree->Fill(); });
 }
 
-void NanoAODOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput const& iLumi) {
-  edm::Service<edm::JobReport> jr;
-  jr->reportLumiSection(m_jrToken, iLumi.id().run(), iLumi.id().value());
-
+void NanoAODOutputModule::writeLuminosityBlockTree(edm::LuminosityBlockForOutput const& iLumi) {
   m_commonLumiBranches.fill(iLumi.id());
 
-  for (auto& t : m_lumiTables)
+  for (auto& t : m_lumiTables) {
     t.fill(iLumi, *m_lumiTree);
+  }
 
   for (unsigned int extensions = 0; extensions <= 1; ++extensions) {
-    for (auto& t : m_lumiTables2)
+    for (auto& t : m_lumiTables2) {
       t.fill(iLumi, *m_lumiTree, extensions);
+    }
   }
 
   tbb::this_task_arena::isolate([&] { m_lumiTree->Fill(); });
-
-  m_processHistoryRegistry.registerProcessHistory(iLumi.processHistory());
 }
 
-void NanoAODOutputModule::writeRun(edm::RunForOutput const& iRun) {
-  edm::Service<edm::JobReport> jr;
-  jr->reportRunNumber(m_jrToken, iRun.id().run());
-
+void NanoAODOutputModule::writeRunTree(edm::RunForOutput const& iRun) {
   m_commonRunBranches.fill(iRun.id());
 
-  for (auto& t : m_runTables)
+  for (auto& t : m_runTables) {
     t.fill(iRun, *m_runTree);
+  }
 
   for (unsigned int extensions = 0; extensions <= 1; ++extensions) {
-    for (auto& t : m_runFlatTables)
+    for (auto& t : m_runFlatTables) {
       t.fill(iRun, *m_runTree, extensions);
+    }
   }
 
   edm::Handle<nanoaod::UniqueString> hstring;
-  for (const auto& p : m_nanoMetadata) {
+  for (auto const& p : m_nanoMetadata) {
     iRun.getByToken(p.second, hstring);
     TObjString* tos = dynamic_cast<TObjString*>(m_file->Get(p.first.c_str()));
     if (tos) {
@@ -278,40 +186,9 @@ void NanoAODOutputModule::writeRun(edm::RunForOutput const& iRun) {
   }
 
   tbb::this_task_arena::isolate([&] { m_runTree->Fill(); });
-
-  m_processHistoryRegistry.registerProcessHistory(iRun.processHistory());
 }
 
-bool NanoAODOutputModule::isFileOpen() const { return nullptr != m_file.get(); }
-
-void NanoAODOutputModule::openFile(edm::FileBlock const&) {
-  m_file = std::make_unique<TFile>(m_fileName.c_str(), "RECREATE", "", m_compressionLevel);
-  edm::Service<edm::JobReport> jr;
-  cms::Digest branchHash;
-  m_jrToken = jr->outputFileOpened(m_fileName,
-                                   m_logicalFileName,
-                                   std::string(),
-                                   m_fakeName ? "PoolOutputModule" : "NanoAODOutputModule",
-                                   description().moduleLabel(),
-                                   edm::createGlobalIdentifier(),
-                                   std::string(),
-                                   branchHash.digest().toString(),
-                                   std::vector<std::string>());
-
-  if (m_compressionAlgorithm == std::string("ZLIB")) {
-    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZLIB);
-  } else if (m_compressionAlgorithm == std::string("LZMA")) {
-    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZMA);
-  } else if (m_compressionAlgorithm == std::string("ZSTD")) {
-    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZSTD);
-  } else if (m_compressionAlgorithm == std::string("LZ4")) {
-    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZ4);
-  } else {
-    throw cms::Exception("Configuration")
-        << "NanoAODOutputModule configured with unknown compression algorithm '" << m_compressionAlgorithm << "'\n"
-        << "Allowed compression algorithms are ZLIB, LZMA, ZSTD, and LZ4\n";
-  }
-  /* Setup file structure here */
+void NanoAODOutputModule::initTables() {
   m_tables.clear();
   m_triggers.clear();
   m_triggers_areSorted = false;
@@ -320,8 +197,8 @@ void NanoAODOutputModule::openFile(edm::FileBlock const&) {
   m_lumiTables.clear();
   m_lumiTables2.clear();
   m_runFlatTables.clear();
-  const auto& keeps = keptProducts();
-  for (const auto& keep : keeps[edm::InEvent]) {
+  auto const& keeps = keptProducts();
+  for (auto const& keep : keeps[edm::InEvent]) {
     if (keep.first->className() == "nanoaod::FlatTable")
       m_tables.emplace_back(keep.first, keep.second);
     else if (keep.first->className() == "edm::TriggerResults") {
@@ -333,7 +210,7 @@ void NanoAODOutputModule::openFile(edm::FileBlock const&) {
       throw cms::Exception("Configuration", "NanoAODOutputModule cannot handle class " + keep.first->className());
   }
 
-  for (const auto& keep : keeps[edm::InLumi]) {
+  for (auto const& keep : keeps[edm::InLumi]) {
     if (keep.first->className() == "nanoaod::MergeableCounterTable")
       m_lumiTables.push_back(SummaryTableOutputBranches(keep.first, keep.second));
     else if (keep.first->className() == "nanoaod::UniqueString" && keep.first->moduleLabel() == "nanoMetadata")
@@ -346,7 +223,7 @@ void NanoAODOutputModule::openFile(edm::FileBlock const&) {
           "NanoAODOutputModule cannot handle class " + keep.first->className() + " in LuminosityBlock branch");
   }
 
-  for (const auto& keep : keeps[edm::InRun]) {
+  for (auto const& keep : keeps[edm::InRun]) {
     if (keep.first->className() == "nanoaod::MergeableCounterTable")
       m_runTables.push_back(SummaryTableOutputBranches(keep.first, keep.second));
     else if (keep.first->className() == "nanoaod::UniqueString" && keep.first->moduleLabel() == "nanoMetadata")
@@ -357,89 +234,23 @@ void NanoAODOutputModule::openFile(edm::FileBlock const&) {
       throw cms::Exception("Configuration",
                            "NanoAODOutputModule cannot handle class " + keep.first->className() + " in Run branch");
   }
-
-  // create the trees
-  m_tree = std::make_unique<TTree>("Events", "Events");
-  m_tree->SetAutoSave(0);
-  m_tree->SetAutoFlush(0);
-  m_commonBranches.branch(*m_tree);
-
-  m_lumiTree = std::make_unique<TTree>("LuminosityBlocks", "LuminosityBlocks");
-  m_lumiTree->SetAutoSave(0);
-  m_commonLumiBranches.branch(*m_lumiTree);
-
-  m_runTree = std::make_unique<TTree>("Runs", "Runs");
-  m_runTree->SetAutoSave(0);
-  m_commonRunBranches.branch(*m_runTree);
-
-  if (m_writeProvenance) {
-    m_metaDataTree = std::make_unique<TTree>(edm::poolNames::metaDataTreeName().c_str(), "Job metadata");
-    m_metaDataTree->SetAutoSave(0);
-    m_parameterSetsTree = std::make_unique<TTree>(edm::poolNames::parameterSetsTreeName().c_str(), "Parameter sets");
-    m_parameterSetsTree->SetAutoSave(0);
-  }
-}
-void NanoAODOutputModule::reallyCloseFile() {
-  if (m_writeProvenance) {
-    int basketSize = 16384;  // fixme configurable?
-    edm::fillParameterSetBranch(m_parameterSetsTree.get(), basketSize);
-    edm::fillProcessHistoryBranch(m_metaDataTree.get(), basketSize, m_processHistoryRegistry);
-    if (m_metaDataTree->GetNbranches() != 0) {
-      m_metaDataTree->SetEntries(-1);
-    }
-    if (m_parameterSetsTree->GetNbranches() != 0) {
-      m_parameterSetsTree->SetEntries(-1);
-    }
-  }
-  m_file->Write();
-  m_file->Close();
-  m_file.reset();
-  m_tree.release();               // apparently root has ownership
-  m_lumiTree.release();           //
-  m_runTree.release();            //
-  m_metaDataTree.release();       //
-  m_parameterSetsTree.release();  //
-  edm::Service<edm::JobReport> jr;
-  jr->outputFileClosed(m_jrToken);
 }
 
 void NanoAODOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
 
-  desc.addUntracked<std::string>("fileName");
-  desc.addUntracked<std::string>("logicalFileName", "");
+  NanoAODOutputModuleBase::fillDescription(desc);
 
-  desc.addUntracked<int>("compressionLevel", 9)->setComment("ROOT compression level of output file.");
-  desc.addUntracked<std::string>("compressionAlgorithm", "ZLIB")
-      ->setComment("Algorithm used to compress data in the ROOT output file, allowed values are ZLIB and LZMA");
-  desc.addUntracked<bool>("saveProvenance", true)
-      ->setComment("Save process provenance information, e.g. for edmProvDump");
-  desc.addUntracked<bool>("fakeNameForCrab", false)
-      ->setComment(
-          "Change the OutputModule name in the fwk job report to fake PoolOutputModule. This is needed to run on cran "
-          "(and publish) till crab is fixed");
-  desc.addUntracked<int>("autoFlush", -10000000)->setComment("Autoflush parameter for ROOT file");
-
-  //replace with whatever you want to get from the EDM by default
-  const std::vector<std::string> keep = {"drop *",
-                                         "keep nanoaodFlatTable_*Table_*_*",
-                                         "keep edmTriggerResults_*_*_*",
-                                         "keep String_*_genModel_*",
-                                         "keep nanoaodMergeableCounterTable_*Table_*_*",
-                                         "keep nanoaodUniqueString_nanoMetadata_*_*"};
-  edm::one::OutputModule<>::fillDescription(desc, keep);
-
-  //Used by Workflow management for their own meta data
-  edm::ParameterSetDescription dataSet;
-  dataSet.setAllowAnything();
-  desc.addUntracked<edm::ParameterSetDescription>("dataset", dataSet)
-      ->setComment("PSet is only used by Data Operations and not by this module.");
-
-  edm::ParameterSetDescription branchSet;
-  branchSet.setAllowAnything();
-  desc.add<edm::ParameterSetDescription>("branches", branchSet);
+  edm::one::OutputModule<>::fillDescription(desc,
+                                            {"drop *",
+                                             "keep nanoaodFlatTable_*Table_*_*",
+                                             "keep edmTriggerResults_*_*_*",
+                                             "keep String_*_genModel_*",
+                                             "keep nanoaodMergeableCounterTable_*Table_*_*",
+                                             "keep nanoaodUniqueString_nanoMetadata_*_*"});
 
   descriptions.addDefault(desc);
 }
 
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(NanoAODOutputModule);

--- a/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
@@ -197,6 +197,8 @@ void NanoAODOutputModule::initTables() {
   m_lumiTables.clear();
   m_lumiTables2.clear();
   m_runFlatTables.clear();
+  m_nanoMetadata.clear();
+
   auto const& keeps = keptProducts();
   for (auto const& keep : keeps[edm::InEvent]) {
     if (keep.first->className() == "nanoaod::FlatTable")

--- a/PhysicsTools/NanoAOD/src/NanoAODOutputModuleBase.cc
+++ b/PhysicsTools/NanoAOD/src/NanoAODOutputModuleBase.cc
@@ -1,0 +1,180 @@
+#include "Compression.h"
+#include "TObjString.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Utilities/interface/Digest.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "IOPool/Provenance/interface/CommonProvenanceFiller.h"
+#include "PhysicsTools/NanoAOD/interface/NanoAODOutputModuleBase.h"
+
+NanoAODOutputModuleBase::NanoAODOutputModuleBase(edm::ParameterSet const& pset)
+    : edm::one::OutputModuleBase::OutputModuleBase(pset),
+      edm::one::OutputModule<>(pset),
+      m_fileName(pset.getUntrackedParameter<std::string>("fileName")),
+      m_logicalFileName(pset.getUntrackedParameter<std::string>("logicalFileName")),
+      m_compressionLevel(pset.getUntrackedParameter<int>("compressionLevel")),
+      m_compressionAlgorithm(pset.getUntrackedParameter<std::string>("compressionAlgorithm")),
+      m_writeProvenance(pset.getUntrackedParameter<bool>("saveProvenance", true)),
+      m_fakeName(pset.getUntrackedParameter<bool>("fakeNameForCrab", false)),
+      m_autoFlush(pset.getUntrackedParameter<int>("autoFlush", -10000000)),
+      m_processHistoryRegistry() {}
+
+void NanoAODOutputModuleBase::write(edm::EventForOutput const& iEvent) {
+  //Get data from 'e' and write it to the file
+  edm::Service<edm::JobReport> jr;
+  jr->eventWrittenToFile(m_jrToken, iEvent.id().run(), iEvent.id().event());
+
+  if (m_autoFlush) {
+    int64_t events = m_eventTree->GetEntriesFast();
+    if (events == kFirstFlush) {
+      m_eventTree->FlushBaskets();
+      float maxMemory;
+      if (m_autoFlush > 0) {
+        // Estimate the memory we'll be using at the first full flush by
+        // linearly scaling the number of events.
+        float percentClusterDone = kFirstFlush / static_cast<float>(m_autoFlush);
+        maxMemory = static_cast<float>(m_eventTree->GetTotBytes()) / percentClusterDone;
+      } else if (m_eventTree->GetZipBytes() == 0) {
+        maxMemory = 100 * 1024 * 1024;  // Degenerate case of no information in the tree; arbitrary value
+      } else {
+        // Estimate the memory we'll be using by scaling the current compression ratio.
+        float cxnRatio = m_eventTree->GetTotBytes() / static_cast<float>(m_eventTree->GetZipBytes());
+        maxMemory = -m_autoFlush * cxnRatio;
+        float percentBytesDone = -m_eventTree->GetZipBytes() / static_cast<float>(m_autoFlush);
+        m_autoFlush = kFirstFlush / percentBytesDone;
+      }
+      m_eventTree->OptimizeBaskets(static_cast<uint32_t>(maxMemory), 1, "");
+    }
+    if (m_eventsSinceFlush == m_autoFlush) {
+      m_eventTree->FlushBaskets();
+      m_eventsSinceFlush = 0;
+    }
+    m_eventsSinceFlush++;
+  }
+
+  m_processHistoryRegistry.registerProcessHistory(iEvent.processHistory());
+
+  writeEventTree(iEvent);
+}
+
+void NanoAODOutputModuleBase::writeLuminosityBlock(edm::LuminosityBlockForOutput const& iLumi) {
+  edm::Service<edm::JobReport> jr;
+  jr->reportLumiSection(m_jrToken, iLumi.id().run(), iLumi.id().value());
+
+  m_processHistoryRegistry.registerProcessHistory(iLumi.processHistory());
+
+  writeLuminosityBlockTree(iLumi);
+}
+
+void NanoAODOutputModuleBase::writeRun(edm::RunForOutput const& iRun) {
+  edm::Service<edm::JobReport> jr;
+  jr->reportRunNumber(m_jrToken, iRun.id().run());
+
+  m_processHistoryRegistry.registerProcessHistory(iRun.processHistory());
+
+  writeRunTree(iRun);
+}
+
+bool NanoAODOutputModuleBase::isFileOpen() const { return nullptr != m_file.get(); }
+
+void NanoAODOutputModuleBase::openFile(edm::FileBlock const&) {
+  m_file = std::make_unique<TFile>(m_fileName.c_str(), "RECREATE", "", m_compressionLevel);
+  edm::Service<edm::JobReport> jr;
+  cms::Digest branchHash;
+  m_jrToken = jr->outputFileOpened(m_fileName,
+                                   m_logicalFileName,
+                                   std::string(),
+                                   m_fakeName ? kFakeOutputModuleType : description().moduleName(),
+                                   description().moduleLabel(),
+                                   edm::createGlobalIdentifier(),
+                                   std::string(),
+                                   branchHash.digest().toString(),
+                                   std::vector<std::string>());
+
+  if (m_compressionAlgorithm == std::string("ZLIB")) {
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZLIB);
+  } else if (m_compressionAlgorithm == std::string("LZMA")) {
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZMA);
+  } else if (m_compressionAlgorithm == std::string("ZSTD")) {
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZSTD);
+  } else if (m_compressionAlgorithm == std::string("LZ4")) {
+    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZ4);
+  } else {
+    throw cms::Exception("Configuration")
+        << "NanoAOD OutputModule configured with unknown compression algorithm '" << m_compressionAlgorithm << "'\n"
+        << "Allowed compression algorithms are ZLIB, LZMA, ZSTD, and LZ4\n";
+  }
+
+  initTables();
+
+  // create the trees
+  m_eventTree = std::make_unique<TTree>("Events", "Events");
+  m_eventTree->SetAutoSave(0);
+  m_eventTree->SetAutoFlush(0);
+  initEventTree(*m_eventTree);
+
+  m_lumiTree = std::make_unique<TTree>("LuminosityBlocks", "LuminosityBlocks");
+  m_lumiTree->SetAutoSave(0);
+  initLuminosityBlockTree(*m_lumiTree);
+
+  m_runTree = std::make_unique<TTree>("Runs", "Runs");
+  m_runTree->SetAutoSave(0);
+  initRunTree(*m_runTree);
+
+  if (m_writeProvenance) {
+    m_metaDataTree = std::make_unique<TTree>(edm::poolNames::metaDataTreeName().c_str(), "Job metadata");
+    m_metaDataTree->SetAutoSave(0);
+    m_parameterSetsTree = std::make_unique<TTree>(edm::poolNames::parameterSetsTreeName().c_str(), "Parameter sets");
+    m_parameterSetsTree->SetAutoSave(0);
+  }
+}
+void NanoAODOutputModuleBase::reallyCloseFile() {
+  if (m_writeProvenance) {
+    int basketSize = 16384;  // fixme configurable?
+    edm::fillParameterSetBranch(m_parameterSetsTree.get(), basketSize);
+    edm::fillProcessHistoryBranch(m_metaDataTree.get(), basketSize, m_processHistoryRegistry);
+    if (m_metaDataTree->GetNbranches() != 0) {
+      m_metaDataTree->SetEntries(-1);
+    }
+    if (m_parameterSetsTree->GetNbranches() != 0) {
+      m_parameterSetsTree->SetEntries(-1);
+    }
+  }
+  m_file->Write();
+  m_file->Close();
+  m_file.reset();
+  m_eventTree.release();          // apparently ROOT has ownership
+  m_lumiTree.release();           //
+  m_runTree.release();            //
+  m_metaDataTree.release();       //
+  m_parameterSetsTree.release();  //
+  edm::Service<edm::JobReport> jr;
+  jr->outputFileClosed(m_jrToken);
+}
+
+void NanoAODOutputModuleBase::fillDescription(edm::ParameterSetDescription& desc) {
+  desc.addUntracked<std::string>("fileName");
+  desc.addUntracked<std::string>("logicalFileName", "");
+
+  desc.addUntracked<int>("compressionLevel", 9)->setComment("ROOT compression level of output file.");
+  desc.addUntracked<std::string>("compressionAlgorithm", "ZLIB")
+      ->setComment("Algorithm used to compress data in the ROOT output file, allowed values are ZLIB and LZMA");
+  desc.addUntracked<bool>("saveProvenance", true)
+      ->setComment("Save process provenance information, e.g. for edmProvDump");
+  desc.addUntracked<bool>("fakeNameForCrab", false)
+      ->setComment(
+          "Change the OutputModule name in the fwk job report to fake PoolOutputModule. This is needed to run on crab "
+          "(and publish) till crab is fixed");
+  desc.addUntracked<int>("autoFlush", -10000000)->setComment("Autoflush parameter for ROOT file");
+
+  //Used by Workflow management for their own meta data
+  edm::ParameterSetDescription dataSet;
+  dataSet.setAllowAnything();
+  desc.addUntracked<edm::ParameterSetDescription>("dataset", dataSet)
+      ->setComment("PSet is only used by Data Operations and not by this module.");
+
+  edm::ParameterSetDescription branchSet;
+  branchSet.setAllowAnything();
+  desc.add<edm::ParameterSetDescription>("branches", branchSet);
+}


### PR DESCRIPTION
#### PR description:

This PR is a possible solution for https://github.com/cms-sw/cmssw/issues/50635 for what concerns the `TTree`-based implementation of the `OutputModule`s producing flat NanoAOD ntuples.
 - It introduces an abstract class named `NanoAODOutputModuleBase`, which serves as a base class for the `NanoAODOutputModule` and `OrbitNanoAODOutputModule` plugins. The base class implements the functionalities that are common to both plugins, reducing the amount of duplicated source code.
 - While checking the implementation of this PR with a LLM (Claude Sonnet 4.6), the latter flagged two possible bugs in the original implementation (one bug per plugin), due to two vector data members not being cleared before being filled in the `openFile()` function. This is fixed in this PR (see the last two commits for more info).
 - Minor technical changes (cleanup of include statements, renaming of a few internal data members, etc) are also included.

Merely technical. No changes expected.

#### PR validation:

Ran `runTheMatrix.py -l 144.903,2500.4302` in `CMSSW_17_0_0_pre2` before and after these changes, and compared the NanoAOD outputs of those workflows (checked the values of the branches of the Event/Lumi/Run `TTree`s for the first 1000 entries of each `TTree`). No differences were spotted, as expected.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
