### PR TITLE
Added ThresholdAbortAllocMonitorPreload

### DIFF
--- a/PerfTools/ThresholdAbortAllocMonitorPreload/BuildFile.xml
+++ b/PerfTools/ThresholdAbortAllocMonitorPreload/BuildFile.xml
@@ -1,0 +1,6 @@
+<environment>
+  <use name="PerfTools/AllocMonitor"/>
+  <export>
+    <lib name="1"/>
+  </export>
+</environment>

--- a/PerfTools/ThresholdAbortAllocMonitorPreload/README.md
+++ b/PerfTools/ThresholdAbortAllocMonitorPreload/README.md
@@ -1,0 +1,29 @@
+# PerfTools/ThresholdAbortAllocMonitorPreload Description
+
+## Introduction
+
+This package generated a library that is meant to be LD_PRELOADed along with libPrefToolsAllocMonitorPreload.so which
+uses `cms::perftools::AllocMonitorRegistry` to register a monitor before an application begins. When the application
+request an allocation that falls within the threshold range, the process will either abort or a special named function
+(`break_threshold_abort_alloc_monitor`) will be called.
+
+## Usage
+
+To use the package, one must issue the following LD_PRELOAD command before running the application (bash version
+shown below)
+```
+LD_PRELOAD="libPerfToolsAllocMonitorPreload.so libPerfToolsThresholdAbortAllocMonitorPreload.so"
+```
+
+the order is important.
+
+The threshold range, how many triggered allocations should be skipped  and whether to abort or call `break_threshold_abort_alloc_monitor` is set via environment variables.
+
+| *Variable* | *Description* |
+| --- | --- |
+| TAAM_MIN | The minimum size (in bytes) of an allocation request which will trigger the system. |
+| TAAM_MAX | The maximum size (in bytes) of an allocation request which will trigger the system. A value of 0 means no max is used for the trigger (just the min). Default is 0. |
+| TAAM_SKIP | Number of triggers (i.e. allocations that fell within the threshold range) to skip before calling abort or `break_threshold_abort_alloc_monitor`. Default is 0. |
+| TAAM_BREAK | If set, will call `break_threshold_abort_alloc_monitor` rather than abort when reach the beyond the skipped triggers. |
+
+If a job forks processes, the forked processes will also be subjected to the triggering.

--- a/PerfTools/ThresholdAbortAllocMonitorPreload/src/preload.cc
+++ b/PerfTools/ThresholdAbortAllocMonitorPreload/src/preload.cc
@@ -1,0 +1,94 @@
+// -*- C++ -*-
+//
+// Package:     PerfTools/ThresholdAbortPreload
+// Class  :     preload
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 23 Aug 2023 17:56:44 GMT
+//
+
+// system include files
+#include <atomic>
+#include <iostream>
+#include <unistd.h>
+#include <cstring>
+#include <charconv>
+#include <format>
+
+// user include files
+#include "PerfTools/AllocMonitor/interface/AllocMonitorBase.h"
+#include "PerfTools/AllocMonitor/interface/AllocMonitorRegistry.h"
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+static volatile std::atomic<int> dummy = 0;
+extern "C" {
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((noinline, optimize("O0")))
+#endif
+void break_threshold_abort_alloc_monitor() {
+  dummy = 1;
+}
+}
+
+namespace {
+  template <typename T>
+  void fromEnv(const char* iEnv, T& oValue) {
+    auto env = std::getenv(iEnv);
+    if (env) {
+      std::from_chars(env, env + strlen(env), oValue);
+    }
+  }
+
+  class MonitorAdaptor : public cms::perftools::AllocMonitorBase {
+  public:
+    MonitorAdaptor() : m_skip{0}, m_min{0}, m_max{0}, m_count{0} {
+      fromEnv("TAAM_SKIP", m_skip);
+      fromEnv("TAAM_MIN", m_min);
+      fromEnv("TAAM_MAX", m_max);
+      if (std::getenv("TAAM_BREAK")) {
+        m_break = true;
+      }
+    }
+
+  private:
+    void allocCalled(size_t iRequested, size_t iActual, void const*) final {
+      if (iRequested >= m_min) {
+        if (m_max == 0 or iRequested <= m_max) {
+          auto v = ++m_count;
+          if (v > m_skip) {
+            if (m_break) {
+              std::cout << std::format(
+                               "break_threshold_abort_alloc_monitor: abort threshold reached count: {} request: {}",
+                               v,
+                               iRequested)
+                        << std::endl;
+              break_threshold_abort_alloc_monitor();
+            } else {
+              std::cout << std::format("abort threshold reached count: {} request: {}", v, iRequested) << std::endl;
+              abort();
+            }
+          }
+        }
+      }
+    }
+    void deallocCalled(size_t iActual, void const*) final {}
+
+    unsigned int m_skip;
+    size_t m_min;
+    size_t m_max;
+    std::atomic<unsigned int> m_count;
+    bool m_break = false;
+  };
+
+  [[maybe_unused]] auto const* const s_instance =
+      cms::perftools::AllocMonitorRegistry::instance().createAndRegisterMonitor<MonitorAdaptor>();
+}  // namespace


### PR DESCRIPTION
#### PR description:

Based on ThresholdAbortAllocMonitor service, but can work on any application.

#### PR validation:

Code compiles. Some simple hand tests shows that it works.

resolves https://github.com/cms-sw/framework-team/issues/2334