### PR TITLE
Nested SoABlocks

### DIFF
--- a/DataFormats/Portable/interface/PortableCollectionCommon.h
+++ b/DataFormats/Portable/interface/PortableCollectionCommon.h
@@ -12,24 +12,26 @@
 
 namespace portablecollection {
 
-  template <std::size_t I, typename TQueue, typename Descriptor, typename ConstDescriptor>
-  void deepCopyColumns(TQueue& queue, Descriptor& dest, ConstDescriptor const& src) {
+  template <std::size_t I = 0, typename TQueue, typename Descriptor, typename ConstDescriptor>
+    requires requires { Descriptor::num_cols; }
+  void deepCopy(TQueue& queue, Descriptor& dest, ConstDescriptor const& src) {
     if constexpr (I < ConstDescriptor::num_cols) {
       assert(std::get<I>(dest.buff).size_bytes() == std::get<I>(src.buff).size_bytes());
       alpaka::memcpy(
           queue,
           alpaka::createView(alpaka::getDev(queue), std::get<I>(dest.buff).data(), std::get<I>(dest.buff).size()),
           alpaka::createView(alpaka::getDev(queue), std::get<I>(src.buff).data(), std::get<I>(src.buff).size()));
-      deepCopyColumns<I + 1>(queue, dest, src);
+      deepCopy<I + 1>(queue, dest, src);
     }
   }
 
   // Helper function implementing the recursive deep copy for blocks
-  template <std::size_t I, typename TQueue, typename Descriptor, typename ConstDescriptor>
-  void deepCopyBlocks(TQueue& queue, Descriptor& dest, ConstDescriptor const& src) {
+  template <std::size_t I = 0, typename TQueue, typename Descriptor, typename ConstDescriptor>
+    requires requires { Descriptor::blocksNumber; }
+  void deepCopy(TQueue& queue, Descriptor& dest, ConstDescriptor const& src) {
     if constexpr (I < ConstDescriptor::blocksNumber) {
-      deepCopyColumns<0>(queue, std::get<I>(dest.buff), std::get<I>(src.buff));
-      deepCopyBlocks<I + 1>(queue, dest, src);
+      deepCopy(queue, std::get<I>(dest.buff), std::get<I>(src.buff));
+      deepCopy<I + 1>(queue, dest, src);
     }
   }
 

--- a/DataFormats/Portable/interface/PortableCollectionCommon.h
+++ b/DataFormats/Portable/interface/PortableCollectionCommon.h
@@ -12,7 +12,7 @@
 
 namespace portablecollection {
 
-  template <int I, typename TQueue, typename Descriptor, typename ConstDescriptor>
+  template <std::size_t I, typename TQueue, typename Descriptor, typename ConstDescriptor>
   void deepCopyColumns(TQueue& queue, Descriptor& dest, ConstDescriptor const& src) {
     if constexpr (I < ConstDescriptor::num_cols) {
       assert(std::get<I>(dest.buff).size_bytes() == std::get<I>(src.buff).size_bytes());
@@ -25,7 +25,7 @@ namespace portablecollection {
   }
 
   // Helper function implementing the recursive deep copy for blocks
-  template <int I, typename TQueue, typename Descriptor, typename ConstDescriptor>
+  template <std::size_t I, typename TQueue, typename Descriptor, typename ConstDescriptor>
   void deepCopyBlocks(TQueue& queue, Descriptor& dest, ConstDescriptor const& src) {
     if constexpr (I < ConstDescriptor::blocksNumber) {
       deepCopyColumns<0>(queue, std::get<I>(dest.buff), std::get<I>(src.buff));

--- a/DataFormats/Portable/interface/PortableCollectionCommon.h
+++ b/DataFormats/Portable/interface/PortableCollectionCommon.h
@@ -13,14 +13,23 @@
 namespace portablecollection {
 
   template <int I, typename TQueue, typename Descriptor, typename ConstDescriptor>
-  void deepCopy(TQueue& queue, Descriptor& dest, ConstDescriptor const& src) {
+  void deepCopyColumns(TQueue& queue, Descriptor& dest, ConstDescriptor const& src) {
     if constexpr (I < ConstDescriptor::num_cols) {
       assert(std::get<I>(dest.buff).size_bytes() == std::get<I>(src.buff).size_bytes());
       alpaka::memcpy(
           queue,
           alpaka::createView(alpaka::getDev(queue), std::get<I>(dest.buff).data(), std::get<I>(dest.buff).size()),
           alpaka::createView(alpaka::getDev(queue), std::get<I>(src.buff).data(), std::get<I>(src.buff).size()));
-      deepCopy<I + 1>(queue, dest, src);
+      deepCopyColumns<I + 1>(queue, dest, src);
+    }
+  }
+
+  // Helper function implementing the recursive deep copy for blocks
+  template <int I, typename TQueue, typename Descriptor, typename ConstDescriptor>
+  void deepCopyBlocks(TQueue& queue, Descriptor& dest, ConstDescriptor const& src) {
+    if constexpr (I < ConstDescriptor::blocksNumber) {
+      deepCopyColumns<0>(queue, std::get<I>(dest.buff), std::get<I>(src.buff));
+      deepCopyBlocks<I + 1>(queue, dest, src);
     }
   }
 

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -127,22 +127,12 @@ public:
     alpaka::memset(std::forward<TQueue>(queue), *buffer_, 0x00);
   }
 
-  // Copy column by column heterogeneously for device to host/device data transfer.
+  // Copy column by column or block by block heterogeneously for device to host/device data transfer.
   template <typename TQueue>
-    requires(alpaka::isQueue<TQueue> && (!requires { Layout::blocksNumber; }))
   void deepCopy(TQueue& queue, ConstView const& view) {
     ConstDescriptor desc{view};
     Descriptor desc_{view_};
-    portablecollection::deepCopyColumns<0>(queue, desc_, desc);
-  }
-
-  // Copy block by block heterogeneously for device to host data transfer.
-  template <typename TQueue>
-    requires(alpaka::isQueue<TQueue> && (requires { Layout::blocksNumber; }))
-  void deepCopy(TQueue& queue, ConstView const& view) {
-    ConstDescriptor desc{view};
-    Descriptor desc_{view_};
-    portablecollection::deepCopyBlocks<0>(queue, desc_, desc);
+    portablecollection::deepCopy(queue, desc_, desc);
   }
 
   // Either Layout::size_type for normal layouts or std::array<Layout::size_type, N> for SoABlocks layouts

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -128,13 +128,21 @@ public:
   }
 
   // Copy column by column heterogeneously for device to host/device data transfer.
-  // TODO: implement heterogeneous deepCopy for SoA blocks
   template <typename TQueue>
     requires(alpaka::isQueue<TQueue> && (!requires { Layout::blocksNumber; }))
   void deepCopy(TQueue& queue, ConstView const& view) {
     ConstDescriptor desc{view};
     Descriptor desc_{view_};
-    portablecollection::deepCopy<0>(queue, desc_, desc);
+    portablecollection::deepCopyColumns<0>(queue, desc_, desc);
+  }
+
+  // Copy block by block heterogeneously for device to host data transfer.
+  template <typename TQueue>
+    requires(alpaka::isQueue<TQueue> && (requires { Layout::blocksNumber; }))
+  void deepCopy(TQueue& queue, ConstView const& view) {
+    ConstDescriptor desc{view};
+    Descriptor desc_{view_};
+    portablecollection::deepCopyBlocks<0>(queue, desc_, desc);
   }
 
   // Either Layout::size_type for normal layouts or std::array<Layout::size_type, N> for SoABlocks layouts

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -169,13 +169,21 @@ public:
   void deepCopy(ConstView const& view) { layout_.deepCopy(view); }
 
   // Copy column by column heterogeneously for device to host data transfer.
-  // TODO: implement heterogeneous deepCopy for SoA blocks
   template <typename TQueue>
     requires(alpaka::isQueue<TQueue> && (!requires { Layout::blocksNumber; }))
   void deepCopy(TQueue& queue, ConstView const& view) {
     ConstDescriptor desc{view};
     Descriptor desc_{view_};
-    portablecollection::deepCopy<0>(queue, desc_, desc);
+    portablecollection::deepCopyColumns<0>(queue, desc_, desc);
+  }
+
+  // Copy block by block heterogeneously for device to host data transfer.
+  template <typename TQueue>
+    requires(alpaka::isQueue<TQueue> && (requires { Layout::blocksNumber; }))
+  void deepCopy(TQueue& queue, ConstView const& view) {
+    ConstDescriptor desc{view};
+    Descriptor desc_{view_};
+    portablecollection::deepCopyBlocks<0>(queue, desc_, desc);
   }
 
   // Either Layout::size_type for normal layouts or std::array<Layout::size_type, N> for SoABlocks layouts

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -168,22 +168,12 @@ public:
   // The view must point to data in host memory.
   void deepCopy(ConstView const& view) { layout_.deepCopy(view); }
 
-  // Copy column by column heterogeneously for device to host data transfer.
+  // Copy column by column or block by block heterogeneously for device to host data transfer.
   template <typename TQueue>
-    requires(alpaka::isQueue<TQueue> && (!requires { Layout::blocksNumber; }))
   void deepCopy(TQueue& queue, ConstView const& view) {
     ConstDescriptor desc{view};
     Descriptor desc_{view_};
-    portablecollection::deepCopyColumns<0>(queue, desc_, desc);
-  }
-
-  // Copy block by block heterogeneously for device to host data transfer.
-  template <typename TQueue>
-    requires(alpaka::isQueue<TQueue> && (requires { Layout::blocksNumber; }))
-  void deepCopy(TQueue& queue, ConstView const& view) {
-    ConstDescriptor desc{view};
-    Descriptor desc_{view_};
-    portablecollection::deepCopyBlocks<0>(queue, desc_, desc);
+    portablecollection::deepCopy(queue, desc_, desc);
   }
 
   // Either Layout::size_type for normal layouts or std::array<Layout::size_type, N> for SoABlocks layouts

--- a/DataFormats/Portable/test/BuildFile.xml
+++ b/DataFormats/Portable/test/BuildFile.xml
@@ -48,3 +48,12 @@
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <flags ALPAKA_BACKENDS="1"/>
 </bin>
+
+<bin name="TestDataFormatsPortableSoABlocksDeepCopy" file="alpaka/test_catch2_heterogeneousDeepCopy_SoABlocks.dev.cc">
+  <use name="catch2"/>
+  <use name="eigen"/>
+  <use name="DataFormats/Portable"/>
+  <use name="DataFormats/SoATemplate"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>

--- a/DataFormats/Portable/test/BuildFile.xml
+++ b/DataFormats/Portable/test/BuildFile.xml
@@ -40,3 +40,11 @@
   <flags ALPAKA_BACKENDS="1"/>
 </bin>
 
+<bin name="TestDataFormatsPortableNestedBlocks" file="alpaka/test_catch2_nestedSoABlocks.dev.cc">
+  <use name="catch2"/>
+  <use name="eigen"/>
+  <use name="DataFormats/Portable"/>
+  <use name="DataFormats/SoATemplate"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>

--- a/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousDeepCopy_SoABlocks.dev.cc
+++ b/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousDeepCopy_SoABlocks.dev.cc
@@ -1,0 +1,122 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include <alpaka/alpaka.hpp>
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+
+#include "DataFormats/SoATemplate/interface/SoABlocks.h"
+#include "DataFormats/Portable/interface/PortableCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+constexpr float step = 0.01;
+
+GENERATE_SOA_LAYOUT(SoAPositionTemplate,
+                    SOA_COLUMN(float, x),
+                    SOA_COLUMN(float, y),
+                    SOA_COLUMN(float, z),
+                    SOA_SCALAR(int, detectorType))
+
+using SoAPosition = SoAPositionTemplate<>;
+using SoAPositionView = SoAPosition::View;
+using SoAPositionConstView = SoAPosition::ConstView;
+
+GENERATE_SOA_LAYOUT(SoAPCATemplate,
+                    SOA_COLUMN(float, vector_1),
+                    SOA_COLUMN(float, vector_2),
+                    SOA_COLUMN(float, vector_3),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, candidateDirection))
+
+using SoAPCA = SoAPCATemplate<>;
+using SoAPCAView = SoAPCA::View;
+using SoAPCAConstView = SoAPCA::ConstView;
+
+GENERATE_SOA_BLOCKS(SoAGenericBlocksTemplate, SOA_BLOCK(position, SoAPositionTemplate), SOA_BLOCK(pca, SoAPCATemplate))
+
+using SoAGenericBlocks = SoAGenericBlocksTemplate<>;
+using SoAGenericBlocksView = SoAGenericBlocks::View;
+using SoAGenericBlocksConstView = SoAGenericBlocks::ConstView;
+
+// Fill SoAs
+struct FillSoAPosition {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, SoAPositionView positionView) const {
+    if (cms::alpakatools::once_per_grid(acc))
+      positionView.detectorType() = 1;
+
+    for (auto local_idx : cms::alpakatools::uniform_elements(acc, positionView.metadata().size())) {
+      positionView[local_idx].x() = static_cast<float>(local_idx);
+      positionView[local_idx].y() = static_cast<float>(local_idx) * 2.0f;
+      positionView[local_idx].z() = static_cast<float>(local_idx) * 3.0f;
+    }
+  }
+};
+
+struct FillSoAPCA {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, SoAPCAView pcaView) const {
+    for (auto local_idx : cms::alpakatools::uniform_elements(acc, pcaView.metadata().size())) {
+      pcaView[local_idx].vector_1() = 1.0f / step;
+      pcaView[local_idx].vector_2() = 2.0f / step;
+      pcaView[local_idx].vector_3() = 3.0f / step;
+      pcaView[local_idx].candidateDirection()(0) = 1.0f / step;
+      pcaView[local_idx].candidateDirection()(1) = 2.0f / step;
+      pcaView[local_idx].candidateDirection()(2) = 3.0f / step;
+    }
+  }
+};
+
+TEST_CASE("Heterogeneous Deep Copy SoABlocks") {
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    std::cout << "No devices available for the " << EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE)
+              << " backend, skipping.\n";
+    return;
+  }
+
+  for (auto const& device : devices) {
+    std::cout << "Running on " << alpaka::getName(device) << std::endl;
+    Queue queue(device);
+
+    // Number of elements
+    const int elemPos = 10;
+    const int elemPCA = 100;
+
+    PortableCollection<Device, SoAPosition> positionCollection(queue, elemPos);
+    PortableCollection<Device, SoAPCA> pcaCollection(queue, elemPCA);
+
+    // Portable Collection Views
+    SoAPositionView& positionCollectionView = positionCollection.view();
+    SoAPCAView& pcaCollectionView = pcaCollection.view();
+
+    // fill up
+    auto blockSize = 64;
+    auto numberOfBlocks = cms::alpakatools::divide_up_by(elemPos, blockSize);
+
+    const auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(numberOfBlocks, blockSize);
+
+    alpaka::exec<Acc1D>(queue, workDiv, FillSoAPosition{}, positionCollectionView);
+
+    alpaka::wait(queue);
+
+    numberOfBlocks = cms::alpakatools::divide_up_by(elemPCA, blockSize);
+
+    const auto workDivPCA = cms::alpakatools::make_workdiv<Acc1D>(numberOfBlocks, blockSize);
+
+    alpaka::exec<Acc1D>(queue, workDivPCA, FillSoAPCA{}, pcaCollectionView);
+
+    alpaka::wait(queue);
+
+    // Build the View of the SoABlocks
+    SoAGenericBlocksView genericBlocksView{positionCollectionView, pcaCollectionView};
+
+    SECTION("Heterogeneous deep copy of the SoABlocks View") {
+      // PortableCollection that will host the aggregated columns
+      PortableCollection<Device, SoAGenericBlocks> genericCollection(queue, elemPos, elemPCA);
+      genericCollection.deepCopy(queue, genericBlocksView);
+    }
+  }
+}

--- a/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousDeepCopy_SoABlocks.dev.cc
+++ b/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousDeepCopy_SoABlocks.dev.cc
@@ -12,62 +12,72 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 
+#include <algorithm>
+
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
-constexpr float step = 0.01;
+GENERATE_SOA_LAYOUT(SoALayout1, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
+GENERATE_SOA_LAYOUT(SoALayout2, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
+GENERATE_SOA_LAYOUT(SoALayout3, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
 
-GENERATE_SOA_LAYOUT(SoAPositionTemplate,
-                    SOA_COLUMN(float, x),
-                    SOA_COLUMN(float, y),
-                    SOA_COLUMN(float, z),
-                    SOA_SCALAR(int, detectorType))
+GENERATE_SOA_BLOCKS(BlocksTemplate, SOA_BLOCK(first, SoALayout1), SOA_BLOCK(second, SoALayout2))
+GENERATE_SOA_BLOCKS(NestedBlocksTemplate, SOA_BLOCK(blocks, BlocksTemplate), SOA_BLOCK(soa, SoALayout3))
 
-using SoAPosition = SoAPositionTemplate<>;
-using SoAPositionView = SoAPosition::View;
-using SoAPositionConstView = SoAPosition::ConstView;
+using BlocksSoA = BlocksTemplate<>;
+using BlocksView = BlocksSoA::View;
+using BlocksConstView = BlocksSoA::ConstView;
 
-GENERATE_SOA_LAYOUT(SoAPCATemplate,
-                    SOA_COLUMN(float, vector_1),
-                    SOA_COLUMN(float, vector_2),
-                    SOA_COLUMN(float, vector_3),
-                    SOA_EIGEN_COLUMN(Eigen::Vector3d, candidateDirection))
-
-using SoAPCA = SoAPCATemplate<>;
-using SoAPCAView = SoAPCA::View;
-using SoAPCAConstView = SoAPCA::ConstView;
-
-GENERATE_SOA_BLOCKS(SoAGenericBlocksTemplate, SOA_BLOCK(position, SoAPositionTemplate), SOA_BLOCK(pca, SoAPCATemplate))
-
-using SoAGenericBlocks = SoAGenericBlocksTemplate<>;
-using SoAGenericBlocksView = SoAGenericBlocks::View;
-using SoAGenericBlocksConstView = SoAGenericBlocks::ConstView;
+using NestedBlocksSoA = NestedBlocksTemplate<>;
+using NestedBlocksView = NestedBlocksSoA::View;
+using NestedBlocksConstView = NestedBlocksSoA::ConstView;
 
 // Fill SoAs
-struct FillSoAPosition {
-  ALPAKA_FN_ACC void operator()(Acc1D const& acc, SoAPositionView positionView) const {
-    if (cms::alpakatools::once_per_grid(acc))
-      positionView.detectorType() = 1;
+struct FillSoA {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, NestedBlocksView view) const {
+    if (cms::alpakatools::once_per_grid(acc)) {
+      view.blocks().first().id() = 21;
+      view.blocks().second().id() = 42;
+      view.soa().id() = 666;
+    }
 
-    for (auto local_idx : cms::alpakatools::uniform_elements(acc, positionView.metadata().size())) {
-      positionView[local_idx].x() = static_cast<float>(local_idx);
-      positionView[local_idx].y() = static_cast<float>(local_idx) * 2.0f;
-      positionView[local_idx].z() = static_cast<float>(local_idx) * 3.0f;
+    for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size()[0])) {
+      view.blocks().first()[i].column() = static_cast<int>(i);
+      view.blocks().first()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
+    }
+
+    for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size()[1])) {
+      view.blocks().second()[i].column() = static_cast<int>(i);
+      view.blocks().second()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
+    }
+
+    for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size()[2])) {
+      view.soa()[i].column() = static_cast<int>(i);
+      view.soa()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
     }
   }
 };
 
-struct FillSoAPCA {
-  ALPAKA_FN_ACC void operator()(Acc1D const& acc, SoAPCAView pcaView) const {
-    for (auto local_idx : cms::alpakatools::uniform_elements(acc, pcaView.metadata().size())) {
-      pcaView[local_idx].vector_1() = 1.0f / step;
-      pcaView[local_idx].vector_2() = 2.0f / step;
-      pcaView[local_idx].vector_3() = 3.0f / step;
-      pcaView[local_idx].candidateDirection()(0) = 1.0f / step;
-      pcaView[local_idx].candidateDirection()(1) = 2.0f / step;
-      pcaView[local_idx].candidateDirection()(2) = 3.0f / step;
-    }
+void check(NestedBlocksConstView nestedBlocksConstView, BlocksConstView genericSoABlocksView) {
+  REQUIRE(nestedBlocksConstView.metadata().size()[0] == genericSoABlocksView.metadata().size()[0]);
+  REQUIRE(nestedBlocksConstView.metadata().size()[1] == genericSoABlocksView.metadata().size()[1]);
+  // Verify data
+  for (NestedBlocksSoA::size_type i = 0; i < genericSoABlocksView.metadata().size()[0]; ++i) {
+    auto nestedFirst = nestedBlocksConstView.blocks().first()[i];
+    auto first = genericSoABlocksView.first()[i];
+    REQUIRE(first.column() == nestedFirst.column());
+    REQUIRE(first.vector() == nestedFirst.vector());
   }
-};
+
+  for (NestedBlocksSoA::size_type i = 0; i < genericSoABlocksView.metadata().size()[0]; ++i) {
+    auto nestedSecond = nestedBlocksConstView.blocks().second()[i];
+    auto second = genericSoABlocksView.second()[i];
+    REQUIRE(second.column() == nestedSecond.column());
+    REQUIRE(second.vector() == nestedSecond.vector());
+  }
+
+  REQUIRE(nestedBlocksConstView.blocks().first().id() == genericSoABlocksView.first().id());
+  REQUIRE(nestedBlocksConstView.blocks().second().id() == genericSoABlocksView.second().id());
+}
 
 TEST_CASE("Heterogeneous Deep Copy SoABlocks") {
   auto const& devices = cms::alpakatools::devices<Platform>();
@@ -81,42 +91,149 @@ TEST_CASE("Heterogeneous Deep Copy SoABlocks") {
     std::cout << "Running on " << alpaka::getName(device) << std::endl;
     Queue queue(device);
 
-    // Number of elements
-    const int elemPos = 10;
-    const int elemPCA = 100;
+    std::array<NestedBlocksSoA::size_type, 3> sizes = {21, 45, 137};
 
-    PortableCollection<Device, SoAPosition> positionCollection(queue, elemPos);
-    PortableCollection<Device, SoAPCA> pcaCollection(queue, elemPCA);
-
-    // Portable Collection Views
-    SoAPositionView& positionCollectionView = positionCollection.view();
-    SoAPCAView& pcaCollectionView = pcaCollection.view();
+    PortableCollection<Device, NestedBlocksSoA> nestedBlocksCollection(queue, sizes);
+    NestedBlocksView nestedBlocksView = nestedBlocksCollection.view();
+    NestedBlocksConstView nestedBlocksConstView = nestedBlocksCollection.const_view();
 
     // fill up
     auto blockSize = 64;
-    auto numberOfBlocks = cms::alpakatools::divide_up_by(elemPos, blockSize);
-
+    NestedBlocksSoA::size_type largestSize = *std::max_element(sizes.begin(), sizes.end());
+    auto numberOfBlocks = cms::alpakatools::divide_up_by(largestSize, blockSize);
     const auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(numberOfBlocks, blockSize);
 
-    alpaka::exec<Acc1D>(queue, workDiv, FillSoAPosition{}, positionCollectionView);
-
+    alpaka::exec<Acc1D>(queue, workDiv, FillSoA{}, nestedBlocksView);
     alpaka::wait(queue);
 
-    numberOfBlocks = cms::alpakatools::divide_up_by(elemPCA, blockSize);
+    PortableHostCollection<NestedBlocksSoA> h_nestedBlocksCollection(queue, sizes);
+    alpaka::memcpy(queue, h_nestedBlocksCollection.buffer(), nestedBlocksCollection.buffer());
 
-    const auto workDivPCA = cms::alpakatools::make_workdiv<Acc1D>(numberOfBlocks, blockSize);
+    SECTION("Deep copy the View host to host and device to device") {
+      BlocksView blocksView{nestedBlocksView.blocks().first(), nestedBlocksView.blocks().second()};
 
-    alpaka::exec<Acc1D>(queue, workDivPCA, FillSoAPCA{}, pcaCollectionView);
+      // Verify metadata
+      REQUIRE(blocksView.metadata().size()[0] == sizes[0]);
+      REQUIRE(blocksView.first().metadata().size() == sizes[0]);
+      REQUIRE(blocksView.metadata().size()[1] == sizes[1]);
+      REQUIRE(blocksView.second().metadata().size() == sizes[1]);
 
-    alpaka::wait(queue);
+      // Check for equality of memory addresses
+      REQUIRE(blocksView.first().metadata().addressOf_column() ==
+              nestedBlocksView.blocks().first().metadata().addressOf_column());
+      REQUIRE(blocksView.first().metadata().addressOf_vector() ==
+              nestedBlocksView.blocks().first().metadata().addressOf_vector());
+      REQUIRE(blocksView.second().metadata().addressOf_column() ==
+              nestedBlocksView.blocks().second().metadata().addressOf_column());
+      REQUIRE(blocksView.second().metadata().addressOf_vector() ==
+              nestedBlocksView.blocks().second().metadata().addressOf_vector());
 
-    // Build the View of the SoABlocks
-    SoAGenericBlocksView genericBlocksView{positionCollectionView, pcaCollectionView};
-
-    SECTION("Heterogeneous deep copy of the SoABlocks View") {
       // PortableCollection that will host the aggregated columns
-      PortableCollection<Device, SoAGenericBlocks> genericCollection(queue, elemPos, elemPCA);
-      genericCollection.deepCopy(queue, genericBlocksView);
+      PortableCollection<Device, BlocksSoA> blocksCollection(queue, sizes[0], sizes[1]);
+      blocksCollection.deepCopy(queue, blocksView);
+
+      BlocksView copiedBlocksView = blocksCollection.view();
+      REQUIRE(copiedBlocksView.first().metadata().addressOf_column() !=
+              nestedBlocksView.blocks().first().metadata().addressOf_column());
+      REQUIRE(copiedBlocksView.first().metadata().addressOf_vector() !=
+              nestedBlocksView.blocks().first().metadata().addressOf_vector());
+      REQUIRE(copiedBlocksView.second().metadata().addressOf_column() !=
+              nestedBlocksView.blocks().second().metadata().addressOf_column());
+      REQUIRE(copiedBlocksView.second().metadata().addressOf_vector() !=
+              nestedBlocksView.blocks().second().metadata().addressOf_vector());
+
+      PortableHostCollection<BlocksSoA> outputHost(cms::alpakatools::host(), sizes[0], sizes[1]);
+      alpaka::memcpy(queue, outputHost.buffer(), blocksCollection.buffer());
+      alpaka::wait(queue);
+
+      check(h_nestedBlocksCollection.const_view(), outputHost.const_view());
+    }
+
+    SECTION("Deep copy the ConstView host to host and device to device") {
+      BlocksConstView blocksConstView{nestedBlocksConstView.blocks().first(), nestedBlocksConstView.blocks().second()};
+
+      // Verify metadata
+      REQUIRE(blocksConstView.metadata().size()[0] == sizes[0]);
+      REQUIRE(blocksConstView.first().metadata().size() == sizes[0]);
+      REQUIRE(blocksConstView.metadata().size()[1] == sizes[1]);
+      REQUIRE(blocksConstView.second().metadata().size() == sizes[1]);
+
+      // Check for equality of memory addresses
+      REQUIRE(blocksConstView.first().metadata().addressOf_column() ==
+              nestedBlocksConstView.blocks().first().metadata().addressOf_column());
+      REQUIRE(blocksConstView.first().metadata().addressOf_vector() ==
+              nestedBlocksConstView.blocks().first().metadata().addressOf_vector());
+      REQUIRE(blocksConstView.second().metadata().addressOf_column() ==
+              nestedBlocksConstView.blocks().second().metadata().addressOf_column());
+      REQUIRE(blocksConstView.second().metadata().addressOf_vector() ==
+              nestedBlocksConstView.blocks().second().metadata().addressOf_vector());
+
+      // PortableCollection that will host the aggregated columns
+      PortableCollection<Device, BlocksSoA> blocksCollection(queue, sizes[0], sizes[1]);
+      blocksCollection.deepCopy(queue, blocksConstView);
+
+      BlocksConstView copiedBlocksConstView = blocksCollection.const_view();
+      REQUIRE(copiedBlocksConstView.first().metadata().addressOf_column() !=
+              nestedBlocksConstView.blocks().first().metadata().addressOf_column());
+      REQUIRE(copiedBlocksConstView.first().metadata().addressOf_vector() !=
+              nestedBlocksConstView.blocks().first().metadata().addressOf_vector());
+      REQUIRE(copiedBlocksConstView.second().metadata().addressOf_column() !=
+              nestedBlocksConstView.blocks().second().metadata().addressOf_column());
+      REQUIRE(copiedBlocksConstView.second().metadata().addressOf_vector() !=
+              nestedBlocksConstView.blocks().second().metadata().addressOf_vector());
+
+      PortableHostCollection<BlocksSoA> outputHost(cms::alpakatools::host(), sizes[0], sizes[1]);
+      alpaka::memcpy(queue, outputHost.buffer(), blocksCollection.buffer());
+      alpaka::wait(queue);
+
+      check(h_nestedBlocksCollection.const_view(), outputHost.const_view());
+    }
+
+    SECTION("Deep copy the ConstView device to host") {
+      BlocksConstView blocksConstView{nestedBlocksConstView.blocks().first(), nestedBlocksConstView.blocks().second()};
+
+      // PortableCollection that will host the aggregated columns
+      PortableHostCollection<BlocksSoA> blocksCollection(queue, sizes[0], sizes[1]);
+      blocksCollection.deepCopy(queue, blocksConstView);
+      alpaka::wait(queue);
+
+      BlocksConstView copiedBlocksConstView = blocksCollection.const_view();
+      REQUIRE(copiedBlocksConstView.first().metadata().addressOf_column() !=
+              nestedBlocksConstView.blocks().first().metadata().addressOf_column());
+      REQUIRE(copiedBlocksConstView.first().metadata().addressOf_vector() !=
+              nestedBlocksConstView.blocks().first().metadata().addressOf_vector());
+      REQUIRE(copiedBlocksConstView.second().metadata().addressOf_column() !=
+              nestedBlocksConstView.blocks().second().metadata().addressOf_column());
+      REQUIRE(copiedBlocksConstView.second().metadata().addressOf_vector() !=
+              nestedBlocksConstView.blocks().second().metadata().addressOf_vector());
+
+      check(h_nestedBlocksCollection.const_view(), blocksCollection.const_view());
+    }
+
+    SECTION("Deep copy the ConstView host to device") {
+      BlocksConstView blocksConstView{h_nestedBlocksCollection.const_view().blocks().first(),
+                                      h_nestedBlocksCollection.const_view().blocks().second()};
+
+      // PortableCollection that will host the aggregated columns
+      PortableCollection<Device, BlocksSoA> blocksCollection(queue, sizes[0], sizes[1]);
+      blocksCollection.deepCopy(queue, blocksConstView);
+      alpaka::wait(queue);
+
+      BlocksConstView copiedBlocksConstView = blocksCollection.const_view();
+      REQUIRE(copiedBlocksConstView.first().metadata().addressOf_column() !=
+              h_nestedBlocksCollection.const_view().blocks().first().metadata().addressOf_column());
+      REQUIRE(copiedBlocksConstView.first().metadata().addressOf_vector() !=
+              h_nestedBlocksCollection.const_view().blocks().first().metadata().addressOf_vector());
+      REQUIRE(copiedBlocksConstView.second().metadata().addressOf_column() !=
+              h_nestedBlocksCollection.const_view().blocks().second().metadata().addressOf_column());
+      REQUIRE(copiedBlocksConstView.second().metadata().addressOf_vector() !=
+              h_nestedBlocksCollection.const_view().blocks().second().metadata().addressOf_vector());
+
+      PortableHostCollection<BlocksSoA> outputHost(cms::alpakatools::host(), sizes[0], sizes[1]);
+      alpaka::memcpy(queue, outputHost.buffer(), blocksCollection.buffer());
+      alpaka::wait(queue);
+
+      check(h_nestedBlocksCollection.const_view(), outputHost.const_view());
     }
   }
 }

--- a/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousDeepCopy_SoABlocks.dev.cc
+++ b/DataFormats/Portable/test/alpaka/test_catch2_heterogeneousDeepCopy_SoABlocks.dev.cc
@@ -19,64 +19,100 @@ using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 GENERATE_SOA_LAYOUT(SoALayout1, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
 GENERATE_SOA_LAYOUT(SoALayout2, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
 GENERATE_SOA_LAYOUT(SoALayout3, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
+GENERATE_SOA_LAYOUT(SoALayout4, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
 
-GENERATE_SOA_BLOCKS(BlocksTemplate, SOA_BLOCK(first, SoALayout1), SOA_BLOCK(second, SoALayout2))
-GENERATE_SOA_BLOCKS(NestedBlocksTemplate, SOA_BLOCK(blocks, BlocksTemplate), SOA_BLOCK(soa, SoALayout3))
+GENERATE_SOA_BLOCKS(FirstBlocksTemplate, SOA_BLOCK(first, SoALayout1), SOA_BLOCK(second, SoALayout2))
+GENERATE_SOA_BLOCKS(SecondBlocksTemplate, SOA_BLOCK(first, SoALayout3), SOA_BLOCK(second, SoALayout4))
 
-using BlocksSoA = BlocksTemplate<>;
-using BlocksView = BlocksSoA::View;
-using BlocksConstView = BlocksSoA::ConstView;
+GENERATE_SOA_BLOCKS(NestedBlocksTemplate,
+                    SOA_BLOCK(firstBlocks, FirstBlocksTemplate),
+                    SOA_BLOCK(secondBlocks, SecondBlocksTemplate),
+                    SOA_BLOCK(firstLayout, SoALayout1),
+                    SOA_BLOCK(secondLayout, SoALayout4))
+
+GENERATE_SOA_BLOCKS(GenericBlocksTemplate, SOA_BLOCK(blocks, FirstBlocksTemplate), SOA_BLOCK(layout, SoALayout4))
 
 using NestedBlocksSoA = NestedBlocksTemplate<>;
 using NestedBlocksView = NestedBlocksSoA::View;
 using NestedBlocksConstView = NestedBlocksSoA::ConstView;
 
+using GenericSoA = GenericBlocksTemplate<>;
+using GenericSoAView = GenericSoA::View;
+using GenericSoAConstView = GenericSoA::ConstView;
+
 // Fill SoAs
 struct FillSoA {
   ALPAKA_FN_ACC void operator()(Acc1D const& acc, NestedBlocksView view) const {
     if (cms::alpakatools::once_per_grid(acc)) {
-      view.blocks().first().id() = 21;
-      view.blocks().second().id() = 42;
-      view.soa().id() = 666;
+      view.firstBlocks().first().id() = 21;
+      view.firstBlocks().second().id() = 22;
+      view.secondBlocks().first().id() = 42;
+      view.secondBlocks().second().id() = 43;
+      view.firstLayout().id() = 333;
+      view.secondLayout().id() = 666;
     }
 
     for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size()[0])) {
-      view.blocks().first()[i].column() = static_cast<int>(i);
-      view.blocks().first()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
+      view.firstBlocks().first()[i].column() = static_cast<int>(i);
+      view.firstBlocks().first()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
     }
 
     for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size()[1])) {
-      view.blocks().second()[i].column() = static_cast<int>(i);
-      view.blocks().second()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
+      view.firstBlocks().second()[i].column() = static_cast<int>(i);
+      view.firstBlocks().second()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
     }
 
     for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size()[2])) {
-      view.soa()[i].column() = static_cast<int>(i);
-      view.soa()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
+      view.secondBlocks().first()[i].column() = static_cast<int>(i);
+      view.secondBlocks().first()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
+    }
+
+    for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size()[3])) {
+      view.secondBlocks().second()[i].column() = static_cast<int>(i);
+      view.secondBlocks().second()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
+    }
+
+    for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size()[4])) {
+      view.firstLayout()[i].column() = static_cast<int>(i);
+      view.firstLayout()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
+    }
+
+    for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size()[5])) {
+      view.secondLayout()[i].column() = static_cast<int>(i);
+      view.secondLayout()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
     }
   }
 };
 
-void check(NestedBlocksConstView nestedBlocksConstView, BlocksConstView genericSoABlocksView) {
+void check(NestedBlocksConstView nestedBlocksConstView, GenericSoAConstView genericSoABlocksView) {
   REQUIRE(nestedBlocksConstView.metadata().size()[0] == genericSoABlocksView.metadata().size()[0]);
   REQUIRE(nestedBlocksConstView.metadata().size()[1] == genericSoABlocksView.metadata().size()[1]);
+  REQUIRE(nestedBlocksConstView.metadata().size()[5] == genericSoABlocksView.metadata().size()[2]);
   // Verify data
   for (NestedBlocksSoA::size_type i = 0; i < genericSoABlocksView.metadata().size()[0]; ++i) {
-    auto nestedFirst = nestedBlocksConstView.blocks().first()[i];
-    auto first = genericSoABlocksView.first()[i];
+    auto nestedFirst = nestedBlocksConstView.firstBlocks().first()[i];
+    auto first = genericSoABlocksView.blocks().first()[i];
     REQUIRE(first.column() == nestedFirst.column());
     REQUIRE(first.vector() == nestedFirst.vector());
   }
 
-  for (NestedBlocksSoA::size_type i = 0; i < genericSoABlocksView.metadata().size()[0]; ++i) {
-    auto nestedSecond = nestedBlocksConstView.blocks().second()[i];
-    auto second = genericSoABlocksView.second()[i];
+  for (NestedBlocksSoA::size_type i = 0; i < genericSoABlocksView.metadata().size()[1]; ++i) {
+    auto nestedSecond = nestedBlocksConstView.firstBlocks().second()[i];
+    auto second = genericSoABlocksView.blocks().second()[i];
     REQUIRE(second.column() == nestedSecond.column());
     REQUIRE(second.vector() == nestedSecond.vector());
   }
 
-  REQUIRE(nestedBlocksConstView.blocks().first().id() == genericSoABlocksView.first().id());
-  REQUIRE(nestedBlocksConstView.blocks().second().id() == genericSoABlocksView.second().id());
+  for (NestedBlocksSoA::size_type i = 0; i < genericSoABlocksView.metadata().size()[2]; ++i) {
+    auto nested = nestedBlocksConstView.secondLayout()[i];
+    auto generic = genericSoABlocksView.layout()[i];
+    REQUIRE(generic.column() == nested.column());
+    REQUIRE(generic.vector() == nested.vector());
+  }
+
+  REQUIRE(nestedBlocksConstView.firstBlocks().first().id() == genericSoABlocksView.blocks().first().id());
+  REQUIRE(nestedBlocksConstView.firstBlocks().second().id() == genericSoABlocksView.blocks().second().id());
+  REQUIRE(nestedBlocksConstView.secondLayout().id() == genericSoABlocksView.layout().id());
 }
 
 TEST_CASE("Heterogeneous Deep Copy SoABlocks") {
@@ -91,7 +127,7 @@ TEST_CASE("Heterogeneous Deep Copy SoABlocks") {
     std::cout << "Running on " << alpaka::getName(device) << std::endl;
     Queue queue(device);
 
-    std::array<NestedBlocksSoA::size_type, 3> sizes = {21, 45, 137};
+    std::array<NestedBlocksSoA::size_type, 6> sizes = {21, 45, 137, 43, 222, 177};
 
     PortableCollection<Device, NestedBlocksSoA> nestedBlocksCollection(queue, sizes);
     NestedBlocksView nestedBlocksView = nestedBlocksCollection.view();
@@ -110,39 +146,49 @@ TEST_CASE("Heterogeneous Deep Copy SoABlocks") {
     alpaka::memcpy(queue, h_nestedBlocksCollection.buffer(), nestedBlocksCollection.buffer());
 
     SECTION("Deep copy the View host to host and device to device") {
-      BlocksView blocksView{nestedBlocksView.blocks().first(), nestedBlocksView.blocks().second()};
+      GenericSoAView genericView{nestedBlocksView.firstBlocks(), nestedBlocksView.secondLayout()};
 
       // Verify metadata
-      REQUIRE(blocksView.metadata().size()[0] == sizes[0]);
-      REQUIRE(blocksView.first().metadata().size() == sizes[0]);
-      REQUIRE(blocksView.metadata().size()[1] == sizes[1]);
-      REQUIRE(blocksView.second().metadata().size() == sizes[1]);
+      REQUIRE(genericView.metadata().size()[0] == sizes[0]);
+      REQUIRE(genericView.blocks().first().metadata().size() == sizes[0]);
+      REQUIRE(genericView.metadata().size()[1] == sizes[1]);
+      REQUIRE(genericView.blocks().second().metadata().size() == sizes[1]);
+      REQUIRE(genericView.metadata().size()[2] == sizes[5]);
+      REQUIRE(genericView.layout().metadata().size() == sizes[5]);
 
       // Check for equality of memory addresses
-      REQUIRE(blocksView.first().metadata().addressOf_column() ==
-              nestedBlocksView.blocks().first().metadata().addressOf_column());
-      REQUIRE(blocksView.first().metadata().addressOf_vector() ==
-              nestedBlocksView.blocks().first().metadata().addressOf_vector());
-      REQUIRE(blocksView.second().metadata().addressOf_column() ==
-              nestedBlocksView.blocks().second().metadata().addressOf_column());
-      REQUIRE(blocksView.second().metadata().addressOf_vector() ==
-              nestedBlocksView.blocks().second().metadata().addressOf_vector());
+      REQUIRE(genericView.blocks().first().metadata().addressOf_column() ==
+              nestedBlocksView.firstBlocks().first().metadata().addressOf_column());
+      REQUIRE(genericView.blocks().first().metadata().addressOf_vector() ==
+              nestedBlocksView.firstBlocks().first().metadata().addressOf_vector());
+      REQUIRE(genericView.blocks().second().metadata().addressOf_column() ==
+              nestedBlocksView.firstBlocks().second().metadata().addressOf_column());
+      REQUIRE(genericView.blocks().second().metadata().addressOf_vector() ==
+              nestedBlocksView.firstBlocks().second().metadata().addressOf_vector());
+      REQUIRE(genericView.layout().metadata().addressOf_column() ==
+              nestedBlocksView.secondLayout().metadata().addressOf_column());
+      REQUIRE(genericView.layout().metadata().addressOf_vector() ==
+              nestedBlocksView.secondLayout().metadata().addressOf_vector());
 
       // PortableCollection that will host the aggregated columns
-      PortableCollection<Device, BlocksSoA> blocksCollection(queue, sizes[0], sizes[1]);
-      blocksCollection.deepCopy(queue, blocksView);
+      PortableCollection<Device, GenericSoA> blocksCollection(queue, sizes[0], sizes[1], sizes[5]);
+      blocksCollection.deepCopy(queue, genericView);
 
-      BlocksView copiedBlocksView = blocksCollection.view();
-      REQUIRE(copiedBlocksView.first().metadata().addressOf_column() !=
-              nestedBlocksView.blocks().first().metadata().addressOf_column());
-      REQUIRE(copiedBlocksView.first().metadata().addressOf_vector() !=
-              nestedBlocksView.blocks().first().metadata().addressOf_vector());
-      REQUIRE(copiedBlocksView.second().metadata().addressOf_column() !=
-              nestedBlocksView.blocks().second().metadata().addressOf_column());
-      REQUIRE(copiedBlocksView.second().metadata().addressOf_vector() !=
-              nestedBlocksView.blocks().second().metadata().addressOf_vector());
+      GenericSoAView copiedBlocksView = blocksCollection.view();
+      REQUIRE(copiedBlocksView.blocks().first().metadata().addressOf_column() !=
+              nestedBlocksView.firstBlocks().first().metadata().addressOf_column());
+      REQUIRE(copiedBlocksView.blocks().first().metadata().addressOf_vector() !=
+              nestedBlocksView.firstBlocks().first().metadata().addressOf_vector());
+      REQUIRE(copiedBlocksView.blocks().second().metadata().addressOf_column() !=
+              nestedBlocksView.firstBlocks().second().metadata().addressOf_column());
+      REQUIRE(copiedBlocksView.blocks().second().metadata().addressOf_vector() !=
+              nestedBlocksView.firstBlocks().second().metadata().addressOf_vector());
+      REQUIRE(copiedBlocksView.layout().metadata().addressOf_column() !=
+              nestedBlocksView.secondLayout().metadata().addressOf_column());
+      REQUIRE(copiedBlocksView.layout().metadata().addressOf_vector() !=
+              nestedBlocksView.secondLayout().metadata().addressOf_vector());
 
-      PortableHostCollection<BlocksSoA> outputHost(cms::alpakatools::host(), sizes[0], sizes[1]);
+      PortableHostCollection<GenericSoA> outputHost(cms::alpakatools::host(), sizes[0], sizes[1], sizes[5]);
       alpaka::memcpy(queue, outputHost.buffer(), blocksCollection.buffer());
       alpaka::wait(queue);
 
@@ -150,87 +196,105 @@ TEST_CASE("Heterogeneous Deep Copy SoABlocks") {
     }
 
     SECTION("Deep copy the ConstView host to host and device to device") {
-      BlocksConstView blocksConstView{nestedBlocksConstView.blocks().first(), nestedBlocksConstView.blocks().second()};
+      GenericSoAConstView genericConstView{nestedBlocksConstView.firstBlocks(), nestedBlocksConstView.secondLayout()};
 
       // Verify metadata
-      REQUIRE(blocksConstView.metadata().size()[0] == sizes[0]);
-      REQUIRE(blocksConstView.first().metadata().size() == sizes[0]);
-      REQUIRE(blocksConstView.metadata().size()[1] == sizes[1]);
-      REQUIRE(blocksConstView.second().metadata().size() == sizes[1]);
+      REQUIRE(genericConstView.metadata().size()[0] == sizes[0]);
+      REQUIRE(genericConstView.blocks().first().metadata().size() == sizes[0]);
+      REQUIRE(genericConstView.metadata().size()[1] == sizes[1]);
+      REQUIRE(genericConstView.blocks().second().metadata().size() == sizes[1]);
+      REQUIRE(genericConstView.metadata().size()[2] == sizes[5]);
+      REQUIRE(genericConstView.layout().metadata().size() == sizes[5]);
 
       // Check for equality of memory addresses
-      REQUIRE(blocksConstView.first().metadata().addressOf_column() ==
-              nestedBlocksConstView.blocks().first().metadata().addressOf_column());
-      REQUIRE(blocksConstView.first().metadata().addressOf_vector() ==
-              nestedBlocksConstView.blocks().first().metadata().addressOf_vector());
-      REQUIRE(blocksConstView.second().metadata().addressOf_column() ==
-              nestedBlocksConstView.blocks().second().metadata().addressOf_column());
-      REQUIRE(blocksConstView.second().metadata().addressOf_vector() ==
-              nestedBlocksConstView.blocks().second().metadata().addressOf_vector());
+      REQUIRE(genericConstView.blocks().first().metadata().addressOf_column() ==
+              nestedBlocksConstView.firstBlocks().first().metadata().addressOf_column());
+      REQUIRE(genericConstView.blocks().first().metadata().addressOf_vector() ==
+              nestedBlocksConstView.firstBlocks().first().metadata().addressOf_vector());
+      REQUIRE(genericConstView.blocks().second().metadata().addressOf_column() ==
+              nestedBlocksConstView.firstBlocks().second().metadata().addressOf_column());
+      REQUIRE(genericConstView.blocks().second().metadata().addressOf_vector() ==
+              nestedBlocksConstView.firstBlocks().second().metadata().addressOf_vector());
+      REQUIRE(genericConstView.layout().metadata().addressOf_column() ==
+              nestedBlocksConstView.secondLayout().metadata().addressOf_column());
+      REQUIRE(genericConstView.layout().metadata().addressOf_vector() ==
+              nestedBlocksConstView.secondLayout().metadata().addressOf_vector());
 
       // PortableCollection that will host the aggregated columns
-      PortableCollection<Device, BlocksSoA> blocksCollection(queue, sizes[0], sizes[1]);
-      blocksCollection.deepCopy(queue, blocksConstView);
+      PortableCollection<Device, GenericSoA> genericCollection(queue, sizes[0], sizes[1], sizes[5]);
+      genericCollection.deepCopy(queue, genericConstView);
 
-      BlocksConstView copiedBlocksConstView = blocksCollection.const_view();
-      REQUIRE(copiedBlocksConstView.first().metadata().addressOf_column() !=
-              nestedBlocksConstView.blocks().first().metadata().addressOf_column());
-      REQUIRE(copiedBlocksConstView.first().metadata().addressOf_vector() !=
-              nestedBlocksConstView.blocks().first().metadata().addressOf_vector());
-      REQUIRE(copiedBlocksConstView.second().metadata().addressOf_column() !=
-              nestedBlocksConstView.blocks().second().metadata().addressOf_column());
-      REQUIRE(copiedBlocksConstView.second().metadata().addressOf_vector() !=
-              nestedBlocksConstView.blocks().second().metadata().addressOf_vector());
+      GenericSoAConstView copiedGenericConstView = genericCollection.const_view();
+      REQUIRE(copiedGenericConstView.blocks().first().metadata().addressOf_column() !=
+              nestedBlocksConstView.firstBlocks().first().metadata().addressOf_column());
+      REQUIRE(copiedGenericConstView.blocks().first().metadata().addressOf_vector() !=
+              nestedBlocksConstView.firstBlocks().first().metadata().addressOf_vector());
+      REQUIRE(copiedGenericConstView.blocks().second().metadata().addressOf_column() !=
+              nestedBlocksConstView.firstBlocks().second().metadata().addressOf_column());
+      REQUIRE(copiedGenericConstView.blocks().second().metadata().addressOf_vector() !=
+              nestedBlocksConstView.firstBlocks().second().metadata().addressOf_vector());
+      REQUIRE(copiedGenericConstView.layout().metadata().addressOf_column() !=
+              nestedBlocksConstView.secondLayout().metadata().addressOf_column());
+      REQUIRE(copiedGenericConstView.layout().metadata().addressOf_vector() !=
+              nestedBlocksConstView.secondLayout().metadata().addressOf_vector());
 
-      PortableHostCollection<BlocksSoA> outputHost(cms::alpakatools::host(), sizes[0], sizes[1]);
-      alpaka::memcpy(queue, outputHost.buffer(), blocksCollection.buffer());
+      PortableHostCollection<GenericSoA> outputHost(cms::alpakatools::host(), sizes[0], sizes[1], sizes[5]);
+      alpaka::memcpy(queue, outputHost.buffer(), genericCollection.buffer());
       alpaka::wait(queue);
 
       check(h_nestedBlocksCollection.const_view(), outputHost.const_view());
     }
 
     SECTION("Deep copy the ConstView device to host") {
-      BlocksConstView blocksConstView{nestedBlocksConstView.blocks().first(), nestedBlocksConstView.blocks().second()};
+      GenericSoAConstView genericConstView{nestedBlocksConstView.firstBlocks(), nestedBlocksConstView.secondLayout()};
 
       // PortableCollection that will host the aggregated columns
-      PortableHostCollection<BlocksSoA> blocksCollection(queue, sizes[0], sizes[1]);
-      blocksCollection.deepCopy(queue, blocksConstView);
+      PortableHostCollection<GenericSoA> genericCollection(queue, sizes[0], sizes[1], sizes[5]);
+      genericCollection.deepCopy(queue, genericConstView);
       alpaka::wait(queue);
 
-      BlocksConstView copiedBlocksConstView = blocksCollection.const_view();
-      REQUIRE(copiedBlocksConstView.first().metadata().addressOf_column() !=
-              nestedBlocksConstView.blocks().first().metadata().addressOf_column());
-      REQUIRE(copiedBlocksConstView.first().metadata().addressOf_vector() !=
-              nestedBlocksConstView.blocks().first().metadata().addressOf_vector());
-      REQUIRE(copiedBlocksConstView.second().metadata().addressOf_column() !=
-              nestedBlocksConstView.blocks().second().metadata().addressOf_column());
-      REQUIRE(copiedBlocksConstView.second().metadata().addressOf_vector() !=
-              nestedBlocksConstView.blocks().second().metadata().addressOf_vector());
+      GenericSoAConstView copiedGenericConstView = genericCollection.const_view();
+      REQUIRE(copiedGenericConstView.blocks().first().metadata().addressOf_column() !=
+              nestedBlocksConstView.firstBlocks().first().metadata().addressOf_column());
+      REQUIRE(copiedGenericConstView.blocks().first().metadata().addressOf_vector() !=
+              nestedBlocksConstView.firstBlocks().first().metadata().addressOf_vector());
+      REQUIRE(copiedGenericConstView.blocks().second().metadata().addressOf_column() !=
+              nestedBlocksConstView.firstBlocks().second().metadata().addressOf_column());
+      REQUIRE(copiedGenericConstView.blocks().second().metadata().addressOf_vector() !=
+              nestedBlocksConstView.firstBlocks().second().metadata().addressOf_vector());
+      REQUIRE(copiedGenericConstView.layout().metadata().addressOf_column() !=
+              nestedBlocksConstView.secondLayout().metadata().addressOf_column());
+      REQUIRE(copiedGenericConstView.layout().metadata().addressOf_vector() !=
+              nestedBlocksConstView.secondLayout().metadata().addressOf_vector());
 
-      check(h_nestedBlocksCollection.const_view(), blocksCollection.const_view());
+      check(h_nestedBlocksCollection.const_view(), genericCollection.const_view());
     }
 
     SECTION("Deep copy the ConstView host to device") {
-      BlocksConstView blocksConstView{h_nestedBlocksCollection.const_view().blocks().first(),
-                                      h_nestedBlocksCollection.const_view().blocks().second()};
+      GenericSoAConstView genericConstView{h_nestedBlocksCollection.const_view().firstBlocks(),
+                                           h_nestedBlocksCollection.const_view().secondLayout()};
 
       // PortableCollection that will host the aggregated columns
-      PortableCollection<Device, BlocksSoA> blocksCollection(queue, sizes[0], sizes[1]);
-      blocksCollection.deepCopy(queue, blocksConstView);
+      PortableCollection<Device, GenericSoA> genericCollection(queue, sizes[0], sizes[1], sizes[5]);
+      genericCollection.deepCopy(queue, genericConstView);
       alpaka::wait(queue);
 
-      BlocksConstView copiedBlocksConstView = blocksCollection.const_view();
-      REQUIRE(copiedBlocksConstView.first().metadata().addressOf_column() !=
-              h_nestedBlocksCollection.const_view().blocks().first().metadata().addressOf_column());
-      REQUIRE(copiedBlocksConstView.first().metadata().addressOf_vector() !=
-              h_nestedBlocksCollection.const_view().blocks().first().metadata().addressOf_vector());
-      REQUIRE(copiedBlocksConstView.second().metadata().addressOf_column() !=
-              h_nestedBlocksCollection.const_view().blocks().second().metadata().addressOf_column());
-      REQUIRE(copiedBlocksConstView.second().metadata().addressOf_vector() !=
-              h_nestedBlocksCollection.const_view().blocks().second().metadata().addressOf_vector());
+      GenericSoAConstView copiedGenericConstView = genericCollection.const_view();
+      REQUIRE(copiedGenericConstView.blocks().first().metadata().addressOf_column() !=
+              h_nestedBlocksCollection.const_view().firstBlocks().first().metadata().addressOf_column());
+      REQUIRE(copiedGenericConstView.blocks().first().metadata().addressOf_vector() !=
+              h_nestedBlocksCollection.const_view().firstBlocks().first().metadata().addressOf_vector());
+      REQUIRE(copiedGenericConstView.blocks().second().metadata().addressOf_column() !=
+              h_nestedBlocksCollection.const_view().firstBlocks().second().metadata().addressOf_column());
+      REQUIRE(copiedGenericConstView.blocks().second().metadata().addressOf_vector() !=
+              h_nestedBlocksCollection.const_view().firstBlocks().second().metadata().addressOf_vector());
+      REQUIRE(copiedGenericConstView.layout().metadata().addressOf_column() !=
+              h_nestedBlocksCollection.const_view().secondLayout().metadata().addressOf_column());
+      REQUIRE(copiedGenericConstView.layout().metadata().addressOf_vector() !=
+              h_nestedBlocksCollection.const_view().secondLayout().metadata().addressOf_vector());
 
-      PortableHostCollection<BlocksSoA> outputHost(cms::alpakatools::host(), sizes[0], sizes[1]);
-      alpaka::memcpy(queue, outputHost.buffer(), blocksCollection.buffer());
+      PortableHostCollection<GenericSoA> outputHost(cms::alpakatools::host(), sizes[0], sizes[1], sizes[5]);
+      alpaka::memcpy(queue, outputHost.buffer(), genericCollection.buffer());
       alpaka::wait(queue);
 
       check(h_nestedBlocksCollection.const_view(), outputHost.const_view());

--- a/DataFormats/Portable/test/alpaka/test_catch2_nestedSoABlocks.dev.cc
+++ b/DataFormats/Portable/test/alpaka/test_catch2_nestedSoABlocks.dev.cc
@@ -20,33 +20,17 @@
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 using namespace Catch::Matchers;
 
-GENERATE_SOA_LAYOUT(SoALayout1, 
-                    SOA_COLUMN(int, column),
-                    SOA_EIGEN_COLUMN(Eigen::Vector3d, vector),
-                    SOA_SCALAR(int, id))
+GENERATE_SOA_LAYOUT(SoALayout1, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
 
-GENERATE_SOA_LAYOUT(SoALayout2, 
-                    SOA_COLUMN(int, column),
-                    SOA_EIGEN_COLUMN(Eigen::Vector3d, vector),
-                    SOA_SCALAR(int, id))
+GENERATE_SOA_LAYOUT(SoALayout2, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
 
-GENERATE_SOA_LAYOUT(SoALayout3, 
-                    SOA_COLUMN(int, column),
-                    SOA_EIGEN_COLUMN(Eigen::Vector3d, vector),
-                    SOA_SCALAR(int, id))
+GENERATE_SOA_LAYOUT(SoALayout3, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
 
-GENERATE_SOA_LAYOUT(SoALayout4, 
-                    SOA_COLUMN(int, column),
-                    SOA_EIGEN_COLUMN(Eigen::Vector3d, vector),
-                    SOA_SCALAR(int, id))
+GENERATE_SOA_LAYOUT(SoALayout4, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
 
-GENERATE_SOA_BLOCKS(BlocksTemplate,
-                    SOA_BLOCK(first, SoALayout1),
-                    SOA_BLOCK(second, SoALayout2))
+GENERATE_SOA_BLOCKS(BlocksTemplate, SOA_BLOCK(first, SoALayout1), SOA_BLOCK(second, SoALayout2))
 
-GENERATE_SOA_BLOCKS(SingleNestedBlocksTemplate,
-                    SOA_BLOCK(blocks, BlocksTemplate),
-                    SOA_BLOCK(soa, SoALayout3))
+GENERATE_SOA_BLOCKS(SingleNestedBlocksTemplate, SOA_BLOCK(blocks, BlocksTemplate), SOA_BLOCK(soa, SoALayout3))
 
 GENERATE_SOA_BLOCKS(DoubleNestedBlocksTemplate,
                     SOA_BLOCK(blocks, SingleNestedBlocksTemplate),
@@ -102,33 +86,33 @@ struct FillSoAs {
 };
 
 void checkNestedSoABlocks(const ConstView& view) {
-    REQUIRE(view.blocks().blocks().first().id() == view.metadata().size()[0]);
-    for (BlockSoA::size_type i = 0; i < view.metadata().size()[0]; ++i) {
-        const auto& element = view.blocks().blocks().first()[i];
-        REQUIRE(element.column() == static_cast<int>(i));
-        REQUIRE(element.vector().isApprox(Eigen::Vector3d(i, i + 1, i + 2)));
-    }
-    
-    REQUIRE(view.blocks().blocks().second().id() == view.metadata().size()[1]);
-    for (BlockSoA::size_type i = 0; i < view.metadata().size()[1]; ++i) {
-        const auto& element = view.blocks().blocks().second()[i];
-        REQUIRE(element.column() == static_cast<int>(i * 10));
-        REQUIRE(element.vector().isApprox(Eigen::Vector3d(i * 10, i * 10 + 1, i * 10 + 2)));
-    }
+  REQUIRE(view.blocks().blocks().first().id() == view.metadata().size()[0]);
+  for (BlockSoA::size_type i = 0; i < view.metadata().size()[0]; ++i) {
+    const auto& element = view.blocks().blocks().first()[i];
+    REQUIRE(element.column() == static_cast<int>(i));
+    REQUIRE(element.vector().isApprox(Eigen::Vector3d(i, i + 1, i + 2)));
+  }
 
-    REQUIRE(view.blocks().soa().id() == view.metadata().size()[2]);
-    for (BlockSoA::size_type i = 0; i < view.metadata().size()[2]; ++i) {
-        const auto& element = view.blocks().soa()[i];
-        REQUIRE(element.column() == static_cast<int>(i * 100));
-        REQUIRE(element.vector().isApprox(Eigen::Vector3d(i * 100, i * 100 + 1, i * 100 + 2)));
-    }
+  REQUIRE(view.blocks().blocks().second().id() == view.metadata().size()[1]);
+  for (BlockSoA::size_type i = 0; i < view.metadata().size()[1]; ++i) {
+    const auto& element = view.blocks().blocks().second()[i];
+    REQUIRE(element.column() == static_cast<int>(i * 10));
+    REQUIRE(element.vector().isApprox(Eigen::Vector3d(i * 10, i * 10 + 1, i * 10 + 2)));
+  }
 
-    REQUIRE(view.soa().id() == view.metadata().size()[3]);
-    for (BlockSoA::size_type i = 0; i < view.metadata().size()[3]; ++i) {
-        const auto& element = view.soa()[i];
-        REQUIRE(element.column() == static_cast<int>(i * 6654));
-        REQUIRE(element.vector().isApprox(Eigen::Vector3d(i * 6654, i * 6654 + 1, i * 6654 + 2)));
-    }
+  REQUIRE(view.blocks().soa().id() == view.metadata().size()[2]);
+  for (BlockSoA::size_type i = 0; i < view.metadata().size()[2]; ++i) {
+    const auto& element = view.blocks().soa()[i];
+    REQUIRE(element.column() == static_cast<int>(i * 100));
+    REQUIRE(element.vector().isApprox(Eigen::Vector3d(i * 100, i * 100 + 1, i * 100 + 2)));
+  }
+
+  REQUIRE(view.soa().id() == view.metadata().size()[3]);
+  for (BlockSoA::size_type i = 0; i < view.metadata().size()[3]; ++i) {
+    const auto& element = view.soa()[i];
+    REQUIRE(element.column() == static_cast<int>(i * 6654));
+    REQUIRE(element.vector().isApprox(Eigen::Vector3d(i * 6654, i * 6654 + 1, i * 6654 + 2)));
+  }
 }
 
 TEST_CASE("NestedSoABlocks minimal test") {
@@ -140,7 +124,6 @@ TEST_CASE("NestedSoABlocks minimal test") {
   }
 
   for (auto const& device : devices) {
-
     std::cout << "Running on " << alpaka::getName(device) << std::endl;
     Queue queue(device);
 
@@ -177,5 +160,4 @@ TEST_CASE("NestedSoABlocks minimal test") {
     ConstView constHostView = nestedBlocksHostCollection.const_view();
     checkNestedSoABlocks(constHostView);
   }
-
 }

--- a/DataFormats/Portable/test/alpaka/test_catch2_nestedSoABlocks.dev.cc
+++ b/DataFormats/Portable/test/alpaka/test_catch2_nestedSoABlocks.dev.cc
@@ -1,0 +1,181 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include <alpaka/alpaka.hpp>
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+
+#include "DataFormats/SoATemplate/interface/SoABlocks.h"
+#include "DataFormats/Portable/interface/PortableCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+#include <algorithm>
+
+// TODO remove
+#include <iostream>
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+using namespace Catch::Matchers;
+
+GENERATE_SOA_LAYOUT(SoALayout1, 
+                    SOA_COLUMN(int, column),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, vector),
+                    SOA_SCALAR(int, id))
+
+GENERATE_SOA_LAYOUT(SoALayout2, 
+                    SOA_COLUMN(int, column),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, vector),
+                    SOA_SCALAR(int, id))
+
+GENERATE_SOA_LAYOUT(SoALayout3, 
+                    SOA_COLUMN(int, column),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, vector),
+                    SOA_SCALAR(int, id))
+
+GENERATE_SOA_LAYOUT(SoALayout4, 
+                    SOA_COLUMN(int, column),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, vector),
+                    SOA_SCALAR(int, id))
+
+GENERATE_SOA_BLOCKS(BlocksTemplate,
+                    SOA_BLOCK(first, SoALayout1),
+                    SOA_BLOCK(second, SoALayout2))
+
+GENERATE_SOA_BLOCKS(SingleNestedBlocksTemplate,
+                    SOA_BLOCK(blocks, BlocksTemplate),
+                    SOA_BLOCK(soa, SoALayout3))
+
+GENERATE_SOA_BLOCKS(DoubleNestedBlocksTemplate,
+                    SOA_BLOCK(blocks, SingleNestedBlocksTemplate),
+                    SOA_BLOCK(soa, SoALayout4))
+
+using BlockSoA = DoubleNestedBlocksTemplate<>;
+using View = BlockSoA::View;
+using ConstView = BlockSoA::ConstView;
+
+// Fill SoAs
+struct FillSoAs {
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc, View view) const {
+    // Fill elements of SoALayout1
+    if (cms::alpakatools::once_per_grid(acc)) {
+      view.blocks().blocks().first().id() = view.metadata().size()[0];
+    }
+    for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size()[0])) {
+      auto element = view.blocks().blocks().first()[i];
+      element.column() = static_cast<int>(i);
+      element.vector() = Eigen::Vector3d(i, i + 1, i + 2);
+    }
+
+    // Fill elements of SoALayout2
+    if (cms::alpakatools::once_per_grid(acc)) {
+      view.blocks().blocks().second().id() = view.metadata().size()[1];
+    }
+    for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size()[1])) {
+      auto element = view.blocks().blocks().second()[i];
+      element.column() = static_cast<int>(i * 10);
+      element.vector() = Eigen::Vector3d(i * 10, i * 10 + 1, i * 10 + 2);
+    }
+
+    // Fill elements of SoALayout3
+    if (cms::alpakatools::once_per_grid(acc)) {
+      view.blocks().soa().id() = view.metadata().size()[2];
+    }
+    for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size()[2])) {
+      auto element = view.blocks().soa()[i];
+      element.column() = static_cast<int>(i * 100);
+      element.vector() = Eigen::Vector3d(i * 100, i * 100 + 1, i * 100 + 2);
+    }
+
+    // Fill elements of SoALayout4
+    if (cms::alpakatools::once_per_grid(acc)) {
+      view.soa().id() = view.metadata().size()[3];
+    }
+    for (auto i : cms::alpakatools::uniform_elements(acc, view.metadata().size()[3])) {
+      auto element = view.soa()[i];
+      element.column() = static_cast<int>(i * 6654);
+      element.vector() = Eigen::Vector3d(i * 6654, i * 6654 + 1, i * 6654 + 2);
+    }
+  }
+};
+
+void checkNestedSoABlocks(const ConstView& view) {
+    REQUIRE(view.blocks().blocks().first().id() == view.metadata().size()[0]);
+    for (BlockSoA::size_type i = 0; i < view.metadata().size()[0]; ++i) {
+        const auto& element = view.blocks().blocks().first()[i];
+        REQUIRE(element.column() == static_cast<int>(i));
+        REQUIRE(element.vector().isApprox(Eigen::Vector3d(i, i + 1, i + 2)));
+    }
+    
+    REQUIRE(view.blocks().blocks().second().id() == view.metadata().size()[1]);
+    for (BlockSoA::size_type i = 0; i < view.metadata().size()[1]; ++i) {
+        const auto& element = view.blocks().blocks().second()[i];
+        REQUIRE(element.column() == static_cast<int>(i * 10));
+        REQUIRE(element.vector().isApprox(Eigen::Vector3d(i * 10, i * 10 + 1, i * 10 + 2)));
+    }
+
+    REQUIRE(view.blocks().soa().id() == view.metadata().size()[2]);
+    for (BlockSoA::size_type i = 0; i < view.metadata().size()[2]; ++i) {
+        const auto& element = view.blocks().soa()[i];
+        REQUIRE(element.column() == static_cast<int>(i * 100));
+        REQUIRE(element.vector().isApprox(Eigen::Vector3d(i * 100, i * 100 + 1, i * 100 + 2)));
+    }
+
+    REQUIRE(view.soa().id() == view.metadata().size()[3]);
+    for (BlockSoA::size_type i = 0; i < view.metadata().size()[3]; ++i) {
+        const auto& element = view.soa()[i];
+        REQUIRE(element.column() == static_cast<int>(i * 6654));
+        REQUIRE(element.vector().isApprox(Eigen::Vector3d(i * 6654, i * 6654 + 1, i * 6654 + 2)));
+    }
+}
+
+TEST_CASE("NestedSoABlocks minimal test") {
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    std::cout << "No devices available for the " << EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE)
+              << " backend, skipping.\n";
+    return;
+  }
+
+  for (auto const& device : devices) {
+
+    std::cout << "Running on " << alpaka::getName(device) << std::endl;
+    Queue queue(device);
+
+    std::array<BlockSoA::size_type, 4> sizes = {2, 1189, 33, 3333};
+    const std::size_t N = *std::max_element(sizes.begin(), sizes.end());
+
+    PortableCollection<Device, BlockSoA> nestedBlocksCollection(queue, sizes);
+    View view = nestedBlocksCollection.view();
+
+    // check that the sizes in the View are correctly propagated from the SoABlocks
+    REQUIRE(view.metadata().size()[0] == sizes[0]);
+    REQUIRE(view.blocks().blocks().first().metadata().size() == sizes[0]);
+    REQUIRE(view.metadata().size()[1] == sizes[1]);
+    REQUIRE(view.blocks().blocks().second().metadata().size() == sizes[1]);
+    REQUIRE(view.metadata().size()[2] == sizes[2]);
+    REQUIRE(view.blocks().soa().metadata().size() == sizes[2]);
+    REQUIRE(view.metadata().size()[3] == sizes[3]);
+    REQUIRE(view.soa().metadata().size() == sizes[3]);
+
+    // Work division
+    const std::size_t blockSize = 256;
+    const std::size_t nBlocks = cms::alpakatools::divide_up_by(N, blockSize);
+    const auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(nBlocks, blockSize);
+
+    // Fill: all layouts
+    alpaka::exec<Acc1D>(queue, workDiv, FillSoAs{}, view);
+    alpaka::wait(queue);
+
+    // Check results on host
+    PortableHostCollection<BlockSoA> nestedBlocksHostCollection(cms::alpakatools::host(), sizes);
+    alpaka::memcpy(queue, nestedBlocksHostCollection.buffer(), nestedBlocksCollection.buffer());
+    alpaka::wait(queue);
+
+    ConstView constHostView = nestedBlocksHostCollection.const_view();
+    checkNestedSoABlocks(constHostView);
+  }
+
+}

--- a/DataFormats/SoATemplate/interface/SoABlocks.h
+++ b/DataFormats/SoATemplate/interface/SoABlocks.h
@@ -558,7 +558,7 @@
     struct Descriptor {                                                                                                \
       Descriptor() = default;                                                                                          \
                                                                                                                        \
-      explicit Descriptor(View& view)                                                                                  \
+      explicit Descriptor(View view)                                                                                  \
           : buff(std::make_tuple(_ITERATE_ON_ALL_COMMA(_ASSIGN_SPANS_TO_BLOCKS, ~, __VA_ARGS__))) {}                   \
                                                                                                                        \
       static constexpr size_type blocksNumber = std::tuple_size<std::tuple<                                            \
@@ -569,7 +569,7 @@
     struct ConstDescriptor {                                                                                           \
       ConstDescriptor() = default;                                                                                     \
                                                                                                                        \
-      explicit ConstDescriptor(ConstView const& view)                                                                  \
+      explicit ConstDescriptor(ConstView const view)                                                                  \
           : buff(std::make_tuple(_ITERATE_ON_ALL_COMMA(_ASSIGN_CONST_SPANS_TO_BLOCKS, ~, __VA_ARGS__))) {}             \
                                                                                                                        \
       static constexpr size_type blocksNumber = std::tuple_size<std::tuple<                                            \

--- a/DataFormats/SoATemplate/interface/SoABlocks.h
+++ b/DataFormats/SoATemplate/interface/SoABlocks.h
@@ -107,7 +107,15 @@
 /*
  * Initialize the array of sizes for the View of an SoA by blocks
  */
-#define _DECLARE_CONST_VIEW_SIZES_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) (BOOST_PP_CAT(NAME, View_).metadata().size())
+#define _DECLARE_CONST_VIEW_SIZES_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME)      \
+  if constexpr (requires { LayoutFor<LAYOUT_NAME>::blocksNumber; }) {      \
+    const auto sizes = BOOST_PP_CAT(NAME, View_).metadata().size();        \
+    for (size_type i = 0; i < LayoutFor<LAYOUT_NAME>::blocksNumber; ++i) { \
+      sizes_[idx++] = sizes[i];                                            \
+    }                                                                      \
+  } else {                                                                 \
+    sizes_[idx++] = BOOST_PP_CAT(NAME, View_).metadata().size();           \
+  }
 
 #define _DECLARE_CONST_VIEW_SIZES(R, DATA, NAME)                                 \
   BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
@@ -125,6 +133,18 @@
               BOOST_PP_EMPTY(),                                                  \
               BOOST_PP_EXPAND(_DECLARE_MEMBERS_CONST_VIEW_BLOCKS_IMPL NAME))
 
+/**
+ * Declare the const_cast version of the blocks
+ * This is used to convert a ConstView into a View
+ */
+#define _DECLARE_CONST_CAST_VIEWS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  (LayoutFor<LAYOUT_NAME>::const_cast_View(view.NAME()))
+
+#define _DECLARE_CONST_CAST_VIEWS(R, DATA, NAME)                                 \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_CONST_CAST_VIEWS_IMPL NAME))
+
 /*
  * Declare accessors for the Layout of each block
  */
@@ -139,9 +159,10 @@
 /*
  * Computation of the size for each block
  */
-#define _ACCUMULATE_SOA_BLOCKS_SIZE_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME)   \
-  _soa_impl_ret += LayoutFor<LAYOUT_NAME>::computeDataSize(sizes[index]); \
-  index++;
+#define _ACCUMULATE_SOA_BLOCKS_SIZE_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME)                      \
+  _soa_impl_ret += LayoutFor<LAYOUT_NAME>::computeDataSize(                                  \
+      cms::soa::detail::extractSegment<LayoutFor<LAYOUT_NAME>, blocksNumber>(sizes, index)); \
+  index += cms::soa::detail::nBlocks<LayoutFor<LAYOUT_NAME>>();
 
 #define _ACCUMULATE_SOA_BLOCKS_SIZE(R, DATA, NAME)                               \
   BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
@@ -151,10 +172,12 @@
 /*
  * Computation of the block location in the memory layout (at SoA by blocks construction time)
  */
-#define _DECLARE_MEMBER_CONSTRUCTION_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
-  BOOST_PP_CAT(NAME, _) = LayoutFor<LAYOUT_NAME>(mem + offset, sizes_[index]);  \
-  offset += LayoutFor<LAYOUT_NAME>::computeDataSize(sizes_[index]);             \
-  index++;
+#define _DECLARE_MEMBER_CONSTRUCTION_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME)                             \
+  BOOST_PP_CAT(NAME, _) = LayoutFor<LAYOUT_NAME>(                                                           \
+      mem + offset, cms::soa::detail::extractSegment<LayoutFor<LAYOUT_NAME>, blocksNumber>(sizes_, index)); \
+  offset += LayoutFor<LAYOUT_NAME>::computeDataSize(                                                        \
+      cms::soa::detail::extractSegment<LayoutFor<LAYOUT_NAME>, blocksNumber>(sizes_, index));               \
+  index += cms::soa::detail::nBlocks<LayoutFor<LAYOUT_NAME>>();
 
 #define _DECLARE_MEMBER_CONSTRUCTION_BLOCKS(R, DATA, NAME)                       \
   BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
@@ -174,7 +197,8 @@
 /*
  * Computate number of blocks
  */
-#define _COUNT_SOA_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) soa_blocks_count += 1;
+#define _COUNT_SOA_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  soa_blocks_count += cms::soa::detail::nBlocks<LayoutFor<LAYOUT_NAME>>();
 
 #define _COUNT_SOA_BLOCKS(R, DATA, NAME)                                         \
   BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
@@ -392,10 +416,10 @@
             sizes_{blocks.sizes_} {}                                                                                   \
                                                                                                                        \
       /* Constructor relying on user provided const views for each block */                                            \
-      SOA_HOST_ONLY ConstViewTemplateFreeParams(                                                                       \
+      SOA_HOST_DEVICE ConstViewTemplateFreeParams(                                                                     \
             _ITERATE_ON_ALL_COMMA(_DECLARE_CONST_VIEW_CONSTRUCTOR_BLOCKS, ~, __VA_ARGS__))                             \
-          : _ITERATE_ON_ALL_COMMA(_INITIALIZE_MEMBER_CONST_VIEW_BLOCKS, ~, __VA_ARGS__),                               \
-            sizes_{{_ITERATE_ON_ALL_COMMA(_DECLARE_CONST_VIEW_SIZES, ~, __VA_ARGS__)}} {}                              \
+          : _ITERATE_ON_ALL_COMMA(_INITIALIZE_MEMBER_CONST_VIEW_BLOCKS, ~, __VA_ARGS__){                               \
+              std::size_t idx = 0; _ITERATE_ON_ALL(_DECLARE_CONST_VIEW_SIZES, ~, __VA_ARGS__)}                         \
                                                                                                                        \
       /* Accessors for the const views for each block */                                                               \
       _ITERATE_ON_ALL(_DECLARE_ACCESSORS_CONST_VIEW_BLOCKS, ~, __VA_ARGS__)                                            \
@@ -476,7 +500,7 @@
           : base_type{blocks} {}                                                                                       \
                                                                                                                        \
       /* Constructor relying on user provided views for each block */                                                  \
-      SOA_HOST_ONLY ViewTemplateFreeParams(_ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONSTRUCTOR_BLOCKS, ~, __VA_ARGS__)) :  \
+      SOA_HOST_DEVICE ViewTemplateFreeParams(_ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONSTRUCTOR_BLOCKS, ~, __VA_ARGS__)) :\
         base_type{_ITERATE_ON_ALL_COMMA(_INITIALIZE_MEMBER_VIEW_BLOCKS, ~, __VA_ARGS__)} {}                            \
                                                                                                                        \
       /* Accessors for the views for each block */                                                                     \
@@ -514,6 +538,14 @@
       sizes_ = _soa_impl_other.sizes_;                                                                                 \
       _ITERATE_ON_ALL(_DECLARE_BLOCKS_MEMBER_ASSIGNMENT, ~, __VA_ARGS__)                                               \
       return *this;                                                                                                    \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* Helper to implement View as derived from ConstView in SoABlocks implementation */                               \
+    template <bool RESTRICT_QUALIFY, cms::soa::RangeChecking::Mode RANGE_CHECKING>                                     \
+    SOA_HOST_DEVICE SOA_INLINE static ViewTemplate<RESTRICT_QUALIFY, RANGE_CHECKING> const_cast_View(                  \
+      ConstViewTemplate<RESTRICT_QUALIFY, RANGE_CHECKING> const& view)  {                                              \
+      return ViewTemplate<RESTRICT_QUALIFY, RANGE_CHECKING>{                                                           \
+        _ITERATE_ON_ALL_COMMA(_DECLARE_CONST_CAST_VIEWS, ~, __VA_ARGS__)};                                             \
     }                                                                                                                  \
                                                                                                                        \
     /*                                                                                                                 \

--- a/DataFormats/SoATemplate/interface/SoABlocks.h
+++ b/DataFormats/SoATemplate/interface/SoABlocks.h
@@ -170,6 +170,49 @@
               BOOST_PP_EXPAND(_ACCUMULATE_SOA_BLOCKS_SIZE_IMPL NAME))
 
 /*
+ * Assignment of spans to each block
+ */
+#define _ASSIGN_SPANS_TO_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  (typename LayoutFor<LAYOUT_NAME>::Descriptor(view.NAME()))
+
+#define _ASSIGN_SPANS_TO_BLOCKS(R, DATA, NAME)                                   \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_ASSIGN_SPANS_TO_BLOCKS_IMPL NAME))
+
+/*
+ * Assignment of const spans to each block
+ */
+#define _ASSIGN_CONST_SPANS_TO_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  (typename LayoutFor<LAYOUT_NAME>::ConstDescriptor(view.NAME()))
+
+#define _ASSIGN_CONST_SPANS_TO_BLOCKS(R, DATA, NAME)                             \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_ASSIGN_CONST_SPANS_TO_BLOCKS_IMPL NAME))
+
+/*
+ * Declaration of the descriptor by composition of descriptors of each block
+ */
+#define _DECLARE_DESCRIPTOR_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) (typename LayoutFor<LAYOUT_NAME>::Descriptor)
+
+#define _DECLARE_DESCRIPTOR_BLOCKS(R, DATA, NAME)                                \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_DESCRIPTOR_BLOCKS_IMPL NAME))
+
+/*
+ * Declaration of the const descriptor by composition of descriptors of each block
+ */
+#define _DECLARE_CONST_DESCRIPTOR_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME) \
+  (typename LayoutFor<LAYOUT_NAME>::ConstDescriptor)
+
+#define _DECLARE_CONST_DESCRIPTOR_BLOCKS(R, DATA, NAME)                          \
+  BOOST_PP_IF(BOOST_PP_GREATER(BOOST_PP_TUPLE_ELEM(0, NAME), _VALUE_TYPE_BLOCK), \
+              BOOST_PP_EMPTY(),                                                  \
+              BOOST_PP_EXPAND(_DECLARE_CONST_DESCRIPTOR_BLOCKS_IMPL NAME))
+
+/*
  * Computation of the block location in the memory layout (at SoA by blocks construction time)
  */
 #define _DECLARE_MEMBER_CONSTRUCTION_BLOCKS_IMPL(VALUE_TYPE, NAME, LAYOUT_NAME)                             \
@@ -512,9 +555,27 @@
     using ViewTemplate = ViewTemplateFreeParams<ALIGNMENT, ALIGNMENT_ENFORCEMENT, RESTRICT_QUALIFY, RANGE_CHECKING>;   \
     using View = ViewTemplate<cms::soa::RestrictQualify::Default, cms::soa::RangeChecking::Default>;                   \
                                                                                                                        \
-    /* TODO: implement Descriptor and ConstDescriptor for Blocks to enable heterogeneous deepCopy */                   \
-    struct Descriptor;                                                                                                 \
-    struct ConstDescriptor;                                                                                            \
+    struct Descriptor {                                                                                                \
+      Descriptor() = default;                                                                                          \
+                                                                                                                       \
+      explicit Descriptor(View& view)                                                                                  \
+          : buff(std::make_tuple(_ITERATE_ON_ALL_COMMA(_ASSIGN_SPANS_TO_BLOCKS, ~, __VA_ARGS__))) {}                   \
+                                                                                                                       \
+      static constexpr size_type blocksNumber = std::tuple_size<std::tuple<                                            \
+                                         _ITERATE_ON_ALL_COMMA(_DECLARE_DESCRIPTOR_BLOCKS, ~, __VA_ARGS__)>>::value;   \
+      std::tuple< _ITERATE_ON_ALL_COMMA(_DECLARE_DESCRIPTOR_BLOCKS, ~, __VA_ARGS__)> buff;                             \
+    };                                                                                                                 \
+                                                                                                                       \
+    struct ConstDescriptor {                                                                                           \
+      ConstDescriptor() = default;                                                                                     \
+                                                                                                                       \
+      explicit ConstDescriptor(ConstView const& view)                                                                  \
+          : buff(std::make_tuple(_ITERATE_ON_ALL_COMMA(_ASSIGN_CONST_SPANS_TO_BLOCKS, ~, __VA_ARGS__))) {}             \
+                                                                                                                       \
+      static constexpr size_type blocksNumber = std::tuple_size<std::tuple<                                            \
+                                   _ITERATE_ON_ALL_COMMA(_DECLARE_CONST_DESCRIPTOR_BLOCKS, ~, __VA_ARGS__)>>::value;   \
+      std::tuple< _ITERATE_ON_ALL_COMMA(_DECLARE_CONST_DESCRIPTOR_BLOCKS, ~, __VA_ARGS__)> buff;                       \
+    };                                                                                                                 \
                                                                                                                        \
     /* Trivial constuctor */                                                                                           \
     CLASS()                                                                                                            \

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -5,6 +5,7 @@
  * Definitions of SoA common parameters for SoA class generators
  */
 
+#include <array>
 #include <cstdint>
 #include <cassert>
 #include <cstring>
@@ -15,6 +16,7 @@
 #include <source_location>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include <boost/preprocessor.hpp>
 
@@ -1091,6 +1093,32 @@ namespace cms::soa::detail {
     return std::span(column.addr_,
                      cms::soa::alignSize(elements * sizeof(typename T::Scalar), alignment) * T::RowsAtCompileTime *
                          T::ColsAtCompileTime / sizeof(typename T::Scalar));
+  }
+
+  // Helper function for extracting the number of blocks of a layout. Falls back to 1 if the layout does not define a static member blocksNumber.
+  template <typename T>
+  constexpr size_type nBlocks() {
+    if constexpr (requires { T::blocksNumber; })
+      return T::blocksNumber;
+    else
+      return static_cast<size_type>(1);
+  }
+
+  // Case 1: type has blocksNumber → returns a sub-array
+  template <typename T, size_type N>
+    requires requires { T::blocksNumber; }
+  [[nodiscard]] constexpr std::array<size_type, T::blocksNumber> extractSegment(const std::array<size_type, N>& sizes,
+                                                                                size_type offset) {
+    return [&]<std::size_t... I>(std::index_sequence<I...>) {
+      return std::array<size_type, T::blocksNumber>{sizes[offset + I]...};
+    }(std::make_index_sequence<T::blocksNumber>{});
+  }
+
+  // Case 2: fallback (single block) → returns a scalar
+  template <typename T, size_type N>
+    requires(!requires { T::blocksNumber; })
+  [[nodiscard]] constexpr size_type extractSegment(const std::array<size_type, N>& sizes, size_type offset) {
+    return sizes[offset];
   }
 
 }  // namespace cms::soa::detail

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -1700,7 +1700,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
     struct ConstDescriptor {                                                                                           \
       ConstDescriptor() = default;                                                                                     \
                                                                                                                        \
-      explicit ConstDescriptor(ConstView const& view)                                                                  \
+      explicit ConstDescriptor(ConstView const view)                                                                   \
           : buff{ _ITERATE_ON_ALL_COMMA(_ASSIGN_SPAN_TO_COLUMNS, ~, __VA_ARGS__)},                                     \
             parameterTypes{ _ITERATE_ON_ALL_COMMA(_ASSIGN_PARAMETER_TO_COLUMNS, ~, __VA_ARGS__)} {}                    \
                                                                                                                        \
@@ -1716,7 +1716,7 @@ _SWITCH_ON_TYPE(VALUE_TYPE,                                                     
     struct Descriptor {                                                                                                \
       Descriptor() = default;                                                                                          \
                                                                                                                        \
-      explicit Descriptor(View& view)                                                                                  \
+      explicit Descriptor(View view)                                                                                   \
           : buff{ _ITERATE_ON_ALL_COMMA(_ASSIGN_SPAN_TO_COLUMNS, ~, __VA_ARGS__)},                                     \
             parameterTypes{ _ITERATE_ON_ALL_COMMA(_ASSIGN_PARAMETER_TO_COLUMNS, ~, __VA_ARGS__)} {}                    \
                                                                                                                        \

--- a/DataFormats/SoATemplate/test/BuildFile.xml
+++ b/DataFormats/SoATemplate/test/BuildFile.xml
@@ -62,6 +62,13 @@
   <use name="DataFormats/SoATemplate"/>
 </bin>
 
+<bin file="SoAGenericNestedBlocksView_t.cc" name="SoAGenericNestedBlocks_t">
+  <use name="boost"/>
+  <use name="catch2"/>
+  <use name="eigen"/>
+  <use name="DataFormats/SoATemplate"/>
+</bin>
+
 <bin file="SoAGenericBlocksView_t.cc" name="SoAGenericBlocks_t">
   <use name="boost"/>
   <use name="catch2"/>

--- a/DataFormats/SoATemplate/test/SoABlocks_t.cc
+++ b/DataFormats/SoATemplate/test/SoABlocks_t.cc
@@ -6,6 +6,8 @@
 
 #include "DataFormats/SoATemplate/interface/SoABlocks.h"
 
+using namespace Catch::Matchers;
+
 // This file tests the main properties of SoABlocks
 
 GENERATE_SOA_LAYOUT(SoAPositionTemplate,
@@ -22,14 +24,23 @@ GENERATE_SOA_LAYOUT(SoAPCATemplate,
 
 GENERATE_SOA_LAYOUT(SoATemplate, SOA_SCALAR(int, id), SOA_SCALAR(int, type), SOA_SCALAR(float, energy))
 
+GENERATE_SOA_LAYOUT(
+    SimpleLayoutTemplate, SOA_COLUMN(float, x), SOA_COLUMN(float, y), SOA_COLUMN(float, z), SOA_COLUMN(float, t))
+
 GENERATE_SOA_BLOCKS(SoABlocksTemplate,
                     SOA_BLOCK(position, SoAPositionTemplate),
                     SOA_BLOCK(pca, SoAPCATemplate),
                     SOA_BLOCK(scalars, SoATemplate))
 
+GENERATE_SOA_BLOCKS(NestedBlocksTemplate, SOA_BLOCK(blocks, SoABlocksTemplate), SOA_BLOCK(simple, SimpleLayoutTemplate))
+
 using SoABlocks = SoABlocksTemplate<>;
 using SoABlocksView = SoABlocks::View;
 using SoABlocksConstView = SoABlocks::ConstView;
+
+using NestedBlocks = NestedBlocksTemplate<>;
+using NestedBlocksView = NestedBlocks::View;
+using NestedBlocksConstView = NestedBlocks::ConstView;
 
 TEST_CASE("SoABlocks") {
   // Create a SoABlocks instance with three blocks of different sizes
@@ -233,5 +244,67 @@ TEST_CASE("SoABlocks") {
     REQUIRE(noRestrictBlockConstView.pca().rangeChecking == cms::soa::RangeChecking::Default);
     REQUIRE(noRestrictBlockConstView.scalars().restrictQualify == cms::soa::RestrictQualify::disabled);
     REQUIRE(noRestrictBlockConstView.scalars().rangeChecking == cms::soa::RangeChecking::Default);
+  }
+
+  SECTION("Check extended blocks layout") {
+    std::array<cms::soa::size_type, 4> sizes{{11, 12, 13, 14}};
+    const std::size_t blocksExtendedBufferSize = NestedBlocks::computeDataSize(sizes);
+
+    std::unique_ptr<std::byte, decltype(std::free) *> buffer{
+        reinterpret_cast<std::byte *>(aligned_alloc(NestedBlocks::alignment, blocksExtendedBufferSize)), std::free};
+
+    NestedBlocks NestedBlocksSoA(buffer.get(), sizes);
+    NestedBlocksView nestedBlocksView{NestedBlocksSoA};
+    NestedBlocksConstView nestedBlocksConstView{NestedBlocksSoA};
+
+    nestedBlocksView.blocks().position().detectorType() = 1;
+    for (int i = 0; i < nestedBlocksView.metadata().size()[0]; ++i) {
+      nestedBlocksView.blocks().position()[i] = {0.1f, 0.2f, 0.3f};
+    }
+
+    for (int i = 0; i < nestedBlocksView.metadata().size()[1]; ++i) {
+      nestedBlocksView.blocks().pca()[i].vector_1() = 0.0f;
+      nestedBlocksView.blocks().pca()[i].vector_2() = 0.0f;
+      nestedBlocksView.blocks().pca()[i].vector_3() = 1.0f;
+      nestedBlocksView.blocks().pca()[i].candidateDirection() = Eigen::Vector3d(1.0, 0.0, 0.0);
+    }
+    nestedBlocksView.blocks().scalars().id() = 42;
+    nestedBlocksView.blocks().scalars().type() = 1;
+    nestedBlocksView.blocks().scalars().energy() = 100.0f;
+
+    for (int i = 0; i < nestedBlocksView.metadata().size()[3]; ++i) {
+      nestedBlocksView.simple()[i] = {2.1f, 2.2f, 2.3f, 2.4f};
+    }
+
+    REQUIRE(NestedBlocksSoA.blocks().position().metadata().size() == 11);
+    REQUIRE(NestedBlocksSoA.blocks().pca().metadata().size() == 12);
+    REQUIRE(NestedBlocksSoA.blocks().scalars().metadata().size() == 13);
+    REQUIRE(NestedBlocksSoA.simple().metadata().size() == 14);
+
+    REQUIRE(nestedBlocksConstView.blocks().position().detectorType() == 1);
+    for (int i = 0; i < nestedBlocksConstView.metadata().size()[0]; ++i) {
+      REQUIRE_THAT(nestedBlocksConstView.blocks().position()[i].x(), WithinRel(0.1f));
+      REQUIRE_THAT(nestedBlocksConstView.blocks().position()[i].y(), WithinRel(0.2f));
+      REQUIRE_THAT(nestedBlocksConstView.blocks().position()[i].z(), WithinRel(0.3f));
+    }
+
+    for (int i = 0; i < nestedBlocksConstView.metadata().size()[1]; ++i) {
+      REQUIRE_THAT(nestedBlocksConstView.blocks().pca()[i].vector_1(), WithinRel(0.0f));
+      REQUIRE_THAT(nestedBlocksConstView.blocks().pca()[i].vector_2(), WithinRel(0.0f));
+      REQUIRE_THAT(nestedBlocksConstView.blocks().pca()[i].vector_3(), WithinRel(1.0f));
+      REQUIRE_THAT(nestedBlocksConstView.blocks().pca()[i].candidateDirection()[0], WithinRel(1.0));
+      REQUIRE_THAT(nestedBlocksConstView.blocks().pca()[i].candidateDirection()[1], WithinRel(0.0));
+      REQUIRE_THAT(nestedBlocksConstView.blocks().pca()[i].candidateDirection()[2], WithinRel(0.0));
+    }
+    REQUIRE(nestedBlocksConstView.blocks().scalars().id() == 42);
+    REQUIRE(nestedBlocksConstView.blocks().scalars().type() == 1);
+    REQUIRE_THAT(nestedBlocksConstView.blocks().scalars().energy(), WithinRel(100.0f));
+
+    for (int i = 0; i < nestedBlocksConstView.metadata().size()[3]; ++i) {
+      REQUIRE_THAT(nestedBlocksConstView.simple()[i].x(), WithinRel(2.1f));
+      REQUIRE_THAT(nestedBlocksConstView.simple()[i].y(), WithinRel(2.2f));
+      REQUIRE_THAT(nestedBlocksConstView.simple()[i].z(), WithinRel(2.3f));
+      REQUIRE_THAT(nestedBlocksConstView.simple()[i].t(), WithinRel(2.4f));
+    }
   }
 }

--- a/DataFormats/SoATemplate/test/SoAGenericNestedBlocksView_t.cc
+++ b/DataFormats/SoATemplate/test/SoAGenericNestedBlocksView_t.cc
@@ -1,0 +1,224 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+
+#include "DataFormats/SoATemplate/interface/SoABlocks.h"
+
+// Similar test to SoAGenericBlocksView but with nested SoABlocks
+
+GENERATE_SOA_LAYOUT(SoALayout1, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
+
+GENERATE_SOA_LAYOUT(SoALayout2, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
+
+GENERATE_SOA_LAYOUT(SoALayout3, SOA_COLUMN(int, column), SOA_EIGEN_COLUMN(Eigen::Vector3d, vector), SOA_SCALAR(int, id))
+
+GENERATE_SOA_BLOCKS(BlocksTemplate, SOA_BLOCK(first, SoALayout1), SOA_BLOCK(second, SoALayout2))
+
+GENERATE_SOA_BLOCKS(NestedBlocksTemplate, SOA_BLOCK(blocks, BlocksTemplate), SOA_BLOCK(soa, SoALayout3))
+
+using BlocksSoA = BlocksTemplate<>;
+using BlocksView = BlocksSoA::View;
+using BlocksConstView = BlocksSoA::ConstView;
+
+using NestedBlocksSoA = NestedBlocksTemplate<>;
+using NestedBlocksView = NestedBlocksSoA::View;
+using NestedBlocksConstView = NestedBlocksSoA::ConstView;
+
+TEST_CASE("SoAGenericNestedBlocksView") {
+  // different number of elements for the SoAs
+  std::array<NestedBlocksSoA::size_type, 3> sizes = {10, 20, 30};
+
+  // buffer sizes
+  const auto bufferSize = NestedBlocksSoA::computeDataSize(sizes);
+
+  // memory buffer for the SoA of positions
+  std::unique_ptr<std::byte, decltype(std::free) *> buffer{
+      reinterpret_cast<std::byte *>(aligned_alloc(NestedBlocksSoA::alignment, bufferSize)), std::free};
+
+  // SoA Layouts
+  NestedBlocksSoA nestedBlocks{buffer.get(), sizes};
+  NestedBlocksView nestedBlocksView{nestedBlocks};
+  NestedBlocksConstView nestedBlocksConstView{nestedBlocks};
+
+  // fill up
+  nestedBlocksView.blocks().first().id() = 21;
+  for (NestedBlocksSoA::size_type i = 0; i < sizes[0]; i++) {
+    nestedBlocksView.blocks().first()[i].column() = static_cast<int>(i);
+    nestedBlocksView.blocks().first()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
+  }
+
+  nestedBlocksView.blocks().second().id() = 42;
+  for (NestedBlocksSoA::size_type i = 0; i < sizes[1]; i++) {
+    nestedBlocksView.blocks().second()[i].column() = static_cast<int>(i);
+    nestedBlocksView.blocks().second()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
+  }
+
+  nestedBlocksView.soa().id() = 666;
+  for (NestedBlocksSoA::size_type i = 0; i < sizes[2]; i++) {
+    nestedBlocksView.soa()[i].column() = static_cast<int>(i);
+    nestedBlocksView.soa()[i].vector() = Eigen::Vector3d(i, i + 1, i + 2);
+  }
+
+  SECTION("GenericBlocks View from nested blocks") {
+    // building the SoABlocks View, there is no need for runtime check for the size since they are different
+    BlocksView blocksView{nestedBlocksView.blocks().first(), nestedBlocksView.blocks().second()};
+
+    // Verify metadata
+    REQUIRE(blocksView.metadata().size()[0] == sizes[0]);
+    REQUIRE(blocksView.first().metadata().size() == sizes[0]);
+    REQUIRE(blocksView.metadata().size()[1] == sizes[1]);
+    REQUIRE(blocksView.second().metadata().size() == sizes[1]);
+
+    // Check for equality of memory addresses
+    REQUIRE(blocksView.first().metadata().addressOf_column() ==
+            nestedBlocksView.blocks().first().metadata().addressOf_column());
+    REQUIRE(blocksView.first().metadata().addressOf_vector() ==
+            nestedBlocksView.blocks().first().metadata().addressOf_vector());
+    REQUIRE(blocksView.second().metadata().addressOf_column() ==
+            nestedBlocksView.blocks().second().metadata().addressOf_column());
+    REQUIRE(blocksView.second().metadata().addressOf_vector() ==
+            nestedBlocksView.blocks().second().metadata().addressOf_vector());
+
+    // Verify data
+    for (NestedBlocksSoA::size_type i = 0; i < sizes[0]; ++i) {
+      auto nestedFirst = nestedBlocksView.blocks().first()[i];
+      auto first = blocksView.first()[i];
+      REQUIRE(first.column() == nestedFirst.column());
+      REQUIRE(first.vector() == nestedFirst.vector());
+    }
+
+    for (NestedBlocksSoA::size_type i = 0; i < sizes[1]; ++i) {
+      auto nestedSecond = nestedBlocksView.blocks().second()[i];
+      auto second = blocksView.second()[i];
+      REQUIRE(second.column() == nestedSecond.column());
+      REQUIRE(second.vector() == nestedSecond.vector());
+    }
+
+    REQUIRE(nestedBlocksView.blocks().first().id() == blocksView.first().id());
+    REQUIRE(nestedBlocksView.blocks().second().id() == blocksView.second().id());
+  }
+
+  SECTION("GenericBlocks ConstView from const nested blocks") {
+    // building the SoABlocks ConstView, there is no need for runtime check for the size since they are different
+    BlocksConstView blocksConstView{nestedBlocksConstView.blocks().first(), nestedBlocksConstView.blocks().second()};
+
+    // Verify metadata
+    REQUIRE(blocksConstView.metadata().size()[0] == sizes[0]);
+    REQUIRE(blocksConstView.first().metadata().size() == sizes[0]);
+    REQUIRE(blocksConstView.metadata().size()[1] == sizes[1]);
+    REQUIRE(blocksConstView.second().metadata().size() == sizes[1]);
+
+    // Check for equality of memory addresses
+    REQUIRE(blocksConstView.first().metadata().addressOf_column() ==
+            nestedBlocksConstView.blocks().first().metadata().addressOf_column());
+    REQUIRE(blocksConstView.first().metadata().addressOf_vector() ==
+            nestedBlocksConstView.blocks().first().metadata().addressOf_vector());
+    REQUIRE(blocksConstView.second().metadata().addressOf_column() ==
+            nestedBlocksConstView.blocks().second().metadata().addressOf_column());
+    REQUIRE(blocksConstView.second().metadata().addressOf_vector() ==
+            nestedBlocksConstView.blocks().second().metadata().addressOf_vector());
+
+    // Verify data
+    for (NestedBlocksSoA::size_type i = 0; i < sizes[0]; ++i) {
+      auto nestedFirst = nestedBlocksConstView.blocks().first()[i];
+      auto first = blocksConstView.first()[i];
+      REQUIRE(first.column() == nestedFirst.column());
+      REQUIRE(first.vector() == nestedFirst.vector());
+    }
+
+    for (NestedBlocksSoA::size_type i = 0; i < sizes[1]; ++i) {
+      auto nestedSecond = nestedBlocksConstView.blocks().second()[i];
+      auto second = blocksConstView.second()[i];
+      REQUIRE(second.column() == nestedSecond.column());
+      REQUIRE(second.vector() == nestedSecond.vector());
+    }
+
+    REQUIRE(nestedBlocksConstView.blocks().first().id() == blocksConstView.first().id());
+    REQUIRE(nestedBlocksConstView.blocks().second().id() == blocksConstView.second().id());
+  }
+
+  SECTION("GenericBlocks ConstView from nested blocks") {
+    // building the SoABlocks ConstView, there is no need for runtime check for the size since they are different
+    BlocksConstView blocksConstView{nestedBlocksView.blocks().first(), nestedBlocksView.blocks().second()};
+
+    // Verify metadata
+    REQUIRE(blocksConstView.metadata().size()[0] == sizes[0]);
+    REQUIRE(blocksConstView.first().metadata().size() == sizes[0]);
+    REQUIRE(blocksConstView.metadata().size()[1] == sizes[1]);
+    REQUIRE(blocksConstView.second().metadata().size() == sizes[1]);
+
+    // Check for equality of memory addresses
+    REQUIRE(blocksConstView.first().metadata().addressOf_column() ==
+            nestedBlocksConstView.blocks().first().metadata().addressOf_column());
+    REQUIRE(blocksConstView.first().metadata().addressOf_vector() ==
+            nestedBlocksConstView.blocks().first().metadata().addressOf_vector());
+    REQUIRE(blocksConstView.second().metadata().addressOf_column() ==
+            nestedBlocksConstView.blocks().second().metadata().addressOf_column());
+    REQUIRE(blocksConstView.second().metadata().addressOf_vector() ==
+            nestedBlocksConstView.blocks().second().metadata().addressOf_vector());
+
+    // Verify data
+    for (NestedBlocksSoA::size_type i = 0; i < sizes[0]; ++i) {
+      auto nestedFirst = nestedBlocksConstView.blocks().first()[i];
+      auto first = blocksConstView.first()[i];
+      REQUIRE(first.column() == nestedFirst.column());
+      REQUIRE(first.vector() == nestedFirst.vector());
+    }
+
+    for (NestedBlocksSoA::size_type i = 0; i < sizes[1]; ++i) {
+      auto nestedSecond = nestedBlocksConstView.blocks().second()[i];
+      auto second = blocksConstView.second()[i];
+      REQUIRE(second.column() == nestedSecond.column());
+      REQUIRE(second.vector() == nestedSecond.vector());
+    }
+
+    REQUIRE(nestedBlocksConstView.blocks().first().id() == blocksConstView.first().id());
+    REQUIRE(nestedBlocksConstView.blocks().second().id() == blocksConstView.second().id());
+  }
+
+  SECTION("Deep copy the nested blocks to a normal blocks layout") {
+    // building the SoABlocks View, there is no need for runtime check for the size since they are different
+    BlocksView genericBlocksView{nestedBlocksView.blocks().first(), nestedBlocksView.blocks().second()};
+
+    // Instantiate a SoABlocks
+    std::array<NestedBlocksSoA::size_type, 2> size = {sizes[0], sizes[1]};
+    const std::size_t blocksBufferSize = BlocksSoA::computeDataSize(size);
+    std::unique_ptr<std::byte, decltype(std::free) *> bufferBlocks{
+        reinterpret_cast<std::byte *>(aligned_alloc(BlocksSoA::alignment, blocksBufferSize)), std::free};
+
+    BlocksSoA genericBlocks{bufferBlocks.get(), size};
+
+    genericBlocks.deepCopy(genericBlocksView);
+
+    BlocksView genericSoABlocksView{genericBlocks};
+    // Check for inequality of memory addresses
+    REQUIRE(genericSoABlocksView.first().metadata().addressOf_column() !=
+            nestedBlocksView.blocks().first().metadata().addressOf_column());
+    REQUIRE(genericSoABlocksView.first().metadata().addressOf_vector() !=
+            nestedBlocksView.blocks().first().metadata().addressOf_vector());
+    REQUIRE(genericSoABlocksView.second().metadata().addressOf_column() !=
+            nestedBlocksView.blocks().second().metadata().addressOf_column());
+    REQUIRE(genericSoABlocksView.second().metadata().addressOf_vector() !=
+            nestedBlocksView.blocks().second().metadata().addressOf_vector());
+
+    // Verify data
+    for (NestedBlocksSoA::size_type i = 0; i < sizes[0]; ++i) {
+      auto nestedFirst = nestedBlocksConstView.blocks().first()[i];
+      auto first = genericSoABlocksView.first()[i];
+      REQUIRE(first.column() == nestedFirst.column());
+      REQUIRE(first.vector() == nestedFirst.vector());
+    }
+
+    for (NestedBlocksSoA::size_type i = 0; i < sizes[1]; ++i) {
+      auto nestedSecond = nestedBlocksConstView.blocks().second()[i];
+      auto second = genericSoABlocksView.second()[i];
+      REQUIRE(second.column() == nestedSecond.column());
+      REQUIRE(second.vector() == nestedSecond.vector());
+    }
+
+    REQUIRE(nestedBlocksConstView.blocks().first().id() == genericSoABlocksView.first().id());
+    REQUIRE(nestedBlocksConstView.blocks().second().id() == genericSoABlocksView.second().id());
+  }
+}


### PR DESCRIPTION
**PR description:**

The `SOA_BLOCK` macro used by `SoABlocks` accepts only `SoALayouts` that are not in itself an `SoABlocks`. If the Layout is an `SoABlocks` itself the macro fails with cryptic error messages. This PR extends `SoABlocks` so that it allows to add an `SOA_BLOCK` which is in itself an SoABlocks Layout. In this way nestes Layouts of Blocks can be formed. 

Furthermore, the PR extends the deepcopy mechanism for SoABlocks. Currently deepcopy was not implemented for SoABlocks.

PR validation:

Added tests for nested blocks and deepcopy of SoABlocks

Tests passed

FYI @sbaldu @felicepantaleo