### PR TITLE
[NGT] Fix loop over track SoA in L2TauTagNNProducer

### DIFF
--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducerAlpaka.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducerAlpaka.cc
@@ -576,10 +576,10 @@ void L2TauNNProducerAlpaka::selectGoodTracksAndVertices(const ZVertexHost& patav
                                                         const TracksHost& patatracks_tsoa,
                                                         std::vector<int>& trkGood,
                                                         std::vector<int>& vtxGood) {
-  const auto maxTracks = patatracks_tsoa.view().tracks().metadata().size();
+  const auto nTracks = patatracks_tsoa.view().tracks().nTracks();
   const int nv = patavtx_soa.view().zvertex().nvFinal();
   trkGood.clear();
-  trkGood.reserve(maxTracks);
+  trkGood.reserve(nTracks);
   vtxGood.clear();
   vtxGood.reserve(nv);
   auto const quality = patatracks_tsoa.view().tracks().quality();
@@ -588,11 +588,8 @@ void L2TauNNProducerAlpaka::selectGoodTracksAndVertices(const ZVertexHost& patav
   std::vector<float> pTSquaredSum(nv, 0);
   std::vector<int> nTrkAssociated(nv, 0);
 
-  for (int32_t trk_idx = 0; trk_idx < maxTracks; ++trk_idx) {
+  for (int32_t trk_idx = 0; trk_idx < nTracks; ++trk_idx) {
     auto n_hits = nHits(patatracks_tsoa.view().tracks(), trk_idx);
-    if (n_hits == 0) {
-      break;
-    }
     int vtx_ass_to_track = patavtx_soa.view().zvertexTracks()[trk_idx].idv();
     if (vtx_ass_to_track >= 0 && vtx_ass_to_track < nv) {
       auto patatrackPt = patatracks_tsoa.view().tracks()[trk_idx].pt();


### PR DESCRIPTION
#### PR description:

This PR fixes issue #51543 of non-reproducible trigger results in tau paths. More detailed explanation in the issue itself. Effectively, the fix consists of setting the loop over the Patatrack pixel track SoA to the correct end (known number of tracks) instead of deducing it from the first track with `nHits=0`, as this is no longer valid after #51085.

#### PR validation:

I tested the setup manually, explicitly reproducibility of the HLT paths inside `HLTrigger/Configuration/test`:
```bash
hltIntegrationTests OnLine_HLT_GRun.py \
 -x realData=1 \
 -x globalTag=@ \
 -d HLT_Integration_GRun_DATA \
 -i file:../RelVal_Raw_GRun_DATA.root \
 -n 100 -j 8 -a cpu \
 >& HLT_Integration_GRun_DATA.log
```

Results look fine and test is passed.
For more validation, the bot tests should be sufficient.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.

FYI @mmusich 
