### PR TITLE
Build RecHitTools per event to fix cross-stream double-free

### DIFF
--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreProducer.cc
@@ -9,8 +9,6 @@ LCToCPAssociatorByEnergyScoreProducerT<HIT, CLUSTER>::LCToCPAssociatorByEnergySc
       caloGeometry_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
       hardScatterOnly_(ps.getParameter<bool>("hardScatterOnly")),
       hits_token_(consumes<multiCollectionT>(ps.getParameter<edm::InputTag>("hits"))) {
-  rhtools_ = std::make_shared<hgcal::RecHitTools>();
-
   // Register the product
   produces<ticl::LayerClusterToCaloParticleAssociatorT<CLUSTER>>();
 }
@@ -23,7 +21,8 @@ void LCToCPAssociatorByEnergyScoreProducerT<HIT, CLUSTER>::produce(edm::StreamID
                                                                    edm::Event &iEvent,
                                                                    const edm::EventSetup &es) const {
   edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeometry_);
-  rhtools_->setGeometry(*geom);
+  auto rhtools = std::make_shared<hgcal::RecHitTools>();
+  rhtools->setGeometry(*geom);
 
   if (!iEvent.getHandle(hitMap_) || !iEvent.getHandle(hits_token_)) {
     if (!iEvent.getHandle(hitMap_)) {
@@ -37,7 +36,7 @@ void LCToCPAssociatorByEnergyScoreProducerT<HIT, CLUSTER>::produce(edm::StreamID
     const std::unordered_map<DetId, const unsigned int> hitMap;  // empty map
     const multiCollectionT hits;
     auto impl = std::make_unique<LCToCPAssociatorByEnergyScoreImplT<HIT, CLUSTER>>(
-        iEvent.productGetter(), hardScatterOnly_, rhtools_, &hitMap, hits);
+        iEvent.productGetter(), hardScatterOnly_, rhtools, &hitMap, hits);
     auto emptyAssociator = std::make_unique<ticl::LayerClusterToCaloParticleAssociatorT<CLUSTER>>(std::move(impl));
     iEvent.put(std::move(emptyAssociator));
     return;
@@ -61,7 +60,7 @@ void LCToCPAssociatorByEnergyScoreProducerT<HIT, CLUSTER>::produce(edm::StreamID
 
   const auto hitMap = &iEvent.get(hitMap_);
   auto impl = std::make_unique<LCToCPAssociatorByEnergyScoreImplT<HIT, CLUSTER>>(
-      iEvent.productGetter(), hardScatterOnly_, rhtools_, hitMap, hits);
+      iEvent.productGetter(), hardScatterOnly_, rhtools, hitMap, hits);
   auto toPut = std::make_unique<ticl::LayerClusterToCaloParticleAssociatorT<CLUSTER>>(std::move(impl));
   iEvent.put(std::move(toPut));
 }

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreProducer.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreProducer.h
@@ -36,7 +36,6 @@ private:
   edm::EDGetTokenT<std::unordered_map<DetId, const unsigned int>> hitMap_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometry_;
   const bool hardScatterOnly_;
-  std::shared_ptr<hgcal::RecHitTools> rhtools_;
   edm::EDGetTokenT<multiCollectionT> hits_token_;
 };
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreProducer.cc
@@ -8,8 +8,6 @@ LCToSCAssociatorByEnergyScoreProducerT<HIT, CLUSTER>::LCToSCAssociatorByEnergySc
       caloGeometry_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
       hardScatterOnly_(ps.getParameter<bool>("hardScatterOnly")),
       hits_token_(consumes<multiCollectionT>(ps.getParameter<edm::InputTag>("hits"))) {
-  rhtools_ = std::make_shared<hgcal::RecHitTools>();
-
   // Register the product
   produces<ticl::LayerClusterToSimClusterAssociatorT<CLUSTER>>();
 }
@@ -22,7 +20,8 @@ void LCToSCAssociatorByEnergyScoreProducerT<HIT, CLUSTER>::produce(edm::StreamID
                                                                    edm::Event &iEvent,
                                                                    const edm::EventSetup &es) const {
   edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeometry_);
-  rhtools_->setGeometry(*geom);
+  auto rhtools = std::make_shared<hgcal::RecHitTools>();
+  rhtools->setGeometry(*geom);
 
   if (!iEvent.getHandle(hitMap_) || !iEvent.getHandle(hits_token_)) {
     if (!iEvent.getHandle(hitMap_)) {
@@ -36,7 +35,7 @@ void LCToSCAssociatorByEnergyScoreProducerT<HIT, CLUSTER>::produce(edm::StreamID
     const std::unordered_map<DetId, const unsigned int> hitMap;  // empty map
     const multiCollectionT hits;
     auto impl = std::make_unique<LCToSCAssociatorByEnergyScoreImplT<HIT, CLUSTER>>(
-        iEvent.productGetter(), hardScatterOnly_, rhtools_, &hitMap, hits);
+        iEvent.productGetter(), hardScatterOnly_, rhtools, &hitMap, hits);
     auto emptyAssociator = std::make_unique<ticl::LayerClusterToSimClusterAssociatorT<CLUSTER>>(std::move(impl));
     iEvent.put(std::move(emptyAssociator));
     return;
@@ -60,7 +59,7 @@ void LCToSCAssociatorByEnergyScoreProducerT<HIT, CLUSTER>::produce(edm::StreamID
 
   const auto hitMap = &iEvent.get(hitMap_);
   auto impl = std::make_unique<LCToSCAssociatorByEnergyScoreImplT<HIT, CLUSTER>>(
-      iEvent.productGetter(), hardScatterOnly_, rhtools_, hitMap, hits);
+      iEvent.productGetter(), hardScatterOnly_, rhtools, hitMap, hits);
   auto toPut = std::make_unique<ticl::LayerClusterToSimClusterAssociatorT<CLUSTER>>(std::move(impl));
   iEvent.put(std::move(toPut));
 }

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreProducer.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreProducer.h
@@ -36,7 +36,6 @@ private:
   edm::EDGetTokenT<std::unordered_map<DetId, const unsigned int>> hitMap_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometry_;
   const bool hardScatterOnly_;
-  std::shared_ptr<hgcal::RecHitTools> rhtools_;
   edm::EDGetTokenT<multiCollectionT> hits_token_;
 };
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreProducer.cc
@@ -25,14 +25,9 @@ public:
 
 private:
   void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
-  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometry_;
-  std::shared_ptr<hgcal::RecHitTools> rhtools_;
 };
 
-LCToSimTSAssociatorByEnergyScoreProducer::LCToSimTSAssociatorByEnergyScoreProducer(const edm::ParameterSet &ps)
-    : caloGeometry_(esConsumes<CaloGeometry, CaloGeometryRecord>()) {
-  rhtools_ = std::make_shared<hgcal::RecHitTools>();
-
+LCToSimTSAssociatorByEnergyScoreProducer::LCToSimTSAssociatorByEnergyScoreProducer(const edm::ParameterSet &) {
   // Register the product
   produces<ticl::LayerClusterToSimTracksterAssociator>();
 }
@@ -41,10 +36,7 @@ LCToSimTSAssociatorByEnergyScoreProducer::~LCToSimTSAssociatorByEnergyScoreProdu
 
 void LCToSimTSAssociatorByEnergyScoreProducer::produce(edm::StreamID,
                                                        edm::Event &iEvent,
-                                                       const edm::EventSetup &es) const {
-  edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeometry_);
-  rhtools_->setGeometry(*geom);
-
+                                                       const edm::EventSetup &) const {
   auto impl = std::make_unique<LCToSimTSAssociatorByEnergyScoreImpl>(iEvent.productGetter());
   auto toPut = std::make_unique<ticl::LayerClusterToSimTracksterAssociator>(std::move(impl));
   iEvent.put(std::move(toPut));

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreProducer.cc
@@ -30,7 +30,6 @@ private:
   edm::EDGetTokenT<std::unordered_map<DetId, const unsigned int>> hitMap_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometry_;
   const bool hardScatterOnly_;
-  std::shared_ptr<hgcal::RecHitTools> rhtools_;
   std::vector<edm::InputTag> hits_label_;
   std::vector<edm::EDGetTokenT<HGCRecHitCollection>> hits_token_;
 };
@@ -40,8 +39,6 @@ TSToSimTSAssociatorByEnergyScoreProducer::TSToSimTSAssociatorByEnergyScoreProduc
       caloGeometry_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
       hardScatterOnly_(ps.getParameter<bool>("hardScatterOnly")),
       hits_label_(ps.getParameter<std::vector<edm::InputTag>>("hits")) {
-  rhtools_ = std::make_shared<hgcal::RecHitTools>();
-
   for (auto &label : hits_label_) {
     hits_token_.push_back(consumes<HGCRecHitCollection>(label));
   }
@@ -56,7 +53,8 @@ void TSToSimTSAssociatorByEnergyScoreProducer::produce(edm::StreamID,
                                                        edm::Event &iEvent,
                                                        const edm::EventSetup &es) const {
   edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeometry_);
-  rhtools_->setGeometry(*geom);
+  auto rhtools = std::make_shared<hgcal::RecHitTools>();
+  rhtools->setGeometry(*geom);
 
   std::vector<const HGCRecHit *> hits;
   for (auto &token : hits_token_) {
@@ -76,7 +74,7 @@ void TSToSimTSAssociatorByEnergyScoreProducer::produce(edm::StreamID,
 
     const std::unordered_map<DetId, const unsigned int> hitMap;  // empty map
     auto impl = std::make_unique<TSToSimTSAssociatorByEnergyScoreImpl>(
-        iEvent.productGetter(), hardScatterOnly_, rhtools_, &hitMap, hits);
+        iEvent.productGetter(), hardScatterOnly_, rhtools, &hitMap, hits);
     auto emptyAssociator = std::make_unique<ticl::TracksterToSimTracksterAssociator>(std::move(impl));
     iEvent.put(std::move(emptyAssociator));
     return;
@@ -84,7 +82,7 @@ void TSToSimTSAssociatorByEnergyScoreProducer::produce(edm::StreamID,
 
   const auto hitMap = &iEvent.get(hitMap_);
   auto impl = std::make_unique<TSToSimTSAssociatorByEnergyScoreImpl>(
-      iEvent.productGetter(), hardScatterOnly_, rhtools_, hitMap, hits);
+      iEvent.productGetter(), hardScatterOnly_, rhtools, hitMap, hits);
   auto toPut = std::make_unique<ticl::TracksterToSimTracksterAssociator>(std::move(impl));
   iEvent.put(std::move(toPut));
 }

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorByEnergyScoreProducer.cc
@@ -32,7 +32,6 @@ private:
   edm::EDGetTokenT<std::unordered_map<DetId, const unsigned int>> hitMap_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometry_;
   const bool hardScatterOnly_;
-  std::shared_ptr<hgcal::RecHitTools> rhtools_;
   std::vector<edm::InputTag> hits_label_;
   std::vector<edm::EDGetTokenT<std::vector<HIT>>> hits_token_;
 };
@@ -44,8 +43,6 @@ TSToSimTSHitLCAssociatorByEnergyScoreProducer<HIT>::TSToSimTSHitLCAssociatorByEn
       caloGeometry_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
       hardScatterOnly_(ps.getParameter<bool>("hardScatterOnly")),
       hits_label_(ps.getParameter<std::vector<edm::InputTag>>("hits")) {
-  rhtools_ = std::make_shared<hgcal::RecHitTools>();
-
   for (auto &label : hits_label_) {
     hits_token_.push_back(consumes<std::vector<HIT>>(label));
   }
@@ -62,7 +59,8 @@ void TSToSimTSHitLCAssociatorByEnergyScoreProducer<HIT>::produce(edm::StreamID,
                                                                  edm::Event &iEvent,
                                                                  const edm::EventSetup &es) const {
   edm::ESHandle<CaloGeometry> geom = es.getHandle(caloGeometry_);
-  rhtools_->setGeometry(*geom);
+  auto rhtools = std::make_shared<hgcal::RecHitTools>();
+  rhtools->setGeometry(*geom);
 
   std::vector<const HIT *> hits;
   for (auto &token : hits_token_) {
@@ -84,7 +82,7 @@ void TSToSimTSHitLCAssociatorByEnergyScoreProducer<HIT>::produce(edm::StreamID,
 
     const std::unordered_map<DetId, const unsigned int> hitMap;  // empty map
     auto impl = std::make_unique<TSToSimTSHitLCAssociatorByEnergyScoreImpl<HIT>>(
-        iEvent.productGetter(), hardScatterOnly_, rhtools_, &hitMap, hits);
+        iEvent.productGetter(), hardScatterOnly_, rhtools, &hitMap, hits);
     auto emptyAssociator = std::make_unique<ticl::TracksterToSimTracksterHitLCAssociator>(std::move(impl));
     iEvent.put(std::move(emptyAssociator));
     return;
@@ -92,7 +90,7 @@ void TSToSimTSHitLCAssociatorByEnergyScoreProducer<HIT>::produce(edm::StreamID,
 
   const auto hitMap = &iEvent.get(hitMap_);
   auto impl = std::make_unique<TSToSimTSHitLCAssociatorByEnergyScoreImpl<HIT>>(
-      iEvent.productGetter(), hardScatterOnly_, rhtools_, hitMap, hits);
+      iEvent.productGetter(), hardScatterOnly_, rhtools, hitMap, hits);
   auto toPut = std::make_unique<ticl::TracksterToSimTracksterHitLCAssociator>(std::move(impl));
   iEvent.put(std::move(toPut));
 }


### PR DESCRIPTION
The five global associator producers mutated a shared RecHitTools member via setGeometry() inside const produce(), racing across streams and giving an ASAN double-free on the RecHitTools internal vector buffer. 

fixes https://github.com/cms-sw/cmssw/issues/51380