### PR TITLE
Fix v19 HGCal ToA jitter constant and per-type time offset generation

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalRecHitL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalRecHitL1Seeded_cfi.py
@@ -63,6 +63,8 @@ hltHGCalRecHitL1Seeded = cms.EDProducer("HGCalRecHitProducer",
 )
 
 phase2_hgcalV19.toModify(hltHGCalRecHitL1Seeded, 
+                         #four silicon thickness slots in v19: the CE-H offset moves from 3 to 4
+                         deltasi_index_regemfac = 4,
                          HGCEE_fCPerMIP = HGCAL_reco_constants.fcPerMip[0:4],
                          HGCHEF_fCPerMIP = HGCAL_reco_constants.fcPerMip[4:8],
                          HGCHFNose_fCPerMIP = [1.25, 2.57, 3.88, 2.57],

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalRecHit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHGCalRecHit_cfi.py
@@ -62,6 +62,8 @@ hltHGCalRecHit = cms.EDProducer("HGCalRecHitProducer",
 )
 
 phase2_hgcalV19.toModify(hltHGCalRecHit, 
+                         #four silicon thickness slots in v19: the CE-H offset moves from 3 to 4
+                         deltasi_index_regemfac = 4,
                          HGCEE_fCPerMIP = HGCAL_reco_constants.fcPerMip[0:4],
                          HGCHEF_fCPerMIP = HGCAL_reco_constants.fcPerMip[4:8],
                          HGCHFNose_fCPerMIP = [1.25, 2.57, 3.88, 2.57],

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersHSiL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersHSiL1Seeded_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
 
 hltHgcalLayerClustersHSiL1Seeded = cms.EDProducer("HGCalLayerClusterProducer",
@@ -45,4 +46,5 @@ hltHgcalLayerClustersHSiL1Seeded = cms.EDProducer("HGCalLayerClusterProducer",
     recHits = cms.InputTag("hltRechitInRegionsHGCAL","HGCHEFRecHits"),
     timeClname = cms.string('timeLayerCluster')
 )
-
+#four silicon thickness slots in v19: the CE-H offset moves from 3 to 4
+phase2_hgcalV19.toModify(hltHgcalLayerClustersHSiL1Seeded, plugin = dict(deltasi_index_regemfac = 4))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersHSi_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHgcalLayerClustersHSi_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
 
 hltHgcalLayerClustersHSi = cms.EDProducer("HGCalLayerClusterProducer",
@@ -45,3 +46,5 @@ hltHgcalLayerClustersHSi = cms.EDProducer("HGCalLayerClusterProducer",
     recHits = cms.InputTag("hltHGCalRecHit","HGCHEFRecHits"),
     timeClname = cms.string('timeLayerCluster')
 )
+#four silicon thickness slots in v19: the CE-H offset moves from 3 to 4
+phase2_hgcalV19.toModify(hltHgcalLayerClustersHSi, plugin = dict(deltasi_index_regemfac = 4))

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
@@ -45,7 +45,9 @@ HGCAL_reco_constants = cms.PSet(
 
 
 
+from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX_v19 as _dEdX_v19
 phase2_hgcalV19.toModify(HGCAL_reco_constants, 
+                         dEdXweights = _dEdX_v19.weights,
                          thicknessCorrection = [0.75, 0.76, 0.75, 0.76, 0.85, 0.85, 0.84, 0.85] , #CEE_12_HD, CEE_200_LD, CEE_300_LD, CEE_200_HD,CEH_12_HD, CEH_200_LD, CEH_300_LD, CEH_200_HD,
                          fcPerMip = 
                                  [2.06, 3.43, 5.15, 3.43, 2.06, 3.43,

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -89,7 +89,7 @@ public:
   };
 
   void generateTimeOffset(CLHEP::HepRandomEngine* engine) {
-    for (int i = 0; i < 3; i++)
+    for (size_t i = 0; i < jitterConstant_ns_.size(); i++)
       eventTimeOffset_ns_[i] = CLHEP::RandGaussQ::shoot(engine, 0, jitterConstant_ns_[i]);
   };
 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -89,7 +89,8 @@ public:
   };
 
   void generateTimeOffset(CLHEP::HepRandomEngine* engine) {
-    for (size_t i = 0; i < jitterConstant_ns_.size(); i++)
+    const size_t n = std::min(eventTimeOffset_ns_.size(), jitterConstant_ns_.size());
+    for (size_t i = 0; i < n; i++)
       eventTimeOffset_ns_[i] = CLHEP::RandGaussQ::shoot(engine, 0, jitterConstant_ns_[i]);
   };
 

--- a/SimCalorimetry/HGCalSimProducers/python/hgcROCParameters_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcROCParameters_cfi.py
@@ -48,6 +48,6 @@ hgcROCSettings = cms.PSet(
 from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
 phase2_hgcalV19.toModify(hgcROCSettings, tdcForToAOnset_fC = [12., 12., 12., 12.])
 phase2_hgcalV19.toModify(hgcROCSettings, jitterNoise_ns = [5., 5., 5., 5.])
-phase2_hgcalV19.toModify(hgcROCSettings, jitterConstant_ns = [0.2,0.2,0.2,0.2])
+phase2_hgcalV19.toModify(hgcROCSettings, jitterConstant_ns = [0.02,0.02,0.02,0.02])
 phase2_hgcalV19.toModify(hgcROCSettings, eventTimeOffset_ns = [0.2,0.2,0.2,0.2])
 

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -317,7 +317,7 @@ def HGCal_setRealisticNoiseSi(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMap
         scaleByDoseAlgo = cms.uint32(byDoseAlgo),
         scaleByDoseFactor = cms.double(byDoseFactor),
         doseMap = byDoseMap,
-        values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises] ), #100,200,300 um, to be deprecated
+        values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises] ), #120,200,300,HD200 um, to be deprecated
         )
 
     #this is to be deprecated
@@ -347,7 +347,7 @@ def HFNose_setRealisticNoiseSi(process,byDose=True,byDoseAlgo=0,byDoseMap=doseMa
         values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises] ), #100,200,300 um
         )
 
-    phase2_hgcalV19.toModify(HFNose_noise_fC, values = [x*fC_per_ele for x in endOfLifeNoises_v19]) #100,200,300 um, to be deprecated
+    phase2_hgcalV19.toModify(process.HFNose_noise_fC, values = [x*fC_per_ele for x in endOfLifeNoises_v19]) #120,200,300,HD200 um, to be deprecated
     return process
 
 


### PR DESCRIPTION
Follow-up to #51524 (HD 200um ZS threshold and v19 local reco constants): three further v19 fixes found by the same validation campaign and a systematic sweep of the digitization chain.

**1. v19 ToA jitter constant and per-type time offset generation.**
The v19 `jitterConstant_ns` was 0.2 ns, ten times the 0.02 ns default, a copy of the adjacent `eventTimeOffset_ns` line. The coherent per-event ToA offset drawn from it shifts all HGCal times by up to a few hundred ps against MTD, failing the trackster-track timing compatibility in TICL candidate linking for most events. In addition `generateTimeOffset` looped over a hardcoded 3 thickness classes, leaving the fourth v19 class (HD 200um) with the configured constant as a frozen +0.2 ns bias instead of a random draw. Measured with single pions (pt 10) from the origin: charged-candidate linking efficiency was 31-50% in v19 vs 94-98% in v17; with this fix it returns to 94.2-98.8%, flat in eta. Related observation for the TICL experts: the compatibility tolerance in `GeneralInterpretationAlgo` has no floor or systematic term, so any inter-detector timing miscalibration becomes a linking cliff rather than a resolution loss, and an unlinked non-muon track currently produces no candidate at all.

**2. HLT twins of the offline v19 constants.**
The same sweep found the offline defects of #51524 duplicated in `HLT_75e33`: `deltasi_index_regemfac` stayed 3 in `hltHGCalRecHit(L1Seeded)` and the HSi layer-cluster producers under v19 (CE-H HD120 rechits +12% energy; HLT CLUE thresholds off by -44% to +78% per cell type), and the v19 pset override never replaced `dEdXweights`, leaving the HLT HGCal energy scale on v16 absorber weights (up to ~10% per layer in CE-E). Fixed with additions to the existing `phase2_hgcalV19` modifiers; verified under the era that the HLT `layerWeights` now equal the offline `dEdX_v19` list.

**3. Hardening and cleanup.**
`generateTimeOffset` now bounds its loop by both array sizes; the v19 `toModify` in `HFNose_setRealisticNoiseSi` targets the process attribute (same defect class as the aging-customise fix in #51524); stale thickness comments corrected.

Validation: single-photon and single-muon A/B scans D121 (v17) vs D122 (v19) in eta [1.3, 3.3] x full phi on identical GEN-SIM, plus single pions from the origin for the linking. At campaign level the #51524 + this-PR fixes together restore HD200 MIP rechit efficiency from 62.9% to 99.1%, recover 55-70% of the pion merged-trackster energy deficit across eta 1.9-2.5, reduce the layer-cluster fragmentation peak from +44% to +35%, and restore track-trackster linking from 31-50% to 94-99%. Build, unit tests of the touched packages, code-checks and code-format are clean.


