### PR TITLE
Updated unit tests for multilayer PF clusterizers

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/test/alpaka/ConstructLinksTest.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/alpaka/ConstructLinksTest.dev.cc
@@ -43,80 +43,111 @@
 
 constexpr double nSigmaEta = 0.01234;
 constexpr double nSigmaPhi = 0.2678;
+// 21
+static constexpr unsigned int nStreams = 1;  //T4:40 RTX:72 L40S:142 4090:128 5080:84
+
+static constexpr unsigned int nIters = 100;
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class ConstructLinksTest {
   public:
-    void apply(Queue& queue,
-               reco::PFMultiDepthClusteringCCLabelsDeviceCollection& mdpfCCLabels,
-               const reco::PFMultiDepthClusteringVarsDeviceCollection& mdpfClusteringVars,
+    void apply(std::vector<Queue>& queues,
+               std::vector<reco::PFMultiDepthClusteringCCLabelsDeviceCollection>& mdpfCCLabels,
+               const std::vector<reco::PFMultiDepthClusteringVarsDeviceCollection>& mdpfClusteringVars,
                const PFMultiDepthClusterParams* nSigma) const;
   };
 
-  void ConstructLinksTest::apply(Queue& queue,
-                                 reco::PFMultiDepthClusteringCCLabelsDeviceCollection& mdpfCCLabels,
-                                 const reco::PFMultiDepthClusteringVarsDeviceCollection& mdpfClusteringVars,
+  void ConstructLinksTest::apply(std::vector<Queue>& queues,
+                                 std::vector<reco::PFMultiDepthClusteringCCLabelsDeviceCollection>& mdpfCCLabels,
+                                 const std::vector<reco::PFMultiDepthClusteringVarsDeviceCollection>& mdpfClusteringVars,
                                  const PFMultiDepthClusterParams* nSigma) const {
-    uint32_t items = std::is_same_v<Device, alpaka::DevCpu> ? 1 : 64;
+    uint32_t items = std::is_same_v<Device, alpaka::DevCpu> ? 1 : 128;
 
-    auto n = static_cast<uint32_t>(mdpfClusteringVars->metadata().size());
-    uint32_t groups = cms::alpakatools::divide_up_by(n, items);
+    auto n = static_cast<uint32_t>(mdpfClusteringVars[0]->metadata().size());
+    uint32_t groups = ::cms::alpakatools::divide_up_by(n, items);
 
     if (groups < 1) {
       printf("Skip kernel launch...\n");
       return;
-    } else {
-      printf("Run kernel in %d threads, %d groups.\n", n, groups);
     }
 
-    auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(groups, items);
+    auto workDiv = ::cms::alpakatools::make_workdiv<Acc1D>(groups, items);
 
-    alpaka::exec<Acc1D>(queue, workDiv, ConstructLinksKernel{}, mdpfCCLabels.view(), mdpfClusteringVars.view(), nSigma);
+    double wall_time = 0.0;
+    for (unsigned int i = 0; i < nIters; i++) {
+      auto wall_start = std::chrono::high_resolution_clock::now();
 
-    alpaka::wait(queue);
+      for (unsigned int s = 0; s < nStreams; s++) {
+        alpaka::exec<Acc1D>(
+            queues[0], workDiv, ConstructLinksKernel{}, mdpfCCLabels[s].view(), mdpfClusteringVars[s].view(), nSigma);
+      }
+
+      for (unsigned int s = 0; s < nStreams; s++)
+        alpaka::wait(queues[s]);
+
+      auto wall_stop = std::chrono::high_resolution_clock::now();
+      //
+      auto wall_diff = wall_stop - wall_start;
+
+      wall_time += static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(wall_diff).count()) / 1e6;
+    }
+
+    printf("Wall time: %f sec per iter, %f per stream per iter\n", wall_time / nIters, wall_time / (nIters * nStreams));
   }
 
-  void launch_construct_links_test(Queue& queue,
-                                   ::reco::PFMultiDepthClusteringCCLabelsHostCollection& hostClusteringCCLabels,
-                                   const ::reco::PFMultiDepthClusteringVarsHostCollection& hostClusteringVars) {
+  void launch_construct_links_test(
+      std::vector<Queue>& queues,
+      std::vector<::reco::PFMultiDepthClusteringCCLabelsHostCollection>& hostClusteringCCLabels,
+      const std::vector<::reco::PFMultiDepthClusteringVarsHostCollection>& hostClusteringVars) {
     ConstructLinksTest construct_links_test{};
-
-    auto hClusteringVars = hostClusteringVars.view();
-
-    const int nClusters = hClusteringVars.size();
-
-    reco::PFMultiDepthClusteringVarsDeviceCollection devClusteringVars{queue, nClusters};
-
-    alpaka::memcpy(queue, devClusteringVars.buffer(), hostClusteringVars.buffer());
-
-    reco::PFMultiDepthClusteringCCLabelsDeviceCollection devClusteringCCLabels{queue, nClusters + 1};
 
     auto params_h = cms::alpakatools::make_host_buffer<PFMultiDepthClusterParams, Platform>();
 
     params_h->nSigmaEta = nSigmaEta;
     params_h->nSigmaPhi = nSigmaPhi;
 
-    auto params_d = cms::alpakatools::make_device_buffer<PFMultiDepthClusterParams>(queue);
+    auto params_d = cms::alpakatools::make_device_buffer<PFMultiDepthClusterParams>(queues[0]);
 
-    alpaka::memcpy(queue, params_d, params_h);
+    alpaka::memcpy(queues[0], params_d, params_h);
 
-    construct_links_test.apply(queue, devClusteringCCLabels, devClusteringVars, params_d.data());
+    auto hClusteringVars = hostClusteringVars[0].view();
 
-    alpaka::memcpy(queue, hostClusteringCCLabels.buffer(), devClusteringCCLabels.buffer());
+    const int nClusters = hClusteringVars.size();
 
-    alpaka::wait(queue);
+    std::vector<reco::PFMultiDepthClusteringVarsDeviceCollection> devClusteringVars;
+    devClusteringVars.reserve(nStreams);
+
+    std::vector<reco::PFMultiDepthClusteringCCLabelsDeviceCollection> devClusteringCCLabels;
+    devClusteringVars.reserve(nStreams);
+
+    for (unsigned int s = 0; s < nStreams; s++) {
+      //
+      auto dev_clustering_vars = reco::PFMultiDepthClusteringVarsDeviceCollection{queues[s], nClusters};
+      //
+      alpaka::memcpy(queues[s], dev_clustering_vars.buffer(), hostClusteringVars[s].buffer());
+
+      devClusteringVars.emplace_back(std::move(dev_clustering_vars));
+
+      devClusteringCCLabels.emplace_back(
+          reco::PFMultiDepthClusteringCCLabelsDeviceCollection(queues[s], nClusters + 1));
+
+      alpaka::wait(queues[s]);
+    }
+
+    construct_links_test.apply(queues, devClusteringCCLabels, devClusteringVars, params_d.data());
+
+    alpaka::memcpy(queues[0], hostClusteringCCLabels[0].buffer(), devClusteringCCLabels[0].buffer());
+
+    for (unsigned int s = 0; s < nStreams; s++)
+      alpaka::wait(queues[s]);
   }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
-void create(::reco::PFClusterCollection& clusters,
-            ::reco::PFMultiDepthClusteringVarsHostCollection& hostClusteringVars,
-            const int nClusters) {
-  auto hClusteringVars = hostClusteringVars.view();
-
+void create(::reco::PFClusterCollection& clusters, const int nClusters) {
   std::mt19937 rng(12345);
 
   // E in [0.5, 120], r in [174, 180], phi in [0, 0.25], z = 0
@@ -124,15 +155,14 @@ void create(::reco::PFClusterCollection& clusters,
   std::uniform_real_distribution<double> r_dist(174.0, 180.0);
   std::uniform_real_distribution<double> phi_dist(0.0, 0.25);
   std::uniform_real_distribution<double> z_dist(0.0, 0.5);
-  std::uniform_real_distribution<double> epRMS2_dist(0.001, 0.05);
 
   std::uniform_int_distribution<int> depth_distr(1, 4);
 
   for (int i = 0; i < nClusters; ++i) {
     const bool is_depth1 = (i % 2 == 0);
     const PFLayer::Layer layer = is_depth1 ? PFLayer::Layer::HCAL_BARREL1 : PFLayer::Layer::HCAL_BARREL2;
-    const double depth = depth_distr(rng);
 
+    const double depth = depth_distr(rng);
     const double energy = energies_dist(rng);
 
     const double r = r_dist(rng);
@@ -142,23 +172,37 @@ void create(::reco::PFClusterCollection& clusters,
     const double y = r * std::sin(phi);
     const double z = z_dist(rng);
 
-    const double etaRMS2_ = epRMS2_dist(rng);
-    const double phiRMS2_ = epRMS2_dist(rng);
-
-    hClusteringVars[i].depth() = depth;
-    hClusteringVars[i].energy() = energy;
-
-    hClusteringVars[i].etaRMS2() = etaRMS2_;
-    hClusteringVars[i].phiRMS2() = phiRMS2_;
-
     ::reco::PFCluster cluster(layer, energy, x, y, z);
     cluster.setDepth(depth);
+
+    clusters.emplace_back(std::move(cluster));
+  }
+}
+
+void load(::reco::PFMultiDepthClusteringVarsHostCollection& hostClusteringVars,
+          const ::reco::PFClusterCollection& clusters) {
+  const int nClusters = clusters.size();
+  auto hClusteringVars = hostClusteringVars.view();
+
+  hClusteringVars.size() = nClusters;
+
+  std::mt19937 rng(12355);
+
+  std::uniform_real_distribution<double> epRMS2_dist(0.001, 0.05);
+
+  for (int i = 0; i < nClusters; ++i) {
+    const ::reco::PFCluster& cluster = clusters[i];
+
+    hClusteringVars[i].depth() = cluster.depth();
+    hClusteringVars[i].energy() = cluster.energy();
+
+    hClusteringVars[i].etaRMS2() = epRMS2_dist(rng);
+    hClusteringVars[i].phiRMS2() = epRMS2_dist(rng);
 
     auto const& crep = cluster.positionREP();
 
     hClusteringVars[i].eta() = crep.eta();
     hClusteringVars[i].phi() = crep.phi();
-    clusters.emplace_back(std::move(cluster));
   }
 }
 
@@ -223,13 +267,15 @@ std::vector<ClusterLink> link(const ::reco::PFClusterCollection& clusters,
   return links;
 }
 
+template <bool verbose = false>
 std::vector<ClusterLink> prune(std::vector<ClusterLink>& links, std::vector<bool>& linkedClusters) {
   std::vector<ClusterLink> goodLinks;
   std::vector<bool> mask(links.size(), false);
   if (links.empty())
     return goodLinks;
 
-  printf("Total number of links : %lu\n", links.size());
+  if constexpr (verbose)
+    printf("Total number of links : %lu\n", links.size());
 
   for (unsigned int i = 0; i < links.size() - 1; ++i) {
     if (mask[i])
@@ -277,11 +323,38 @@ std::vector<ClusterLink> prune(std::vector<ClusterLink>& links, std::vector<bool
     linkedClusters[links[i].to()] = true;
   }
 
-  printf("Total pruned links %u\n", pruned_links);
+  if constexpr (verbose)
+    printf("Total pruned links %u\n", pruned_links);
 
-  printf("Total number of selected links : %lu\n", goodLinks.size());
+  if constexpr (verbose)
+    printf("Total number of selected links : %lu\n", goodLinks.size());
 
   return goodLinks;
+}
+
+void runPruningTest(const ::reco::PFClusterCollection& clusters,
+                    const std::vector<double>& etaRMS2,
+                    const std::vector<double>& phiRMS2) {
+  double dummyEn = 0.;
+  // Time loop
+  auto start = std::chrono::steady_clock::now();
+
+  for (unsigned int i = 0; i < nIters; i++) {
+    //link
+    auto&& links = link(clusters, etaRMS2, phiRMS2);
+
+    std::vector<bool> linked(clusters.size(), false);
+    //prune
+    auto&& prunedLinks = prune(links, linked);
+
+    dummyEn += prunedLinks[0].energy();
+  }
+
+  auto seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+
+  std::cout << "Legacy function execution time : " << seconds / nIters << " sec per stream per iter." << std::endl;
+
+  std::cout << "Link 0 energy " << dummyEn / nIters << std::endl;
 }
 
 int checkConstructLinks(const ::reco::PFClusterCollection& clusters,
@@ -298,6 +371,9 @@ int checkConstructLinks(const ::reco::PFClusterCollection& clusters,
     etaRMS2[i] = hClusteringVars[i].etaRMS2();
     phiRMS2[i] = hClusteringVars[i].phiRMS2();
   }
+  // Check time:
+  runPruningTest(clusters, etaRMS2, phiRMS2);
+
   //link
   auto&& links = link(clusters, etaRMS2, phiRMS2);
 
@@ -347,27 +423,40 @@ int main() {
     exit(EXIT_FAILURE);
   }
 
-  const int nClusters = 145;
+  const int nClusters = 1024;
+
+  ::reco::PFClusterCollection clusters;
+  clusters.reserve(nClusters);
+  create(clusters, nClusters);
 
   // run the test on each device
   for (auto const& device : devices) {
-    auto queue = Queue(device);
+    std::vector<Queue> queues;
+    queues.reserve(nStreams);
 
-    ::reco::PFClusterCollection clusters;
-    clusters.reserve(nClusters);
+    std::vector<::reco::PFMultiDepthClusteringVarsHostCollection> hostClusteringVars;
+    hostClusteringVars.reserve(nStreams);
 
-    ::reco::PFMultiDepthClusteringVarsHostCollection hostClusteringVars{queue, nClusters};
+    std::vector<::reco::PFMultiDepthClusteringCCLabelsHostCollection> hostClusteringCCLabels;
+    hostClusteringCCLabels.reserve(nStreams);
 
-    ::reco::PFMultiDepthClusteringCCLabelsHostCollection hostClusteringCCLabels{queue, nClusters + 1};
+    for (unsigned int s = 0; s < nStreams; s++) {
+      auto queue = Queue(device);
 
-    auto hClusteringVars = hostClusteringVars.view();
-    hClusteringVars.size() = nClusters;
+      auto host_clustering_vars = ::reco::PFMultiDepthClusteringVarsHostCollection(queue, nClusters);
 
-    create(clusters, hostClusteringVars, nClusters);
+      load(host_clustering_vars, clusters);
 
-    launch_construct_links_test(queue, hostClusteringCCLabels, hostClusteringVars);
+      hostClusteringVars.emplace_back(std::move(host_clustering_vars));
 
-    auto nerrors = checkConstructLinks(clusters, hostClusteringCCLabels, hostClusteringVars);
+      hostClusteringCCLabels.emplace_back(::reco::PFMultiDepthClusteringCCLabelsHostCollection(queue, nClusters + 1));
+
+      queues.emplace_back(std::move(queue));
+    }
+
+    launch_construct_links_test(queues, hostClusteringCCLabels, hostClusteringVars);
+
+    auto nerrors = checkConstructLinks(clusters, hostClusteringCCLabels[0], hostClusteringVars[0]);
 
     if (nerrors != 0) {
       std::cerr << nerrors << " errors detected, exiting." << std::endl;

--- a/RecoParticleFlow/PFClusterProducer/test/alpaka/EpilogueTest.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/alpaka/EpilogueTest.dev.cc
@@ -831,14 +831,14 @@ int main(int argc, char **argv) {
   if (devices.empty()) {
     std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
                  "the test will be skipped.\n";
-    return EXIT_FAILURE; // Prefer returning over raw exit() in main
+    return EXIT_FAILURE;  // Prefer returning over raw exit() in main
   }
 
   int nStreams = 1;
   int nClusters = multiblock ? 1024 : 512;
   int nIters = nColdIters + 100;
 
-  auto parseArg = [](const char* arg, const std::string& name) {
+  auto parseArg = [](const char *arg, const std::string &name) {
     try {
       return std::stoi(arg);
     } catch (...) {
@@ -858,8 +858,10 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (argc > 2) nStreams = parseArg(argv[2], "<nStreams>");
-  if (argc > 3) nIters   = parseArg(argv[3], "<nIters>");
+  if (argc > 2)
+    nStreams = parseArg(argv[2], "<nStreams>");
+  if (argc > 3)
+    nIters = parseArg(argv[3], "<nIters>");
 
   int threadsPerBlock = multiblock ? 128 : nClusters;
 
@@ -890,7 +892,7 @@ int main(int argc, char **argv) {
   const int nHits = sizes.first;
   const int nFracs = sizes.second;
 
-  std::vector<int> cc_roots = {0, 1, 5, 9, 38 , 45, 49, 66, 71, 77, 89, 91, 99 };
+  std::vector<int> cc_roots = {0, 1, 5, 9, 38, 45, 49, 66, 71, 77, 89, 91, 99};
 
   const int cc_num = static_cast<int>(cc_roots.size());
 

--- a/RecoParticleFlow/PFClusterProducer/test/alpaka/EpilogueTest.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/alpaka/EpilogueTest.dev.cc
@@ -53,11 +53,16 @@ static constexpr bool cooperative = true;
 static constexpr bool cooperative = false;
 #endif
 
+//T4:40 RTX:72 L40S:142 4090:128 5080:84
+
+//static constexpr unsigned int nIters = 10000;
+static constexpr int nColdIters = 10;
+
 using PFRecHitsNeighbours = Eigen::Matrix<int32_t, 8, 1>;
 
 using namespace reco;
 
-static bool verbose = true;
+static bool verbose = false;
 
 // Simple axis-aligned test cell:
 namespace {
@@ -97,9 +102,9 @@ namespace {
     }
   };
 
-  CaloCellGeometry::CornersMgr s_cornersMgr(65536, CaloCellGeometry::k_cornerSize);  //k_cornerSize = 8;
+  CaloCellGeometry::CornersMgr s_cornersMgr(8 * 1048576, CaloCellGeometry::k_cornerSize);  //k_cornerSize = 8;
 
-  CaloCellGeometry::ParMgr s_parMgr(65536, /*subSize=*/BoxCell::kNPar);
+  CaloCellGeometry::ParMgr s_parMgr(8 * 1048576, /*subSize=*/BoxCell::kNPar);
 
   CaloCellGeometry::ParVecVec s_parBlocks;
 
@@ -135,26 +140,33 @@ static inline reco::PFRecHit makePFRecHit(
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class EpilogueTest {
+    const int nStreams;
+    const int nIters;
+    const int threads;
+
   public:
-    void apply(Queue &queue,
-               reco::PFClusterDeviceCollection &outPFCluster,
-               reco::PFRecHitFractionDeviceCollection &outPFRecHitFracs,
-               reco::PFMultiDepthClusteringCCLabelsDeviceCollection &mdpfClusteringVars,
-               const reco::PFClusterDeviceCollection &pfClusters,
-               const reco::PFRecHitFractionDeviceCollection &pfRecHitFracs,
-               const reco::PFRecHitDeviceCollection &pfRecHit) const;
+    EpilogueTest(const int nStreams, const int nIters, const int threads)
+        : nStreams(nStreams), nIters(nIters), threads(threads) {}
+
+    void apply(std::vector<Queue> &queues,
+               std::vector<reco::PFClusterDeviceCollection> &outPFCluster,
+               std::vector<reco::PFRecHitFractionDeviceCollection> &outPFRecHitFracs,
+               std::vector<reco::PFMultiDepthClusteringCCLabelsDeviceCollection> &mdpfClusteringVars,
+               const std::vector<reco::PFClusterDeviceCollection> &pfClusters,
+               const std::vector<reco::PFRecHitFractionDeviceCollection> &pfRecHitFracs,
+               const std::vector<reco::PFRecHitDeviceCollection> &pfRecHit) const;
   };
 
-  void EpilogueTest::apply(Queue &queue,
-                           reco::PFClusterDeviceCollection &outPFCluster,
-                           reco::PFRecHitFractionDeviceCollection &outPFRecHitFracs,
-                           reco::PFMultiDepthClusteringCCLabelsDeviceCollection &mdpfClusteringVars,
-                           const reco::PFClusterDeviceCollection &pfClusters,
-                           const reco::PFRecHitFractionDeviceCollection &pfRecHitFracs,
-                           const reco::PFRecHitDeviceCollection &pfRecHit) const {
-    uint32_t items = std::is_same_v<Device, alpaka::DevCpu> ? 1 : (multiblock ? 128 : 512);
+  void EpilogueTest::apply(std::vector<Queue> &queues,
+                           std::vector<reco::PFClusterDeviceCollection> &outPFCluster,
+                           std::vector<reco::PFRecHitFractionDeviceCollection> &outPFRecHitFracs,
+                           std::vector<reco::PFMultiDepthClusteringCCLabelsDeviceCollection> &mdpfClusteringVars,
+                           const std::vector<reco::PFClusterDeviceCollection> &pfClusters,
+                           const std::vector<reco::PFRecHitFractionDeviceCollection> &pfRecHitFracs,
+                           const std::vector<reco::PFRecHitDeviceCollection> &pfRecHit) const {
+    uint32_t items = std::is_same_v<Device, alpaka::DevCpu> ? 1 : threads;
 
-    auto n = static_cast<uint32_t>(mdpfClusteringVars->metadata().size());
+    auto n = static_cast<uint32_t>(mdpfClusteringVars[0]->metadata().size());
     uint32_t groups = cms::alpakatools::divide_up_by(n, items);
 
     if (groups < 1) {
@@ -166,120 +178,171 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(groups, items);
 
-    if constexpr (multiblock) {
-      if constexpr (cooperative) {
-        printf("Running multiblock epilogue in cooperative mode.\n");
-      } else {
-        printf("Running multiblock epilogue in noncooperative mode.\n");
-      }
-      reco::PFMultiDepthECLCCEpilogueArgsDeviceCollection devClusteringEpilogueArgs{queue, n};
-
-      devClusteringEpilogueArgs.zeroInitialise(queue);
-
-      alpaka::exec<Acc1D>(queue,
-                          workDiv,
-                          ECLCCEpilogueRecHitFracOffsetsKernel{},
-                          devClusteringEpilogueArgs.view(),
-                          mdpfClusteringVars.view(),
-                          pfClusters.view());
-
-      alpaka::exec<Acc1D>(queue,
-                          workDiv,
-                          ECLCCEpilogueCCOffsetsKernel{},
-                          outPFCluster.view(),
-                          devClusteringEpilogueArgs.view(),
-                          mdpfClusteringVars.view(),
-                          pfClusters.view());
-
-      alpaka::exec<Acc1D>(queue,
-                          workDiv,
-                          ECLCCFinalizeEpilogueKernel<32, cooperative>{},
-                          outPFCluster.view(),
-                          outPFRecHitFracs.view(),
-                          devClusteringEpilogueArgs.view(),
-                          mdpfClusteringVars.view(),
-                          pfClusters.view(),
-                          pfRecHitFracs.view(),
-                          pfRecHit.view());
-
-      alpaka::exec<Acc1D>(
-          queue, workDiv, ECLCCLoadSeedsKernel{}, outPFCluster.view(), devClusteringEpilogueArgs.view());
+    if constexpr (cooperative) {
+      printf("Running epilogue in cooperative mode.\n");
     } else {
-      if constexpr (cooperative) {
-        printf("Running legacy epilogue in cooperative mode.\n");
-      } else {
-        printf("Running legacy epilogue in noncooperative mode.\n");
-      }
-      if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
-        alpaka::exec<Acc1D>(queue,
-                            workDiv,
-                            ECLCCEpilogueNaiveKernel{},
-                            outPFCluster.view(),
-                            outPFRecHitFracs.view(),
-                            mdpfClusteringVars.view(),
-                            pfClusters.view(),
-                            pfRecHitFracs.view(),
-                            pfRecHit.view());
-      } else {
-        alpaka::exec<Acc1D>(queue,
-                            workDiv,
-                            ECLCCEpilogueKernel<32, cooperative>{},
-                            outPFCluster.view(),
-                            outPFRecHitFracs.view(),
-                            mdpfClusteringVars.view(),
-                            pfClusters.view(),
-                            pfRecHitFracs.view(),
-                            pfRecHit.view());
-      }
+      printf("Running epilogue in noncooperative mode.\n");
     }
 
-    alpaka::wait(queue);
+    std::vector<reco::PFMultiDepthECLCCEpilogueArgsDeviceCollection> devClusteringEpilogueArgs;
+    devClusteringEpilogueArgs.reserve(nStreams);
+
+    for (int s = 0; s < nStreams; s++) {
+      devClusteringEpilogueArgs.emplace_back(reco::PFMultiDepthECLCCEpilogueArgsDeviceCollection(queues[s], n));
+      alpaka::wait(queues[s]);
+    }
+
+    double wall_time = 0.0;
+    for (int i = 0; i < nIters; i++) {
+      auto wall_start = std::chrono::high_resolution_clock::now();
+
+      if constexpr (multiblock) {
+        for (int s = 0; s < nStreams; s++) {
+          devClusteringEpilogueArgs[s].zeroInitialise(queues[s]);
+
+          alpaka::exec<Acc1D>(queues[s],
+                              workDiv,
+                              ECLCCEpilogueRecHitFracOffsetsKernel{},
+                              devClusteringEpilogueArgs[s].view(),
+                              mdpfClusteringVars[s].view(),
+                              pfClusters[s].view());
+
+          alpaka::exec<Acc1D>(queues[s],
+                              workDiv,
+                              ECLCCEpilogueCCOffsetsKernel{},
+                              outPFCluster[s].view(),
+                              devClusteringEpilogueArgs[s].view(),
+                              mdpfClusteringVars[s].view(),
+                              pfClusters[s].view());
+
+          alpaka::exec<Acc1D>(queues[s],
+                              workDiv,
+                              ECLCCFinalizeEpilogueKernel<32, cooperative>{},
+                              outPFCluster[s].view(),
+                              outPFRecHitFracs[s].view(),
+                              devClusteringEpilogueArgs[s].view(),
+                              mdpfClusteringVars[s].view(),
+                              pfClusters[s].view(),
+                              pfRecHitFracs[s].view(),
+                              pfRecHit[s].view());
+
+          alpaka::exec<Acc1D>(
+              queues[s], workDiv, ECLCCLoadSeedsKernel{}, outPFCluster[s].view(), devClusteringEpilogueArgs[s].view());
+        }  //nStreams
+      } else {
+        if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
+          for (int s = 0; s < nStreams; s++) {
+            alpaka::exec<Acc1D>(queues[s],
+                                workDiv,
+                                ECLCCEpilogueNaiveKernel{},
+                                outPFCluster[s].view(),
+                                outPFRecHitFracs[s].view(),
+                                mdpfClusteringVars[s].view(),
+                                pfClusters[s].view(),
+                                pfRecHitFracs[s].view(),
+                                pfRecHit[s].view());
+          }
+        } else {
+          for (int s = 0; s < nStreams; s++) {
+            alpaka::exec<Acc1D>(queues[s],
+                                workDiv,
+                                ECLCCEpilogueKernel<32, cooperative>{},
+                                outPFCluster[s].view(),
+                                outPFRecHitFracs[s].view(),
+                                mdpfClusteringVars[s].view(),
+                                pfClusters[s].view(),
+                                pfRecHitFracs[s].view(),
+                                pfRecHit[s].view());
+          }
+        }
+      }  //end multi-block
+
+      for (int s = 0; s < nStreams; s++)
+        alpaka::wait(queues[s]);
+
+      auto wall_stop = std::chrono::high_resolution_clock::now();
+      //
+      auto wall_diff = wall_stop - wall_start;
+
+      //printf("Current wall time %10e\n", static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(wall_diff).count()) / 1e6);
+
+      if (i > nColdIters)
+        wall_time +=
+            static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(wall_diff).count()) / 1e6;
+    }
+
+    unsigned int measIters = nIters - nColdIters;
+    const auto walltime_per_iter = wall_time / measIters;
+    const auto throughput = static_cast<double>(nStreams) / walltime_per_iter;
+    printf("Wall time: %f sec per iter, throuput %6e events per second\n", wall_time / measIters, throughput);
   }
 
-  void launch_epilogue_test(Queue &queue,
-                            reco::PFClusterHostCollection &outClusters,
-                            reco::PFRecHitFractionHostCollection &outRecHitFracs,
-                            const ::reco::PFMultiDepthClusteringCCLabelsHostCollection &hostClusteringVars,
-                            const ::reco::PFClusterHostCollection &hostClusters,
-                            const ::reco::PFRecHitHostCollection &hostRecHits,
-                            const ::reco::PFRecHitFractionHostCollection &hostRecHitFracs) {
-    EpilogueTest epilogue_test{};
+  void launch_epilogue_test(std::vector<Queue> &queues,
+                            std::vector<reco::PFClusterHostCollection> &outClusters,
+                            std::vector<reco::PFRecHitFractionHostCollection> &outRecHitFracs,
+                            const std::vector<::reco::PFMultiDepthClusteringCCLabelsHostCollection> &hostClusteringVars,
+                            const std::vector<::reco::PFClusterHostCollection> &hostClusters,
+                            const std::vector<::reco::PFRecHitHostCollection> &hostRecHits,
+                            const std::vector<::reco::PFRecHitFractionHostCollection> &hostRecHitFracs,
+                            const int nStreams,
+                            const int nIters,
+                            const int threadsPerBlock) {
+    EpilogueTest epilogue_test(nStreams, nIters, threadsPerBlock);
 
-    auto hOutClusters = outClusters.view();
-    auto hClusters = hostClusters.view();
-    auto hRecHits = hostRecHits.view();
-    //auto hRecHitFracs = hostRecHitFracs.view();
+    auto hOutClusters = outClusters[0].view();
+    auto hClusters = hostClusters[0].view();
+    auto hRecHits = hostRecHits[0].view();
 
     const int nClusters = hClusters.size();
-    const int nHits = hRecHits.size();
     const int nFracs = hClusters.nRHFracs();
-
+    const int nHits = hRecHits.size();
     const int nOutClusters = hOutClusters.size();
 
-    reco::PFClusterDeviceCollection outDevClusters{queue, nOutClusters};
-    reco::PFRecHitFractionDeviceCollection outDevRecHitFracs{queue, nFracs};
+    std::vector<reco::PFClusterDeviceCollection> outDevClusters;
+    outDevClusters.reserve(nStreams);
+    std::vector<reco::PFRecHitFractionDeviceCollection> outDevRecHitFracs;
+    outDevRecHitFracs.reserve(nStreams);
 
-    reco::PFClusterDeviceCollection devClusters{queue, nClusters};
-    reco::PFRecHitDeviceCollection devRecHits{queue, nHits};
-    reco::PFRecHitFractionDeviceCollection devRecHitFracs{queue, nFracs};
+    std::vector<reco::PFClusterDeviceCollection> devClusters;
+    devClusters.reserve(nStreams);
+    std::vector<reco::PFRecHitDeviceCollection> devRecHits;
+    devRecHits.reserve(nStreams);
+    std::vector<reco::PFRecHitFractionDeviceCollection> devRecHitFracs;
+    devRecHitFracs.reserve(nStreams);
 
-    alpaka::memcpy(queue, devClusters.buffer(), hostClusters.buffer());
-    alpaka::memcpy(queue, devRecHits.buffer(), hostRecHits.buffer());
-    alpaka::memcpy(queue, devRecHitFracs.buffer(), hostRecHitFracs.buffer());
+    std::vector<reco::PFMultiDepthClusteringCCLabelsDeviceCollection> devClusteringVars;
+    devClusteringVars.reserve(nStreams);
 
-    reco::PFMultiDepthClusteringCCLabelsDeviceCollection devClusteringVars{queue, nClusters};
+    for (int s = 0; s < nStreams; s++) {
+      auto dev_clusters = reco::PFClusterDeviceCollection{queues[s], nClusters};
+      auto dev_hits = reco::PFRecHitDeviceCollection{queues[s], nHits};
+      auto dev_rhfrac = reco::PFRecHitFractionDeviceCollection{queues[s], nFracs};
+      auto dev_clustering_vars = reco::PFMultiDepthClusteringCCLabelsDeviceCollection{queues[s], nClusters};
+      //
+      alpaka::memcpy(queues[s], dev_clusters.buffer(), hostClusters[s].buffer());
+      alpaka::memcpy(queues[s], dev_hits.buffer(), hostRecHits[s].buffer());
+      alpaka::memcpy(queues[s], dev_rhfrac.buffer(), hostRecHitFracs[s].buffer());
+      alpaka::memcpy(queues[s], dev_clustering_vars.buffer(), hostClusteringVars[s].buffer());
 
-    alpaka::memcpy(queue, devClusteringVars.buffer(), hostClusteringVars.buffer());
+      devClusters.emplace_back(std::move(dev_clusters));
+      devRecHits.emplace_back(std::move(dev_hits));
+      devRecHitFracs.emplace_back(std::move(dev_rhfrac));
+      devClusteringVars.emplace_back(std::move(dev_clustering_vars));
+
+      outDevClusters.emplace_back(reco::PFClusterDeviceCollection(queues[s], nOutClusters));
+      outDevRecHitFracs.emplace_back(reco::PFRecHitFractionDeviceCollection(queues[s], nFracs));
+    }
 
     printf("Run epilogue kernel %d %d %d \n", nClusters, nHits, nFracs);
     epilogue_test.apply(
-        queue, outDevClusters, outDevRecHitFracs, devClusteringVars, devClusters, devRecHitFracs, devRecHits);
+        queues, outDevClusters, outDevRecHitFracs, devClusteringVars, devClusters, devRecHitFracs, devRecHits);
     printf("...done.\n");
 
-    alpaka::memcpy(queue, outClusters.buffer(), outDevClusters.buffer());
-    alpaka::memcpy(queue, outRecHitFracs.buffer(), outDevRecHitFracs.buffer());
+    alpaka::memcpy(queues[0], outClusters[0].buffer(), outDevClusters[0].buffer());
+    alpaka::memcpy(queues[0], outRecHitFracs[0].buffer(), outDevRecHitFracs[0].buffer());
 
-    alpaka::wait(queue);
+    for (int s = 0; s < nStreams; s++)
+      alpaka::wait(queues[s]);
   }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
@@ -299,7 +362,7 @@ std::pair<int, int> create(::reco::PFClusterCollection &clusters,
                            const int nClusters,
                            const int minHitsPerCluster = 2,
                            const int maxHitsPerCluster = 10,
-                           const float shareProbability = 0.05f) {
+                           const float shareProbability = 0.75f) {
   std::mt19937 rng(12345);
 
   // E in [0.5, 120], r in [174, 180], phi in [0, 0.25], z = 0
@@ -423,17 +486,11 @@ std::pair<int, int> create(::reco::PFClusterCollection &clusters,
 
     if (ownerEntry < 0)
       continue;
-
-    const float leftover = std::max(0.f, 1.f - ownerFrac);
-    if (leftover <= 0.f)
-      continue;
-
-    // give the neighbor between 20% and 80% of the leftover
-    const float share_frac = leftover * (0.2f + 0.6f * uni_distr(rng));
+    const float share_frac = ownerFrac * (0.2f + 0.6f * uni_distr(rng));
 
     rhfracs.push_back(Fraction{i, neigh_idx, share_frac});
-
     rhfracs[ownerEntry].frac -= share_frac;
+
     if (rhfracs[ownerEntry].frac < 0.f)
       rhfracs[ownerEntry].frac = 0.f;
     ++nFracs;
@@ -643,7 +700,8 @@ int checkEpilogue(Queue &queue,
   }
 
   for (auto &cc_root : cc_roots) {
-    printf("\n\n>>>>> Process cc root %d\n", cc_root);
+    if (verbose)
+      printf("\n\n>>>>> Process cc root %d\n", cc_root);
     int tot_recFracSize = 0;
     bool is_valid_seed = false;
     int cc_seed = inHostClustersView[cc_root].seedRHIdx();
@@ -668,18 +726,21 @@ int checkEpilogue(Queue &queue,
 
         if (is_valid_seed == false) {
           nerrors += 1;
-          printf("Component seed is not valid for cluster %d!\n", rep);
+          if (verbose)
+            printf("Component seed is not valid for cluster %d!\n", rep);
         } else {
           if (cc_energy < seed_energy) {
             cc_seed = seed;
             cc_energy = seed_energy;
-            printf("updated seed for cluster %d\n", rep);
+            if (verbose)
+              printf("updated seed for cluster %d\n", rep);
           }
           is_valid_seed = false;
         }
       }
     }
-    printf("TOT rh size = %d , seed = %d (energy %f)\n", tot_recFracSize, cc_seed, cc_energy);
+    if (verbose)
+      printf("TOT rh size = %d , seed = %d (energy %f)\n", tot_recFracSize, cc_seed, cc_energy);
   }
 
   const int outClustersNum = outHostClustersView.size();
@@ -691,12 +752,13 @@ int checkEpilogue(Queue &queue,
 
     const auto seed = outHostClustersView[i].seedRHIdx();
     const auto energy = recHitsView[seed].energy();
-    printf("OUT cluster RHF offset %d RHF size %d  idx %d seed %d energy %f\n",
-           recFracOffset,
-           recFracSize,
-           clidx,
-           seed,
-           energy);
+    if (verbose)
+      printf("OUT cluster RHF offset %d RHF size %d  idx %d seed %d energy %f\n",
+             recFracOffset,
+             recFracSize,
+             clidx,
+             seed,
+             energy);
   }
 
   for (int i = 0; i < outClustersNum; i++) {
@@ -758,17 +820,58 @@ int checkEpilogue(Queue &queue,
 using namespace edm;
 using namespace std;
 
-int main() {
-  // get the list of devices on the current platform
+int main(int argc, char **argv) {
+  if (argc > 5) {
+    std::cerr << "Usage: " << argv[0] << " [<nClusters>] [<nStreams>] [<nIters>] [<threadsPerBlock>]\n";
+    return 1;
+  }
+
+  // Get the list of devices on the current platform
   auto const &devices = cms::alpakatools::devices<Platform>();
   if (devices.empty()) {
     std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
-      "the test will be skipped.\n";
-    exit(EXIT_FAILURE);
+                 "the test will be skipped.\n";
+    return EXIT_FAILURE; // Prefer returning over raw exit() in main
   }
 
-  const int nClusters = multiblock ? 1200 : 500;
-  const int maxHitsPerCluster = multiblock ? 8 : 23;
+  int nStreams = 1;
+  int nClusters = multiblock ? 1024 : 512;
+  int nIters = nColdIters + 100;
+
+  auto parseArg = [](const char* arg, const std::string& name) {
+    try {
+      return std::stoi(arg);
+    } catch (...) {
+      std::cerr << "Error: Invalid integer value provided for " << name << ": '" << arg << "'\n";
+      std::exit(EXIT_FAILURE);
+    }
+  };
+
+  if (argc > 1) {
+    nClusters = parseArg(argv[1], "<nClusters>");
+
+    if constexpr (multiblock == false) {
+      if (nClusters > 1024) {
+        std::cerr << "Abort the test: <nClusters> cannot exceed 1024 for a single-block run.\n";
+        return 1;
+      }
+    }
+  }
+
+  if (argc > 2) nStreams = parseArg(argv[2], "<nStreams>");
+  if (argc > 3) nIters   = parseArg(argv[3], "<nIters>");
+
+  int threadsPerBlock = multiblock ? 128 : nClusters;
+
+  if (argc > 4) {
+    if constexpr (multiblock) {
+      threadsPerBlock = parseArg(argv[4], "<threadsPerBlock>");
+    } else {
+      std::cout << "Warning: <threadsPerBlock> argument ignored for single-block runs (it matches nClusters).\n";
+    }
+  }
+
+  const int maxHitsPerCluster = 99;
   const int minHitsPerCluster = 1;
 
   ::reco::PFClusterCollection clusters;
@@ -787,7 +890,7 @@ int main() {
   const int nHits = sizes.first;
   const int nFracs = sizes.second;
 
-  std::vector<int> cc_roots = {0, 1, 5, 9, 33, 38, 101, 113, 313, 331};
+  std::vector<int> cc_roots = {0, 1, 5, 9, 38 , 45, 49, 66, 71, 77, 89, 91, 99 };
 
   const int cc_num = static_cast<int>(cc_roots.size());
 
@@ -798,49 +901,84 @@ int main() {
 
   // run the test on each device
   for (auto const &device : devices) {
-    auto queue = Queue(device);
+    std::vector<Queue> queues;
+    queues.reserve(nStreams);
 
-    ::reco::PFClusterHostCollection outHostClusters{queue, cc_num};
-    ::reco::PFRecHitFractionHostCollection outHostRecHitFracs{queue, nFracs};
+    std::vector<::reco::PFClusterHostCollection> outHostClusters;
+    outHostClusters.reserve(nStreams);
+    std::vector<::reco::PFRecHitFractionHostCollection> outHostRecHitFracs;
+    outHostRecHitFracs.reserve(nStreams);
 
-    ::reco::PFClusterHostCollection hostClusters{queue, nClusters};
-    ::reco::PFRecHitHostCollection hostRecHits{queue, nHits};
-    ::reco::PFRecHitFractionHostCollection hostRecHitFracs{queue, nFracs};
+    std::vector<::reco::PFClusterHostCollection> hostClusters;
+    hostClusters.reserve(nStreams);
+    std::vector<::reco::PFRecHitHostCollection> hostRecHits;
+    hostRecHits.reserve(nStreams);
+    std::vector<::reco::PFRecHitFractionHostCollection> hostRecHitFracs;
+    hostRecHitFracs.reserve(nStreams);
 
-    ::reco::PFMultiDepthClusteringCCLabelsHostCollection hostClusteringVars{queue, nClusters};
+    std::vector<::reco::PFMultiDepthClusteringCCLabelsHostCollection> hostClusteringVars;
+    hostClusteringVars.reserve(nStreams);
 
-    auto hClusters = hostClusters.view();
-    auto outHClusters = outHostClusters.view();
-    auto hRecHits = hostRecHits.view();
+    for (int s = 0; s < nStreams; s++) {
+      auto queue = Queue(device);
 
-    auto hClusteringVars = hostClusteringVars.view();
+      auto out_host_clusters = ::reco::PFClusterHostCollection(queue, cc_num);
 
-    hRecHits.size() = nHits;
+      auto host_clusters = ::reco::PFClusterHostCollection(queue, nClusters);
+      auto host_hits = ::reco::PFRecHitHostCollection(queue, nHits);
+      auto host_rhfracs = ::reco::PFRecHitFractionHostCollection(queue, nFracs);
+      auto host_clustering_vars = ::reco::PFMultiDepthClusteringCCLabelsHostCollection(queue, nClusters);
 
-    hClusters.nTopos() = nClusters;
-    hClusters.nSeeds() = nClusters;
-    hClusters.nRHFracs() = nFracs;
-    hClusters.size() = nClusters;
+      auto outHClusters = out_host_clusters.view();
+      auto hClusters = host_clusters.view();
+      auto hRecHits = host_hits.view();
+      auto hClusteringVars = host_clustering_vars.view();
 
-    outHClusters.size() = cc_num;
+      outHClusters.size() = cc_num;
 
-    hClusteringVars.size() = nClusters;
-    hClusteringVars.ncomponents() = 0;
+      hRecHits.size() = nHits;
 
-    load(hostClusters, hostRecHits, hostRecHitFracs, clusters, hits, rhfracs, seedIdx);
+      hClusters.nTopos() = nClusters;
+      hClusters.nSeeds() = nClusters;
+      hClusters.nRHFracs() = nFracs;
+      hClusters.size() = nClusters;
 
-    create_cc_list(hostClusteringVars, cc_roots, nClusters);
+      hClusteringVars.size() = nClusters;
+      hClusteringVars.ncomponents() = 0;
 
-    launch_epilogue_test(
-        queue, outHostClusters, outHostRecHitFracs, hostClusteringVars, hostClusters, hostRecHits, hostRecHitFracs);
+      load(host_clusters, host_hits, host_rhfracs, clusters, hits, rhfracs, seedIdx);
 
-    auto nerrs = checkEpilogue(queue,
-                               outHostClusters,
-                               outHostRecHitFracs,
-                               hostClusters,
-                               hostRecHits,
-                               hostRecHitFracs,
-                               hostClusteringVars,
+      create_cc_list(host_clustering_vars, cc_roots, nClusters);
+
+      hostClusters.emplace_back(std::move(host_clusters));
+      hostRecHits.emplace_back(std::move(host_hits));
+      hostRecHitFracs.emplace_back(std::move(host_rhfracs));
+
+      outHostClusters.emplace_back(std::move(out_host_clusters));
+      outHostRecHitFracs.emplace_back(::reco::PFRecHitFractionHostCollection(queue, nFracs));
+      hostClusteringVars.emplace_back(std::move(host_clustering_vars));
+
+      queues.emplace_back(std::move(queue));
+    }
+
+    launch_epilogue_test(queues,
+                         outHostClusters,
+                         outHostRecHitFracs,
+                         hostClusteringVars,
+                         hostClusters,
+                         hostRecHits,
+                         hostRecHitFracs,
+                         nStreams,
+                         nIters,
+                         threadsPerBlock);
+
+    auto nerrs = checkEpilogue(queues[0],
+                               outHostClusters[0],
+                               outHostRecHitFracs[0],
+                               hostClusters[0],
+                               hostRecHits[0],
+                               hostRecHitFracs[0],
+                               hostClusteringVars[0],
                                cc_roots);
 
     if (nerrs != 0) {

--- a/RecoParticleFlow/PFClusterProducer/test/alpaka/ShowerShapeTest.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/alpaka/ShowerShapeTest.dev.cc
@@ -628,8 +628,8 @@ int main(int argc, char** argv) {
   }
 
   int nStreams = 1;
-  int nClusters =  1024;
-  int nIters =  nColdIters + 10;
+  int nClusters = 1024;
+  int nIters = nColdIters + 10;
 
   if (argc > 1) {
     nClusters = std::stoi(argv[1]);

--- a/RecoParticleFlow/PFClusterProducer/test/alpaka/ShowerShapeTest.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/alpaka/ShowerShapeTest.dev.cc
@@ -45,6 +45,10 @@ static constexpr bool cooperative = true;
 #else
 static constexpr bool cooperative = false;
 #endif
+// 21
+//static constexpr unsigned int nStreams = 32;  //T4:40 RTX:72 L40S:142 4090:128 5080:84
+
+static constexpr int nColdIters = 10;
 
 using PFRecHitsNeighbours = Eigen::Matrix<int32_t, 8, 1>;
 
@@ -91,10 +95,10 @@ namespace {
     }
   };
 
-  CaloCellGeometry::CornersMgr s_cornersMgr(65536,
+  CaloCellGeometry::CornersMgr s_cornersMgr(4 * 1048576,
                                             CaloCellGeometry::k_cornerSize);  //k_cornerSize = 8;
 
-  CaloCellGeometry::ParMgr s_parMgr(65536, /*subSize=*/BoxCell::kNPar);
+  CaloCellGeometry::ParMgr s_parMgr(4 * 1048576, /*subSize=*/BoxCell::kNPar);
 
   CaloCellGeometry::ParVecVec s_parBlocks;
 
@@ -127,22 +131,29 @@ inline reco::PFRecHit makePFRecHit(
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class ShowerShapeTest {
+    const int nStreams;
+    const int nIters;
+    const int threads;
+
   public:
-    void apply(Queue& queue,
-               reco::PFMultiDepthClusteringVarsDeviceCollection& mdpfClusteringVars,
-               const reco::PFClusterDeviceCollection& pfClusters,
-               const reco::PFRecHitFractionDeviceCollection& pfRecHitFracs,
-               const reco::PFRecHitDeviceCollection& pfRecHit) const;
+    ShowerShapeTest(const int nStreams, const int nIters, const int threads)
+        : nStreams(nStreams), nIters(nIters), threads(threads) {}
+
+    void apply(std::vector<Queue>& queues,
+               std::vector<reco::PFMultiDepthClusteringVarsDeviceCollection>& mdpfClusteringVars,
+               const std::vector<reco::PFClusterDeviceCollection>& pfClusters,
+               const std::vector<reco::PFRecHitFractionDeviceCollection>& pfRecHitFracs,
+               const std::vector<reco::PFRecHitDeviceCollection>& pfRecHit) const;
   };
 
-  void ShowerShapeTest::apply(Queue& queue,
-                              reco::PFMultiDepthClusteringVarsDeviceCollection& mdpfClusteringVars,
-                              const reco::PFClusterDeviceCollection& pfClusters,
-                              const reco::PFRecHitFractionDeviceCollection& pfRecHitFracs,
-                              const reco::PFRecHitDeviceCollection& pfRecHit) const {
-    uint32_t items = std::is_same_v<Device, alpaka::DevCpu> ? 1 : 64;
+  void ShowerShapeTest::apply(std::vector<Queue>& queues,
+                              std::vector<reco::PFMultiDepthClusteringVarsDeviceCollection>& mdpfClusteringVars,
+                              const std::vector<reco::PFClusterDeviceCollection>& pfClusters,
+                              const std::vector<reco::PFRecHitFractionDeviceCollection>& pfRecHitFracs,
+                              const std::vector<reco::PFRecHitDeviceCollection>& pfRecHit) const {
+    uint32_t items = std::is_same_v<Device, alpaka::DevCpu> ? 1 : threads;
 
-    auto n = static_cast<uint32_t>(pfClusters->metadata().size());
+    auto n = static_cast<uint32_t>(pfClusters[0]->metadata().size());
     uint32_t groups = ::cms::alpakatools::divide_up_by(n, items);
 
     if (groups < 1) {
@@ -152,46 +163,87 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     auto workDiv = ::cms::alpakatools::make_workdiv<Acc1D>(groups, items);
 
-    alpaka::exec<Acc1D>(queue,
-                        workDiv,
-                        ShowerShapeKernel<cooperative>{},
-                        mdpfClusteringVars.view(),
-                        pfClusters.view(),
-                        pfRecHitFracs.view(),
-                        pfRecHit.view(),
-                        thrsh);
+    double wall_time = 0.0;
+    for (int i = 0; i < nIters; i++) {
+      auto wall_start = std::chrono::high_resolution_clock::now();
 
-    alpaka::wait(queue);
+      for (int s = 0; s < nStreams; s++) {
+        alpaka::exec<Acc1D>(queues[s],
+                            workDiv,
+                            ShowerShapeKernel<cooperative>{},
+                            mdpfClusteringVars[s].view(),
+                            pfClusters[s].view(),
+                            pfRecHitFracs[s].view(),
+                            pfRecHit[s].view(),
+                            thrsh);
+      }
+
+      for (int s = 0; s < nStreams; s++)
+        alpaka::wait(queues[s]);
+
+      auto wall_stop = std::chrono::high_resolution_clock::now();
+      //
+      auto wall_diff = wall_stop - wall_start;
+
+      if (i > nColdIters)
+        wall_time +=
+            static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(wall_diff).count()) / 1e6;
+    }
+
+    printf("Wall time: %f sec per iter, %f per stream per iter\n",
+           wall_time / (nIters - nColdIters),
+           wall_time / ((nIters - nColdIters) * nStreams));
   }
 
-  void launch_shower_shape_test(Queue& queue,
-                                ::reco::PFMultiDepthClusteringVarsHostCollection& hostClusteringVars,
-                                const ::reco::PFClusterHostCollection& hostClusters,
-                                const ::reco::PFRecHitHostCollection& hostRecHits,
-                                const ::reco::PFRecHitFractionHostCollection& hostRecHitFracs) {
-    ShowerShapeTest shower_shape_test{};
+  void launch_shower_shape_test(std::vector<Queue>& queues,
+                                std::vector<::reco::PFMultiDepthClusteringVarsHostCollection>& hostClusteringVars,
+                                const std::vector<::reco::PFClusterHostCollection>& hostClusters,
+                                const std::vector<::reco::PFRecHitHostCollection>& hostRecHits,
+                                const std::vector<::reco::PFRecHitFractionHostCollection>& hostRecHitFracs,
+                                const int nStreams,
+                                const int nIters,
+                                const int threadsPerBlock) {
+    ShowerShapeTest shower_shape_test(nStreams, nIters, threadsPerBlock);
 
-    auto hClusters = hostClusters.view();
-    auto hRecHits = hostRecHits.view();
+    const auto hClusters = hostClusters[0].const_view();
+    const auto hRecHits = hostRecHits[0].const_view();
 
     const int nClusters = hClusters.size();
     const int nHits = hRecHits.size();
     const int nFracs = hClusters.nRHFracs();
 
-    reco::PFClusterDeviceCollection devClusters{queue, nClusters};
-    reco::PFRecHitDeviceCollection devRecHits{queue, nHits};
-    reco::PFRecHitFractionDeviceCollection devRecHitFracs{queue, nFracs};
+    std::vector<reco::PFClusterDeviceCollection> devClusters;
+    devClusters.reserve(nStreams);
+    std::vector<reco::PFRecHitDeviceCollection> devRecHits;
+    devRecHits.reserve(nStreams);
+    std::vector<reco::PFRecHitFractionDeviceCollection> devRecHitFracs;
+    devRecHitFracs.reserve(nStreams);
 
-    alpaka::memcpy(queue, devClusters.buffer(), hostClusters.buffer());
-    alpaka::memcpy(queue, devRecHits.buffer(), hostRecHits.buffer());
-    alpaka::memcpy(queue, devRecHitFracs.buffer(), hostRecHitFracs.buffer());
+    std::vector<reco::PFMultiDepthClusteringVarsDeviceCollection> devClusteringVars;
+    devClusteringVars.reserve(nStreams);
 
-    reco::PFMultiDepthClusteringVarsDeviceCollection devClusteringVars{queue, nClusters};
+    for (int s = 0; s < nStreams; s++) {
+      //
+      auto dev_clusters = reco::PFClusterDeviceCollection{queues[s], nClusters};
+      auto dev_hits = reco::PFRecHitDeviceCollection{queues[s], nHits};
+      auto dev_rhfrac = reco::PFRecHitFractionDeviceCollection{queues[s], nFracs};
+      //
+      alpaka::memcpy(queues[s], dev_clusters.buffer(), hostClusters[s].buffer());
+      alpaka::memcpy(queues[s], dev_hits.buffer(), hostRecHits[s].buffer());
+      alpaka::memcpy(queues[s], dev_rhfrac.buffer(), hostRecHitFracs[s].buffer());
 
-    shower_shape_test.apply(queue, devClusteringVars, devClusters, devRecHitFracs, devRecHits);
+      devClusters.emplace_back(std::move(dev_clusters));
+      devRecHits.emplace_back(std::move(dev_hits));
+      devRecHitFracs.emplace_back(std::move(dev_rhfrac));
 
-    alpaka::memcpy(queue, hostClusteringVars.buffer(), devClusteringVars.buffer());
-    alpaka::wait(queue);
+      devClusteringVars.emplace_back(reco::PFMultiDepthClusteringVarsDeviceCollection(queues[s], nClusters));
+    }
+
+    shower_shape_test.apply(queues, devClusteringVars, devClusters, devRecHitFracs, devRecHits);
+
+    alpaka::memcpy(queues[0], hostClusteringVars[0].buffer(), devClusteringVars[0].buffer());
+    for (int s = 0; s < nStreams; s++)
+      alpaka::wait(queues[s]);
   }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
@@ -211,7 +263,7 @@ std::pair<int, int> create(::reco::PFClusterCollection& clusters,
                            const int nClusters,
                            const int minHitsPerCluster = 2,
                            const int maxHitsPerCluster = 10,
-                           const float shareProbability = 0.05f) {
+                           const float shareProbability = 0.67f) {
   std::mt19937 rng(12345);
 
   // E in [0.5, 120], r in [174, 180], phi in [0, 0.25], z = 0
@@ -334,16 +386,11 @@ std::pair<int, int> create(::reco::PFClusterCollection& clusters,
     if (ownerEntry < 0)
       continue;
 
-    const float leftover = std::max(0.f, 1.f - ownerFrac);
-    if (leftover <= 0.f)
-      continue;
-
-    // give the neighbor between 20% and 80% of the leftover
-    const float share_frac = leftover * (0.2f + 0.6f * uni_distr(rng));
+    const float share_frac = ownerFrac * (0.2f + 0.6f * uni_distr(rng));
 
     rhfracs.push_back(Fraction{i, neigh_idx, share_frac});
-
     rhfracs[ownerEntry].frac -= share_frac;
+
     if (rhfracs[ownerEntry].frac < 0.f)
       rhfracs[ownerEntry].frac = 0.f;
     ++nFracs;
@@ -427,9 +474,78 @@ void load(::reco::PFClusterHostCollection& hostClusters,
   }
 }
 
-int checkShowerShapes(const ::reco::PFClusterCollection& clusters,
-                      const ::reco::PFRecHitCollection& recHits,
-                      const ::reco::PFMultiDepthClusteringVarsHostCollection& hostClusteringVars) {
+template <std::floating_point compute_t, std::floating_point reduce_t>
+inline void calculateShowerShapes(const ::reco::PFClusterCollection& clusters,
+                                  std::vector<reduce_t>& etaRMS2,
+                                  std::vector<reduce_t>& phiRMS2) {
+  const unsigned int nClusters = clusters.size();
+
+#pragma omp parallel for schedule(static)
+  for (unsigned int i = 0; i < nClusters; ++i) {
+    const ::reco::PFCluster& cluster = clusters[i];
+
+    reduce_t etaSum = 0.0;
+    reduce_t phiSum = 0.0;
+
+    auto const& crep = cluster.positionREP();
+    auto const& fractions = cluster.recHitFractions();
+
+    const unsigned int nFractions = fractions.size();
+
+#pragma omp simd reduction(+ : etaSum, phiSum)
+    for (unsigned int j = 0; j < nFractions; ++j) {
+      const auto& frac = fractions[j];
+
+      auto const& h = *frac.recHitRef();
+      auto const& rep = h.positionREP();
+
+      const compute_t frcxenergy = static_cast<compute_t>(frac.fraction()) * static_cast<compute_t>(h.energy());
+
+      const compute_t rep_eta = rep.eta();
+      const compute_t crep_eta = crep.eta();
+
+      etaSum += (frcxenergy)*std::abs(rep_eta - crep_eta);
+
+      const compute_t rep_phi = rep.phi();
+      const compute_t crep_phi = crep.phi();
+
+      phiSum += (frcxenergy)*std::abs(deltaPhi(rep_phi, crep_phi));
+    }
+
+    const compute_t inv_energy = 1.f / cluster.energy();
+    etaRMS2[i] = std::max(etaSum * inv_energy, static_cast<reduce_t>(thrsh));
+    etaRMS2[i] *= etaRMS2[i];
+    phiRMS2[i] = std::max(phiSum * inv_energy, static_cast<reduce_t>(thrsh));
+    phiRMS2[i] *= phiRMS2[i];
+  }
+}
+
+void runShowerShapesTest(const ::reco::PFClusterCollection& clusters, const int nIters) {
+  using reduce_t = double;
+  using compute_t = double;
+
+  std::vector<reduce_t> etaRMS2(clusters.size(), 0);
+  std::vector<reduce_t> phiRMS2(clusters.size(), 0);
+
+  // Time loop
+  auto start = std::chrono::steady_clock::now();
+
+  for (int i = 0; i < nIters; i++) {
+    //calculate cluster shapes
+    calculateShowerShapes<compute_t, reduce_t>(clusters, etaRMS2, phiRMS2);
+  }
+
+  auto seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+
+  std::cout << "Legacy function execution time : " << seconds / nIters << " sec per stream per iter." << std::endl;
+}
+
+std::vector<std::pair<int, double>> checkShowerShapes(
+    const ::reco::PFClusterCollection& clusters,
+    const ::reco::PFRecHitCollection& recHits,
+    const ::reco::PFMultiDepthClusteringVarsHostCollection& hostClusteringVars) {
+  runShowerShapesTest(clusters, 1000);
+
   const int nClusters = clusters.size();
 
   std::vector<double> etaRMS2(nClusters, 0.0);
@@ -457,30 +573,52 @@ int checkShowerShapes(const ::reco::PFClusterCollection& clusters,
     phiRMS2[i] *= phiRMS2[i];
   }
 
-  int nerrors = 0;
-
   auto hClusteringVars = hostClusteringVars.view();
-  double tol = 5e-6;
 
-  for (int i = 0; i < nClusters; i++) {
-    const auto x = std::abs(hClusteringVars[i].etaRMS2() - etaRMS2[i]) / etaRMS2[i];
-    if (x > tol) {
-      printf("Result for cluster id %d : etaRMS2 %f (%f), %f\n", i, hClusteringVars[i].etaRMS2(), etaRMS2[i], x);
-      nerrors += 1;
+  std::vector<std::pair<int, double>> errors_record;
+  errors_record.reserve(6);
+
+  double tol = 5e-6;
+  constexpr double tol_step = 1e-1;
+
+  while (tol <= 5e-1) {
+    int errs = 0;
+    for (int i = 0; i < nClusters; i++) {
+      const auto x = std::abs(hClusteringVars[i].etaRMS2() - etaRMS2[i]) / etaRMS2[i];
+      if (x > tol) {
+        printf("Result for cluster id %d\t and tol %f \t: etaRMS2 %f (%f), %f\n",
+               i,
+               tol,
+               hClusteringVars[i].etaRMS2(),
+               etaRMS2[i],
+               x);
+        errs += 1;
+      }
+      const auto y = std::abs(hClusteringVars[i].phiRMS2() - phiRMS2[i]) / phiRMS2[i];
+      if (y > tol) {
+        printf("Result for cluster id %d\t and tol %f \t: phiRMS2 %f (%f), %f\n",
+               i,
+               tol,
+               hClusteringVars[i].phiRMS2(),
+               phiRMS2[i],
+               y);
+        errs += 1;
+      }
     }
-    const auto y = std::abs(hClusteringVars[i].phiRMS2() - phiRMS2[i]) / phiRMS2[i];
-    if (y > tol) {
-      printf("Result for cluster id %d : phiRMS2 %f (%f), %f\n", i, hClusteringVars[i].phiRMS2(), phiRMS2[i], y);
-      nerrors += 1;
-    }
+    errors_record.push_back(std::make_pair(errs, tol));
+    tol /= tol_step;
   }
-  return nerrors;
+  return errors_record;
 }
 
 using namespace edm;
 using namespace std;
 
-int main() {
+int main(int argc, char** argv) {
+  if (argc > 5) {
+    std::cerr << "Usage: " << argv[0] << " <nClusters> <nStreams> <nIters> <threadsPerBlock>\n";
+    return 1;
+  }
   // get the list of devices on the current platform
   auto const& devices = ::cms::alpakatools::devices<Platform>();
   if (devices.empty()) {
@@ -489,10 +627,28 @@ int main() {
     exit(EXIT_FAILURE);
   }
 
-  const int nClusters = 145;
+  int nStreams = 1;
+  int nClusters =  1024;
+  int nIters =  nColdIters + 10;
 
-  const int maxHitsPerCluster = 67;
-  const int minHitsPerCluster = 23;
+  if (argc > 1) {
+    nClusters = std::stoi(argv[1]);
+  }
+
+  if (argc > 2)
+    nStreams = std::stoi(argv[2]);
+
+  if (argc > 3)
+    nIters = std::stoi(argv[3]);
+
+  int threadsPerBlock = nClusters > 1024 ? 128 : nClusters;
+
+  if (argc > 4) {
+    threadsPerBlock = std::stoi(argv[4]);
+  }
+
+  const int maxHitsPerCluster = 99;
+  const int minHitsPerCluster = 1;
 
   ::reco::PFClusterCollection clusters;
   clusters.reserve(nClusters);
@@ -512,33 +668,60 @@ int main() {
 
   // run the test on each device
   for (auto const& device : devices) {
-    auto queue = Queue(device);
+    std::vector<Queue> queues;
+    queues.reserve(nStreams);
 
-    ::reco::PFClusterHostCollection hostClusters{queue, nClusters};
-    ::reco::PFRecHitHostCollection hostRecHits{queue, nHits};
-    ::reco::PFRecHitFractionHostCollection hostRecHitFracs{queue, nFracs};
+    std::vector<::reco::PFClusterHostCollection> hostClusters;
+    hostClusters.reserve(nStreams);
+    std::vector<::reco::PFRecHitHostCollection> hostRecHits;
+    hostRecHits.reserve(nStreams);
+    std::vector<::reco::PFRecHitFractionHostCollection> hostRecHitFracs;
+    hostRecHitFracs.reserve(nStreams);
 
-    auto hClusters = hostClusters.view();
-    auto hRecHits = hostRecHits.view();
+    std::vector<::reco::PFMultiDepthClusteringVarsHostCollection> hostClusteringVars;
+    hostClusteringVars.reserve(nStreams);
 
-    hRecHits.size() = nHits;
+    for (int s = 0; s < nStreams; s++) {
+      auto queue = Queue(device);
 
-    hClusters.nTopos() = nClusters;
-    hClusters.nSeeds() = nClusters;
-    hClusters.nRHFracs() = nFracs;
-    hClusters.size() = nClusters;
+      auto host_clusters = ::reco::PFClusterHostCollection(queue, nClusters);
+      auto host_hits = ::reco::PFRecHitHostCollection(queue, nHits);
+      auto host_rhfracs = ::reco::PFRecHitFractionHostCollection(queue, nFracs);
 
-    load(hostClusters, hostRecHits, hostRecHitFracs, clusters, hits, rhfracs, seedIdx);
+      auto hClusters = host_clusters.view();
+      auto hRecHits = host_hits.view();
 
-    ::reco::PFMultiDepthClusteringVarsHostCollection hostClusteringVars{queue, nClusters};
+      hRecHits.size() = nHits;
 
-    launch_shower_shape_test(queue, hostClusteringVars, hostClusters, hostRecHits, hostRecHitFracs);
+      hClusters.nTopos() = nClusters;
+      hClusters.nSeeds() = nClusters;
+      hClusters.nRHFracs() = nFracs;
+      hClusters.size() = nClusters;
 
-    auto nerrors = checkShowerShapes(clusters, hits, hostClusteringVars);
+      load(host_clusters, host_hits, host_rhfracs, clusters, hits, rhfracs, seedIdx);
 
+      hostClusters.emplace_back(std::move(host_clusters));
+      hostRecHits.emplace_back(std::move(host_hits));
+      hostRecHitFracs.emplace_back(std::move(host_rhfracs));
+
+      hostClusteringVars.emplace_back(::reco::PFMultiDepthClusteringVarsHostCollection(queue, nClusters));
+
+      queues.emplace_back(std::move(queue));
+    }
+
+    launch_shower_shape_test(
+        queues, hostClusteringVars, hostClusters, hostRecHits, hostRecHitFracs, nStreams, nIters, threadsPerBlock);
+
+    auto errors_record = checkShowerShapes(clusters, hits, hostClusteringVars[0]);
+
+    int nerrors = 0;
+
+    for (auto& e : errors_record) {
+      nerrors += e.first;
+      std::cout << "Tolerance : " << e.second << "\t, errors : " << e.first << "\t" << std::endl;
+    }
     if (nerrors != 0) {
-      std::cerr << nerrors << " errors detected, exiting." << std::endl;
-      std::exit(-1);
+      std::cerr << nerrors << " errors detected, done." << std::endl;
     }
   }
 

--- a/RecoParticleFlow/PFClusterProducer/test/alpaka/ShowerShapeTest.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/alpaka/ShowerShapeTest.dev.cc
@@ -480,7 +480,6 @@ inline void calculateShowerShapes(const ::reco::PFClusterCollection& clusters,
                                   std::vector<reduce_t>& phiRMS2) {
   const unsigned int nClusters = clusters.size();
 
-#pragma omp parallel for schedule(static)
   for (unsigned int i = 0; i < nClusters; ++i) {
     const ::reco::PFCluster& cluster = clusters[i];
 
@@ -492,7 +491,6 @@ inline void calculateShowerShapes(const ::reco::PFClusterCollection& clusters,
 
     const unsigned int nFractions = fractions.size();
 
-#pragma omp simd reduction(+ : etaSum, phiSum)
     for (unsigned int j = 0; j < nFractions; ++j) {
       const auto& frac = fractions[j];
 


### PR DESCRIPTION
This PR introduces extended versions of the multi-layer PF clusterizer unit tests that dispatch compute kernels concurrently across multiple queues, enabling stress testing of the compute device under high workloads.
The code was originally developed to evaluate the stability of various clusterizer components, particularly the shower-shape computation, link construction and pruning, and epilogue kernels.

Resolves https://github.com/cms-sw/framework-team/issues/2294