### PR TITLE
Added PeriodicAllocMonitorPreload

### DIFF
--- a/PerfTools/AllocMonitor/plugins/PeriodicAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/PeriodicAllocMonitor.cc
@@ -24,6 +24,8 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 
+//NOTE: Any changes to this code may also be appropriate for PerfTools/PeriodicAllocMonitorPreload/src/preload.cc
+
 namespace {
   class MonitorAdaptor : public cms::perftools::AllocMonitorBase {
   public:

--- a/PerfTools/PeriodicAllocMonitorPreload/BuildFile.xml
+++ b/PerfTools/PeriodicAllocMonitorPreload/BuildFile.xml
@@ -1,0 +1,6 @@
+<environment>
+  <use name="PerfTools/AllocMonitor"/>
+  <export>
+    <lib name="1"/>
+  </export>
+</environment>

--- a/PerfTools/PeriodicAllocMonitorPreload/README.md
+++ b/PerfTools/PeriodicAllocMonitorPreload/README.md
@@ -1,0 +1,36 @@
+# PerfTools/PeriodicAllocMonitorPreload Description
+
+## Introduction
+
+This package generated a library that is meant to be LD_PRELOADed along with libPrefToolsAllocMonitorPreload.so which
+uses `cms::perftools::AllocMonitorRegistry` to register a monitor before an application begins. As the application
+is running this library will periodically report statistics about the allocations and deallocations to a file.
+
+## Usage
+
+To use the package, one must issue the following LD_PRELOAD command before running the application (bash version
+shown below)
+```
+LD_PRELOAD="libPerfToolsAllocMonitorPreload.so libPerfToolsPeriodicAllocMonitorPreload.so"
+```
+
+the order is important.
+
+Both the base part of the file name to be used as well as the interval between samples can be set via environment variables
+
+| *Variable* | *Description* |
+| --- | --- |
+| PAM_FILENAME | The base part of the file name to write. The process id of the job will be appended to the base name followed by `.csv`. The reason for the process name is to handle the case where the function forks another process. In that case we need the new process to write to its own file. If the environment variable is not set, the value of  "periodic_alloc_" will be used. |
+| PAM_INTERVAL_MS | this is the number of milliseconds the system should wait before reporting the information. If the environment variable is not set, the value of "1000" will be used. |
+
+## Reporting
+The output file contains the following information on each line
+- The time, in milliseconds, since the service was created
+- Total amount of bytes requested by all allocation calls since the service started
+- The maximum amount of _used_ (i.e. actual size) allocated memory that has been seen up to this point in the job
+- The amount of _used_ memory allocated at the time the report was made.
+- The largest single allocation request that has been seen up to the time of the report
+- Number of calls made to allocation functions
+- Number of calls made to deallocation functions
+
+If a job forks processes, the forked processes will also report the above information.

--- a/PerfTools/PeriodicAllocMonitorPreload/src/preload.cc
+++ b/PerfTools/PeriodicAllocMonitorPreload/src/preload.cc
@@ -1,0 +1,150 @@
+// -*- C++ -*-
+//
+// Package:     PerfTools/PeriodicAllocMonitorPreload
+// Class  :     preload
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Aug 2023 17:56:44 GMT
+//
+
+// system include files
+#include <atomic>
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <thread>
+#include <unistd.h>
+#include <string>
+#include <cstdlib>
+#include <cstring>
+#include <charconv>
+
+// user include files
+#include "PerfTools/AllocMonitor/interface/AllocMonitorBase.h"
+#include "PerfTools/AllocMonitor/interface/AllocMonitorRegistry.h"
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+// Hooks the target application can be instrumented with to pause and
+// unpause the PeriodicAllocMonitorPreload. Pausing the monitoring during a
+// multithreaded execution can result in unexpected results, because
+// the setting is global.
+
+//NOTE: Any changes to this code may also be appropriate for PerfTools/AllocMonitor/plugins/PeriodicAllocMonitor.cc
+
+namespace {
+  class MonitorAdaptor : public cms::perftools::AllocMonitorBase {
+  public:
+    MonitorAdaptor() {
+      auto pid = getpid();
+      std::string base = "periodic_alloc_";
+      auto envFileName = std::getenv("PAM_FILENAME");
+      if (envFileName) {
+        base = envFileName;
+      }
+      std::string fileName = base + std::to_string(pid) + ".csv";
+
+      unsigned long long interval = 1000;
+      auto envInterval = std::getenv("PAM_INTERVAL_MS");
+      if (envInterval) {
+        (void)std::from_chars(envInterval, envInterval + strlen(envInterval), interval);
+      }
+
+      threadShutDown_ = false;
+      thread_ = std::thread([this, fileName, interval]() {
+        auto const start = std::chrono::steady_clock::now();
+        std::ofstream fs(fileName);
+        fs << "timestamp, total-requested, max-actual, "
+              "present-actual, max-single, nAllocs, nDeallocs\n";
+        while (continueRunning_.load()) {
+          auto const now = std::chrono::steady_clock::now();
+          auto reportNow = report();
+
+          fs << std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count() << ", "
+             << reportNow.requested_ << ", " << reportNow.maxActual_ << ", " << reportNow.presentActual_ << ", "
+             << reportNow.maxSingleRequested_ << ", " << reportNow.nAllocations_ << ", " << reportNow.nDeallocations_
+             << std::endl;
+          std::this_thread::sleep_for(std::chrono::milliseconds(interval));
+        }
+      });
+    }
+    ~MonitorAdaptor() override {
+      if (not threadShutDown_) {
+        continueRunning_ = false;
+        thread_.join();
+      }
+    }
+
+    struct Report {
+      size_t requested_;
+      long long presentActual_;
+      long long maxActual_;
+      size_t nAllocations_;
+      size_t nDeallocations_;
+      size_t maxSingleRequested_;
+    };
+    Report report() const {
+      Report report;
+      report.requested_ = requested_.load(std::memory_order_acquire);
+      report.maxActual_ = maxActual_.load(std::memory_order_acquire);
+      report.presentActual_ = presentActual_.load(std::memory_order_acquire);
+      report.nAllocations_ = nAllocations_.load(std::memory_order_acquire);
+      report.nDeallocations_ = nDeallocations_.load(std::memory_order_acquire);
+      report.maxSingleRequested_ = maxSingleRequested_.load(std::memory_order_acquire);
+
+      return report;
+    }
+
+  private:
+    void allocCalled(size_t iRequested, size_t iActual, void const*) final {
+      nAllocations_.fetch_add(1, std::memory_order_acq_rel);
+      requested_.fetch_add(iRequested, std::memory_order_acq_rel);
+
+      //returns previous value
+      auto a = presentActual_.fetch_add(iActual, std::memory_order_acq_rel);
+      a += iActual;
+
+      auto max = maxActual_.load(std::memory_order_relaxed);
+      while (a > max) {
+        if (maxActual_.compare_exchange_strong(max, a, std::memory_order_acq_rel)) {
+          break;
+        }
+      }
+
+      auto single = maxSingleRequested_.load(std::memory_order_relaxed);
+      while (iRequested > single) {
+        if (maxSingleRequested_.compare_exchange_strong(single, iRequested, std::memory_order_acq_rel)) {
+          break;
+        }
+      }
+    }
+    void deallocCalled(size_t iActual, void const*) final {
+      if (0 == iActual)
+        return;
+      nDeallocations_.fetch_add(1, std::memory_order_acq_rel);
+      presentActual_.fetch_sub(iActual, std::memory_order_acq_rel);
+    }
+
+    std::atomic<size_t> requested_ = 0;
+    std::atomic<long long> presentActual_ = 0;
+    std::atomic<long long> maxActual_ = 0;
+    std::atomic<size_t> nAllocations_ = 0;
+    std::atomic<size_t> nDeallocations_ = 0;
+    std::atomic<size_t> maxSingleRequested_ = 0;
+    std::thread thread_;
+    std::atomic<bool> continueRunning_ = true;
+    bool threadShutDown_ = true;
+  };
+
+  [[maybe_unused]] auto const* const s_instance =
+      cms::perftools::AllocMonitorRegistry::instance().createAndRegisterMonitor<MonitorAdaptor>();
+}  // namespace


### PR DESCRIPTION

#### PR description:

This uses the same idea as the PeriodicAllocMonitor service but can work on any application via the use of LD_PRELOAD.

#### PR validation:

Code compiles. A simple hand run test appears to work fine.

resolves https://github.com/cms-sw/framework-team/issues/2329