### PR TITLE
[WarningFix]Fix clang thread-safety warning in DQMEDAnalyzer.h

### DIFF
--- a/DQMServices/Core/interface/DQMEDAnalyzer.h
+++ b/DQMServices/Core/interface/DQMEDAnalyzer.h
@@ -26,6 +26,18 @@ namespace edm::stream::impl {
 #include "DataFormats/Histograms/interface/DQMToken.h"
 
 struct DQMEDAnalyzerGlobalCache {
+public:
+  void setTokensOnce(edm::EDPutTokenT<DQMToken> lumi, edm::EDPutTokenT<DQMToken> run) const {
+    std::scoped_lock lock(master_);
+    if (runToken_.isUninitialized()) {
+      lumiToken_ = lumi;
+      runToken_ = run;
+    }
+  }
+  edm::EDPutTokenT<DQMToken> lumiToken() const { return lumiToken_; }
+  edm::EDPutTokenT<DQMToken> runToken() const { return runToken_; }
+
+private:
   // slightly overkill for now, but we might want to putt the full DQMStore
   // here at some point.
   mutable std::mutex master_;
@@ -69,11 +81,7 @@ public:
     // we need to store the tokens here.
     // This also requires locking, since the streams will run in parallel.
     // See https://github.com/cms-sw/cmssw/issues/27291#issuecomment-505909101
-    auto lock = std::scoped_lock(globalCache()->master_);
-    if (globalCache()->runToken_.isUninitialized()) {
-      globalCache()->lumiToken_ = lumiToken_;
-      globalCache()->runToken_ = runToken_;
-    }
+    globalCache()->setTokensOnce(lumiToken_, runToken_);
   }
 
   void beginRun(edm::Run const& run, edm::EventSetup const& setup) final {
@@ -108,14 +116,14 @@ public:
   static void globalEndLuminosityBlockProduce(edm::LuminosityBlock& lumi,
                                               edm::EventSetup const& setup,
                                               LuminosityBlockContext const* context) {
-    lumi.emplace(context->global()->lumiToken_);
+    lumi.emplace(context->global()->lumiToken());
   }
 
   void endRun(edm::Run const& run, edm::EventSetup const& setup) final {
     edm::Service<DQMStore>()->leaveLumi(run.run(), /* lumi */ 0, meId());
   }
   static void globalEndRunProduce(edm::Run& run, edm::EventSetup const& setup, RunContext const* context) {
-    run.emplace<DQMToken>(context->global()->runToken_);
+    run.emplace<DQMToken>(context->global()->runToken());
   }
 
   static void globalEndJob(DQMEDAnalyzerGlobalCache const*) {}


### PR DESCRIPTION
#### PR description:

While going through some clang static analysis logs for DQM/L1TMonitor, I kept seeing the same warning show up over and over (in every file that includes DQMEDAnalyzer.h):
```
  warning: Class 'DQMEDAnalyzerGlobalCache' has publically-accessible
  mutable member 'lumiToken_', this is not allowed [threadsafety.PublicMutableMember]
```
Turns out this isn't really coming from DQM/L1TMonitor at all, it's a warning about DQMEDAnalyzer.h itself, so it shows up in every package that uses it. Two members in DQMEDAnalyzerGlobalCache (lumiToken_ and runToken_) are marked `mutable` and were just sitting there public, which the checker doesn't like because in theory anyone could write to them from outside without any locking.
So I made the members private and move that same locking/check logic into a small method (setTokensOnce) + two read-only getters for the two places that were reading the values directly. Nothing about the locking, timing, or what gets stored changes.it is  just behind a proper interface now.
This PR doesn't touch the design from #27125 or the locking from #27291 - it only makes the tokens private.

Is this solution acceptable?
logs[here](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_20_1_X_2026-07-15-2300/el9_amd64_gcc13/build-logs/DQM/L1TMonitor/log.html)