### PR TITLE
Update ECAL Phase 2 sample noise correlations - 200X

### DIFF
--- a/SimCalorimetry/EcalSimProducers/python/ecalDigiParameters_Ph2_cff.py
+++ b/SimCalorimetry/EcalSimProducers/python/ecalDigiParameters_Ph2_cff.py
@@ -4,15 +4,15 @@ ecal_digi_parameters = cms.PSet(
     EBdigiCollectionPh2 = cms.string(''),
     UseLCcorrection  = cms.untracked.bool(True),
 
-    #NOTE: Phase2 noise correlation matrices with fake numbers to simply test the code flow.
-
+    # Phase2 noise correlation matrices for G10 from 2023 TB
     EBCorrNoiseMatrixG10Ph2 = cms.vdouble (
-    1.00000, 0.71073, 0.55721, 0.46089, 0.40449,
-    0.35931, 0.33924, 0.32439, 0.31581, 0.30481, 0.40449,0.40449,0.40449,0.40449,0.40449,0.40449) ,
+    1.0000, 0.6986, 0.3782, 0.2452, 0.2900, 0.3532, 0.3911, 0.3896,
+    0.3892, 0.3842, 0.3796, 0.3711, 0.3763, 0.3791, 0.3867, 0.3820),
 
+    # G1 numbers duplicated from G10 in lack of measured G1 correlations
     EBCorrNoiseMatrixG01Ph2 = cms.vdouble (
-    1.00000, 0.73354, 0.64442, 0.58851, 0.55425,
-    0.53082, 0.51916, 0.51097, 0.50732, 0.50409, 0.40449,0.40449,0.40449,0.40449,0.40449,0.40449) ,
+    1.0000, 0.6986, 0.3782, 0.2452, 0.2900, 0.3532, 0.3911, 0.3896,
+    0.3892, 0.3842, 0.3796, 0.3711, 0.3763, 0.3791, 0.3867, 0.3820),
 
     EcalPreMixStage1 = cms.bool(False)
 )


### PR DESCRIPTION
#### PR description:

Update ECAL Phase 2 sample noise correlations from 2023 TB measurement. Since only the gain 10 correlations were measured from the 2023 TB data the gain 1 correlations are duplicated from the gain 10 ones until properly measured correlations from more recent TBs become available.

Only ECAL Phase 2 development workflows are affected by this change. No changes are expected to standard workflows.

#### PR validation:

Passes 34402.612, 34634.61299.

Backport of https://github.com/cms-sw/cmssw/pull/51476 to improve the Phase 2 simulation.