### PR TITLE
[17.0] Prevent MPI deadlock after a configuration error

### DIFF
--- a/HeterogeneousCore/MPICore/plugins/MPIController.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIController.cc
@@ -76,6 +76,11 @@ private:
   std::vector<std::vector<std::unique_ptr<MPIChannel>>> channels_;
   edm::EDPutTokenT<MPIToken> token_;
   Mode mode_;
+  // Set once beginJob() has sent the initial Connect message to all followers.
+  // Used to prevent the MPIController from hanging in it's destructor's
+  // MPI_Comm_disconnect() in the case some other module in the local process
+  // has crashed at construction time.
+  bool connected_ = false;
 };
 
 MPIController::MPIController(edm::ParameterSet const& config)
@@ -185,6 +190,12 @@ MPIController::MPIController(edm::ParameterSet const& config)
 }
 
 MPIController::~MPIController() {
+  if (!connected_) {
+    // Some module crashed at construction time. Return so that the error
+    // message can be printed.
+    return;
+  }
+
   // Disconnect the per-stream communicators.
   for (auto& channels : channels_) {
     for (auto& channel : channels) {
@@ -208,6 +219,7 @@ void MPIController::beginJob() {
   for (auto& follower : followers_) {
     follower.sendConnect();
   }
+  connected_ = true;
 
   /* is there a way to access all known process histories ?
   edm::ProcessHistoryRegistry const& registry = * edm::ProcessHistoryRegistry::instance();


### PR DESCRIPTION
#### PR description:

Prevent the `MPIController`'s destructor from deadlocking after a construction-time crashes in other modules.

The `MPIController` calls `beginJob()` only after the constructors of all modules (including MPIController itself) have completed in the local process. If any module in the local proces crashes in its constructor, `MPIController`'s `beginJob()` is never called.

On the remote process, however, `MPISource` waits for this `beginJob()` (specifically for the `"EDM_MPI_Connect"` message) in its constructor.

If any module in the local process crashes at construction time (e.g. because of config parse errors), the FW calls the destructor of every module, including the `MPIController`. In this case `beginJob()` never ran, so the Source's constructor blocks forever. The destructor of `MPIController` calls `MPI_Comm_disconnect()`, which will also blocks forever since the source hasn't even got past its constructor.

And the original exception is never printed.

The fix is to track if `beginJob()` completed. If it did, skip `MPI_Comm_disconnect()` in MPIController's destructor, so that the original error can be printed.


#### PR validation:

Existing tests pass.
No new tests have been added.


#### Backport

Backport #51425 to 17.0.x for Run 3 tests.