### PR TITLE
Move Phase2Muon type assignment to the main muon loop

### DIFF
--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -621,8 +621,6 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
               muon.setType(muon.type() | reco::Muon::GEMMuon);
             if (goodME0Muon)
               muon.setType(muon.type() | reco::Muon::ME0Muon);
-            if (isPhase2_)
-              muon.setType(muon.type() | reco::Muon::Phase2Muon);
             LogTrace("MuonIdentification") << "Found a corresponding global muon. Set energy, matches and move on";
             break;
           }
@@ -712,7 +710,8 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   // Fill various information
   for (unsigned int i = 0; i < outputMuons->size(); ++i) {
     auto& muon = outputMuons->at(i);
-
+    if (isPhase2_)
+      muon.setType(muon.type() | reco::Muon::Phase2Muon);
     // Fill muonID
     if ((fillMatching_ && !muon.isMatchesValid()) || (fillEnergy_ && !muon.isEnergyValid())) {
       // predict direction based on the muon interaction region location


### PR DESCRIPTION
#### PR description:

The assignment of the Phase2Muon type (introduced in #51053) was performed only on tracker muons with a corresponding global muon. Since it must be a general flag, moved the assignment in the main loop, where `outputMuons` collection is completely filled.

#### PR validation:

Validated with `runTheMatrix.py -l limited -i all --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport needed.
