### PR TITLE
backport 20_0_X - Fix HGCal HD 200um (type 3) handling in legacy digitizer ZS and v19 local reco constants

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -280,5 +280,7 @@ phase2_hgcalV16.toModify(HGCalRecHit,
 
 phase2_hgcalV19.toModify(HGCalRecHit, 
                          thicknessCorrection = [0.75, 0.76, 0.75, 0.76, 0.85, 0.85, 0.84, 0.85] , 
+                         #four silicon categories per section in v19: CE-H offset moves from 3 to 4
+                         deltasi_index_regemfac = 4,
                          sciThicknessCorrection =  0.69,
                          layerWeights = dEdX_v19.weights) 

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
@@ -82,6 +82,25 @@ hgcalLayerClustersHFNose = hgcalLayerClusters_.clone(
     )
 )
 
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
+from RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi import fCPerMIP_mean_V19
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import nonAgedNoises_v9_v19
+
+#The v19 geometry adds a fourth silicon sensor category (HD 200um, type 3), so
+#the silicon constants have 4 entries per section (8 regional factors plus 1
+#for scintillator) and the CE-H offset moves from 3 to 4. The clones above copy
+#the pre-modifier defaults at import time, so the v19 values must be set here
+#explicitly.
+_v19SiPlugin = dict(
+    deltasi_index_regemfac = 4,
+    maxNumberOfThickIndices = 8,
+    thicknessCorrection = [0.75, 0.76, 0.75, 0.76, 0.85, 0.85, 0.84, 0.85],
+    fcPerMip = fCPerMIP_mean_V19.value() + fCPerMIP_mean_V19.value(),
+    noises = nonAgedNoises_v9_v19 + nonAgedNoises_v9_v19,
+)
+for _clusters in (hgcalLayerClustersEE, hgcalLayerClustersHSi, hgcalLayerClustersHSci):
+    phase2_hgcalV19.toModify(_clusters, plugin = dict(**_v19SiPlugin))
+
 hgcalMergeLayerClusters = hgcalMergeLayerClusters_.clone(
 )
 

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
@@ -176,10 +176,14 @@ void HGCDigitizerBase::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& coll,
       //note that in this legacy case, gainIdx is kept at 0, fixed
       cce = (cce_.empty() ? 1.f : cce_[cell.thickness - 1]);
       noiseWidth = cell.size * noise_fC_[cell.thickness - 1];
+      //cell.thickness (1,2,3 for 120,200,300um) doubles as the MIP-charge scale
+      //of the threshold; HD 200um sensors (cell.thickness==4) carry the MIP
+      //charge of a 200um sensor, not four times that of 120um
+      const int mipScaleFactor = (cell.thickness == 4) ? 2 : cell.thickness;
       thrADC =
           thresholdFollowsMIP_
-              ? std::floor(cell.thickness * cce * myFEelectronics_->getADCThreshold() / myFEelectronics_->getADClsb())
-              : std::floor(cell.thickness * myFEelectronics_->getADCThreshold() / myFEelectronics_->getADClsb());
+              ? std::floor(mipScaleFactor * cce * myFEelectronics_->getADCThreshold() / myFEelectronics_->getADClsb())
+              : std::floor(mipScaleFactor * myFEelectronics_->getADCThreshold() / myFEelectronics_->getADClsb());
     }
 
     //loop over time samples, compute toa and add noise

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -329,10 +329,11 @@ def HGCal_setRealisticNoiseSi(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMap
     process.HGCAL_noises = cms.PSet(
         values = cms.vdouble([x for x in endOfLifeNoises])  
         )
-    phase2_hgcalV19.toModify(HGCAL_noise_fC, values = [x*fC_per_ele for x in endOfLifeNoises_v19] ) #100,200,300 um, to be deprecated
-    phase2_hgcalV19.toModify(HGCAL_noise_fC, values = [x*fC_per_ele for x in endOfLifeNoises_v19] ) #100,200,300 um, to be deprecated
-    phase2_hgcalV19.toModify(HGCAL_chargeCollectionEfficiencies, values = endOfLifeNoises_v19)
-    phase2_hgcalV19.toModify(HGCAL_noises, values = [x for x in endOfLifeNoises_v19])
+    #target the PSets just attached to the process: the module-level objects of
+    #the same names are not the ones the digitizers resolve on a loaded process
+    phase2_hgcalV19.toModify(process.HGCAL_noise_fC, values = [x*fC_per_ele for x in endOfLifeNoises_v19] ) #120,200,300,HD200 um, to be deprecated
+    phase2_hgcalV19.toModify(process.HGCAL_chargeCollectionEfficiencies, values = endOfLifeCCEs_v19)
+    phase2_hgcalV19.toModify(process.HGCAL_noises, values = [x for x in endOfLifeNoises_v19])
 
     return process
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/51524
