### PR TITLE
Rename GPU check macros to uppercase

### DIFF
--- a/DataFormats/GeometrySurface/test/gpuFrameTransformTest.cpp
+++ b/DataFormats/GeometrySurface/test/gpuFrameTransformTest.cpp
@@ -75,7 +75,7 @@ int main(void) {
   SFrame sf1(f1.position().x(), f1.position().y(), f1.position().z(), f1.rotation());
 
   auto d_sf = cms::cuda::make_device_unique<char[]>(sizeof(SFrame), nullptr);
-  cudaCheck(cudaMemcpy(d_sf.get(), &sf1, sizeof(SFrame), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_sf.get(), &sf1, sizeof(SFrame), cudaMemcpyHostToDevice));
 
   for (auto i = 0U; i < size; ++i) {
     xl[i] = yl[i] = 0.1f * float(i) - float(size / 2);
@@ -86,9 +86,9 @@ int main(void) {
   std::shuffle(xl, xl + size, g);
   std::shuffle(yl, yl + size, g);
 
-  cudaCheck(cudaMemcpy(d_xl.get(), xl, size32, cudaMemcpyHostToDevice));
-  cudaCheck(cudaMemcpy(d_yl.get(), yl, size32, cudaMemcpyHostToDevice));
-  cudaCheck(cudaMemcpy(d_le.get(), le, 3 * size32, cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_xl.get(), xl, size32, cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_yl.get(), yl, size32, cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_le.get(), le, 3 * size32, cudaMemcpyHostToDevice));
 
   toGlobalWrapper((SFrame const *)(d_sf.get()),
                   d_xl.get(),
@@ -99,10 +99,10 @@ int main(void) {
                   d_le.get(),
                   d_ge.get(),
                   size);
-  cudaCheck(cudaMemcpy(x, d_x.get(), size32, cudaMemcpyDeviceToHost));
-  cudaCheck(cudaMemcpy(y, d_y.get(), size32, cudaMemcpyDeviceToHost));
-  cudaCheck(cudaMemcpy(z, d_z.get(), size32, cudaMemcpyDeviceToHost));
-  cudaCheck(cudaMemcpy(ge, d_ge.get(), 6 * size32, cudaMemcpyDeviceToHost));
+  CUDA_CHECK(cudaMemcpy(x, d_x.get(), size32, cudaMemcpyDeviceToHost));
+  CUDA_CHECK(cudaMemcpy(y, d_y.get(), size32, cudaMemcpyDeviceToHost));
+  CUDA_CHECK(cudaMemcpy(z, d_z.get(), size32, cudaMemcpyDeviceToHost));
+  CUDA_CHECK(cudaMemcpy(ge, d_ge.get(), 6 * size32, cudaMemcpyDeviceToHost));
 
   float eps = 0.;
   for (auto i = 0U; i < size; ++i) {

--- a/DataFormats/Math/test/CholeskyInvert_t.cu
+++ b/DataFormats/Math/test/CholeskyInvert_t.cu
@@ -125,7 +125,7 @@ void go(bool soa) {
   std::cout << mm[SIZE / 2](1, 1) << std::endl;
 
   auto m_d = cms::cuda::make_device_unique<double[]>(DIM * DIM * stride(), nullptr);
-  cudaCheck(cudaMemcpy(m_d.get(), (double const *)(mm), stride() * sizeof(MX), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(m_d.get(), (double const *)(mm), stride() * sizeof(MX), cudaMemcpyHostToDevice));
 
   constexpr int NKK =
 #ifdef DOPROF
@@ -144,7 +144,7 @@ void go(bool soa) {
     else
       cms::cuda::launch(invert<MX, DIM>, {blocksPerGrid, threadsPerBlock}, (MX *)(m_d.get()), SIZE);
 
-    cudaCheck(cudaMemcpy(&mm, m_d.get(), stride() * sizeof(MX), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(&mm, m_d.get(), stride() * sizeof(MX), cudaMemcpyDeviceToHost));
 
     delta += (std::chrono::high_resolution_clock::now() - start);
 
@@ -156,7 +156,7 @@ void go(bool soa) {
 
 #ifndef DOPROF
       cms::cuda::launch(invertSeq<MX, DIM>, {blocksPerGrid, threadsPerBlock}, (MX *)(m_d.get()), SIZE);
-      cudaCheck(cudaMemcpy(&mm, m_d.get(), stride() * sizeof(MX), cudaMemcpyDeviceToHost));
+      CUDA_CHECK(cudaMemcpy(&mm, m_d.get(), stride() * sizeof(MX), cudaMemcpyDeviceToHost));
 #endif
       delta1 += (std::chrono::high_resolution_clock::now() - start);
 

--- a/DataFormats/Math/test/cudaAtan2Test.cu
+++ b/DataFormats/Math/test/cudaAtan2Test.cu
@@ -71,7 +71,7 @@ void go() {
   auto diff_d = cms::cuda::make_device_unique<int[]>(3, nullptr);
 
   int diffs[3];
-  cudaCheck(cudaMemset(diff_d.get(), 0, 3 * 4));
+  CUDA_CHECK(cudaMemset(diff_d.get(), 0, 3 * 4));
 
   // Launch the diff CUDA Kernel
   dim3 threadsPerBlock(32, 32, 1);
@@ -82,7 +82,7 @@ void go() {
 
   cms::cuda::launch(diffAtan<DEGREE>, {blocksPerGrid, threadsPerBlock}, diff_d.get());
 
-  cudaCheck(cudaMemcpy(diffs, diff_d.get(), 3 * 4, cudaMemcpyDeviceToHost));
+  CUDA_CHECK(cudaMemcpy(diffs, diff_d.get(), 3 * 4, cudaMemcpyDeviceToHost));
   delta += (std::chrono::high_resolution_clock::now() - start);
 
   float mdiff = diffs[0] * 1.e-7;

--- a/DataFormats/Math/test/cudaMathTest.cu
+++ b/DataFormats/Math/test/cudaMathTest.cu
@@ -105,8 +105,8 @@ void go() {
   auto d_B = cms::cuda::make_device_unique<float[]>(numElements, nullptr);
   auto d_C = cms::cuda::make_device_unique<float[]>(numElements, nullptr);
 
-  cudaCheck(cudaMemcpy(d_A.get(), h_A.get(), size, cudaMemcpyHostToDevice));
-  cudaCheck(cudaMemcpy(d_B.get(), h_B.get(), size, cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_A.get(), h_A.get(), size, cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_B.get(), h_B.get(), size, cudaMemcpyHostToDevice));
   delta += (std::chrono::high_resolution_clock::now() - start);
   std::cout << "cuda alloc+copy took " << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count() << " ms"
             << std::endl;
@@ -131,7 +131,7 @@ void go() {
             << std::endl;
 
   delta -= (std::chrono::high_resolution_clock::now() - start);
-  cudaCheck(cudaMemcpy(h_C.get(), d_C.get(), size, cudaMemcpyDeviceToHost));
+  CUDA_CHECK(cudaMemcpy(h_C.get(), d_C.get(), size, cudaMemcpyDeviceToHost));
   delta += (std::chrono::high_resolution_clock::now() - start);
   std::cout << "cuda copy back took " << std::chrono::duration_cast<std::chrono::milliseconds>(delta).count() << " ms"
             << std::endl;

--- a/DataFormats/Math/test/simpleCholeskyTest.cu
+++ b/DataFormats/Math/test/simpleCholeskyTest.cu
@@ -95,9 +95,9 @@ int main() {
   cudaMalloc(&d, sizeof(M));
   cudaMemcpy(d, &m, sizeof(M), cudaMemcpyHostToDevice);
   invert<M, DIM><<<1, 1>>>((M*)d, 1);
-  cudaCheck(cudaDeviceSynchronize());
+  CUDA_CHECK(cudaDeviceSynchronize());
   invertE<M, DIM><<<1, 1>>>((M*)d, 1);
-  cudaCheck(cudaDeviceSynchronize());
+  CUDA_CHECK(cudaDeviceSynchronize());
 
   return 0;
 }

--- a/DataFormats/SoATemplate/test/SoACustomizedMethods_t.cu
+++ b/DataFormats/SoATemplate/test/SoACustomizedMethods_t.cu
@@ -32,7 +32,7 @@ TEST_CASE("SoACustomizedMethods CUDA", "[SoACustomizedMethods][cuda]") {
   const std::size_t bufferSize = SoA::computeDataSize(elems);
 
   std::byte* h_buf = nullptr;
-  cudaCheck(cudaMallocHost(&h_buf, bufferSize));
+  CUDA_CHECK(cudaMallocHost(&h_buf, bufferSize));
   SoA h_soahdLayout(h_buf, elems);
   SoAView h_view(h_soahdLayout);
   SoAConstView h_Constview(h_soahdLayout);
@@ -49,7 +49,7 @@ TEST_CASE("SoACustomizedMethods CUDA", "[SoACustomizedMethods][cuda]") {
   h_view.detectorType() = 42;
 
   std::byte* d_buf = nullptr;
-  cudaCheck(cudaMalloc(&d_buf, bufferSize));
+  CUDA_CHECK(cudaMalloc(&d_buf, bufferSize));
   SoA d_soahdLayout(d_buf, elems);
   SoAView d_view(d_soahdLayout);
   SoAConstView d_Constview(d_soahdLayout);
@@ -62,18 +62,18 @@ TEST_CASE("SoACustomizedMethods CUDA", "[SoACustomizedMethods][cuda]") {
   double* d_velocity_norms;
   double* d_times;
 
-  cudaCheck(cudaMalloc(&d_position_norms, elems * sizeof(float)));
-  cudaCheck(cudaMalloc(&d_velocity_norms, elems * sizeof(double)));
-  cudaCheck(cudaMalloc(&d_times, elems * sizeof(double)));
+  CUDA_CHECK(cudaMalloc(&d_position_norms, elems * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&d_velocity_norms, elems * sizeof(double)));
+  CUDA_CHECK(cudaMalloc(&d_times, elems * sizeof(double)));
 
   // Host → Device copy
-  cudaCheck(cudaMemcpy(d_buf, h_buf, bufferSize, cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_buf, h_buf, bufferSize, cudaMemcpyHostToDevice));
 
   SECTION("ConstView methods CUDA") {
     calculateNorm<<<(elems + 255) / 256, 256>>>(d_Constview, d_position_norms, d_velocity_norms);
 
-    cudaCheck(cudaMemcpy(h_position_norms.data(), d_position_norms, elems * sizeof(float), cudaMemcpyDeviceToHost));
-    cudaCheck(cudaMemcpy(h_velocity_norms.data(), d_velocity_norms, elems * sizeof(double), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_position_norms.data(), d_position_norms, elems * sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_velocity_norms.data(), d_velocity_norms, elems * sizeof(double), cudaMemcpyDeviceToHost));
 
     // Check for the correctness of the square_norm() functions
     for (size_t i = 0; i < elems; i++) {
@@ -100,8 +100,8 @@ TEST_CASE("SoACustomizedMethods CUDA", "[SoACustomizedMethods][cuda]") {
 
     checkNormalise<<<(elems + 255) / 256, 256>>>(d_view, d_times);
 
-    cudaCheck(cudaMemcpy(h_times.data(), d_times, elems * sizeof(double), cudaMemcpyDeviceToHost));
-    cudaCheck(cudaMemcpy(h_buf, d_buf, bufferSize, cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_times.data(), d_times, elems * sizeof(double), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_buf, d_buf, bufferSize, cudaMemcpyDeviceToHost));
 
     // Check for the correctness of the time() function
     for (size_t i = 0; i < elems; i++) {
@@ -117,9 +117,9 @@ TEST_CASE("SoACustomizedMethods CUDA", "[SoACustomizedMethods][cuda]") {
   }
 
   // ===== cleanup =====
-  cudaCheck(cudaFree(d_position_norms));
-  cudaCheck(cudaFree(d_velocity_norms));
-  cudaCheck(cudaFree(d_times));
-  cudaCheck(cudaFree(d_buf));
-  cudaCheck(cudaFreeHost(h_buf));
+  CUDA_CHECK(cudaFree(d_position_norms));
+  CUDA_CHECK(cudaFree(d_velocity_norms));
+  CUDA_CHECK(cudaFree(d_times));
+  CUDA_CHECK(cudaFree(d_buf));
+  CUDA_CHECK(cudaFreeHost(h_buf));
 }

--- a/DataFormats/SoATemplate/test/SoACustomizedMethods_t.hip.cc
+++ b/DataFormats/SoATemplate/test/SoACustomizedMethods_t.hip.cc
@@ -34,7 +34,7 @@ TEST_CASE("SoACustomizedMethods hip", "[SoACustomizedMethods][hip]") {
   const std::size_t bufferSize = SoA::computeDataSize(elems);
 
   std::byte* h_buf = nullptr;
-  hipCheck(hipHostMalloc(&h_buf, bufferSize));
+  HIP_CHECK(hipHostMalloc(&h_buf, bufferSize));
   SoA h_soahdLayout(h_buf, elems);
   SoAView h_view(h_soahdLayout);
   SoAConstView h_Constview(h_soahdLayout);
@@ -51,7 +51,7 @@ TEST_CASE("SoACustomizedMethods hip", "[SoACustomizedMethods][hip]") {
   h_view.detectorType() = 42;
 
   std::byte* d_buf = nullptr;
-  hipCheck(hipMalloc(&d_buf, bufferSize));
+  HIP_CHECK(hipMalloc(&d_buf, bufferSize));
   SoA d_soahdLayout(d_buf, elems);
   SoAView d_view(d_soahdLayout);
   SoAConstView d_Constview(d_soahdLayout);
@@ -64,18 +64,18 @@ TEST_CASE("SoACustomizedMethods hip", "[SoACustomizedMethods][hip]") {
   double* d_velocity_norms;
   double* d_times;
 
-  hipCheck(hipMalloc(&d_position_norms, elems * sizeof(float)));
-  hipCheck(hipMalloc(&d_velocity_norms, elems * sizeof(double)));
-  hipCheck(hipMalloc(&d_times, elems * sizeof(double)));
+  HIP_CHECK(hipMalloc(&d_position_norms, elems * sizeof(float)));
+  HIP_CHECK(hipMalloc(&d_velocity_norms, elems * sizeof(double)));
+  HIP_CHECK(hipMalloc(&d_times, elems * sizeof(double)));
 
   // Host → Device copy
-  hipCheck(hipMemcpy(d_buf, h_buf, bufferSize, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(d_buf, h_buf, bufferSize, hipMemcpyHostToDevice));
 
   SECTION("ConstView methods HIP") {
     calculateNorm<<<(elems + 255) / 256, 256>>>(d_Constview, d_position_norms, d_velocity_norms);
 
-    hipCheck(hipMemcpy(h_position_norms.data(), d_position_norms, elems * sizeof(float), hipMemcpyDeviceToHost));
-    hipCheck(hipMemcpy(h_velocity_norms.data(), d_velocity_norms, elems * sizeof(double), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipMemcpy(h_position_norms.data(), d_position_norms, elems * sizeof(float), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipMemcpy(h_velocity_norms.data(), d_velocity_norms, elems * sizeof(double), hipMemcpyDeviceToHost));
 
     // Check for the correctness of the square_norm() functions
     for (size_t i = 0; i < elems; i++) {
@@ -102,8 +102,8 @@ TEST_CASE("SoACustomizedMethods hip", "[SoACustomizedMethods][hip]") {
 
     checkNormalise<<<(elems + 255) / 256, 256>>>(d_view, d_times);
 
-    hipCheck(hipMemcpy(h_times.data(), d_times, elems * sizeof(double), hipMemcpyDeviceToHost));
-    hipCheck(hipMemcpy(h_buf, d_buf, bufferSize, hipMemcpyDeviceToHost));
+    HIP_CHECK(hipMemcpy(h_times.data(), d_times, elems * sizeof(double), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipMemcpy(h_buf, d_buf, bufferSize, hipMemcpyDeviceToHost));
 
     // Check for the correctness of the time() function
     for (size_t i = 0; i < elems; i++) {
@@ -119,9 +119,9 @@ TEST_CASE("SoACustomizedMethods hip", "[SoACustomizedMethods][hip]") {
   }
 
   // ===== cleanup =====
-  hipCheck(hipFree(d_position_norms));
-  hipCheck(hipFree(d_velocity_norms));
-  hipCheck(hipFree(d_times));
-  hipCheck(hipFree(d_buf));
-  hipCheck(hipFreeHost(h_buf));
+  HIP_CHECK(hipFree(d_position_norms));
+  HIP_CHECK(hipFree(d_velocity_norms));
+  HIP_CHECK(hipFree(d_times));
+  HIP_CHECK(hipFree(d_buf));
+  HIP_CHECK(hipFreeHost(h_buf));
 }

--- a/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
+++ b/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
@@ -115,7 +115,7 @@ int main(void) {
   cms::cudatest::requireDevices();
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+  CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   // Non-aligned number of elements to check alignment features.
   constexpr unsigned int numElements = 65537;
@@ -123,7 +123,7 @@ int main(void) {
   // Allocate buffer and store on host
   size_t hostDeviceSize = SoAHostDeviceLayout::computeDataSize(numElements);
   std::byte* h_buf = nullptr;
-  cudaCheck(cudaMallocHost(&h_buf, hostDeviceSize));
+  CUDA_CHECK(cudaMallocHost(&h_buf, hostDeviceSize));
   SoAHostDeviceLayout h_soahdLayout(h_buf, numElements);
   SoAHostDeviceView h_soahd(h_soahdLayout);
 
@@ -137,7 +137,7 @@ int main(void) {
   // Alocate buffer, stores and views on the device (single, shared buffer).
   size_t deviceOnlySize = SoADeviceOnlyLayout::computeDataSize(numElements);
   std::byte* d_buf = nullptr;
-  cudaCheck(cudaMallocHost(&d_buf, hostDeviceSize + deviceOnlySize));
+  CUDA_CHECK(cudaMallocHost(&d_buf, hostDeviceSize + deviceOnlySize));
   SoAHostDeviceLayout d_soahdLayout(d_buf, numElements);
   SoADeviceOnlyLayout d_soadoLayout(d_soahdLayout.metadata().nextByte(), numElements);
   SoAHostDeviceView d_soahdView(d_soahdLayout);
@@ -228,13 +228,13 @@ int main(void) {
   sn = numElements + 2;
 
   // Push to device
-  cudaCheck(cudaMemcpyAsync(d_buf, h_buf, hostDeviceSize, cudaMemcpyDefault, stream));
+  CUDA_CHECK(cudaMemcpyAsync(d_buf, h_buf, hostDeviceSize, cudaMemcpyDefault, stream));
 
   // Process on device
   crossProduct<<<(numElements + 255) / 256, 256, 0, stream>>>(d_soahdView, numElements);
 
   // Paint the device only with 0xFF initially
-  cudaCheck(cudaMemsetAsync(d_soadoLayout.metadata().data(), 0xFF, d_soadoLayout.metadata().byteSize(), stream));
+  CUDA_CHECK(cudaMemsetAsync(d_soadoLayout.metadata().data(), 0xFF, d_soadoLayout.metadata().byteSize(), stream));
 
   // Produce to the device only area
   producerKernel<<<(numElements + 255) / 256, 256, 0, stream>>>(d_soaFullView, numElements);
@@ -243,10 +243,10 @@ int main(void) {
   consumerKernel<<<(numElements + 255) / 256, 256, 0, stream>>>(d_soaFullView, numElements);
 
   // Get result back
-  cudaCheck(cudaMemcpyAsync(h_buf, d_buf, hostDeviceSize, cudaMemcpyDefault, stream));
+  CUDA_CHECK(cudaMemcpyAsync(h_buf, d_buf, hostDeviceSize, cudaMemcpyDefault, stream));
 
   // Wait and validate.
-  cudaCheck(cudaStreamSynchronize(stream));
+  CUDA_CHECK(cudaStreamSynchronize(stream));
   for (size_t i = 0; i < numElements; ++i) {
     auto si = h_soahd_c[i];
     assert(si.r() == si.a().cross(si.b()));
@@ -322,7 +322,7 @@ int main(void) {
 
   // Wait and confirm that the CUDA kernel failed
   try {
-    cudaCheck(cudaStreamSynchronize(stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
     std::cout << "Fail: expected range-check exception not caught while executing the kernel." << std::endl;
     assert(false);
   } catch (const std::runtime_error&) {

--- a/DataFormats/SoATemplate/test/SoALayoutAndView_t.hip.cc
+++ b/DataFormats/SoATemplate/test/SoALayoutAndView_t.hip.cc
@@ -116,7 +116,7 @@ int main(void) {
   cms::rocmtest::requireDevices();
 
   hipStream_t stream;
-  hipCheck(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+  HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
 
   // Non-aligned number of elements to check alignment features.
   constexpr unsigned int numElements = 65537;
@@ -124,7 +124,7 @@ int main(void) {
   // Allocate buffer and store on host
   size_t hostDeviceSize = SoAHostDeviceLayout::computeDataSize(numElements);
   std::byte* h_buf = nullptr;
-  hipCheck(hipHostMalloc((void**)&h_buf, hostDeviceSize));
+  HIP_CHECK(hipHostMalloc((void**)&h_buf, hostDeviceSize));
   SoAHostDeviceLayout h_soahdLayout(h_buf, numElements);
   SoAHostDeviceView h_soahd(h_soahdLayout);
 
@@ -138,7 +138,7 @@ int main(void) {
   // Alocate buffer, stores and views on the device (single, shared buffer).
   size_t deviceOnlySize = SoADeviceOnlyLayout::computeDataSize(numElements);
   std::byte* d_buf = nullptr;
-  hipCheck(hipHostMalloc((void**)&d_buf, hostDeviceSize + deviceOnlySize));
+  HIP_CHECK(hipHostMalloc((void**)&d_buf, hostDeviceSize + deviceOnlySize));
   SoAHostDeviceLayout d_soahdLayout(d_buf, numElements);
   SoADeviceOnlyLayout d_soadoLayout(d_soahdLayout.metadata().nextByte(), numElements);
   SoAHostDeviceView d_soahdView(d_soahdLayout);
@@ -229,13 +229,13 @@ int main(void) {
   sn = numElements + 2;
 
   // Push to device
-  hipCheck(hipMemcpyAsync(d_buf, h_buf, hostDeviceSize, hipMemcpyDefault, stream));
+  HIP_CHECK(hipMemcpyAsync(d_buf, h_buf, hostDeviceSize, hipMemcpyDefault, stream));
 
   // Process on device
   crossProduct<<<(numElements + 255) / 256, 256, 0, stream>>>(d_soahdView, numElements);
 
   // Paint the device only with 0xFF initially
-  hipCheck(hipMemsetAsync(d_soadoLayout.metadata().data(), 0xFF, d_soadoLayout.metadata().byteSize(), stream));
+  HIP_CHECK(hipMemsetAsync(d_soadoLayout.metadata().data(), 0xFF, d_soadoLayout.metadata().byteSize(), stream));
 
   // Produce to the device only area
   producerKernel<<<(numElements + 255) / 256, 256, 0, stream>>>(d_soaFullView, numElements);
@@ -244,10 +244,10 @@ int main(void) {
   consumerKernel<<<(numElements + 255) / 256, 256, 0, stream>>>(d_soaFullView, numElements);
 
   // Get result back
-  hipCheck(hipMemcpyAsync(h_buf, d_buf, hostDeviceSize, hipMemcpyDefault, stream));
+  HIP_CHECK(hipMemcpyAsync(h_buf, d_buf, hostDeviceSize, hipMemcpyDefault, stream));
 
   // Wait and validate.
-  hipCheck(hipStreamSynchronize(stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
   for (size_t i = 0; i < numElements; ++i) {
     auto si = h_soahd_c[i];
     assert(si.r() == si.a().cross(si.b()));
@@ -325,7 +325,7 @@ int main(void) {
 
   // Wait and confirm that the ROCm kernel failed
   try {
-    hipCheck(hipStreamSynchronize(stream));
+    HIP_CHECK(hipStreamSynchronize(stream));
     std::cout << "Fail: expected range-check exception not caught while executing the kernel." << std::endl;
     assert(false);
   } catch (const std::runtime_error&) {

--- a/Geometry/TrackerGeometryBuilder/test/phase1PixelTopology_t.cu
+++ b/Geometry/TrackerGeometryBuilder/test/phase1PixelTopology_t.cu
@@ -173,7 +173,7 @@ int main() {
   testLayer();
 
   kernel_testLayer<<<1, 1>>>();
-  cudaCheck(cudaDeviceSynchronize());
+  CUDA_CHECK(cudaDeviceSynchronize());
 
   return 0;
 }

--- a/HeterogeneousCore/CUDACore/test/cudaTimeMeasurement.cu
+++ b/HeterogeneousCore/CUDACore/test/cudaTimeMeasurement.cu
@@ -549,8 +549,8 @@ Timing cudaTimePart0(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
   for (int i = 0; i < averg; i++) {
     std::fill(vect.vect3Gpu.begin(), vect.vect3Gpu.end(), 0);  //clear each value of vector's elements
 
-    cudaCheck(cudaEventCreate(&timing.start));  //inialize Event.
-    cudaCheck(cudaEventCreate(&timing.stop));
+    CUDA_CHECK(cudaEventCreate(&timing.start));  //inialize Event.
+    CUDA_CHECK(cudaEventCreate(&timing.stop));
 
     ////////////////////////// Copy From Host To Device //////////////////////////////////
     timing.copyToDevice[0] = std::chrono::steady_clock::now();  //get current tick time  in monotonic point.
@@ -562,7 +562,7 @@ Timing cudaTimePart0(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
     blocks = std::min(blocks, 8);  // Number 8 is least number can be got from lowest Nevedia GPUs.
 
     ////////////////////////// CAll Device Kernel //////////////////////////////////
-    cudaCheck(cudaEventRecord(timing.start));
+    CUDA_CHECK(cudaEventRecord(timing.start));
     timing.operationOnDeviceByHost[0] = std::chrono::steady_clock::now();
 
     addVectorsGpu<<<blocks, threads>>>(vect.vect1.data(),
@@ -570,11 +570,11 @@ Timing cudaTimePart0(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
                                        vect.vect3Gpu.data(),
                                        sizeOfVector,
                                        task);  //call device function to add two vectors and save into vect3Gpu.
-    cudaCheck(cudaGetLastError());
+    CUDA_CHECK(cudaGetLastError());
 
-    cudaCheck(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaDeviceSynchronize());
     timing.operationOnDeviceByHost[1] = std::chrono::steady_clock::now();
-    cudaCheck(cudaEventRecord(timing.stop));
+    CUDA_CHECK(cudaEventRecord(timing.stop));
 
     ////////////////////////// Copy From Device To Host //////////////////////////////////
     timing.copyToHost[0] = std::chrono::steady_clock::now();
@@ -585,8 +585,8 @@ Timing cudaTimePart0(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
 
     calculateTimeDuration(timing, i);
 
-    cudaCheck(cudaEventDestroy(timing.start));
-    cudaCheck(cudaEventDestroy(timing.stop));
+    CUDA_CHECK(cudaEventDestroy(timing.start));
+    CUDA_CHECK(cudaEventDestroy(timing.stop));
   }
 
   //////////////////// End Average //////////////////////
@@ -607,24 +607,24 @@ Timing cudaTimePart0(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
 Timing cudaTimePart1(Timing &timing, Vectors &vect, Pointers &dvect, int size, int startSave) {
   std::cout << "\nCudaMalloc is applied Part 1.\n";
   timing.partChosen = 1;
-  cudaCheck(
+  CUDA_CHECK(
       cudaMalloc((void **)&dvect.dVect1, size));  //allocate memory space for vector in the global memory of the Device.
-  cudaCheck(cudaMalloc((void **)&dvect.dVect2, size));
-  cudaCheck(cudaMalloc((void **)&dvect.dVect3, size));
+  CUDA_CHECK(cudaMalloc((void **)&dvect.dVect2, size));
+  CUDA_CHECK(cudaMalloc((void **)&dvect.dVect3, size));
 
   //////////// Start Average From Here /////////////////////
   for (int i = 0; i < averg; i++) {
     std::fill(vect.vect3Gpu.begin(), vect.vect3Gpu.end(), 0);
 
-    cudaCheck(cudaEventCreate(&timing.start));  //inialize Event.
-    cudaCheck(cudaEventCreate(&timing.stop));
+    CUDA_CHECK(cudaEventCreate(&timing.start));  //inialize Event.
+    CUDA_CHECK(cudaEventCreate(&timing.stop));
 
     ////////////////////////// Copy From Host To Device //////////////////////////////////
     timing.copyToDevice[0] = std::chrono::steady_clock::now();  //get current tick time  in monotonic point.
 
-    cudaCheck(cudaMemcpy(
+    CUDA_CHECK(cudaMemcpy(
         dvect.dVect1, vect.vect1.data(), size, cudaMemcpyHostToDevice));  //copy random vector from host to device.
-    cudaCheck(cudaMemcpy(dvect.dVect2, vect.vect2.data(), size, cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(dvect.dVect2, vect.vect2.data(), size, cudaMemcpyHostToDevice));
 
     timing.copyToDevice[1] = std::chrono::steady_clock::now();  //get current tick time  in monotonic point.
 
@@ -633,7 +633,7 @@ Timing cudaTimePart1(Timing &timing, Vectors &vect, Pointers &dvect, int size, i
     blocks = std::min(blocks, 8);  // Number 8 is least number can be got from lowest Nevedia GPUs.
 
     ////////////////////////// CAll Device Kernel //////////////////////////////////
-    cudaCheck(cudaEventRecord(timing.start));
+    CUDA_CHECK(cudaEventRecord(timing.start));
     timing.operationOnDeviceByHost[0] = std::chrono::steady_clock::now();
 
     addVectorsGpu<<<blocks, threads>>>(dvect.dVect1,
@@ -641,17 +641,17 @@ Timing cudaTimePart1(Timing &timing, Vectors &vect, Pointers &dvect, int size, i
                                        dvect.dVect3,
                                        sizeOfVector,
                                        task);  //call device function to add two vectors and save into vect3Gpu.
-    cudaCheck(cudaGetLastError());
+    CUDA_CHECK(cudaGetLastError());
 
-    cudaCheck(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaDeviceSynchronize());
 
     timing.operationOnDeviceByHost[1] = std::chrono::steady_clock::now();
-    cudaCheck(cudaEventRecord(timing.stop));
+    CUDA_CHECK(cudaEventRecord(timing.stop));
 
     ////////////////////////// Copy From Device To Host //////////////////////////////////
     timing.copyToHost[0] = std::chrono::steady_clock::now();
 
-    cudaCheck(cudaMemcpy(
+    CUDA_CHECK(cudaMemcpy(
         vect.vect3Gpu.data(),
         dvect.dVect3,
         size,
@@ -661,8 +661,8 @@ Timing cudaTimePart1(Timing &timing, Vectors &vect, Pointers &dvect, int size, i
 
     calculateTimeDuration(timing, i);
 
-    cudaCheck(cudaEventDestroy(timing.start));
-    cudaCheck(cudaEventDestroy(timing.stop));
+    CUDA_CHECK(cudaEventDestroy(timing.start));
+    CUDA_CHECK(cudaEventDestroy(timing.stop));
   }
 
   //////////////////// End Average //////////////////////
@@ -677,9 +677,9 @@ Timing cudaTimePart1(Timing &timing, Vectors &vect, Pointers &dvect, int size, i
       std::cout << "\nThe File is saved successfuly.\n";
     }
   }
-  cudaCheck(cudaFree(dvect.dVect1));
-  cudaCheck(cudaFree(dvect.dVect2));
-  cudaCheck(cudaFree(dvect.dVect3));
+  CUDA_CHECK(cudaFree(dvect.dVect1));
+  CUDA_CHECK(cudaFree(dvect.dVect2));
+  CUDA_CHECK(cudaFree(dvect.dVect3));
 
   return timing;
 }
@@ -691,14 +691,14 @@ Timing cudaTimePart2(Timing &timing, Vectors &vect, int size) {
   for (int i = 0; i < averg; i++) {
     std::fill(vect.vect3Gpu.begin(), vect.vect3Gpu.end(), 0);
 
-    cudaCheck(cudaEventCreate(&timing.start));  //inialize Event.
-    cudaCheck(cudaEventCreate(&timing.stop));
+    CUDA_CHECK(cudaEventCreate(&timing.start));  //inialize Event.
+    CUDA_CHECK(cudaEventCreate(&timing.stop));
 
     timing.copyToDevice[0] = std::chrono::steady_clock::now();  //get current tick time  in monotonic point.
 
-    cudaCheck(cudaHostRegister(vect.vect1.data(), size, cudaHostRegisterDefault));
-    cudaCheck(cudaHostRegister(vect.vect2.data(), size, cudaHostRegisterDefault));
-    cudaCheck(cudaHostRegister(vect.vect3Gpu.data(), size, cudaHostRegisterDefault));
+    CUDA_CHECK(cudaHostRegister(vect.vect1.data(), size, cudaHostRegisterDefault));
+    CUDA_CHECK(cudaHostRegister(vect.vect2.data(), size, cudaHostRegisterDefault));
+    CUDA_CHECK(cudaHostRegister(vect.vect3Gpu.data(), size, cudaHostRegisterDefault));
 
     timing.copyToDevice[1] = std::chrono::steady_clock::now();  //get current tick time  in monotonic point.
 
@@ -707,8 +707,8 @@ Timing cudaTimePart2(Timing &timing, Vectors &vect, int size) {
     blocks = std::min(blocks, 8);  // Number 8 is least number can be got from lowest Nevedia GPUs.
 
     timing.operationOnDeviceByHost[0] = std::chrono::steady_clock::now();
-    cudaCheck(cudaEventRecord(timing.start));
-    cudaCheck(cudaEventSynchronize(
+    CUDA_CHECK(cudaEventRecord(timing.start));
+    CUDA_CHECK(cudaEventSynchronize(
         timing.start));  //If the cudaEventBlockingSync flag has not been set, then the CPU thread will busy-wait until the event has been completed by the GPU.
 
     addVectorsGpu<<<blocks, threads>>>(vect.vect1.data(),
@@ -716,26 +716,26 @@ Timing cudaTimePart2(Timing &timing, Vectors &vect, int size) {
                                        vect.vect3Gpu.data(),
                                        sizeOfVector,
                                        task);  //call device function to add two vectors and save into vect3Gpu.
-    cudaCheck(cudaGetLastError());
+    CUDA_CHECK(cudaGetLastError());
 
-    cudaCheck(cudaDeviceSynchronize());
-    cudaCheck(cudaEventRecord(timing.stop));
-    cudaCheck(cudaEventSynchronize(timing.stop));
+    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaEventRecord(timing.stop));
+    CUDA_CHECK(cudaEventSynchronize(timing.stop));
 
     timing.operationOnDeviceByHost[1] = std::chrono::steady_clock::now();
 
     timing.copyToHost[0] = std::chrono::steady_clock::now();
 
-    cudaCheck(cudaHostUnregister(vect.vect1.data()));
-    cudaCheck(cudaHostUnregister(vect.vect2.data()));
-    cudaCheck(cudaHostUnregister(vect.vect3Gpu.data()));
+    CUDA_CHECK(cudaHostUnregister(vect.vect1.data()));
+    CUDA_CHECK(cudaHostUnregister(vect.vect2.data()));
+    CUDA_CHECK(cudaHostUnregister(vect.vect3Gpu.data()));
 
     timing.copyToHost[1] = std::chrono::steady_clock::now();
 
     calculateTimeDuration(timing, i);
 
-    cudaCheck(cudaEventDestroy(timing.start));
-    cudaCheck(cudaEventDestroy(timing.stop));
+    CUDA_CHECK(cudaEventDestroy(timing.start));
+    CUDA_CHECK(cudaEventDestroy(timing.stop));
   }
   //////////////////// End Average //////////////////////
   bool test = 0;
@@ -759,21 +759,21 @@ Timing cudaTimePart3(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
   std::cout << "\nCudaMallocHost is applied Part 3.\n";
   timing.partChosen = 3;
 
-  cudaCheck(cudaMallocHost((void **)&dvect.dVect1, size));  //allocate memory space for vector in the host memory.
-  cudaCheck(cudaMallocHost((void **)&dvect.dVect2, size));
-  cudaCheck(cudaMallocHost((void **)&dvect.dVect3, size));
+  CUDA_CHECK(cudaMallocHost((void **)&dvect.dVect1, size));  //allocate memory space for vector in the host memory.
+  CUDA_CHECK(cudaMallocHost((void **)&dvect.dVect2, size));
+  CUDA_CHECK(cudaMallocHost((void **)&dvect.dVect3, size));
 
   //////////// Start Average From Here /////////////////////
   for (int i = 0; i < averg; i++) {
     std::fill(vect.vect3Gpu.begin(), vect.vect3Gpu.end(), 0);
 
-    cudaCheck(cudaEventCreate(&timing.start));  //inialize Event.
-    cudaCheck(cudaEventCreate(&timing.stop));
+    CUDA_CHECK(cudaEventCreate(&timing.start));  //inialize Event.
+    CUDA_CHECK(cudaEventCreate(&timing.stop));
 
     timing.copyToDevice[0] = std::chrono::steady_clock::now();  //get current tick time  in monotonic point.
 
-    cudaCheck(cudaMemcpy(dvect.dVect1, vect.vect1.data(), size, cudaMemcpyHostToDevice));
-    cudaCheck(cudaMemcpy(dvect.dVect2, vect.vect2.data(), size, cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(dvect.dVect1, vect.vect1.data(), size, cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(dvect.dVect2, vect.vect2.data(), size, cudaMemcpyHostToDevice));
 
     timing.copyToDevice[1] = std::chrono::steady_clock::now();  //get current tick time  in monotonic point.
 
@@ -782,8 +782,8 @@ Timing cudaTimePart3(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
     blocks = std::min(blocks, 8);  // Number 8 is least number can be got from lowest Nevedia GPUs.
 
     timing.operationOnDeviceByHost[0] = std::chrono::steady_clock::now();
-    cudaCheck(cudaEventRecord(timing.start));
-    cudaCheck(cudaEventSynchronize(
+    CUDA_CHECK(cudaEventRecord(timing.start));
+    CUDA_CHECK(cudaEventSynchronize(
         timing.start));  //Waits for an event to complete.If the cudaEventBlockingSync flag has not been set, then the CPU thread will busy-wait until the event has been completed by the GPU.
 
     addVectorsGpu<<<blocks, threads>>>(dvect.dVect1,
@@ -791,25 +791,25 @@ Timing cudaTimePart3(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
                                        dvect.dVect3,
                                        sizeOfVector,
                                        task);  //call device function to add two vectors and save into vect3Gpu.
-    cudaCheck(cudaGetLastError());
+    CUDA_CHECK(cudaGetLastError());
 
-    cudaCheck(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaDeviceSynchronize());
 
-    cudaCheck(cudaEventRecord(timing.stop));
-    cudaCheck(cudaEventSynchronize(timing.stop));
+    CUDA_CHECK(cudaEventRecord(timing.stop));
+    CUDA_CHECK(cudaEventSynchronize(timing.stop));
 
     timing.operationOnDeviceByHost[1] = std::chrono::steady_clock::now();
 
     timing.copyToHost[0] = std::chrono::steady_clock::now();
 
-    cudaCheck(cudaMemcpy(vect.vect3Gpu.data(), dvect.dVect3, size, cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(vect.vect3Gpu.data(), dvect.dVect3, size, cudaMemcpyDeviceToHost));
 
     timing.copyToHost[1] = std::chrono::steady_clock::now();
 
     calculateTimeDuration(timing, i);
 
-    cudaCheck(cudaEventDestroy(timing.start));
-    cudaCheck(cudaEventDestroy(timing.stop));
+    CUDA_CHECK(cudaEventDestroy(timing.start));
+    CUDA_CHECK(cudaEventDestroy(timing.stop));
   }
   //////////////////// End Average //////////////////////
   bool test = 0;
@@ -825,9 +825,9 @@ Timing cudaTimePart3(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
       std::cout << "\nThe File is saved successfuly.\n";
     }
   }
-  cudaCheck(cudaFreeHost(dvect.dVect1));
-  cudaCheck(cudaFreeHost(dvect.dVect2));
-  cudaCheck(cudaFreeHost(dvect.dVect3));
+  CUDA_CHECK(cudaFreeHost(dvect.dVect1));
+  CUDA_CHECK(cudaFreeHost(dvect.dVect2));
+  CUDA_CHECK(cudaFreeHost(dvect.dVect3));
   return timing;
 }
 Timing cudaTimePart4(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
@@ -835,28 +835,28 @@ Timing cudaTimePart4(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
   timing.partChosen = 4;
 
   //Using cudaMallocHost for pinning Vector Memory.
-  cudaCheck(cudaMallocHost((void **)&dvect.dVect1, size));  //allocate memory inside the host and pinned that memory.
-  cudaCheck(cudaMallocHost((void **)&dvect.dVect2, size));
-  cudaCheck(cudaMallocHost((void **)&dvect.dVect3, size));
+  CUDA_CHECK(cudaMallocHost((void **)&dvect.dVect1, size));  //allocate memory inside the host and pinned that memory.
+  CUDA_CHECK(cudaMallocHost((void **)&dvect.dVect2, size));
+  CUDA_CHECK(cudaMallocHost((void **)&dvect.dVect3, size));
 
-  cudaCheck(cudaMalloc((void **)&dvect.dVect1Extra, size));  //Allocate memory inside the device.
-  cudaCheck(cudaMalloc((void **)&dvect.dVect2Extra, size));
-  cudaCheck(cudaMalloc((void **)&dvect.dVect3Extra, size));
+  CUDA_CHECK(cudaMalloc((void **)&dvect.dVect1Extra, size));  //Allocate memory inside the device.
+  CUDA_CHECK(cudaMalloc((void **)&dvect.dVect2Extra, size));
+  CUDA_CHECK(cudaMalloc((void **)&dvect.dVect3Extra, size));
 
   //////////// Start Average From Here /////////////////////
   for (int i = 0; i < averg; i++) {
     std::fill(vect.vect3Gpu.begin(), vect.vect3Gpu.end(), 0);
 
-    cudaCheck(cudaEventCreate(&timing.start));  //inialize Event.
-    cudaCheck(cudaEventCreate(&timing.stop));
+    CUDA_CHECK(cudaEventCreate(&timing.start));  //inialize Event.
+    CUDA_CHECK(cudaEventCreate(&timing.stop));
 
     timing.copyToDevice[0] = std::chrono::steady_clock::now();  //get current tick time  in monotonic point.
 
     memcpy(dvect.dVect1, vect.vect1.data(), size);  //Copy from vector host to pinned buffer Host.
     memcpy(dvect.dVect2, vect.vect2.data(), size);
 
-    cudaCheck(cudaMemcpy(dvect.dVect1Extra, dvect.dVect1, size, cudaMemcpyHostToDevice));
-    cudaCheck(cudaMemcpy(dvect.dVect2Extra, dvect.dVect2, size, cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(dvect.dVect1Extra, dvect.dVect1, size, cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(dvect.dVect2Extra, dvect.dVect2, size, cudaMemcpyHostToDevice));
 
     timing.copyToDevice[1] = std::chrono::steady_clock::now();  //get current tick time  in monotonic point.
 
@@ -865,8 +865,8 @@ Timing cudaTimePart4(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
     blocks = std::min(blocks, 8);  // Number 8 is least number can be got from lowest Nevedia GPUs.
 
     timing.operationOnDeviceByHost[0] = std::chrono::steady_clock::now();
-    cudaCheck(cudaEventRecord(timing.start));
-    cudaCheck(cudaEventSynchronize(
+    CUDA_CHECK(cudaEventRecord(timing.start));
+    CUDA_CHECK(cudaEventSynchronize(
         timing.start));  //Waits for an event to complete.If the cudaEventBlockingSync flag has not been set, then the CPU thread will busy-wait until the event has been completed by the GPU.
 
     addVectorsGpu<<<blocks, threads>>>(dvect.dVect1Extra,
@@ -874,25 +874,25 @@ Timing cudaTimePart4(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
                                        dvect.dVect3Extra,
                                        sizeOfVector,
                                        task);  //call device function to add two vectors and save into vect3Gpu.
-    cudaCheck(cudaGetLastError());
+    CUDA_CHECK(cudaGetLastError());
 
-    cudaCheck(cudaDeviceSynchronize());
-    cudaCheck(cudaEventRecord(timing.stop));
-    cudaCheck(cudaEventSynchronize(timing.stop));
+    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaEventRecord(timing.stop));
+    CUDA_CHECK(cudaEventSynchronize(timing.stop));
 
     timing.operationOnDeviceByHost[1] = std::chrono::steady_clock::now();
 
     timing.copyToHost[0] = std::chrono::steady_clock::now();
 
-    cudaCheck(cudaMemcpy(dvect.dVect3, dvect.dVect3Extra, size, cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(dvect.dVect3, dvect.dVect3Extra, size, cudaMemcpyDeviceToHost));
     memcpy(vect.vect3Gpu.data(), dvect.dVect3, size);  //copy pinned host buffer to vector host.
 
     timing.copyToHost[1] = std::chrono::steady_clock::now();
 
     calculateTimeDuration(timing, i);
 
-    cudaCheck(cudaEventDestroy(timing.start));
-    cudaCheck(cudaEventDestroy(timing.stop));
+    CUDA_CHECK(cudaEventDestroy(timing.start));
+    CUDA_CHECK(cudaEventDestroy(timing.stop));
   }
   //////////////////// End Average //////////////////////
   bool test = 0;
@@ -908,12 +908,12 @@ Timing cudaTimePart4(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
     }
   }
 
-  cudaCheck(cudaFreeHost(dvect.dVect1));
-  cudaCheck(cudaFreeHost(dvect.dVect2));
-  cudaCheck(cudaFreeHost(dvect.dVect3));
-  cudaCheck(cudaFree(dvect.dVect1Extra));
-  cudaCheck(cudaFree(dvect.dVect2Extra));
-  cudaCheck(cudaFree(dvect.dVect3Extra));
+  CUDA_CHECK(cudaFreeHost(dvect.dVect1));
+  CUDA_CHECK(cudaFreeHost(dvect.dVect2));
+  CUDA_CHECK(cudaFreeHost(dvect.dVect3));
+  CUDA_CHECK(cudaFree(dvect.dVect1Extra));
+  CUDA_CHECK(cudaFree(dvect.dVect2Extra));
+  CUDA_CHECK(cudaFree(dvect.dVect3Extra));
 
   return timing;
 }
@@ -922,28 +922,28 @@ Timing cudaTimePart5(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
   std::cout << "\nCudaHostRegister is applied Part 5.\n";
   timing.partChosen = 5;
 
-  cudaCheck(
+  CUDA_CHECK(
       cudaMalloc((void **)&dvect.dVect1, size));  //allocate memory space for vector in the global memory of the Device.
-  cudaCheck(cudaMalloc((void **)&dvect.dVect2, size));
-  cudaCheck(cudaMalloc((void **)&dvect.dVect3, size));
+  CUDA_CHECK(cudaMalloc((void **)&dvect.dVect2, size));
+  CUDA_CHECK(cudaMalloc((void **)&dvect.dVect3, size));
 
   //////////// Start Average From Here /////////////////////
   for (int i = 0; i < averg; i++) {
     std::fill(vect.vect3Gpu.begin(), vect.vect3Gpu.end(), 0);
 
-    cudaCheck(cudaEventCreate(&timing.start));  //inialize Event.
-    cudaCheck(cudaEventCreate(&timing.stop));
+    CUDA_CHECK(cudaEventCreate(&timing.start));  //inialize Event.
+    CUDA_CHECK(cudaEventCreate(&timing.stop));
 
     timing.copyToDevice[0] = std::chrono::steady_clock::now();  //get current tick time  in monotonic point.
-    cudaCheck(cudaHostRegister(vect.vect1.data(), size, cudaHostRegisterDefault));
-    cudaCheck(cudaHostRegister(vect.vect2.data(), size, cudaHostRegisterDefault));
-    cudaCheck(cudaHostRegister(vect.vect3Gpu.data(), size, cudaHostRegisterDefault));
+    CUDA_CHECK(cudaHostRegister(vect.vect1.data(), size, cudaHostRegisterDefault));
+    CUDA_CHECK(cudaHostRegister(vect.vect2.data(), size, cudaHostRegisterDefault));
+    CUDA_CHECK(cudaHostRegister(vect.vect3Gpu.data(), size, cudaHostRegisterDefault));
 
-    cudaCheck(cudaMemcpy(dvect.dVect1,
-                         vect.vect1.data(),
-                         size,
-                         cudaMemcpyHostToDevice));  //copy pinned vector in the host to buffer in the device.
-    cudaCheck(cudaMemcpy(dvect.dVect2, vect.vect2.data(), size, cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(dvect.dVect1,
+                          vect.vect1.data(),
+                          size,
+                          cudaMemcpyHostToDevice));  //copy pinned vector in the host to buffer in the device.
+    CUDA_CHECK(cudaMemcpy(dvect.dVect2, vect.vect2.data(), size, cudaMemcpyHostToDevice));
 
     timing.copyToDevice[1] = std::chrono::steady_clock::now();  //get current tick time  in monotonic point.
 
@@ -952,8 +952,8 @@ Timing cudaTimePart5(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
     blocks = std::min(blocks, 8);  // Number 8 is least number can be got from lowest Nevedia GPUs.
 
     timing.operationOnDeviceByHost[0] = std::chrono::steady_clock::now();
-    cudaCheck(cudaEventRecord(timing.start));
-    cudaCheck(cudaEventSynchronize(
+    CUDA_CHECK(cudaEventRecord(timing.start));
+    CUDA_CHECK(cudaEventSynchronize(
         timing.start));  //If the cudaEventBlockingSync flag has not been set, then the CPU thread will busy-wait until the event has been completed by the GPU.
 
     addVectorsGpu<<<blocks, threads>>>(dvect.dVect1,
@@ -961,30 +961,30 @@ Timing cudaTimePart5(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
                                        dvect.dVect3,
                                        sizeOfVector,
                                        task);  //call device function to add two vectors and save into vect3Gpu.
-    cudaCheck(cudaGetLastError());
+    CUDA_CHECK(cudaGetLastError());
 
-    cudaCheck(cudaDeviceSynchronize());
-    cudaCheck(cudaEventRecord(timing.stop));
-    cudaCheck(cudaEventSynchronize(timing.stop));
+    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaEventRecord(timing.stop));
+    CUDA_CHECK(cudaEventSynchronize(timing.stop));
 
     timing.operationOnDeviceByHost[1] = std::chrono::steady_clock::now();
 
     timing.copyToHost[0] = std::chrono::steady_clock::now();
 
-    cudaCheck(cudaMemcpy(vect.vect3Gpu.data(),
-                         dvect.dVect3,
-                         size,
-                         cudaMemcpyDeviceToHost));  //copy  buffer in the device to pinned vector in the host.
-    cudaCheck(cudaHostUnregister(vect.vect1.data()));
-    cudaCheck(cudaHostUnregister(vect.vect2.data()));
-    cudaCheck(cudaHostUnregister(vect.vect3Gpu.data()));
+    CUDA_CHECK(cudaMemcpy(vect.vect3Gpu.data(),
+                          dvect.dVect3,
+                          size,
+                          cudaMemcpyDeviceToHost));  //copy  buffer in the device to pinned vector in the host.
+    CUDA_CHECK(cudaHostUnregister(vect.vect1.data()));
+    CUDA_CHECK(cudaHostUnregister(vect.vect2.data()));
+    CUDA_CHECK(cudaHostUnregister(vect.vect3Gpu.data()));
 
     timing.copyToHost[1] = std::chrono::steady_clock::now();
 
     calculateTimeDuration(timing, i);
 
-    cudaCheck(cudaEventDestroy(timing.start));
-    cudaCheck(cudaEventDestroy(timing.stop));
+    CUDA_CHECK(cudaEventDestroy(timing.start));
+    CUDA_CHECK(cudaEventDestroy(timing.stop));
   }
   //////////////////// End Average //////////////////////
   bool test = 0;
@@ -1000,8 +1000,8 @@ Timing cudaTimePart5(Timing &timing, Vectors &vect, Pointers &dvect, int size) {
       std::cout << "\nThe File is saved successfuly.\n";
     }
   }
-  cudaCheck(cudaFree(dvect.dVect1));
-  cudaCheck(cudaFree(dvect.dVect2));
-  cudaCheck(cudaFree(dvect.dVect3));
+  CUDA_CHECK(cudaFree(dvect.dVect1));
+  CUDA_CHECK(cudaFree(dvect.dVect2));
+  CUDA_CHECK(cudaFree(dvect.dVect3));
   return timing;
 }

--- a/HeterogeneousCore/CUDACore/test/mpiCudaGeneric.cu
+++ b/HeterogeneousCore/CUDACore/test/mpiCudaGeneric.cu
@@ -582,10 +582,11 @@ Timing blockSendPart1(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
 
   if (mpiData.rank)  //Only for Workers
   {
-    cudaCheck(cudaMalloc((void **)&pointer.dVect1,
-                         user.sizeVectorBytes));  //allocate memory space for vector in the global memory of the Device.
-    cudaCheck(cudaMalloc((void **)&pointer.dVect2, user.sizeVectorBytes));
-    cudaCheck(cudaMalloc((void **)&pointer.dVect3, user.sizeVectorBytes));
+    CUDA_CHECK(
+        cudaMalloc((void **)&pointer.dVect1,
+                   user.sizeVectorBytes));  //allocate memory space for vector in the global memory of the Device.
+    CUDA_CHECK(cudaMalloc((void **)&pointer.dVect2, user.sizeVectorBytes));
+    CUDA_CHECK(cudaMalloc((void **)&pointer.dVect3, user.sizeVectorBytes));
   }
   ///////////////////////////// Start of Average ////////////////////////
   for (int a = 0; a <= average; ++a) {
@@ -626,17 +627,17 @@ Timing blockSendPart1(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
                MPI_COMM_WORLD,
                MPI_STATUS_IGNORE);
 
-      cudaCheck(cudaMemcpy(pointer.dVect1,
-                           mpiData.mVectWorker1,
-                           user.sizeVectorBytes,
-                           cudaMemcpyHostToDevice));  //copy random vector from host to device.
-      cudaCheck(cudaMemcpy(pointer.dVect2, mpiData.mVectWorker2, user.sizeVectorBytes, cudaMemcpyHostToDevice));
+      CUDA_CHECK(cudaMemcpy(pointer.dVect1,
+                            mpiData.mVectWorker1,
+                            user.sizeVectorBytes,
+                            cudaMemcpyHostToDevice));  //copy random vector from host to device.
+      CUDA_CHECK(cudaMemcpy(pointer.dVect2, mpiData.mVectWorker2, user.sizeVectorBytes, cudaMemcpyHostToDevice));
 
       timing.inputPreparationHost[1] = MPI_Wtime();
       ///////////////////////////////////////////////////////////////////////////////////////
 
-      cudaCheck(cudaEventCreate(&timing.start));  //inialize Event.
-      cudaCheck(cudaEventCreate(&timing.stop));
+      CUDA_CHECK(cudaEventCreate(&timing.start));  //inialize Event.
+      CUDA_CHECK(cudaEventCreate(&timing.stop));
 
       ///////////////////////////// Operation on Device with respect of Host //////////////////
 
@@ -645,7 +646,7 @@ Timing blockSendPart1(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
       blocks = std::min(blocks, 8);  // Number 8 is least number can be got from lowest Nevedia GPUs.
 
       ////////////////////////// CAll Device Kernel //////////////////////////////////
-      cudaCheck(cudaEventRecord(timing.start));
+      CUDA_CHECK(cudaEventRecord(timing.start));
       timing.operationOnDeviceByHost[0] = MPI_Wtime();
 
       addVectorsGpu<<<blocks, threads>>>(pointer.dVect1,
@@ -654,16 +655,16 @@ Timing blockSendPart1(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
                                          sizeVector,
                                          task);  //call device function to add two vectors and save into vect3Gpu.
 
-      cudaCheck(cudaGetLastError());
-      cudaCheck(cudaDeviceSynchronize());
-      cudaCheck(cudaEventRecord(timing.stop));
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+      CUDA_CHECK(cudaEventRecord(timing.stop));
 
       timing.operationOnDeviceByHost[1] = MPI_Wtime();
       /////////////////////////////////////////////////////////////////////////////////////////////
 
       /////////////////////////////////// Output Prepation for the Host //////////////////////////////////////
       timing.outputPreparationHost[0] = MPI_Wtime();
-      cudaCheck(cudaMemcpy(
+      CUDA_CHECK(cudaMemcpy(
           mpiData.mVectWorker3,
           pointer.dVect3,
           user.sizeVectorBytes,
@@ -702,15 +703,15 @@ Timing blockSendPart1(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
       calculateTimeDuration(timing, a - 1, mpiData.rank);
 
     if (mpiData.rank) {
-      cudaCheck(cudaEventDestroy(timing.start));
-      cudaCheck(cudaEventDestroy(timing.stop));
+      CUDA_CHECK(cudaEventDestroy(timing.start));
+      CUDA_CHECK(cudaEventDestroy(timing.stop));
     }
   }
   ///////////////////////////// End of Average ////////////////////////
   if (mpiData.rank) {
-    cudaCheck(cudaFree(pointer.dVect1));
-    cudaCheck(cudaFree(pointer.dVect2));
-    cudaCheck(cudaFree(pointer.dVect3));
+    CUDA_CHECK(cudaFree(pointer.dVect1));
+    CUDA_CHECK(cudaFree(pointer.dVect2));
+    CUDA_CHECK(cudaFree(pointer.dVect3));
   }
   ///
   bool test = 0;
@@ -745,13 +746,14 @@ Timing blockSendPart2(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
 
   if (mpiData.rank)  //Only for Workers
   {
-    cudaCheck(cudaMallocHost((void **)&pointer.vect1, user.sizeVectorBytes));  //allocate Pinned memory on the Host.
-    cudaCheck(cudaMallocHost((void **)&pointer.vect2, user.sizeVectorBytes));
-    cudaCheck(cudaMallocHost((void **)&pointer.vect3, user.sizeVectorBytes));
-    cudaCheck(cudaMalloc((void **)&pointer.dVect1,
-                         user.sizeVectorBytes));  //allocate memory space for vector in the global memory of the Device.
-    cudaCheck(cudaMalloc((void **)&pointer.dVect2, user.sizeVectorBytes));
-    cudaCheck(cudaMalloc((void **)&pointer.dVect3, user.sizeVectorBytes));
+    CUDA_CHECK(cudaMallocHost((void **)&pointer.vect1, user.sizeVectorBytes));  //allocate Pinned memory on the Host.
+    CUDA_CHECK(cudaMallocHost((void **)&pointer.vect2, user.sizeVectorBytes));
+    CUDA_CHECK(cudaMallocHost((void **)&pointer.vect3, user.sizeVectorBytes));
+    CUDA_CHECK(
+        cudaMalloc((void **)&pointer.dVect1,
+                   user.sizeVectorBytes));  //allocate memory space for vector in the global memory of the Device.
+    CUDA_CHECK(cudaMalloc((void **)&pointer.dVect2, user.sizeVectorBytes));
+    CUDA_CHECK(cudaMalloc((void **)&pointer.dVect3, user.sizeVectorBytes));
   }
   ///////////////////////////// Start of Average ////////////////////////
   for (int a = 0; a <= average; ++a) {
@@ -793,17 +795,17 @@ Timing blockSendPart2(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
                MPI_COMM_WORLD,
                MPI_STATUS_IGNORE);
 
-      cudaCheck(cudaMemcpy(pointer.dVect1,
-                           pointer.vect1,
-                           user.sizeVectorBytes,
-                           cudaMemcpyHostToDevice));  //copy random vector from host to device.
-      cudaCheck(cudaMemcpy(pointer.dVect2, pointer.vect2, user.sizeVectorBytes, cudaMemcpyHostToDevice));
+      CUDA_CHECK(cudaMemcpy(pointer.dVect1,
+                            pointer.vect1,
+                            user.sizeVectorBytes,
+                            cudaMemcpyHostToDevice));  //copy random vector from host to device.
+      CUDA_CHECK(cudaMemcpy(pointer.dVect2, pointer.vect2, user.sizeVectorBytes, cudaMemcpyHostToDevice));
 
       timing.inputPreparationHost[1] = MPI_Wtime();
       ///////////////////////////////////////////////////////////////////////////////////////
 
-      cudaCheck(cudaEventCreate(&timing.start));  //inialize Event.
-      cudaCheck(cudaEventCreate(&timing.stop));
+      CUDA_CHECK(cudaEventCreate(&timing.start));  //inialize Event.
+      CUDA_CHECK(cudaEventCreate(&timing.stop));
 
       ///////////////////////////// Operation on Device with respect of Host //////////////////
 
@@ -812,7 +814,7 @@ Timing blockSendPart2(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
       blocks = std::min(blocks, 8);  // Number 8 is least number can be got from lowest Nevedia GPUs.
 
       ////////////////////////// CAll Device Kernel //////////////////////////////////
-      cudaCheck(cudaEventRecord(timing.start));
+      CUDA_CHECK(cudaEventRecord(timing.start));
       timing.operationOnDeviceByHost[0] = MPI_Wtime();
 
       addVectorsGpu<<<blocks, threads>>>(pointer.dVect1,
@@ -821,9 +823,9 @@ Timing blockSendPart2(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
                                          sizeVector,
                                          task);  //call device function to add two vectors and save into vect3Gpu.
 
-      cudaCheck(cudaGetLastError());
-      cudaCheck(cudaDeviceSynchronize());
-      cudaCheck(cudaEventRecord(timing.stop));
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+      CUDA_CHECK(cudaEventRecord(timing.stop));
 
       timing.operationOnDeviceByHost[1] = MPI_Wtime();
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -831,7 +833,7 @@ Timing blockSendPart2(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
       /////////////////////////////////// Output Prepation for the Host //////////////////////////////////////
       timing.outputPreparationHost[0] = MPI_Wtime();
 
-      cudaCheck(cudaMemcpy(
+      CUDA_CHECK(cudaMemcpy(
           pointer.vect3,
           pointer.dVect3,
           user.sizeVectorBytes,
@@ -871,18 +873,18 @@ Timing blockSendPart2(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
       calculateTimeDuration(timing, a - 1, mpiData.rank);
 
     if (mpiData.rank) {
-      cudaCheck(cudaEventDestroy(timing.start));
-      cudaCheck(cudaEventDestroy(timing.stop));
+      CUDA_CHECK(cudaEventDestroy(timing.start));
+      CUDA_CHECK(cudaEventDestroy(timing.stop));
     }
   }
   ///////////////////////////// End of Average ////////////////////////
   if (mpiData.rank) {
-    cudaCheck(cudaFreeHost(pointer.vect1));
-    cudaCheck(cudaFreeHost(pointer.vect2));
-    cudaCheck(cudaFreeHost(pointer.vect3));
-    cudaCheck(cudaFree(pointer.dVect1));
-    cudaCheck(cudaFree(pointer.dVect2));
-    cudaCheck(cudaFree(pointer.dVect3));
+    CUDA_CHECK(cudaFreeHost(pointer.vect1));
+    CUDA_CHECK(cudaFreeHost(pointer.vect2));
+    CUDA_CHECK(cudaFreeHost(pointer.vect3));
+    CUDA_CHECK(cudaFree(pointer.dVect1));
+    CUDA_CHECK(cudaFree(pointer.dVect2));
+    CUDA_CHECK(cudaFree(pointer.dVect3));
   }
 
   bool test = 0;
@@ -917,10 +919,11 @@ Timing blockSendPart3(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
 
   if (mpiData.rank)  //Only for Workers
   {
-    cudaCheck(cudaMalloc((void **)&pointer.dVect1,
-                         user.sizeVectorBytes));  //allocate memory space for vector in the global memory of the Device.
-    cudaCheck(cudaMalloc((void **)&pointer.dVect2, user.sizeVectorBytes));
-    cudaCheck(cudaMalloc((void **)&pointer.dVect3, user.sizeVectorBytes));
+    CUDA_CHECK(
+        cudaMalloc((void **)&pointer.dVect1,
+                   user.sizeVectorBytes));  //allocate memory space for vector in the global memory of the Device.
+    CUDA_CHECK(cudaMalloc((void **)&pointer.dVect2, user.sizeVectorBytes));
+    CUDA_CHECK(cudaMalloc((void **)&pointer.dVect3, user.sizeVectorBytes));
   }
   ///////////////////////////// Start of Average ////////////////////////
   for (int a = 0; a <= average; ++a) {
@@ -961,14 +964,14 @@ Timing blockSendPart3(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
                MPI_COMM_WORLD,
                MPI_STATUS_IGNORE);
 
-      // cudaCheck(cudaMemcpy(pointer.dVect1, mpiData.mVectWorker1, user.sizeVectorBytes, cudaMemcpyHostToDevice));  //copy random vector from host to device.
-      // cudaCheck(cudaMemcpy(pointer.dVect2, mpiData.mVectWorker2, user.sizeVectorBytes, cudaMemcpyHostToDevice));
+      // CUDA_CHECK(cudaMemcpy(pointer.dVect1, mpiData.mVectWorker1, user.sizeVectorBytes, cudaMemcpyHostToDevice));  //copy random vector from host to device.
+      // CUDA_CHECK(cudaMemcpy(pointer.dVect2, mpiData.mVectWorker2, user.sizeVectorBytes, cudaMemcpyHostToDevice));
 
       timing.inputPreparationHost[1] = MPI_Wtime();
       ///////////////////////////////////////////////////////////////////////////////////////
 
-      cudaCheck(cudaEventCreate(&timing.start));  //inialize Event.
-      cudaCheck(cudaEventCreate(&timing.stop));
+      CUDA_CHECK(cudaEventCreate(&timing.start));  //inialize Event.
+      CUDA_CHECK(cudaEventCreate(&timing.stop));
 
       ///////////////////////////// Operation on Device with respect of Host //////////////////
 
@@ -977,7 +980,7 @@ Timing blockSendPart3(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
       blocks = std::min(blocks, 8);  // Number 8 is least number can be got from lowest Nevedia GPUs.
 
       ////////////////////////// CAll Device Kernel //////////////////////////////////
-      cudaCheck(cudaEventRecord(timing.start));
+      CUDA_CHECK(cudaEventRecord(timing.start));
       timing.operationOnDeviceByHost[0] = MPI_Wtime();
 
       addVectorsGpu<<<blocks, threads>>>(pointer.dVect1,
@@ -986,16 +989,16 @@ Timing blockSendPart3(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
                                          sizeVector,
                                          task);  //call device function to add two vectors and save into vect3Gpu.
 
-      cudaCheck(cudaGetLastError());
-      cudaCheck(cudaDeviceSynchronize());
-      cudaCheck(cudaEventRecord(timing.stop));
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+      CUDA_CHECK(cudaEventRecord(timing.stop));
 
       timing.operationOnDeviceByHost[1] = MPI_Wtime();
       /////////////////////////////////////////////////////////////////////////////////////////////
 
       /////////////////////////////////// Output Prepation for the Host //////////////////////////////////////
       timing.outputPreparationHost[0] = MPI_Wtime();
-      //cudaCheck(cudaMemcpy(mpiData.mVectWorker3,pointer.dVect3,user.sizeVectorBytes,cudaMemcpyDeviceToHost));  //copy summing result vector from Device to Host.// Try_Regist(3) delete this
+      //CUDA_CHECK(cudaMemcpy(mpiData.mVectWorker3,pointer.dVect3,user.sizeVectorBytes,cudaMemcpyDeviceToHost));  //copy summing result vector from Device to Host.// Try_Regist(3) delete this
 
       MPI_Send(&pointer.dVect3[0],
                mpiData.numberToSend[mpiData.rank],
@@ -1030,15 +1033,15 @@ Timing blockSendPart3(MPIData &mpiData, Timing &timing, Pointers &pointer, UserC
       calculateTimeDuration(timing, a - 1, mpiData.rank);
 
     if (mpiData.rank) {
-      cudaCheck(cudaEventDestroy(timing.start));
-      cudaCheck(cudaEventDestroy(timing.stop));
+      CUDA_CHECK(cudaEventDestroy(timing.start));
+      CUDA_CHECK(cudaEventDestroy(timing.stop));
     }
   }
   ///////////////////////////// End of Average ////////////////////////
   if (mpiData.rank) {
-    cudaCheck(cudaFree(pointer.dVect1));
-    cudaCheck(cudaFree(pointer.dVect2));
-    cudaCheck(cudaFree(pointer.dVect3));
+    CUDA_CHECK(cudaFree(pointer.dVect1));
+    CUDA_CHECK(cudaFree(pointer.dVect2));
+    CUDA_CHECK(cudaFree(pointer.dVect3));
   }
   ///
   bool test = 0;

--- a/HeterogeneousCore/CUDACore/test/testStreamEvent.cu
+++ b/HeterogeneousCore/CUDACore/test/testStreamEvent.cu
@@ -40,8 +40,8 @@ int main() {
   cudaStream_t stream1, stream2;
   cudaEvent_t event1, event2;
 
-  cudaCheck(cudaMalloc(&dev_points1, ARRAY_SIZE * sizeof(float)));
-  cudaCheck(cudaMallocHost(&host_points1, ARRAY_SIZE * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&dev_points1, ARRAY_SIZE * sizeof(float)));
+  CUDA_CHECK(cudaMallocHost(&host_points1, ARRAY_SIZE * sizeof(float)));
   cudaStreamCreateWithFlags(&stream1, cudaStreamNonBlocking);
   cudaStreamCreateWithFlags(&stream2, cudaStreamNonBlocking);
   cudaEventCreate(&event1);
@@ -51,7 +51,7 @@ int main() {
     host_points1[j] = static_cast<float>(j);
   }
 
-  cudaCheck(cudaMemcpyAsync(dev_points1, host_points1, ARRAY_SIZE * sizeof(float), cudaMemcpyHostToDevice, stream1));
+  CUDA_CHECK(cudaMemcpyAsync(dev_points1, host_points1, ARRAY_SIZE * sizeof(float), cudaMemcpyHostToDevice, stream1));
   kernel_looping<<<1, 16, 0, stream1>>>(dev_points1, ARRAY_SIZE);
   if (debug)
     std::cout << "Kernel launched on stream1" << std::endl;

--- a/HeterogeneousCore/CUDAServices/plugins/CUDAMonitoringService.cc
+++ b/HeterogeneousCore/CUDAServices/plugins/CUDAMonitoringService.cc
@@ -81,12 +81,12 @@ namespace {
   void dumpUsedMemory(T& log, int num) {
     auto const cachingDeviceAllocatorStatus = cms::cuda::deviceAllocatorStatus();
     int old = 0;
-    cudaCheck(cudaGetDevice(&old));
+    CUDA_CHECK(cudaGetDevice(&old));
     constexpr auto mbytes = 1 << 20;
     for (int i = 0; i < num; ++i) {
       size_t freeMemory, totalMemory;
-      cudaCheck(cudaSetDevice(i));
-      cudaCheck(cudaMemGetInfo(&freeMemory, &totalMemory));
+      CUDA_CHECK(cudaSetDevice(i));
+      CUDA_CHECK(cudaMemGetInfo(&freeMemory, &totalMemory));
       log << "\n"
           << i << ": " << (totalMemory - freeMemory) / mbytes << " MB used / " << totalMemory / mbytes << " MB total";
       auto found = cachingDeviceAllocatorStatus.find(i);
@@ -97,7 +97,7 @@ namespace {
             << (cached.live + cached.free) / mbytes << " MB total cached";
       }
     }
-    cudaCheck(cudaSetDevice(old));
+    CUDA_CHECK(cudaSetDevice(old));
   }
 }  // namespace
 

--- a/HeterogeneousCore/CUDAServices/plugins/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/plugins/CUDAService.cc
@@ -60,7 +60,7 @@ private:
 void setCudaLimit(cudaLimit limit, const char* name, size_t request) {
   // read the current device
   int device;
-  cudaCheck(cudaGetDevice(&device));
+  CUDA_CHECK(cudaGetDevice(&device));
   // try to set the requested limit
   auto result = cudaDeviceSetLimit(limit, request);
   if (cudaErrorUnsupportedLimit == result) {
@@ -167,14 +167,14 @@ namespace {
 
   void devicePreallocate(int numberOfDevices, const std::vector<unsigned int>& bufferSizes) {
     int device;
-    cudaCheck(cudaGetDevice(&device));
+    CUDA_CHECK(cudaGetDevice(&device));
     for (int i = 0; i < numberOfDevices; ++i) {
-      cudaCheck(cudaSetDevice(i));
+      CUDA_CHECK(cudaSetDevice(i));
       preallocate<cms::cuda::device::unique_ptr>(
           [&](size_t size, cudaStream_t stream) { return cms::cuda::make_device_unique<char[]>(size, stream); },
           bufferSizes);
     }
-    cudaCheck(cudaSetDevice(device));
+    CUDA_CHECK(cudaSetDevice(device));
   }
 
   void hostPreallocate(const std::vector<unsigned int>& bufferSizes) {
@@ -209,19 +209,19 @@ CUDAService::CUDAService(edm::ParameterSet const& config) : verbose_(config.getU
     std::strncpy(systemDriverVersion, "unknown", sizeof(systemDriverVersion) - 1);
     systemDriverVersion[sizeof(systemDriverVersion) - 1] = '\0';
   } else {
-    nvmlCheck(nvmlSystemGetDriverVersion(systemDriverVersion, sizeof(systemDriverVersion)));
-    nvmlCheck(nvmlShutdown());
+    NVML_CHECK(nvmlSystemGetDriverVersion(systemDriverVersion, sizeof(systemDriverVersion)));
+    NVML_CHECK(nvmlShutdown());
   }
 
   // CUDA driver version, e.g. 11.4
   // the full version, like 11.4.1 or 11.4.100, is not reported
   int driverVersion = 0;
-  cudaCheck(cudaDriverGetVersion(&driverVersion));
+  CUDA_CHECK(cudaDriverGetVersion(&driverVersion));
 
   // CUDA runtime version, e.g. 11.4
   // the full version, like 11.4.1 or 11.4.108, is not reported
   int runtimeVersion = 0;
-  cudaCheck(cudaRuntimeGetVersion(&runtimeVersion));
+  CUDA_CHECK(cudaRuntimeGetVersion(&runtimeVersion));
 
   edm::LogInfo log("CUDAService");
   if (verbose_) {
@@ -248,7 +248,7 @@ CUDAService::CUDAService(edm::ParameterSet const& config) : verbose_(config.getU
     // read information about the compute device.
     // see the documentation of cudaGetDeviceProperties() for more information.
     cudaDeviceProp properties;
-    cudaCheck(cudaGetDeviceProperties(&properties, i));
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, i));
     log << '\n' << "CUDA device " << i << ": " << properties.name;
     if (verbose_) {
       log << '\n';
@@ -275,7 +275,7 @@ CUDAService::CUDAService(edm::ParameterSet const& config) : verbose_(config.getU
 #if CUDART_VERSION < 13000
       singleToDoublePrecisionPerfRatio = properties.singleToDoublePrecisionPerfRatio;
 #else
-      cudaCheck(
+      CUDA_CHECK(
           cudaDeviceGetAttribute(&singleToDoublePrecisionPerfRatio, cudaDevAttrSingleToDoublePrecisionPerfRatio, i));
 #endif
       log << "  single to double performance: " << std::setw(8) << singleToDoublePrecisionPerfRatio << ":1\n";
@@ -294,7 +294,7 @@ CUDAService::CUDAService(edm::ParameterSet const& config) : verbose_(config.getU
 #if CUDART_VERSION < 13000
       computeMode = properties.computeMode;
 #else
-      cudaCheck(cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode, i));
+      CUDA_CHECK(cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode, i));
 #endif
       if (computeMode < 0 or computeMode >= cudaComputeModeUnknown) {
         computeMode = cudaComputeModeUnknown;
@@ -303,14 +303,14 @@ CUDAService::CUDAService(edm::ParameterSet const& config) : verbose_(config.getU
     }
 
     // TODO if a device is in exclusive use, skip it and remove it from the list, instead of failing with abort()
-    cudaCheck(cudaSetDevice(i));
-    cudaCheck(cudaSetDeviceFlags(cudaDeviceScheduleAuto | cudaDeviceMapHost));
+    CUDA_CHECK(cudaSetDevice(i));
+    CUDA_CHECK(cudaSetDeviceFlags(cudaDeviceScheduleAuto | cudaDeviceMapHost));
 
     // read the free and total amount of memory available for allocation by the device, in bytes.
     // see the documentation of cudaMemGetInfo() for more information.
     if (verbose_) {
       size_t freeMemory, totalMemory;
-      cudaCheck(cudaMemGetInfo(&freeMemory, &totalMemory));
+      CUDA_CHECK(cudaMemGetInfo(&freeMemory, &totalMemory));
       log << "  memory: " << std::setw(6) << freeMemory / (1 << 20) << " MB free / " << std::setw(6)
           << totalMemory / (1 << 20) << " MB total\n";
       log << "  constant memory:               " << std::setw(6) << properties.totalConstMem / (1 << 10) << " kB\n";
@@ -357,7 +357,7 @@ CUDAService::CUDAService(edm::ParameterSet const& config) : verbose_(config.getU
     if (verbose_) {
       log << "CUDA flags\n";
       unsigned int flags;
-      cudaCheck(cudaGetDeviceFlags(&flags));
+      CUDA_CHECK(cudaGetDeviceFlags(&flags));
       switch (flags & cudaDeviceScheduleMask) {
         case cudaDeviceScheduleAuto:
           log << "  thread policy:                   default\n";
@@ -417,14 +417,14 @@ CUDAService::CUDAService(edm::ParameterSet const& config) : verbose_(config.getU
     if (verbose_) {
       size_t value;
       log << "CUDA limits\n";
-      cudaCheck(cudaDeviceGetLimit(&value, cudaLimitPrintfFifoSize));
+      CUDA_CHECK(cudaDeviceGetLimit(&value, cudaLimitPrintfFifoSize));
       log << "  printf buffer size:        " << std::setw(10) << value / (1 << 20) << " MB\n";
-      cudaCheck(cudaDeviceGetLimit(&value, cudaLimitStackSize));
+      CUDA_CHECK(cudaDeviceGetLimit(&value, cudaLimitStackSize));
       log << "  stack size:                " << std::setw(10) << value / (1 << 10) << " kB\n";
-      cudaCheck(cudaDeviceGetLimit(&value, cudaLimitMallocHeapSize));
+      CUDA_CHECK(cudaDeviceGetLimit(&value, cudaLimitMallocHeapSize));
       log << "  malloc heap size:          " << std::setw(10) << value / (1 << 20) << " MB\n";
       if ((properties.major > 3) or (properties.major == 3 and properties.minor >= 5)) {
-        cudaCheck(cudaDeviceGetLimit(&value, cudaLimitDevRuntimePendingLaunchCount));
+        CUDA_CHECK(cudaDeviceGetLimit(&value, cudaLimitDevRuntimePendingLaunchCount));
         log << "  runtime pending launch count: " << std::setw(10) << value << '\n';
       }
     }
@@ -468,8 +468,8 @@ CUDAService::~CUDAService() {
     cms::cuda::getStreamCache().clear();
 
     for (int i = 0; i < numberOfDevices_; ++i) {
-      cudaCheck(cudaSetDevice(i));
-      cudaCheck(cudaDeviceSynchronize());
+      CUDA_CHECK(cudaSetDevice(i));
+      CUDA_CHECK(cudaDeviceSynchronize());
       // Explicitly destroys and cleans up all resources associated with the current device in the
       // current process. Any subsequent API call to this device will reinitialize the device.
       // Useful to check for memory leaks with `cuda-memcheck --tool memcheck --leak-check full`.

--- a/HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h
@@ -12,7 +12,7 @@ namespace cms {
       // Store the original device, without setting a new one
       ScopedSetDevice() {
         // Store the original device
-        cudaCheck(cudaGetDevice(&originalDevice_));
+        CUDA_CHECK(cudaGetDevice(&originalDevice_));
       }
 
       // Store the original device, and set a new current device
@@ -33,7 +33,7 @@ namespace cms {
       // that will be restored when this object is destroyed
       void set(int device) {
         // Change the current device
-        cudaCheck(cudaSetDevice(device));
+        CUDA_CHECK(cudaSetDevice(device));
       }
 
     private:

--- a/HeterogeneousCore/CUDAUtilities/interface/copyAsync.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/copyAsync.h
@@ -22,7 +22,7 @@ namespace cms {
       // let's add an assert with a more helpful message
       static_assert(std::is_array<T>::value == false,
                     "For array types, use the other overload with the size parameter");
-      cudaCheck(cudaMemcpyAsync(dst.get(), src.get(), sizeof(T), cudaMemcpyHostToDevice, stream));
+      CUDA_CHECK(cudaMemcpyAsync(dst.get(), src.get(), sizeof(T), cudaMemcpyHostToDevice, stream));
     }
 
     template <typename T>
@@ -31,14 +31,14 @@ namespace cms {
       // let's add an assert with a more helpful message
       static_assert(std::is_array<T>::value == false,
                     "For array types, use the other overload with the size parameter");
-      cudaCheck(cudaMemcpyAsync(dst.get(), src.get(), sizeof(T), cudaMemcpyHostToDevice, stream));
+      CUDA_CHECK(cudaMemcpyAsync(dst.get(), src.get(), sizeof(T), cudaMemcpyHostToDevice, stream));
     }
 
     template <typename T>
     inline void copyAsync(host::unique_ptr<T>& dst, const device::unique_ptr<T>& src, cudaStream_t stream) {
       static_assert(std::is_array<T>::value == false,
                     "For array types, use the other overload with the size parameter");
-      cudaCheck(cudaMemcpyAsync(dst.get(), src.get(), sizeof(T), cudaMemcpyDeviceToHost, stream));
+      CUDA_CHECK(cudaMemcpyAsync(dst.get(), src.get(), sizeof(T), cudaMemcpyDeviceToHost, stream));
     }
 
     // Multiple elements
@@ -48,7 +48,7 @@ namespace cms {
                           const host::unique_ptr<T[]>& src,
                           size_t nelements,
                           cudaStream_t stream) {
-      cudaCheck(cudaMemcpyAsync(dst.get(), src.get(), nelements * sizeof(T), cudaMemcpyHostToDevice, stream));
+      CUDA_CHECK(cudaMemcpyAsync(dst.get(), src.get(), nelements * sizeof(T), cudaMemcpyHostToDevice, stream));
     }
 
     template <typename T>
@@ -56,7 +56,7 @@ namespace cms {
                           const host::noncached::unique_ptr<T[]>& src,
                           size_t nelements,
                           cudaStream_t stream) {
-      cudaCheck(cudaMemcpyAsync(dst.get(), src.get(), nelements * sizeof(T), cudaMemcpyHostToDevice, stream));
+      CUDA_CHECK(cudaMemcpyAsync(dst.get(), src.get(), nelements * sizeof(T), cudaMemcpyHostToDevice, stream));
     }
 
     template <typename T>
@@ -64,7 +64,7 @@ namespace cms {
                           const device::unique_ptr<T[]>& src,
                           size_t nelements,
                           cudaStream_t stream) {
-      cudaCheck(cudaMemcpyAsync(dst.get(), src.get(), nelements * sizeof(T), cudaMemcpyDeviceToHost, stream));
+      CUDA_CHECK(cudaMemcpyAsync(dst.get(), src.get(), nelements * sizeof(T), cudaMemcpyDeviceToHost, stream));
     }
 
     // copy from a host vector using pinned memory
@@ -72,7 +72,7 @@ namespace cms {
     inline void copyAsync(cms::cuda::device::unique_ptr<T[]>& dst,
                           const std::vector<T, cms::cuda::HostAllocator<T>>& src,
                           cudaStream_t stream) {
-      cudaCheck(cudaMemcpyAsync(dst.get(), src.data(), src.size() * sizeof(T), cudaMemcpyHostToDevice, stream));
+      CUDA_CHECK(cudaMemcpyAsync(dst.get(), src.data(), src.size() * sizeof(T), cudaMemcpyHostToDevice, stream));
     }
 
     // special case used to transfer conditions data
@@ -80,7 +80,7 @@ namespace cms {
     inline void copyAsync(edm::propagate_const_array<cms::cuda::device::unique_ptr<T[]>>& dst,
                           const std::vector<T, cms::cuda::HostAllocator<T>>& src,
                           cudaStream_t stream) {
-      cudaCheck(cudaMemcpyAsync(
+      CUDA_CHECK(cudaMemcpyAsync(
           get_underlying(dst).get(), src.data(), src.size() * sizeof(T), cudaMemcpyHostToDevice, stream));
     }
   }  // namespace cuda

--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -27,18 +27,18 @@ namespace cms {
       std::ostringstream out;
       out << "\n";
       out << file << ", line " << line << ":\n";
-      out << "cudaCheck(" << cmd << ");\n";
+      out << "CUDA_CHECK(" << cmd << ");\n";
       out << error << ": " << message << "\n";
       if (!description.empty())
         out << description << "\n";
       throw std::runtime_error(out.str());
     }
 
-    inline bool cudaCheck_(const char* file,
-                           int line,
-                           const char* cmd,
-                           CUresult result,
-                           std::string_view description = std::string_view()) {
+    inline bool cudaCheck(const char* file,
+                          int line,
+                          const char* cmd,
+                          CUresult result,
+                          std::string_view description = std::string_view()) {
       if (LIKELY(result == CUDA_SUCCESS))
         return true;
 
@@ -50,11 +50,11 @@ namespace cms {
       return false;
     }
 
-    inline bool cudaCheck_(const char* file,
-                           int line,
-                           const char* cmd,
-                           cudaError_t result,
-                           std::string_view description = std::string_view()) {
+    inline bool cudaCheck(const char* file,
+                          int line,
+                          const char* cmd,
+                          cudaError_t result,
+                          std::string_view description = std::string_view()) {
       if (LIKELY(result == cudaSuccess))
         return true;
 
@@ -66,6 +66,6 @@ namespace cms {
   }  // namespace cuda
 }  // namespace cms
 
-#define cudaCheck(ARG, ...) (cms::cuda::cudaCheck_(__FILE__, __LINE__, #ARG, (ARG), ##__VA_ARGS__))
+#define CUDA_CHECK(ARG, ...) (cms::cuda::cudaCheck(__FILE__, __LINE__, #ARG, (ARG), ##__VA_ARGS__))
 
 #endif  // HeterogeneousCore_CUDAUtilities_cudaCheck_h

--- a/HeterogeneousCore/CUDAUtilities/interface/currentDevice.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/currentDevice.h
@@ -9,7 +9,7 @@ namespace cms {
   namespace cuda {
     inline int currentDevice() {
       int dev;
-      cudaCheck(cudaGetDevice(&dev));
+      CUDA_CHECK(cudaGetDevice(&dev));
       return dev;
     }
   }  // namespace cuda

--- a/HeterogeneousCore/CUDAUtilities/interface/deviceCount.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/deviceCount.h
@@ -9,7 +9,7 @@ namespace cms {
   namespace cuda {
     inline int deviceCount() {
       int ndevices;
-      cudaCheck(cudaGetDeviceCount(&ndevices));
+      CUDA_CHECK(cudaGetDeviceCount(&ndevices));
       return ndevices;
     }
   }  // namespace cuda

--- a/HeterogeneousCore/CUDAUtilities/interface/eventWorkHasCompleted.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/eventWorkHasCompleted.h
@@ -23,7 +23,7 @@ namespace cms {
         return false;
       }
       // leave error case handling to cudaCheck
-      cudaCheck(ret);
+      CUDA_CHECK(ret);
       return false;  // to keep compiler happy
     }
   }  // namespace cuda

--- a/HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h
@@ -15,7 +15,7 @@ namespace cms {
           // Additional layer of types to distinguish from host::unique_ptr
           class HostDeleter {
           public:
-            void operator()(void *ptr) { cudaCheck(cudaFreeHost(ptr)); }
+            void operator()(void *ptr) { CUDA_CHECK(cudaFreeHost(ptr)); }
           };
         }  // namespace impl
 
@@ -49,7 +49,7 @@ namespace cms {
       static_assert(std::is_trivially_constructible<T>::value,
                     "Allocating with non-trivial constructor on the pinned host memory is not supported");
       void *mem;
-      cudaCheck(cudaHostAlloc(&mem, sizeof(T), flags));
+      CUDA_CHECK(cudaHostAlloc(&mem, sizeof(T), flags));
       return typename host::noncached::impl::make_host_unique_selector<T>::non_array(reinterpret_cast<T *>(mem));
     }
 
@@ -60,7 +60,7 @@ namespace cms {
       static_assert(std::is_trivially_constructible<element_type>::value,
                     "Allocating with non-trivial constructor on the pinned host memory is not supported");
       void *mem;
-      cudaCheck(cudaHostAlloc(&mem, n * sizeof(element_type), flags));
+      CUDA_CHECK(cudaHostAlloc(&mem, n * sizeof(element_type), flags));
       return typename host::noncached::impl::make_host_unique_selector<T>::unbounded_array(
           reinterpret_cast<element_type *>(mem));
     }

--- a/HeterogeneousCore/CUDAUtilities/interface/launch.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/launch.h
@@ -94,7 +94,7 @@ namespace cms {
     // wrappers for cudaLaunchKernel
 
     inline void launch(void (*kernel)(), LaunchParameters config) {
-      cudaCheck(cudaLaunchKernel(
+      CUDA_CHECK(cudaLaunchKernel(
           (const void*)kernel, config.gridDim, config.blockDim, nullptr, config.sharedMem, config.stream));
     }
 
@@ -112,14 +112,14 @@ namespace cms {
       void const* pointers[size];
 
       detail::pointer_setter<size>()(pointers, args_copy);
-      cudaCheck(cudaLaunchKernel(
+      CUDA_CHECK(cudaLaunchKernel(
           (const void*)kernel, config.gridDim, config.blockDim, (void**)pointers, config.sharedMem, config.stream));
     }
 
     // wrappers for cudaLaunchCooperativeKernel
 
     inline void launch_cooperative(void (*kernel)(), LaunchParameters config) {
-      cudaCheck(cudaLaunchCooperativeKernel(
+      CUDA_CHECK(cudaLaunchCooperativeKernel(
           (const void*)kernel, config.gridDim, config.blockDim, nullptr, config.sharedMem, config.stream));
     }
 
@@ -137,7 +137,7 @@ namespace cms {
       void const* pointers[size];
 
       detail::pointer_setter<size>()(pointers, args_copy);
-      cudaCheck(cudaLaunchCooperativeKernel(
+      CUDA_CHECK(cudaLaunchCooperativeKernel(
           (const void*)kernel, config.gridDim, config.blockDim, (void**)pointers, config.sharedMem, config.stream));
     }
 

--- a/HeterogeneousCore/CUDAUtilities/interface/memsetAsync.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/memsetAsync.h
@@ -14,7 +14,7 @@ namespace cms {
       // let's add an assert with a more helpful message
       static_assert(std::is_array<T>::value == false,
                     "For array types, use the other overload with the size parameter");
-      cudaCheck(cudaMemsetAsync(ptr.get(), value, sizeof(T), stream));
+      CUDA_CHECK(cudaMemsetAsync(ptr.get(), value, sizeof(T), stream));
     }
 
     /**
@@ -25,7 +25,7 @@ namespace cms {
    */
     template <typename T>
     inline void memsetAsync(device::unique_ptr<T[]>& ptr, int value, size_t nelements, cudaStream_t stream) {
-      cudaCheck(cudaMemsetAsync(ptr.get(), value, nelements * sizeof(T), stream));
+      CUDA_CHECK(cudaMemsetAsync(ptr.get(), value, nelements * sizeof(T), stream));
     }
   }  // namespace cuda
 }  // namespace cms

--- a/HeterogeneousCore/CUDAUtilities/interface/nvmlCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/nvmlCheck.h
@@ -26,18 +26,18 @@ namespace cms {
       std::ostringstream out;
       out << "\n";
       out << file << ", line " << line << ":\n";
-      out << "nvmlCheck(" << cmd << ");\n";
+      out << "NVML_CHECK(" << cmd << ");\n";
       out << error << ": " << message << "\n";
       if (!description.empty())
         out << description << "\n";
       throw std::runtime_error(out.str());
     }
 
-    inline bool nvmlCheck_(const char* file,
-                           int line,
-                           const char* cmd,
-                           nvmlReturn_t result,
-                           std::string_view description = std::string_view()) {
+    inline bool nvmlCheck(const char* file,
+                          int line,
+                          const char* cmd,
+                          nvmlReturn_t result,
+                          std::string_view description = std::string_view()) {
       if (LIKELY(result == NVML_SUCCESS))
         return true;
 
@@ -49,6 +49,6 @@ namespace cms {
   }  // namespace cuda
 }  // namespace cms
 
-#define nvmlCheck(ARG, ...) (cms::cuda::nvmlCheck_(__FILE__, __LINE__, #ARG, (ARG), ##__VA_ARGS__))
+#define NVML_CHECK(ARG, ...) (cms::cuda::nvmlCheck(__FILE__, __LINE__, #ARG, (ARG), ##__VA_ARGS__))
 
 #endif  // HeterogeneousCore_CUDAUtilities_nvmlCheck_h

--- a/HeterogeneousCore/CUDAUtilities/src/CachingDeviceAllocator.h
+++ b/HeterogeneousCore/CUDAUtilities/src/CachingDeviceAllocator.h
@@ -342,7 +342,7 @@ namespace notcub {
 
       if (device == INVALID_DEVICE_ORDINAL) {
         // CMS: throw exception on error
-        cudaCheck(error = cudaGetDevice(&entrypoint_device));
+        CUDA_CHECK(error = cudaGetDevice(&entrypoint_device));
         device = entrypoint_device;
       }
 
@@ -419,8 +419,8 @@ namespace notcub {
         // Set runtime's current device to specified device (entrypoint may not be set)
         if (device != entrypoint_device) {
           // CMS: throw exception on error
-          cudaCheck(error = cudaGetDevice(&entrypoint_device));
-          cudaCheck(error = cudaSetDevice(device));
+          CUDA_CHECK(error = cudaGetDevice(&entrypoint_device));
+          CUDA_CHECK(error = cudaSetDevice(device));
         }
 
         // Attempt to allocate
@@ -486,12 +486,12 @@ namespace notcub {
 
           // Try to allocate again
           // CMS: throw exception on error
-          cudaCheck(error = cudaMalloc(&search_key.d_ptr, search_key.bytes));
+          CUDA_CHECK(error = cudaMalloc(&search_key.d_ptr, search_key.bytes));
         }
 
         // Create ready event
         // CMS: throw exception on error
-        cudaCheck(error = cudaEventCreateWithFlags(&search_key.ready_event, cudaEventDisableTiming));
+        CUDA_CHECK(error = cudaEventCreateWithFlags(&search_key.ready_event, cudaEventDisableTiming));
 
         // Insert into live blocks
         mutex_locker.lock();
@@ -513,7 +513,7 @@ namespace notcub {
         // Attempt to revert back to previous device if necessary
         if ((entrypoint_device != INVALID_DEVICE_ORDINAL) && (entrypoint_device != device)) {
           // CMS: throw exception on error
-          cudaCheck(error = cudaSetDevice(entrypoint_device));
+          CUDA_CHECK(error = cudaSetDevice(entrypoint_device));
         }
       }
 
@@ -561,7 +561,7 @@ namespace notcub {
 
       if (device == INVALID_DEVICE_ORDINAL) {
         // CMS: throw exception on error
-        cudaCheck(error = cudaGetDevice(&entrypoint_device));
+        CUDA_CHECK(error = cudaGetDevice(&entrypoint_device));
         device = entrypoint_device;
       }
 
@@ -607,14 +607,14 @@ namespace notcub {
       // First set to specified device (entrypoint may not be set)
       if (device != entrypoint_device) {
         // CMS: throw exception on error
-        cudaCheck(error = cudaGetDevice(&entrypoint_device));
-        cudaCheck(error = cudaSetDevice(device));
+        CUDA_CHECK(error = cudaGetDevice(&entrypoint_device));
+        CUDA_CHECK(error = cudaSetDevice(device));
       }
 
       if (recached) {
         // Insert the ready event in the associated stream (must have current device set properly)
         // CMS: throw exception on error
-        cudaCheck(error = cudaEventRecord(search_key.ready_event, search_key.associated_stream));
+        CUDA_CHECK(error = cudaEventRecord(search_key.ready_event, search_key.associated_stream));
       }
 
       // Unlock
@@ -623,8 +623,8 @@ namespace notcub {
       if (!recached) {
         // Free the allocation from the runtime and cleanup the event.
         // CMS: throw exception on error
-        cudaCheck(error = cudaFree(d_ptr));
-        cudaCheck(error = cudaEventDestroy(search_key.ready_event));
+        CUDA_CHECK(error = cudaFree(d_ptr));
+        CUDA_CHECK(error = cudaEventDestroy(search_key.ready_event));
 
         if (debug)
           // CMS: improved debug message
@@ -645,7 +645,7 @@ namespace notcub {
       // Reset device
       if ((entrypoint_device != INVALID_DEVICE_ORDINAL) && (entrypoint_device != device)) {
         // CMS: throw exception on error
-        cudaCheck(error = cudaSetDevice(entrypoint_device));
+        CUDA_CHECK(error = cudaSetDevice(entrypoint_device));
       }
 
       return error;
@@ -718,7 +718,7 @@ namespace notcub {
       // Attempt to revert back to entry-point device if necessary
       if (entrypoint_device != INVALID_DEVICE_ORDINAL) {
         // CMS: throw exception on error
-        cudaCheck(error = cudaSetDevice(entrypoint_device));
+        CUDA_CHECK(error = cudaSetDevice(entrypoint_device));
       }
 
       return error;

--- a/HeterogeneousCore/CUDAUtilities/src/CachingHostAllocator.h
+++ b/HeterogeneousCore/CUDAUtilities/src/CachingHostAllocator.h
@@ -319,7 +319,7 @@ namespace notcub {
       int device = INVALID_DEVICE_ORDINAL;
       cudaError_t error = cudaSuccess;
 
-      cudaCheck(error = cudaGetDevice(&device));
+      CUDA_CHECK(error = cudaGetDevice(&device));
 
       // Create a block descriptor for the requested allocation
       bool found = false;
@@ -356,10 +356,10 @@ namespace notcub {
             search_key.associated_stream = active_stream;
             if (search_key.device != device) {
               // If "associated" device changes, need to re-create the event on the right device
-              cudaCheck(error = cudaSetDevice(search_key.device));
-              cudaCheck(error = cudaEventDestroy(search_key.ready_event));
-              cudaCheck(error = cudaSetDevice(device));
-              cudaCheck(error = cudaEventCreateWithFlags(&search_key.ready_event, cudaEventDisableTiming));
+              CUDA_CHECK(error = cudaSetDevice(search_key.device));
+              CUDA_CHECK(error = cudaEventDestroy(search_key.ready_event));
+              CUDA_CHECK(error = cudaSetDevice(device));
+              CUDA_CHECK(error = cudaEventCreateWithFlags(&search_key.ready_event, cudaEventDisableTiming));
               search_key.device = device;
             }
 
@@ -452,11 +452,11 @@ namespace notcub {
             return error;
 
           // Try to allocate again
-          cudaCheck(error = cudaHostAlloc(&search_key.d_ptr, search_key.bytes, cudaHostAllocDefault));
+          CUDA_CHECK(error = cudaHostAlloc(&search_key.d_ptr, search_key.bytes, cudaHostAllocDefault));
         }
 
         // Create ready event
-        cudaCheck(error = cudaEventCreateWithFlags(&search_key.ready_event, cudaEventDisableTiming));
+        CUDA_CHECK(error = cudaEventCreateWithFlags(&search_key.ready_event, cudaEventDisableTiming));
 
         // Insert into live blocks
         mutex_locker.lock();
@@ -532,14 +532,14 @@ namespace notcub {
         }
       }
 
-      cudaCheck(error = cudaGetDevice(&entrypoint_device));
+      CUDA_CHECK(error = cudaGetDevice(&entrypoint_device));
       if (entrypoint_device != search_key.device) {
-        cudaCheck(error = cudaSetDevice(search_key.device));
+        CUDA_CHECK(error = cudaSetDevice(search_key.device));
       }
 
       if (recached) {
         // Insert the ready event in the associated stream (must have current device set properly)
-        cudaCheck(error = cudaEventRecord(search_key.ready_event, search_key.associated_stream));
+        CUDA_CHECK(error = cudaEventRecord(search_key.ready_event, search_key.associated_stream));
       }
 
       // Unlock
@@ -547,8 +547,8 @@ namespace notcub {
 
       if (!recached) {
         // Free the allocation from the runtime and cleanup the event.
-        cudaCheck(error = cudaFreeHost(d_ptr));
-        cudaCheck(error = cudaEventDestroy(search_key.ready_event));
+        CUDA_CHECK(error = cudaFreeHost(d_ptr));
+        CUDA_CHECK(error = cudaEventDestroy(search_key.ready_event));
 
         if (debug)
           printf(
@@ -566,7 +566,7 @@ namespace notcub {
 
       // Reset device
       if ((entrypoint_device != INVALID_DEVICE_ORDINAL) && (entrypoint_device != search_key.device)) {
-        cudaCheck(error = cudaSetDevice(entrypoint_device));
+        CUDA_CHECK(error = cudaSetDevice(entrypoint_device));
       }
 
       return error;
@@ -625,7 +625,7 @@ namespace notcub {
 
       // Attempt to revert back to entry-point device if necessary
       if (entrypoint_device != INVALID_DEVICE_ORDINAL) {
-        cudaCheck(error = cudaSetDevice(entrypoint_device));
+        CUDA_CHECK(error = cudaSetDevice(entrypoint_device));
       }
 
       return error;

--- a/HeterogeneousCore/CUDAUtilities/src/EventCache.cc
+++ b/HeterogeneousCore/CUDAUtilities/src/EventCache.cc
@@ -10,7 +10,7 @@ namespace cms::cuda {
   void EventCache::Deleter::operator()(cudaEvent_t event) const {
     if (device_ != -1) {
       ScopedSetDevice deviceGuard{device_};
-      cudaCheck(cudaEventDestroy(event));
+      CUDA_CHECK(cudaEventDestroy(event));
     }
   }
 
@@ -48,7 +48,7 @@ namespace cms::cuda {
       // it should be a bit faster to ignore timings
       // cudaEventBlockingSync is needed to let the thread calling
       // cudaEventSynchronize() to sleep instead of spinning the CPU
-      cudaCheck(cudaEventCreateWithFlags(&event, cudaEventDisableTiming | cudaEventBlockingSync));
+      CUDA_CHECK(cudaEventCreateWithFlags(&event, cudaEventDisableTiming | cudaEventBlockingSync));
       return std::unique_ptr<BareEvent, Deleter>(event, Deleter{dev});
     });
   }

--- a/HeterogeneousCore/CUDAUtilities/src/StreamCache.cc
+++ b/HeterogeneousCore/CUDAUtilities/src/StreamCache.cc
@@ -9,7 +9,7 @@ namespace cms::cuda {
   void StreamCache::Deleter::operator()(cudaStream_t stream) const {
     if (device_ != -1) {
       ScopedSetDevice deviceGuard{device_};
-      cudaCheck(cudaStreamDestroy(stream));
+      CUDA_CHECK(cudaStreamDestroy(stream));
     }
   }
 
@@ -21,7 +21,7 @@ namespace cms::cuda {
     const auto dev = currentDevice();
     return cache_[dev].makeOrGet([dev]() {
       cudaStream_t stream;
-      cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+      CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
       return std::unique_ptr<BareStream, Deleter>(stream, Deleter{dev});
     });
   }

--- a/HeterogeneousCore/CUDAUtilities/src/allocate_device.cc
+++ b/HeterogeneousCore/CUDAUtilities/src/allocate_device.cc
@@ -20,20 +20,20 @@ namespace cms::cuda {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
       }
-      cudaCheck(allocator::getCachingDeviceAllocator().DeviceAllocate(dev, &ptr, nbytes, stream));
+      CUDA_CHECK(allocator::getCachingDeviceAllocator().DeviceAllocate(dev, &ptr, nbytes, stream));
     } else {
       ScopedSetDevice setDeviceForThisScope(dev);
-      cudaCheck(cudaMalloc(&ptr, nbytes));
+      CUDA_CHECK(cudaMalloc(&ptr, nbytes));
     }
     return ptr;
   }
 
   void free_device(int device, void *ptr) {
     if constexpr (allocator::useCaching) {
-      cudaCheck(allocator::getCachingDeviceAllocator().DeviceFree(device, ptr));
+      CUDA_CHECK(allocator::getCachingDeviceAllocator().DeviceFree(device, ptr));
     } else {
       ScopedSetDevice setDeviceForThisScope(device);
-      cudaCheck(cudaFree(ptr));
+      CUDA_CHECK(cudaFree(ptr));
     }
   }
 

--- a/HeterogeneousCore/CUDAUtilities/src/allocate_host.cc
+++ b/HeterogeneousCore/CUDAUtilities/src/allocate_host.cc
@@ -19,18 +19,18 @@ namespace cms::cuda {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
       }
-      cudaCheck(allocator::getCachingHostAllocator().HostAllocate(&ptr, nbytes, stream));
+      CUDA_CHECK(allocator::getCachingHostAllocator().HostAllocate(&ptr, nbytes, stream));
     } else {
-      cudaCheck(cudaMallocHost(&ptr, nbytes));
+      CUDA_CHECK(cudaMallocHost(&ptr, nbytes));
     }
     return ptr;
   }
 
   void free_host(void *ptr) {
     if constexpr (allocator::useCaching) {
-      cudaCheck(allocator::getCachingHostAllocator().HostFree(ptr));
+      CUDA_CHECK(allocator::getCachingHostAllocator().HostFree(ptr));
     } else {
-      cudaCheck(cudaFreeHost(ptr));
+      CUDA_CHECK(cudaFreeHost(ptr));
     }
   }
 

--- a/HeterogeneousCore/CUDAUtilities/src/cachingAllocatorCommon.h
+++ b/HeterogeneousCore/CUDAUtilities/src/cachingAllocatorCommon.h
@@ -23,15 +23,15 @@ namespace cms::cuda::allocator {
   inline size_t minCachedBytes() {
     size_t ret = std::numeric_limits<size_t>::max();
     int currentDevice;
-    cudaCheck(cudaGetDevice(&currentDevice));
+    CUDA_CHECK(cudaGetDevice(&currentDevice));
     const int numberOfDevices = deviceCount();
     for (int i = 0; i < numberOfDevices; ++i) {
       size_t freeMemory, totalMemory;
-      cudaCheck(cudaSetDevice(i));
-      cudaCheck(cudaMemGetInfo(&freeMemory, &totalMemory));
+      CUDA_CHECK(cudaSetDevice(i));
+      CUDA_CHECK(cudaMemGetInfo(&freeMemory, &totalMemory));
       ret = std::min(ret, static_cast<size_t>(maxCachedFraction * freeMemory));
     }
-    cudaCheck(cudaSetDevice(currentDevice));
+    CUDA_CHECK(cudaSetDevice(currentDevice));
     if (maxCachedBytes > 0) {
       ret = std::min(ret, maxCachedBytes);
     }

--- a/HeterogeneousCore/CUDAUtilities/test/copyAsync_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/copyAsync_t.cpp
@@ -12,7 +12,7 @@ TEST_CASE("copyAsync", "[cudaMemTools]") {
   }
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+  CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   SECTION("Host to device") {
     SECTION("Single element") {
@@ -23,8 +23,8 @@ TEST_CASE("copyAsync", "[cudaMemTools]") {
       auto host = cms::cuda::make_host_unique<int>(stream);
 
       cms::cuda::copyAsync(device, host_orig, stream);
-      cudaCheck(cudaMemcpyAsync(host.get(), device.get(), sizeof(int), cudaMemcpyDeviceToHost, stream));
-      cudaCheck(cudaStreamSynchronize(stream));
+      CUDA_CHECK(cudaMemcpyAsync(host.get(), device.get(), sizeof(int), cudaMemcpyDeviceToHost, stream));
+      CUDA_CHECK(cudaStreamSynchronize(stream));
 
       REQUIRE(*host == 42);
     }
@@ -42,8 +42,8 @@ TEST_CASE("copyAsync", "[cudaMemTools]") {
 
       SECTION("Copy all") {
         cms::cuda::copyAsync(device, host_orig, N, stream);
-        cudaCheck(cudaMemcpyAsync(host.get(), device.get(), N * sizeof(int), cudaMemcpyDeviceToHost, stream));
-        cudaCheck(cudaStreamSynchronize(stream));
+        CUDA_CHECK(cudaMemcpyAsync(host.get(), device.get(), N * sizeof(int), cudaMemcpyDeviceToHost, stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
         for (int i = 0; i < N; ++i) {
           CHECK(host[i] == i);
         }
@@ -55,8 +55,8 @@ TEST_CASE("copyAsync", "[cudaMemTools]") {
 
       SECTION("Copy some") {
         cms::cuda::copyAsync(device, host_orig, 42, stream);
-        cudaCheck(cudaMemcpyAsync(host.get(), device.get(), 42 * sizeof(int), cudaMemcpyDeviceToHost, stream));
-        cudaCheck(cudaStreamSynchronize(stream));
+        CUDA_CHECK(cudaMemcpyAsync(host.get(), device.get(), 42 * sizeof(int), cudaMemcpyDeviceToHost, stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
         for (int i = 0; i < 42; ++i) {
           CHECK(host[i] == 200 + i);
         }
@@ -72,9 +72,9 @@ TEST_CASE("copyAsync", "[cudaMemTools]") {
       auto device = cms::cuda::make_device_unique<int>(stream);
       auto host = cms::cuda::make_host_unique<int>(stream);
 
-      cudaCheck(cudaMemcpyAsync(device.get(), host_orig.get(), sizeof(int), cudaMemcpyHostToDevice, stream));
+      CUDA_CHECK(cudaMemcpyAsync(device.get(), host_orig.get(), sizeof(int), cudaMemcpyHostToDevice, stream));
       cms::cuda::copyAsync(host, device, stream);
-      cudaCheck(cudaStreamSynchronize(stream));
+      CUDA_CHECK(cudaStreamSynchronize(stream));
 
       REQUIRE(*host == 42);
     }
@@ -91,9 +91,9 @@ TEST_CASE("copyAsync", "[cudaMemTools]") {
       auto host = cms::cuda::make_host_unique<int[]>(N, stream);
 
       SECTION("Copy all") {
-        cudaCheck(cudaMemcpyAsync(device.get(), host_orig.get(), N * sizeof(int), cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(device.get(), host_orig.get(), N * sizeof(int), cudaMemcpyHostToDevice, stream));
         cms::cuda::copyAsync(host, device, N, stream);
-        cudaCheck(cudaStreamSynchronize(stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
         for (int i = 0; i < N; ++i) {
           CHECK(host[i] == i);
         }
@@ -104,9 +104,9 @@ TEST_CASE("copyAsync", "[cudaMemTools]") {
       }
 
       SECTION("Copy some") {
-        cudaCheck(cudaMemcpyAsync(device.get(), host_orig.get(), 42 * sizeof(int), cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaMemcpyAsync(device.get(), host_orig.get(), 42 * sizeof(int), cudaMemcpyHostToDevice, stream));
         cms::cuda::copyAsync(host, device, 42, stream);
-        cudaCheck(cudaStreamSynchronize(stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
         for (int i = 0; i < 42; ++i) {
           CHECK(host[i] == 200 + i);
         }
@@ -114,5 +114,5 @@ TEST_CASE("copyAsync", "[cudaMemTools]") {
     }
   }
 
-  cudaCheck(cudaStreamDestroy(stream));
+  CUDA_CHECK(cudaStreamDestroy(stream));
 }

--- a/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
@@ -10,7 +10,7 @@ TEST_CASE("device_unique_ptr", "[cudaMemTools]") {
   }
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+  CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   SECTION("Single element") {
     auto ptr = cms::cuda::make_device_unique<int>(stream);
@@ -20,7 +20,7 @@ TEST_CASE("device_unique_ptr", "[cudaMemTools]") {
   SECTION("Reset") {
     auto ptr = cms::cuda::make_device_unique<int>(stream);
     REQUIRE(ptr != nullptr);
-    cudaCheck(cudaStreamSynchronize(stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     ptr.reset();
     REQUIRE(ptr.get() == nullptr);
@@ -29,7 +29,7 @@ TEST_CASE("device_unique_ptr", "[cudaMemTools]") {
   SECTION("Multiple elements") {
     auto ptr = cms::cuda::make_device_unique<int[]>(10, stream);
     REQUIRE(ptr != nullptr);
-    cudaCheck(cudaStreamSynchronize(stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     ptr.reset();
     REQUIRE(ptr.get() == nullptr);
@@ -42,5 +42,5 @@ TEST_CASE("device_unique_ptr", "[cudaMemTools]") {
     REQUIRE_THROWS(ptr = cms::cuda::make_device_unique<char[]>(maxSize + 1, stream));
   }
 
-  cudaCheck(cudaStreamDestroy(stream));
+  CUDA_CHECK(cudaStreamDestroy(stream));
 }

--- a/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
@@ -10,7 +10,7 @@ TEST_CASE("host_unique_ptr", "[cudaMemTools]") {
   }
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+  CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   SECTION("Single element") {
     auto ptr = cms::cuda::make_host_unique<int>(stream);
@@ -20,7 +20,7 @@ TEST_CASE("host_unique_ptr", "[cudaMemTools]") {
   SECTION("Reset") {
     auto ptr = cms::cuda::make_host_unique<int>(stream);
     REQUIRE(ptr != nullptr);
-    cudaCheck(cudaStreamSynchronize(stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     ptr.reset();
     REQUIRE(ptr.get() == nullptr);
@@ -29,7 +29,7 @@ TEST_CASE("host_unique_ptr", "[cudaMemTools]") {
   SECTION("Multiple elements") {
     auto ptr = cms::cuda::make_host_unique<int[]>(10, stream);
     REQUIRE(ptr != nullptr);
-    cudaCheck(cudaStreamSynchronize(stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     ptr.reset();
     REQUIRE(ptr.get() == nullptr);
@@ -42,5 +42,5 @@ TEST_CASE("host_unique_ptr", "[cudaMemTools]") {
     REQUIRE_THROWS(ptr = cms::cuda::make_host_unique<char[]>(maxSize + 1, stream));
   }
 
-  cudaCheck(cudaStreamDestroy(stream));
+  CUDA_CHECK(cudaStreamDestroy(stream));
 }

--- a/HeterogeneousCore/CUDAUtilities/test/memsetAsync_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/memsetAsync_t.cpp
@@ -13,7 +13,7 @@ TEST_CASE("memsetAsync", "[cudaMemTools]") {
   }
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+  CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   SECTION("Single element") {
     auto host_orig = cms::cuda::make_host_unique<int>(stream);
@@ -24,7 +24,7 @@ TEST_CASE("memsetAsync", "[cudaMemTools]") {
     cms::cuda::copyAsync(device, host_orig, stream);
     cms::cuda::memsetAsync(device, 0, stream);
     cms::cuda::copyAsync(host, device, stream);
-    cudaCheck(cudaStreamSynchronize(stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     REQUIRE(*host == 0);
   }
@@ -42,12 +42,12 @@ TEST_CASE("memsetAsync", "[cudaMemTools]") {
     cms::cuda::copyAsync(device, host_orig, N, stream);
     cms::cuda::memsetAsync(device, 0, N, stream);
     cms::cuda::copyAsync(host, device, N, stream);
-    cudaCheck(cudaStreamSynchronize(stream));
+    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     for (int i = 0; i < N; ++i) {
       CHECK(host[i] == 0);
     }
   }
 
-  cudaCheck(cudaStreamDestroy(stream));
+  CUDA_CHECK(cudaStreamDestroy(stream));
 }

--- a/HeterogeneousCore/CUDAUtilities/test/testCudaCheck.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/testCudaCheck.cpp
@@ -9,12 +9,12 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 TEST_CASE("HeterogeneousCore/CUDAUtilities testCudaCheck", "[testCudaCheck]") {
-  SECTION("Test cudaCheck() driver API") {
-    REQUIRE_NOTHROW(cudaCheck(CUDA_SUCCESS));
-    REQUIRE_THROWS(cudaCheck(CUDA_ERROR_UNKNOWN));
+  SECTION("Test CUDA_CHECK() driver API") {
+    REQUIRE_NOTHROW(CUDA_CHECK(CUDA_SUCCESS));
+    REQUIRE_THROWS(CUDA_CHECK(CUDA_ERROR_UNKNOWN));
   }
-  SECTION("Test cudaCheck() runtime API") {
-    REQUIRE_NOTHROW(cudaCheck(cudaSuccess));
-    REQUIRE_THROWS(cudaCheck(cudaErrorUnknown));
+  SECTION("Test CUDA_CHECK() runtime API") {
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaSuccess));
+    REQUIRE_THROWS(CUDA_CHECK(cudaErrorUnknown));
   }
 }

--- a/HeterogeneousCore/CUDAUtilities/test/testRequireCUDADevices.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/testRequireCUDADevices.cpp
@@ -14,7 +14,7 @@ TEST_CASE("HeterogeneousCore/CUDAUtilities testRequireCUDADevices", "[testRequir
     cms::cudatest::requireDevices();
 
     int devices = 0;
-    cudaCheck(cudaGetDeviceCount(&devices));
+    CUDA_CHECK(cudaGetDeviceCount(&devices));
 
     REQUIRE(devices > 0);
   }

--- a/HeterogeneousCore/ROCmServices/plugins/ROCmMonitoringService.cc
+++ b/HeterogeneousCore/ROCmServices/plugins/ROCmMonitoringService.cc
@@ -79,16 +79,16 @@ namespace {
   template <typename T>
   void dumpUsedMemory(T& log, int num) {
     int old = 0;
-    hipCheck(hipGetDevice(&old));
+    HIP_CHECK(hipGetDevice(&old));
     constexpr auto mbytes = 1 << 20;
     for (int i = 0; i < num; ++i) {
       size_t freeMemory, totalMemory;
-      hipCheck(hipSetDevice(i));
-      hipCheck(hipMemGetInfo(&freeMemory, &totalMemory));
+      HIP_CHECK(hipSetDevice(i));
+      HIP_CHECK(hipMemGetInfo(&freeMemory, &totalMemory));
       log << "\n"
           << i << ": " << (totalMemory - freeMemory) / mbytes << " MB used / " << totalMemory / mbytes << " MB total";
     }
-    hipCheck(hipSetDevice(old));
+    HIP_CHECK(hipSetDevice(old));
   }
 }  // namespace
 

--- a/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
+++ b/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
@@ -56,7 +56,7 @@ void setHipLimit(hipLimit_t limit, const char* name, size_t request) {
 #if HIP_VERSION >= 50400000
   // read the current device
   int device;
-  hipCheck(hipGetDevice(&device));
+  HIP_CHECK(hipGetDevice(&device));
   // try to set the requested limit
   auto result = hipDeviceSetLimit(limit, request);
   if (hipErrorUnsupportedLimit == result) {
@@ -101,19 +101,19 @@ ROCmService::ROCmService(edm::ParameterSet const& config) : verbose_(config.getU
 
   // AMD system driver version, e.g. 5.16.9.22.20 or 6.1.5
   char systemDriverVersion[256];
-  rsmiCheck(rsmi_init(0x00));
-  rsmiCheck(rsmi_version_str_get(RSMI_SW_COMP_DRIVER, systemDriverVersion, sizeof(systemDriverVersion) - 1));
-  rsmiCheck(rsmi_shut_down());
+  RSMI_CHECK(rsmi_init(0x00));
+  RSMI_CHECK(rsmi_version_str_get(RSMI_SW_COMP_DRIVER, systemDriverVersion, sizeof(systemDriverVersion) - 1));
+  RSMI_CHECK(rsmi_shut_down());
 
   // ROCm driver version, e.g. 11.4
   // the full version, like 11.4.1 or 11.4.100, is not reported
   int driverVersion = 0;
-  hipCheck(hipDriverGetVersion(&driverVersion));
+  HIP_CHECK(hipDriverGetVersion(&driverVersion));
 
   // ROCm runtime version, e.g. 11.4
   // the full version, like 11.4.1 or 11.4.108, is not reported
   int runtimeVersion = 0;
-  hipCheck(hipRuntimeGetVersion(&runtimeVersion));
+  HIP_CHECK(hipRuntimeGetVersion(&runtimeVersion));
 
   edm::LogInfo log("ROCmService");
   if (verbose_) {
@@ -146,7 +146,7 @@ ROCmService::ROCmService(edm::ParameterSet const& config) : verbose_(config.getU
     // read information about the compute device.
     // see the documentation of hipGetDeviceProperties() for more information.
     hipDeviceProp_t properties;
-    hipCheck(hipGetDeviceProperties(&properties, i));
+    HIP_CHECK(hipGetDeviceProperties(&properties, i));
     log << '\n' << "ROCm device " << i << ": " << properties.name;
     if (verbose_) {
       log << '\n';
@@ -182,15 +182,15 @@ ROCmService::ROCmService(edm::ParameterSet const& config) : verbose_(config.getU
     }
 
     // TODO if a device is in exclusive use, skip it and remove it from the list, instead of failing with an exception
-    hipCheck(hipSetDevice(i));
-    hipCheck(hipSetDeviceFlags(hipDeviceScheduleAuto | hipDeviceMapHost));
+    HIP_CHECK(hipSetDevice(i));
+    HIP_CHECK(hipSetDeviceFlags(hipDeviceScheduleAuto | hipDeviceMapHost));
 
     if (verbose_) {
       // read the free and total amount of memory available for allocation by the device, in bytes.
       // see the documentation of hipMemGetInfo() for more information.
       size_t freeMemory = 0;
       size_t totalMemory = 0;
-      hipCheck(hipMemGetInfo(&freeMemory, &totalMemory));
+      HIP_CHECK(hipMemGetInfo(&freeMemory, &totalMemory));
       log << "  memory: " << std::setw(6) << freeMemory / (1 << 20) << " MB free / " << std::setw(6)
           << totalMemory / (1 << 20) << " MB total\n";
       log << "  constant memory:             " << std::setw(8) << properties.totalConstMem / (1 << 10) << " kB\n";
@@ -225,7 +225,7 @@ ROCmService::ROCmService(edm::ParameterSet const& config) : verbose_(config.getU
     if (verbose_) {
       log << "ROCm flags\n";
       unsigned int flags;
-      hipCheck(hipGetDeviceFlags(&flags));
+      HIP_CHECK(hipGetDeviceFlags(&flags));
       switch (flags & hipDeviceScheduleMask) {
         case hipDeviceScheduleAuto:
           log << "  thread policy:                   default\n";
@@ -274,10 +274,10 @@ ROCmService::ROCmService(edm::ParameterSet const& config) : verbose_(config.getU
       size_t value;
       log << "ROCm limits\n";
 #if HIP_VERSION >= 50400000
-      hipCheck(hipDeviceGetLimit(&value, hipLimitStackSize));
+      HIP_CHECK(hipDeviceGetLimit(&value, hipLimitStackSize));
       log << "  stack size:                " << std::setw(10) << value / (1 << 10) << " kB\n";
 #endif
-      hipCheck(hipDeviceGetLimit(&value, hipLimitMallocHeapSize));
+      HIP_CHECK(hipDeviceGetLimit(&value, hipLimitMallocHeapSize));
       log << "  malloc heap size:          " << std::setw(10) << value / (1 << 20) << " MB\n";
     }
   }
@@ -300,12 +300,12 @@ ROCmService::ROCmService(edm::ParameterSet const& config) : verbose_(config.getU
 ROCmService::~ROCmService() {
   if (enabled_) {
     for (int i = 0; i < numberOfDevices_; ++i) {
-      hipCheck(hipSetDevice(i));
-      hipCheck(hipDeviceSynchronize());
+      HIP_CHECK(hipSetDevice(i));
+      HIP_CHECK(hipDeviceSynchronize());
       // Explicitly destroys and cleans up all resources associated with the current device in the
       // current process. Any subsequent API call to this device will reinitialize the device.
       // Useful to check for memory leaks.
-      hipCheck(hipDeviceReset());
+      HIP_CHECK(hipDeviceReset());
     }
   }
 }

--- a/HeterogeneousCore/ROCmUtilities/bin/rocmComputeCapabilities.cpp
+++ b/HeterogeneousCore/ROCmUtilities/bin/rocmComputeCapabilities.cpp
@@ -20,7 +20,7 @@ int main() {
 
   for (int i = 0; i < devices; ++i) {
     hipDeviceProp_t properties;
-    hipCheck(hipGetDeviceProperties(&properties, i));
+    HIP_CHECK(hipGetDeviceProperties(&properties, i));
     std::cout << std::setw(4) << i << "    " << std::setw(8) << properties.gcnArchName << "    " << properties.name;
     if (not isRocmDeviceSupported(i)) {
       std::cout << " (unsupported)";

--- a/HeterogeneousCore/ROCmUtilities/interface/hipCheck.h
+++ b/HeterogeneousCore/ROCmUtilities/interface/hipCheck.h
@@ -26,18 +26,18 @@ namespace cms {
       std::ostringstream out;
       out << "\n";
       out << file << ", line " << line << ":\n";
-      out << "hipCheck(" << cmd << ");\n";
+      out << "HIP_CHECK(" << cmd << ");\n";
       out << error << ": " << message << "\n";
       if (!description.empty())
         out << description << "\n";
       throw std::runtime_error(out.str());
     }
 
-    inline bool hipCheck_(const char* file,
-                          int line,
-                          const char* cmd,
-                          hipError_t result,
-                          std::string_view description = std::string_view()) {
+    inline bool hipCheck(const char* file,
+                         int line,
+                         const char* cmd,
+                         hipError_t result,
+                         std::string_view description = std::string_view()) {
       if (LIKELY(result == hipSuccess))
         return true;
 
@@ -49,6 +49,6 @@ namespace cms {
   }  // namespace rocm
 }  // namespace cms
 
-#define hipCheck(ARG, ...) (cms::rocm::hipCheck_(__FILE__, __LINE__, #ARG, (ARG), ##__VA_ARGS__))
+#define HIP_CHECK(ARG, ...) (cms::rocm::hipCheck(__FILE__, __LINE__, #ARG, (ARG), ##__VA_ARGS__))
 
 #endif  // HeterogeneousCore_ROCmUtilities_hipCheck_h

--- a/HeterogeneousCore/ROCmUtilities/interface/rsmiCheck.h
+++ b/HeterogeneousCore/ROCmUtilities/interface/rsmiCheck.h
@@ -26,18 +26,18 @@ namespace cms {
       std::ostringstream out;
       out << "\n";
       out << file << ", line " << line << ":\n";
-      out << "rsmiCheck(" << cmd << ");\n";
+      out << "RSMI_CHECK(" << cmd << ");\n";
       out << error << ": " << message << "\n";
       if (!description.empty())
         out << description << "\n";
       throw std::runtime_error(out.str());
     }
 
-    inline bool rsmiCheck_(const char* file,
-                           int line,
-                           const char* cmd,
-                           rsmi_status_t result,
-                           std::string_view description = std::string_view()) {
+    inline bool rsmiCheck(const char* file,
+                          int line,
+                          const char* cmd,
+                          rsmi_status_t result,
+                          std::string_view description = std::string_view()) {
       if (LIKELY(result == RSMI_STATUS_SUCCESS))
         return true;
 
@@ -50,6 +50,6 @@ namespace cms {
   }  // namespace rocm
 }  // namespace cms
 
-#define rsmiCheck(ARG, ...) (cms::rocm::rsmiCheck_(__FILE__, __LINE__, #ARG, (ARG), ##__VA_ARGS__))
+#define RSMI_CHECK(ARG, ...) (cms::rocm::rsmiCheck(__FILE__, __LINE__, #ARG, (ARG), ##__VA_ARGS__))
 
 #endif  // HeterogeneousCore_ROCmUtilities_rsmiCheck_h

--- a/HeterogeneousCore/ROCmUtilities/test/testHipCheck.cpp
+++ b/HeterogeneousCore/ROCmUtilities/test/testHipCheck.cpp
@@ -9,8 +9,8 @@
 #include "HeterogeneousCore/ROCmUtilities/interface/hipCheck.h"
 
 TEST_CASE("HeterogeneousCore/ROCmUtilities testHipCheck", "[testHipCheck]") {
-  SECTION("Test hipCheck() API") {
-    REQUIRE_NOTHROW(hipCheck(hipSuccess));
-    REQUIRE_THROWS(hipCheck(hipErrorUnknown));
+  SECTION("Test HIP_CHECK() API") {
+    REQUIRE_NOTHROW(HIP_CHECK(hipSuccess));
+    REQUIRE_THROWS(HIP_CHECK(hipErrorUnknown));
   }
 }

--- a/HeterogeneousCore/ROCmUtilities/test/testRequireROCmDevices.cpp
+++ b/HeterogeneousCore/ROCmUtilities/test/testRequireROCmDevices.cpp
@@ -14,7 +14,7 @@ TEST_CASE("HeterogeneousCore/ROCmUtilities testRequireROCmDevices", "[testRequir
     cms::rocmtest::requireDevices();
 
     int devices = 0;
-    hipCheck(hipGetDeviceCount(&devices));
+    HIP_CHECK(hipGetDeviceCount(&devices));
 
     REQUIRE(devices > 0);
   }

--- a/HeterogeneousCore/SonicTriton/src/TritonMemResource.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonMemResource.cc
@@ -158,9 +158,9 @@ TritonGpuShmResource<IO>::TritonGpuShmResource(TritonData<IO>* data, const std::
   //cudaMalloc of size zero succeeds, but leaves addr as nullptr -> IPC failure
   this->size_ = std::max<size_t>(this->size_, 1);
   //todo: get server device id somehow?
-  cudaCheck(cudaSetDevice(deviceId_), "unable to set device ID to " + std::to_string(deviceId_));
-  cudaCheck(cudaMalloc((void**)&this->addr_, this->size_), "unable to allocate GPU memory for key: " + this->name_);
-  cudaCheck(cudaIpcGetMemHandle(handle_.get(), this->addr_), "unable to get IPC handle for key: " + this->name_);
+  CUDA_CHECK(cudaSetDevice(deviceId_), "unable to set device ID to " + std::to_string(deviceId_));
+  CUDA_CHECK(cudaMalloc((void**)&this->addr_, this->size_), "unable to allocate GPU memory for key: " + this->name_);
+  CUDA_CHECK(cudaIpcGetMemHandle(handle_.get(), this->addr_), "unable to get IPC handle for key: " + this->name_);
   TRITON_THROW_IF_ERROR(
       this->data_->grpcClient()->RegisterCudaSharedMemory(this->name_, *handle_, deviceId_, this->size_),
       "unable to register CUDA shared memory region: " + this->name_);
@@ -178,23 +178,23 @@ void TritonGpuShmResource<IO>::close() {
   TRITON_THROW_IF_ERROR(this->data_->grpcClient()->UnregisterCudaSharedMemory(this->name_),
                         "unable to unregister CUDA shared memory region: " + this->name_,
                         this->data_->client()->service());
-  cudaCheck(cudaFree(this->addr_), "unable to free GPU memory for key: " + this->name_);
+  CUDA_CHECK(cudaFree(this->addr_), "unable to free GPU memory for key: " + this->name_);
   this->closed_ = true;
 }
 
 template <>
 void TritonInputGpuShmResource::copyInput(const void* values, size_t offset, unsigned entry) {
   if (sizeOrig_ > 0)
-    cudaCheck(cudaMemcpy(addr_ + offset, values, data_->entries_[entry].byteSizePerBatch_, cudaMemcpyHostToDevice),
-              data_->name_ + " toServer(): unable to memcpy " +
-                  std::to_string(data_->entries_[entry].byteSizePerBatch_) + " bytes to GPU");
+    CUDA_CHECK(cudaMemcpy(addr_ + offset, values, data_->entries_[entry].byteSizePerBatch_, cudaMemcpyHostToDevice),
+               data_->name_ + " toServer(): unable to memcpy " +
+                   std::to_string(data_->entries_[entry].byteSizePerBatch_) + " bytes to GPU");
 }
 
 template <>
 void TritonOutputGpuShmResource::copyOutput() {
   //copy back from gpu, keep in scope
   auto ptr = std::make_shared<std::vector<uint8_t>>(data_->totalByteSize_);
-  cudaCheck(
+  CUDA_CHECK(
       cudaMemcpy(ptr->data(), addr_, data_->totalByteSize_, cudaMemcpyDeviceToHost),
       data_->name_ + " fromServer(): unable to memcpy " + std::to_string(data_->totalByteSize_) + " bytes from GPU");
   data_->holder_ = ptr;

--- a/HeterogeneousTest/CUDADevice/README.md
+++ b/HeterogeneousTest/CUDADevice/README.md
@@ -48,7 +48,7 @@ Unfortunately, the CUDA kernels used in the `CUDATestDeviceAdditionModule` plugi
 the `HeterogeneousTest/CUDAKernel` library run into some kind of conflict, leading to the error
 ```
 HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu, line 17:
-cudaCheck(cudaGetLastError());
+CUDA_CHECK(cudaGetLastError());
 cudaErrorInvalidDeviceFunction: invalid device function
 ```
 Using together the other three plugins does work correctly.

--- a/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionAlgo.cu
+++ b/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionAlgo.cu
@@ -21,7 +21,7 @@ namespace HeterogeneousTestCUDADevicePlugins {
                              float* __restrict__ out,
                              size_t size) {
     kernel_add_vectors_f<<<32, 32>>>(in1, in2, out, size);
-    cudaCheck(cudaGetLastError());
+    CUDA_CHECK(cudaGetLastError());
   }
 
 }  // namespace HeterogeneousTestCUDADevicePlugins

--- a/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionModule.cc
+++ b/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionModule.cc
@@ -72,25 +72,25 @@ void CUDATestDeviceAdditionModule::analyze(edm::StreamID, edm::Event const& even
   float* in1_d;
   float* in2_d;
   float* out_d;
-  cudaCheck(cudaMalloc(&in1_d, size_ * sizeof(float)));
-  cudaCheck(cudaMalloc(&in2_d, size_ * sizeof(float)));
-  cudaCheck(cudaMalloc(&out_d, size_ * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&in1_d, size_ * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&in2_d, size_ * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&out_d, size_ * sizeof(float)));
 
   // copy the input data to the device
-  cudaCheck(cudaMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
-  cudaCheck(cudaMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
 
   // fill the output buffer with zeros
-  cudaCheck(cudaMemset(out_d, 0, size_ * sizeof(float)));
+  CUDA_CHECK(cudaMemset(out_d, 0, size_ * sizeof(float)));
 
   // launch the 1-dimensional kernel for vector addition
   HeterogeneousTestCUDADevicePlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
 
   // copy the results from the device to the host
-  cudaCheck(cudaMemcpy(out_h.data(), out_d, size_ * sizeof(float), cudaMemcpyDeviceToHost));
+  CUDA_CHECK(cudaMemcpy(out_h.data(), out_d, size_ * sizeof(float), cudaMemcpyDeviceToHost));
 
   // wait for all the operations to complete
-  cudaCheck(cudaDeviceSynchronize());
+  CUDA_CHECK(cudaDeviceSynchronize());
 
   // check the results
   for (size_t i = 0; i < size_; ++i) {

--- a/HeterogeneousTest/CUDADevice/test/testDeviceAddition.cu
+++ b/HeterogeneousTest/CUDADevice/test/testDeviceAddition.cu
@@ -50,26 +50,26 @@ TEST_CASE("HeterogeneousTest/CUDADevice test", "[cudaTestDeviceAddition]") {
     float* in1_d;
     float* in2_d;
     float* out_d;
-    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&in1_d, size * sizeof(float))));
-    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&in2_d, size * sizeof(float))));
-    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&out_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMalloc(&in1_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMalloc(&in2_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMalloc(&out_d, size * sizeof(float))));
 
     // copy the input data to the device
-    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(in1_d, in1_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
-    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(in2_d, in2_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMemcpy(in1_d, in1_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMemcpy(in2_d, in2_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
 
     // fill the output buffer with zeros
-    REQUIRE_NOTHROW(cudaCheck(cudaMemset(out_d, 0, size * sizeof(float))));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMemset(out_d, 0, size * sizeof(float))));
 
     // launch the 1-dimensional kernel for vector addition
     kernel_add_vectors_f<<<32, 32>>>(in1_d, in2_d, out_d, size);
-    REQUIRE_NOTHROW(cudaCheck(cudaGetLastError()));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaGetLastError()));
 
     // copy the results from the device to the host
-    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(out_h.data(), out_d, size * sizeof(float), cudaMemcpyDeviceToHost)));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMemcpy(out_h.data(), out_d, size * sizeof(float), cudaMemcpyDeviceToHost)));
 
     // wait for all the operations to complete
-    REQUIRE_NOTHROW(cudaCheck(cudaDeviceSynchronize()));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaDeviceSynchronize()));
 
     // check the results
     for (size_t i = 0; i < size; ++i) {

--- a/HeterogeneousTest/CUDAKernel/README.md
+++ b/HeterogeneousTest/CUDAKernel/README.md
@@ -48,7 +48,7 @@ Unfortunately, the CUDA kernels used in the `CUDATestDeviceAdditionModule` plugi
 the `HeterogeneousTest/CUDAKernel` library run into some kind of conflict, leading to the error
 ```
 HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu, line 17:
-cudaCheck(cudaGetLastError());
+CUDA_CHECK(cudaGetLastError());
 cudaErrorInvalidDeviceFunction: invalid device function
 ```
 Using together the other three plugins does work correctly.

--- a/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu
+++ b/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu
@@ -14,7 +14,7 @@ namespace HeterogeneousTestCUDAKernelPlugins {
                              float* __restrict__ out,
                              size_t size) {
     cms::cudatest::kernel_add_vectors_f<<<32, 32>>>(in1, in2, out, size);
-    cudaCheck(cudaGetLastError());
+    CUDA_CHECK(cudaGetLastError());
   }
 
 }  // namespace HeterogeneousTestCUDAKernelPlugins

--- a/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionModule.cc
+++ b/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionModule.cc
@@ -72,25 +72,25 @@ void CUDATestKernelAdditionModule::analyze(edm::StreamID, edm::Event const& even
   float* in1_d;
   float* in2_d;
   float* out_d;
-  cudaCheck(cudaMalloc(&in1_d, size_ * sizeof(float)));
-  cudaCheck(cudaMalloc(&in2_d, size_ * sizeof(float)));
-  cudaCheck(cudaMalloc(&out_d, size_ * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&in1_d, size_ * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&in2_d, size_ * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&out_d, size_ * sizeof(float)));
 
   // copy the input data to the device
-  cudaCheck(cudaMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
-  cudaCheck(cudaMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
 
   // fill the output buffer with zeros
-  cudaCheck(cudaMemset(out_d, 0, size_ * sizeof(float)));
+  CUDA_CHECK(cudaMemset(out_d, 0, size_ * sizeof(float)));
 
   // launch the 1-dimensional kernel for vector addition
   HeterogeneousTestCUDAKernelPlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
 
   // copy the results from the device to the host
-  cudaCheck(cudaMemcpy(out_h.data(), out_d, size_ * sizeof(float), cudaMemcpyDeviceToHost));
+  CUDA_CHECK(cudaMemcpy(out_h.data(), out_d, size_ * sizeof(float), cudaMemcpyDeviceToHost));
 
   // wait for all the operations to complete
-  cudaCheck(cudaDeviceSynchronize());
+  CUDA_CHECK(cudaDeviceSynchronize());
 
   // check the results
   for (size_t i = 0; i < size_; ++i) {

--- a/HeterogeneousTest/CUDAKernel/test/testDeviceAdditionKernel.cu
+++ b/HeterogeneousTest/CUDAKernel/test/testDeviceAdditionKernel.cu
@@ -43,26 +43,26 @@ TEST_CASE("HeterogeneousTest/CUDAKernel test", "[cudaTestKernelAdditionKernel]")
     float* in1_d;
     float* in2_d;
     float* out_d;
-    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&in1_d, size * sizeof(float))));
-    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&in2_d, size * sizeof(float))));
-    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&out_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMalloc(&in1_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMalloc(&in2_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMalloc(&out_d, size * sizeof(float))));
 
     // copy the input data to the device
-    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(in1_d, in1_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
-    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(in2_d, in2_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMemcpy(in1_d, in1_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMemcpy(in2_d, in2_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
 
     // fill the output buffer with zeros
-    REQUIRE_NOTHROW(cudaCheck(cudaMemset(out_d, 0, size * sizeof(float))));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMemset(out_d, 0, size * sizeof(float))));
 
     // launch the 1-dimensional kernel for vector addition
     cms::cudatest::kernel_add_vectors_f<<<32, 32>>>(in1_d, in2_d, out_d, size);
-    REQUIRE_NOTHROW(cudaCheck(cudaGetLastError()));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaGetLastError()));
 
     // copy the results from the device to the host
-    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(out_h.data(), out_d, size * sizeof(float), cudaMemcpyDeviceToHost)));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMemcpy(out_h.data(), out_d, size * sizeof(float), cudaMemcpyDeviceToHost)));
 
     // wait for all the operations to complete
-    REQUIRE_NOTHROW(cudaCheck(cudaDeviceSynchronize()));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaDeviceSynchronize()));
 
     // check the results
     for (size_t i = 0; i < size; ++i) {

--- a/HeterogeneousTest/CUDAOpaque/README.md
+++ b/HeterogeneousTest/CUDAOpaque/README.md
@@ -48,7 +48,7 @@ Unfortunately, the CUDA kernels used in the `CUDATestDeviceAdditionModule` plugi
 the `HeterogeneousTest/CUDAKernel` library run into some kind of conflict, leading to the error
 ```
 HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu, line 17:
-cudaCheck(cudaGetLastError());
+CUDA_CHECK(cudaGetLastError());
 cudaErrorInvalidDeviceFunction: invalid device function
 ```
 Using together the other three plugins does work correctly.

--- a/HeterogeneousTest/CUDAOpaque/src/DeviceAdditionOpaque.cc
+++ b/HeterogeneousTest/CUDAOpaque/src/DeviceAdditionOpaque.cc
@@ -13,30 +13,30 @@ namespace cms::cudatest {
     float* in1_d;
     float* in2_d;
     float* out_d;
-    cudaCheck(cudaMalloc(&in1_d, size * sizeof(float)));
-    cudaCheck(cudaMalloc(&in2_d, size * sizeof(float)));
-    cudaCheck(cudaMalloc(&out_d, size * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&in1_d, size * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&in2_d, size * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&out_d, size * sizeof(float)));
 
     // copy the input data to the device
-    cudaCheck(cudaMemcpy(in1_d, in1_h, size * sizeof(float), cudaMemcpyHostToDevice));
-    cudaCheck(cudaMemcpy(in2_d, in2_h, size * sizeof(float), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(in1_d, in1_h, size * sizeof(float), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(in2_d, in2_h, size * sizeof(float), cudaMemcpyHostToDevice));
 
     // fill the output buffer with zeros
-    cudaCheck(cudaMemset(out_d, 0, size * sizeof(float)));
+    CUDA_CHECK(cudaMemset(out_d, 0, size * sizeof(float)));
 
     // launch the 1-dimensional kernel for vector addition
     wrapper_add_vectors_f(in1_d, in2_d, out_d, size);
 
     // copy the results from the device to the host
-    cudaCheck(cudaMemcpy(out_h, out_d, size * sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(out_h, out_d, size * sizeof(float), cudaMemcpyDeviceToHost));
 
     // wait for all the operations to complete
-    cudaCheck(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaDeviceSynchronize());
 
     // free the input and output buffers on the device
-    cudaCheck(cudaFree(in1_d));
-    cudaCheck(cudaFree(in2_d));
-    cudaCheck(cudaFree(out_d));
+    CUDA_CHECK(cudaFree(in1_d));
+    CUDA_CHECK(cudaFree(in2_d));
+    CUDA_CHECK(cudaFree(out_d));
   }
 
   void opaque_add_vectors_d(const double* in1_h, const double* in2_h, double* out_h, size_t size) {
@@ -44,30 +44,30 @@ namespace cms::cudatest {
     double* in1_d;
     double* in2_d;
     double* out_d;
-    cudaCheck(cudaMalloc(&in1_d, size * sizeof(double)));
-    cudaCheck(cudaMalloc(&in2_d, size * sizeof(double)));
-    cudaCheck(cudaMalloc(&out_d, size * sizeof(double)));
+    CUDA_CHECK(cudaMalloc(&in1_d, size * sizeof(double)));
+    CUDA_CHECK(cudaMalloc(&in2_d, size * sizeof(double)));
+    CUDA_CHECK(cudaMalloc(&out_d, size * sizeof(double)));
 
     // copy the input data to the device
-    cudaCheck(cudaMemcpy(in1_d, in1_h, size * sizeof(double), cudaMemcpyHostToDevice));
-    cudaCheck(cudaMemcpy(in2_d, in2_h, size * sizeof(double), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(in1_d, in1_h, size * sizeof(double), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(in2_d, in2_h, size * sizeof(double), cudaMemcpyHostToDevice));
 
     // fill the output buffer with zeros
-    cudaCheck(cudaMemset(out_d, 0, size * sizeof(double)));
+    CUDA_CHECK(cudaMemset(out_d, 0, size * sizeof(double)));
 
     // launch the 1-dimensional kernel for vector addition
     wrapper_add_vectors_d(in1_d, in2_d, out_d, size);
 
     // copy the results from the device to the host
-    cudaCheck(cudaMemcpy(out_h, out_d, size * sizeof(double), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(out_h, out_d, size * sizeof(double), cudaMemcpyDeviceToHost));
 
     // wait for all the operations to complete
-    cudaCheck(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaDeviceSynchronize());
 
     // free the input and output buffers on the device
-    cudaCheck(cudaFree(in1_d));
-    cudaCheck(cudaFree(in2_d));
-    cudaCheck(cudaFree(out_d));
+    CUDA_CHECK(cudaFree(in1_d));
+    CUDA_CHECK(cudaFree(in2_d));
+    CUDA_CHECK(cudaFree(out_d));
   }
 
 }  // namespace cms::cudatest

--- a/HeterogeneousTest/CUDAWrapper/README.md
+++ b/HeterogeneousTest/CUDAWrapper/README.md
@@ -50,7 +50,7 @@ Unfortunately, the CUDA kernels used in the `CUDATestDeviceAdditionModule` plugi
 the `HeterogeneousTest/CUDAKernel` library run into some kind of conflict, leading to the error
 ```
 HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu, line 17:
-cudaCheck(cudaGetLastError());
+CUDA_CHECK(cudaGetLastError());
 cudaErrorInvalidDeviceFunction: invalid device function
 ```
 Using together the other three plugins does work correctly.

--- a/HeterogeneousTest/CUDAWrapper/plugins/CUDATestWrapperAdditionModule.cc
+++ b/HeterogeneousTest/CUDAWrapper/plugins/CUDATestWrapperAdditionModule.cc
@@ -73,25 +73,25 @@ void CUDATestWrapperAdditionModule::analyze(edm::StreamID,
   float* in1_d;
   float* in2_d;
   float* out_d;
-  cudaCheck(cudaMalloc(&in1_d, size_ * sizeof(float)));
-  cudaCheck(cudaMalloc(&in2_d, size_ * sizeof(float)));
-  cudaCheck(cudaMalloc(&out_d, size_ * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&in1_d, size_ * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&in2_d, size_ * sizeof(float)));
+  CUDA_CHECK(cudaMalloc(&out_d, size_ * sizeof(float)));
 
   // copy the input data to the device
-  cudaCheck(cudaMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
-  cudaCheck(cudaMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
 
   // fill the output buffer with zeros
-  cudaCheck(cudaMemset(out_d, 0, size_ * sizeof(float)));
+  CUDA_CHECK(cudaMemset(out_d, 0, size_ * sizeof(float)));
 
   // launch the 1-dimensional kernel for vector addition
   cms::cudatest::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
 
   // copy the results from the device to the host
-  cudaCheck(cudaMemcpy(out_h.data(), out_d, size_ * sizeof(float), cudaMemcpyDeviceToHost));
+  CUDA_CHECK(cudaMemcpy(out_h.data(), out_d, size_ * sizeof(float), cudaMemcpyDeviceToHost));
 
   // wait for all the operations to complete
-  cudaCheck(cudaDeviceSynchronize());
+  CUDA_CHECK(cudaDeviceSynchronize());
 
   // check the results
   for (size_t i = 0; i < size_; ++i) {

--- a/HeterogeneousTest/CUDAWrapper/src/DeviceAdditionWrapper.cu
+++ b/HeterogeneousTest/CUDAWrapper/src/DeviceAdditionWrapper.cu
@@ -14,7 +14,7 @@ namespace cms::cudatest {
                              size_t size) {
     // launch the 1-dimensional kernel for vector addition
     kernel_add_vectors_f<<<32, 32>>>(in1, in2, out, size);
-    cudaCheck(cudaGetLastError());
+    CUDA_CHECK(cudaGetLastError());
   }
 
   void wrapper_add_vectors_d(const double* __restrict__ in1,
@@ -23,7 +23,7 @@ namespace cms::cudatest {
                              size_t size) {
     // launch the 1-dimensional kernel for vector addition
     kernel_add_vectors_d<<<32, 32>>>(in1, in2, out, size);
-    cudaCheck(cudaGetLastError());
+    CUDA_CHECK(cudaGetLastError());
   }
 
 }  // namespace cms::cudatest

--- a/HeterogeneousTest/CUDAWrapper/test/testDeviceAdditionWrapper.cc
+++ b/HeterogeneousTest/CUDAWrapper/test/testDeviceAdditionWrapper.cc
@@ -43,25 +43,25 @@ TEST_CASE("HeterogeneousTest/CUDAWrapper test", "[cudaTestWrapperAdditionWrapper
     float* in1_d;
     float* in2_d;
     float* out_d;
-    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&in1_d, size * sizeof(float))));
-    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&in2_d, size * sizeof(float))));
-    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&out_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMalloc(&in1_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMalloc(&in2_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMalloc(&out_d, size * sizeof(float))));
 
     // copy the input data to the device
-    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(in1_d, in1_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
-    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(in2_d, in2_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMemcpy(in1_d, in1_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMemcpy(in2_d, in2_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
 
     // fill the output buffer with zeros
-    REQUIRE_NOTHROW(cudaCheck(cudaMemset(out_d, 0, size * sizeof(float))));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMemset(out_d, 0, size * sizeof(float))));
 
     // launch the 1-dimensional kernel for vector addition
     REQUIRE_NOTHROW(cms::cudatest::wrapper_add_vectors_f(in1_d, in2_d, out_d, size));
 
     // copy the results from the device to the host
-    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(out_h.data(), out_d, size * sizeof(float), cudaMemcpyDeviceToHost)));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaMemcpy(out_h.data(), out_d, size * sizeof(float), cudaMemcpyDeviceToHost)));
 
     // wait for all the operations to complete
-    REQUIRE_NOTHROW(cudaCheck(cudaDeviceSynchronize()));
+    REQUIRE_NOTHROW(CUDA_CHECK(cudaDeviceSynchronize()));
 
     // check the results
     for (size_t i = 0; i < size; ++i) {

--- a/HeterogeneousTest/ROCmDevice/plugins/ROCmTestDeviceAdditionAlgo.hip.cc
+++ b/HeterogeneousTest/ROCmDevice/plugins/ROCmTestDeviceAdditionAlgo.hip.cc
@@ -21,7 +21,7 @@ namespace HeterogeneousTestROCmDevicePlugins {
                              float* __restrict__ out,
                              size_t size) {
     kernel_add_vectors_f<<<32, 32>>>(in1, in2, out, size);
-    hipCheck(hipGetLastError());
+    HIP_CHECK(hipGetLastError());
   }
 
 }  // namespace HeterogeneousTestROCmDevicePlugins

--- a/HeterogeneousTest/ROCmDevice/plugins/ROCmTestDeviceAdditionModule.cc
+++ b/HeterogeneousTest/ROCmDevice/plugins/ROCmTestDeviceAdditionModule.cc
@@ -72,25 +72,25 @@ void ROCmTestDeviceAdditionModule::analyze(edm::StreamID, edm::Event const& even
   float* in1_d;
   float* in2_d;
   float* out_d;
-  hipCheck(hipMalloc(&in1_d, size_ * sizeof(float)));
-  hipCheck(hipMalloc(&in2_d, size_ * sizeof(float)));
-  hipCheck(hipMalloc(&out_d, size_ * sizeof(float)));
+  HIP_CHECK(hipMalloc(&in1_d, size_ * sizeof(float)));
+  HIP_CHECK(hipMalloc(&in2_d, size_ * sizeof(float)));
+  HIP_CHECK(hipMalloc(&out_d, size_ * sizeof(float)));
 
   // copy the input data to the device
-  hipCheck(hipMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), hipMemcpyHostToDevice));
-  hipCheck(hipMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), hipMemcpyHostToDevice));
 
   // fill the output buffer with zeros
-  hipCheck(hipMemset(out_d, 0, size_ * sizeof(float)));
+  HIP_CHECK(hipMemset(out_d, 0, size_ * sizeof(float)));
 
   // launch the 1-dimensional kernel for vector addition
   HeterogeneousTestROCmDevicePlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
 
   // copy the results from the device to the host
-  hipCheck(hipMemcpy(out_h.data(), out_d, size_ * sizeof(float), hipMemcpyDeviceToHost));
+  HIP_CHECK(hipMemcpy(out_h.data(), out_d, size_ * sizeof(float), hipMemcpyDeviceToHost));
 
   // wait for all the operations to complete
-  hipCheck(hipDeviceSynchronize());
+  HIP_CHECK(hipDeviceSynchronize());
 
   // check the results
   for (size_t i = 0; i < size_; ++i) {

--- a/HeterogeneousTest/ROCmDevice/test/testDeviceAddition.hip.cc
+++ b/HeterogeneousTest/ROCmDevice/test/testDeviceAddition.hip.cc
@@ -50,26 +50,26 @@ TEST_CASE("HeterogeneousTest/ROCmDevice test", "[rocmTestDeviceAddition]") {
     float* in1_d;
     float* in2_d;
     float* out_d;
-    REQUIRE_NOTHROW(hipCheck(hipMalloc(&in1_d, size * sizeof(float))));
-    REQUIRE_NOTHROW(hipCheck(hipMalloc(&in2_d, size * sizeof(float))));
-    REQUIRE_NOTHROW(hipCheck(hipMalloc(&out_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMalloc(&in1_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMalloc(&in2_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMalloc(&out_d, size * sizeof(float))));
 
     // copy the input data to the device
-    REQUIRE_NOTHROW(hipCheck(hipMemcpy(in1_d, in1_h.data(), size * sizeof(float), hipMemcpyHostToDevice)));
-    REQUIRE_NOTHROW(hipCheck(hipMemcpy(in2_d, in2_h.data(), size * sizeof(float), hipMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMemcpy(in1_d, in1_h.data(), size * sizeof(float), hipMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMemcpy(in2_d, in2_h.data(), size * sizeof(float), hipMemcpyHostToDevice)));
 
     // fill the output buffer with zeros
-    REQUIRE_NOTHROW(hipCheck(hipMemset(out_d, 0, size * sizeof(float))));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMemset(out_d, 0, size * sizeof(float))));
 
     // launch the 1-dimensional kernel for vector addition
     kernel_add_vectors_f<<<32, 32>>>(in1_d, in2_d, out_d, size);
-    REQUIRE_NOTHROW(hipCheck(hipGetLastError()));
+    REQUIRE_NOTHROW(HIP_CHECK(hipGetLastError()));
 
     // copy the results from the device to the host
-    REQUIRE_NOTHROW(hipCheck(hipMemcpy(out_h.data(), out_d, size * sizeof(float), hipMemcpyDeviceToHost)));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMemcpy(out_h.data(), out_d, size * sizeof(float), hipMemcpyDeviceToHost)));
 
     // wait for all the operations to complete
-    REQUIRE_NOTHROW(hipCheck(hipDeviceSynchronize()));
+    REQUIRE_NOTHROW(HIP_CHECK(hipDeviceSynchronize()));
 
     // check the results
     for (size_t i = 0; i < size; ++i) {

--- a/HeterogeneousTest/ROCmKernel/plugins/ROCmTestKernelAdditionAlgo.hip.cc
+++ b/HeterogeneousTest/ROCmKernel/plugins/ROCmTestKernelAdditionAlgo.hip.cc
@@ -14,7 +14,7 @@ namespace HeterogeneousTestROCmKernelPlugins {
                              float* __restrict__ out,
                              size_t size) {
     cms::rocmtest::kernel_add_vectors_f<<<32, 32>>>(in1, in2, out, size);
-    hipCheck(hipGetLastError());
+    HIP_CHECK(hipGetLastError());
   }
 
 }  // namespace HeterogeneousTestROCmKernelPlugins

--- a/HeterogeneousTest/ROCmKernel/plugins/ROCmTestKernelAdditionModule.cc
+++ b/HeterogeneousTest/ROCmKernel/plugins/ROCmTestKernelAdditionModule.cc
@@ -72,25 +72,25 @@ void ROCmTestKernelAdditionModule::analyze(edm::StreamID, edm::Event const& even
   float* in1_d;
   float* in2_d;
   float* out_d;
-  hipCheck(hipMalloc(&in1_d, size_ * sizeof(float)));
-  hipCheck(hipMalloc(&in2_d, size_ * sizeof(float)));
-  hipCheck(hipMalloc(&out_d, size_ * sizeof(float)));
+  HIP_CHECK(hipMalloc(&in1_d, size_ * sizeof(float)));
+  HIP_CHECK(hipMalloc(&in2_d, size_ * sizeof(float)));
+  HIP_CHECK(hipMalloc(&out_d, size_ * sizeof(float)));
 
   // copy the input data to the device
-  hipCheck(hipMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), hipMemcpyHostToDevice));
-  hipCheck(hipMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), hipMemcpyHostToDevice));
 
   // fill the output buffer with zeros
-  hipCheck(hipMemset(out_d, 0, size_ * sizeof(float)));
+  HIP_CHECK(hipMemset(out_d, 0, size_ * sizeof(float)));
 
   // launch the 1-dimensional kernel for vector addition
   HeterogeneousTestROCmKernelPlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
 
   // copy the results from the device to the host
-  hipCheck(hipMemcpy(out_h.data(), out_d, size_ * sizeof(float), hipMemcpyDeviceToHost));
+  HIP_CHECK(hipMemcpy(out_h.data(), out_d, size_ * sizeof(float), hipMemcpyDeviceToHost));
 
   // wait for all the operations to complete
-  hipCheck(hipDeviceSynchronize());
+  HIP_CHECK(hipDeviceSynchronize());
 
   // check the results
   for (size_t i = 0; i < size_; ++i) {

--- a/HeterogeneousTest/ROCmKernel/test/testDeviceAdditionKernel.hip.cc
+++ b/HeterogeneousTest/ROCmKernel/test/testDeviceAdditionKernel.hip.cc
@@ -43,26 +43,26 @@ TEST_CASE("HeterogeneousTest/ROCmKernel test", "[rocmTestKernelAdditionKernel]")
     float* in1_d;
     float* in2_d;
     float* out_d;
-    REQUIRE_NOTHROW(hipCheck(hipMalloc(&in1_d, size * sizeof(float))));
-    REQUIRE_NOTHROW(hipCheck(hipMalloc(&in2_d, size * sizeof(float))));
-    REQUIRE_NOTHROW(hipCheck(hipMalloc(&out_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMalloc(&in1_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMalloc(&in2_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMalloc(&out_d, size * sizeof(float))));
 
     // copy the input data to the device
-    REQUIRE_NOTHROW(hipCheck(hipMemcpy(in1_d, in1_h.data(), size * sizeof(float), hipMemcpyHostToDevice)));
-    REQUIRE_NOTHROW(hipCheck(hipMemcpy(in2_d, in2_h.data(), size * sizeof(float), hipMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMemcpy(in1_d, in1_h.data(), size * sizeof(float), hipMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMemcpy(in2_d, in2_h.data(), size * sizeof(float), hipMemcpyHostToDevice)));
 
     // fill the output buffer with zeros
-    REQUIRE_NOTHROW(hipCheck(hipMemset(out_d, 0, size * sizeof(float))));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMemset(out_d, 0, size * sizeof(float))));
 
     // launch the 1-dimensional kernel for vector addition
     cms::rocmtest::kernel_add_vectors_f<<<32, 32>>>(in1_d, in2_d, out_d, size);
-    REQUIRE_NOTHROW(hipCheck(hipGetLastError()));
+    REQUIRE_NOTHROW(HIP_CHECK(hipGetLastError()));
 
     // copy the results from the device to the host
-    REQUIRE_NOTHROW(hipCheck(hipMemcpy(out_h.data(), out_d, size * sizeof(float), hipMemcpyDeviceToHost)));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMemcpy(out_h.data(), out_d, size * sizeof(float), hipMemcpyDeviceToHost)));
 
     // wait for all the operations to complete
-    REQUIRE_NOTHROW(hipCheck(hipDeviceSynchronize()));
+    REQUIRE_NOTHROW(HIP_CHECK(hipDeviceSynchronize()));
 
     // check the results
     for (size_t i = 0; i < size; ++i) {

--- a/HeterogeneousTest/ROCmOpaque/src/DeviceAdditionOpaque.cc
+++ b/HeterogeneousTest/ROCmOpaque/src/DeviceAdditionOpaque.cc
@@ -13,30 +13,30 @@ namespace cms::rocmtest {
     float* in1_d;
     float* in2_d;
     float* out_d;
-    hipCheck(hipMalloc(&in1_d, size * sizeof(float)));
-    hipCheck(hipMalloc(&in2_d, size * sizeof(float)));
-    hipCheck(hipMalloc(&out_d, size * sizeof(float)));
+    HIP_CHECK(hipMalloc(&in1_d, size * sizeof(float)));
+    HIP_CHECK(hipMalloc(&in2_d, size * sizeof(float)));
+    HIP_CHECK(hipMalloc(&out_d, size * sizeof(float)));
 
     // copy the input data to the device
-    hipCheck(hipMemcpy(in1_d, in1_h, size * sizeof(float), hipMemcpyHostToDevice));
-    hipCheck(hipMemcpy(in2_d, in2_h, size * sizeof(float), hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(in1_d, in1_h, size * sizeof(float), hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(in2_d, in2_h, size * sizeof(float), hipMemcpyHostToDevice));
 
     // fill the output buffer with zeros
-    hipCheck(hipMemset(out_d, 0, size * sizeof(float)));
+    HIP_CHECK(hipMemset(out_d, 0, size * sizeof(float)));
 
     // launch the 1-dimensional kernel for vector addition
     wrapper_add_vectors_f(in1_d, in2_d, out_d, size);
 
     // copy the results from the device to the host
-    hipCheck(hipMemcpy(out_h, out_d, size * sizeof(float), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipMemcpy(out_h, out_d, size * sizeof(float), hipMemcpyDeviceToHost));
 
     // wait for all the operations to complete
-    hipCheck(hipDeviceSynchronize());
+    HIP_CHECK(hipDeviceSynchronize());
 
     // free the input and output buffers on the device
-    hipCheck(hipFree(in1_d));
-    hipCheck(hipFree(in2_d));
-    hipCheck(hipFree(out_d));
+    HIP_CHECK(hipFree(in1_d));
+    HIP_CHECK(hipFree(in2_d));
+    HIP_CHECK(hipFree(out_d));
   }
 
   void opaque_add_vectors_d(const double* in1_h, const double* in2_h, double* out_h, size_t size) {
@@ -44,30 +44,30 @@ namespace cms::rocmtest {
     double* in1_d;
     double* in2_d;
     double* out_d;
-    hipCheck(hipMalloc(&in1_d, size * sizeof(double)));
-    hipCheck(hipMalloc(&in2_d, size * sizeof(double)));
-    hipCheck(hipMalloc(&out_d, size * sizeof(double)));
+    HIP_CHECK(hipMalloc(&in1_d, size * sizeof(double)));
+    HIP_CHECK(hipMalloc(&in2_d, size * sizeof(double)));
+    HIP_CHECK(hipMalloc(&out_d, size * sizeof(double)));
 
     // copy the input data to the device
-    hipCheck(hipMemcpy(in1_d, in1_h, size * sizeof(double), hipMemcpyHostToDevice));
-    hipCheck(hipMemcpy(in2_d, in2_h, size * sizeof(double), hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(in1_d, in1_h, size * sizeof(double), hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(in2_d, in2_h, size * sizeof(double), hipMemcpyHostToDevice));
 
     // fill the output buffer with zeros
-    hipCheck(hipMemset(out_d, 0, size * sizeof(double)));
+    HIP_CHECK(hipMemset(out_d, 0, size * sizeof(double)));
 
     // launch the 1-dimensional kernel for vector addition
     wrapper_add_vectors_d(in1_d, in2_d, out_d, size);
 
     // copy the results from the device to the host
-    hipCheck(hipMemcpy(out_h, out_d, size * sizeof(double), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipMemcpy(out_h, out_d, size * sizeof(double), hipMemcpyDeviceToHost));
 
     // wait for all the operations to complete
-    hipCheck(hipDeviceSynchronize());
+    HIP_CHECK(hipDeviceSynchronize());
 
     // free the input and output buffers on the device
-    hipCheck(hipFree(in1_d));
-    hipCheck(hipFree(in2_d));
-    hipCheck(hipFree(out_d));
+    HIP_CHECK(hipFree(in1_d));
+    HIP_CHECK(hipFree(in2_d));
+    HIP_CHECK(hipFree(out_d));
   }
 
 }  // namespace cms::rocmtest

--- a/HeterogeneousTest/ROCmWrapper/plugins/ROCmTestWrapperAdditionModule.cc
+++ b/HeterogeneousTest/ROCmWrapper/plugins/ROCmTestWrapperAdditionModule.cc
@@ -73,25 +73,25 @@ void ROCmTestWrapperAdditionModule::analyze(edm::StreamID,
   float* in1_d;
   float* in2_d;
   float* out_d;
-  hipCheck(hipMalloc(&in1_d, size_ * sizeof(float)));
-  hipCheck(hipMalloc(&in2_d, size_ * sizeof(float)));
-  hipCheck(hipMalloc(&out_d, size_ * sizeof(float)));
+  HIP_CHECK(hipMalloc(&in1_d, size_ * sizeof(float)));
+  HIP_CHECK(hipMalloc(&in2_d, size_ * sizeof(float)));
+  HIP_CHECK(hipMalloc(&out_d, size_ * sizeof(float)));
 
   // copy the input data to the device
-  hipCheck(hipMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), hipMemcpyHostToDevice));
-  hipCheck(hipMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), hipMemcpyHostToDevice));
 
   // fill the output buffer with zeros
-  hipCheck(hipMemset(out_d, 0, size_ * sizeof(float)));
+  HIP_CHECK(hipMemset(out_d, 0, size_ * sizeof(float)));
 
   // launch the 1-dimensional kernel for vector addition
   cms::rocmtest::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
 
   // copy the results from the device to the host
-  hipCheck(hipMemcpy(out_h.data(), out_d, size_ * sizeof(float), hipMemcpyDeviceToHost));
+  HIP_CHECK(hipMemcpy(out_h.data(), out_d, size_ * sizeof(float), hipMemcpyDeviceToHost));
 
   // wait for all the operations to complete
-  hipCheck(hipDeviceSynchronize());
+  HIP_CHECK(hipDeviceSynchronize());
 
   // check the results
   for (size_t i = 0; i < size_; ++i) {

--- a/HeterogeneousTest/ROCmWrapper/src/DeviceAdditionWrapper.hip.cc
+++ b/HeterogeneousTest/ROCmWrapper/src/DeviceAdditionWrapper.hip.cc
@@ -14,7 +14,7 @@ namespace cms::rocmtest {
                              size_t size) {
     // launch the 1-dimensional kernel for vector addition
     kernel_add_vectors_f<<<32, 32>>>(in1, in2, out, size);
-    hipCheck(hipGetLastError());
+    HIP_CHECK(hipGetLastError());
   }
 
   void wrapper_add_vectors_d(const double* __restrict__ in1,
@@ -23,7 +23,7 @@ namespace cms::rocmtest {
                              size_t size) {
     // launch the 1-dimensional kernel for vector addition
     kernel_add_vectors_d<<<32, 32>>>(in1, in2, out, size);
-    hipCheck(hipGetLastError());
+    HIP_CHECK(hipGetLastError());
   }
 
 }  // namespace cms::rocmtest

--- a/HeterogeneousTest/ROCmWrapper/test/testDeviceAdditionWrapper.cc
+++ b/HeterogeneousTest/ROCmWrapper/test/testDeviceAdditionWrapper.cc
@@ -43,25 +43,25 @@ TEST_CASE("HeterogeneousTest/ROCmWrapper test", "[rocmTestWrapperAdditionWrapper
     float* in1_d;
     float* in2_d;
     float* out_d;
-    REQUIRE_NOTHROW(hipCheck(hipMalloc(&in1_d, size * sizeof(float))));
-    REQUIRE_NOTHROW(hipCheck(hipMalloc(&in2_d, size * sizeof(float))));
-    REQUIRE_NOTHROW(hipCheck(hipMalloc(&out_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMalloc(&in1_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMalloc(&in2_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMalloc(&out_d, size * sizeof(float))));
 
     // copy the input data to the device
-    REQUIRE_NOTHROW(hipCheck(hipMemcpy(in1_d, in1_h.data(), size * sizeof(float), hipMemcpyHostToDevice)));
-    REQUIRE_NOTHROW(hipCheck(hipMemcpy(in2_d, in2_h.data(), size * sizeof(float), hipMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMemcpy(in1_d, in1_h.data(), size * sizeof(float), hipMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMemcpy(in2_d, in2_h.data(), size * sizeof(float), hipMemcpyHostToDevice)));
 
     // fill the output buffer with zeros
-    REQUIRE_NOTHROW(hipCheck(hipMemset(out_d, 0, size * sizeof(float))));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMemset(out_d, 0, size * sizeof(float))));
 
     // launch the 1-dimensional kernel for vector addition
     REQUIRE_NOTHROW(cms::rocmtest::wrapper_add_vectors_f(in1_d, in2_d, out_d, size));
 
     // copy the results from the device to the host
-    REQUIRE_NOTHROW(hipCheck(hipMemcpy(out_h.data(), out_d, size * sizeof(float), hipMemcpyDeviceToHost)));
+    REQUIRE_NOTHROW(HIP_CHECK(hipMemcpy(out_h.data(), out_d, size * sizeof(float), hipMemcpyDeviceToHost)));
 
     // wait for all the operations to complete
-    REQUIRE_NOTHROW(hipCheck(hipDeviceSynchronize()));
+    REQUIRE_NOTHROW(HIP_CHECK(hipDeviceSynchronize()));
 
     // check the results
     for (size_t i = 0; i < size; ++i) {

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -54,29 +54,29 @@ const pixelCPEforGPU::ParamsOnGPUT<TrackerTraits>* PixelCPEFast<TrackerTraits>::
   const auto& data = gpuData_.dataForCurrentDeviceAsync(cudaStream, [this](GPUData& data, cudaStream_t stream) {
     // and now copy to device...
 
-    cudaCheck(cudaMalloc((void**)&data.paramsOnGPU_h.m_commonParams, sizeof(pixelCPEforGPU::CommonParams)));
-    cudaCheck(cudaMalloc((void**)&data.paramsOnGPU_h.m_detParams,
+    CUDA_CHECK(cudaMalloc((void**)&data.paramsOnGPU_h.m_commonParams, sizeof(pixelCPEforGPU::CommonParams)));
+    CUDA_CHECK(cudaMalloc((void**)&data.paramsOnGPU_h.m_detParams,
                          this->detParamsGPU_.size() * sizeof(pixelCPEforGPU::DetParams)));
-    cudaCheck(cudaMalloc((void**)&data.paramsOnGPU_h.m_averageGeometry, sizeof(AverageGeometry)));
-    cudaCheck(cudaMalloc((void**)&data.paramsOnGPU_h.m_layerGeometry, sizeof(LayerGeometry)));
-    cudaCheck(cudaMalloc((void**)&data.paramsOnGPU_d, sizeof(ParamsOnGPU)));
-    cudaCheck(cudaMemcpyAsync(data.paramsOnGPU_d, &data.paramsOnGPU_h, sizeof(ParamsOnGPU), cudaMemcpyDefault, stream));
-    cudaCheck(cudaMemcpyAsync((void*)data.paramsOnGPU_h.m_commonParams,
+    CUDA_CHECK(cudaMalloc((void**)&data.paramsOnGPU_h.m_averageGeometry, sizeof(AverageGeometry)));
+    CUDA_CHECK(cudaMalloc((void**)&data.paramsOnGPU_h.m_layerGeometry, sizeof(LayerGeometry)));
+    CUDA_CHECK(cudaMalloc((void**)&data.paramsOnGPU_d, sizeof(ParamsOnGPU)));
+    CUDA_CHECK(cudaMemcpyAsync(data.paramsOnGPU_d, &data.paramsOnGPU_h, sizeof(ParamsOnGPU), cudaMemcpyDefault, stream));
+    CUDA_CHECK(cudaMemcpyAsync((void*)data.paramsOnGPU_h.m_commonParams,
                               &this->commonParamsGPU_,
                               sizeof(pixelCPEforGPU::CommonParams),
                               cudaMemcpyDefault,
                               stream));
-    cudaCheck(cudaMemcpyAsync((void*)data.paramsOnGPU_h.m_averageGeometry,
+    CUDA_CHECK(cudaMemcpyAsync((void*)data.paramsOnGPU_h.m_averageGeometry,
                               &this->averageGeometry_,
                               sizeof(AverageGeometry),
                               cudaMemcpyDefault,
                               stream));
-    cudaCheck(cudaMemcpyAsync((void*)data.paramsOnGPU_h.m_layerGeometry,
+    CUDA_CHECK(cudaMemcpyAsync((void*)data.paramsOnGPU_h.m_layerGeometry,
                               &this->layerGeometry_,
                               sizeof(LayerGeometry),
                               cudaMemcpyDefault,
                               stream));
-    cudaCheck(cudaMemcpyAsync((void*)data.paramsOnGPU_h.m_detParams,
+    CUDA_CHECK(cudaMemcpyAsync((void*)data.paramsOnGPU_h.m_detParams,
                               this->detParamsGPU_.data(),
                               this->detParamsGPU_.size() * sizeof(pixelCPEforGPU::DetParams),
                               cudaMemcpyDefault,


### PR DESCRIPTION
#### PR description:

Rename GPU check macros to uppercase

Rename:
  - `cudaCheck(...)` to `CUDA_CHECK(...)`
  - `nvmlCheck(...)` to `NVML_CHECK(...)`
  - `hipCheck(...)` to `HIP_CHECK(...)`
  - `rsmiCheck(...)` to `RSMI_CHECK(...)`

#### PR validation:

Unit tests ran successfully.