### PR TITLE
Fix ECAL DQM warnings about missing endcap collections in Phase 2 - 200X

### DIFF
--- a/DQM/EcalMonitorTasks/interface/ClusterTask.h
+++ b/DQM/EcalMonitorTasks/interface/ClusterTask.h
@@ -1,5 +1,5 @@
-#ifndef ClusterTask_H
-#define ClusterTask_H
+#ifndef DQM_EcalMonitorTasks_ClusterTask_h
+#define DQM_EcalMonitorTasks_ClusterTask_h
 
 #include "DQWorkerTask.h"
 
@@ -49,6 +49,7 @@ namespace ecaldqm {
     //    int ievt_;
     //    int massCalcPrescale_;
     bool doExtra_;
+    bool doEndcaps_;
     float energyThreshold_;
     float swissCrossMaxThreshold_;
     std::vector<std::string> egTriggerAlgos_;
@@ -65,22 +66,40 @@ namespace ecaldqm {
   inline bool ClusterTask::analyze(void const* _p, Collections _collection) {
     switch (_collection) {
       case kEBRecHit:
-      case kEERecHit:
         if (_p)
           runOnRecHits(*static_cast<EcalRecHitCollection const*>(_p), _collection);
         return true;
         break;
+      case kEERecHit:
+        if (doEndcaps_) {
+          if (_p)
+            runOnRecHits(*static_cast<EcalRecHitCollection const*>(_p), _collection);
+          return true;
+        }
+        break;
       case kEBBasicCluster:
-      case kEEBasicCluster:
         if (_p)
           runOnBasicClusters(*static_cast<edm::View<reco::CaloCluster> const*>(_p), _collection);
         return true;
         break;
+      case kEEBasicCluster:
+        if (doEndcaps_) {
+          if (_p)
+            runOnBasicClusters(*static_cast<edm::View<reco::CaloCluster> const*>(_p), _collection);
+          return true;
+        }
+        break;
       case kEBSuperCluster:
-      case kEESuperCluster:
         if (_p)
           runOnSuperClusters(*static_cast<reco::SuperClusterCollection const*>(_p), _collection);
         return true;
+        break;
+      case kEESuperCluster:
+        if (doEndcaps_) {
+          if (_p)
+            runOnSuperClusters(*static_cast<reco::SuperClusterCollection const*>(_p), _collection);
+          return true;
+        }
         break;
       default:
         break;

--- a/DQM/EcalMonitorTasks/interface/EnergyTask.h
+++ b/DQM/EcalMonitorTasks/interface/EnergyTask.h
@@ -1,5 +1,5 @@
-#ifndef EnergyTask_H
-#define EnergyTask_H
+#ifndef DQM_EcalMonitorTasks_EnergyTask_h
+#define DQM_EcalMonitorTasks_EnergyTask_h
 
 #include "DQWorkerTask.h"
 
@@ -24,15 +24,22 @@ namespace ecaldqm {
 
     bool isPhysicsRun_;
     //    float threshS9_;
+    bool doEndcaps_;
   };
 
   inline bool EnergyTask::analyze(void const* _p, Collections _collection) {
     switch (_collection) {
       case kEBRecHit:
-      case kEERecHit:
         if (_p)
           runOnRecHits(*static_cast<EcalRecHitCollection const*>(_p));
         return true;
+        break;
+      case kEERecHit:
+        if (doEndcaps_) {
+          if (_p)
+            runOnRecHits(*static_cast<EcalRecHitCollection const*>(_p));
+          return true;
+        }
         break;
       default:
         break;

--- a/DQM/EcalMonitorTasks/interface/TimingTask.h
+++ b/DQM/EcalMonitorTasks/interface/TimingTask.h
@@ -1,5 +1,5 @@
-#ifndef TimingTask_H
-#define TimingTask_H
+#ifndef DQM_EcalMonitorTasks_TimingTask_h
+#define DQM_EcalMonitorTasks_TimingTask_h
 
 #include "DQWorkerTask.h"
 
@@ -22,6 +22,8 @@ namespace ecaldqm {
   private:
     void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
     void setParams(edm::ParameterSet const&) override;
+
+    bool doEndcaps_;
 
     std::vector<int> bxBinEdges_;
     double bxBin_;
@@ -50,16 +52,28 @@ namespace ecaldqm {
   inline bool TimingTask::analyze(void const* _p, Collections _collection) {
     switch (_collection) {
       case kEBRecHit:
-      case kEERecHit:
         if (_p)
           runOnRecHits(*static_cast<EcalRecHitCollection const*>(_p), _collection);
         return true;
         break;
+      case kEERecHit:
+        if (doEndcaps_) {
+          if (_p)
+            runOnRecHits(*static_cast<EcalRecHitCollection const*>(_p), _collection);
+          return true;
+        }
+        break;
       case kEBUncalibRecHit:
-      case kEEUncalibRecHit:
         if (_p)
           runOnUncalibRecHits(*static_cast<EcalUncalibratedRecHitCollection const*>(_p));
         return true;
+        break;
+      case kEEUncalibRecHit:
+        if (doEndcaps_) {
+          if (_p)
+            runOnUncalibRecHits(*static_cast<EcalUncalibratedRecHitCollection const*>(_p));
+          return true;
+        }
         break;
       default:
         break;

--- a/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
@@ -7,6 +7,7 @@ triggerTypes = cms.untracked.vstring('ECAL', 'HCAL', 'CSC', 'DT', 'RPC')
 ecalClusterTask = cms.untracked.PSet(
     params = cms.untracked.PSet(
         doExtra = cms.untracked.bool(True),
+        doEndcaps = cms.untracked.bool(True),
         energyThreshold = cms.untracked.double(energyThreshold),
         egTriggerAlgos = cms.untracked.vstring(
             "L1_SingleEG2",
@@ -573,3 +574,5 @@ ecalClusterTask = cms.untracked.PSet(
         )
     )
 )
+
+ecalClusterTaskPhase2 = ecalClusterTask.clone(params = dict(doExtra = False, doEndcaps = False))

--- a/DQM/EcalMonitorTasks/python/CollectionTags_cfi.py
+++ b/DQM/EcalMonitorTasks/python/CollectionTags_cfi.py
@@ -61,11 +61,7 @@ ecalDQMCollectionTags = cms.PSet(
 
 ecalDQMCollectionTagsPhase2 = cms.PSet(
     EBUncalibRecHit = cms.untracked.InputTag("ecalUncalibRecHitPhase2", "EcalUncalibRecHitsEB"),
-    EEUncalibRecHit = cms.untracked.InputTag("None"),
     EBRecHit = cms.untracked.InputTag("ecalRecHit", "EcalRecHitsEB"),
-    EERecHit = cms.untracked.InputTag("None"),
     EBBasicCluster = cms.untracked.InputTag("hybridSuperClusters", "hybridBarrelBasicClusters"),
-    EEBasicCluster = cms.untracked.InputTag("None"),
     EBSuperCluster = cms.untracked.InputTag("hybridSuperClusters"),
-    EESuperCluster = cms.untracked.InputTag("None")
 )

--- a/DQM/EcalMonitorTasks/python/EcalMonitorTaskEcalOnly_cfi.py
+++ b/DQM/EcalMonitorTasks/python/EcalMonitorTaskEcalOnly_cfi.py
@@ -12,9 +12,9 @@ ecalMonitorTaskEcalOnly = _ecalMonitorTask.clone(
 
 # Changes for Phase 2
 from DQM.EcalMonitorTasks.CollectionTags_cfi import ecalDQMCollectionTagsPhase2
-from DQM.EcalMonitorTasks.ClusterTask_cfi import ecalClusterTask
-from DQM.EcalMonitorTasks.EnergyTask_cfi import ecalEnergyTask
-from DQM.EcalMonitorTasks.TimingTask_cfi import ecalTimingTask
+from DQM.EcalMonitorTasks.ClusterTask_cfi import ecalClusterTaskPhase2
+from DQM.EcalMonitorTasks.EnergyTask_cfi import ecalEnergyTaskPhase2
+from DQM.EcalMonitorTasks.TimingTask_cfi import ecalTimingTaskPhase2
 from DQM.EcalMonitorTasks.ecalPiZeroTask_cfi import ecalPiZeroTask
 
 ecalMonitorTaskEcalOnlyPhase2 = ecalMonitorTaskEcalOnly.clone(
@@ -25,11 +25,12 @@ ecalMonitorTaskEcalOnlyPhase2 = ecalMonitorTaskEcalOnly.clone(
         "PiZeroTask"
     ),
     workerParameters = cms.untracked.PSet(
-        ClusterTask = ecalClusterTask,
-        EnergyTask = ecalEnergyTask,
-        TimingTask = ecalTimingTask,
+        ClusterTask = ecalClusterTaskPhase2,
+        EnergyTask = ecalEnergyTaskPhase2,
+        TimingTask = ecalTimingTaskPhase2,
         PiZeroTask = ecalPiZeroTask
     ),
     collectionTags = ecalDQMCollectionTagsPhase2,
+    # skip EcalRawData collection to prevent event type filtering while no Phase 2 raw data is defined
     skipCollections = cms.untracked.vstring('EcalRawData')
 )

--- a/DQM/EcalMonitorTasks/python/EcalMonitorTask_cff.py
+++ b/DQM/EcalMonitorTasks/python/EcalMonitorTask_cff.py
@@ -29,6 +29,9 @@ alpaka.toModify(ecalMonitorTask.skipCollections, func = lambda skipCollections: 
 
 # Changes for Phase 2
 from DQM.EcalMonitorTasks.CollectionTags_cfi import ecalDQMCollectionTagsPhase2
+from DQM.EcalMonitorTasks.ClusterTask_cfi import ecalClusterTaskPhase2
+from DQM.EcalMonitorTasks.EnergyTask_cfi import ecalEnergyTaskPhase2
+from DQM.EcalMonitorTasks.TimingTask_cfi import ecalTimingTaskPhase2
 ecalMonitorTaskPhase2 = ecalMonitorTask.clone(
     workers = cms.untracked.vstring(
         "ClusterTask",
@@ -37,11 +40,12 @@ ecalMonitorTaskPhase2 = ecalMonitorTask.clone(
         "PiZeroTask"
     ),
     workerParameters = cms.untracked.PSet(
-        ClusterTask = ecalClusterTask,
-        EnergyTask = ecalEnergyTask,
-        TimingTask = ecalTimingTask,
+        ClusterTask = ecalClusterTaskPhase2,
+        EnergyTask = ecalEnergyTaskPhase2,
+        TimingTask = ecalTimingTaskPhase2,
         PiZeroTask = ecalPiZeroTask
     ),
     collectionTags = ecalDQMCollectionTagsPhase2,
+    # skip EcalRawData collection to prevent event type filtering while no Phase 2 raw data is defined
     skipCollections = cms.untracked.vstring('EcalRawData')
 )

--- a/DQM/EcalMonitorTasks/python/EnergyTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/EnergyTask_cfi.py
@@ -5,7 +5,8 @@ threshS9 = 0.125
 ecalEnergyTask = cms.untracked.PSet(
     params = cms.untracked.PSet(
         #    threshS9 = cms.untracked.double(0.125),
-        isPhysicsRun = cms.untracked.bool(True)
+        isPhysicsRun = cms.untracked.bool(True),
+        doEndcaps = cms.untracked.bool(True)
     ),
     MEs = cms.untracked.PSet(
         HitMapAll = cms.untracked.PSet(
@@ -67,3 +68,4 @@ ecalEnergyTask = cms.untracked.PSet(
     )
 )
 
+ecalEnergyTaskPhase2 = ecalEnergyTask.clone(params = dict(doEndcaps = False))

--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -38,6 +38,7 @@ summaryTimeWindow = 7.
 
 ecalTimingTask = cms.untracked.PSet(
     params = cms.untracked.PSet(
+        doEndcaps = cms.untracked.bool(True),
         bxBins = cms.untracked.vint32(bxBins),
         bxBinsFine = cms.untracked.vint32(bxBinsFine),
         chi2ThresholdEE = cms.untracked.double(chi2ThresholdEE),
@@ -345,3 +346,5 @@ ecalTimingTask = cms.untracked.PSet(
         )
     )
 )
+
+ecalTimingTaskPhase2 = ecalTimingTask.clone(params = dict(doEndcaps = False))

--- a/DQM/EcalMonitorTasks/src/ClusterTask.cc
+++ b/DQM/EcalMonitorTasks/src/ClusterTask.cc
@@ -22,6 +22,7 @@ namespace ecaldqm {
         //    ievt_(0),
         //    massCalcPrescale_(_workerParams.getUntrackedParameter<int>("massCalcPrescale")),
         doExtra_(true),
+        doEndcaps_(true),
         energyThreshold_(0.),
         swissCrossMaxThreshold_(3.),
         egTriggerAlgos_(),
@@ -33,6 +34,7 @@ namespace ecaldqm {
 
   void ClusterTask::setParams(edm::ParameterSet const& _params) {
     doExtra_ = _params.getUntrackedParameter<bool>("doExtra");
+    doEndcaps_ = _params.getUntrackedParameter<bool>("doEndcaps");
 
     if (!doExtra_) {
       MEs_.erase(std::string("SCSizeVsEnergy"));
@@ -68,7 +70,9 @@ namespace ecaldqm {
 
   void ClusterTask::addDependencies(DependencySet& _dependencies) {
     _dependencies.push_back(Dependency(kEBSuperCluster, kEBRecHit));
-    _dependencies.push_back(Dependency(kEESuperCluster, kEERecHit));
+    if (doEndcaps_) {
+      _dependencies.push_back(Dependency(kEESuperCluster, kEERecHit));
+    }
   }
 
   void ClusterTask::beginEvent(edm::Event const& _evt, edm::EventSetup const& _es, bool const&, bool&) {
@@ -183,8 +187,6 @@ namespace ecaldqm {
   }
 
   void ClusterTask::endEvent(edm::Event const&, edm::EventSetup const&) {
-    //    ++ievt_;
-
     ebHits_ = nullptr;
     eeHits_ = nullptr;
   }
@@ -537,10 +539,12 @@ namespace ecaldqm {
   }
 
   void ClusterTask::setTokens(edm::ConsumesCollector& _collector) {
-    L1GlobalTriggerReadoutRecordToken_ =
-        _collector.consumes<L1GlobalTriggerReadoutRecord>(L1GlobalTriggerReadoutRecordTag_);
-    L1MuGMTReadoutCollectionToken_ = _collector.consumes<L1MuGMTReadoutCollection>(L1MuGMTReadoutCollectionTag_);
-    menuRcd = _collector.esConsumes();
+    if (doExtra_) {
+      L1GlobalTriggerReadoutRecordToken_ =
+          _collector.consumes<L1GlobalTriggerReadoutRecord>(L1GlobalTriggerReadoutRecordTag_);
+      L1MuGMTReadoutCollectionToken_ = _collector.consumes<L1MuGMTReadoutCollection>(L1MuGMTReadoutCollectionTag_);
+      menuRcd = _collector.esConsumes();
+    }
   }
 
   DEFINE_ECALDQM_WORKER(ClusterTask);

--- a/DQM/EcalMonitorTasks/src/EnergyTask.cc
+++ b/DQM/EcalMonitorTasks/src/EnergyTask.cc
@@ -8,10 +8,11 @@
 #include "DataFormats/EcalRawData/interface/EcalDCCHeaderBlock.h"
 
 namespace ecaldqm {
-  EnergyTask::EnergyTask() : DQWorkerTask(), isPhysicsRun_(false) {}
+  EnergyTask::EnergyTask() : DQWorkerTask(), isPhysicsRun_(false), doEndcaps_(true) {}
 
   void EnergyTask::setParams(edm::ParameterSet const& _params) {
     isPhysicsRun_ = _params.getUntrackedParameter<bool>("isPhysicsRun");
+    doEndcaps_ = _params.getUntrackedParameter<bool>("doEndcaps");
   }
 
   bool EnergyTask::filterRunType(short const* _runType) {

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -12,6 +12,7 @@
 namespace ecaldqm {
   TimingTask::TimingTask()
       : DQWorkerTask(),
+        doEndcaps_(true),
         bxBinEdges_(),
         bxBin_(0.),
         chi2ThresholdEB_(0.),
@@ -31,6 +32,7 @@ namespace ecaldqm {
         meTime1D_nonCorr(nullptr) {}
 
   void TimingTask::setParams(edm::ParameterSet const& _params) {
+    doEndcaps_ = _params.getUntrackedParameter<bool>("doEndcaps");
     bxBinEdges_ = onlineMode_ ? _params.getUntrackedParameter<std::vector<int> >("bxBins")
                               : _params.getUntrackedParameter<std::vector<int> >("bxBinsFine");
     chi2ThresholdEB_ = _params.getUntrackedParameter<double>("chi2ThresholdEB");

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -58,6 +58,7 @@ _phase2_ecal_extraCommands = cms.PSet( # using PSet in order to potentially cust
 phase2_ecal_devel.toModify(SimCalorimetryFEVTDEBUG, outputCommands = SimCalorimetryFEVTDEBUG.outputCommands + _phase2_ecal_extraCommands.v)
 phase2_ecal_devel.toModify(SimCalorimetryPREMIX, outputCommands = SimCalorimetryPREMIX.outputCommands + _phase2_ecal_extraCommands.v)
 phase2_ecal_devel.toModify(SimCalorimetryRAW, outputCommands = SimCalorimetryRAW.outputCommands + _phase2_ecal_extraCommands.v)
+phase2_ecal_devel.toModify(SimCalorimetryRECO, outputCommands = SimCalorimetryRECO.outputCommands + _phase2_ecal_extraCommands.v)
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify( SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep EBDigiCollectionPh2_mixData_*_*') )


### PR DESCRIPTION
#### PR description:

Do not run on ECAL endcap collections for the ECAL Phase 2 DQM tasks (Cluster, Energy, Timing). This PR removes warning messages about missing collections when running the ECAL DQM with the ECAL development era modifier (`phase2_ecal_devel`).

Additionally, the ECAL Phase 2 collections are added to the RECO event content with the ECAL development modifiers.

No changes to outputs are expected.

#### PR validation:

The warning messages are removed in WF 34402.612

Backport of #51532 to reduce log warnings when producing samples with ECAL development workflows.