### PR TITLE
Change ECAL Phase 2 TP sample type to uint16_t

### DIFF
--- a/DataFormats/EcalDigi/interface/EcalEBPhase2TriggerPrimitiveSample.h
+++ b/DataFormats/EcalDigi/interface/EcalEBPhase2TriggerPrimitiveSample.h
@@ -12,13 +12,13 @@
 class EcalEBPhase2TriggerPrimitiveSample {
 public:
   EcalEBPhase2TriggerPrimitiveSample();
-  EcalEBPhase2TriggerPrimitiveSample(uint32_t data);
+  EcalEBPhase2TriggerPrimitiveSample(uint16_t data);
   EcalEBPhase2TriggerPrimitiveSample(int encodedEt);
   EcalEBPhase2TriggerPrimitiveSample(int encodedEt, bool isASpike);
   EcalEBPhase2TriggerPrimitiveSample(int encodedEt, bool isASpike, int timing);
 
   ///Set data
-  void setValue(uint32_t data) { theSample_ = data; }
+  void setValue(uint16_t data) { theSample_ = data; }
   // The sample is a 16 bit word defined as:
   //
   //     o o o o o    o     o o o o o o o o o o
@@ -28,7 +28,7 @@ public:
   //
 
   /// get the raw word
-  uint32_t raw() const { return theSample_ & 0xffff; }
+  uint16_t raw() const { return theSample_ & 0xffff; }
 
   /// get the encoded Et (10 bits)
   int encodedEt() const { return (raw()) & 0x3FF; }
@@ -38,10 +38,10 @@ public:
   int time() const { return raw() >> 11; }
 
   /// for streaming
-  uint32_t operator()() { return raw(); }
+  uint16_t operator()() { return raw(); }
 
 private:
-  uint32_t theSample_;
+  uint16_t theSample_;
 };
 
 std::ostream& operator<<(std::ostream& s, const EcalEBPhase2TriggerPrimitiveSample& samp);

--- a/DataFormats/EcalDigi/src/EcalEBPhase2TriggerPrimitiveSample.cc
+++ b/DataFormats/EcalDigi/src/EcalEBPhase2TriggerPrimitiveSample.cc
@@ -2,7 +2,7 @@
 #include <iostream>
 
 EcalEBPhase2TriggerPrimitiveSample::EcalEBPhase2TriggerPrimitiveSample() : theSample_(0) {}
-EcalEBPhase2TriggerPrimitiveSample::EcalEBPhase2TriggerPrimitiveSample(uint32_t data) : theSample_(data) {
+EcalEBPhase2TriggerPrimitiveSample::EcalEBPhase2TriggerPrimitiveSample(uint16_t data) : theSample_(data) {
   theSample_ = raw();
 }
 

--- a/DataFormats/EcalDigi/src/classes_def.xml
+++ b/DataFormats/EcalDigi/src/classes_def.xml
@@ -23,7 +23,8 @@
    <class name="EcalEBTriggerPrimitiveSample" ClassVersion="3">
     <version ClassVersion="3" checksum="4171161153"/>
    </class>
-   <class name="EcalEBPhase2TriggerPrimitiveSample" ClassVersion="3">
+   <class name="EcalEBPhase2TriggerPrimitiveSample" ClassVersion="4">
+    <version ClassVersion="4" checksum="3260368367"/>
     <version ClassVersion="3" checksum="362263034"/>
    </class>
    <class name="io_v1::EcalTriggerPrimitiveDigi" ClassVersion="3">


### PR DESCRIPTION
#### PR description:

The ECAL Phase 2 TP sample is a 16 bit word. Therefore the data type to store it can be `uint16_t` instead of `uint32_t`.

#### PR validation:

Passes the ECAL Phase 2 development workflow 34434.612.