### PR TITLE
[16.1.X] Correct compatible det propagation in setSecondHitPattern

### DIFF
--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -287,10 +287,10 @@ void TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj,
         }  //end loop over layers
       };  // end lambda
 
-  localProp->setPropagationDirection(oppositeToMomentum);
+  localProp->setPropagationDirection(dirForInnerLayers);
   loopOverLayer(innerCompLayers, innerTSOS);
 
-  localProp->setPropagationDirection(alongMomentum);
+  localProp->setPropagationDirection(dirForOuterLayers);
   outIn = !outIn;  // if inOut should mark missing_outer
   loopOverLayer(outerCompLayers, outerTSOS);
 }


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/51478
 to 16.1.X