### PR TITLE
[17.0] Fix `edmMpiConfigSplitter` logic for duplicated modules

### DIFF
--- a/HeterogeneousCore/MPICore/python/configuration_splitter/module_dependency_analyzer.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/module_dependency_analyzer.py
@@ -189,16 +189,137 @@ class ModuleDependencyAnalyzer:
 
         return ordered_components
     
+    
+    def _connected_groups_except(
+        self,
+        graph: Dict[str, Set[str]],
+        module_order: List[str],
+        exceptions: Set[str],
+    ) -> List[List[str]]:
+        """
+        Weakly connected groups where exception nodes do not connect
+        non-exception nodes together.
+
+        Exception nodes may appear in multiple groups.
+        """
+
+        # Build undirected graph
+        undirected = defaultdict(set)
+
+        for src in graph:
+            undirected[src]
+            for dst in graph[src]:
+                undirected[src].add(dst)
+                undirected[dst].add(src)
+
+        groups = []
+
+        # Tracks only non-exception nodes already assigned
+        assigned_non_exception = set()
+
+        for root in module_order:
+            if root in exceptions:
+                continue
+
+            if root in assigned_non_exception:
+                continue
+
+            stack = [root]
+            visited = set()
+
+            while stack:
+                node = stack.pop()
+
+                if node in visited:
+                    continue
+
+                visited.add(node)
+
+                for neigh in undirected[node]:
+                    if neigh in visited:
+                        continue
+
+                    if node in exceptions:
+                        # exception nodes may only expand to other exceptions
+                        if neigh in exceptions:
+                            stack.append(neigh)
+                    else:
+                        # normal nodes may expand to everything
+                        stack.append(neigh)
+
+            # Mark only non-exception nodes as assigned
+            assigned_non_exception.update(
+                n for n in visited if n not in exceptions
+            )
+
+            groups.append(visited)
+
+        # Handle graphs containing only exception nodes
+        for node in module_order:
+            if node in exceptions and not any(node in g for g in groups):
+                groups.append({node})
+
+        # Topologically order each group exactly like your current code
+        ordered_groups = []
+
+        for comp in groups:
+            indegree = {n: 0 for n in comp}
+            local_edges = defaultdict(set)
+
+            for src in comp:
+                for dst in graph.get(src, []):
+                    if dst in comp:
+                        local_edges[src].add(dst)
+                        indegree[dst] += 1
+
+            queue = deque(sorted(
+                n for n in comp
+                if indegree[n] == 0
+            ))
+
+            ordered = []
+
+            while queue:
+                n = queue.popleft()
+                ordered.append(n)
+
+                for dst in local_edges.get(n, []):
+                    indegree[dst] -= 1
+                    if indegree[dst] == 0:
+                        queue.append(dst)
+
+            if len(ordered) < len(comp):
+                remaining = sorted(set(comp) - set(ordered))
+                ordered.extend(remaining)
+
+            ordered_groups.append(ordered)
+
+        return ordered_groups
+    
+        
     def dependency_groups(self, modules: List[str]) -> List[List[str]]:
         """
         Get dependency groups (ordered)
         """
         graph = self._restricted_graph(modules)
         return self._connected_groups(graph, modules)
+    
+    def dependency_groups_except(
+        self,
+        modules: List[str],
+        exceptions: List[str] = None,
+    ) -> List[List[str]]:
+        graph = self._restricted_graph(modules)
+        return self._connected_groups_except(
+            graph,
+            modules,
+            set(exceptions or [])
+        )
 
     def grouped_external_dependencies(
         self,
         groups: List[List[str]],
+        exceptions: List[str]
     ) -> List[Set[str]]:
         """
         Grouped external dependencies
@@ -211,7 +332,7 @@ class ModuleDependencyAnalyzer:
 
             for m in group:
                 for prod in self.module_inputs.get(m, []):
-                    if prod not in gset:
+                    if prod not in gset and prod not in exceptions:
                         deps.add(prod)
 
             grouped.append(deps)

--- a/HeterogeneousCore/MPICore/python/configuration_splitter/split_remote.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/split_remote.py
@@ -20,15 +20,25 @@ def split_remote(local_process, args, cpp_names_of_the_products):
     modules_to_offload.extend(m for m in modules_to_run_on_both if m not in modules_to_offload)
 
     analyzer = ModuleDependencyAnalyzer(local_process)
-
-    groups = analyzer.dependency_groups(modules_to_offload)
-    grouped_deps = analyzer.grouped_external_dependencies(groups)
+    groups = analyzer.dependency_groups_except(modules_to_offload, modules_to_run_on_both)
+    grouped_deps = analyzer.grouped_external_dependencies(groups, exceptions=modules_to_run_on_both)
     producer_to_groups = analyzer.producer_to_groups(grouped_deps)
+    
+    first_dependency_in_a_group = [""]*len(groups)
+    for i,group in enumerate(groups):
+        elem = group[0]
+        j=0
+        while elem in modules_to_run_on_both and j<len(group):
+            elem=group[j]
+            j+=1
+        first_dependency_in_a_group[i]=elem
+        
 
     if args.verbose:
         print("Dependency groups: ", groups)
         print("Grouped depencencies:", grouped_deps )
         print("Local producers - dependant groups correspondance: ", producer_to_groups)
+        print("Modules to insert path state capture before for each group: ", first_dependency_in_a_group)
 
     # get products whose data needs to be sent, excluding modules without local dependencies and modules which should run on both processes
     modules_to_send, modules_without_local_deps = analyzer.modules_to_send_back_by_group(groups, modules_to_run_on_both)
@@ -66,9 +76,9 @@ def split_remote(local_process, args, cpp_names_of_the_products):
     # send the data needed by offloaded modules from local to remote
     remote_filters_by_group = [[] for _ in range(len(groups))]
     for local_dependency, group_indices in producer_to_groups.items():
-        first_dependency_in_a_group = [groups[i][0] for i in group_indices]
+        markers = [first_dependency_in_a_group[i] for i in group_indices]
         capture_name = f"activityCaptureBefore{local_dependency.title()}"
-        insert_path_state_capture_before(local_process, first_modules_in_a_group=first_dependency_in_a_group, capture_name=capture_name)
+        insert_path_state_capture_before(local_process, first_modules_in_a_group=markers, capture_name=capture_name)
         sender = create_sender(
                 module_name=local_dependency,
                 products=cpp_names_of_the_products[local_dependency],
@@ -103,7 +113,7 @@ def split_remote(local_process, args, cpp_names_of_the_products):
         if len(group_indices) >= 2:
             for group_idx in group_indices:
                 capture_name=f"activityCaptureBefore{args.remote_process_name.title()}Group{group_idx}"
-                insert_path_state_capture_before(local_process, first_modules_in_a_group=[groups[group_idx][0]], capture_name=capture_name)
+                insert_path_state_capture_before(local_process, first_modules_in_a_group=[first_dependency_in_a_group[group_idx]], capture_name=capture_name)
                 sender = create_sender(
                         module_name=local_dependency,
                         products=[],
@@ -200,8 +210,10 @@ def split_remote(local_process, args, cpp_names_of_the_products):
  
     # add all needed paths to the process and schedule them
     for i, group in enumerate(groups):
-        make_new_path(local_process, f"Offload{args.remote_process_name.title()}Group{i}", mpi_path_modules_local[i])
-        make_new_path(remote_process, f"MPIPathGroup{i}", mpi_path_modules_remote[i])
+        if mpi_path_modules_local[i]:
+            make_new_path(local_process, f"Offload{args.remote_process_name.title()}Group{i}", mpi_path_modules_local[i])
+        if mpi_path_modules_remote[i]:
+            make_new_path(remote_process, f"MPIPathGroup{i}", mpi_path_modules_remote[i])
         make_new_path(remote_process, args.remote_process_name.title()+"RemoteOffloadedSequence"+str(i), remote_filters_by_group[i]+group+per_group_remote_captures[i])
     
     if args.verbose:


### PR DESCRIPTION
### PR description:

This pull request introduces a fix to the logic of `edmMpiConfigSplitter` from `HeterogeneousCore/MPICore` to not group together the modules in the remote menu if the only linkage between them consists of helper modules which run on both server and remote. 

#### PR validation:

Unit tests

#### Backport

Backport of #51318 to 17.0.x for Run 3 tests.