### PR TITLE
[RECO] Changes to EventContent to make it RISCV64 compliant

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -991,8 +991,7 @@ REDIGIEventContent.inputCommands.append('drop *_randomEngineStateProducer_*_*')
 # MiniAOD is a bit special: the files tend to be so small that letting
 # ROOT automatically determine when to flush is a surprisingly big overhead.
 #
-from PhysicsTools.PatAlgos.slimming.slimming_cff import MicroEventContent,MicroEventContentMC,MicroEventContentGEN
-from PhysicsTools.PatAlgos.slimming.MicroEventContent_cff import MiniAODOverrideBranchesSplitLevel
+from PhysicsTools.PatAlgos.slimming.MicroEventContent_cff import MicroEventContent,MicroEventContentMC,MicroEventContentGEN,MiniAODOverrideBranchesSplitLevel
 
 MINIAODEventContent= cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),


### PR DESCRIPTION
#### PR description:
The import from a secondary file was creating the following crash:
```shell
  File "/cvmfs/cms-ib.cern.ch/sw/riscv64/nweek-02949/fc42_riscv64_gcc15/cms/cmssw/CMSSW_20_1_X_2026-07-09-2300/src/Configuration/EventContent/python/EventContent_cff.py", line 994, in <module>
    from PhysicsTools.PatAlgos.slimming.slimming_cff import MicroEventContent,MicroEventContentMC,MicroEventContentGEN
  File "/cvmfs/cms-ib.cern.ch/sw/riscv64/nweek-02949/fc42_riscv64_gcc15/cms/cmssw/CMSSW_20_1_X_2026-07-09-2300/src/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py", line 3, in <module>
    from PhysicsTools.PatAlgos.slimming.packedPFCandidates_cff import *
  File "/cvmfs/cms-ib.cern.ch/sw/riscv64/nweek-02949/fc42_riscv64_gcc15/cms/cmssw/CMSSW_20_1_X_2026-07-09-2300/src/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cff.py", line 5, in <module>
    from CommonTools.ParticleFlow.PFBRECO_cff import pfPileUpPFBRECO, pfNoPileUpPFBRECO
  File "/cvmfs/cms-ib.cern.ch/sw/riscv64/nweek-02949/fc42_riscv64_gcc15/cms/cmssw/CMSSW_20_1_X_2026-07-09-2300/src/CommonTools/ParticleFlow/python/PFBRECO_cff.py", line 4, in <module>
    from RecoParticleFlow.PFProducer.pfLinker_cff import particleFlowPtrs
  File "/cvmfs/cms-ib.cern.ch/sw/riscv64/nweek-02949/fc42_riscv64_gcc15/cms/cmssw/CMSSW_20_1_X_2026-07-09-2300/src/RecoParticleFlow/PFProducer/python/pfLinker_cff.py", line 3, in <module>
    import RecoParticleFlow.PFProducer.pfLinker_cfi
ModuleNotFoundError: No module named 'RecoParticleFlow.PFProducer.pfLinker_cfi'
``` 
as was pointed out and suggested in https://github.com/cms-sw/cmssw/issues/50354#issuecomment-4981481424
Solves https://github.com/cms-sw/cmssw/issues/50354

#### PR validation:

Tested under  RISC-V conditions using a docker:
```shell
ssh cmsdev45
mkdir -p /build/`whoami`
cd  /build/`whoami`
wget https://raw.githubusercontent.com/cms-sw/cms-bot/refs/heads/master/dockerrun.sh
export SCRAM_ARCH=fc42_riscv64_gcc15
source dockerrun.sh
dockerrun bash
scram l CMSSW_20_1_X
scram p CMSSW_20_1_X_2026-07-09-2300
cd CMSSW_20_1_X_2026-07-09-2300/
cmsenv
``` 
and then using the following workflow:

```shell
cmsDriver.py MinBias_8TeV_pythia8_TuneCUETP8M1_cff --relval 9000,300 -s GEN,SIM -n 10 --conditions auto:run1_mc --beamspot Realistic8TeVCollision --datatier GEN-SIM --eventcontent RAWSIM --customise Validation/Performance/TimeMemorySummary.customiseWithTimeMemorySummary --prefix --fileout file:step1.root --suffix "-j JobReport1.xml " --nThreads 4
``` 
#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport