### PR TITLE
[17_0_X] Add `cudaKernelStackBudget` tool and richer CUDA device information

### DIFF
--- a/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
@@ -15,4 +15,8 @@
   <library file="CUDAMonitoringService.cc CUDAService.cc NVProfilerService.cc" name="HeterogeneousCoreCUDAServicesPlugins">
     <flags EDM_PLUGIN="1"/>
   </library>
+  <library file="CuptiKernelLoggerService.cc" name="HeterogeneousCoreCUDAServicesCuptiKernelLogger">
+    <use name="cupti"/>
+    <flags EDM_PLUGIN="1"/>
+  </library>
 </iftool>

--- a/HeterogeneousCore/CUDAServices/plugins/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/plugins/CUDAService.cc
@@ -264,8 +264,13 @@ CUDAService::CUDAService(edm::ParameterSet const& config) : verbose_(config.getU
     if (verbose_) {
       log << '\n';
       log << "  streaming multiprocessors: " << std::setw(13) << properties.multiProcessorCount << '\n';
+      log << "  max threads per multiprocessor: " << std::setw(8) << properties.maxThreadsPerMultiProcessor << '\n';
+      log << "  max resident threads: " << std::setw(18)
+          << properties.multiProcessorCount * properties.maxThreadsPerMultiProcessor << '\n';
       log << "  CUDA cores: " << std::setw(28)
           << properties.multiProcessorCount * getCudaCoresPerSM(properties.major, properties.minor) << '\n';
+      log << "  max resident threads per CUDA core: " << std::setw(4)
+          << properties.maxThreadsPerMultiProcessor / getCudaCoresPerSM(properties.major, properties.minor) << '\n';
       log << "  single to double performance: " << std::setw(8) << properties.singleToDoublePrecisionPerfRatio
           << ":1\n";
     }

--- a/HeterogeneousCore/CUDAServices/plugins/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/plugins/CUDAService.cc
@@ -267,8 +267,8 @@ CUDAService::CUDAService(edm::ParameterSet const& config) : verbose_(config.getU
       log << "  max threads per multiprocessor: " << std::setw(8) << properties.maxThreadsPerMultiProcessor << '\n';
       log << "  max resident threads: " << std::setw(18)
           << properties.multiProcessorCount * properties.maxThreadsPerMultiProcessor << '\n';
-      log << "  CUDA cores: " << std::setw(28)
-          << properties.multiProcessorCount * getCudaCoresPerSM(properties.major, properties.minor) << '\n';
+      auto const coresPerSM = getCudaCoresPerSM(properties.major, properties.minor);
+      log << "  CUDA cores: " << std::setw(28) << properties.multiProcessorCount * coresPerSM << '\n';
       log << "  max resident threads per CUDA core: " << std::setw(4)
           << properties.maxThreadsPerMultiProcessor / getCudaCoresPerSM(properties.major, properties.minor) << '\n';
       log << "  single to double performance: " << std::setw(8) << properties.singleToDoublePrecisionPerfRatio

--- a/HeterogeneousCore/CUDAServices/plugins/CuptiKernelLoggerService.cc
+++ b/HeterogeneousCore/CUDAServices/plugins/CuptiKernelLoggerService.cc
@@ -5,16 +5,18 @@
 // reads its output; it can also be added to any configuration directly:
 //
 //   process.CuptiKernelLoggerService = cms.Service("CuptiKernelLoggerService",
-//       kernelLog  = cms.untracked.string("kernels.txt"),    # "<mangled kernel>\t<module>" lines
+//       kernelLog  = cms.untracked.string("kernels.txt"),    # "<mangled kernel>\t<module>\t<dyn shared>" lines
 //       libraryLog = cms.untracked.string("libraries.txt"))  # one loaded library path per line
 //
 // It subscribes to the CUPTI launch callbacks (runtime and driver API) and, for each launch,
-// records the kernel together with the module running on the calling thread. CUPTI allows a
-// single subscriber per process, so if another CUPTI client (NVProfilerService, nsys, ncu)
-// is already active the subscription fails and the service logs a warning explaining why its
-// logs will be empty.
+// records the kernel together with the module running on the calling thread and the largest amount
+// of dynamic shared memory the launch requested. CUPTI allows a single subscriber per process, so
+// if another CUPTI client (NVProfilerService, nsys, ncu) is already active the subscription fails
+// and the service logs a warning explaining why its logs will be empty.
 
+#include <cstddef>
 #include <fstream>
+#include <map>
 #include <mutex>
 #include <set>
 #include <string>
@@ -23,6 +25,7 @@
 
 #include <link.h>  // dl_iterate_phdr
 
+#include <cuda_runtime_api.h>  // cudaLaunchConfig_t (dynamicSmemBytes)
 #include <cupti.h>
 
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
@@ -37,16 +40,64 @@
 
 namespace {
   std::mutex g_mutex;
-  // (mangled kernel name, module label) pairs seen during the job
-  std::set<std::pair<std::string, std::string>> g_records;
+  // (mangled kernel name, module label) -> largest dynamic shared memory (bytes) requested by any
+  // launch of that kernel from that module. Static shared memory is a compile-time property read
+  // separately with cuobjdump; the dynamic amount is only known here, at launch time.
+  std::map<std::pair<std::string, std::string_view>, std::size_t> g_records;
   // modules currently executing acquire()/produce() on this host thread; a kernel launch fires
   // its callback synchronously on the same thread, so the top of the stack is the module that
   // issued the launch (empty when a kernel is launched outside any module)
-  thread_local std::vector<std::string> t_modules;
+  thread_local std::vector<std::string_view> t_modules;
+
+  // dynamic shared memory (bytes) requested by a launch, read from the callback's function
+  // arguments. The field lives at a different place in each entry point's parameter struct (and
+  // __cudaLaunchKernel exposes no typed struct at all, so it reports 0); this is harmless because a
+  // single launch also surfaces through cudaLaunchKernel/cuLaunchKernel, whose structs do carry it,
+  // and g_records keeps the maximum across all of a kernel's launches.
+  std::size_t dynamicSharedBytes(CUpti_CallbackDomain domain, CUpti_CallbackId cbid, const void* params) {
+    if (params == nullptr) {
+      return 0;
+    }
+    if (domain == CUPTI_CB_DOMAIN_RUNTIME_API) {
+      switch (cbid) {
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000:
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_ptsz_v7000:
+          return static_cast<const cudaLaunchKernel_v7000_params*>(params)->sharedMem;
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_v9000:
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_ptsz_v9000:
+          return static_cast<const cudaLaunchCooperativeKernel_v9000_params*>(params)->sharedMem;
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060:
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_ptsz_v11060: {
+          auto const* p = static_cast<const cudaLaunchKernelExC_v11060_params*>(params);
+          return p->config ? p->config->dynamicSmemBytes : 0;
+        }
+        default:  // e.g. __cudaLaunchKernel: no parameter struct to read
+          return 0;
+      }
+    }
+    if (domain == CUPTI_CB_DOMAIN_DRIVER_API) {
+      switch (cbid) {
+        case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel:
+        case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel_ptsz:
+          return static_cast<const cuLaunchKernel_params*>(params)->sharedMemBytes;
+        case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel:
+        case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel_ptsz:
+          return static_cast<const cuLaunchCooperativeKernel_params*>(params)->sharedMemBytes;
+        case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx:
+        case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx_ptsz: {
+          auto const* p = static_cast<const cuLaunchKernelEx_params*>(params);
+          return p->config ? p->config->sharedMemBytes : 0;
+        }
+        default:
+          return 0;
+      }
+    }
+    return 0;
+  }
 
   void CUPTIAPI launchCallback(void* /* userdata */,
                                CUpti_CallbackDomain domain,
-                               CUpti_CallbackId /* cbid */,
+                               CUpti_CallbackId cbid,
                                const void* callbackData) {
     if (domain != CUPTI_CB_DOMAIN_RUNTIME_API && domain != CUPTI_CB_DOMAIN_DRIVER_API) {
       return;
@@ -55,9 +106,16 @@ namespace {
     if (data->callbackSite != CUPTI_API_ENTER || data->symbolName == nullptr) {
       return;
     }
-    std::string module = t_modules.empty() ? std::string() : t_modules.back();
+    std::size_t dynamicShared = dynamicSharedBytes(domain, cbid, data->functionParams);
+    std::string_view module = t_modules.empty() ? std::string_view() : t_modules.back();
     std::lock_guard<std::mutex> guard(g_mutex);
-    g_records.emplace(data->symbolName, std::move(module));
+    // Each launch can surface through several of the enabled entry points (a runtime cudaLaunchKernel
+    // dispatches to the driver cuLaunchKernel, both firing here), but keying the map on
+    // (kernel, module) and keeping the maximum dynamic shared memory collapses those into one entry.
+    std::size_t& maxDynamicShared = g_records[std::pair<std::string, std::string_view>(data->symbolName, module)];
+    if (dynamicShared > maxDynamicShared) {
+      maxDynamicShared = dynamicShared;
+    }
   }
 
   int collectLoadedObject(struct dl_phdr_info* info, size_t /* size */, void* data) {
@@ -111,6 +169,10 @@ CuptiKernelLoggerService::CuptiKernelLoggerService(edm::ParameterSet const& conf
   }
 
   // enable every kernel-launch entry point; the launch path used depends on the Alpaka/CUDA code.
+  // each runtime/driver entry point exposes a distinct callback id for the default-stream "legacy"
+  // flavour and for the "_ptsz" per-thread-default-stream flavour selected by nvcc
+  // --default-stream per-thread, so enable both to cover either compilation mode. Overlapping
+  // callbacks do not cause duplicate records: g_records is a map keyed on (kernel, module).
   // a failed enable would silently drop that path, so warn rather than report an empty log later
   auto enable = [&](CUpti_CallbackDomain domain, CUpti_CallbackId cbid) {
     CUptiResult status = cuptiEnableCallback(1, subscriber_, domain, cbid);
@@ -122,12 +184,22 @@ CuptiKernelLoggerService::CuptiKernelLoggerService(edm::ParameterSet const& conf
           << "); launches through that entry point will not be recorded.";
     }
   };
+  // runtime API (cudaLaunch*); __cudaLaunchKernel is the internal entry point CUDA 13 dispatches to
   enable(CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000);
+  enable(CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_ptsz_v7000);
   enable(CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060);
+  enable(CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_ptsz_v11060);
   enable(CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_v9000);
+  enable(CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_ptsz_v9000);
+  enable(CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernelMultiDevice_v9000);
+  // driver API (cuLaunch*)
   enable(CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel);
+  enable(CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel_ptsz);
   enable(CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx);
+  enable(CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx_ptsz);
   enable(CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel);
+  enable(CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel_ptsz);
+  enable(CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernelMultiDevice);
 
   // bracket the host phases where kernels are launched, so the callback can attribute each
   // launch to the running module: acquire() for ExternalWork modules, produce() for the rest
@@ -148,7 +220,7 @@ CuptiKernelLoggerService::~CuptiKernelLoggerService() {
 }
 
 void CuptiKernelLoggerService::pushModule(edm::StreamContext const&, edm::ModuleCallingContext const& mcc) {
-  t_modules.push_back(mcc.moduleDescription()->moduleLabel());
+  t_modules.push_back(std::string_view(mcc.moduleDescription()->moduleLabel()));
 }
 
 void CuptiKernelLoggerService::popModule(edm::StreamContext const&, edm::ModuleCallingContext const&) {
@@ -161,8 +233,9 @@ void CuptiKernelLoggerService::writeLogs() {
   std::lock_guard<std::mutex> guard(g_mutex);
   if (not kernelLog_.empty()) {
     std::ofstream out(kernelLog_);
-    for (auto const& [kernel, module] : g_records) {
-      out << kernel << '\t' << module << '\n';
+    for (auto const& [key, dynamicShared] : g_records) {
+      auto const& [kernel, module] = key;
+      out << kernel << '\t' << module << '\t' << dynamicShared << '\n';
     }
   }
   if (not libraryLog_.empty()) {
@@ -180,7 +253,9 @@ void CuptiKernelLoggerService::fillDescriptions(edm::ConfigurationDescriptions& 
   edm::ParameterSetDescription desc;
   desc.setComment("CUPTI kernel-launch logger service");
   desc.addUntracked<std::string>("kernelLog", "kernels.txt")
-      ->setComment("Path to a text file where the service will write <mangled kernel>\\t<module> lines");
+      ->setComment(
+          "Path to a text file where the service will write "
+          "<mangled kernel>\\t<module>\\t<max dynamic shared bytes> lines");
   desc.addUntracked<std::string>("libraryLog", "libraries.txt")
       ->setComment("Path to a text file where the service will write one loaded library path per line");
   descriptions.add("CuptiKernelLoggerService", desc);

--- a/HeterogeneousCore/CUDAServices/plugins/CuptiKernelLoggerService.cc
+++ b/HeterogeneousCore/CUDAServices/plugins/CuptiKernelLoggerService.cc
@@ -1,0 +1,189 @@
+// CUPTI kernel-launch logger service.
+//
+// An EDM service that records which CUDA kernels a cmsRun job launches and which module
+// launched each of them. cudaKernelStackBudget --launched adds it to the configuration and
+// reads its output; it can also be added to any configuration directly:
+//
+//   process.CuptiKernelLoggerService = cms.Service("CuptiKernelLoggerService",
+//       kernelLog  = cms.untracked.string("kernels.txt"),    # "<mangled kernel>\t<module>" lines
+//       libraryLog = cms.untracked.string("libraries.txt"))  # one loaded library path per line
+//
+// It subscribes to the CUPTI launch callbacks (runtime and driver API) and, for each launch,
+// records the kernel together with the module running on the calling thread. CUPTI allows a
+// single subscriber per process, so if another CUPTI client (NVProfilerService, nsys, ncu)
+// is already active the subscription fails and the service logs a warning explaining why its
+// logs will be empty.
+
+#include <fstream>
+#include <mutex>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <link.h>  // dl_iterate_phdr
+
+#include <cupti.h>
+
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+
+namespace {
+  std::mutex g_mutex;
+  // (mangled kernel name, module label) pairs seen during the job
+  std::set<std::pair<std::string, std::string>> g_records;
+  // modules currently executing acquire()/produce() on this host thread; a kernel launch fires
+  // its callback synchronously on the same thread, so the top of the stack is the module that
+  // issued the launch (empty when a kernel is launched outside any module)
+  thread_local std::vector<std::string> t_modules;
+
+  void CUPTIAPI launchCallback(void* /* userdata */,
+                               CUpti_CallbackDomain domain,
+                               CUpti_CallbackId /* cbid */,
+                               const void* callbackData) {
+    if (domain != CUPTI_CB_DOMAIN_RUNTIME_API && domain != CUPTI_CB_DOMAIN_DRIVER_API) {
+      return;
+    }
+    auto const* data = static_cast<const CUpti_CallbackData*>(callbackData);
+    if (data->callbackSite != CUPTI_API_ENTER || data->symbolName == nullptr) {
+      return;
+    }
+    std::string module = t_modules.empty() ? std::string() : t_modules.back();
+    std::lock_guard<std::mutex> guard(g_mutex);
+    g_records.emplace(data->symbolName, std::move(module));
+  }
+
+  int collectLoadedObject(struct dl_phdr_info* info, size_t /* size */, void* data) {
+    if (info->dlpi_name != nullptr && info->dlpi_name[0] != '\0') {
+      static_cast<std::set<std::string>*>(data)->emplace(info->dlpi_name);
+    }
+    return 0;
+  }
+}  // namespace
+
+class CuptiKernelLoggerService {
+public:
+  CuptiKernelLoggerService(edm::ParameterSet const&, edm::ActivityRegistry&);
+  ~CuptiKernelLoggerService();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void pushModule(edm::StreamContext const&, edm::ModuleCallingContext const&);
+  void popModule(edm::StreamContext const&, edm::ModuleCallingContext const&);
+  void writeLogs();
+
+  const std::string kernelLog_;
+  const std::string libraryLog_;
+
+  CUpti_SubscriberHandle subscriber_ = nullptr;
+};
+
+CuptiKernelLoggerService::CuptiKernelLoggerService(edm::ParameterSet const& config, edm::ActivityRegistry& registry)
+    : kernelLog_(config.getUntrackedParameter<std::string>("kernelLog", "")),
+      libraryLog_(config.getUntrackedParameter<std::string>("libraryLog", "")) {
+  // writeLogs needs no CUPTI (libraryLog comes from dl_iterate_phdr), so register it
+  // unconditionally; the kernel records simply stay empty if the subscription below fails
+  registry.watchPostEndJob(this, &CuptiKernelLoggerService::writeLogs);
+
+  CUptiResult result = cuptiSubscribe(&subscriber_, reinterpret_cast<CUpti_CallbackFunc>(launchCallback), nullptr);
+  if (result != CUPTI_SUCCESS) {
+    subscriber_ = nullptr;  // leave no handle for the destructor to unsubscribe
+    if (result == CUPTI_ERROR_MULTIPLE_SUBSCRIBERS_NOT_SUPPORTED || result == CUPTI_ERROR_MAX_LIMIT_REACHED) {
+      edm::LogWarning("CuptiKernelLoggerService")
+          << "Another CUPTI client is already active in this process (for example NVProfilerService, "
+             "nsys or ncu). CUPTI allows only one subscriber per process, so CuptiKernelLoggerService "
+             "could not attach and its logs will be empty. Remove the other CUPTI client and rerun.";
+    } else {
+      const char* message = nullptr;
+      cuptiGetResultString(result, &message);
+      edm::LogWarning("CuptiKernelLoggerService") << "cuptiSubscribe failed (" << (message ? message : "unknown error")
+                                                  << "); CuptiKernelLoggerService logs will be empty.";
+    }
+    return;
+  }
+
+  // enable every kernel-launch entry point; the launch path used depends on the Alpaka/CUDA code.
+  // a failed enable would silently drop that path, so warn rather than report an empty log later
+  auto enable = [&](CUpti_CallbackDomain domain, CUpti_CallbackId cbid) {
+    CUptiResult status = cuptiEnableCallback(1, subscriber_, domain, cbid);
+    if (status != CUPTI_SUCCESS) {
+      const char* message = nullptr;
+      cuptiGetResultString(status, &message);
+      edm::LogWarning("CuptiKernelLoggerService")
+          << "cuptiEnableCallback failed for callback id " << cbid << " (" << (message ? message : "unknown error")
+          << "); launches through that entry point will not be recorded.";
+    }
+  };
+  enable(CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000);
+  enable(CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060);
+  enable(CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_v9000);
+  enable(CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel);
+  enable(CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx);
+  enable(CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel);
+
+  // bracket the host phases where kernels are launched, so the callback can attribute each
+  // launch to the running module: acquire() for ExternalWork modules, produce() for the rest
+  registry.watchPreModuleEventAcquire(this, &CuptiKernelLoggerService::pushModule);
+  registry.watchPostModuleEventAcquire(this, &CuptiKernelLoggerService::popModule);
+  registry.watchPreModuleEvent(this, &CuptiKernelLoggerService::pushModule);
+  registry.watchPostModuleEvent(this, &CuptiKernelLoggerService::popModule);
+
+  edm::LogInfo("CuptiKernelLoggerService") << "CUPTI kernel logger service successfully initialised." << '\n'
+                                           << "Launched kernels will be written to '" << kernelLog_ << "'\n"
+                                           << "Loaded libraries will be written to '" << libraryLog_ << "'.";
+}
+
+CuptiKernelLoggerService::~CuptiKernelLoggerService() {
+  if (subscriber_ != nullptr) {
+    cuptiUnsubscribe(subscriber_);
+  }
+}
+
+void CuptiKernelLoggerService::pushModule(edm::StreamContext const&, edm::ModuleCallingContext const& mcc) {
+  t_modules.push_back(mcc.moduleDescription()->moduleLabel());
+}
+
+void CuptiKernelLoggerService::popModule(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+  if (not t_modules.empty()) {
+    t_modules.pop_back();
+  }
+}
+
+void CuptiKernelLoggerService::writeLogs() {
+  std::lock_guard<std::mutex> guard(g_mutex);
+  if (not kernelLog_.empty()) {
+    std::ofstream out(kernelLog_);
+    for (auto const& [kernel, module] : g_records) {
+      out << kernel << '\t' << module << '\n';
+    }
+  }
+  if (not libraryLog_.empty()) {
+    std::set<std::string> libraries;
+    // loop over the loaded shared objects and calls their callback
+    dl_iterate_phdr(collectLoadedObject, &libraries);
+    std::ofstream out(libraryLog_);
+    for (auto const& library : libraries) {
+      out << library << '\n';
+    }
+  }
+}
+
+void CuptiKernelLoggerService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("CUPTI kernel-launch logger service");
+  desc.addUntracked<std::string>("kernelLog", "kernels.txt")
+      ->setComment("Path to a text file where the service will write <mangled kernel>\\t<module> lines");
+  desc.addUntracked<std::string>("libraryLog", "libraries.txt")
+      ->setComment("Path to a text file where the service will write one loaded library path per line");
+  descriptions.add("CuptiKernelLoggerService", desc);
+}
+
+DEFINE_FWK_SERVICE(CuptiKernelLoggerService);

--- a/HeterogeneousCore/CUDAUtilities/bin/cudaComputeCapabilities.cpp
+++ b/HeterogeneousCore/CUDAUtilities/bin/cudaComputeCapabilities.cpp
@@ -1,7 +1,13 @@
 // C/C++ standard headers
+#include <algorithm>
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 // CUDA headers
 #include <cuda_runtime.h>
@@ -9,7 +15,108 @@
 // CMSSW headers
 #include "isCudaDeviceSupported.h"
 
-int main() {
+namespace {
+  // print a short usage message
+  void printUsage(std::string_view name) {
+    std::cout << "Usage: " << name << " [--verbose|-v] [--help|-h]\n\n"
+              << "Print the index, compute capability and name of each visible CUDA device.\n\n"
+              << "Options:\n"
+              << "  -v, --verbose   print detailed properties for each device\n"
+              << "  -h, --help      print this help message and exit\n";
+  }
+
+  std::string_view yesno(int value) { return value ? "yes" : "no"; }
+
+  // format the PCI location as domain:bus:device, like nvidia-smi
+  std::string pciId(cudaDeviceProp const& properties) {
+    std::ostringstream out;
+    out << std::hex << std::setfill('0') << std::setw(4) << properties.pciDomainID << ':' << std::setw(2)
+        << properties.pciBusID << ':' << std::setw(2) << properties.pciDeviceID << ".0";
+    return out.str();
+  }
+
+  // print the detailed properties of a device, indented under its summary line
+  void printDetails(int device, cudaDeviceProp const& properties) {
+    // query CUDA attributes by ordinal
+    auto attribute = [device](cudaDeviceAttr attr) {
+      int value = 0;
+      cudaDeviceGetAttribute(&value, attr, device);
+      return value;
+    };
+
+    // compose a value and an optional unit into a single string
+    auto value = [](auto const& v, std::string_view unit = "") {
+      std::ostringstream out;
+      out << v << unit;
+      return out.str();
+    };
+
+    // compose the three components of a dimension into "x X y X z"
+    auto dimensions = [](const int* d) {
+      std::ostringstream out;
+      out << d[0] << " x " << d[1] << " x " << d[2];
+      return out.str();
+    };
+
+    std::vector<std::pair<std::string_view, std::string>> rows = {
+        {"PCI device id:", pciId(properties)},
+        {"integrated:", value(yesno(properties.integrated))},
+        {"total global memory:", value(properties.totalGlobalMem >> 20, " MiB")},
+        {"L2 cache size:", value(properties.l2CacheSize >> 10, " KiB")},
+        {"shared memory per block:", value(properties.sharedMemPerBlock >> 10, " KiB")},
+        {"shared memory per multiprocessor:", value(properties.sharedMemPerMultiprocessor >> 10, " KiB")},
+        {"memory bus width:", value(properties.memoryBusWidth, " bits")},
+        {"memory clock rate:", value(attribute(cudaDevAttrMemoryClockRate) / 1000, " MHz")},
+        {"GPU clock rate:", value(attribute(cudaDevAttrClockRate) / 1000, " MHz")},
+        {"multiprocessors:", value(properties.multiProcessorCount)},
+        {"warp size:", value(properties.warpSize)},
+        {"max threads per multiprocessor:", value(properties.maxThreadsPerMultiProcessor)},
+        {"max resident threads:", value(properties.multiProcessorCount * properties.maxThreadsPerMultiProcessor)},
+        {"max threads per block:", value(properties.maxThreadsPerBlock)},
+        {"max block dimensions:", dimensions(properties.maxThreadsDim)},
+        {"max grid dimensions:", dimensions(properties.maxGridSize)},
+        {"registers per block:", value(properties.regsPerBlock)},
+        {"ECC enabled:", value(yesno(properties.ECCEnabled))},
+        {"concurrent kernels:", value(yesno(properties.concurrentKernels))},
+        {"async engine count:", value(properties.asyncEngineCount)},
+        {"cooperative launch:", value(yesno(properties.cooperativeLaunch))},
+        {"unified addressing:", value(yesno(properties.unifiedAddressing))},
+        {"managed memory:", value(yesno(properties.managedMemory))},
+        {"can map host memory:", value(yesno(properties.canMapHostMemory))},
+    };
+
+    // align the label column on the left and the value column on the right, so that
+    // both the left and right margins of the indented block line up for every row
+    std::size_t labelWidth = 0;
+    std::size_t valueWidth = 0;
+    for (auto const& [label, text] : rows) {
+      labelWidth = std::max(labelWidth, label.size());
+      valueWidth = std::max(valueWidth, text.size());
+    }
+
+    for (auto const& [label, text] : rows) {
+      std::cout << "        " << std::left << std::setw(static_cast<int>(labelWidth)) << label << "  " << std::right
+                << std::setw(static_cast<int>(valueWidth)) << text << "\n";
+    }
+  }
+}  // namespace
+
+int main(int argc, char** argv) {
+  bool verbose = false;
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "--verbose" or arg == "-v") {
+      verbose = true;
+    } else if (arg == "--help" or arg == "-h") {
+      printUsage(argv[0]);
+      return EXIT_SUCCESS;
+    } else {
+      std::cerr << "cudaComputeCapabilities: unrecognised option '" << arg << "'\n";
+      printUsage(argv[0]);
+      return EXIT_FAILURE;
+    }
+  }
+
   int devices = 0;
   cudaError_t status = cudaGetDeviceCount(&devices);
   if (status != cudaSuccess) {
@@ -26,6 +133,10 @@ int main() {
       std::cout << " (unsupported)";
     }
     std::cout << std::endl;
+
+    if (verbose) {
+      printDetails(i, properties);
+    }
   }
 
   return EXIT_SUCCESS;

--- a/HeterogeneousCore/CUDAUtilities/python/kernelStackBudget.py
+++ b/HeterogeneousCore/CUDAUtilities/python/kernelStackBudget.py
@@ -1,0 +1,775 @@
+"""Estimate the worst-case CUDA local-memory backing store reserved by a cmsRun job.
+
+A CUDA kernel with a large per-thread stack frame makes the driver reserve
+cudaLimitStackSize * maxResidentThreads bytes of device memory, where
+maxResidentThreads = multiProcessorCount * maxThreadsPerMultiProcessor. The limit must cover
+the largest per-thread stack frame among the kernels that launch, so the reservation can
+quietly consume a large slice of device memory.
+
+By default the tool works statically: it loads the configuration, resolves each scheduled
+module to its plugin library, reads the per-kernel STACK size with cuobjdump, and reports
+maxResidentThreads * max(STACK) per device. That is a conservative upper bound over every
+kernel in those libraries. The --launched mode runs the job once under a CUPTI logger and
+reports only the kernels that actually launched.
+"""
+
+import concurrent.futures
+import os
+import re
+import shutil
+import struct
+import subprocess
+import sys
+from collections import defaultdict
+
+from FWCore.ParameterSet.processFromFile import processFromFile
+
+_ALPAKA_SUFFIX = "@alpaka"
+
+# cuobjdump --dump-resource-usage parsing
+_ARCH_RE = re.compile(r"arch\s*=\s*(sm_\d+)")
+_FUNC_RE = re.compile(r"Function\s+(\S+):")
+_USAGE_RE = re.compile(r"REG:(\d+)\s+STACK:(\d+)\s+SHARED:(\d+)\s+LOCAL:(\d+)")
+
+# cudaComputeCapabilities --verbose parsing; a device line looks like "   0     9.0    NVIDIA H100 NVL"
+_DEVICE_RE = re.compile(r"^\s*(\d+)\s+(\d+\.\d+)\s+(.+?)(?:\s+\(unsupported\))?\s*$")
+_MAXRES_RE = re.compile(r"max resident threads:\s*(\d+)")
+
+
+def find_tool(name):
+    """Locate a CUDA/CMSSW tool, preferring the build's CUDA external, then $PATH."""
+    cuda_base = os.environ.get("CUDA_BASE")
+    if cuda_base:
+        candidate = os.path.join(cuda_base, "bin", name)
+        if os.path.exists(candidate):
+            return candidate
+    return shutil.which(name)
+
+
+def lib_directories():
+    """Library directories to search, local developer area first, then the base release."""
+    arch = os.environ.get("SCRAM_ARCH", "")
+    dirs = []
+    for var in ("CMSSW_BASE", "CMSSW_RELEASE_BASE"):
+        top = os.environ.get(var)
+        if top:
+            path = os.path.join(top, "lib", arch)
+            if os.path.isdir(path) and path not in dirs:
+                dirs.append(path)
+    return dirs
+
+
+def parse_plugin_cache(lib_dirs):
+    """Return a {plugin_name: shared_object_basename} map from the .edmplugincache files.
+
+    Cache lines look like "<library.so> <pluginName> <category>". Developer-area caches are
+    read last so locally rebuilt plugins win over the base release.
+    """
+    mapping = {}
+    for directory in reversed(lib_dirs):  # base release first, local area overwrites
+        cache = os.path.join(directory, ".edmplugincache")
+        try:
+            with open(cache) as handle:
+                for line in handle:
+                    fields = line.split()
+                    if len(fields) >= 2:
+                        mapping[fields[1]] = fields[0]
+        except OSError:
+            continue
+    return mapping
+
+
+def resolve_library_path(basename, lib_dirs):
+    """Resolve a shared-object basename to a full path (developer area first)."""
+    for directory in lib_dirs:
+        candidate = os.path.join(directory, basename)
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def _module_backend(module, default_backend):
+    """Return the Alpaka backend an @alpaka module resolves to."""
+    alpaka = getattr(module, "alpaka", None)
+    if alpaka is not None and hasattr(alpaka, "backend"):
+        backend = alpaka.backend.value()
+        if backend:
+            return backend
+    return default_backend
+
+
+def plugin_name_for(cpp_type, module, default_backend):
+    """Map a module C++ type to its registered plugin name.
+
+    "Foo@alpaka" becomes "alpaka_<backend>::Foo", mirroring ModuleTypeResolverAlpaka in
+    HeterogeneousCore/AlpakaCore. Any other type is its own plugin name.
+    """
+    if cpp_type.endswith(_ALPAKA_SUFFIX):
+        base = cpp_type[: -len(_ALPAKA_SUFFIX)]
+        return "alpaka_{}::{}".format(_module_backend(module, default_backend), base)
+    return cpp_type
+
+
+def scheduled_modules(process):
+    """Return [(label, cpp_type, module)] for modules that would run for this configuration.
+
+    Uses the explicit cms.Schedule when present (it already pulls in associated Tasks),
+    otherwise the union of all Paths and EndPaths. Alpaka ESProducers are added always because
+    they are loaded on demand rather than scheduled on a path.
+    """
+    labels = set()
+    schedule = process.schedule_() if hasattr(process, "schedule_") else None
+    if schedule is not None:
+        labels |= set(schedule.moduleNames())
+    else:
+        for container in (process.paths_(), process.endpaths_()):
+            for path in container.values():
+                labels |= set(path.moduleNames())
+
+    lookup = {}
+    for getter in ("producers_", "filters_", "analyzers_", "outputModules_"):
+        lookup.update(getattr(process, getter)())
+
+    result = []
+    for label in sorted(labels):
+        module = lookup.get(label)
+        if module is not None:
+            result.append((label, module.type_(), module))
+
+    for label, module in process.es_producers_().items():
+        cpp_type = module.type_()
+        if cpp_type.endswith(_ALPAKA_SUFFIX):
+            result.append((label, cpp_type, module))
+
+    return result
+
+
+def loaded_cuda_libraries(process, default_backend, plugin_cache, lib_dirs):
+    """Return ({library_path: sorted labels}, unresolved) for the configuration's CUDA libraries.
+
+    A library is kept only if it embeds device code, checked with has_device_code.
+    """
+    libraries = defaultdict(set)
+    unresolved = []
+    for label, cpp_type, module in scheduled_modules(process):
+        plugin = plugin_name_for(cpp_type, module, default_backend)
+        basename = plugin_cache.get(plugin)
+        if basename is None:
+            unresolved.append((label, plugin))
+            continue
+        path = resolve_library_path(basename, lib_dirs)
+        if path is None:
+            unresolved.append((label, basename))
+            continue
+        if not has_device_code(path):
+            continue
+        libraries[path].add(label)
+    return {path: sorted(labels) for path, labels in libraries.items()}, unresolved
+
+
+def parse_resource_usage(text):
+    """Parse cuobjdump --dump-resource-usage output into per-kernel records."""
+    records = []
+    arch = None
+    kernel = None
+    for line in text.splitlines():
+        match = _ARCH_RE.search(line)
+        if match:
+            arch, kernel = match.group(1), None
+            continue
+        match = _FUNC_RE.search(line)
+        if match:
+            kernel = match.group(1)
+            continue
+        match = _USAGE_RE.search(line)
+        # require an arch context too, so a stray usage block never yields an arch=None record
+        if match and kernel is not None and arch is not None:
+            reg, stack, shared, local = (int(value) for value in match.groups())
+            records.append(
+                {"arch": arch, "kernel": kernel, "reg": reg, "stack": stack, "shared": shared, "local": local}
+            )
+            kernel = None
+    return records
+
+
+def kernel_resource_usage(library_path, cuobjdump):
+    """Run cuobjdump on a library and return its per-kernel resource records (or [])."""
+    try:
+        completed = subprocess.run(
+            [cuobjdump, "--dump-resource-usage", library_path],
+            capture_output=True,
+            text=True,
+            errors="replace",
+        )
+    except OSError:
+        return []
+    # cuobjdump exits non-zero for host-only libraries; an empty parse is the natural result
+    return parse_resource_usage(completed.stdout)
+
+
+def has_device_code(path):
+    """True if the ELF64 shared object embeds a CUDA fatbin section."""
+    try:
+        with open(path, "rb") as handle:
+            header = handle.read(64)
+            if header[:4] != b"\x7fELF" or header[4] != 2:  # ELF64 only (the build platform)
+                return False
+            endian = "<" if header[5] == 1 else ">"
+            sh_offset = struct.unpack_from(endian + "Q", header, 40)[0]
+            sh_entsize = struct.unpack_from(endian + "H", header, 58)[0]
+            sh_count = struct.unpack_from(endian + "H", header, 60)[0]
+            str_index = struct.unpack_from(endian + "H", header, 62)[0]
+            if not sh_offset or not sh_entsize:
+                return False
+            # extended numbering keeps the real count and string-table index in section 0
+            if sh_count == 0 or str_index == 0xFFFF:
+                handle.seek(sh_offset)
+                first = handle.read(sh_entsize)
+                if sh_count == 0:
+                    sh_count = struct.unpack_from(endian + "Q", first, 32)[0]  # sh_size
+                if str_index == 0xFFFF:
+                    str_index = struct.unpack_from(endian + "I", first, 40)[0]  # sh_link
+            if str_index >= sh_count:
+                return False
+            handle.seek(sh_offset)
+            sections = handle.read(sh_entsize * sh_count)
+            base = str_index * sh_entsize
+            str_offset = struct.unpack_from(endian + "Q", sections, base + 24)[0]
+            str_size = struct.unpack_from(endian + "Q", sections, base + 32)[0]
+            handle.seek(str_offset)
+            strtab = handle.read(str_size)
+            return b".nv_fatbin" in strtab or b"__nv_relfatbin" in strtab
+    except (OSError, struct.error, IndexError):
+        return False
+
+
+def demangle(names):
+    """Return a {mangled: demangled} map using a C++ demangler, falling back to identity.
+
+    Prefers llvm-cxxfilt: GNU c++filt gives up on very long mangled names (deep Alpaka
+    template instantiations exceed its demangler limits) and returns them unchanged.
+    """
+    names = list(names)
+    cxxfilt = shutil.which("llvm-cxxfilt") or shutil.which("c++filt")
+    if not cxxfilt or not names:
+        return {name: name for name in names}
+    try:
+        completed = subprocess.run(
+            [cxxfilt], input="\n".join(names), capture_output=True, text=True, errors="replace"
+        )
+        demangled = completed.stdout.splitlines()
+        if len(demangled) == len(names):
+            return dict(zip(names, demangled))
+    except OSError:
+        pass
+    return {name: name for name in names}
+
+
+def short_kernel_name(name):
+    """Reduce an Alpaka kernel name to the meaningful inner kernel type.
+
+    Alpaka wraps every kernel as alpaka::detail::gpuKernel<REAL_KERNEL, Acc, ...>(...); the
+    first template argument is the kernel that matters. Names without that wrapper (e.g. plain
+    CUDA kernels) are returned unchanged.
+    """
+    marker = "gpuKernel<"
+    start = name.find(marker)
+    if start < 0:
+        return name
+    start += len(marker)
+    depth = 1
+    index = start
+    while index < len(name) and depth > 0:
+        char = name[index]
+        if char == "<":
+            depth += 1
+        elif char == ">":
+            depth -= 1
+            if depth == 0:
+                break
+        elif char == "," and depth == 1:
+            break
+        index += 1
+    return name[start:index].strip()
+
+
+def compute_capability_to_sm(compute_capability):
+    """Convert a compute capability ('9.0', '90', 'sm_90' or 'sm_9.0') to a cuobjdump arch.
+
+    Always returns 'sm_<digits>' so callers can int() the numeric part; a dotted form
+    ('9.0' or 'sm_9.0') has its separator removed rather than passed through verbatim.
+    """
+    text = str(compute_capability)
+    if text.startswith("sm_"):
+        text = text[len("sm_"):]
+    if "." in text:
+        major, minor = text.split(".", 1)
+        return "sm_{}{}".format(major, minor)
+    return "sm_{}".format(text)
+
+
+def parse_device_info(text):
+    """Parse cudaComputeCapabilities --verbose output into device descriptors."""
+    devices = []
+    current = None
+    for line in text.splitlines():
+        match = _DEVICE_RE.match(line)
+        if match:
+            current = {
+                "index": int(match.group(1)),
+                "compute_capability": match.group(2),
+                "name": match.group(3).strip(),
+                "max_resident_threads": None,
+            }
+            devices.append(current)
+            continue
+        if current is not None:
+            match = _MAXRES_RE.search(line)
+            if match:
+                current["max_resident_threads"] = int(match.group(1))
+    return devices
+
+
+def detect_devices():
+    """Detect local devices by running cudaComputeCapabilities --verbose (or [])."""
+    tool = find_tool("cudaComputeCapabilities")
+    if not tool:
+        return []
+    try:
+        completed = subprocess.run([tool, "--verbose"], capture_output=True, text=True, errors="replace")
+    except OSError:
+        return []
+    if completed.returncode != 0:
+        # surface the real CUDA error (driver/permission/no-device) instead of letting the
+        # empty parse masquerade as "no devices detected"
+        if completed.stderr:
+            sys.stderr.write(completed.stderr)
+        return []
+    return parse_device_info(completed.stdout)
+
+
+def select_arch(target_sm, available_sms):
+    """Pick the embedded arch matching the device, else the highest embedded arch below it."""
+    if target_sm in available_sms:
+        return target_sm, False
+    target_n = int(target_sm.split("_")[1])
+    lower = sorted((int(sm.split("_")[1]) for sm in available_sms if int(sm.split("_")[1]) <= target_n))
+    if lower:
+        return "sm_{}".format(lower[-1]), True
+    return None, False
+
+
+def _scan_libraries(paths, cuobjdump, from_config):
+    """Run cuobjdump on each library concurrently and return tagged per-kernel records."""
+    paths = list(paths)
+    if not paths:
+        return []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, len(paths))) as pool:
+        per_library = list(pool.map(lambda path: kernel_resource_usage(path, cuobjdump), paths))
+    records = []
+    for path, found in zip(paths, per_library):
+        basename = os.path.basename(path)
+        for record in found:
+            record["library"] = basename
+            record["config"] = from_config
+            records.append(record)
+    return records
+
+
+def _human_bytes(value):
+    return "{:.1f} MiB ({} B)".format(value / (1024 * 1024), value)
+
+
+def _worst(records, key):
+    return max(records, key=lambda record: record[key]) if records else None
+
+
+def _modules_suffix(kernel, launched_modules):
+    """' [moduleA, moduleB]' attribution suffix, or '' when no attribution is available."""
+    if launched_modules is None:
+        return ""
+    modules = launched_modules.get(kernel)
+    return "  [{}]".format(", ".join(modules)) if modules else "  [unattributed]"
+
+
+def _emit_reservation(out, label, worst, max_resident, launched_modules=None):
+    """Write a 'reservation = threads x stack' block for the worst kernel (or a zero line)."""
+    if worst is None or worst["stack"] == 0:
+        out.write("  {}: {}\n".format(label, _human_bytes(0)))
+        return
+    out.write("  {}: {} = {} threads x {} B\n".format(
+        label, _human_bytes(max_resident * worst["stack"]), max_resident, worst["stack"]))
+    out.write("      largest stack frame {} B in {}\n".format(worst["stack"], worst["library"]))
+    out.write("      kernel: {}{}\n".format(worst["short"], _modules_suffix(worst["kernel"], launched_modules)))
+
+
+def _report(out, records, library_labels, devices, unresolved, top, verbose,
+            launched_names=None, unmatched_display=None, launched_modules=None):
+    """Write the human-readable budget report to out.
+
+    With launched_names (a set of mangled kernel names captured from a real run), the headline
+    budget covers only those kernels and the configuration's all-kernels figure is shown as a
+    static upper bound; otherwise only the static figure is reported. Records tagged
+    config=False come from libraries the run loaded that are not configuration plugins; they
+    locate launched kernels and never feed the static bound.
+    """
+    nlibraries = len(library_labels)
+    nmodules = len(set().union(*library_labels.values())) if library_labels else 0
+    config_records = [record for record in records if record.get("config", True)]
+    # pick the device arch from the configuration's libraries when available, so the static
+    # bound is never blanked out by an extra run-loaded library that happens to add an arch
+    arch_pool = config_records if config_records else records
+    available_sms = sorted({record["arch"] for record in arch_pool}, key=lambda sm: int(sm.split("_")[1]))
+    record_names = {record["kernel"] for record in records}
+    extra_libraries = {record["library"] for record in records if not record.get("config", True)}
+
+    out.write("CUDA kernel stack-frame memory budget\n")
+    out.write("  scheduled modules using CUDA libraries: {}\n".format(nmodules))
+    out.write("  CUDA libraries from the configuration:  {}\n".format(nlibraries))
+    if launched_names is not None:
+        out.write("  extra libraries scanned from the run:   {}\n".format(len(extra_libraries)))
+    out.write("  kernels inspected:                      {}\n".format(len(records)))
+    if launched_names is not None:
+        matched = record_names & launched_names
+        out.write("  kernels actually launched (CUPTI):      {} ({} matched to stack data)\n".format(
+            len(launched_names), len(matched)))
+    if not records:
+        out.write("\n  no CUDA kernels found for this configuration: reservation is 0 B.\n")
+
+    for device in devices:
+        cc = device["compute_capability"]
+        max_resident = device["max_resident_threads"]
+        target_sm = compute_capability_to_sm(cc)
+        name = device.get("name", "")
+        index = device.get("index")
+        prefix = "device {}: ".format(index) if index is not None else ""
+        out.write("\n{}{} (compute capability {}, {})\n".format(prefix, name, cc, target_sm))
+
+        if max_resident is None:
+            out.write("  max resident threads unknown: pass --max-resident-threads.\n")
+            continue
+        out.write("  max resident threads: {}\n".format(max_resident))
+
+        if not records:
+            out.write("  worst-case reservation: {}\n".format(_human_bytes(0)))
+            continue
+
+        chosen_sm, fell_back = select_arch(target_sm, available_sms)
+        if chosen_sm is None:
+            out.write("  no embedded arch <= {} (have {}); cannot estimate.\n".format(target_sm, ", ".join(available_sms)))
+            continue
+        if fell_back:
+            out.write("  WARNING: {} not embedded; using nearest lower arch {}.\n".format(target_sm, chosen_sm))
+
+        arch_records = [record for record in records if record["arch"] == chosen_sm]
+
+        if launched_names is None:
+            active = arch_records
+            _emit_reservation(out, "worst-case reservation", _worst(active, "stack"), max_resident)
+        else:
+            active = [record for record in arch_records if record["kernel"] in launched_names]
+            _emit_reservation(out, "reservation (launched kernels)", _worst(active, "stack"), max_resident,
+                              launched_modules)
+            # the static upper bound stays over the configuration's CUDA libraries only
+            static_active = [record for record in arch_records if record.get("config", True)]
+            static_worst = _worst(static_active, "stack")
+            static_bytes = max_resident * static_worst["stack"] if static_worst else 0
+            out.write("  static upper bound (config's CUDA libraries): {}\n".format(_human_bytes(static_bytes)))
+
+        worst_local = _worst(active, "local")
+        if worst_local is not None and worst_local["local"] > 0:
+            out.write("  (largest local-memory/spill per thread: {} B in {})\n".format(
+                worst_local["local"], worst_local["library"]))
+
+        if verbose:
+            spilling = sorted(
+                (record for record in active if record["stack"] > 0),
+                key=lambda record: record["stack"],
+                reverse=True,
+            )
+            out.write("  spilling kernels ({}):\n".format(len(spilling)))
+            shown = spilling if top <= 0 else spilling[:top]
+            for record in shown:
+                out.write("    STACK {:>6} B  LOCAL {:>6} B  REG {:>3}  {}{}\n".format(
+                    record["stack"], record["local"], record["reg"], record["short"],
+                    _modules_suffix(record["kernel"], launched_modules)))
+            hidden = spilling[len(shown):]
+            if hidden:
+                lo, hi = hidden[-1]["stack"], hidden[0]["stack"]
+                out.write("    ({} more kernels with STACK {}-{} B not shown; pass --top 0 to list all)\n".format(
+                    len(hidden), lo, hi))
+
+    if verbose and library_labels:
+        out.write("\nCUDA libraries from the configuration:\n")
+        for path in sorted(library_labels):
+            out.write("  {}\n".format(os.path.basename(path)))
+            out.write("    used by: {}\n".format(", ".join(library_labels[path])))
+        if extra_libraries:
+            out.write("additional libraries scanned from the run:\n")
+            for library in sorted(extra_libraries):
+                out.write("  {}\n".format(library))
+
+    if launched_names is not None and unmatched_display:
+        out.write("\nNOTE: {} launched kernel(s) were not found in any scanned library, so their\n"
+                  "      stack frames are not included (typically statically linked into cmsRun or\n"
+                  "      a dependency without a fatbin):\n".format(len(unmatched_display)))
+        shown = unmatched_display if top <= 0 else unmatched_display[:top]
+        for kernel in shown:
+            out.write("  {}\n".format(kernel))
+        if len(unmatched_display) > len(shown):
+            out.write("  (... {} more; pass --top 0 to list all)\n".format(len(unmatched_display) - len(shown)))
+
+    if unresolved:
+        out.write("\nWARNING: {} scheduled module(s) could not be resolved to a library:\n".format(len(unresolved)))
+        for label, plugin in unresolved:
+            out.write("  {} -> {}\n".format(label, plugin))
+
+
+def _iter_file_lines(path):
+    """Yield the lines of path; yield nothing if it cannot be opened."""
+    try:
+        handle = open(path)
+    except OSError:
+        return
+    with handle:
+        for line in handle:
+            yield line
+
+
+def _read_lines(path):
+    """Read a file into the set of its non-empty, stripped lines."""
+    return {stripped for line in _iter_file_lines(path) if (stripped := line.strip())}
+
+
+def _read_launched(path):
+    """Read the CuptiKernelLoggerService kernel log.
+
+    Lines are "<mangled kernel>\\t<module label>" (the module may be empty). Returns the set of
+    launched kernel names and a {kernel: sorted module labels} attribution map.
+    """
+    names = set()
+    modules = defaultdict(set)
+    for line in _iter_file_lines(path):
+        kernel, _, module = line.rstrip("\n").partition("\t")
+        kernel = kernel.strip()
+        if not kernel:
+            continue
+        names.add(kernel)
+        module = module.strip()
+        if module:
+            modules[kernel].add(module)
+    return names, {kernel: sorted(labels) for kernel, labels in modules.items()}
+
+
+def capture_launched_kernels(config, config_args):
+    """Run cmsRun once with CuptiKernelLoggerService added to the configuration.
+
+    Returns (launched kernel names, {kernel: modules}, loaded library paths, returncode).
+    cmsRun's own output streams to the terminal so the run is visible.
+    """
+    import tempfile
+
+    cmsrun = shutil.which("cmsRun")
+    if not cmsrun:
+        raise RuntimeError("cmsRun not found on PATH (set up the CMSSW environment)")
+
+    kernel_handle, kernel_log = tempfile.mkstemp(prefix="kernel-log-", suffix=".txt")
+    os.close(kernel_handle)
+    library_handle, library_log = tempfile.mkstemp(prefix="kernel-libs-", suffix=".txt")
+    os.close(library_handle)
+    wrapper_handle, wrapper = tempfile.mkstemp(prefix="kernel-budget-cfg-", suffix=".py")
+    os.close(wrapper_handle)
+    # run the user configuration unchanged, then attach the logging service (mirroring
+    # processFromFile's sys.path / __file__ handling so the config resolves the same way)
+    config = os.path.abspath(config)
+    with open(wrapper, "w") as out:
+        out.write(
+            "import sys, FWCore.ParameterSet.Config as cms\n"
+            "sys.path.insert(0, {dir!r})\n"
+            "__file__ = {config!r}\n"
+            "exec(compile(open({config!r}).read(), {config!r}, 'exec'))\n"
+            "process.add_(cms.Service('CuptiKernelLoggerService',\n"
+            "    kernelLog=cms.untracked.string({kernel!r}),\n"
+            "    libraryLog=cms.untracked.string({library!r})))\n"
+            # subscribe the service in the MessageLogger
+            "if not hasattr(process, 'MessageLogger'):\n"
+            "    process.load('FWCore.MessageService.MessageLogger_cfi')\n"
+            "if not hasattr(process.MessageLogger, 'CuptiKernelLoggerService'):\n"
+            "    process.MessageLogger.CuptiKernelLoggerService = cms.untracked.PSet()\n".format(
+                dir=os.path.dirname(config), config=config, kernel=kernel_log, library=library_log))
+    try:
+        completed = subprocess.run([cmsrun, wrapper] + list(config_args))
+        names, modules = _read_launched(kernel_log)
+        return names, modules, _read_lines(library_log), completed.returncode
+    finally:
+        for path in (kernel_log, library_log, wrapper):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
+def _value_option_strings(parser):
+    """Return the set of option strings (e.g. '--top') that consume a following value.
+
+    Derived from the parser itself so _split_cli stays in sync with the declared options: a
+    new value-taking flag is recognised automatically, with no second list to update.
+    """
+    options = set()
+    for action in parser._actions:
+        if action.option_strings and action.nargs != 0:
+            options.update(action.option_strings)
+    return options
+
+
+def _split_cli(argv, value_options=None):
+    """Split argv into (tool options, config path, config arguments).
+
+    The first bare token (not an option and not an option's value) is the configuration;
+    everything after it is forwarded to the configuration verbatim. This keeps the tool's own
+    flags order-independent while letting the config keep flags of the same name. value_options
+    is the set of flags that take a separate value (see _value_option_strings); it defaults to
+    the tool's own parser so callers and tests need not recompute it.
+    """
+    if value_options is None:
+        value_options = _value_option_strings(_build_parser())
+    tool_args = []
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if not token.startswith("-"):
+            return tool_args, token, argv[index + 1:]
+        tool_args.append(token)
+        if token in value_options and index + 1 < len(argv):
+            tool_args.append(argv[index + 1])
+            index += 2
+        else:
+            index += 1
+    return tool_args, None, []
+
+
+def _build_parser():
+    """Build the argument parser. allow_abbrev is off so abbreviated flags (e.g. --comp) are a
+    clean error rather than being silently treated as the CONFIG path by _split_cli."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="cudaKernelStackBudget",
+        allow_abbrev=False,
+        usage="%(prog)s [options] CONFIG.py [config args...]",
+        description="Estimate the worst-case CUDA local-memory backing store reserved by a "
+                    "cmsRun configuration, from the largest per-thread kernel stack frame "
+                    "(known at compile time) across the plugin libraries the config loads. "
+                    "The result is a conservative upper bound (max stack over all kernels in "
+                    "the loaded CUDA libraries, not only the kernels each module launches). "
+                    "Tool options must precede CONFIG.py; anything after it is forwarded to "
+                    "the configuration.",
+    )
+    parser.add_argument("config", help="cmsRun Python configuration file")
+    parser.add_argument("--backend", default="cuda_async",
+                        help="Alpaka backend to resolve @alpaka modules to (default: cuda_async)")
+    parser.add_argument("--compute-capability", dest="compute_capability",
+                        help="target compute capability, e.g. 9.0 or 90 (default: auto-detect devices)")
+    parser.add_argument("--max-resident-threads", dest="max_resident_threads", type=int,
+                        help="multiProcessorCount * maxThreadsPerMultiProcessor for the target device")
+    parser.add_argument("--launched", action="store_true",
+                        help="run cmsRun once with the CUPTI logger service and report only the "
+                             "kernels actually launched, with the module that launched each "
+                             "(in addition to the static upper bound)")
+    parser.add_argument("--top", type=int, default=25,
+                        help="cap the verbose spilling-kernel listing at N rows (0 = all; default 25)")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="print the per-kernel and per-library breakdown")
+    return parser
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+    parser = _build_parser()
+    tool_args, config, config_args = _split_cli(argv, _value_option_strings(parser))
+    args = parser.parse_args(tool_args + ([config] if config is not None else []))
+
+    if args.compute_capability is not None:
+        normalized = args.compute_capability[3:] if args.compute_capability.startswith("sm_") else args.compute_capability
+        if not re.fullmatch(r"\d+(\.\d+)?", normalized):
+            parser.error("invalid --compute-capability {!r}; expected e.g. 9.0 or 90".format(args.compute_capability))
+
+    cuobjdump = find_tool("cuobjdump")
+    if not cuobjdump:
+        parser.error("cuobjdump not found (set up the CUDA environment, e.g. cmsenv)")
+
+    # pass a list (never None) so processFromFile resets the config's sys.argv; otherwise the
+    # config would parse this tool's argv
+    try:
+        process = processFromFile(config, config_args)
+    except SystemExit as error:
+        parser.error("configuration {} exited during loading (code {})".format(config, error.code))
+    except Exception as error:
+        parser.error("could not load configuration {}: {}".format(config, error))
+    lib_dirs = lib_directories()
+    plugin_cache = parse_plugin_cache(lib_dirs)
+    library_labels, unresolved = loaded_cuda_libraries(process, args.backend, plugin_cache, lib_dirs)
+
+    # static analyzer: every kernel in the configuration's CUDA libraries
+    records = _scan_libraries(library_labels, cuobjdump, True)
+
+    exit_code = 0
+    launched_names = None
+    launched_modules = None
+    unmatched_display = None
+    if args.launched:
+        sys.stderr.write("Running cmsRun with the CUPTI kernel logger service to capture launched kernels...\n")
+        launched_names, launched_modules, loaded_libraries, returncode = capture_launched_kernels(config, config_args)
+        if returncode != 0:
+            # the launched data is incomplete; report it and fail so automation notices
+            sys.stderr.write("WARNING: cmsRun exited with code {}; launched-kernel data may be incomplete.\n".format(
+                returncode))
+            exit_code = 1
+        if not launched_names:
+            sys.stderr.write("WARNING: no launched kernels captured. If this was a GPU run the service may not "
+                             "have attached (another CUPTI client active, a non-CUDA backend, or an abnormal "
+                             "exit); the launched figures below will read 0 B.\n")
+        # scan libraries the run loaded but the configuration did not, so launched kernels in
+        # services or shared device libraries are found; has_device_code skips host-only ones.
+        # realpath dedup avoids rescanning a configuration library reached via a different path.
+        inspected = {os.path.realpath(path) for path in library_labels}
+        extra = []
+        for library in sorted(loaded_libraries):
+            real = os.path.realpath(library)
+            if real in inspected or not os.path.exists(library) or not has_device_code(library):
+                continue
+            inspected.add(real)
+            extra.append(library)
+        records += _scan_libraries(extra, cuobjdump, False)
+
+    # only the spilling kernels (STACK > 0) are ever displayed (worst-stack headline and the
+    # verbose listing), so demangle just those; the rest keep their mangled name as "short"
+    names = demangle({record["kernel"] for record in records if record["stack"] > 0})
+    for record in records:
+        record["demangled"] = names.get(record["kernel"], record["kernel"])
+        record["short"] = short_kernel_name(record["demangled"])
+
+    if launched_names:
+        unmatched = sorted(launched_names - {record["kernel"] for record in records})
+        if unmatched:
+            unmatched_names = demangle(unmatched)
+            unmatched_display = sorted(short_kernel_name(unmatched_names.get(name, name)) for name in unmatched)
+
+    if args.compute_capability is not None or args.max_resident_threads is not None:
+        if args.compute_capability is None or args.max_resident_threads is None:
+            parser.error("--compute-capability and --max-resident-threads must be given together")
+        devices = [{
+            "index": None,
+            "compute_capability": args.compute_capability,
+            "name": "target device",
+            "max_resident_threads": args.max_resident_threads,
+        }]
+    else:
+        devices = detect_devices()
+        if not devices:
+            parser.error("no CUDA devices detected; pass --compute-capability and --max-resident-threads")
+
+    _report(sys.stdout, records, library_labels, devices, unresolved, args.top, args.verbose,
+            launched_names, unmatched_display, launched_modules)
+    return exit_code

--- a/HeterogeneousCore/CUDAUtilities/python/kernelStackBudget.py
+++ b/HeterogeneousCore/CUDAUtilities/python/kernelStackBudget.py
@@ -11,6 +11,16 @@ module to its plugin library, reads the per-kernel STACK size with cuobjdump, an
 maxResidentThreads * max(STACK) per device. That is a conservative upper bound over every
 kernel in those libraries. The --launched mode runs the job once under a CUPTI logger and
 reports only the kernels that actually launched.
+
+Alongside the stack budget it reports each kernel's per-block shared-memory use: the static
+amount from cuobjdump and, in --launched mode, the dynamic amount requested at launch (from
+CUPTI) and their total. That helps decide whether register/local spills could be steered into
+the on-chip L1/shared memory instead of global memory.
+
+If the target device has no compatible embedded SASS arch (it would JIT-compile the PTX at
+runtime), the tool exits with an error rather than report figures that would not describe what
+actually runs; arch compatibility follows the CUDA rules for base, family ('f') and accelerated
+('a') targets.
 """
 
 import concurrent.futures
@@ -26,8 +36,9 @@ from FWCore.ParameterSet.processFromFile import processFromFile
 
 _ALPAKA_SUFFIX = "@alpaka"
 
-# cuobjdump --dump-resource-usage parsing
-_ARCH_RE = re.compile(r"arch\s*=\s*(sm_\d+)")
+# cuobjdump --dump-resource-usage parsing; the arch carries the CUDA 12.9+ variant suffix, e.g.
+# "arch = sm_90a" (accelerated) or "arch = sm_100f" (family-specific)
+_ARCH_RE = re.compile(r"arch\s*=\s*(sm_\d+[af]?)")
 _FUNC_RE = re.compile(r"Function\s+(\S+):")
 _USAGE_RE = re.compile(r"REG:(\d+)\s+STACK:(\d+)\s+SHARED:(\d+)\s+LOCAL:(\d+)")
 
@@ -37,25 +48,35 @@ _MAXRES_RE = re.compile(r"max resident threads:\s*(\d+)")
 
 
 def find_tool(name):
-    """Locate a CUDA/CMSSW tool, preferring the build's CUDA external, then $PATH."""
-    cuda_base = os.environ.get("CUDA_BASE")
-    if cuda_base:
-        candidate = os.path.join(cuda_base, "bin", name)
-        if os.path.exists(candidate):
-            return candidate
+    """Locate a CUDA/CMSSW tool on $PATH (cmsenv puts the CUDA external's bin/ on it)."""
     return shutil.which(name)
 
 
 def lib_directories():
-    """Library directories to search, local developer area first, then the base release."""
+    """CMSSW plugin-library directories to search, developer area first, then the release base(s).
+
+    Ordering matters: locally rebuilt plugins in the developer area must shadow the release, so
+    the developer-area directories have to come first.
+
+    The directories are read from LD_LIBRARY_PATH, which scram (cmsenv) fills with every plugin
+    directory in the right precedence order (local, then cvmfs).
+    """
     arch = os.environ.get("SCRAM_ARCH", "")
     dirs = []
-    for var in ("CMSSW_BASE", "CMSSW_RELEASE_BASE"):
-        top = os.environ.get(var)
-        if top:
-            path = os.path.join(top, "lib", arch)
-            if os.path.isdir(path) and path not in dirs:
-                dirs.append(path)
+
+    def add(path):
+        if path and os.path.isdir(path) and path not in dirs:
+            dirs.append(path)
+
+    def is_plugin_dir(path):
+        parts = path.rstrip("/").split(os.sep)
+        return (len(parts) >= 2 and parts[-2:] == ["lib", arch]) or \
+               (len(parts) >= 3 and parts[-3:-1] == ["lib", arch])
+
+    for path in os.environ.get("LD_LIBRARY_PATH", "").split(os.pathsep):
+        if is_plugin_dir(path):
+            add(path)
+
     return dirs
 
 
@@ -89,7 +110,11 @@ def resolve_library_path(basename, lib_dirs):
 
 
 def _module_backend(module, default_backend):
-    """Return the Alpaka backend an @alpaka module resolves to."""
+    """Return the Alpaka backend an @alpaka module resolves to.
+
+    A per-module 'alpaka.backend' set explicitly in the configuration wins; otherwise the
+    process-wide default_backend applies (see config_backend).
+    """
     alpaka = getattr(module, "alpaka", None)
     if alpaka is not None and hasattr(alpaka, "backend"):
         backend = alpaka.backend.value()
@@ -108,6 +133,52 @@ def plugin_name_for(cpp_type, module, default_backend):
         base = cpp_type[: -len(_ALPAKA_SUFFIX)]
         return "alpaka_{}::{}".format(_module_backend(module, default_backend), base)
     return cpp_type
+
+
+# accelerator name (process.options.accelerators) -> Alpaka backend, in the priority order
+# ModuleTypeResolverAlpaka uses when picking the default backend
+_ACCELERATOR_BACKENDS = (
+    ("gpu-nvidia", "cuda_async"),
+    ("gpu-amd", "rocm_async"),
+    ("cpu", "serial_sync"),
+)
+# the Alpaka backend that emits CUDA device code: the only backend this tool can analyse, the
+# natural default, and what '*' (all accelerators, nvidia first) resolves to here
+_CUDA_BACKEND = "cuda_async"
+
+
+def config_backend(process):
+    """Return the Alpaka backend @alpaka modules resolve to, honouring the configuration.
+
+    Mirrors HeterogeneousCore/AlpakaCore ModuleTypeResolverAlpaka: an explicit
+    ProcessAcceleratorAlpaka.setBackend(...) wins; otherwise the backend follows
+    process.options.accelerators (the first of gpu-nvidia -> cuda_async, gpu-amd -> rocm_async,
+    cpu -> serial_sync that the requested accelerators allow). '*' (the default) allows all, which
+    for this tool means cuda_async. Anything that cannot be read falls back to cuda_async.
+    """
+    import fnmatch
+
+    # an explicit ProcessAcceleratorAlpaka.setBackend(...) takes precedence over the accelerators
+    try:
+        accelerators = process.processAccelerators_()
+    except (AttributeError, TypeError):
+        accelerators = {}
+    for accelerator in accelerators.values():
+        if type(accelerator).__name__ == "ProcessAcceleratorAlpaka":
+            backend = getattr(accelerator, "_backend", None)
+            if backend:
+                return backend
+
+    # otherwise follow process.options.accelerators (patterns such as 'gpu-*' are allowed)
+    try:
+        selected = list(process.options.accelerators)
+    except (AttributeError, TypeError):
+        selected = []
+    if selected and "*" not in selected:
+        for name, backend in _ACCELERATOR_BACKENDS:
+            if any(fnmatch.fnmatch(name, pattern) for pattern in selected):
+                return backend
+    return _CUDA_BACKEND
 
 
 def scheduled_modules(process):
@@ -348,15 +419,126 @@ def detect_devices():
     return parse_device_info(completed.stdout)
 
 
+def _parse_arch(sm):
+    """Split an arch string into (compute-capability number, variant suffix).
+
+    'sm_75' -> (75, ''), 'sm_100' -> (100, ''), 'sm_100f' -> (100, 'f'), 'sm_90a' -> (90, 'a').
+    The 'f' (family-specific) and 'a' (architecture-specific, "accelerated") suffixes are the CUDA
+    12.9+ arch-conditional variants that cuobjdump reports in its "arch = ..." line.
+    """
+    body = sm.split("_", 1)[1]
+    suffix = ""
+    if body and body[-1] in "af":
+        suffix, body = body[-1], body[:-1]
+    return int(body), suffix
+
+
+# preference when several compatible arch variants are embedded for the same function: accelerated
+# ('a') over family ('f') over base, then the higher compute capability
+_ARCH_VARIANT_PRIORITY = {"a": 2, "f": 1, "": 0}
+
+
+def _arch_preference(arch):
+    """Sort key for the arch the driver would prefer: variant first (a > f > base), then CC."""
+    number, suffix = _parse_arch(arch)
+    return (_ARCH_VARIANT_PRIORITY[suffix], number)
+
+
+def _sm_major_minor(sm):
+    """Split an arch string into (major, minor), ignoring any variant suffix.
+
+    Compute capabilities have a single-digit minor revision, so the last digit of the number is the
+    minor and everything before it is the major (two digits from Blackwell/sm_10x onwards).
+    """
+    number, _ = _parse_arch(sm)
+    return number // 10, number % 10
+
+
+# major compute-capability generations whose base (no-suffix) SASS is forward-compatible beyond the
+# usual same-major rule. Blackwell datacenter (sm_10x) and consumer (sm_12x) share this: base sm_100
+# also runs on sm_120, whereas sm_100f (family-specific) and sm_100a (accelerated) do not.
+_BASE_COMPATIBLE_GENERATIONS = (frozenset({10, 12}),)
+
+
+def _arch_runs_on(arch, device_number):
+    """True if SASS compiled for `arch` runs on a device of compute capability `device_number`.
+
+    `arch` is a cuobjdump arch string, optionally with a variant suffix; `device_number` is the
+    device's plain compute capability (e.g. 120 for sm_120). CUDA binary (SASS) compatibility:
+      * accelerated ('a', e.g. sm_100a): only the exact same compute capability, nothing else.
+      * family ('f', e.g. sm_100f): same major generation, forward across minor revisions.
+      * base (no suffix): same major generation forward, plus the cross-generation families NVIDIA
+        declares forward-compatible (Blackwell base sm_10x also runs on sm_12x).
+    SASS is never backward compatible: a device never runs code built for a higher capability, and
+    (for example) a Turing sm_75 device runs Volta sm_70 code but not Pascal sm_6x code.
+    """
+    number, suffix = _parse_arch(arch)
+    if suffix == "a":
+        return device_number == number
+    if device_number < number:
+        return False
+    major, device_major = number // 10, device_number // 10
+    if device_major == major:
+        return True
+    if suffix == "f":
+        return False
+    return any(major in family and device_major in family for family in _BASE_COMPATIBLE_GENERATIONS)
+
+
 def select_arch(target_sm, available_sms):
-    """Pick the embedded arch matching the device, else the highest embedded arch below it."""
-    if target_sm in available_sms:
-        return target_sm, False
-    target_n = int(target_sm.split("_")[1])
-    lower = sorted((int(sm.split("_")[1]) for sm in available_sms if int(sm.split("_")[1]) <= target_n))
-    if lower:
-        return "sm_{}".format(lower[-1]), True
-    return None, False
+    """Pick the embedded SASS arch that will run on a device of compute capability `target_sm`.
+
+    Returns (chosen_sm, fell_back). chosen_sm is None when no embedded arch runs on the device --
+    the driver would JIT-compile the embedded PTX, whose per-kernel resource usage cuobjdump cannot
+    report (cudaKernelStackBudget treats that as a fatal error). fell_back is True when the chosen
+    arch is not the device's own compute capability (a compatible lower/other arch is used instead).
+
+    Compatibility follows _arch_runs_on: exact match for 'a' (accelerated) variants, same major
+    generation forward for 'f' (family) variants, and that plus the declared cross-generation
+    families for base arches. Among the compatible arches the highest compute capability is chosen.
+    PTX JIT resource usage is not known untile runtime: sm incompatibility is treated as an error.
+    """
+    device_number, _ = _parse_arch(target_sm)
+    compatible = [sm for sm in available_sms if _arch_runs_on(sm, device_number)]
+    if not compatible:
+        return None, False
+    chosen = max(compatible, key=lambda sm: _parse_arch(sm)[0])
+    return chosen, _parse_arch(chosen)[0] != device_number
+
+
+def _available_arches(records):
+    """Sorted embedded SASS arches, preferring the configuration's own libraries.
+
+    Run-loaded libraries (config=False) are ignored while the configuration's libraries provide any
+    arch, so an extra library that happens to embed a different arch cannot skew the selection.
+    """
+    config_records = [record for record in records if record.get("config", True)]
+    pool = config_records if config_records else records
+    return sorted({record["arch"] for record in pool}, key=lambda sm: _parse_arch(sm)[0])
+
+
+def _device_records(records, device_number):
+    """Per (kernel, library), the record for the arch the driver would run on the device.
+
+    A function is embedded once per arch; among the arches that run on the device the most specific
+    variant is preferred in the following order:
+    - accelerated ('a') (e.g. sm_100a)
+    - family ('f') (e.g. sm_100f)
+    - base (e.g. sm_100)
+    - if the code was not compiled for base, take the highest compatible compute capability
+    Functions with no device-compatible arch are dropped.
+    Selecting per function (rather than filtering on one 'chosen' arch string) keeps arch-variant
+    functions that an exact arch-string match would otherwise miss.
+    """
+    best = {}
+    for record in records:
+        if not _arch_runs_on(record["arch"], device_number):
+            continue
+        key = (record["kernel"], record["library"])
+        current = best.get(key)
+        if current is None or _arch_preference(record["arch"]) > _arch_preference(current["arch"]):
+            best[key] = record
+    return list(best.values())
 
 
 def _scan_libraries(paths, cuobjdump, from_config):
@@ -381,7 +563,7 @@ def _human_bytes(value):
 
 
 def _worst(records, key):
-    return max(records, key=lambda record: record[key]) if records else None
+    return max(records, key=lambda record: record.get(key, 0)) if records else None
 
 
 def _modules_suffix(kernel, launched_modules):
@@ -392,8 +574,12 @@ def _modules_suffix(kernel, launched_modules):
     return "  [{}]".format(", ".join(modules)) if modules else "  [unattributed]"
 
 
-def _emit_reservation(out, label, worst, max_resident, launched_modules=None):
-    """Write a 'reservation = threads x stack' block for the worst kernel (or a zero line)."""
+def _emit_reservation(out, label, worst, max_resident, launched_modules=None, launched=False):
+    """Write a 'reservation = threads x stack' block for the worst kernel (or a zero line).
+
+    The block also reports that kernel's per-block shared-memory use: the static amount (from
+    cuobjdump) and, when launched is set, the dynamic amount captured at launch and their total.
+    """
     if worst is None or worst["stack"] == 0:
         out.write("  {}: {}\n".format(label, _human_bytes(0)))
         return
@@ -401,6 +587,13 @@ def _emit_reservation(out, label, worst, max_resident, launched_modules=None):
         label, _human_bytes(max_resident * worst["stack"]), max_resident, worst["stack"]))
     out.write("      largest stack frame {} B in {}\n".format(worst["stack"], worst["library"]))
     out.write("      kernel: {}{}\n".format(worst["short"], _modules_suffix(worst["kernel"], launched_modules)))
+    static_shared = worst.get("shared", 0)
+    if launched:
+        dynamic_shared = worst.get("dyn_shared", 0)
+        out.write("      shared memory: {} B total = {} B static + {} B dynamic\n".format(
+            static_shared + dynamic_shared, static_shared, dynamic_shared))
+    else:
+        out.write("      shared memory: {} B static\n".format(static_shared))
 
 
 def _report(out, records, library_labels, devices, unresolved, top, verbose,
@@ -415,11 +608,9 @@ def _report(out, records, library_labels, devices, unresolved, top, verbose,
     """
     nlibraries = len(library_labels)
     nmodules = len(set().union(*library_labels.values())) if library_labels else 0
-    config_records = [record for record in records if record.get("config", True)]
-    # pick the device arch from the configuration's libraries when available, so the static
+    # the device arch is chosen from the configuration's own libraries when available, so the static
     # bound is never blanked out by an extra run-loaded library that happens to add an arch
-    arch_pool = config_records if config_records else records
-    available_sms = sorted({record["arch"] for record in arch_pool}, key=lambda sm: int(sm.split("_")[1]))
+    available_sms = _available_arches(records)
     record_names = {record["kernel"] for record in records}
     extra_libraries = {record["library"] for record in records if not record.get("config", True)}
 
@@ -454,14 +645,17 @@ def _report(out, records, library_labels, devices, unresolved, top, verbose,
             out.write("  worst-case reservation: {}\n".format(_human_bytes(0)))
             continue
 
+        # main() already rejects a device with no compatible arch (it would JIT from PTX); this is a
+        # defensive guard for direct callers of _report
         chosen_sm, fell_back = select_arch(target_sm, available_sms)
         if chosen_sm is None:
-            out.write("  no embedded arch <= {} (have {}); cannot estimate.\n".format(target_sm, ", ".join(available_sms)))
+            out.write("  no embedded arch runs on {} (have {}); would JIT from PTX, cannot estimate.\n".format(
+                target_sm, ", ".join(available_sms)))
             continue
         if fell_back:
-            out.write("  WARNING: {} not embedded; using nearest lower arch {}.\n".format(target_sm, chosen_sm))
+            out.write("  WARNING: {} not embedded; using compatible arch {}.\n".format(target_sm, chosen_sm))
 
-        arch_records = [record for record in records if record["arch"] == chosen_sm]
+        arch_records = _device_records(records, _parse_arch(target_sm)[0])
 
         if launched_names is None:
             active = arch_records
@@ -469,7 +663,7 @@ def _report(out, records, library_labels, devices, unresolved, top, verbose,
         else:
             active = [record for record in arch_records if record["kernel"] in launched_names]
             _emit_reservation(out, "reservation (launched kernels)", _worst(active, "stack"), max_resident,
-                              launched_modules)
+                              launched_modules, launched=True)
             # the static upper bound stays over the configuration's CUDA libraries only
             static_active = [record for record in arch_records if record.get("config", True)]
             static_worst = _worst(static_active, "stack")
@@ -490,9 +684,12 @@ def _report(out, records, library_labels, devices, unresolved, top, verbose,
             out.write("  spilling kernels ({}):\n".format(len(spilling)))
             shown = spilling if top <= 0 else spilling[:top]
             for record in shown:
-                out.write("    STACK {:>6} B  LOCAL {:>6} B  REG {:>3}  {}{}\n".format(
-                    record["stack"], record["local"], record["reg"], record["short"],
-                    _modules_suffix(record["kernel"], launched_modules)))
+                # SHARED is the static per-block shared memory; DYN (launched runs only) is the
+                # dynamic amount requested at launch, so SHARED + DYN is the per-block total
+                dyn_col = "  DYN {:>6} B".format(record.get("dyn_shared", 0)) if launched_names is not None else ""
+                out.write("    STACK {:>6} B  LOCAL {:>6} B  SHARED {:>6} B{}  REG {:>3}  {}{}\n".format(
+                    record["stack"], record["local"], record.get("shared", 0), dyn_col,
+                    record["reg"], record["short"], _modules_suffix(record["kernel"], launched_modules)))
             hidden = spilling[len(shown):]
             if hidden:
                 lo, hi = hidden[-1]["stack"], hidden[0]["stack"]
@@ -544,28 +741,39 @@ def _read_lines(path):
 def _read_launched(path):
     """Read the CuptiKernelLoggerService kernel log.
 
-    Lines are "<mangled kernel>\\t<module label>" (the module may be empty). Returns the set of
-    launched kernel names and a {kernel: sorted module labels} attribution map.
+    Lines are "<mangled kernel>\\t<module label>\\t<max dynamic shared bytes>" (the module may be
+    empty).
+    Returns the set of launched kernel names, a {kernel: sorted module labels} attribution map,
+    and a {kernel: max dynamic shared bytes} map (only kernels seen with a non-zero amount).
     """
     names = set()
     modules = defaultdict(set)
+    dynamic_shared = {}
     for line in _iter_file_lines(path):
-        kernel, _, module = line.rstrip("\n").partition("\t")
-        kernel = kernel.strip()
+        fields = line.rstrip("\n").split("\t")
+        kernel = fields[0].strip()
         if not kernel:
             continue
         names.add(kernel)
-        module = module.strip()
+        module = fields[1].strip() if len(fields) > 1 else ""
         if module:
             modules[kernel].add(module)
-    return names, {kernel: sorted(labels) for kernel, labels in modules.items()}
+        if len(fields) > 2:
+            try:
+                shared = int(fields[2].strip() or "0")
+            except ValueError:
+                shared = 0
+            if shared > dynamic_shared.get(kernel, 0):
+                dynamic_shared[kernel] = shared
+    return names, {kernel: sorted(labels) for kernel, labels in modules.items()}, dynamic_shared
 
 
 def capture_launched_kernels(config, config_args):
     """Run cmsRun once with CuptiKernelLoggerService added to the configuration.
 
-    Returns (launched kernel names, {kernel: modules}, loaded library paths, returncode).
-    cmsRun's own output streams to the terminal so the run is visible.
+    Returns (launched kernel names, {kernel: modules}, {kernel: max dynamic shared bytes},
+    loaded library paths, returncode). cmsRun's own output streams to the terminal so the run is
+    visible.
     """
     import tempfile
 
@@ -599,8 +807,8 @@ def capture_launched_kernels(config, config_args):
                 dir=os.path.dirname(config), config=config, kernel=kernel_log, library=library_log))
     try:
         completed = subprocess.run([cmsrun, wrapper] + list(config_args))
-        names, modules = _read_launched(kernel_log)
-        return names, modules, _read_lines(library_log), completed.returncode
+        names, modules, dynamic_shared = _read_launched(kernel_log)
+        return names, modules, dynamic_shared, _read_lines(library_log), completed.returncode
     finally:
         for path in (kernel_log, library_log, wrapper):
             try:
@@ -666,8 +874,6 @@ def _build_parser():
                     "the configuration.",
     )
     parser.add_argument("config", help="cmsRun Python configuration file")
-    parser.add_argument("--backend", default="cuda_async",
-                        help="Alpaka backend to resolve @alpaka modules to (default: cuda_async)")
     parser.add_argument("--compute-capability", dest="compute_capability",
                         help="target compute capability, e.g. 9.0 or 90 (default: auto-detect devices)")
     parser.add_argument("--max-resident-threads", dest="max_resident_threads", type=int,
@@ -679,7 +885,7 @@ def _build_parser():
     parser.add_argument("--top", type=int, default=25,
                         help="cap the verbose spilling-kernel listing at N rows (0 = all; default 25)")
     parser.add_argument("-v", "--verbose", action="store_true",
-                        help="print the per-kernel and per-library breakdown")
+                        help="print the per-kernel (stack, local and shared memory) and per-library breakdown")
     return parser
 
 
@@ -691,8 +897,10 @@ def main(argv=None):
     args = parser.parse_args(tool_args + ([config] if config is not None else []))
 
     if args.compute_capability is not None:
-        normalized = args.compute_capability[3:] if args.compute_capability.startswith("sm_") else args.compute_capability
-        if not re.fullmatch(r"\d+(\.\d+)?", normalized):
+        # validate through the same normalisation the report uses (compute_capability_to_sm)
+        try:
+            _sm_major_minor(compute_capability_to_sm(args.compute_capability))
+        except (ValueError, IndexError):
             parser.error("invalid --compute-capability {!r}; expected e.g. 9.0 or 90".format(args.compute_capability))
 
     cuobjdump = find_tool("cuobjdump")
@@ -709,18 +917,72 @@ def main(argv=None):
         parser.error("could not load configuration {}: {}".format(config, error))
     lib_dirs = lib_directories()
     plugin_cache = parse_plugin_cache(lib_dirs)
-    library_labels, unresolved = loaded_cuda_libraries(process, args.backend, plugin_cache, lib_dirs)
+    # the backend @alpaka modules resolve to comes from the configuration (setBackend / accelerators)
+    default_backend = config_backend(process)
+    if default_backend != _CUDA_BACKEND:
+        # exit from non cuda_async configs
+        parser.error(
+            "the configuration resolves Alpaka modules to the '{}' backend, not the CUDA backend "
+            "'{}'."
+            "\nThis job would not launch CUDA kernels, so there is no device-memory budget to "
+            "estimate."
+            "\nConfigure a CUDA GPU, e.g. process.options.accelerators = ['gpu-nvidia'] or "
+            "process.ProcessAcceleratorAlpaka.setBackend('{}').".format(
+                default_backend, _CUDA_BACKEND, _CUDA_BACKEND))
+    library_labels, unresolved = loaded_cuda_libraries(process, default_backend, plugin_cache, lib_dirs)
 
     # static analyzer: every kernel in the configuration's CUDA libraries
     records = _scan_libraries(library_labels, cuobjdump, True)
 
+    # resolve the target device(s) and check arch compatibility up front, before the (possibly slow)
+    # --launched cmsRun. A device with no compatible embedded SASS arch would JIT-compile PTX at
+    # runtime, so cuobjdump's resource usage would not describe what runs: warn and skip such a
+    # device, keeping any that can be estimated, and only error out if none can.
+    if args.compute_capability is not None or args.max_resident_threads is not None:
+        if args.compute_capability is None or args.max_resident_threads is None:
+            parser.error("--compute-capability and --max-resident-threads must be given together")
+        devices = [{
+            "index": None,
+            "compute_capability": args.compute_capability,
+            "name": "target device",
+            "max_resident_threads": args.max_resident_threads,
+        }]
+    else:
+        devices = detect_devices()
+        if not devices:
+            parser.error("no CUDA devices detected; pass --compute-capability and --max-resident-threads")
+    if records:
+        available_sms = _available_arches(records)
+        satisfiable = []
+        for device in devices:
+            target_sm = compute_capability_to_sm(device["compute_capability"])
+            if select_arch(target_sm, available_sms)[0] is not None:
+                satisfiable.append(device)
+                continue
+            prefix = "device {}: ".format(device["index"]) if device.get("index") is not None else ""
+            sys.stderr.write(
+                "WARNING: {}{} (compute capability {}, {}) has no compatible embedded CUDA arch and "
+                "would JIT-compile PTX at runtime."
+                "\nSkipping it (its stack/shared-memory usage cannot be reported)."
+                "\nEmbedded arches: {}.\n".format(
+                    prefix, device.get("name", ""), device["compute_capability"], target_sm,
+                    ", ".join(available_sms)))
+        if not satisfiable:
+            parser.error(
+                "no target CUDA device can run the embedded arches ({}):"
+                "\nevery device would JIT-compile PTX at runtime, so the result would be meaningless."
+                "\nRebuild the CUDA libraries for a compatible architecture.".format(", ".join(available_sms)))
+        devices = satisfiable
+
     exit_code = 0
     launched_names = None
     launched_modules = None
+    launched_shared = None
     unmatched_display = None
     if args.launched:
         sys.stderr.write("Running cmsRun with the CUPTI kernel logger service to capture launched kernels...\n")
-        launched_names, launched_modules, loaded_libraries, returncode = capture_launched_kernels(config, config_args)
+        launched_names, launched_modules, launched_shared, loaded_libraries, returncode = capture_launched_kernels(
+            config, config_args)
         if returncode != 0:
             # the launched data is incomplete; report it and fail so automation notices
             sys.stderr.write("WARNING: cmsRun exited with code {}; launched-kernel data may be incomplete.\n".format(
@@ -749,26 +1011,16 @@ def main(argv=None):
     for record in records:
         record["demangled"] = names.get(record["kernel"], record["kernel"])
         record["short"] = short_kernel_name(record["demangled"])
+        # attach the launch-time dynamic shared memory (0 in static mode) and the per-block total
+        dynamic_shared = launched_shared.get(record["kernel"], 0) if launched_shared else 0
+        record["dyn_shared"] = dynamic_shared
+        record["total_shared"] = record.get("shared", 0) + dynamic_shared
 
     if launched_names:
         unmatched = sorted(launched_names - {record["kernel"] for record in records})
         if unmatched:
             unmatched_names = demangle(unmatched)
             unmatched_display = sorted(short_kernel_name(unmatched_names.get(name, name)) for name in unmatched)
-
-    if args.compute_capability is not None or args.max_resident_threads is not None:
-        if args.compute_capability is None or args.max_resident_threads is None:
-            parser.error("--compute-capability and --max-resident-threads must be given together")
-        devices = [{
-            "index": None,
-            "compute_capability": args.compute_capability,
-            "name": "target device",
-            "max_resident_threads": args.max_resident_threads,
-        }]
-    else:
-        devices = detect_devices()
-        if not devices:
-            parser.error("no CUDA devices detected; pass --compute-capability and --max-resident-threads")
 
     _report(sys.stdout, records, library_labels, devices, unresolved, args.top, args.verbose,
             launched_names, unmatched_display, launched_modules)

--- a/HeterogeneousCore/CUDAUtilities/scripts/cudaKernelStackBudget
+++ b/HeterogeneousCore/CUDAUtilities/scripts/cudaKernelStackBudget
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Estimate the worst-case CUDA local-memory backing store reserved by a cmsRun config.
+
+Thin command-line wrapper; the implementation lives in
+HeterogeneousCore.CUDAUtilities.kernelStackBudget so it can be unit tested.
+"""
+import sys
+
+from HeterogeneousCore.CUDAUtilities.kernelStackBudget import main
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
@@ -34,3 +34,5 @@
     <use name="cuda"/>
   </bin>
 </iftool>
+
+<test name="TestHeterogeneousCoreCUDAUtilitiesKernelStackBudget" command="python3 ${LOCALTOP}/src/HeterogeneousCore/CUDAUtilities/test/testKernelStackBudget.py"/>

--- a/HeterogeneousCore/CUDAUtilities/test/testKernelStackBudget.py
+++ b/HeterogeneousCore/CUDAUtilities/test/testKernelStackBudget.py
@@ -9,6 +9,7 @@ import contextlib
 import io
 import os
 import tempfile
+import types
 import unittest
 from unittest import mock
 
@@ -66,6 +67,14 @@ class ResourceUsageTest(unittest.TestCase):
     def test_empty_input(self):
         self.assertEqual(ksb.parse_resource_usage(""), [])
 
+    def test_parses_arch_variant_suffix(self):
+        # cuobjdump reports the CUDA 12.9+ 'a'/'f' variant suffix, which must be preserved
+        text = ("arch = sm_90a\n"
+                " Function _Zk:\n"
+                "  REG:10 STACK:8 SHARED:0 LOCAL:0 CONSTANT[0]:0 TEXTURE:0 SURFACE:0 SAMPLER:0\n")
+        records = ksb.parse_resource_usage(text)
+        self.assertEqual(records[0]["arch"], "sm_90a")
+
 
 class DeviceInfoTest(unittest.TestCase):
     def test_parses_devices_and_max_resident(self):
@@ -104,6 +113,68 @@ class ArchTest(unittest.TestCase):
         self.assertEqual(ksb.select_arch("sm_90", available), ("sm_90", False))
         self.assertEqual(ksb.select_arch("sm_89", available), ("sm_80", True))
         self.assertEqual(ksb.select_arch("sm_50", available), (None, False))
+
+    def test_select_arch_respects_major_generation(self):
+        # SASS is compatible only within a major generation and forward across minor revisions:
+        # Turing (sm_75) runs Volta (sm_70) code, but not Pascal (sm_6x, older major)
+        self.assertEqual(ksb.select_arch("sm_75", ["sm_70"]), ("sm_70", True))
+        self.assertEqual(ksb.select_arch("sm_75", ["sm_60", "sm_61"]), (None, False))
+        # a newer major is never selected for an older device
+        self.assertEqual(ksb.select_arch("sm_80", ["sm_90"]), (None, False))
+        # within a major, the highest minor <= the device's is chosen (sm_86 runs on sm_89)
+        self.assertEqual(ksb.select_arch("sm_89", ["sm_80", "sm_86"]), ("sm_86", True))
+        # a higher minor of the same major is not backward compatible (sm_86 does not run on sm_80)
+        self.assertEqual(ksb.select_arch("sm_80", ["sm_86"]), (None, False))
+        # two-digit majors split correctly (sm_100 -> major 10, minor 0)
+        self.assertEqual(ksb._sm_major_minor("sm_100"), (10, 0))
+
+    def test_parse_arch_variants(self):
+        self.assertEqual(ksb._parse_arch("sm_90"), (90, ""))
+        self.assertEqual(ksb._parse_arch("sm_90a"), (90, "a"))
+        self.assertEqual(ksb._parse_arch("sm_100f"), (100, "f"))
+        self.assertEqual(ksb._parse_arch("sm_120"), (120, ""))
+
+    def test_select_arch_family_and_accelerated_variants(self):
+        # base sm_100 runs across the Blackwell generation, including consumer sm_120
+        self.assertEqual(ksb.select_arch("sm_103", ["sm_100"]), ("sm_100", True))
+        self.assertEqual(ksb.select_arch("sm_120", ["sm_100"]), ("sm_100", True))
+        # family-specific sm_100f stays within its major generation (sm_10x), not sm_120
+        self.assertEqual(ksb.select_arch("sm_103", ["sm_100f"]), ("sm_100f", True))
+        self.assertEqual(ksb.select_arch("sm_120", ["sm_100f"]), (None, False))
+        # accelerated sm_100a runs only on exactly sm_100 (exact match is not a fallback)
+        self.assertEqual(ksb.select_arch("sm_100", ["sm_100a"]), ("sm_100a", False))
+        self.assertEqual(ksb.select_arch("sm_103", ["sm_100a"]), (None, False))
+        # sm_90a (Hopper accelerated) runs on sm_90 but not sm_100
+        self.assertEqual(ksb.select_arch("sm_90", ["sm_90a"]), ("sm_90a", False))
+        self.assertEqual(ksb.select_arch("sm_100", ["sm_90a"]), (None, False))
+        # among compatible arches the highest compute capability is chosen
+        self.assertEqual(ksb.select_arch("sm_120", ["sm_100", "sm_103"]), ("sm_103", True))
+
+
+class DeviceRecordsTest(unittest.TestCase):
+    def _rec(self, arch, kernel="_Zk", library="libA.so", stack=0):
+        return {"arch": arch, "kernel": kernel, "library": library, "stack": stack}
+
+    def test_prefers_accelerated_then_family_then_base(self):
+        # all three variants of the device's own CC are compatible; the accelerated one wins
+        picked = ksb._device_records([self._rec("sm_100"), self._rec("sm_100f"), self._rec("sm_100a")], 100)
+        self.assertEqual([r["arch"] for r in picked], ["sm_100a"])
+
+    def test_family_preferred_over_base_even_with_lower_cc(self):
+        # device sm_103: sm_100a is incompatible (needs exactly sm_100); family sm_100f beats base
+        # sm_103 despite the lower compute capability, per the a > f > base preference
+        picked = ksb._device_records([self._rec("sm_100f"), self._rec("sm_103"), self._rec("sm_100a")], 103)
+        self.assertEqual([r["arch"] for r in picked], ["sm_100f"])
+
+    def test_highest_cc_wins_within_the_same_variant(self):
+        # device sm_89: sm_80 and sm_86 are both compatible base arches; the higher one is chosen
+        picked = ksb._device_records([self._rec("sm_80"), self._rec("sm_86")], 89)
+        self.assertEqual([r["arch"] for r in picked], ["sm_86"])
+
+    def test_drops_functions_with_no_compatible_arch(self):
+        # sm_80 does not run on an sm_90 device (different major); the function would JIT, so drop it
+        picked = ksb._device_records([self._rec("sm_80", kernel="_Zonly80")], 90)
+        self.assertEqual(picked, [])
 
 
 class ShortNameTest(unittest.TestCase):
@@ -153,6 +224,57 @@ class PluginNameTest(unittest.TestCase):
         )
 
 
+class ProcessAcceleratorAlpaka:
+    """Fake ProcessAcceleratorAlpaka; config_backend matches it by type(...).__name__."""
+
+    def __init__(self, backend=None):
+        self._backend = backend
+
+
+class _FakeProcess:
+    def __init__(self, accelerators=(), option_accelerators=("*",)):
+        self._accelerators = {type(a).__name__: a for a in accelerators}
+        self.options = types.SimpleNamespace(accelerators=list(option_accelerators))
+
+    def processAccelerators_(self):
+        return self._accelerators
+
+
+class ConfigBackendTest(unittest.TestCase):
+    def test_defaults_to_cuda_async(self):
+        self.assertEqual(ksb.config_backend(_FakeProcess()), "cuda_async")
+
+    def test_explicit_set_backend_wins(self):
+        proc = _FakeProcess(accelerators=[ProcessAcceleratorAlpaka("serial_sync")])
+        self.assertEqual(ksb.config_backend(proc), "serial_sync")
+
+    def test_accelerators_cpu_selects_serial_sync(self):
+        self.assertEqual(ksb.config_backend(_FakeProcess(option_accelerators=("cpu",))), "serial_sync")
+
+    def test_accelerators_gpu_pattern_selects_cuda(self):
+        self.assertEqual(ksb.config_backend(_FakeProcess(option_accelerators=("gpu-*",))), "cuda_async")
+
+    def test_unreadable_process_falls_back_to_cuda_async(self):
+        self.assertEqual(ksb.config_backend(object()), "cuda_async")
+
+
+class LibDirectoriesTest(unittest.TestCase):
+    def test_derives_from_ld_library_path_and_covers_microarch(self):
+        with tempfile.TemporaryDirectory() as root:
+            arch = "el9_amd64_gcc14"
+            dev = os.path.join(root, "dev", "lib", arch)
+            microarch = os.path.join(dev, "x86-64-v3")          # micro-architecture subdirectory
+            base = os.path.join(root, "base", "lib", arch)
+            external = os.path.join(root, "dev", "external", arch, "lib")  # must be skipped
+            for directory in (microarch, base, external):
+                os.makedirs(directory)
+            ld = os.pathsep.join([microarch, dev, external, base, "/opt/cuda/lib64"])
+            with mock.patch.dict(os.environ, {"SCRAM_ARCH": arch, "LD_LIBRARY_PATH": ld}, clear=True):
+                dirs = ksb.lib_directories()
+            # kept: lib/$ARCH and its micro-arch subdir, developer area first; dropped: externals
+            self.assertEqual(dirs, [microarch, dev, base])
+
+
 class PluginCacheTest(unittest.TestCase):
     def test_parses_name_to_library(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -166,22 +288,35 @@ class PluginCacheTest(unittest.TestCase):
 
 
 class ReadLaunchedTest(unittest.TestCase):
-    def test_parses_kernels_and_module_attribution(self):
+    def test_parses_kernels_module_and_dynamic_shared(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "kernels.txt")
+            with open(path, "w") as handle:
+                handle.write("_Zk1\tmodA\t2048\n")
+                handle.write("_Zk1\tmodB\t4096\n")  # second module, larger dynamic shared memory
+                handle.write("_Zk2\t\t0\n")          # no module, no dynamic shared
+                handle.write("\n")                    # blank line ignored
+            names, modules, dynamic_shared = ksb._read_launched(path)
+        self.assertEqual(names, {"_Zk1", "_Zk2"})
+        self.assertEqual(modules, {"_Zk1": ["modA", "modB"]})  # sorted, deduped; _Zk2 has none
+        self.assertEqual(dynamic_shared, {"_Zk1": 4096})       # max across launches; _Zk2 zero -> absent
+
+    def test_missing_file_is_empty(self):
+        names, modules, dynamic_shared = ksb._read_launched("/no/such/file")
+        self.assertEqual(names, set())
+        self.assertEqual(modules, {})
+        self.assertEqual(dynamic_shared, {})
+
+    def test_reads_legacy_two_column_lines(self):
+        # logs written by an older service (before the dynamic-shared column) still parse
         with tempfile.TemporaryDirectory() as directory:
             path = os.path.join(directory, "kernels.txt")
             with open(path, "w") as handle:
                 handle.write("_Zk1\tmodA\n")
-                handle.write("_Zk1\tmodB\n")  # same kernel launched by a second module
-                handle.write("_Zk2\t\n")       # launched with no attributed module
-                handle.write("\n")             # blank line ignored
-            names, modules = ksb._read_launched(path)
-        self.assertEqual(names, {"_Zk1", "_Zk2"})
-        self.assertEqual(modules, {"_Zk1": ["modA", "modB"]})  # sorted, deduped; _Zk2 has none
-
-    def test_missing_file_is_empty(self):
-        names, modules = ksb._read_launched("/no/such/file")
-        self.assertEqual(names, set())
-        self.assertEqual(modules, {})
+            names, modules, dynamic_shared = ksb._read_launched(path)
+        self.assertEqual(names, {"_Zk1"})
+        self.assertEqual(modules, {"_Zk1": ["modA"]})
+        self.assertEqual(dynamic_shared, {})
 
     def test_read_lines_strips_and_dedups(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -194,7 +329,7 @@ class ReadLaunchedTest(unittest.TestCase):
 class ValueOptionsTest(unittest.TestCase):
     def test_value_options_derived_from_parser(self):
         options = ksb._value_option_strings(ksb._build_parser())
-        self.assertEqual(options, {"--backend", "--compute-capability", "--max-resident-threads", "--top"})
+        self.assertEqual(options, {"--compute-capability", "--max-resident-threads", "--top"})
 
     def test_store_true_flags_are_not_value_options(self):
         options = ksb._value_option_strings(ksb._build_parser())
@@ -221,9 +356,9 @@ class ReportTest(unittest.TestCase):
         # the kernel with the biggest stack frame (_ZbigA, 1024 B) is NOT launched;
         # only the smaller _Zsmall (64 B) is, so the launched budget must be lower
         return [
-            {"arch": "sm_90", "kernel": "_ZbigA", "stack": 1024, "local": 0, "reg": 40,
+            {"arch": "sm_90", "kernel": "_ZbigA", "stack": 1024, "local": 0, "shared": 8192, "reg": 40,
              "library": "libX.so", "demangled": "BigA", "short": "BigA"},
-            {"arch": "sm_90", "kernel": "_Zsmall", "stack": 64, "local": 0, "reg": 20,
+            {"arch": "sm_90", "kernel": "_Zsmall", "stack": 64, "local": 0, "shared": 1024, "reg": 20,
              "library": "libX.so", "demangled": "Small", "short": "Small"},
         ]
 
@@ -265,6 +400,60 @@ class ReportTest(unittest.TestCase):
                     launched_names={"_Zsmall"}, launched_modules={"_Zsmall": ["modA", "modB"]})
         self.assertIn("[modA, modB]", out.getvalue())
 
+    def test_static_mode_reports_worst_stack_kernel_static_shared(self):
+        out = io.StringIO()
+        ksb._report(out, self._records(), {"libX.so": ["m"]}, self._devices(), [], 25, False)
+        text = out.getvalue()
+        # the worst-case reservation is _ZbigA (largest stack, 1024 B); its static shared is reported
+        self.assertIn("worst-case reservation", text)
+        self.assertIn("shared memory: 8192 B static", text)
+
+    def test_launched_mode_reports_worst_stack_kernel_shared(self):
+        records = self._records()
+        # attach dynamic shared as main() would; the worst-STACK launched kernel (_ZbigA) requests
+        # 16384 B of dynamic shared memory, reported together with its 8192 B static amount. Note the
+        # figures describe _ZbigA (largest stack), not _Zsmall which happens to use less shared memory
+        for record in records:
+            record["dyn_shared"] = 16384 if record["kernel"] == "_ZbigA" else 0
+            record["total_shared"] = record["shared"] + record["dyn_shared"]
+        out = io.StringIO()
+        ksb._report(out, records, {"libX.so": ["m"]}, self._devices(), [], 25, False,
+                    launched_names={"_ZbigA", "_Zsmall"})
+        text = out.getvalue()
+        self.assertIn("reservation (launched kernels)", text)
+        self.assertIn("shared memory: 24576 B total = 8192 B static + 16384 B dynamic", text)
+
+    def test_arch_variant_kernels_counted_on_compatible_device(self):
+        # a base sm_90 kernel and an accelerated sm_90a kernel both run on an sm_90 device; the
+        # sm_90a one must still be counted even though the device's plain arch is sm_90
+        records = [
+            {"arch": "sm_90", "kernel": "_Zbase", "stack": 100, "local": 0, "shared": 0, "reg": 20,
+             "library": "libA.so", "demangled": "Base", "short": "Base"},
+            {"arch": "sm_90a", "kernel": "_Zaccel", "stack": 900, "local": 0, "shared": 0, "reg": 40,
+             "library": "libB.so", "demangled": "Accel", "short": "Accel"},
+        ]
+        out = io.StringIO()
+        ksb._report(out, records, {"libA.so": ["m"], "libB.so": ["n"]}, self._devices(), [], 25, False)
+        text = out.getvalue()
+        # the sm_90a kernel (900 B stack) drives the reservation on the sm_90 device
+        self.assertIn("largest stack frame 900 B", text)
+        self.assertIn("kernel: Accel", text)
+
+    def test_verbose_shows_dynamic_shared_column_only_when_launched(self):
+        records = self._records()
+        for record in records:
+            record["dyn_shared"] = 512 if record["kernel"] == "_Zsmall" else 0
+            record["total_shared"] = record["shared"] + record["dyn_shared"]
+        launched = io.StringIO()
+        ksb._report(launched, records, {"libX.so": ["m"]}, self._devices(), [], 25, True,
+                    launched_names={"_ZbigA", "_Zsmall"})
+        self.assertIn("SHARED", launched.getvalue())
+        self.assertIn("DYN", launched.getvalue())
+        static = io.StringIO()
+        ksb._report(static, self._records(), {"libX.so": ["m"]}, self._devices(), [], 25, True)
+        self.assertIn("SHARED", static.getvalue())     # static shared column always present
+        self.assertNotIn("DYN", static.getvalue())     # dynamic column only in launched mode
+
 
 class SplitCliTest(unittest.TestCase):
     def test_options_before_config_and_forwarded_args(self):
@@ -274,8 +463,8 @@ class SplitCliTest(unittest.TestCase):
         self.assertEqual(forwarded, ["--run", "2"])
 
     def test_equals_form_value_option(self):
-        tool, config, forwarded = ksb._split_cli(["--backend=serial_sync", "cfg.py"])
-        self.assertEqual(tool, ["--backend=serial_sync"])
+        tool, config, forwarded = ksb._split_cli(["--compute-capability=9.0", "cfg.py"])
+        self.assertEqual(tool, ["--compute-capability=9.0"])
         self.assertEqual(config, "cfg.py")
         self.assertEqual(forwarded, [])
 
@@ -289,12 +478,14 @@ class MainIntegrationTest(unittest.TestCase):
     so CLI splitting, validation, arch normalisation, exit codes and the report run for real."""
 
     _RECORDS = [
-        {"arch": "sm_90", "kernel": "_Zbig", "stack": 512, "local": 0, "reg": 40},
-        {"arch": "sm_90", "kernel": "_Zsmall", "stack": 64, "local": 0, "reg": 20},
+        {"arch": "sm_90", "kernel": "_Zbig", "stack": 512, "local": 0, "shared": 2048, "reg": 40},
+        {"arch": "sm_90", "kernel": "_Zsmall", "stack": 64, "local": 0, "shared": 256, "reg": 20},
     ]
 
     def _run(self, argv, **extra):
         def scan(paths, cuobjdump, from_config):
+            if not paths:  # mirror _scan_libraries: nothing to scan -> no records
+                return []
             return [dict(record, library="libX.so", config=from_config) for record in self._RECORDS]
 
         stubs = dict(
@@ -323,9 +514,48 @@ class MainIntegrationTest(unittest.TestCase):
         # regression: a failed cmsRun used to still exit 0 and hide the failure from automation
         code, _, err = self._run(
             ["--launched", "--compute-capability", "90", "--max-resident-threads", "1000", "cfg.py"],
-            capture_launched_kernels=lambda config, args: (set(), {}, set(), 42))
+            capture_launched_kernels=lambda config, args: (set(), {}, {}, set(), 42))
         self.assertNotEqual(code, 0)
         self.assertIn("cmsRun exited with code 42", err)
+
+    def test_invalid_compute_capability_is_rejected(self):
+        # a non-numeric capability is caught by the compute_capability_to_sm normalisation
+        with self.assertRaises(SystemExit):
+            self._run(["--compute-capability", "abc", "--max-resident-threads", "1000", "cfg.py"])
+
+    def test_incompatible_device_arch_exits_with_error(self):
+        # the libraries embed sm_90 SASS (per _RECORDS) but the only target is sm_50 (Maxwell): no
+        # compatible arch and no other device, so the tool must exit with an error
+        with self.assertRaises(SystemExit):
+            self._run(["--compute-capability", "50", "--max-resident-threads", "1000", "cfg.py"])
+
+    def test_partially_compatible_devices_warn_and_continue(self):
+        # two detected GPUs: sm_90 (matches the embedded sm_90) and sm_50 (no compatible arch). The
+        # incompatible one is warned about and skipped; the tool still reports the compatible one.
+        dev90 = {"index": 0, "compute_capability": "9.0", "name": "GPU90", "max_resident_threads": 1000}
+        dev50 = {"index": 1, "compute_capability": "5.0", "name": "GPU50", "max_resident_threads": 500}
+        code, text, err = self._run(["cfg.py"], detect_devices=lambda: [dev90, dev50])
+        self.assertEqual(code, 0)
+        self.assertIn("sm_50", err)         # warned about the incompatible device
+        self.assertIn("GPU90", text)        # still reported the compatible one
+        self.assertNotIn("GPU50", text)     # the incompatible one is skipped in the report
+
+    def test_launched_reports_dynamic_shared_end_to_end(self):
+        # a successful launched run where _Zbig requests 4096 B of dynamic shared memory; main()
+        # must attach it to the record and the report must combine it with the 2048 B static amount
+        code, text, _ = self._run(
+            ["--launched", "--compute-capability", "90", "--max-resident-threads", "1000", "cfg.py"],
+            capture_launched_kernels=lambda config, args: ({"_Zbig"}, {"_Zbig": ["m"]}, {"_Zbig": 4096}, set(), 0))
+        self.assertEqual(code, 0)
+        # _Zbig is the largest-stack launched kernel; its shared memory is reported in the block
+        self.assertIn("shared memory: 6144 B total = 2048 B static + 4096 B dynamic", text)
+
+    def test_non_cuda_backend_exits_early(self):
+        # a CPU/serial (or AMD) configuration launches no CUDA kernels: fail fast with an error
+        # instead of running to the end and reporting an empty budget
+        with self.assertRaises(SystemExit):
+            self._run(["--compute-capability", "90", "--max-resident-threads", "1000", "cfg.py"],
+                      config_backend=lambda process: "serial_sync")
 
 
 if __name__ == "__main__":

--- a/HeterogeneousCore/CUDAUtilities/test/testKernelStackBudget.py
+++ b/HeterogeneousCore/CUDAUtilities/test/testKernelStackBudget.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Unit tests for kernelStackBudget.
+
+These cover the pure parsing/helper functions and, with the heavy I/O stubbed (cuobjdump,
+cmsRun, the configuration and the demangler), the end-to-end main() path: CLI splitting,
+option validation, compute-capability normalisation, exit codes and the report.
+"""
+import contextlib
+import io
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from HeterogeneousCore.CUDAUtilities import kernelStackBudget as ksb
+
+
+# a realistic cuobjdump --dump-resource-usage excerpt (two arches, two kernels)
+RESOURCE_USAGE = """
+Fatbin elf code:
+================
+arch = sm_80
+identifier = foo.cu.o
+
+Resource usage:
+ Common:
+  GLOBAL:216
+ Function _Z6kernelv:
+  REG:26 STACK:80 SHARED:0 LOCAL:0 CONSTANT[0]:352 TEXTURE:0 SURFACE:0 SAMPLER:0
+ Function _Z9spillsLotv:
+  REG:57 STACK:112 SHARED:10144 LOCAL:48 CONSTANT[0]:0 TEXTURE:0 SURFACE:0 SAMPLER:0
+
+Fatbin elf code:
+================
+arch = sm_90
+identifier = foo.cu.o
+
+Resource usage:
+ Common:
+  GLOBAL:216
+ Function _Z6kernelv:
+  REG:24 STACK:16 SHARED:0 LOCAL:0 CONSTANT[0]:352 TEXTURE:0 SURFACE:0 SAMPLER:0
+"""
+
+# a cudaComputeCapabilities --verbose excerpt
+DEVICE_VERBOSE = """\
+   0     9.0    NVIDIA H100 NVL
+        multiprocessors:                                          132
+        max threads per multiprocessor:                          2048
+        max resident threads:                                  270336
+   1     8.0    NVIDIA A100 (unsupported)
+        max resident threads:                                  221184
+"""
+
+
+class ResourceUsageTest(unittest.TestCase):
+    def test_parses_per_arch_kernels(self):
+        records = ksb.parse_resource_usage(RESOURCE_USAGE)
+        self.assertEqual(len(records), 3)
+        sm80 = [r for r in records if r["arch"] == "sm_80"]
+        self.assertEqual(max(r["stack"] for r in sm80), 112)
+        self.assertEqual(max(r["local"] for r in sm80), 48)
+        sm90 = [r for r in records if r["arch"] == "sm_90"]
+        self.assertEqual(max(r["stack"] for r in sm90), 16)
+
+    def test_empty_input(self):
+        self.assertEqual(ksb.parse_resource_usage(""), [])
+
+
+class DeviceInfoTest(unittest.TestCase):
+    def test_parses_devices_and_max_resident(self):
+        devices = ksb.parse_device_info(DEVICE_VERBOSE)
+        self.assertEqual(len(devices), 2)
+        self.assertEqual(devices[0]["compute_capability"], "9.0")
+        self.assertEqual(devices[0]["max_resident_threads"], 270336)
+        self.assertEqual(devices[0]["name"], "NVIDIA H100 NVL")
+        # "(unsupported)" must not bleed into the device name
+        self.assertEqual(devices[1]["name"], "NVIDIA A100")
+        self.assertEqual(devices[1]["max_resident_threads"], 221184)
+
+    def test_detail_lines_are_not_parsed_as_devices(self):
+        # only the two summary lines start a device; the indented detail rows (which carry
+        # numbers too) must not be mistaken for additional devices
+        devices = ksb.parse_device_info(DEVICE_VERBOSE)
+        self.assertEqual([d["index"] for d in devices], [0, 1])
+        self.assertEqual([d["compute_capability"] for d in devices], ["9.0", "8.0"])
+
+
+class ArchTest(unittest.TestCase):
+    def test_compute_capability_to_sm(self):
+        self.assertEqual(ksb.compute_capability_to_sm("9.0"), "sm_90")
+        self.assertEqual(ksb.compute_capability_to_sm("90"), "sm_90")
+        self.assertEqual(ksb.compute_capability_to_sm("12.0"), "sm_120")
+        self.assertEqual(ksb.compute_capability_to_sm("sm_90"), "sm_90")
+
+    def test_dotted_sm_capability_normalises(self):
+        # regression: 'sm_9.0' must become 'sm_90', not pass through and later break int()
+        self.assertEqual(ksb.compute_capability_to_sm("sm_9.0"), "sm_90")
+        target, fell_back = ksb.select_arch(ksb.compute_capability_to_sm("sm_9.0"), ["sm_80", "sm_90"])
+        self.assertEqual((target, fell_back), ("sm_90", False))
+
+    def test_select_arch(self):
+        available = ["sm_70", "sm_80", "sm_90"]
+        self.assertEqual(ksb.select_arch("sm_90", available), ("sm_90", False))
+        self.assertEqual(ksb.select_arch("sm_89", available), ("sm_80", True))
+        self.assertEqual(ksb.select_arch("sm_50", available), (None, False))
+
+
+class ShortNameTest(unittest.TestCase):
+    def test_extracts_inner_alpaka_kernel(self):
+        name = ("void alpaka::detail::gpuKernel<alpaka_cuda_async::TestAlgoKernelUpdate, "
+                "alpaka::AccGpuUniformCudaHipRt<alpaka::ApiCudaRt, std::integral_constant<unsigned long, 1ul> > >"
+                "(alpaka::Vec<...>, ...)")
+        self.assertEqual(ksb.short_kernel_name(name), "alpaka_cuda_async::TestAlgoKernelUpdate")
+
+    def test_passthrough_for_plain_kernel(self):
+        self.assertEqual(ksb.short_kernel_name("myPlainKernel(int*)"), "myPlainKernel(int*)")
+
+
+class _FakeBackend:
+    def __init__(self, value):
+        self._value = value
+
+    def value(self):
+        return self._value
+
+
+class _FakeAlpaka:
+    def __init__(self, backend):
+        self.backend = _FakeBackend(backend)
+
+
+class _FakeModule:
+    def __init__(self, backend=None):
+        if backend is not None:
+            self.alpaka = _FakeAlpaka(backend)
+
+
+class PluginNameTest(unittest.TestCase):
+    def test_plain_type_is_its_own_plugin(self):
+        self.assertEqual(ksb.plugin_name_for("FooProducer", _FakeModule(), "cuda_async"), "FooProducer")
+
+    def test_alpaka_default_backend(self):
+        self.assertEqual(
+            ksb.plugin_name_for("Foo@alpaka", _FakeModule(), "cuda_async"),
+            "alpaka_cuda_async::Foo",
+        )
+
+    def test_alpaka_explicit_backend_wins(self):
+        self.assertEqual(
+            ksb.plugin_name_for("Foo@alpaka", _FakeModule("serial_sync"), "cuda_async"),
+            "alpaka_serial_sync::Foo",
+        )
+
+
+class PluginCacheTest(unittest.TestCase):
+    def test_parses_name_to_library(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with open(os.path.join(directory, ".edmplugincache"), "w") as handle:
+                handle.write("pluginFooCudaAsync.so alpaka_cuda_async::Foo CMS%EDM%Framework%Module\n")
+                handle.write("pluginFooCudaAsync.so alpaka_cuda_async::Foo CMS%EDM%Framework%ParameterSet%Description\n")
+                handle.write("pluginBar.so BarProducer CMS%EDM%Framework%Module\n")
+            mapping = ksb.parse_plugin_cache([directory])
+        self.assertEqual(mapping["alpaka_cuda_async::Foo"], "pluginFooCudaAsync.so")
+        self.assertEqual(mapping["BarProducer"], "pluginBar.so")
+
+
+class ReadLaunchedTest(unittest.TestCase):
+    def test_parses_kernels_and_module_attribution(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "kernels.txt")
+            with open(path, "w") as handle:
+                handle.write("_Zk1\tmodA\n")
+                handle.write("_Zk1\tmodB\n")  # same kernel launched by a second module
+                handle.write("_Zk2\t\n")       # launched with no attributed module
+                handle.write("\n")             # blank line ignored
+            names, modules = ksb._read_launched(path)
+        self.assertEqual(names, {"_Zk1", "_Zk2"})
+        self.assertEqual(modules, {"_Zk1": ["modA", "modB"]})  # sorted, deduped; _Zk2 has none
+
+    def test_missing_file_is_empty(self):
+        names, modules = ksb._read_launched("/no/such/file")
+        self.assertEqual(names, set())
+        self.assertEqual(modules, {})
+
+    def test_read_lines_strips_and_dedups(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "libs.txt")
+            with open(path, "w") as handle:
+                handle.write("/a/libX.so\n\n  /a/libY.so  \n/a/libX.so\n")
+            self.assertEqual(ksb._read_lines(path), {"/a/libX.so", "/a/libY.so"})
+
+
+class ValueOptionsTest(unittest.TestCase):
+    def test_value_options_derived_from_parser(self):
+        options = ksb._value_option_strings(ksb._build_parser())
+        self.assertEqual(options, {"--backend", "--compute-capability", "--max-resident-threads", "--top"})
+
+    def test_store_true_flags_are_not_value_options(self):
+        options = ksb._value_option_strings(ksb._build_parser())
+        self.assertNotIn("--launched", options)
+        self.assertNotIn("--verbose", options)
+
+    def test_value_option_consumes_following_token(self):
+        options = ksb._value_option_strings(ksb._build_parser())
+        tool, config, forwarded = ksb._split_cli(["--compute-capability", "9.0", "cfg.py"], options)
+        self.assertEqual(tool, ["--compute-capability", "9.0"])
+        self.assertEqual(config, "cfg.py")
+        self.assertEqual(forwarded, [])
+
+    def test_abbreviated_flag_is_rejected(self):
+        # regression: '--comp' used to be swallowed by _split_cli while the real config was
+        # forwarded away; with allow_abbrev off the parser now rejects it cleanly
+        parser = ksb._build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["--comp", "9.0", "cfg.py"])
+
+
+class ReportTest(unittest.TestCase):
+    def _records(self):
+        # the kernel with the biggest stack frame (_ZbigA, 1024 B) is NOT launched;
+        # only the smaller _Zsmall (64 B) is, so the launched budget must be lower
+        return [
+            {"arch": "sm_90", "kernel": "_ZbigA", "stack": 1024, "local": 0, "reg": 40,
+             "library": "libX.so", "demangled": "BigA", "short": "BigA"},
+            {"arch": "sm_90", "kernel": "_Zsmall", "stack": 64, "local": 0, "reg": 20,
+             "library": "libX.so", "demangled": "Small", "short": "Small"},
+        ]
+
+    def _devices(self):
+        return [{"index": None, "compute_capability": "9.0", "name": "dev", "max_resident_threads": 1000}]
+
+    def test_static_mode_uses_largest_kernel(self):
+        out = io.StringIO()
+        ksb._report(out, self._records(), {"libX.so": ["m"]}, self._devices(), [], 25, False)
+        text = out.getvalue()
+        self.assertIn("worst-case reservation: ", text)
+        self.assertIn("1024000 B", text)  # 1000 threads x 1024 B
+
+    def test_launched_mode_lowers_budget_to_launched_kernels(self):
+        out = io.StringIO()
+        ksb._report(out, self._records(), {"libX.so": ["m"]}, self._devices(), [], 25, False,
+                    launched_names={"_Zsmall"})
+        text = out.getvalue()
+        self.assertIn("kernels actually launched (CUPTI):      1 (1 matched to stack data)", text)
+        self.assertIn("reservation (launched kernels): ", text)
+        self.assertIn("64000 B", text)    # 1000 threads x 64 B (launched)
+        self.assertIn("static upper bound", text)
+        self.assertIn("1024000 B", text)  # 1000 threads x 1024 B (all kernels)
+
+    def test_launched_mode_with_no_kernels_is_zero(self):
+        out = io.StringIO()
+        ksb._report(out, self._records(), {"libX.so": ["m"]}, self._devices(), [], 25, False,
+                    launched_names=set())
+        text = out.getvalue()
+        self.assertIn("kernels actually launched (CUPTI):      0 (0 matched to stack data)", text)
+        self.assertIn("reservation (launched kernels): ", text)
+        self.assertIn("(0 B)", text)       # the launched reservation is zero
+        self.assertIn("static upper bound", text)
+        self.assertIn("1024000 B", text)   # but the static bound still covers every kernel
+
+    def test_launched_mode_reports_module_attribution(self):
+        out = io.StringIO()
+        ksb._report(out, self._records(), {"libX.so": ["m"]}, self._devices(), [], 25, False,
+                    launched_names={"_Zsmall"}, launched_modules={"_Zsmall": ["modA", "modB"]})
+        self.assertIn("[modA, modB]", out.getvalue())
+
+
+class SplitCliTest(unittest.TestCase):
+    def test_options_before_config_and_forwarded_args(self):
+        tool, config, forwarded = ksb._split_cli(["--top", "5", "-v", "cfg.py", "--run", "2"])
+        self.assertEqual(tool, ["--top", "5", "-v"])
+        self.assertEqual(config, "cfg.py")
+        self.assertEqual(forwarded, ["--run", "2"])
+
+    def test_equals_form_value_option(self):
+        tool, config, forwarded = ksb._split_cli(["--backend=serial_sync", "cfg.py"])
+        self.assertEqual(tool, ["--backend=serial_sync"])
+        self.assertEqual(config, "cfg.py")
+        self.assertEqual(forwarded, [])
+
+    def test_no_config(self):
+        tool, config, forwarded = ksb._split_cli(["--help"])
+        self.assertEqual(config, None)
+
+
+class MainIntegrationTest(unittest.TestCase):
+    """Drive main() end-to-end with cuobjdump, cmsRun, the config and the demangler stubbed,
+    so CLI splitting, validation, arch normalisation, exit codes and the report run for real."""
+
+    _RECORDS = [
+        {"arch": "sm_90", "kernel": "_Zbig", "stack": 512, "local": 0, "reg": 40},
+        {"arch": "sm_90", "kernel": "_Zsmall", "stack": 64, "local": 0, "reg": 20},
+    ]
+
+    def _run(self, argv, **extra):
+        def scan(paths, cuobjdump, from_config):
+            return [dict(record, library="libX.so", config=from_config) for record in self._RECORDS]
+
+        stubs = dict(
+            processFromFile=lambda config, args: object(),
+            find_tool=lambda name: "/bin/true",
+            loaded_cuda_libraries=lambda *a, **k: ({"libX.so": ["m"]}, []),
+            _scan_libraries=scan,
+            demangle=lambda names: {name: name for name in names},
+        )
+        stubs.update(extra)
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch.multiple(ksb, **stubs), \
+                contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = ksb.main(argv)
+        return code, out.getvalue(), err.getvalue()
+
+    def test_static_report_accepts_dotted_sm_capability(self):
+        # regression: '--compute-capability sm_9.0' used to crash with an uncaught ValueError
+        code, text, _ = self._run(
+            ["--compute-capability", "sm_9.0", "--max-resident-threads", "1000", "cfg.py"])
+        self.assertEqual(code, 0)
+        self.assertIn("worst-case reservation", text)
+        self.assertIn("512000 B", text)  # 1000 threads x 512 B (largest stack frame)
+
+    def test_launched_failure_propagates_nonzero_exit(self):
+        # regression: a failed cmsRun used to still exit 0 and hide the failure from automation
+        code, _, err = self._run(
+            ["--launched", "--compute-capability", "90", "--max-resident-threads", "1000", "cfg.py"],
+            capture_launched_kernels=lambda config, args: (set(), {}, set(), 42))
+        self.assertNotEqual(code, 0)
+        self.assertIn("cmsRun exited with code 42", err)
+
+
+if __name__ == "__main__":
+    # verbose so every check is listed by name: the abbreviated-flag test deliberately makes
+    # argparse print a usage/error message, and showing each result makes clear it belongs to
+    # that (passing) test rather than signalling a failure
+    unittest.main(verbosity=2)


### PR DESCRIPTION
#### PR description:

Almost verbatim backport of #51395 (full description there) for Run 3 studies.
Removed mentions of CUDA 13 and related signals. In particular, removed
```
enable(CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID___cudaLaunchKernel_v13000);
enable(CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID___cudaLaunchKernel_ptsz_v13000);
```
since they are only supported from CUDA 13 onwards and added
```
enable(CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernelMultiDevice_v9000);
enable(CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernelMultiDevice);
```
whose support was dropped in CUDA 13.

#### PR validation:

The code compiles, runs and produces the expected output (with slight differences with what's shown in the original PR either due to the change in CUDA version or some other code developments)

- Sample output from static mode (verbose)
```
CUDA kernel stack-frame memory budget
  scheduled modules using CUDA libraries: 5
  CUDA libraries from the configuration:  3
  kernels inspected:                      1439

device 0: NVIDIA H100 NVL (compute capability 9.0, sm_90)
  max resident threads: 270336
  worst-case reservation: 1119.9 MiB (1174339584 B) = 270336 threads x 4344 B
      largest stack frame 4344 B in pluginRecoTrackerPixelSeedingPortableCudaAsync.so
      kernel: alpaka_cuda_async::Kernel_CircleFit<5, pixelTopology::HIonPhase1>
      shared memory: 0 B static
  spilling kernels (144):
    STACK   4344 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_CircleFit<5, pixelTopology::HIonPhase1>
    STACK   4344 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_CircleFit<5, pixelTopology::Phase2OT>
    STACK   4344 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_CircleFit<5, pixelTopology::Phase2>
    STACK   4344 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_CircleFit<5, pixelTopology::Phase1>
    STACK   2536 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_CircleFit<4, pixelTopology::HIonPhase1>
    STACK   2536 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_CircleFit<4, pixelTopology::Phase2OT>
    STACK   2536 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_CircleFit<4, pixelTopology::Phase2>
    STACK   2536 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_CircleFit<4, pixelTopology::Phase1>
    STACK   1560 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_CircleFit<3, pixelTopology::HIonPhase1>
    STACK   1560 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_CircleFit<3, pixelTopology::Phase2OT>
    STACK   1560 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_CircleFit<3, pixelTopology::Phase2>
    STACK   1560 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_CircleFit<3, pixelTopology::Phase1>
    STACK    800 B  LOCAL      0 B  SHARED      0 B  REG 140  alpaka_cuda_async::caHitNtupletGeneratorKernels::Kernel_find_ntuplets<pixelTopology::Phase2OT>
    STACK    800 B  LOCAL      0 B  SHARED      0 B  REG 140  alpaka_cuda_async::caHitNtupletGeneratorKernels::Kernel_find_ntuplets<pixelTopology::Phase2>
    STACK    576 B  LOCAL      0 B  SHARED  42440 B  REG  96  alpaka_cuda_async::pixelClustering::FindClus<pixelTopology::HIonPhase1>
    STACK    448 B  LOCAL      0 B  SHARED  37240 B  REG  96  alpaka_cuda_async::pixelClustering::FindClus<pixelTopology::Phase1>
    STACK    304 B  LOCAL      0 B  SHARED  34768 B  REG  76  alpaka_cuda_async::pixelClustering::FindClus<pixelTopology::Phase2>
    STACK    272 B  LOCAL      0 B  SHARED      0 B  REG  78  alpaka_cuda_async::caHitNtupletGeneratorKernels::Kernel_find_ntuplets<pixelTopology::HIonPhase1>
    STACK    272 B  LOCAL      0 B  SHARED      0 B  REG  78  alpaka_cuda_async::caHitNtupletGeneratorKernels::Kernel_find_ntuplets<pixelTopology::Phase1>
    STACK    232 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_BLFit<6, pixelTopology::HIonPhase1>
    STACK    232 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_BLFit<6, pixelTopology::Phase2OT>
    STACK    232 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_BLFit<6, pixelTopology::Phase2>
    STACK    232 B  LOCAL      0 B  SHARED      0 B  REG 255  alpaka_cuda_async::Kernel_BLFit<6, pixelTopology::Phase1>
    STACK    200 B  LOCAL      0 B  SHARED      0 B  REG 216  alpaka_cuda_async::Kernel_BLFit<5, pixelTopology::HIonPhase1>
    STACK    200 B  LOCAL      0 B  SHARED      0 B  REG 216  alpaka_cuda_async::Kernel_BLFit<5, pixelTopology::Phase2OT>
    (119 more kernels with STACK 16-200 B not shown; pass --top 0 to list all)

CUDA libraries from the configuration:
  pluginRecoLocalTrackerSiPixelClusterizerPluginsPortableCudaAsync.so
    used by: hltPhase2SiPixelClustersSoA
  pluginRecoLocalTrackerSiPixelRecHitsPluginsPortableCudaAsync.so
    used by: hltESPPixelCPEFastParamsPhase2, hltPhase2PixelRecHitsExtendedSoA, hltPhase2SiPixelRecHitsSoA
  pluginRecoTrackerPixelSeedingPortableCudaAsync.so
    used by: hltPhase2PixelTracksSoA
```

- Sample output from `--launched` mode (verbose)
```
CUDA kernel stack-frame memory budget
  scheduled modules using CUDA libraries: 5
  CUDA libraries from the configuration:  3
  extra libraries scanned from the run:   1
  kernels inspected:                      1810
  kernels actually launched (CUPTI):      81 (81 matched to stack data)

device 0: NVIDIA H100 NVL (compute capability 9.0, sm_90)
  max resident threads: 270336
  reservation (launched kernels): 206.2 MiB (216268800 B) = 270336 threads x 800 B
      largest stack frame 800 B in pluginRecoTrackerPixelSeedingPortableCudaAsync.so
      kernel: alpaka_cuda_async::caHitNtupletGeneratorKernels::Kernel_find_ntuplets<pixelTopology::Phase2OT>  [hltPhase2PixelTracksSoA]
      shared memory: 0 B total = 0 B static + 0 B dynamic
  static upper bound (config's CUDA libraries): 1119.9 MiB (1174339584 B)
  spilling kernels (38):
    STACK    800 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG 140  alpaka_cuda_async::caHitNtupletGeneratorKernels::Kernel_find_ntuplets<pixelTopology::Phase2OT>  [hltPhase2PixelTracksSoA]
    STACK    304 B  LOCAL      0 B  SHARED  34768 B  DYN      0 B  REG  76  alpaka_cuda_async::pixelClustering::FindClus<pixelTopology::Phase2>  [hltPhase2SiPixelClustersSoA]
    STACK    232 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG 255  alpaka_cuda_async::Kernel_BLFit<6, pixelTopology::Phase2OT>  [hltPhase2PixelTracksSoA]
    STACK    200 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG 216  alpaka_cuda_async::Kernel_BLFit<5, pixelTopology::Phase2OT>  [hltPhase2PixelTracksSoA]
    STACK    160 B  LOCAL      0 B  SHARED   1028 B  DYN      0 B  REG 168  alpaka_cuda_async::lst::CreateQuintupletsT<false>  [hltLST]
    STACK    152 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG 180  alpaka_cuda_async::Kernel_BLFit<4, pixelTopology::Phase2OT>  [hltPhase2PixelTracksSoA]
    STACK    136 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG 142  alpaka_cuda_async::Kernel_BLFit<3, pixelTopology::Phase2OT>  [hltPhase2PixelTracksSoA]
    STACK    128 B  LOCAL      0 B  SHARED   1028 B  DYN      0 B  REG 168  alpaka_cuda_async::lst::CreateQuadrupletsT<false>  [hltLST]
    STACK    128 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG 161  alpaka_cuda_async::lst::CountTripletLSConnectionsT<false>  [hltLST]
    STACK    112 B  LOCAL      0 B  SHARED  10144 B  DYN      0 B  REG  57  alpaka_cuda_async::pixelRecHits::GetHits<pixelTopology::Phase2>  [hltPhase2SiPixelRecHitsSoA]
    STACK     96 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG 128  alpaka_cuda_async::lst::CountTripletConnectionsT<false>  [hltLST]
    STACK     80 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG 128  alpaka_cuda_async::lst::CreatePixelQuintupletsFromMap  [hltLST]
    STACK     48 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG  72  alpaka_cuda_async::lst::AddPixelSegmentToEventKernel  [hltLST]
    STACK     32 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG  28  alpaka_cuda_async::caHitNtupletGeneratorKernels::Kernel_fillMultiplicity<pixelTopology::Phase2OT>  [hltPhase2PixelTracksSoA]
    STACK     32 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG  28  alpaka_cuda_async::caHitNtupletGeneratorKernels::Kernel_countMultiplicity<pixelTopology::Phase2OT>  [hltPhase2PixelTracksSoA]
    STACK     32 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG  36  alpaka_cuda_async::caHitNtupletGeneratorKernels::Kernel_earlyDuplicateRemover<pixelTopology::Phase2OT>  [hltPhase2PixelTracksSoA]
    STACK     32 B  LOCAL      0 B  SHARED  18752 B  DYN      0 B  REG  41  pixelClustering::ClusterChargeCut<pixelTopology::Phase2>  [hltPhase2SiPixelClustersSoA]
    STACK     32 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG 128  alpaka_cuda_async::lst::CreatePixelTripletsFromMap  [hltLST]
    STACK     32 B  LOCAL      0 B  SHARED   1028 B  DYN      0 B  REG 127  alpaka_cuda_async::lst::CreateTripletsT<false>  [hltLST]
    STACK     32 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG  54  alpaka_cuda_async::lst::CountSegmentConnectionsT<false>  [hltLST]
    STACK     32 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG  38  alpaka_cuda_async::lst::HitLoopKernel  [hltLST]
    STACK     16 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG  52  alpaka_cuda_async::Kernel_BLFastFit<6>  [hltPhase2PixelTracksSoA]
    STACK     16 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG  52  alpaka_cuda_async::Kernel_BLFastFit<5>  [hltPhase2PixelTracksSoA]
    STACK     16 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG  52  alpaka_cuda_async::Kernel_BLFastFit<4>  [hltPhase2PixelTracksSoA]
    STACK     16 B  LOCAL      0 B  SHARED      0 B  DYN      0 B  REG  53  alpaka_cuda_async::Kernel_BLFastFit<3>  [hltPhase2PixelTracksSoA]
    (13 more kernels with STACK 16-16 B not shown; pass --top 0 to list all)

CUDA libraries from the configuration:
  pluginRecoLocalTrackerSiPixelClusterizerPluginsPortableCudaAsync.so
    used by: hltPhase2SiPixelClustersSoA
  pluginRecoLocalTrackerSiPixelRecHitsPluginsPortableCudaAsync.so
    used by: hltESPPixelCPEFastParamsPhase2, hltPhase2PixelRecHitsExtendedSoA, hltPhase2SiPixelRecHitsSoA
  pluginRecoTrackerPixelSeedingPortableCudaAsync.so
    used by: hltPhase2PixelTracksSoA
additional libraries scanned from the run:
  libRecoTrackerLSTCoreCudaAsync.so
```