### PR TITLE
Enable the MC-truth graph with configurable event-content levels

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C17I13M9_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C17I13M9_cff.py
@@ -3,5 +3,10 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
 from Configuration.Eras.Modifier_phase2_hgcalV12_cff import phase2_hgcalV12
 from Configuration.Eras.Modifier_phase2_hgcalV16_cff import phase2_hgcalV16
+# MC-truth graph on by default for Run4. This is the common HGCal-geometry-agnostic
+# Phase-2 base, so every geometry era layered on it (C20 hfnose, C22 V18, C26 V19 and
+# future versions) inherits truth. Gated at DIGI by (enableTruth & phase2_hgcal);
+# FastSim drops it via fastSimPhase2, premix drops it at the digitizer level.
+from Configuration.ProcessModifiers.enableTruth_cff import enableTruth
 
-Phase2C17I13M9 = cms.ModifierChain(Phase2C11I13M9.copyAndExclude([phase2_hgcalV12]),phase2_hgcalV16)
+Phase2C17I13M9 = cms.ModifierChain(Phase2C11I13M9.copyAndExclude([phase2_hgcalV12]), phase2_hgcalV16, enableTruth)

--- a/Configuration/Eras/python/Era_Phase2C22I13M9_FastSim_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C22I13M9_FastSim_cff.py
@@ -3,4 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Phase2C22I13M9_cff import Phase2C22I13M9
 from Configuration.Eras.Util_fastSimPhase2_cff import fastSimPhase2
 
+# fastSimPhase2 excludes enableTruth: the truth accumulator reads full-sim g4SimHits
+# during classic mixing, which FastSim does not provide.
 Phase2C22I13M9_FastSim = fastSimPhase2(Phase2C22I13M9)

--- a/Configuration/Eras/python/Era_Phase2C22I13M9_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C22I13M9_cff.py
@@ -3,4 +3,5 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 from Configuration.Eras.Modifier_phase2_hgcalV18_cff import phase2_hgcalV18
 
+# enableTruth (MC-truth graph default for Run4) is inherited from Phase2C17I13M9.
 Phase2C22I13M9 = cms.ModifierChain(Phase2C17I13M9, phase2_hgcalV18)

--- a/Configuration/Eras/python/Util_fastSimPhase2_cff.py
+++ b/Configuration/Eras/python/Util_fastSimPhase2_cff.py
@@ -8,9 +8,12 @@ from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_la
 from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProdPhase2
 from Configuration.Eras.Modifier_phase2_fastSim_cff import phase2_fastSim
+# The MC-truth graph accumulator reads full-sim g4SimHits during classic mixing, which
+# FastSim does not provide, so enableTruth is dropped from every FastSim era here.
+from Configuration.ProcessModifiers.enableTruth_cff import enableTruth
 
 def fastSimPhase2(obj):
     return cms.ModifierChain(
-        obj.copyAndExclude([run3_GEM, phase2_muon, phase2_GEM, phase2_timing, phase2_timing_layer, phase2_trigger, trackingMkFitProdPhase2]),
+        obj.copyAndExclude([run3_GEM, phase2_muon, phase2_GEM, phase2_timing, phase2_timing_layer, phase2_trigger, trackingMkFitProdPhase2, enableTruth]),
         phase2_fastSim,
     )

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -699,6 +699,20 @@ FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_MergedTrackTruth_*')
 FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_StripDigiSimLink_*')
 FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_PixelDigiSimLink_*')
 
+# MC-truth graph: under enableTruth, persist the compact truth (logical graph +
+# unresolved hit index + raw merged graph). Kept in FEVTDEBUGHLT (the DIGI-RAW and
+# RECO tier for Phase-2) so it bridges DIGI->RECO, and in RECOSIM for downstream.
+from Configuration.ProcessModifiers.enableTruth_cff import enableTruth
+_truthKeeps = [
+    'keep *_truthLogicalGraphProducer_*_*',
+    'keep *_truthLogicalGraphHitIndexProducer_*_*',
+    'keep TruthGraph_mix_*_*',
+]
+enableTruth.toModify(FEVTDEBUGHLTEventContent,
+                     outputCommands=FEVTDEBUGHLTEventContent.outputCommands + _truthKeeps)
+enableTruth.toModify(RECOSIMEventContent,
+                     outputCommands=RECOSIMEventContent.outputCommands + _truthKeeps)
+
 from Configuration.ProcessModifiers.hltClusterSplitting_cff import hltClusterSplitting
 hltClusterSplitting.toModify(FEVTDEBUGHLTEventContent,
                               outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1015,12 +1015,12 @@ upgradeWFs['ticlv5_TrackLinkingGNN'].step4 = {'--procModifiers': 'ticlv5_TrackLi
 
 class UpgradeWorkflow_enableTruth(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
-        # enableTruth runs the truth-graph producers in RecoGlobal (step3) and,
-        # in GenSim (step1), keeps the full ancestor branch of every stored
-        # SimTrack (g4SimHits PersistencyEmin -> 0 via the modifier) so the
-        # truth graph stays connected to the generator. The Branch validators run
-        # in the RecoGlobal VALIDATION and their efficiency harvesting in
-        # HARVESTGlobal (step4), so the modifier must reach the harvesting step too.
+        # enableTruth runs the truth-graph producers in RecoGlobal (step3). The Branch
+        # validators run in the RecoGlobal VALIDATION and their efficiency harvesting
+        # in HARVESTGlobal (step4), so the modifier must reach the harvesting step too.
+        # GenSim (step1) needs no modifier: SimVertex ancestor reconnection
+        # (g4SimHits TrackingAction.ReconnectDroppedAncestors) is a baseline default,
+        # so the truth graph is connected to the generator in every sample.
         if 'GenSim' in step or 'RecoGlobal' in step or 'HARVESTGlobal' in step:
             stepDict[stepName][k] = deepcopy(stepDict[step][k])
 

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -46,6 +46,26 @@ premix_stage2.toReplaceWith(pdigiTask_nogen, pdigiTask_nogen.copyAndExclude([add
 
 pdigiTask = cms.Task(pdigiTask_nogen, fixGenInfoTask, tpPruningTask)
 
+# enableTruth: build the pileup-aware logical graph + unresolved hit index right
+# after mixing (they consume the mix products and run at DIGI, triggered by the
+# truth output keeps). The accumulator itself is registered in the mixing digitizers
+# (SimGeneral/MixingModule/digitizers_cfi) under the same modifier.
+from Configuration.ProcessModifiers.enableTruth_cff import enableTruth
+# Import the producers by name (not just the Task) so process.load labels them.
+from PhysicsTools.TruthInfo.truthGraphMixedDigi_cff import (
+    truthGraphMixedDigiTask,
+    truthLogicalGraphProducer,
+    truthLogicalGraphHitIndexProducer,
+)
+_pdigiTaskBase = pdigiTask.copy()  # base without the truth build (for the premix case)
+_pdigiTaskTruth = pdigiTask.copy()
+_pdigiTaskTruth.add(truthGraphMixedDigiTask)
+enableTruth.toReplaceWith(pdigiTask, _pdigiTaskTruth)
+# Premixing has no raw pileup g4SimHits, so the accumulator (and hence the graph +
+# index build) is dropped under premix even if enableTruth is on. Applied after the
+# enableTruth line, so it wins by code order.
+premix_stage2.toReplaceWith(pdigiTask, _pdigiTaskBase)
+
 doAllDigi = cms.Sequence(doAllDigiTask)
 pdigi = cms.Sequence(pdigiTask)
 pdigi_valid = cms.Sequence(pdigiTask)

--- a/PhysicsTools/TruthInfo/BuildFile.xml
+++ b/PhysicsTools/TruthInfo/BuildFile.xml
@@ -7,6 +7,11 @@
 <use name="SimDataFormats/EncodedEventId"/>
 <use name="SimDataFormats/Associations"/>
 <use name="SimDataFormats/TruthInfo"/>
+<use name="SimDataFormats/GeneratorProducts"/>
+<use name="DataFormats/HepMCCandidate"/>
+<use name="PhysicsTools/HepMCCandAlgos"/>
+<use name="hepmc"/>
+<use name="hepmc3"/>
 <use name="heppdt"/>
 
 <export>

--- a/PhysicsTools/TruthInfo/doc/resource_cost.md
+++ b/PhysicsTools/TruthInfo/doc/resource_cost.md
@@ -57,7 +57,27 @@ two graph structures alone are 166.0 kB/event.
 For context, the whole RECO event is 7991.4 kB/event compressed. Graph products are 4.9%
 of it, legacy truth 7.8%.
 
-### 1.1 What changed since the first version of this document
+### 1.1 The table above predates the pruning-scope fix and is now an UNDERCOUNT
+
+The hitless-subgraph pruning used to be wired to the HGCAL endcap only, so every
+particle depositing solely in the ECAL/HCAL barrel, and under pileup every pileup
+charged particle, was pruned as hitless. The graph was smaller because it was wrong.
+
+Controlled A/B, same 10 ttbar events, same job, only the producer's sim-hit collections
+changed (compressed bytes per event):
+
+| branch | pruning on HGCAL only | pruning on the full detector |
+|---|---:|---:|
+| `TruthGraph` (`mix`) | 35264 | 34661 |
+| `truth::Graph` | 50570 | 128166 |
+| `truth::LogicalGraphHitIndex` | 116202 | 143477 |
+| **total** | **202037** | **306304** |
+
+The graph branch grows 2.5x because it now keeps the barrel particles it always should
+have kept. The table in section 1 was measured before this fix and must be re-measured
+on the reference conditions before any size claim is quoted from it again.
+
+### 1.2 What changed since the first version of this document
 
 Two things moved in opposite directions and the net is a saving.
 

--- a/PhysicsTools/TruthInfo/doc/resource_cost.md
+++ b/PhysicsTools/TruthInfo/doc/resource_cost.md
@@ -1,0 +1,163 @@
+# Computing cost: the MC-truth graph against the legacy frozen truth objects
+
+What it costs to keep `TrackingParticle`, `TrackingVertex`, `CaloParticle` and
+`SimCluster`, and what it costs to keep the truth graph plus its associators instead.
+Every number below was measured on one sample; nothing is extrapolated. Where a
+quantity was not measured it is listed as not measured rather than estimated.
+
+## Sample and conditions
+
+Identical for every number in this document.
+
+| | |
+|---|---|
+| Process | `TTbar_14TeV_TuneCP5`, no pileup (`mixNoPU_cfi`) |
+| Events | 10 |
+| Release | `CMSSW_20_1_X_2026-07-22-2300` |
+| Geometry, era, global tag | `ExtendedRun4D122`, `Phase2C26I13M9`, `auto:phase2_realistic_T35` |
+| Steps | GEN,SIM then DIGI,L1,DIGI2RAW,HLT:@relvalRun4 then RAW2DIGI,L1Reco,RECO |
+| Host | AMD EPYC 9754, 1 thread, 1 stream |
+
+Everything here is NO PILEUP. PU200 is not measured and the ratios are expected to move
+there, because the legacy objects and the graph scale differently with the number of
+overlaid interactions.
+
+## 1. Event size
+
+Read with `edmEventSize -v`. Both schemes first appear at DIGI and are copied unchanged
+into RECO, so the DIGI and RECO byte counts are identical.
+
+| Scheme | branches | uncompressed kB/event | compressed kB/event |
+|---|---:|---:|---:|
+| Legacy: TrackingParticle, TrackingVertex, CaloParticle, SimCluster and their Refs | 14 | 1731.4 | 622.5 |
+| Graph: `TruthGraph`, `truth::Graph`, `truth::LogicalGraphHitIndex` | 3 | 1564.3 | 415.4 |
+| Truth-branch association maps, 3 domains x 4 working points x 2 directions | 27 | 172.2 | 29.2 |
+| **Graph total** | **30** | **1736.5** | **444.6** |
+
+Dropping the legacy collections and keeping the graph plus all four association working
+points saves **177.9 kB/event compressed, 29%** of the truth payload. The four working
+points are a validation convenience: a production configuration with one working point
+would write about 7 kB/event of maps instead of 29, so the saving becomes about 32%.
+
+The single largest graph branch is the hit index at 271.0 kB/event compressed. It is a
+separate product and can be dropped on its own; the two graph structures alone are
+144.4 kB/event.
+
+For context, the whole RECO event is 8043.0 kB/event compressed. Graph products are 5.5%
+of it, legacy truth 7.7%.
+
+### Cost per object
+
+| Collection | objects/event | compressed bytes/object |
+|---|---:|---:|
+| `truth::Graph` particles + vertices | 1186.5 + 557.3 | 53 |
+| `TrackingParticle` (MergedTrackTruth) | 896.1 | 99 |
+| `CaloParticle` (MergedCaloTruth) | 185.4 | 414 |
+
+The graph node is cheaper for a structural reason, not a compression accident. A
+`TrackingParticle` embeds `std::vector<SimTrack> g4Tracks_`, and so do `CaloParticle` and
+`SimCluster`; each `SimTrack` carries 12 members and the same SimTracks are already
+persisted separately in `SimTracks_g4SimHits` (431.2 kB/event compressed). The legacy
+classes also store their topology as `edm::Ref` and `RefVector` members
+(`parentVertex_`, `decayVertices_`, `daughterTracks_`, `sourceTracks_`, `simClusters_`).
+`truth::ParticleData` and `truth::VertexData` embed no SimTrack and no Ref: topology
+lives once, in the CSR offset arrays of `truth::Graph`, and the hit payload is factored
+out into the hit index instead of being duplicated as parallel `hits_` and `fractions_`
+vectors in every `CaloParticle` and every `SimCluster`.
+
+The duplication is the point. The legacy scheme writes four distinct `SimCluster`
+collections plus `CaloParticle` plus `TrackingParticle` and `TrackingVertex`, each
+re-embedding its own SimTrack copies and hit arrays. The graph writes one structure
+covering tracker and calorimeter together: 1186.5 particles per event against
+896.1 + 185.4 + 423.5 legacy objects.
+
+## 2. CPU and allocated memory at DIGI
+
+`TrackingTruthAccumulator`, `CaloTruthAccumulator` and `TruthGraphAccumulator` are all
+`DigiAccumulatorMixMod` plugins inside the single `mix` module, so the FastTimerService
+cannot separate them. They were isolated by an A/B on the same input, same 10 events,
+same host, deleting entries from `process.mix.digitizers`, three repetitions each.
+
+| Variant | mix real ms/event (mean, sd, n=3) | mix allocated kB/event |
+|---|---:|---:|
+| as shipped | 2449.0, 2.6 | 969 965.4 |
+| without `TruthGraphAccumulator` | 2469.1, 40.6 | 960 045.1 |
+| without `TrackingTruth` and `CaloTruth` | 2430.0, 14.2 | 940 884.7 |
+| without all three | 2408.2, 6.2 | 930 964.4 |
+
+All three truth accumulators together cost **40.8 +- 3.9 ms/event**, which is **1.7% of
+the 2449 ms/event that `mix` costs**. The split of that time between graph and legacy is
+NOT resolved at three repetitions: the two independent estimates of each disagree by
+more than their errors.
+
+The allocated-memory split is exact and additive (9920.3 + 29080.7 = 39001.0):
+
+- `TruthGraphAccumulator`: **9.9 MB/event**
+- `TrackingTruthAccumulator` + `CaloTruthAccumulator`: **29.1 MB/event**, a factor **2.9**
+  more.
+
+The graph's own downstream stages are ordinary EDProducers and are separately timed:
+`truthLogicalGraphProducer` 3.5 ms/event, `truthLogicalGraphHitIndexProducer`
+5.4 ms/event.
+
+## 3. CPU at RECO
+
+Re-run of the RECO step with the FastTimerService; the framework TimeReport agrees to the
+microsecond.
+
+| Module | real ms/event | allocated kB/event |
+|---|---:|---:|
+| `allTrackToTruthBranchAssociators` | 3.713 | 1669.0 |
+| `allVertexToTruthBranchAssociators` | 0.475 | 155.6 |
+| `allSecondaryVertexToTruthBranchAssociators` | 0.091 | 140.3 |
+| total | 4.28 | 1964.9 |
+
+That is **0.38% of the 1119.7 ms/event** summed over all scheduled RECO modules, and it
+is with four working points per domain. No legacy truth producer runs in this RECO
+sequence, so there is no legacy counterpart to compare the associators against.
+
+## 4. What the graph does NOT save
+
+Stated plainly, because the opposite is easy to assume.
+
+**The DIGI-time accumulation step is not removed.** All three accumulators exist for the
+same reason: pileup sub-event SimTracks, SimVertices and SimHits are only reachable
+through `PileUpEventPrincipal` while mixing runs, and are never in the output event. The
+sources make this explicit:
+
+- `SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc:407` and `:471`
+- `SimGeneral/CaloAnalysis/plugins/CaloTruthAccumulator.cc:684` and `:782`
+- `PhysicsTools/TruthInfo/plugins/TruthGraphAccumulator.cc:458` and `:469`
+
+The graph replaces two accumulators with one; it does not eliminate the step. The saving
+is in what that step allocates and writes, not in skipping it.
+
+**MTD legacy truth is untouched.** `MtdSimClusters`, `MtdSimLayerClusters`,
+`MtdSimTracksters` and `MtdCaloParticles` are a further 243.6 kB/event compressed that
+the graph does not currently replace.
+
+**Raw SimTracks and SimVertices stay.** 529.8 kB/event compressed, written by the SIM
+step and consumed by both schemes.
+
+## 5. Not measured
+
+- PU200, or any pileup at all. The DIGI log of this chain even warns that pileup-aware
+  truth needs classic, non-premixed pileup.
+- Peak RSS. No log in this chain reports `SimpleMemoryCheck`, and no instrumentation was
+  added. The memory figures above are the FastTimerService allocated-bytes counter.
+- The CPU split between `TruthGraphAccumulator` and the two legacy accumulators inside
+  `mix`. Only the combined 40.8 +- 3.9 ms/event is resolved at three repetitions.
+- A true A/B of file size with the graph removed from the chain; the per-branch sizes
+  above are read off the single existing chain.
+- Legacy associator CPU at RECO, for example `quickTrackAssociatorByHits`, which is not
+  in this RECO sequence.
+- Any multi-threaded scaling. Everything is one thread, one stream.
+
+## Summary
+
+On a no-pileup ttbar event, replacing the frozen truth objects with the graph and its
+associators is a **29% reduction of the persisted truth payload** (622.5 to
+444.6 kB/event compressed, or about 32% with a single working point), a **factor 2.9 less
+memory allocated during mixing** (29.1 to 9.9 MB/event), and a RECO-side association cost
+of 4.28 ms/event, 0.38% of the scheduled reconstruction. The DIGI-time accumulation step
+itself is not removed, and the pileup case is not yet measured.

--- a/PhysicsTools/TruthInfo/doc/resource_cost.md
+++ b/PhysicsTools/TruthInfo/doc/resource_cost.md
@@ -18,9 +18,8 @@ Identical for every number in this document.
 | Steps | GEN,SIM then DIGI,L1,DIGI2RAW,HLT:@relvalRun4 then RAW2DIGI,L1Reco,RECO |
 | Host | AMD EPYC 9754, 1 thread, 1 stream |
 
-Everything here is NO PILEUP. PU200 is not measured and the ratios are expected to move
-there, because the legacy objects and the graph scale differently with the number of
-overlaid interactions.
+Sections 1 to 6 are NO PILEUP. Section 7 measures the event size at PU200, where the
+two schemes scale very differently; the CPU and memory numbers remain no-PU only.
 
 ## 1. Event size
 
@@ -249,12 +248,35 @@ that signature without changing any value a consumer reads. This is a hypothesis
 result: confirming it needs a C++-side dump of the raw buffer, because PyROOT cannot read
 the unsplit struct reliably, which is also why `kind` is excluded from the hashes above.
 
-## 7. Not measured
+## 7. Event size at PU200
 
-- PU200, or any pileup at all. The DIGI log of this chain even warns that pileup-aware
-  truth needs classic, non-premixed pileup. This matters most for the shared hit index:
-  its saving comes from not duplicating a hit under every ancestor, and pileup changes
-  both the hit count and the shape of the ancestry.
+Same signal process, same release and geometry, 10 events, classic mixing with an
+average of 200 minimum-bias interactions from a D122 truth-enabled library, default
+truth wiring, no selection preset. Compressed kB/event:
+
+| Scheme | kB/event | vs no pileup |
+|---|---:|---:|
+| Legacy: TrackingParticle, 2x TrackingVertex, 4x SimCluster, CaloParticle | 56717 | x91 |
+| Graph: `TruthGraph`, `truth::Graph`, `truth::LogicalGraphHitIndex` | 8791 | x24 |
+
+At PU200 the graph is **15.5% of the legacy truth payload**, a factor 6.5, against 59%
+with no pileup: the saving grows with pileup because the legacy objects re-embed their
+SimTrack copies and hit arrays per object and per collection, and pileup multiplies the
+objects, while the graph's topology stays CSR and its hits stay stored once. The shared
+hit index is 4762 kB/event of the graph total and remained the persisted layout in 10 of
+10 events, with no fallback and no degradation warnings.
+
+MTD legacy truth, which neither scheme replaces, is a further 9859 kB/event at PU200.
+
+The pileup GEN half is collapsed (`collapsePileupGen=True`): each pileup interaction
+carries one Interaction vertex, one UnderlyingEvent vertex holding its stable particles,
+and nothing else, so the graph cost of 200 extra interactions is dominated by their
+SIM tracks and hits, not their generator records.
+
+## 8. Not measured
+
+- CPU and allocated memory at PU200. Section 7 measures the event size there; the
+  accumulator A/B of section 2 and the RECO timings of section 3 are no-PU only.
 - The RECO-side associator numbers in section 3 predate the shared hit index. Section 1.1
   gives the measured before/after for `allTrackToTruthBranchAssociators` on the same 10
   events, but the per-module table in section 3 was not re-measured with the
@@ -277,4 +299,5 @@ associators is a **37% reduction of the persisted truth payload** (622.5 to
 9.9 MB/event), and a RECO-side association cost of a few ms/event, well under 1% of the
 scheduled reconstruction. That is with the full signal GEN half included, which the
 legacy collections do not carry at all. The DIGI-time accumulation step itself is not
-removed, and the pileup case is not yet measured.
+removed. At PU200 the size advantage grows to a factor 6.5 (section 7); the CPU and
+memory numbers remain no-PU only.

--- a/PhysicsTools/TruthInfo/doc/resource_cost.md
+++ b/PhysicsTools/TruthInfo/doc/resource_cost.md
@@ -30,22 +30,38 @@ into RECO, so the DIGI and RECO byte counts are identical.
 | Scheme | branches | uncompressed kB/event | compressed kB/event |
 |---|---:|---:|---:|
 | Legacy: TrackingParticle, TrackingVertex, CaloParticle, SimCluster and their Refs | 14 | 1731.4 | 622.5 |
-| Graph: `TruthGraph`, `truth::Graph`, `truth::LogicalGraphHitIndex` | 3 | 1149.8 | 368.0 |
+| Graph, **default** hit index: `TruthGraph`, `truth::Graph`, `truth::LogicalGraphHitIndex` | 3 | 3304.2 | 611.3 |
+| Graph, **shared** hit index (`sharedSubgraphStore=True`, off by default) | 3 | 1149.8 | 368.3 |
 | Truth-branch association maps and their root/target index vectors | 23 | 168.8 | 25.1 |
-| **Graph total** | **26** | **1318.6** | **393.1** |
+| **Graph total, default index** | **26** | **3473.0** | **636.4** |
+| **Graph total, shared index** | **26** | **1318.6** | **393.4** |
 
 The legacy row is carried over unchanged: nothing in the graph work touches those
 collections. The graph and association rows were re-measured on the current build.
 
-Dropping the legacy collections and keeping the graph plus all four association working
-points saves **229.4 kB/event compressed, 37%** of the truth payload.
+State it plainly: **as shipped today the graph is not a saving.** Dropping the legacy
+collections and keeping the graph plus all four association working points costs
+**13.9 kB/event more, +2.2%**, because the graph carries the full signal GEN half and the
+default hit index stores a hit once per ancestor that contains it.
 
-The single largest graph branch is the hit index at 202.3 kB/event compressed. It is a
-separate product and can be dropped on its own; the two graph structures alone are
-165.7 kB/event.
+Turning on the shared hit index changes that to a **229.1 kB/event saving, 37%**, and it
+is measured, not projected: section 1.1 has the A/B and the correctness check. It is off
+by default only because the consumers of `LogicalGraphHitIndex::subgraphHits` have not
+been migrated to it yet (see section 5), not because of any doubt about the numbers.
 
-For context, the whole RECO event is 7991.4 kB/event compressed. Graph products are 4.9%
-of it, legacy truth 7.8%.
+!!! note "The chain is not bit-reproducible, so read the last digit as noise"
+    Two runs of the identical configuration differ in 64 of 1338 branches, HLT tracking
+    among them. `TruthGraph_mix` ranged 53793 to 56124 compressed bytes/event over four
+    runs, a 4.2% spread, so the graph row uses its mean of 54.9 kB/event. The hit index
+    and `truth::Graph` are stable to the byte, and so is everything derived from them.
+    Section 6 has the detail.
+
+The single largest graph branch is the hit index: 445.3 kB/event compressed by default,
+202.3 with the shared layout. It is a separate product and can be dropped on its own; the
+two graph structures alone are 166.0 kB/event.
+
+For context, the whole RECO event is 7991.4 kB/event compressed. Graph products are 8.0%
+of it by default and 4.9% with the shared index, legacy truth 7.8%.
 
 ### 1.1 What changed since the first version of this document
 
@@ -70,7 +86,14 @@ A/B on the same GEN-SIM, 10 events, compressed bytes/event of the three graph br
 | no GEN half, materialised index | 271013 | 92499 | 54037 | 417549 |
 | full GEN half, materialised index | 696729 | 126768 | 74681 | 898178 |
 | collapsed GEN half, materialised index | 445329 | 111070 | 55413 | 611812 |
-| **collapsed GEN half, shared index (current default)** | **202300** | **111070** | **54583** | **368000** |
+| collapsed GEN half, **shared** index (opt-in) | **202300** | 111070 | 54938 | **368308** |
+
+The third row is the **default** today. The fourth is what the shared index achieves and
+what the migration in section 5 would make the default.
+
+The `TruthGraph_mix` column carries the run-to-run spread noted above, so differences of
+about a kB in that column and in the total are not significant. The hit index column,
+which is what these variants are about, is stable to the byte.
 
 The materialised index stored a hit once per ancestor containing it: 26744 hits per event
 became 46259 stored entries even with no GEN half at all, and 1467228 with the full one.
@@ -176,7 +199,75 @@ the graph does not currently replace.
 **Raw SimTracks and SimVertices stay.** 529.8 kB/event compressed, written by the SIM
 step and consumed by both schemes.
 
-## 5. Not measured
+## 5. Blocking the shared hit index: `subgraphHits` consumers
+
+The shared layout is correct and measured, and it is off by default because of one API
+problem, not one physics problem.
+
+`LogicalGraphHitIndex::subgraphHits` returns a single span. In the shared layout a
+particle that carries hits owns exactly one slot range, so its span is fine, but a
+GEN-only particle owns several and the accessor returns an **empty** span. Nineteen call
+sites across seven files still use it and none of them expect that:
+
+- `BranchHGCalValidator.cc:393,397`, `BranchTrackingValidator.cc:162,166`,
+  `BranchTrackerReplacementValidator.cc:83,87`, `BranchTruthReplacementValidator.cc:152,156`
+  use `subgraphHits(...).size()` as a smallest-footprint tie-break between matches. A
+  GEN-only root reads as size 0 and therefore **wins** a tie-break meant to pick the
+  tightest branch, which inverts it.
+- `BranchHGCalValidator.cc:319,428`, `BranchTruthReplacementValidator.cc:119`,
+  `BranchRecoValidator.cc:134`, `TruthBranchRecoValidator.cc:322` and six sites in
+  `TruthLogicalGraphDumper.cc` read the hits or the count directly and would silently see
+  nothing for a GEN-only particle.
+
+The associator does reach GEN-only roots: `BranchHGCalValidator.cc:484` constructs
+`BranchHitAssociator` with an empty root list, and `emptyRootsMeansAll` defaults to true,
+so every particle is a candidate. `BranchHitAssociator` itself was migrated and is correct
+under both layouts; nothing else was.
+
+`appendSubgraphHits` is the accessor that is correct for every particle in both layouts.
+Migrating these sites is not mechanical: several want a coalesced per-cell energy, and the
+`.size()` tie-break needs a decision about whether the footprint is counted in distinct
+cells or in raw entries. It also changes validator output, so it needs an A/B against the
+published galleries. That is the work that stands between the measured 37% saving and it
+being the default.
+
+## 6. This chain is not bit-reproducible, and that is not a truth-graph property
+
+Read the byte counts in section 1 with this in mind. Two runs of the identical
+configuration, same input file, same host, one thread, do not write the same file:
+**64 of 1338 branches differ in compressed size**, and five of them differ uncompressed
+too, so the difference is real content and not just packing. The largest by absolute
+delta happens to be `TruthGraph_mix` (56123.9 against 55250.2 compressed bytes/event,
+uncompressed identical at 498985), but it is in company:
+
+| branch | compressed | uncompressed |
+|---|---|---|
+| `TruthGraph_mix` | 56123.9 -> 55250.2 | same |
+| `recoTrackExtras_hltGeneralTracks` | 46859.7 -> 46867.5 | differs |
+| `recoTracks_hltInitialStepTrackSelectionHighPurity` | 8934.8 -> 8937.2 | same |
+| `recoVertexs_hltOfflinePrimaryVertices` | 521.2 -> 519.8 | same |
+| `uints_hltPhase2PixelTracksCAExtension` | 525.9 -> 527.2 | same |
+
+HLT tracking output changing between identical runs is the root of most of this, and it
+is upstream of and independent of the truth graph.
+
+The part that matters here is that the truth **content** is reproducible. `truth::Graph`
+and `truth::LogicalGraphHitIndex` hash identically across the same runs, over the logical
+particle and vertex records, all eight CSR arrays, and every hit and offset of all four
+channels. Of `TruthGraph`'s own persisted arrays, `offsets`, `edges`, `edgeKind`,
+`pdgId`, `status`, `statusFlags`, `eventId`, `genEventOfNode`, `simVertexProcessType`,
+`simTrackBackscattered` and `simTrackToGen` are all identical run to run.
+
+One loose end specific to this package, worth a look but not a blocker:
+`TruthGraph_mix` is the one branch whose compressed size moves while its uncompressed
+size does not, which means same length and different bytes. `TruthGraph::NodeRef` is
+`{ NodeKind kind; int64_t key; }` with `NodeKind` a `uint8_t`, so it carries seven bytes
+of padding and the branch is written unsplit; uninitialised padding would produce exactly
+that signature without changing any value a consumer reads. This is a hypothesis, not a
+result: confirming it needs a C++-side dump of the raw buffer, because PyROOT cannot read
+the unsplit struct reliably, which is also why `kind` is excluded from the hashes above.
+
+## 7. Not measured
 
 - PU200, or any pileup at all. The DIGI log of this chain even warns that pileup-aware
   truth needs classic, non-premixed pileup. This matters most for the shared hit index:

--- a/PhysicsTools/TruthInfo/doc/resource_cost.md
+++ b/PhysicsTools/TruthInfo/doc/resource_cost.md
@@ -30,24 +30,19 @@ into RECO, so the DIGI and RECO byte counts are identical.
 | Scheme | branches | uncompressed kB/event | compressed kB/event |
 |---|---:|---:|---:|
 | Legacy: TrackingParticle, TrackingVertex, CaloParticle, SimCluster and their Refs | 14 | 1731.4 | 622.5 |
-| Graph, **default** hit index: `TruthGraph`, `truth::Graph`, `truth::LogicalGraphHitIndex` | 3 | 3304.2 | 611.3 |
-| Graph, **shared** hit index (`sharedSubgraphStore=True`, off by default) | 3 | 1149.8 | 368.3 |
+| Graph, **default** (shared) hit index: `TruthGraph`, `truth::Graph`, `truth::LogicalGraphHitIndex` | 3 | 1149.8 | 368.3 |
+| Graph, materialised hit index (`sharedSubgraphStore=False`) | 3 | 3304.2 | 611.3 |
 | Truth-branch association maps and their root/target index vectors | 23 | 168.8 | 25.1 |
-| **Graph total, default index** | **26** | **3473.0** | **636.4** |
-| **Graph total, shared index** | **26** | **1318.6** | **393.4** |
+| **Graph total, default index** | **26** | **1318.6** | **393.4** |
 
 The legacy row is carried over unchanged: nothing in the graph work touches those
 collections. The graph and association rows were re-measured on the current build.
 
-State it plainly: **as shipped today the graph is not a saving.** Dropping the legacy
-collections and keeping the graph plus all four association working points costs
-**13.9 kB/event more, +2.2%**, because the graph carries the full signal GEN half and the
-default hit index stores a hit once per ancestor that contains it.
-
-Turning on the shared hit index changes that to a **229.1 kB/event saving, 37%**, and it
-is measured, not projected: section 1.1 has the A/B and the correctness check. It is off
-by default only because the consumers of `LogicalGraphHitIndex::subgraphHits` have not
-been migrated to it yet (see section 5), not because of any doubt about the numbers.
+Dropping the legacy collections and keeping the graph plus all four association working
+points saves **229.1 kB/event compressed, 37%** of the truth payload, and that is with the
+full signal GEN half included, which the legacy collections do not carry at all. Keeping
+the materialised index instead would cost 13.9 kB/event more than legacy, +2.2%, so the
+shared index is what makes the graph a saving rather than a cost.
 
 !!! note "The chain is not bit-reproducible, so read the last digit as noise"
     Two runs of the identical configuration differ in 64 of 1338 branches, HLT tracking
@@ -56,12 +51,12 @@ been migrated to it yet (see section 5), not because of any doubt about the numb
     and `truth::Graph` are stable to the byte, and so is everything derived from them.
     Section 6 has the detail.
 
-The single largest graph branch is the hit index: 445.3 kB/event compressed by default,
-202.3 with the shared layout. It is a separate product and can be dropped on its own; the
+The single largest graph branch is the hit index: 202.3 kB/event compressed by default,
+445.3 if the materialised layout is selected. It is a separate product and can be dropped on its own; the
 two graph structures alone are 166.0 kB/event.
 
-For context, the whole RECO event is 7991.4 kB/event compressed. Graph products are 8.0%
-of it by default and 4.9% with the shared index, legacy truth 7.8%.
+For context, the whole RECO event is 7991.4 kB/event compressed. Graph products are 4.9%
+of it, legacy truth 7.8%.
 
 ### 1.1 What changed since the first version of this document
 
@@ -86,10 +81,7 @@ A/B on the same GEN-SIM, 10 events, compressed bytes/event of the three graph br
 | no GEN half, materialised index | 271013 | 92499 | 54037 | 417549 |
 | full GEN half, materialised index | 696729 | 126768 | 74681 | 898178 |
 | collapsed GEN half, materialised index | 445329 | 111070 | 55413 | 611812 |
-| collapsed GEN half, **shared** index (opt-in) | **202300** | 111070 | 54938 | **368308** |
-
-The third row is the **default** today. The fourth is what the shared index achieves and
-what the migration in section 5 would make the default.
+| **collapsed GEN half, shared index (the default)** | **202300** | **111070** | **54938** | **368308** |
 
 The `TruthGraph_mix` column carries the run-to-run spread noted above, so differences of
 about a kB in that column and in the total are not significant. The hit index column,
@@ -199,37 +191,27 @@ the graph does not currently replace.
 **Raw SimTracks and SimVertices stay.** 529.8 kB/event compressed, written by the SIM
 step and consumed by both schemes.
 
-## 5. Blocking the shared hit index: `subgraphHits` consumers
-
-The shared layout is correct and measured, and it is off by default because of one API
-problem, not one physics problem.
+## 5. Reading a subgraph in either layout
 
 `LogicalGraphHitIndex::subgraphHits` returns a single span. In the shared layout a
 particle that carries hits owns exactly one slot range, so its span is fine, but a
-GEN-only particle owns several and the accessor returns an **empty** span. Nineteen call
-sites across seven files still use it and none of them expect that:
+GEN-only particle owns several and the accessor returns an **empty** span. Four validators
+used its size as a smallest-footprint tie-break, where a zero-size answer makes a GEN-only
+root win a comparison meant to pick the tightest branch, so a naive switch of layout would
+have read as a near-total loss of reproduction efficiency.
 
-- `BranchHGCalValidator.cc:393,397`, `BranchTrackingValidator.cc:162,166`,
-  `BranchTrackerReplacementValidator.cc:83,87`, `BranchTruthReplacementValidator.cc:152,156`
-  use `subgraphHits(...).size()` as a smallest-footprint tie-break between matches. A
-  GEN-only root reads as size 0 and therefore **wins** a tie-break meant to pick the
-  tightest branch, which inverts it.
-- `BranchHGCalValidator.cc:319,428`, `BranchTruthReplacementValidator.cc:119`,
-  `BranchRecoValidator.cc:134`, `TruthBranchRecoValidator.cc:322` and six sites in
-  `TruthLogicalGraphDumper.cc` read the hits or the count directly and would silently see
-  nothing for a GEN-only particle.
+`truth::SubgraphHitView` is what consumers use instead. It returns the coalesced,
+detId-sorted span in either layout: the materialised one already persists that form and is
+handed back untouched, the shared one is coalesced once per particle and cached, and a
+particle whose subgraph is a single one-slot range needs neither, since the builder already
+sorted and summed its own direct hits. Hold one per event and per module; it caches, so it
+is not thread safe.
 
-The associator does reach GEN-only roots: `BranchHGCalValidator.cc:484` constructs
-`BranchHitAssociator` with an empty root list, and `emptyRootsMeansAll` defaults to true,
-so every particle is a candidate. `BranchHitAssociator` itself was migrated and is correct
-under both layouts; nothing else was.
-
-`appendSubgraphHits` is the accessor that is correct for every particle in both layouts.
-Migrating these sites is not mechanical: several want a coalesced per-cell energy, and the
-`.size()` tie-break needs a decision about whether the footprint is counted in distinct
-cells or in raw entries. It also changes validator output, so it needs an A/B against the
-published galleries. That is the work that stands between the measured 37% saving and it
-being the default.
+All seven consumers now go through it, and the arithmetic in each is unchanged. Verified on
+10 ttbar events by running the calorimeter validator over a materialised index and a shared
+index and comparing every monitor element: **50 compared, 50 non-empty, 0 differing**. That
+rests on the accessor-level equivalence measured in section 1.1, which covered every
+particle and every channel.
 
 ## 6. This chain is not bit-reproducible, and that is not a truth-graph property
 
@@ -291,7 +273,7 @@ the unsplit struct reliably, which is also why `kind` is excluded from the hashe
 
 On a no-pileup ttbar event, replacing the frozen truth objects with the graph and its
 associators is a **37% reduction of the persisted truth payload** (622.5 to
-393.1 kB/event compressed), a **factor 2.9 less memory allocated during mixing** (29.1 to
+393.4 kB/event compressed), a **factor 2.9 less memory allocated during mixing** (29.1 to
 9.9 MB/event), and a RECO-side association cost of a few ms/event, well under 1% of the
 scheduled reconstruction. That is with the full signal GEN half included, which the
 legacy collections do not carry at all. The DIGI-time accumulation step itself is not

--- a/PhysicsTools/TruthInfo/doc/resource_cost.md
+++ b/PhysicsTools/TruthInfo/doc/resource_cost.md
@@ -30,21 +30,58 @@ into RECO, so the DIGI and RECO byte counts are identical.
 | Scheme | branches | uncompressed kB/event | compressed kB/event |
 |---|---:|---:|---:|
 | Legacy: TrackingParticle, TrackingVertex, CaloParticle, SimCluster and their Refs | 14 | 1731.4 | 622.5 |
-| Graph: `TruthGraph`, `truth::Graph`, `truth::LogicalGraphHitIndex` | 3 | 1564.3 | 415.4 |
-| Truth-branch association maps, 3 domains x 4 working points x 2 directions | 27 | 172.2 | 29.2 |
-| **Graph total** | **30** | **1736.5** | **444.6** |
+| Graph: `TruthGraph`, `truth::Graph`, `truth::LogicalGraphHitIndex` | 3 | 1149.8 | 368.0 |
+| Truth-branch association maps and their root/target index vectors | 23 | 168.8 | 25.1 |
+| **Graph total** | **26** | **1318.6** | **393.1** |
+
+The legacy row is carried over unchanged: nothing in the graph work touches those
+collections. The graph and association rows were re-measured on the current build.
 
 Dropping the legacy collections and keeping the graph plus all four association working
-points saves **177.9 kB/event compressed, 29%** of the truth payload. The four working
-points are a validation convenience: a production configuration with one working point
-would write about 7 kB/event of maps instead of 29, so the saving becomes about 32%.
+points saves **229.4 kB/event compressed, 37%** of the truth payload.
 
-The single largest graph branch is the hit index at 271.0 kB/event compressed. It is a
+The single largest graph branch is the hit index at 202.3 kB/event compressed. It is a
 separate product and can be dropped on its own; the two graph structures alone are
-144.4 kB/event.
+165.7 kB/event.
 
-For context, the whole RECO event is 8043.0 kB/event compressed. Graph products are 5.5%
-of it, legacy truth 7.7%.
+For context, the whole RECO event is 7991.4 kB/event compressed. Graph products are 4.9%
+of it, legacy truth 7.8%.
+
+### 1.1 What changed since the first version of this document
+
+Two things moved in opposite directions and the net is a saving.
+
+The graph now carries the **full signal GEN half**, contracted: the parton shower and the
+intermediate copies of a resonance are collapsed away by `truth::collapseGenShower`, so a
+resonance appearing several times is one node whose children are its decay products. That
+half did not exist when this document was first written.
+
+The hit index now uses the **shared subgraph store**. Each hit is written once, in an
+order that makes a particle's subtree a contiguous run of slots, so a subgraph is a set of
+ranges of that one store rather than a second materialised copy under every ancestor. A
+GEN-only particle sits above the SIM tree in a DAG, so it owns a merged set of runs rather
+than a single one; measured over 3 events, 1039 such particles need 2547 ranges, mean
+2.45, median 1, max 183.
+
+A/B on the same GEN-SIM, 10 events, compressed bytes/event of the three graph branches:
+
+| variant | hit index | `truth::Graph` | `TruthGraph_mix` | total |
+|---|---:|---:|---:|---:|
+| no GEN half, materialised index | 271013 | 92499 | 54037 | 417549 |
+| full GEN half, materialised index | 696729 | 126768 | 74681 | 898178 |
+| collapsed GEN half, materialised index | 445329 | 111070 | 55413 | 611812 |
+| **collapsed GEN half, shared index (current default)** | **202300** | **111070** | **54583** | **368000** |
+
+The materialised index stored a hit once per ancestor containing it: 26744 hits per event
+became 46259 stored entries even with no GEN half at all, and 1467228 with the full one.
+The shared store keeps the 26744. Reading is automatic in both layouts, which is what
+keeps every file written before this change readable.
+
+The cost is paid at query time: a range is in tree order and repeats a detId hit by
+several descendants, so a consumer that needs per-cell energies coalesces it.
+`BranchHitAssociator` does this once per candidate root at construction. Measured on the
+same 10 events, `allTrackToTruthBranchAssociators` goes from 10.1 to 12.2 ms/event and the
+whole RECO job from 692.5 to 694.9 ms/event, +0.3%.
 
 ### Cost per object
 
@@ -142,7 +179,13 @@ step and consumed by both schemes.
 ## 5. Not measured
 
 - PU200, or any pileup at all. The DIGI log of this chain even warns that pileup-aware
-  truth needs classic, non-premixed pileup.
+  truth needs classic, non-premixed pileup. This matters most for the shared hit index:
+  its saving comes from not duplicating a hit under every ancestor, and pileup changes
+  both the hit count and the shape of the ancestry.
+- The RECO-side associator numbers in section 3 predate the shared hit index. Section 1.1
+  gives the measured before/after for `allTrackToTruthBranchAssociators` on the same 10
+  events, but the per-module table in section 3 was not re-measured with the
+  FastTimerService.
 - Peak RSS. No log in this chain reports `SimpleMemoryCheck`, and no instrumentation was
   added. The memory figures above are the FastTimerService allocated-bytes counter.
 - The CPU split between `TruthGraphAccumulator` and the two legacy accumulators inside
@@ -156,8 +199,9 @@ step and consumed by both schemes.
 ## Summary
 
 On a no-pileup ttbar event, replacing the frozen truth objects with the graph and its
-associators is a **29% reduction of the persisted truth payload** (622.5 to
-444.6 kB/event compressed, or about 32% with a single working point), a **factor 2.9 less
-memory allocated during mixing** (29.1 to 9.9 MB/event), and a RECO-side association cost
-of 4.28 ms/event, 0.38% of the scheduled reconstruction. The DIGI-time accumulation step
-itself is not removed, and the pileup case is not yet measured.
+associators is a **37% reduction of the persisted truth payload** (622.5 to
+393.1 kB/event compressed), a **factor 2.9 less memory allocated during mixing** (29.1 to
+9.9 MB/event), and a RECO-side association cost of a few ms/event, well under 1% of the
+scheduled reconstruction. That is with the full signal GEN half included, which the
+legacy collections do not carry at all. The DIGI-time accumulation step itself is not
+removed, and the pileup case is not yet measured.

--- a/PhysicsTools/TruthInfo/interface/BranchHitAssociator.h
+++ b/PhysicsTools/TruthInfo/interface/BranchHitAssociator.h
@@ -6,6 +6,7 @@
 #define PhysicsTools_TruthInfo_interface_BranchHitAssociator_h
 
 #include <cstdint>
+#include <limits>
 #include <ranges>
 #include <span>
 #include <vector>
@@ -78,6 +79,10 @@ namespace truth {
     }
 
   private:
+    // Fill the coalesced per-root hit store used by the shared layout. A no-op for a
+    // materialised index, which already persists the coalesced spans.
+    void buildRootHits();
+
     [[nodiscard]] std::span<const LogicalGraphHitIndex::Hit> rootHits(uint32_t rootId) const;
 
     // Candidate roots whose subgraph touches a cell, by binary search; empty span
@@ -107,6 +112,16 @@ namespace truth {
     // score. Computed once with the inverted index so bestBranches() needs no
     // full branch-hit scan.
     std::vector<double> rootSelfEnergySq_;
+
+    // Shared layout only: the candidate roots' subgraph hits, coalesced here once at
+    // construction because the persisted store keeps them in tree order with a detId
+    // repeated per contributing descendant, while the merge-join below needs one
+    // ascending entry per detId. Materialised indices keep using the persisted spans,
+    // so these stay empty. CSR over roots_, in the order roots_ holds them.
+    std::vector<uint32_t> rootHitOffsets_;
+    std::vector<LogicalGraphHitIndex::Hit> rootHitStorage_;
+    std::vector<uint32_t> rootHitSlotOfRoot_;  // particle id -> position in roots_, or kNoRoot
+    static constexpr uint32_t kNoRoot = std::numeric_limits<uint32_t>::max();
   };
 
 }  // namespace truth

--- a/PhysicsTools/TruthInfo/interface/BranchHitAssociator.h
+++ b/PhysicsTools/TruthInfo/interface/BranchHitAssociator.h
@@ -120,8 +120,12 @@ namespace truth {
     // so these stay empty. CSR over roots_, in the order roots_ holds them.
     std::vector<uint32_t> rootHitOffsets_;
     std::vector<LogicalGraphHitIndex::Hit> rootHitStorage_;
-    std::vector<uint32_t> rootHitSlotOfRoot_;  // particle id -> position in roots_, or kNoRoot
+    // particle id -> position in rootHitOffsets_, or kNoRoot when the particle is not a
+    // candidate, or kPersistedSpan when the persisted span is already coalesced and no
+    // private copy was made.
+    std::vector<uint32_t> rootHitSlotOfRoot_;
     static constexpr uint32_t kNoRoot = std::numeric_limits<uint32_t>::max();
+    static constexpr uint32_t kPersistedSpan = kNoRoot - 1u;
   };
 
 }  // namespace truth

--- a/PhysicsTools/TruthInfo/interface/BranchHitAssociator.h
+++ b/PhysicsTools/TruthInfo/interface/BranchHitAssociator.h
@@ -61,7 +61,7 @@ namespace truth {
     explicit BranchHitAssociator(LogicalGraphHitIndex const& hitIndex,
                                  std::vector<uint32_t> candidateRoots = {},
                                  Metric metric = Metric::SharedEnergy,
-                                 HitChannel channel = HitChannel::HGCalCalo,
+                                 HitChannel channel = HitChannel::Calo,
                                  bool emptyRootsMeansAll = true);
 
     // Best branches for a reco object's hits, sorted by score ascending. If

--- a/PhysicsTools/TruthInfo/interface/GenGraphBuild.h
+++ b/PhysicsTools/TruthInfo/interface/GenGraphBuild.h
@@ -1,0 +1,60 @@
+// Original author: Felice Pantaleo (CERN) <felice.pantaleo@cern.ch>
+//
+// The HepMC record flattened into the arrays a TruthGraph GEN half needs: the
+// vertex and particle barcodes, the two edge lists, and the per-barcode pdgId,
+// status and packed reco::GenStatusFlags.
+//
+// Shared by TruthGraphProducer, which builds the graph from an unmixed event, and
+// by TruthGraphAccumulator, which builds it per sub-event during mixing. Both must
+// produce the same GEN half for the same HepMC record.
+
+#ifndef PhysicsTools_TruthInfo_GenGraphBuild_h
+#define PhysicsTools_TruthInfo_GenGraphBuild_h
+
+#include <cstdint>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace HepMC {
+  class GenEvent;
+}
+namespace HepMC3 {
+  class GenEvent;
+}
+
+namespace truth {
+
+  // Node keys for the GEN realm. A GenVertex and a GenParticle can carry the same
+  // barcode, so the low bit separates them.
+  [[nodiscard]] inline int64_t genKeyVertex(int barcode) { return (static_cast<int64_t>(barcode) << 1) | 1LL; }
+  [[nodiscard]] inline int64_t genKeyParticle(int barcode) { return static_cast<int64_t>(barcode) << 1; }
+
+  struct GenBuild {
+    std::vector<int> vtxBarcodes;
+    std::vector<int> partBarcodes;
+
+    // index -> barcode in HepMC iteration order, for diagnostics only.
+    // SimTrack::genpartIndex() is a barcode, not an index into this vector.
+    std::vector<int> particleBarcodeByIndex;
+
+    std::vector<std::pair<int, int>> vtxToPart;
+    std::vector<std::pair<int, int>> partToVtx;
+
+    std::unordered_map<int, int32_t> particlePdgIdByBarcode;
+    std::unordered_map<int, int16_t> particleStatusByBarcode;
+    // Packed reco::GenStatusFlags from MCTruthHelper, the same helper
+    // GenParticleProducer uses, so no barcode-to-reco::GenParticle association is
+    // needed. HepMC2 only; the HepMC3 path leaves them 0 until MCTruthHelper grows a
+    // HepMC3 specialization.
+    std::unordered_map<int, uint16_t> particleStatusFlagsByBarcode;
+
+    [[nodiscard]] bool empty() const { return partBarcodes.empty() && vtxBarcodes.empty(); }
+  };
+
+  [[nodiscard]] GenBuild buildFromHepMC2(HepMC::GenEvent const& ev);
+  [[nodiscard]] GenBuild buildFromHepMC3(HepMC3::GenEvent const& ev);
+
+}  // namespace truth
+
+#endif

--- a/PhysicsTools/TruthInfo/interface/GenGraphBuild.h
+++ b/PhysicsTools/TruthInfo/interface/GenGraphBuild.h
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -54,6 +55,32 @@ namespace truth {
 
   [[nodiscard]] GenBuild buildFromHepMC2(HepMC::GenEvent const& ev);
   [[nodiscard]] GenBuild buildFromHepMC3(HepMC3::GenEvent const& ev);
+
+  // Contract the parton shower and the intermediate copies of a resonance away. A GEN
+  // particle survives if its barcode is in `simContinuedBarcodes` (some SimTrack
+  // continues it), or its status is 1, or it is flagged isHardProcess, or it is flagged
+  // isLastCopy and is not a parton, diquark, string, cluster or beam pseudoparticle.
+  // Ancestry is kept, not cut: every survivor is re-attached through its own production
+  // GenVertex to its nearest surviving ancestors, and a GenVertex survives only if it
+  // still produces a surviving particle.
+  //
+  // The isHardProcess and isLastCopy rules read the packed reco::GenStatusFlags, which
+  // only buildFromHepMC2 fills; on the HepMC3 path they are 0, so the keep set there
+  // degrades to the SIM-continued and status 1 particles.
+  void collapseGenShower(GenBuild& gb, std::unordered_set<int> const& simContinuedBarcodes);
+
+  // The barcodes some SimTrack continues, which is the input to the first keep rule
+  // above. Templated on the container so this header keeps its HepMC-only dependencies.
+  template <typename SimTrackContainerT>
+  [[nodiscard]] std::unordered_set<int> simContinuedGenBarcodes(SimTrackContainerT const& tracks) {
+    std::unordered_set<int> barcodes;
+    barcodes.reserve(tracks.size() * 2);
+    for (auto const& track : tracks) {
+      if (track.genpartIndex() != -1)
+        barcodes.insert(track.genpartIndex());
+    }
+    return barcodes;
+  }
 
 }  // namespace truth
 

--- a/PhysicsTools/TruthInfo/interface/GenGraphBuild.h
+++ b/PhysicsTools/TruthInfo/interface/GenGraphBuild.h
@@ -67,7 +67,12 @@ namespace truth {
   // The isHardProcess and isLastCopy rules read the packed reco::GenStatusFlags, which
   // only buildFromHepMC2 fills; on the HepMC3 path they are 0, so the keep set there
   // degrades to the SIM-continued and status 1 particles.
-  void collapseGenShower(GenBuild& gb, std::unordered_set<int> const& simContinuedBarcodes);
+  // Returns false when the record carried no packed status flags at all, which makes the
+  // isHardProcess and isLastCopy rules dead and degrades the keep set to the SIM-continued
+  // and status 1 particles. buildFromHepMC3 does not fill them, so that is the HepMC3
+  // path; the caller is expected to say so out loud rather than silently ship a keep set
+  // that drops every intermediate resonance.
+  [[nodiscard]] bool collapseGenShower(GenBuild& gb, std::unordered_set<int> const& simContinuedBarcodes);
 
   // The barcodes some SimTrack continues, which is the input to the first keep rule
   // above. Templated on the container so this header keeps its HepMC-only dependencies.

--- a/PhysicsTools/TruthInfo/interface/LogicalGraphHitIndexBuilder.h
+++ b/PhysicsTools/TruthInfo/interface/LogicalGraphHitIndexBuilder.h
@@ -20,9 +20,9 @@ namespace truth {
   public:
     // sharedSubgraphStore selects the shared layout described in LogicalGraphHitIndex:
     // each hit is stored once, in an order that makes every subtree a contiguous range,
-    // instead of being copied into each ancestor's aggregate. False, the default, builds
-    // the materialised layout.
-    explicit LogicalGraphHitIndexBuilder(uint32_t nParticles, bool sharedSubgraphStore = false);
+    // instead of being copied into each ancestor's aggregate. This is what the producer
+    // writes by default. False builds the materialised layout.
+    explicit LogicalGraphHitIndexBuilder(uint32_t nParticles, bool sharedSubgraphStore = true);
 
     // trackId is event-local (each mixing sub-event reuses 1,2,3,...); it MUST be
     // namespaced by the packed EncodedEventId or signal and pileup collide.

--- a/PhysicsTools/TruthInfo/interface/LogicalGraphHitIndexBuilder.h
+++ b/PhysicsTools/TruthInfo/interface/LogicalGraphHitIndexBuilder.h
@@ -18,11 +18,11 @@ namespace truth {
 
   class LogicalGraphHitIndexBuilder {
   public:
-    // sharedSubgraphStore selects the shared layout described in LogicalGraphHitIndex,
-    // which is the one the producer writes by default: each hit is stored once, in an
-    // order that makes every subtree a contiguous range, instead of being copied into
-    // each ancestor's aggregate. False builds the materialised layout instead.
-    explicit LogicalGraphHitIndexBuilder(uint32_t nParticles, bool sharedSubgraphStore = true);
+    // sharedSubgraphStore selects the shared layout described in LogicalGraphHitIndex:
+    // each hit is stored once, in an order that makes every subtree a contiguous range,
+    // instead of being copied into each ancestor's aggregate. False, the default, builds
+    // the materialised layout.
+    explicit LogicalGraphHitIndexBuilder(uint32_t nParticles, bool sharedSubgraphStore = false);
 
     // trackId is event-local (each mixing sub-event reuses 1,2,3,...); it MUST be
     // namespaced by the packed EncodedEventId or signal and pileup collide.

--- a/PhysicsTools/TruthInfo/interface/LogicalGraphHitIndexBuilder.h
+++ b/PhysicsTools/TruthInfo/interface/LogicalGraphHitIndexBuilder.h
@@ -97,8 +97,12 @@ namespace truth {
     // at most one parent that also has a SimTrack, whereas the GEN half above them is a
     // DAG whose vertices have several incoming particles. Fills the DFS slot of every
     // particle and the number of particles in its subtree.
-    // False when a hit-carrying particle has more than one hit-carrying parent, which
-    // the shared layout cannot represent; the outputs are then meaningless.
+    // Per particle, whether its descendant closure contains anything with a SimTrack.
+    [[nodiscard]] std::vector<uint8_t> closureReachesSimTrack() const;
+
+    // False when the hit-carrying particles do not form a forest the tree can carry,
+    // either because one has two hit-carrying parents or because one has a GEN-only
+    // child with hit-carrying descendants of its own; the outputs are then meaningless.
     [[nodiscard]] bool buildDfsOrder(std::vector<uint32_t>& slotToParticle,
                                      std::vector<uint32_t>& dfsPos,
                                      std::vector<uint32_t>& subtreeCount) const;

--- a/PhysicsTools/TruthInfo/interface/LogicalGraphHitIndexBuilder.h
+++ b/PhysicsTools/TruthInfo/interface/LogicalGraphHitIndexBuilder.h
@@ -7,7 +7,9 @@
 
 #include <array>
 #include <cstdint>
+#include <limits>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "SimDataFormats/TruthInfo/interface/LogicalGraphHitIndex.h"
@@ -16,7 +18,11 @@ namespace truth {
 
   class LogicalGraphHitIndexBuilder {
   public:
-    explicit LogicalGraphHitIndexBuilder(uint32_t nParticles);
+    // sharedSubgraphStore selects the shared layout described in LogicalGraphHitIndex,
+    // which is the one the producer writes by default: each hit is stored once, in an
+    // order that makes every subtree a contiguous range, instead of being copied into
+    // each ancestor's aggregate. False builds the materialised layout instead.
+    explicit LogicalGraphHitIndexBuilder(uint32_t nParticles, bool sharedSubgraphStore = true);
 
     // trackId is event-local (each mixing sub-event reuses 1,2,3,...); it MUST be
     // namespaced by the packed EncodedEventId or signal and pileup collide.
@@ -41,8 +47,14 @@ namespace truth {
 
     [[nodiscard]] LogicalGraphHitIndex finish();
 
+    // Whether finish() actually wrote the shared layout. False when it was not asked
+    // for, and also when it was asked for but the hit-carrying particles did not form
+    // a forest, in which case finish() falls back to the materialised layout.
+    [[nodiscard]] bool usedSharedStore() const { return usedSharedStore_; }
+
   private:
     using Hit = LogicalGraphHitIndex::Hit;
+    using SlotRange = LogicalGraphHitIndex::SlotRange;
 
     // Per-particle hits are accumulated as a flat, append-only list and coalesced
     // (summed per detId, sorted) lazily. This keeps the hot insertion path a
@@ -79,10 +91,40 @@ namespace truth {
                             std::vector<uint32_t>& offsets,
                             std::vector<Hit>& storage);
 
+    // Order the particles so that every subtree occupies consecutive slots, which is
+    // what lets a subgraph be a range of the single hit store. The tree is the SIM
+    // parentage alone: only particles with a SimTrack carry hits, and each of those has
+    // at most one parent that also has a SimTrack, whereas the GEN half above them is a
+    // DAG whose vertices have several incoming particles. Fills the DFS slot of every
+    // particle and the number of particles in its subtree.
+    // False when a hit-carrying particle has more than one hit-carrying parent, which
+    // the shared layout cannot represent; the outputs are then meaningless.
+    [[nodiscard]] bool buildDfsOrder(std::vector<uint32_t>& slotToParticle,
+                                     std::vector<uint32_t>& dfsPos,
+                                     std::vector<uint32_t>& subtreeCount) const;
+
+    // Slot ranges covering each particle's subgraph: one run for a hit-carrying
+    // particle, the merged union of the runs below it for a GEN-only particle.
+    void buildSubgraphRanges(std::vector<uint32_t> const& dfsPos,
+                             std::vector<uint32_t> const& subtreeCount,
+                             std::vector<uint32_t>& rangeOffsets,
+                             std::vector<SlotRange>& ranges) const;
+
+    [[nodiscard]] LogicalGraphHitIndex finishShared();
+    [[nodiscard]] LogicalGraphHitIndex finishMaterialised();
+
+    static constexpr uint32_t kNoParent = std::numeric_limits<uint32_t>::max();
+
     uint32_t nParticles_ = 0;
+    bool sharedSubgraphStore_ = false;
+    bool usedSharedStore_ = false;
 
     std::unordered_map<uint64_t, uint32_t> trackIdToParticle_;
     std::vector<std::vector<uint32_t>> children_;
+
+    // Whether a particle has a SimTrack, so it can carry hits and take part in the
+    // SIM parentage tree.
+    std::vector<uint8_t> hasSimTrack_;
 
     // [channel index][particle] -> direct hit list. Subgraph hits are aggregated
     // in finish().

--- a/PhysicsTools/TruthInfo/interface/SubgraphHitView.h
+++ b/PhysicsTools/TruthInfo/interface/SubgraphHitView.h
@@ -1,0 +1,62 @@
+// Original author: Felice Pantaleo (CERN) <felice.pantaleo@cern.ch>
+// Part of the MC-truth-graph prototype - under heavy development, not yet open
+// to external contributions (see PhysicsTools/TruthInfo/README.md).
+
+#ifndef PhysicsTools_TruthInfo_SubgraphHitView_h
+#define PhysicsTools_TruthInfo_SubgraphHitView_h
+
+#include <cstdint>
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+#include "SimDataFormats/TruthInfo/interface/LogicalGraphHitIndex.h"
+
+namespace truth {
+
+  // A particle's subgraph hits, coalesced and detId-sorted, whichever layout the index
+  // carries. Use this rather than LogicalGraphHitIndex::subgraphHits when the particle
+  // can be any node of the graph: that accessor returns a single span, so under the
+  // shared layout it is empty for a GEN-only particle, which spans several slot ranges.
+  //
+  // The materialised layout persists exactly this form, so it is handed back untouched.
+  // The shared layout stores each hit once, in tree order and repeating a detId per
+  // contributing descendant, so it is coalesced here and kept for the rest of the event.
+  // A particle whose subgraph is a single one-slot range needs no work either way: the
+  // builder already sorted and summed its direct hits.
+  //
+  // Hold one per event and per module. It caches, so it is not thread safe and must not
+  // be a member of a global or stream module shared across concurrent events.
+  class SubgraphHitView {
+  public:
+    using Hit = LogicalGraphHitIndex::Hit;
+
+    explicit SubgraphHitView(LogicalGraphHitIndex const& hitIndex) : hitIndex_(&hitIndex) {}
+
+    [[nodiscard]] std::span<const Hit> subgraphHits(HitChannel channel, uint32_t particleId);
+
+    // Pass-throughs, so a caller that needs both can hold the view alone rather than the
+    // view and the index side by side, which is how the wrong accessor gets used again.
+    [[nodiscard]] std::span<const Hit> directHits(HitChannel channel, uint32_t particleId) const {
+      return hitIndex_->directHits(channel, particleId);
+    }
+    [[nodiscard]] bool hasChannel(HitChannel channel) const { return hitIndex_->hasChannel(channel); }
+    [[nodiscard]] uint32_t nParticles() const { return hitIndex_->nParticles(); }
+    [[nodiscard]] LogicalGraphHitIndex const& index() const { return *hitIndex_; }
+
+  private:
+    [[nodiscard]] static uint64_t key(HitChannel channel, uint32_t particleId) {
+      return (static_cast<uint64_t>(channel) << 32) | particleId;
+    }
+
+    LogicalGraphHitIndex const* hitIndex_;
+
+    // One vector per coalesced particle, not offsets into a shared store: a store that
+    // grows would reallocate and dangle every span already handed out. An unordered_map
+    // node keeps its vector put, so a span stays valid for the life of the view.
+    std::unordered_map<uint64_t, std::vector<Hit>> cached_;
+  };
+
+}  // namespace truth
+
+#endif

--- a/PhysicsTools/TruthInfo/plugins/BranchHGCalValidator.cc
+++ b/PhysicsTools/TruthInfo/plugins/BranchHGCalValidator.cc
@@ -42,6 +42,7 @@
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 
 #include "PhysicsTools/TruthInfo/interface/BranchHitAssociator.h"
+#include "PhysicsTools/TruthInfo/interface/SubgraphHitView.h"
 #include "SimDataFormats/TruthInfo/interface/Graph.h"
 #include "SimDataFormats/TruthInfo/interface/LogicalGraphHitIndex.h"
 #include "SimDataFormats/TruthInfo/interface/TruthGraph.h"
@@ -100,7 +101,7 @@ private:
   void validate(Collection const& objects,
                 truth::Graph const& graph,
                 TruthGraph const& raw,
-                truth::LogicalGraphHitIndex const& hitIndex,
+                truth::SubgraphHitView& hitIndex,
                 truth::BranchHitAssociator const& assoc,
                 std::unordered_map<uint32_t, uint32_t> const& tidToParticle,
                 std::unordered_map<uint32_t, float> const& cellSimEnergy,
@@ -274,7 +275,7 @@ template <class Collection>
 void BranchHGCalValidator::validate(Collection const& objects,
                                     truth::Graph const& graph,
                                     TruthGraph const& raw,
-                                    truth::LogicalGraphHitIndex const& hitIndex,
+                                    truth::SubgraphHitView& hitIndex,
                                     truth::BranchHitAssociator const& assoc,
                                     std::unordered_map<uint32_t, uint32_t> const& tidToParticle,
                                     std::unordered_map<uint32_t, float> const& cellSimEnergy,
@@ -478,10 +479,11 @@ std::unordered_map<uint32_t, float> BranchHGCalValidator::collectRecHitEnergyByD
 void BranchHGCalValidator::analyze(edm::Event const& event, edm::EventSetup const&) {
   auto const& graph = event.get(graphToken_);
   auto const& raw = event.get(rawToken_);
-  auto const& hitIndex = event.get(hitIndexToken_);
+  auto const& hitIndexProduct = event.get(hitIndexToken_);
+  truth::SubgraphHitView hitIndex(hitIndexProduct);
 
   const auto tidToParticle = buildTrackIdToParticle(graph, raw);
-  truth::BranchHitAssociator assoc(hitIndex, {}, truth::BranchHitAssociator::Metric::SharedHits);
+  truth::BranchHitAssociator assoc(hitIndexProduct, {}, truth::BranchHitAssociator::Metric::SharedHits);
 
   // Per-cell deposited (sim) energy = sum of every particle's direct Calo hits
   // in that cell (each PCaloHit belongs to exactly one SimTrack), and per-cell

--- a/PhysicsTools/TruthInfo/plugins/BranchHGCalValidator.cc
+++ b/PhysicsTools/TruthInfo/plugins/BranchHGCalValidator.cc
@@ -316,7 +316,7 @@ void BranchHGCalValidator::validate(Collection const& objects,
     // ratio - the reco ratio stays finite only because the extra cells lack RecHits).
     std::unordered_map<uint32_t, double> branchCellEnergy;
     double branchEnergy = 0.;
-    for (auto const& hit : hitIndex.subgraphHits(truth::HitChannel::HGCalCalo, particleId)) {
+    for (auto const& hit : hitIndex.subgraphHits(truth::HitChannel::Calo, particleId)) {
       branchCellEnergy[hit.detId] += hit.energy;
       branchEnergy += hit.energy;
     }
@@ -390,11 +390,11 @@ void BranchHGCalValidator::validate(Collection const& objects,
     if (!matches.empty()) {
       const float bestScore = matches.front().score;
       uint32_t tightest = matches.front().rootParticleId;
-      std::size_t tightestSize = hitIndex.subgraphHits(truth::HitChannel::HGCalCalo, tightest).size();
+      std::size_t tightestSize = hitIndex.subgraphHits(truth::HitChannel::Calo, tightest).size();
       for (auto const& m : matches) {
         if (m.score > bestScore)
           break;
-        const std::size_t size = hitIndex.subgraphHits(truth::HitChannel::HGCalCalo, m.rootParticleId).size();
+        const std::size_t size = hitIndex.subgraphHits(truth::HitChannel::Calo, m.rootParticleId).size();
         if (size < tightestSize) {
           tightestSize = size;
           tightest = m.rootParticleId;
@@ -425,7 +425,7 @@ void BranchHGCalValidator::validate(Collection const& objects,
       // Best Branch's purity / completeness / response vs the object.
       std::unordered_set<uint32_t> bestDetIds;
       double bestBranchEnergy = 0.;
-      for (auto const& hit : hitIndex.subgraphHits(truth::HitChannel::HGCalCalo, tightest)) {
+      for (auto const& hit : hitIndex.subgraphHits(truth::HitChannel::Calo, tightest)) {
         bestDetIds.insert(hit.detId);
         bestBranchEnergy += hit.energy;
       }
@@ -483,13 +483,13 @@ void BranchHGCalValidator::analyze(edm::Event const& event, edm::EventSetup cons
   const auto tidToParticle = buildTrackIdToParticle(graph, raw);
   truth::BranchHitAssociator assoc(hitIndex, {}, truth::BranchHitAssociator::Metric::SharedHits);
 
-  // Per-cell deposited (sim) energy = sum of every particle's direct HGCalCalo hits
+  // Per-cell deposited (sim) energy = sum of every particle's direct Calo hits
   // in that cell (each PCaloHit belongs to exactly one SimTrack), and per-cell
   // reconstructed energy from the RecHit collections; both keyed by DetId so the
   // raw response can normalise a Branch's energy by the object's own hit energy.
   std::unordered_map<uint32_t, float> cellSimEnergy;
   for (uint32_t p = 0; p < hitIndex.nParticles(); ++p)
-    for (auto const& hit : hitIndex.directHits(truth::HitChannel::HGCalCalo, p))
+    for (auto const& hit : hitIndex.directHits(truth::HitChannel::Calo, p))
       cellSimEnergy[hit.detId] += hit.energy;
   const auto recHitEnergyByDetId = collectRecHitEnergyByDetId(event);
 

--- a/PhysicsTools/TruthInfo/plugins/BranchRecoValidator.cc
+++ b/PhysicsTools/TruthInfo/plugins/BranchRecoValidator.cc
@@ -41,6 +41,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 #include "PhysicsTools/TruthInfo/interface/BranchHitAssociator.h"
+#include "PhysicsTools/TruthInfo/interface/SubgraphHitView.h"
 #include "SimDataFormats/TruthInfo/interface/Graph.h"
 #include "SimDataFormats/TruthInfo/interface/LogicalGraphHitIndex.h"
 #include "PhysicsTools/TruthInfo/interface/RecoHitAdapters.h"
@@ -129,8 +130,8 @@ private:
     return std::abs(eta) >= minAbsEta_ && std::abs(eta) <= maxAbsEta_ && x >= minX_;
   }
   // Per-object span hits in the relevant channel (calo subgraph or tracker subgraph).
-  [[nodiscard]] std::span<const truth::LogicalGraphHitIndex::Hit> channelHits(
-      truth::LogicalGraphHitIndex const& hitIndex, uint32_t root) const {
+  [[nodiscard]] std::span<const truth::LogicalGraphHitIndex::Hit> channelHits(truth::SubgraphHitView& hitIndex,
+                                                                              uint32_t root) const {
     return hitIndex.subgraphHits(Traits::channel(), root);
   }
 
@@ -214,6 +215,7 @@ template <class Traits>
 void BranchRecoValidatorT<Traits>::analyze(edm::Event const& event, edm::EventSetup const&) {
   auto const& graph = event.get(graphToken_);
   auto const& hitIndex = event.get(hitIndexToken_);
+  truth::SubgraphHitView subgraphView(hitIndex);
 
   // Candidate / associator roots = the interesting particles (empty config -> all).
   std::vector<uint32_t> roots;
@@ -270,7 +272,7 @@ void BranchRecoValidatorT<Traits>::analyze(edm::Event const& event, edm::EventSe
            interestingPdgIds_.end();
   };
   for (uint32_t r = 0; r < nP; ++r) {
-    if (!considerRoot(r) || channelHits(hitIndex, r).empty())
+    if (!considerRoot(r) || channelHits(subgraphView, r).empty())
       continue;
     auto const& p = graph.particles()[r].momentum;
     const double eta = p.eta();

--- a/PhysicsTools/TruthInfo/plugins/BranchRecoValidator.cc
+++ b/PhysicsTools/TruthInfo/plugins/BranchRecoValidator.cc
@@ -103,7 +103,7 @@ namespace {
     static constexpr truth::BranchHitAssociator::Metric metric() {
       return truth::BranchHitAssociator::Metric::SharedEnergy;
     }
-    static constexpr truth::HitChannel channel() { return truth::HitChannel::HGCalCalo; }
+    static constexpr truth::HitChannel channel() { return truth::HitChannel::Calo; }
     static double particleX(math::XYZTLorentzVectorD const& p) { return p.energy(); }
     static void fillDescriptions(edm::ParameterSetDescription& desc) {
       desc.add<edm::InputTag>("recoCollection", edm::InputTag("ticlTrackstersCLUE3DHigh"));

--- a/PhysicsTools/TruthInfo/plugins/BranchTrackerReplacementValidator.cc
+++ b/PhysicsTools/TruthInfo/plugins/BranchTrackerReplacementValidator.cc
@@ -28,6 +28,7 @@
 #include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h"
 
 #include "PhysicsTools/TruthInfo/interface/BranchHitAssociator.h"
+#include "PhysicsTools/TruthInfo/interface/SubgraphHitView.h"
 #include "SimDataFormats/TruthInfo/interface/Graph.h"
 #include "SimDataFormats/TruthInfo/interface/LogicalGraphHitIndex.h"
 #include "SimDataFormats/TruthInfo/interface/TruthGraph.h"
@@ -75,7 +76,7 @@ namespace {
   }
 
   // tightest (smallest tracker subgraph) among the best-scoring matches.
-  int tightestBest(std::vector<truth::BranchMatch> const& matches, truth::LogicalGraphHitIndex const& hitIndex) {
+  int tightestBest(std::vector<truth::BranchMatch> const& matches, truth::SubgraphHitView& hitIndex) {
     if (matches.empty())
       return -1;
     const float best = matches.front().score;
@@ -98,6 +99,7 @@ void BranchTrackerReplacementValidator::analyze(edm::Event const& event, edm::Ev
   auto const& graph = event.get(graphToken_);
   auto const& raw = event.get(rawToken_);
   auto const& hitIndex = event.get(hitIndexToken_);
+  truth::SubgraphHitView subgraphView(hitIndex);
   auto const& tracks = event.get(trackToken_);
   auto const& clusterTP = event.get(clusterTPToken_);
 
@@ -117,7 +119,7 @@ void BranchTrackerReplacementValidator::analyze(edm::Event const& event, edm::Ev
     }
     int branchParticle = -1;
     if (!trackHits.empty())
-      branchParticle = tightestBest(assoc.bestBranches(std::span<const truth::RecoHit>(trackHits)), hitIndex);
+      branchParticle = tightestBest(assoc.bestBranches(std::span<const truth::RecoHit>(trackHits)), subgraphView);
 
     // TP side: shared clusters via ClusterTPAssociation -> dominant TP -> particle.
     auto clusters = track_associator::hitsToClusterRefs(track.recHitsBegin(), track.recHitsEnd());

--- a/PhysicsTools/TruthInfo/plugins/BranchTrackingValidator.cc
+++ b/PhysicsTools/TruthInfo/plugins/BranchTrackingValidator.cc
@@ -42,6 +42,7 @@
 #include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociation.h"
 
 #include "PhysicsTools/TruthInfo/interface/BranchHitAssociator.h"
+#include "PhysicsTools/TruthInfo/interface/SubgraphHitView.h"
 #include "SimDataFormats/TruthInfo/interface/Graph.h"
 #include "SimDataFormats/TruthInfo/interface/LogicalGraphHitIndex.h"
 #include "SimDataFormats/TruthInfo/interface/TruthGraph.h"
@@ -153,7 +154,7 @@ namespace {
     uint32_t sharedHits = 0;
   };
 
-  BestMatch tightestBest(std::vector<truth::BranchMatch> const& matches, truth::LogicalGraphHitIndex const& hitIndex) {
+  BestMatch tightestBest(std::vector<truth::BranchMatch> const& matches, truth::SubgraphHitView& hitIndex) {
     if (matches.empty())
       return {};
     const float best = matches.front().score;
@@ -178,6 +179,7 @@ void BranchTrackingValidator::analyze(edm::Event const& event, edm::EventSetup c
   auto const& graph = event.get(graphToken_);
   auto const& raw = event.get(rawToken_);
   auto const& hitIndex = event.get(hitIndexToken_);
+  truth::SubgraphHitView subgraphView(hitIndex);
   auto const& tracks = event.get(trackToken_);
   auto const& clusterTP = event.get(clusterTPToken_);
 
@@ -205,7 +207,7 @@ void BranchTrackingValidator::analyze(edm::Event const& event, edm::EventSetup c
     std::vector<truth::BranchMatch> matches;
     if (!trackHits.empty()) {
       matches = assoc.bestBranches(std::span<const truth::RecoHit>(trackHits));
-      branch = tightestBest(matches, hitIndex);
+      branch = tightestBest(matches, subgraphView);
     }
 
     // TP side: shared clusters via ClusterTPAssociation -> dominant TP -> particle.

--- a/PhysicsTools/TruthInfo/plugins/BranchTruthReplacementValidator.cc
+++ b/PhysicsTools/TruthInfo/plugins/BranchTruthReplacementValidator.cc
@@ -116,7 +116,7 @@ void BranchTruthReplacementValidator::validate(Collection const& objects,
 
     // Branch subgraph calo hits for the mapped logical particle.
     std::unordered_set<uint32_t> branchDetIds;
-    for (auto const& hit : hitIndex.subgraphHits(truth::HitChannel::HGCalCalo, particleId))
+    for (auto const& hit : hitIndex.subgraphHits(truth::HitChannel::Calo, particleId))
       branchDetIds.insert(hit.detId);
 
     // Legacy object hits, and the reco-like hit list for the matcher.
@@ -149,11 +149,11 @@ void BranchTruthReplacementValidator::validate(Collection const& objects,
     if (!matches.empty()) {
       const float bestScore = matches.front().score;
       uint32_t tightest = matches.front().rootParticleId;
-      std::size_t tightestSize = hitIndex.subgraphHits(truth::HitChannel::HGCalCalo, tightest).size();
+      std::size_t tightestSize = hitIndex.subgraphHits(truth::HitChannel::Calo, tightest).size();
       for (auto const& m : matches) {
         if (m.score > bestScore)
           break;
-        const std::size_t size = hitIndex.subgraphHits(truth::HitChannel::HGCalCalo, m.rootParticleId).size();
+        const std::size_t size = hitIndex.subgraphHits(truth::HitChannel::Calo, m.rootParticleId).size();
         if (size < tightestSize) {
           tightestSize = size;
           tightest = m.rootParticleId;

--- a/PhysicsTools/TruthInfo/plugins/BranchTruthReplacementValidator.cc
+++ b/PhysicsTools/TruthInfo/plugins/BranchTruthReplacementValidator.cc
@@ -29,6 +29,7 @@
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 
 #include "PhysicsTools/TruthInfo/interface/BranchHitAssociator.h"
+#include "PhysicsTools/TruthInfo/interface/SubgraphHitView.h"
 #include "SimDataFormats/TruthInfo/interface/Graph.h"
 #include "SimDataFormats/TruthInfo/interface/LogicalGraphHitIndex.h"
 #include "SimDataFormats/TruthInfo/interface/TruthGraph.h"
@@ -54,7 +55,7 @@ private:
   void validate(Collection const& objects,
                 truth::Graph const& graph,
                 TruthGraph const& raw,
-                truth::LogicalGraphHitIndex const& hitIndex,
+                truth::SubgraphHitView& hitIndex,
                 truth::BranchHitAssociator const& assoc,
                 std::unordered_map<uint32_t, uint32_t> const& tidToParticle,
                 Stats& stats);
@@ -97,7 +98,7 @@ template <class Collection>
 void BranchTruthReplacementValidator::validate(Collection const& objects,
                                                truth::Graph const& graph,
                                                TruthGraph const& raw,
-                                               truth::LogicalGraphHitIndex const& hitIndex,
+                                               truth::SubgraphHitView& hitIndex,
                                                truth::BranchHitAssociator const& assoc,
                                                std::unordered_map<uint32_t, uint32_t> const& tidToParticle,
                                                Stats& stats) {
@@ -168,12 +169,13 @@ void BranchTruthReplacementValidator::validate(Collection const& objects,
 void BranchTruthReplacementValidator::analyze(edm::Event const& event, edm::EventSetup const&) {
   auto const& graph = event.get(graphToken_);
   auto const& raw = event.get(rawToken_);
-  auto const& hitIndex = event.get(hitIndexToken_);
+  auto const& hitIndexProduct = event.get(hitIndexToken_);
+  truth::SubgraphHitView hitIndex(hitIndexProduct);
 
   const auto tidToParticle = buildTrackIdToParticle(graph, raw);
 
   // SharedHits metric: best branch = the one sharing the most calo cells.
-  truth::BranchHitAssociator assoc(hitIndex, {}, truth::BranchHitAssociator::Metric::SharedHits);
+  truth::BranchHitAssociator assoc(hitIndexProduct, {}, truth::BranchHitAssociator::Metric::SharedHits);
 
   validate(event.get(caloParticleToken_), graph, raw, hitIndex, assoc, tidToParticle, caloParticleStats_);
   validate(event.get(simClusterToken_), graph, raw, hitIndex, assoc, tidToParticle, simClusterStats_);

--- a/PhysicsTools/TruthInfo/plugins/LogicalGraphHitIndexProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/LogicalGraphHitIndexProducer.cc
@@ -283,13 +283,14 @@ void TruthLogicalGraphHitIndexProducer::fillDescriptions(edm::ConfigurationDescr
           "Apply HcalHitRelabeller to the HCAL simulation DetIds, which are in packed test numbering, so the index "
           "stores the reco HcalDetIds the association matches on. Affects the HCAL collections only.");
 
-  desc.add<bool>("sharedSubgraphStore", true)
+  desc.add<bool>("sharedSubgraphStore", false)
       ->setComment(
           "Store each hit once, ordered so that a particle's subtree is a contiguous range, instead of copying every "
-          "descendant's hits into each ancestor's aggregate. Subgraph spans are then in tree order rather than detId "
-          "order and repeat a detId hit by several descendants, so a consumer that needs per-cell energies coalesces "
-          "them. Set false to write the materialised layout, which is what indices written before this option exist "
-          "carry; reading either layout is automatic.");
+          "descendant's hits into each ancestor's aggregate, which cuts the index from 445 to 202 kB/event on ttbar. "
+          "Off by default until the consumers of LogicalGraphHitIndex::subgraphHits are migrated: that accessor "
+          "returns a single span, so under this layout it is empty for a GEN-only particle, whose subgraph spans "
+          "several ranges. Use appendSubgraphHits, which is correct for every particle in both layouts. Reading "
+          "either layout is automatic.");
 
   desc.add<edm::InputTag>("mtdSimLayerClusters", edm::InputTag("mix", "MergedMtdTruthLC"))
       ->setComment(

--- a/PhysicsTools/TruthInfo/plugins/LogicalGraphHitIndexProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/LogicalGraphHitIndexProducer.cc
@@ -83,8 +83,8 @@ namespace {
 
   // Map a config channel name to its HitChannel; false if unknown.
   bool channelFromName(std::string const& name, truth::HitChannel& out) {
-    if (name == "HGCalCalo") {
-      out = truth::HitChannel::HGCalCalo;
+    if (name == "Calo") {
+      out = truth::HitChannel::Calo;
       return true;
     }
     if (name == "Tracker") {
@@ -182,7 +182,10 @@ private:
 
   std::array<bool, truth::kNumHitChannels> fillChannel_{};
 
+  // Sim-to-reco DetId conversion, one switch per calorimeter numbering scheme: the
+  // HGCAL hexagon unpacking and the HCAL HcalHitRelabeller are selected independently.
   bool doHGCalRelabelling_ = true;
+  bool doHcalRelabelling_ = true;
 };
 
 TruthLogicalGraphHitIndexProducer::TruthLogicalGraphHitIndexProducer(edm::ParameterSet const& cfg)
@@ -193,7 +196,8 @@ TruthLogicalGraphHitIndexProducer::TruthLogicalGraphHitIndexProducer(edm::Parame
       trackerSimHitTags_(cfg.getParameter<std::vector<edm::InputTag>>("trackerSimHitCollections")),
       muonSimHitTags_(cfg.getParameter<std::vector<edm::InputTag>>("muonSimHitCollections")),
       geomToken_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
-      doHGCalRelabelling_(cfg.getParameter<bool>("doHGCalRelabelling")) {
+      doHGCalRelabelling_(cfg.getParameter<bool>("doHGCalRelabelling")),
+      doHcalRelabelling_(cfg.getParameter<bool>("doHcalRelabelling")) {
   simHitTokens_.reserve(simHitTags_.size());
   for (auto const& tag : simHitTags_) {
     simHitTokens_.push_back(consumes<std::vector<PCaloHit>>(tag));
@@ -235,9 +239,9 @@ void TruthLogicalGraphHitIndexProducer::fillDescriptions(edm::ConfigurationDescr
   desc.add<edm::InputTag>("rawSrc", edm::InputTag("truthGraphProducer"));
   desc.add<edm::InputTag>("recHitMap", edm::InputTag("detIdToRecHitMapProducer"));
 
-  desc.add<std::vector<std::string>>("subdetectors", {"HGCalCalo", "Tracker", "MTD", "Muon"})
+  desc.add<std::vector<std::string>>("subdetectors", {"Calo", "Tracker", "MTD", "Muon"})
       ->setComment(
-          "Detector channels to fill (subdetector selection): any of HGCalCalo, Tracker, MTD, Muon. Each reads its "
+          "Detector channels to fill (subdetector selection): any of Calo, Tracker, MTD, Muon. Each reads its "
           "own per-subdetector hit collections below; channels left out of this list stay empty in the index.");
 
   desc.add<std::vector<edm::InputTag>>("simHitCollections",
@@ -269,7 +273,13 @@ void TruthLogicalGraphHitIndexProducer::fillDescriptions(edm::ConfigurationDescr
       ->setComment("Muon-chamber PSimHit collections matched to particles via PSimHit::trackId()");
 
   desc.add<bool>("doHGCalRelabelling", true)
-      ->setComment("Convert old HGCAL simulation DetIds to reco DetIds before looking up recHits");
+      ->setComment(
+          "Convert old HGCAL simulation DetIds to reco DetIds before looking up recHits. No-op for the Run4 "
+          "geometries, whose HGCAL simulation DetId is already the reco DetId. Affects the HGCAL collections only.");
+  desc.add<bool>("doHcalRelabelling", true)
+      ->setComment(
+          "Apply HcalHitRelabeller to the HCAL simulation DetIds, which are in packed test numbering, so the index "
+          "stores the reco HcalDetIds the association matches on. Affects the HCAL collections only.");
 
   desc.add<edm::InputTag>("mtdSimLayerClusters", edm::InputTag("mix", "MergedMtdTruthLC"))
       ->setComment(
@@ -300,7 +310,7 @@ void TruthLogicalGraphHitIndexProducer::produce(edm::StreamID, edm::Event& event
   fillTrackToParticleMap(graphView, rawGraph, builder);
 
   // Each subdetector channel is filled only when selected (see "subdetectors").
-  if (fillChannel_[static_cast<std::size_t>(truth::HitChannel::HGCalCalo)])
+  if (fillChannel_[static_cast<std::size_t>(truth::HitChannel::Calo)])
     fillSimHits(event, setup, builder, recHitMap);
   if (fillChannel_[static_cast<std::size_t>(truth::HitChannel::Tracker)])
     fillTrackerSimHits(event, builder);
@@ -347,15 +357,20 @@ void TruthLogicalGraphHitIndexProducer::fillTrackToParticleMap(LogicalGraphView 
 RelabelContext TruthLogicalGraphHitIndexProducer::makeRelabelContext(edm::EventSetup const& setup) const {
   RelabelContext context;
 
-  if (!doHGCalRelabelling_)
+  if (!doHGCalRelabelling_ && !doHcalRelabelling_)
     return context;
 
   auto const& geom = setup.getData(geomToken_);
 
-  auto const* hcalGeometry = static_cast<HcalGeometry const*>(geom.getSubdetectorGeometry(DetId::Hcal, HcalEndcap));
-  if (hcalGeometry != nullptr) {
-    context.hcalConstants = hcalGeometry->topology().dddConstants();
+  if (doHcalRelabelling_) {
+    auto const* hcalGeometry = static_cast<HcalGeometry const*>(geom.getSubdetectorGeometry(DetId::Hcal, HcalEndcap));
+    if (hcalGeometry != nullptr) {
+      context.hcalConstants = hcalGeometry->topology().dddConstants();
+    }
   }
+
+  if (!doHGCalRelabelling_)
+    return context;
 
   auto const* eeGeometry =
       static_cast<HGCalGeometry const*>(geom.getSubdetectorGeometry(DetId::HGCalEE, ForwardSubdetector::ForwardEmpty));
@@ -402,6 +417,12 @@ uint32_t TruthLogicalGraphHitIndexProducer::recoDetIdForSimHit(PCaloHit const& s
                                                                RelabelContext const& context) const {
   const uint32_t simId = simHit.id();
 
+  if (isHcalCollection) {
+    if (doHcalRelabelling_ && context.hcalConstants != nullptr)
+      return HcalHitRelabeller::relabel(simId, context.hcalConstants).rawId();
+    return simId;
+  }
+
   if (!doHGCalRelabelling_) {
     return simId;
   }
@@ -438,10 +459,6 @@ uint32_t TruthLogicalGraphHitIndexProducer::recoDetIdForSimHit(PCaloHit const& s
       return 0;
 
     return HGCalDetId(static_cast<ForwardSubdetector>(subdet), zp, layer, subsec, sec, cell).rawId();
-  }
-
-  if (isHcalCollection && context.hcalConstants != nullptr) {
-    return HcalHitRelabeller::relabel(simId, context.hcalConstants).rawId();
   }
 
   return simId;
@@ -487,7 +504,7 @@ void TruthLogicalGraphHitIndexProducer::fillSimHits(edm::Event& event,
         }
       }
 
-      builder.addHit(truth::HitChannel::HGCalCalo,
+      builder.addHit(truth::HitChannel::Calo,
                      simHit.eventId().rawId(),
                      static_cast<uint32_t>(geantTrackId),
                      detId,

--- a/PhysicsTools/TruthInfo/plugins/LogicalGraphHitIndexProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/LogicalGraphHitIndexProducer.cc
@@ -283,14 +283,14 @@ void TruthLogicalGraphHitIndexProducer::fillDescriptions(edm::ConfigurationDescr
           "Apply HcalHitRelabeller to the HCAL simulation DetIds, which are in packed test numbering, so the index "
           "stores the reco HcalDetIds the association matches on. Affects the HCAL collections only.");
 
-  desc.add<bool>("sharedSubgraphStore", false)
+  desc.add<bool>("sharedSubgraphStore", true)
       ->setComment(
           "Store each hit once, ordered so that a particle's subtree is a contiguous range, instead of copying every "
           "descendant's hits into each ancestor's aggregate, which cuts the index from 445 to 202 kB/event on ttbar. "
-          "Off by default until the consumers of LogicalGraphHitIndex::subgraphHits are migrated: that accessor "
-          "returns a single span, so under this layout it is empty for a GEN-only particle, whose subgraph spans "
-          "several ranges. Use appendSubgraphHits, which is correct for every particle in both layouts. Reading "
-          "either layout is automatic.");
+          "LogicalGraphHitIndex::subgraphHits returns a single span, so under this layout it is empty for a "
+          "GEN-only particle, whose subgraph spans several ranges: a consumer that can be handed any particle uses "
+          "truth::SubgraphHitView, which is correct in both layouts. Set false to write the materialised layout. "
+          "Reading either layout is automatic.");
 
   desc.add<edm::InputTag>("mtdSimLayerClusters", edm::InputTag("mix", "MergedMtdTruthLC"))
       ->setComment(

--- a/PhysicsTools/TruthInfo/plugins/LogicalGraphHitIndexProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/LogicalGraphHitIndexProducer.cc
@@ -186,6 +186,7 @@ private:
   // HGCAL hexagon unpacking and the HCAL HcalHitRelabeller are selected independently.
   bool doHGCalRelabelling_ = true;
   bool doHcalRelabelling_ = true;
+  bool sharedSubgraphStore_ = false;
 };
 
 TruthLogicalGraphHitIndexProducer::TruthLogicalGraphHitIndexProducer(edm::ParameterSet const& cfg)
@@ -197,7 +198,8 @@ TruthLogicalGraphHitIndexProducer::TruthLogicalGraphHitIndexProducer(edm::Parame
       muonSimHitTags_(cfg.getParameter<std::vector<edm::InputTag>>("muonSimHitCollections")),
       geomToken_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
       doHGCalRelabelling_(cfg.getParameter<bool>("doHGCalRelabelling")),
-      doHcalRelabelling_(cfg.getParameter<bool>("doHcalRelabelling")) {
+      doHcalRelabelling_(cfg.getParameter<bool>("doHcalRelabelling")),
+      sharedSubgraphStore_(cfg.getParameter<bool>("sharedSubgraphStore")) {
   simHitTokens_.reserve(simHitTags_.size());
   for (auto const& tag : simHitTags_) {
     simHitTokens_.push_back(consumes<std::vector<PCaloHit>>(tag));
@@ -281,6 +283,14 @@ void TruthLogicalGraphHitIndexProducer::fillDescriptions(edm::ConfigurationDescr
           "Apply HcalHitRelabeller to the HCAL simulation DetIds, which are in packed test numbering, so the index "
           "stores the reco HcalDetIds the association matches on. Affects the HCAL collections only.");
 
+  desc.add<bool>("sharedSubgraphStore", true)
+      ->setComment(
+          "Store each hit once, ordered so that a particle's subtree is a contiguous range, instead of copying every "
+          "descendant's hits into each ancestor's aggregate. Subgraph spans are then in tree order rather than detId "
+          "order and repeat a detId hit by several descendants, so a consumer that needs per-cell energies coalesces "
+          "them. Set false to write the materialised layout, which is what indices written before this option exist "
+          "carry; reading either layout is automatic.");
+
   desc.add<edm::InputTag>("mtdSimLayerClusters", edm::InputTag("mix", "MergedMtdTruthLC"))
       ->setComment(
           "MtdSimLayerCluster collection (BTL/ETL); keyed by SimTrack trackId via particleId(). The signal "
@@ -305,7 +315,7 @@ void TruthLogicalGraphHitIndexProducer::produce(edm::StreamID, edm::Event& event
 
   LogicalGraphView graphView(graph);
 
-  truth::LogicalGraphHitIndexBuilder builder(graphView.nParticles());
+  truth::LogicalGraphHitIndexBuilder builder(graphView.nParticles(), sharedSubgraphStore_);
 
   fillTrackToParticleMap(graphView, rawGraph, builder);
 

--- a/PhysicsTools/TruthInfo/plugins/TruthBranchCaloAssociationProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthBranchCaloAssociationProducer.cc
@@ -143,7 +143,7 @@ void TruthBranchCaloAssociationProducer::produce(edm::Event& event, edm::EventSe
   truth::BranchHitAssociator assoc(hitIndex,
                                    roots,
                                    truth::BranchHitAssociator::Metric::SharedEnergy,
-                                   truth::HitChannel::HGCalCalo,
+                                   truth::HitChannel::Calo,
                                    /*emptyRootsMeansAll=*/!restrictRoots);
 
   associate(event.get(caloParticleToken_), graph, assoc, "caloParticleToBranch", "branchToCaloParticle", event);

--- a/PhysicsTools/TruthInfo/plugins/TruthGraphAccumulator.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthGraphAccumulator.cc
@@ -23,6 +23,11 @@
 //        record. A selection preset seeded on a resonance pdgId needs this: the
 //        collapsed form has stable particles only and nothing to seed on.
 //
+//   collapseGenShower (default true): applies to the full chain above. The parton
+//        shower and the intermediate copies of a resonance are contracted away,
+//        keeping ancestry, so a resonance that appears several times is one node whose
+//        children are its decay products. See truth::collapseGenShower.
+//
 //   pileupBunchCrossings (default {0} = in-time pileup only): which bunch crossings
 //        to include for pileup.
 //
@@ -130,19 +135,28 @@ namespace {
   }
 
   // The full HepMC record for one sub-event, in the same flattened form
-  // TruthGraphProducer builds from an unmixed event.
+  // TruthGraphProducer builds from an unmixed event, optionally with the parton
+  // shower and the intermediate resonance copies contracted away.
   template <class EvT>
-  truth::GenBuild readFullGen(EvT const& ev, edm::InputTag const& hepmc3Tag, edm::InputTag const& hepmc2Tag) {
+  truth::GenBuild readFullGen(EvT const& ev,
+                              edm::InputTag const& hepmc3Tag,
+                              edm::InputTag const& hepmc2Tag,
+                              bool collapseShower,
+                              edm::SimTrackContainer const& tracks) {
+    truth::GenBuild gb;
     edm::Handle<edm::HepMC3Product> h3;
     if (ev.getByLabel(hepmc3Tag, h3) && h3.isValid() && h3->GetEvent() != nullptr) {
       HepMC3::GenEvent ev3;
       ev3.read_data(*h3->GetEvent());
-      return truth::buildFromHepMC3(ev3);
+      gb = truth::buildFromHepMC3(ev3);
+    } else {
+      edm::Handle<edm::HepMCProduct> h2;
+      if (ev.getByLabel(hepmc2Tag, h2) && h2.isValid() && h2->GetEvent() != nullptr)
+        gb = truth::buildFromHepMC2(*h2->GetEvent());
     }
-    edm::Handle<edm::HepMCProduct> h2;
-    if (ev.getByLabel(hepmc2Tag, h2) && h2.isValid() && h2->GetEvent() != nullptr)
-      return truth::buildFromHepMC2(*h2->GetEvent());
-    return {};
+    if (collapseShower && !gb.empty())
+      truth::collapseGenShower(gb, truth::simContinuedGenBarcodes(tracks));
+    return gb;
   }
 }  // namespace
 
@@ -204,6 +218,7 @@ private:
   const std::vector<int> pileupBunchCrossings_;
   const bool collapsePileupGen_;
   const bool collapseSignalGen_;
+  const bool collapseGenShower_;
   const bool computeCellEnergyBudget_;
 
   int pileupCount_ = 0;
@@ -277,6 +292,7 @@ TruthGraphAccumulator::TruthGraphAccumulator(edm::ParameterSet const& cfg,
       pileupBunchCrossings_(cfg.getParameter<std::vector<int>>("pileupBunchCrossings")),
       collapsePileupGen_(cfg.getParameter<bool>("collapsePileupGen")),
       collapseSignalGen_(cfg.getParameter<bool>("collapseSignalGen")),
+      collapseGenShower_(cfg.getParameter<bool>("collapseGenShower")),
       computeCellEnergyBudget_(
           cfg.existsAs<bool>("computeCellEnergyBudget") ? cfg.getParameter<bool>("computeCellEnergyBudget") : false) {
   producesCollector.produces<TruthGraph>();
@@ -564,7 +580,7 @@ void TruthGraphAccumulator::accumulate(edm::Event const& event, edm::EventSetup 
   if (collapseSignalGen_)
     stableGen = readStableGen(event, hepmc3Tag_, hepmc2Tag_);
   else
-    fullGen = readFullGen(event, hepmc3Tag_, hepmc2Tag_);
+    fullGen = readFullGen(event, hepmc3Tag_, hepmc2Tag_, collapseGenShower_, *tracks);
   const EncodedEventId sigEid(0, 0);
   addSubEvent(stableGen, &fullGen, *tracks, *vertices, sigEid, 0);
   addSubEventHits(event, sigEid);
@@ -593,7 +609,7 @@ void TruthGraphAccumulator::accumulate(PileUpEventPrincipal const& pep, edm::Eve
   if (collapsePileupGen_)
     stableGen = readStableGen(pep, hepmc3Tag_, hepmc2Tag_);
   else
-    fullGen = readFullGen(pep, hepmc3Tag_, hepmc2Tag_);
+    fullGen = readFullGen(pep, hepmc3Tag_, hepmc2Tag_, collapseGenShower_, *tracks);
 
   // Global counter across bunch crossings: EncodedEventId stores abs(bx), so a
   // per-bx counter would give (-1,1) and (+1,1) identical packed ids. A single

--- a/PhysicsTools/TruthInfo/plugins/TruthGraphAccumulator.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthGraphAccumulator.cc
@@ -154,8 +154,16 @@ namespace {
       if (ev.getByLabel(hepmc2Tag, h2) && h2.isValid() && h2->GetEvent() != nullptr)
         gb = truth::buildFromHepMC2(*h2->GetEvent());
     }
-    if (collapseShower && !gb.empty())
-      truth::collapseGenShower(gb, truth::simContinuedGenBarcodes(tracks));
+    if (collapseShower && !gb.empty()) {
+      if (!truth::collapseGenShower(gb, truth::simContinuedGenBarcodes(tracks))) {
+        edm::LogWarning("TruthGraphAccumulator")
+            << "collapseGenShower ran on a GEN record with no packed status flags, which "
+               "buildFromHepMC3 does not fill. The isHardProcess and isLastCopy keep rules "
+               "are then dead and every intermediate resonance is dropped, so a selection "
+               "preset seeded on a resonance pdgId will match nothing. Set "
+               "collapseGenShower=False on a HepMC3 sample.";
+      }
+    }
     return gb;
   }
 }  // namespace
@@ -422,17 +430,60 @@ void TruthGraphAccumulator::addSubEvent(std::vector<std::pair<int, int>> const& 
         pushEdge(itP->second, itV->second, TruthGraph::EdgeKind::Gen);
     }
 
-    unsigned int nRoots = 0;
-    for (int vbc : fullGen->vtxBarcodes) {
-      if (vtxIncoming[vbc] != 0)
-        continue;
-      ++nRoots;
-      pushEdge(genEventNode, genVtxBarcodeToNode.at(vbc), TruthGraph::EdgeKind::Gen);
+    // Attach the GenEvent node PER CONNECTED COMPONENT, which is what TruthGraphProducer
+    // does on an unmixed event and what GenGraphBuild.h requires of both: a component
+    // whose vertices all have an incoming particle has no source of its own, and a
+    // single sub-event-wide root count would let one component with a source suppress
+    // the fallback for another that has none, leaving the second unreachable.
+    // A collider record is entirely the fallback case: the beam particles give the first
+    // vertex an incoming particle, so no vertex is a source.
+    std::unordered_map<int, int> componentOfVtx;
+    {
+      // Two vertices are in the same component when a particle touches both.
+      std::unordered_map<int, std::vector<int>> partAdjacency;
+      std::unordered_map<int, std::vector<int>> vtxNeighbours;
+      for (auto const& [vbc, pbc] : fullGen->vtxToPart)
+        partAdjacency[pbc].push_back(vbc);
+      for (auto const& [pbc, vbc] : fullGen->partToVtx)
+        partAdjacency[pbc].push_back(vbc);
+      for (auto const& [pbc, vtxs] : partAdjacency) {
+        for (std::size_t i = 1; i < vtxs.size(); ++i) {
+          vtxNeighbours[vtxs[0]].push_back(vtxs[i]);
+          vtxNeighbours[vtxs[i]].push_back(vtxs[0]);
+        }
+      }
+
+      int nextComponent = 0;
+      std::vector<int> stack;
+      for (int vbc : fullGen->vtxBarcodes) {
+        if (componentOfVtx.count(vbc) != 0)
+          continue;
+        const int component = nextComponent++;
+        stack.push_back(vbc);
+        componentOfVtx.emplace(vbc, component);
+        while (!stack.empty()) {
+          const int current = stack.back();
+          stack.pop_back();
+          const auto it = vtxNeighbours.find(current);
+          if (it == vtxNeighbours.end())
+            continue;
+          for (const int next : it->second) {
+            if (componentOfVtx.emplace(next, component).second)
+              stack.push_back(next);
+          }
+        }
+      }
     }
-    // A record whose vertices all have an incoming particle has no source to attach
-    // to, so attach every vertex and keep the component reachable.
-    if (nRoots == 0) {
-      for (int vbc : fullGen->vtxBarcodes)
+
+    std::unordered_map<int, unsigned int> rootsInComponent;
+    for (int vbc : fullGen->vtxBarcodes) {
+      if (vtxIncoming[vbc] == 0)
+        ++rootsInComponent[componentOfVtx.at(vbc)];
+    }
+    for (int vbc : fullGen->vtxBarcodes) {
+      const bool isSource = vtxIncoming[vbc] == 0;
+      const bool componentHasNoSource = rootsInComponent[componentOfVtx.at(vbc)] == 0;
+      if (isSource || componentHasNoSource)
         pushEdge(genEventNode, genVtxBarcodeToNode.at(vbc), TruthGraph::EdgeKind::Gen);
     }
   } else if (!stableGen.empty()) {

--- a/PhysicsTools/TruthInfo/plugins/TruthGraphAccumulator.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthGraphAccumulator.cc
@@ -142,7 +142,8 @@ namespace {
                               edm::InputTag const& hepmc3Tag,
                               edm::InputTag const& hepmc2Tag,
                               bool collapseShower,
-                              edm::SimTrackContainer const& tracks) {
+                              edm::SimTrackContainer const& tracks,
+                              bool& degradedCollapseWarned) {
     truth::GenBuild gb;
     edm::Handle<edm::HepMC3Product> h3;
     if (ev.getByLabel(hepmc3Tag, h3) && h3.isValid() && h3->GetEvent() != nullptr) {
@@ -155,7 +156,10 @@ namespace {
         gb = truth::buildFromHepMC2(*h2->GetEvent());
     }
     if (collapseShower && !gb.empty()) {
-      if (!truth::collapseGenShower(gb, truth::simContinuedGenBarcodes(tracks))) {
+      // The degraded path is a property of the sample, not of one sub-event, so one
+      // warning per stream says everything 200 per event would.
+      if (!truth::collapseGenShower(gb, truth::simContinuedGenBarcodes(tracks)) && !degradedCollapseWarned) {
+        degradedCollapseWarned = true;
         edm::LogWarning("TruthGraphAccumulator")
             << "collapseGenShower ran on a GEN record with no packed status flags, which "
                "buildFromHepMC3 does not fill. The isHardProcess and isLastCopy keep rules "
@@ -234,6 +238,7 @@ private:
   // first collection that goes missing and hides every later one, so a real premix
   // problem in the calorimeter can be masked by an unrelated tracker collection.
   std::set<std::string> missingHitsWarned_;
+  bool degradedCollapseWarned_ = false;
 
   // Merged calorimeter sim-hits across signal + kept pileup, each re-tagged with its
   // sub-event EncodedEventId so the (eventId,trackId) hit-index key resolves pileup
@@ -475,6 +480,12 @@ void TruthGraphAccumulator::addSubEvent(std::vector<std::pair<int, int>> const& 
       }
     }
 
+    // Residual gap, shared with TruthGraphProducer so the two stay consistent: source
+    // counting is per undirected component, but reachability from the GenEvent node is
+    // DIRECTED. A component containing both a true source and a beam-fed branch would
+    // attach only the source and leave the branch unreachable. No current record mixes
+    // the two in one component: a collider record is wholly sourceless and a gun record
+    // wholly source-rooted.
     std::unordered_map<int, unsigned int> rootsInComponent;
     for (int vbc : fullGen->vtxBarcodes) {
       if (vtxIncoming[vbc] == 0)
@@ -631,7 +642,7 @@ void TruthGraphAccumulator::accumulate(edm::Event const& event, edm::EventSetup 
   if (collapseSignalGen_)
     stableGen = readStableGen(event, hepmc3Tag_, hepmc2Tag_);
   else
-    fullGen = readFullGen(event, hepmc3Tag_, hepmc2Tag_, collapseGenShower_, *tracks);
+    fullGen = readFullGen(event, hepmc3Tag_, hepmc2Tag_, collapseGenShower_, *tracks, degradedCollapseWarned_);
   const EncodedEventId sigEid(0, 0);
   addSubEvent(stableGen, &fullGen, *tracks, *vertices, sigEid, 0);
   addSubEventHits(event, sigEid);
@@ -660,7 +671,7 @@ void TruthGraphAccumulator::accumulate(PileUpEventPrincipal const& pep, edm::Eve
   if (collapsePileupGen_)
     stableGen = readStableGen(pep, hepmc3Tag_, hepmc2Tag_);
   else
-    fullGen = readFullGen(pep, hepmc3Tag_, hepmc2Tag_, collapseGenShower_, *tracks);
+    fullGen = readFullGen(pep, hepmc3Tag_, hepmc2Tag_, collapseGenShower_, *tracks, degradedCollapseWarned_);
 
   // Global counter across bunch crossings: EncodedEventId stores abs(bx), so a
   // per-bx counter would give (-1,1) and (+1,1) identical packed ids. A single

--- a/PhysicsTools/TruthInfo/plugins/TruthGraphAccumulator.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthGraphAccumulator.cc
@@ -30,6 +30,8 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <set>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -181,7 +183,10 @@ private:
   const bool computeCellEnergyBudget_;
 
   int pileupCount_ = 0;
-  bool missingCaloHitsWarned_ = false;
+  // Warn once PER COLLECTION, not once overall: a single shared flag reports only the
+  // first collection that goes missing and hides every later one, so a real premix
+  // problem in the calorimeter can be masked by an unrelated tracker collection.
+  std::set<std::string> missingHitsWarned_;
 
   // Merged calorimeter sim-hits across signal + kept pileup, each re-tagged with its
   // sub-event EncodedEventId so the (eventId,trackId) hit-index key resolves pileup
@@ -388,14 +393,15 @@ void TruthGraphAccumulator::mergeHits(EvT const& ev,
     edm::Handle<std::vector<HitT>> hits;
     ev.getByLabel(tag, hits);
     if (!hits.isValid()) {
-      // Under premixed pileup the pileup sim-hits are already digitized away, so every
-      // pileup handle is invalid and the merged collection ends up signal-only, silently
-      // reverting the pileup-aware truth to signal-only. Warn once.
-      if (!missingCaloHitsWarned_) {
+      // State the fact, then the two things that cause it. Naming premixing as THE cause
+      // is wrong and actively misleading: a collection configured here but absent from
+      // the running geometry, for instance the strip tracker under Run4, produces the
+      // same invalid handle and nothing is wrong.
+      if (missingHitsWarned_.insert(tag.encode()).second) {
         edm::LogWarning("TruthGraphAccumulator")
-            << "sim-hit collection " << tag.encode()
-            << " not found for a sub-event; pileup-aware truth needs classic (non-premixed) pileup.";
-        missingCaloHitsWarned_ = true;
+            << "sim-hit collection " << tag.encode() << " not found in a sub-event, so it contributes no truth hits."
+            << " Either this collection does not exist in the running geometry, or the pileup is premixed and its"
+            << " sim-hits were digitized away; pileup-aware truth needs classic (non-premixed) pileup.";
       }
       continue;
     }

--- a/PhysicsTools/TruthInfo/plugins/TruthGraphAccumulator.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthGraphAccumulator.cc
@@ -11,14 +11,17 @@
 // identical for standard mixing and premixing, and it is consistent with the
 // digis by construction.
 //
-// GEN handling is configurable per realm:
-//   collapsePileupGen (default true) : for pileup, collapse the GEN decay chain to
-//        the stable (status 1) GEN particles on a single gen vertex, keep the SIM
-//        continuation (GenToSim links). This is the compact default the user asked
-//        for; it also connects each pileup interaction into one component.
-//   collapseSignalGen (default false): the signal keeps its full graph. Full GEN+SIM
-//        for the signal reuses the standard TruthGraphProducer build and is staged;
-//        until then collapseSignalGen=false leaves the signal as SIM-only here.
+// GEN handling is configurable per realm, and the same flag means the same thing for
+// both:
+//   collapsePileupGen (default true) : collapse the GEN decay chain to the stable
+//        (status 1) GEN particles on a single gen vertex, keep the SIM continuation
+//        (GenToSim links). Compact, and it connects each pileup interaction into one
+//        component.
+//   collapseSignalGen (default false): keep the full HepMC decay chain, built by the
+//        shared truth::GenBuild that TruthGraphProducer uses, so the signal carries
+//        intermediate (status 2) particles, GenStatusFlags and the hard-process
+//        record. A selection preset seeded on a resonance pdgId needs this: the
+//        collapsed form has stable particles only and nothing to seed on.
 //
 //   pileupBunchCrossings (default {0} = in-time pileup only): which bunch crossings
 //        to include for pileup.
@@ -65,6 +68,7 @@
 #include "HepMC3/GenEvent.h"
 #include "HepMC3/GenParticle.h"
 
+#include "PhysicsTools/TruthInfo/interface/GenGraphBuild.h"
 #include "SimDataFormats/TruthInfo/interface/TruthGraph.h"
 
 namespace {
@@ -124,6 +128,22 @@ namespace {
       return stableFromHepMC2(*h2->GetEvent());
     return {};
   }
+
+  // The full HepMC record for one sub-event, in the same flattened form
+  // TruthGraphProducer builds from an unmixed event.
+  template <class EvT>
+  truth::GenBuild readFullGen(EvT const& ev, edm::InputTag const& hepmc3Tag, edm::InputTag const& hepmc2Tag) {
+    edm::Handle<edm::HepMC3Product> h3;
+    if (ev.getByLabel(hepmc3Tag, h3) && h3.isValid() && h3->GetEvent() != nullptr) {
+      HepMC3::GenEvent ev3;
+      ev3.read_data(*h3->GetEvent());
+      return truth::buildFromHepMC3(ev3);
+    }
+    edm::Handle<edm::HepMCProduct> h2;
+    if (ev.getByLabel(hepmc2Tag, h2) && h2.isValid() && h2->GetEvent() != nullptr)
+      return truth::buildFromHepMC2(*h2->GetEvent());
+    return {};
+  }
 }  // namespace
 
 class TruthGraphAccumulator : public DigiAccumulatorMixMod {
@@ -136,13 +156,17 @@ public:
   void finalizeEvent(edm::Event&, edm::EventSetup const&) override;
 
 private:
-  // Append one sub-event. SimTrack/SimVertex ids are local to this sub-event. If
-  // `stableGen` is non-empty, also add a single collapsed gen vertex with those
-  // stable particles and GenToSim links to the primary SimTracks.
+  // Append one sub-event. SimTrack/SimVertex ids are local to this sub-event.
+  // The GEN half is `fullGen` when that is non-null and non-empty, otherwise the
+  // collapsed `stableGen` when that is non-empty, otherwise absent. Either GEN form
+  // is linked to the primary SimTracks by GenToSim edges. `genEvent` identifies the
+  // sub-event the GEN nodes belong to.
   void addSubEvent(std::vector<std::pair<int, int>> const& stableGen,
+                   truth::GenBuild const* fullGen,
                    edm::SimTrackContainer const& tracks,
                    edm::SimVertexContainer const& vertices,
-                   EncodedEventId const& eid);
+                   EncodedEventId const& eid,
+                   int32_t genEvent);
 
   // Append this sub-event's sim-hits to the merged collections, re-tagged with `eid`
   // so they carry per-interaction provenance (native hits are all tagged (0,0)).
@@ -214,9 +238,16 @@ private:
   // out-of-time; a cell with no all-bx energy at all is pure noise.
   std::unordered_map<uint32_t, float> cellInTimeEnergy_;
 
+  // Rejected GenToSim links, summed over the event's sub-events: a SimTrack whose
+  // genpartIndex resolves to a GEN particle of a different pdgId is not that
+  // particle's continuation, so the link is dropped rather than written wrong.
+  unsigned int rejectedGenToSimLinks_ = 0;
+
   std::vector<TruthGraph::NodeRef> nodes_;
   std::vector<int32_t> pdgId_;
   std::vector<int16_t> status_;
+  std::vector<uint16_t> statusFlags_;
+  std::vector<int32_t> genEventOfNode_;
   std::vector<uint64_t> eventId_;
   std::vector<int32_t> simTrackToVtx_;
   std::vector<int32_t> simTrackToGen_;
@@ -274,6 +305,7 @@ TruthGraphAccumulator::TruthGraphAccumulator(edm::ParameterSet const& cfg,
 
 void TruthGraphAccumulator::initializeEvent(edm::Event const&, edm::EventSetup const&) {
   pileupCount_ = 0;
+  rejectedGenToSimLinks_ = 0;
   mergedCaloHits_.clear();
   mergedEcalHits_.clear();
   mergedHcalHits_.clear();
@@ -283,6 +315,8 @@ void TruthGraphAccumulator::initializeEvent(edm::Event const&, edm::EventSetup c
   nodes_.clear();
   pdgId_.clear();
   status_.clear();
+  statusFlags_.clear();
+  genEventOfNode_.clear();
   eventId_.clear();
   simTrackToVtx_.clear();
   simTrackToGen_.clear();
@@ -296,15 +330,19 @@ void TruthGraphAccumulator::initializeEvent(edm::Event const&, edm::EventSetup c
 }
 
 void TruthGraphAccumulator::addSubEvent(std::vector<std::pair<int, int>> const& stableGen,
+                                        truth::GenBuild const* fullGen,
                                         edm::SimTrackContainer const& tracks,
                                         edm::SimVertexContainer const& vertices,
-                                        EncodedEventId const& eid) {
+                                        EncodedEventId const& eid,
+                                        int32_t genEvent) {
   const uint64_t packed = packEventId(eid);
   auto pushNode = [&](TruthGraph::NodeKind kind, int64_t key, int32_t pdg, int16_t st) {
     const uint32_t node = static_cast<uint32_t>(nodes_.size());
     nodes_.push_back(TruthGraph::NodeRef{kind, key});
     pdgId_.push_back(pdg);
     status_.push_back(st);
+    statusFlags_.push_back(0);
+    genEventOfNode_.push_back(-1);
     eventId_.push_back(packed);
     simTrackToVtx_.push_back(-1);
     simTrackToGen_.push_back(-1);
@@ -317,15 +355,79 @@ void TruthGraphAccumulator::addSubEvent(std::vector<std::pair<int, int>> const& 
     edgeKinds_.push_back(static_cast<uint8_t>(k));
   };
 
-  // Collapsed GEN: one gen vertex + the stable gen particles. barcode -> node.
+  // GEN realm, one of two forms. Either way genBarcodeToNode maps a HepMC barcode to
+  // its GenParticle node, which is what GenToSim linking below needs.
   std::unordered_map<int, uint32_t> genBarcodeToNode;
-  int32_t genVtxNode = -1;
-  if (!stableGen.empty()) {
-    genVtxNode = static_cast<int32_t>(pushNode(TruthGraph::NodeKind::GenVertex, 0, 0, 0));
+  const bool useFullGen = (fullGen != nullptr && !fullGen->empty());
+
+  if (useFullGen) {
+    // Full HepMC decay chain: every particle at its own status, both Gen edge
+    // directions, and the GenEvent node attached to the vertices with no incoming
+    // particle so the component has a single source.
+    const uint32_t genEventNode = pushNode(TruthGraph::NodeKind::GenEvent, static_cast<int64_t>(genEvent), 0, 0);
+    genEventOfNode_[genEventNode] = genEvent;
+
+    std::unordered_map<int, uint32_t> genVtxBarcodeToNode;
+    genVtxBarcodeToNode.reserve(fullGen->vtxBarcodes.size() * 2);
+    for (int vbc : fullGen->vtxBarcodes) {
+      const uint32_t vn = pushNode(TruthGraph::NodeKind::GenVertex, static_cast<int64_t>(vbc), 0, 0);
+      genEventOfNode_[vn] = genEvent;
+      genVtxBarcodeToNode.emplace(vbc, vn);
+    }
+
+    genBarcodeToNode.reserve(fullGen->partBarcodes.size() * 2);
+    for (int pbc : fullGen->partBarcodes) {
+      const auto itPdg = fullGen->particlePdgIdByBarcode.find(pbc);
+      const auto itStatus = fullGen->particleStatusByBarcode.find(pbc);
+      const int32_t pdg = (itPdg != fullGen->particlePdgIdByBarcode.end()) ? itPdg->second : 0;
+      const int16_t st = (itStatus != fullGen->particleStatusByBarcode.end()) ? itStatus->second : 0;
+      const uint32_t pn = pushNode(TruthGraph::NodeKind::GenParticle, static_cast<int64_t>(pbc), pdg, st);
+      const auto itFlags = fullGen->particleStatusFlagsByBarcode.find(pbc);
+      if (itFlags != fullGen->particleStatusFlagsByBarcode.end())
+        statusFlags_[pn] = itFlags->second;
+      genEventOfNode_[pn] = genEvent;
+      genBarcodeToNode.emplace(pbc, pn);
+    }
+
+    std::unordered_map<int, unsigned int> vtxIncoming;
+    for (auto const& [pbc, vbc] : fullGen->partToVtx)
+      ++vtxIncoming[vbc];
+
+    for (auto const& [vbc, pbc] : fullGen->vtxToPart) {
+      auto itV = genVtxBarcodeToNode.find(vbc);
+      auto itP = genBarcodeToNode.find(pbc);
+      if (itV != genVtxBarcodeToNode.end() && itP != genBarcodeToNode.end())
+        pushEdge(itV->second, itP->second, TruthGraph::EdgeKind::Gen);
+    }
+    for (auto const& [pbc, vbc] : fullGen->partToVtx) {
+      auto itP = genBarcodeToNode.find(pbc);
+      auto itV = genVtxBarcodeToNode.find(vbc);
+      if (itP != genBarcodeToNode.end() && itV != genVtxBarcodeToNode.end())
+        pushEdge(itP->second, itV->second, TruthGraph::EdgeKind::Gen);
+    }
+
+    unsigned int nRoots = 0;
+    for (int vbc : fullGen->vtxBarcodes) {
+      if (vtxIncoming[vbc] != 0)
+        continue;
+      ++nRoots;
+      pushEdge(genEventNode, genVtxBarcodeToNode.at(vbc), TruthGraph::EdgeKind::Gen);
+    }
+    // A record whose vertices all have an incoming particle has no source to attach
+    // to, so attach every vertex and keep the component reachable.
+    if (nRoots == 0) {
+      for (int vbc : fullGen->vtxBarcodes)
+        pushEdge(genEventNode, genVtxBarcodeToNode.at(vbc), TruthGraph::EdgeKind::Gen);
+    }
+  } else if (!stableGen.empty()) {
+    // Collapsed GEN: one gen vertex + the stable gen particles.
+    const uint32_t genVtxNode = pushNode(TruthGraph::NodeKind::GenVertex, 0, 0, 0);
+    genEventOfNode_[genVtxNode] = genEvent;
     genBarcodeToNode.reserve(stableGen.size() * 2);
     for (auto const& [barcode, pdg] : stableGen) {
       const uint32_t pn = pushNode(TruthGraph::NodeKind::GenParticle, barcode, pdg, 1);
-      pushEdge(static_cast<uint32_t>(genVtxNode), pn, TruthGraph::EdgeKind::Gen);
+      genEventOfNode_[pn] = genEvent;
+      pushEdge(genVtxNode, pn, TruthGraph::EdgeKind::Gen);
       genBarcodeToNode.emplace(barcode, pn);
     }
   }
@@ -369,7 +471,9 @@ void TruthGraphAccumulator::addSubEvent(std::vector<std::pair<int, int>> const& 
       pushEdge(pIt->second, vIt->second, TruthGraph::EdgeKind::Sim);
   }
 
-  // GenToSim: a primary SimTrack's genpartIndex is the stable particle's barcode.
+  // GenToSim: a primary SimTrack's genpartIndex is its GEN particle's barcode. The
+  // two must agree on pdgId, otherwise the barcode does not identify this track's
+  // generator particle and no link is written.
   if (!genBarcodeToNode.empty()) {
     for (auto const& t : tracks) {
       auto gIt = genBarcodeToNode.find(t.genpartIndex());
@@ -378,6 +482,10 @@ void TruthGraphAccumulator::addSubEvent(std::vector<std::pair<int, int>> const& 
       auto sIt = trackIdToNode.find(t.trackId());
       if (sIt == trackIdToNode.end())
         continue;
+      if (pdgId_[gIt->second] != t.type()) {
+        ++rejectedGenToSimLinks_;
+        continue;
+      }
       pushEdge(gIt->second, sIt->second, TruthGraph::EdgeKind::GenToSim);
       simTrackToGen_[sIt->second] = static_cast<int32_t>(gIt->second);
     }
@@ -452,10 +560,13 @@ void TruthGraphAccumulator::accumulate(edm::Event const& event, edm::EventSetup 
   if (!tracks.isValid() || !vertices.isValid())
     return;
   std::vector<std::pair<int, int>> stableGen;
+  truth::GenBuild fullGen;
   if (collapseSignalGen_)
     stableGen = readStableGen(event, hepmc3Tag_, hepmc2Tag_);
+  else
+    fullGen = readFullGen(event, hepmc3Tag_, hepmc2Tag_);
   const EncodedEventId sigEid(0, 0);
-  addSubEvent(stableGen, *tracks, *vertices, sigEid);
+  addSubEvent(stableGen, &fullGen, *tracks, *vertices, sigEid, 0);
   addSubEventHits(event, sigEid);
   if (computeCellEnergyBudget_)
     accumulateCellEnergy(event, 0);  // signal is in-time (bx 0)
@@ -478,8 +589,11 @@ void TruthGraphAccumulator::accumulate(PileUpEventPrincipal const& pep, edm::Eve
     return;
 
   std::vector<std::pair<int, int>> stableGen;
+  truth::GenBuild fullGen;
   if (collapsePileupGen_)
     stableGen = readStableGen(pep, hepmc3Tag_, hepmc2Tag_);
+  else
+    fullGen = readFullGen(pep, hepmc3Tag_, hepmc2Tag_);
 
   // Global counter across bunch crossings: EncodedEventId stores abs(bx), so a
   // per-bx counter would give (-1,1) and (+1,1) identical packed ids. A single
@@ -491,7 +605,7 @@ void TruthGraphAccumulator::accumulate(PileUpEventPrincipal const& pep, edm::Eve
     throw cms::Exception("TruthGraphAccumulator")
         << "pileup sub-event count " << puIndex << " exceeds the 16-bit EncodedEventId event field";
   const EncodedEventId puEid(bx, puIndex);
-  addSubEvent(stableGen, *tracks, *vertices, puEid);
+  addSubEvent(stableGen, &fullGen, *tracks, *vertices, puEid, puIndex);
   addSubEventHits(pep, puEid);
 }
 
@@ -507,9 +621,15 @@ void TruthGraphAccumulator::finalizeEvent(edm::Event& event, edm::EventSetup con
   out->simTrackToGen() = std::move(simTrackToGen_);
   out->simVertexProcessType() = std::move(simVertexProcessType_);
   out->simTrackBackscattered() = std::move(simTrackBackscattered_);
-  out->statusFlags().assign(nNodes, 0);
-  out->genEventOfNode().assign(nNodes, -1);
+  out->statusFlags() = std::move(statusFlags_);
+  out->genEventOfNode() = std::move(genEventOfNode_);
   out->simVtxToGen().assign(nNodes, -1);
+
+  if (rejectedGenToSimLinks_ != 0) {
+    edm::LogWarning("TruthGraphAccumulator")
+        << rejectedGenToSimLinks_ << " GenToSim links dropped in this event because the SimTrack pdgId disagreed with"
+        << " the GEN particle its genpartIndex points at.";
+  }
 
   // CSR out-edges via the counting-sort cursor scatter: each edge lands in its
   // source's range, by construction (no sort, no permutation vector).

--- a/PhysicsTools/TruthInfo/plugins/TruthGraphAccumulator.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthGraphAccumulator.cc
@@ -44,6 +44,8 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
+#include <array>
+
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
@@ -64,6 +66,18 @@
 #include "SimDataFormats/TruthInfo/interface/TruthGraph.h"
 
 namespace {
+  // HGCAL Si ADC pulse shape (hgcROCParameters adcPulse), peak at index 2 = the
+  // in-time (BX0) readout sample. A hit at bunch crossing bx enters the BX0 sample
+  // with the pulse value at offset -bx from its peak, i.e. adcPulse[2 - bx], so
+  // out-of-time energy contributes to the digitized amplitude only through the small
+  // pulse tails. (Prototype: the SiPM HEback FE has a different shape; one shape is
+  // used here for all HGCal calo.)
+  constexpr std::array<float, 6> kAdcPulse{{0.00f, 0.017f, 0.817f, 0.163f, 0.003f, 0.000f}};
+  float pulseWeight(int bx) {
+    const int idx = 2 - bx;
+    return (idx >= 0 && idx < static_cast<int>(kAdcPulse.size())) ? kAdcPulse[idx] : 0.f;
+  }
+
   uint64_t packEventId(EncodedEventId const& id) {
     // EncodedEventId is a single uint32 rawId; use the typed accessor rather than a
     // byte copy so the key stays portable and cannot pick up a future member/padding.
@@ -142,6 +156,15 @@ private:
                  EncodedEventId const& eid,
                  std::vector<HitT>& out);
 
+  // Prototype energy-budget closure: sum this sub-event's HGCal calo hit energy per
+  // raw sim DetId, both raw and weighted by the ADC pulse shape at this bunch
+  // crossing (pulseWeight(bx)). Called for EVERY sub-event (signal + all bunch
+  // crossings, before the in-time keepBx filter), so the totals carry the
+  // out-of-time pileup the per-particle graph deliberately leaves out; the
+  // pulse-weighted total is the digitized-amplitude proxy that matches reco.
+  template <class EvT>
+  void accumulateCellEnergy(EvT const& ev, int bx);
+
   const edm::InputTag simTrackTag_;
   const edm::InputTag simVertexTag_;
   const edm::InputTag hepmc3Tag_;
@@ -155,6 +178,7 @@ private:
   const std::vector<int> pileupBunchCrossings_;
   const bool collapsePileupGen_;
   const bool collapseSignalGen_;
+  const bool computeCellEnergyBudget_;
 
   int pileupCount_ = 0;
   bool missingCaloHitsWarned_ = false;
@@ -171,6 +195,19 @@ private:
   std::vector<PSimHit> mergedTrackerHits_;
   std::vector<PSimHit> mergedMuonHits_;
   std::vector<PSimHit> mergedMtdHits_;
+
+  // Prototype: per-cell HGCal calorimeter energy summed over ALL bunch crossings
+  // (in-time + out-of-time), keyed by raw sim DetId. cellTotalEnergy_ is the raw
+  // sum; cellWeightedEnergy_ weights each hit by the ADC pulse shape at its bunch
+  // crossing (pulseWeight), so out-of-time enters only through the pulse tails and
+  // the total is a proxy for the digitized BX0 amplitude. The energy-budget closure:
+  // "untracked" = this total minus the energy on retained in-time truth branches.
+  std::unordered_map<uint32_t, float> cellTotalEnergy_;
+  std::unordered_map<uint32_t, float> cellWeightedEnergy_;
+  // In-time (bx 0) pulse-weighted energy per cell: the reference the in-time truth
+  // graph can track. A cell with all-bx energy but no in-time energy is pure
+  // out-of-time; a cell with no all-bx energy at all is pure noise.
+  std::unordered_map<uint32_t, float> cellInTimeEnergy_;
 
   std::vector<TruthGraph::NodeRef> nodes_;
   std::vector<int32_t> pdgId_;
@@ -203,7 +240,9 @@ TruthGraphAccumulator::TruthGraphAccumulator(edm::ParameterSet const& cfg,
       mtdHitTags_(cfg.getParameter<std::vector<edm::InputTag>>("mtdHits")),
       pileupBunchCrossings_(cfg.getParameter<std::vector<int>>("pileupBunchCrossings")),
       collapsePileupGen_(cfg.getParameter<bool>("collapsePileupGen")),
-      collapseSignalGen_(cfg.getParameter<bool>("collapseSignalGen")) {
+      collapseSignalGen_(cfg.getParameter<bool>("collapseSignalGen")),
+      computeCellEnergyBudget_(
+          cfg.existsAs<bool>("computeCellEnergyBudget") ? cfg.getParameter<bool>("computeCellEnergyBudget") : false) {
   producesCollector.produces<TruthGraph>();
   producesCollector.produces<std::vector<PCaloHit>>("mergedHGCHits");
   producesCollector.produces<std::vector<PCaloHit>>("mergedEcalHits");
@@ -211,6 +250,11 @@ TruthGraphAccumulator::TruthGraphAccumulator(edm::ParameterSet const& cfg,
   producesCollector.produces<std::vector<PSimHit>>("mergedTrackerHits");
   producesCollector.produces<std::vector<PSimHit>>("mergedMuonHits");
   producesCollector.produces<std::vector<PSimHit>>("mergedMtdHits");
+  if (computeCellEnergyBudget_) {
+    producesCollector.produces<std::vector<unsigned int>>("cellTotalDetId");
+    producesCollector.produces<std::vector<float>>("cellTotalEnergy");
+    producesCollector.produces<std::vector<float>>("cellInTimeEnergy");
+  }
   iC.consumes<edm::SimTrackContainer>(simTrackTag_);
   iC.consumes<edm::SimVertexContainer>(simVertexTag_);
   iC.mayConsume<edm::HepMC3Product>(hepmc3Tag_);
@@ -241,6 +285,9 @@ void TruthGraphAccumulator::initializeEvent(edm::Event const&, edm::EventSetup c
   edgeKinds_.clear();
   simVertexProcessType_.clear();
   simTrackBackscattered_.clear();
+  cellTotalEnergy_.clear();
+  cellWeightedEnergy_.clear();
+  cellInTimeEnergy_.clear();
 }
 
 void TruthGraphAccumulator::addSubEvent(std::vector<std::pair<int, int>> const& stableGen,
@@ -370,6 +417,27 @@ void TruthGraphAccumulator::addSubEventHits(EvT const& ev, EncodedEventId const&
   mergeHits(ev, mtdHitTags_, eid, mergedMtdHits_);
 }
 
+template <class EvT>
+void TruthGraphAccumulator::accumulateCellEnergy(EvT const& ev, int bx) {
+  // HGCal calorimeter only (the TICL-relevant calo) for this prototype, summed by
+  // raw sim DetId. hit.id() is the sim DetId, hit.energy() the deposited energy; the
+  // pulse-shape weight for this bunch crossing down-weights out-of-time deposits the
+  // way the shaper does.
+  const float w = pulseWeight(bx);
+  for (auto const& tag : caloHitTags_) {
+    edm::Handle<std::vector<PCaloHit>> hits;
+    ev.getByLabel(tag, hits);
+    if (!hits.isValid())
+      continue;
+    for (auto const& hit : *hits) {
+      cellTotalEnergy_[hit.id()] += hit.energy();
+      cellWeightedEnergy_[hit.id()] += hit.energy() * w;
+      if (bx == 0)
+        cellInTimeEnergy_[hit.id()] += hit.energy() * w;
+    }
+  }
+}
+
 void TruthGraphAccumulator::accumulate(edm::Event const& event, edm::EventSetup const&) {
   edm::Handle<edm::SimTrackContainer> tracks;
   edm::Handle<edm::SimVertexContainer> vertices;
@@ -383,10 +451,16 @@ void TruthGraphAccumulator::accumulate(edm::Event const& event, edm::EventSetup 
   const EncodedEventId sigEid(0, 0);
   addSubEvent(stableGen, *tracks, *vertices, sigEid);
   addSubEventHits(event, sigEid);
+  if (computeCellEnergyBudget_)
+    accumulateCellEnergy(event, 0);  // signal is in-time (bx 0)
 }
 
 void TruthGraphAccumulator::accumulate(PileUpEventPrincipal const& pep, edm::EventSetup const&, edm::StreamID const&) {
   const int bx = pep.bunchCrossing();
+  // Sum the per-cell energy over EVERY bunch crossing, before the in-time filter, so
+  // the budget total carries the out-of-time pileup the per-particle graph drops.
+  if (computeCellEnergyBudget_)
+    accumulateCellEnergy(pep, bx);
   if (!keepBx(bx))
     return;
 
@@ -452,6 +526,45 @@ void TruthGraphAccumulator::finalizeEvent(edm::Event& event, edm::EventSetup con
     throw cms::Exception("TruthGraphAccumulator") << "Produced TruthGraph is not consistent";
 
   event.put(std::move(out));
+
+  if (computeCellEnergyBudget_) {
+    // Compute before mergedCaloHits_ is moved below. Persist the pulse-weighted total
+    // (the digitized-amplitude proxy that matches reco); log the raw and the weighted
+    // out-of-time fraction so the pulse-shape suppression of out-of-time is visible.
+    auto detIds = std::make_unique<std::vector<unsigned int>>();
+    auto energies = std::make_unique<std::vector<float>>();
+    auto inTime = std::make_unique<std::vector<float>>();  // parallel to detIds
+    detIds->reserve(cellWeightedEnergy_.size());
+    energies->reserve(cellWeightedEnergy_.size());
+    inTime->reserve(cellWeightedEnergy_.size());
+    double allBxWeighted = 0.;
+    for (auto const& [detId, energy] : cellWeightedEnergy_) {
+      detIds->push_back(detId);
+      energies->push_back(energy);
+      auto const it = cellInTimeEnergy_.find(detId);
+      inTime->push_back(it == cellInTimeEnergy_.end() ? 0.f : it->second);
+      allBxWeighted += energy;
+    }
+    double allBxRaw = 0.;
+    for (auto const& [detId, energy] : cellTotalEnergy_)
+      allBxRaw += energy;
+    // In-time (bx 0) energy is what went into the kept merged collection; its
+    // digitized weight is pulseWeight(0).
+    double inTimeRaw = 0.;
+    for (auto const& hit : mergedCaloHits_)
+      inTimeRaw += hit.energy();
+    const double inTimeWeighted = inTimeRaw * pulseWeight(0);
+    const double untrackedRaw = allBxRaw - inTimeRaw;
+    const double untrackedWeighted = allBxWeighted - inTimeWeighted;
+    edm::LogPrint("TruthGraphAccumulator")
+        << "cell energy budget (HGCal): cells=" << cellWeightedEnergy_.size() << " | raw: allBx=" << allBxRaw
+        << " inTime=" << inTimeRaw << " untrackedFraction=" << (allBxRaw > 0. ? untrackedRaw / allBxRaw : 0.)
+        << " | pulse-weighted: allBx=" << allBxWeighted << " inTime=" << inTimeWeighted
+        << " untrackedFraction=" << (allBxWeighted > 0. ? untrackedWeighted / allBxWeighted : 0.);
+    event.put(std::move(detIds), "cellTotalDetId");
+    event.put(std::move(energies), "cellTotalEnergy");
+    event.put(std::move(inTime), "cellInTimeEnergy");
+  }
 
   event.put(std::make_unique<std::vector<PCaloHit>>(std::move(mergedCaloHits_)), "mergedHGCHits");
   event.put(std::make_unique<std::vector<PCaloHit>>(std::move(mergedEcalHits_)), "mergedEcalHits");

--- a/PhysicsTools/TruthInfo/plugins/TruthGraphProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthGraphProducer.cc
@@ -174,7 +174,14 @@ public:
     }
 
     if (haveGen && collapseGenShower_)
-      truth::collapseGenShower(gb, truth::simContinuedGenBarcodes(simTracks));
+      if (!truth::collapseGenShower(gb, truth::simContinuedGenBarcodes(simTracks))) {
+        edm::LogWarning("TruthGraphProducer")
+            << "collapseGenShower ran on a GEN record with no packed status flags, which "
+               "buildFromHepMC3 does not fill. The isHardProcess and isLastCopy keep rules "
+               "are then dead and every intermediate resonance is dropped, so a selection "
+               "preset seeded on a resonance pdgId will match nothing. Set "
+               "collapseGenShower=False on a HepMC3 sample.";
+      }
 
     const uint32_t nSimVtx = static_cast<uint32_t>(simVertices.size());
     const uint32_t nSimTrk = static_cast<uint32_t>(simTracks.size());

--- a/PhysicsTools/TruthInfo/plugins/TruthGraphProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthGraphProducer.cc
@@ -39,8 +39,14 @@
 #include "HepMC3/GenParticle.h"
 #include "HepMC3/GenVertex.h"
 
-#include "PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h"
+#include "PhysicsTools/TruthInfo/interface/GenGraphBuild.h"
 #include "SimDataFormats/TruthInfo/interface/TruthGraph.h"
+
+using truth::buildFromHepMC2;
+using truth::buildFromHepMC3;
+using truth::GenBuild;
+using truth::genKeyParticle;
+using truth::genKeyVertex;
 
 namespace {
 
@@ -85,158 +91,6 @@ namespace {
         ++r[a];
     }
   };
-
-  inline int64_t genKeyVertex(int barcode) { return (int64_t(barcode) << 1) | 1LL; }
-
-  inline int64_t genKeyParticle(int barcode) { return (int64_t(barcode) << 1); }
-
-  struct GenBuild {
-    std::vector<int> vtxBarcodes;
-    std::vector<int> partBarcodes;
-
-    // index -> barcode in HepMC iteration order. Kept only for diagnostics.
-    // SimTrack::genpartIndex() is not an index into this vector: for primary
-    // SimTracks it is a HepMC barcode.
-    std::vector<int> particleBarcodeByIndex;
-
-    std::vector<std::pair<int, int>> vtxToPart;
-    std::vector<std::pair<int, int>> partToVtx;
-
-    std::unordered_map<int, int32_t> particlePdgIdByBarcode;
-    std::unordered_map<int, int16_t> particleStatusByBarcode;
-    // Packed reco::GenStatusFlags computed from the HepMC record via MCTruthHelper
-    // (the same helper GenParticleProducer uses), so no barcode-to-reco::GenParticle
-    // association is needed. HepMC2 only; the HepMC3 path leaves them 0 until
-    // MCTruthHelper grows a HepMC3 specialization.
-    std::unordered_map<int, uint16_t> particleStatusFlagsByBarcode;
-  };
-
-  GenBuild buildFromHepMC2(HepMC::GenEvent const& ev) {
-    GenBuild gb;
-
-    std::unordered_set<int> seenV;
-    std::unordered_set<int> seenP;
-
-    gb.particlePdgIdByBarcode.reserve(ev.particles_size() * 2);
-    gb.particleStatusByBarcode.reserve(ev.particles_size() * 2);
-    gb.particleBarcodeByIndex.reserve(ev.particles_size());
-
-    for (auto v = ev.vertices_begin(); v != ev.vertices_end(); ++v) {
-      if (*v == nullptr)
-        continue;
-
-      const int vbc = (*v)->barcode();
-
-      if (seenV.insert(vbc).second)
-        gb.vtxBarcodes.push_back(vbc);
-
-      for (auto po = (*v)->particles_out_const_begin(); po != (*v)->particles_out_const_end(); ++po) {
-        if (*po == nullptr)
-          continue;
-
-        const int pbc = (*po)->barcode();
-
-        if (seenP.insert(pbc).second)
-          gb.partBarcodes.push_back(pbc);
-
-        gb.vtxToPart.emplace_back(vbc, pbc);
-      }
-
-      for (auto pi = (*v)->particles_in_const_begin(); pi != (*v)->particles_in_const_end(); ++pi) {
-        if (*pi == nullptr)
-          continue;
-
-        const int pbc = (*pi)->barcode();
-
-        if (seenP.insert(pbc).second)
-          gb.partBarcodes.push_back(pbc);
-
-        gb.partToVtx.emplace_back(pbc, vbc);
-      }
-    }
-
-    MCTruthHelper<HepMC::GenParticle> mcTruthHelper;
-    for (auto p = ev.particles_begin(); p != ev.particles_end(); ++p) {
-      if (*p == nullptr)
-        continue;
-
-      const int pbc = (*p)->barcode();
-
-      gb.particleBarcodeByIndex.push_back(pbc);
-      gb.particlePdgIdByBarcode.emplace(pbc, (*p)->pdg_id());
-      gb.particleStatusByBarcode.emplace(pbc, static_cast<int16_t>((*p)->status()));
-
-      reco::GenStatusFlags flags;
-      mcTruthHelper.fillGenStatusFlags(**p, flags);
-      gb.particleStatusFlagsByBarcode.emplace(pbc, static_cast<uint16_t>(flags.flags_.to_ulong()));
-
-      if (seenP.insert(pbc).second)
-        gb.partBarcodes.push_back(pbc);
-    }
-
-    return gb;
-  }
-
-  GenBuild buildFromHepMC3(HepMC3::GenEvent const& ev) {
-    GenBuild gb;
-
-    std::unordered_set<int> seenV;
-    std::unordered_set<int> seenP;
-
-    gb.particlePdgIdByBarcode.reserve(ev.particles().size() * 2);
-    gb.particleStatusByBarcode.reserve(ev.particles().size() * 2);
-    gb.particleBarcodeByIndex.reserve(ev.particles().size());
-
-    for (auto const& vptr : ev.vertices()) {
-      if (!vptr)
-        continue;
-
-      const int vbc = vptr->id();
-
-      if (seenV.insert(vbc).second)
-        gb.vtxBarcodes.push_back(vbc);
-
-      for (auto const& po : vptr->particles_out()) {
-        if (!po)
-          continue;
-
-        const int pbc = po->id();
-
-        if (seenP.insert(pbc).second)
-          gb.partBarcodes.push_back(pbc);
-
-        gb.vtxToPart.emplace_back(vbc, pbc);
-      }
-
-      for (auto const& pi : vptr->particles_in()) {
-        if (!pi)
-          continue;
-
-        const int pbc = pi->id();
-
-        if (seenP.insert(pbc).second)
-          gb.partBarcodes.push_back(pbc);
-
-        gb.partToVtx.emplace_back(pbc, vbc);
-      }
-    }
-
-    for (auto const& pptr : ev.particles()) {
-      if (!pptr)
-        continue;
-
-      const int pbc = pptr->id();
-
-      gb.particleBarcodeByIndex.push_back(pbc);
-      gb.particlePdgIdByBarcode.emplace(pbc, pptr->pid());
-      gb.particleStatusByBarcode.emplace(pbc, static_cast<int16_t>(pptr->status()));
-
-      if (seenP.insert(pbc).second)
-        gb.partBarcodes.push_back(pbc);
-    }
-
-    return gb;
-  }
 
   template <typename HandleT>
   bool validHandle(HandleT const& h) {

--- a/PhysicsTools/TruthInfo/plugins/TruthGraphProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthGraphProducer.cc
@@ -174,7 +174,9 @@ public:
     }
 
     if (haveGen && collapseGenShower_)
-      if (!truth::collapseGenShower(gb, truth::simContinuedGenBarcodes(simTracks))) {
+      if (!truth::collapseGenShower(gb, truth::simContinuedGenBarcodes(simTracks)) && !degradedCollapseWarned_) {
+        // Sample-level condition; once per stream is the whole message.
+        degradedCollapseWarned_ = true;
         edm::LogWarning("TruthGraphProducer")
             << "collapseGenShower ran on a GEN record with no packed status flags, which "
                "buildFromHepMC3 does not fill. The isHardProcess and isLastCopy keep rules "
@@ -440,6 +442,12 @@ public:
           ++it->second;
       }
 
+      // Residual gap, shared with TruthGraphAccumulator so the two stay consistent: source
+      // counting is per undirected component, but reachability from the GenEvent node is
+      // DIRECTED. A component containing both a true source and a beam-fed branch would
+      // attach only the source and leave the branch unreachable. No current record mixes
+      // the two in one component: a collider record is wholly sourceless and a gun record
+      // wholly source-rooted.
       std::vector<std::vector<int>> rootsByComp(nGenEvents);
       std::vector<std::vector<int>> allVtxByComp(nGenEvents);
 
@@ -627,6 +635,7 @@ private:
 
   bool addGenToSimEdges_;
   bool collapseGenShower_;
+  bool degradedCollapseWarned_ = false;
 };
 
 DEFINE_FWK_MODULE(TruthGraphProducer);

--- a/PhysicsTools/TruthInfo/plugins/TruthGraphProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthGraphProducer.cc
@@ -106,7 +106,8 @@ public:
         hepmc2Token_(mayConsume<edm::HepMCProduct>(cfg.getParameter<edm::InputTag>("genEventHepMC"))),
         simTrackToken_(consumes<edm::SimTrackContainer>(cfg.getParameter<edm::InputTag>("simTracks"))),
         simVertexToken_(consumes<edm::SimVertexContainer>(cfg.getParameter<edm::InputTag>("simVertices"))),
-        addGenToSimEdges_(cfg.getParameter<bool>("addGenToSimEdges")) {
+        addGenToSimEdges_(cfg.getParameter<bool>("addGenToSimEdges")),
+        collapseGenShower_(cfg.getParameter<bool>("collapseGenShower")) {
     produces<TruthGraph>();
   }
 
@@ -127,6 +128,13 @@ public:
         ->setComment(
             "If true, add GenParticle -> SimTrack cross edges. The association is built only for primary "
             "SimTracks, interpreting SimTrack::genpartIndex() as a HepMC barcode.");
+
+    desc.add<bool>("collapseGenShower", true)
+        ->setComment(
+            "If true, contract the GEN parton shower and the intermediate copies of a resonance, keeping ancestry. "
+            "A GEN particle survives if a SimTrack continues it, or it is stable, or it is flagged isHardProcess, "
+            "or it is the last copy of something that is not a parton, diquark, string, cluster or beam "
+            "pseudoparticle.");
 
     descriptions.addWithDefaultLabel(desc);
   }
@@ -164,6 +172,9 @@ public:
         haveGen = true;
       }
     }
+
+    if (haveGen && collapseGenShower_)
+      truth::collapseGenShower(gb, truth::simContinuedGenBarcodes(simTracks));
 
     const uint32_t nSimVtx = static_cast<uint32_t>(simVertices.size());
     const uint32_t nSimTrk = static_cast<uint32_t>(simTracks.size());
@@ -608,6 +619,7 @@ private:
   edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken_;
 
   bool addGenToSimEdges_;
+  bool collapseGenShower_;
 };
 
 DEFINE_FWK_MODULE(TruthGraphProducer);

--- a/PhysicsTools/TruthInfo/plugins/TruthLogicalGraphDumper.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthLogicalGraphDumper.cc
@@ -26,6 +26,7 @@
 
 #include "SimDataFormats/TruthInfo/interface/Graph.h"
 #include "SimDataFormats/TruthInfo/interface/LogicalGraphHitIndex.h"
+#include "PhysicsTools/TruthInfo/interface/SubgraphHitView.h"
 #include "SimDataFormats/TruthInfo/interface/TruthGraph.h"
 
 namespace {
@@ -455,7 +456,10 @@ public:
     if (useHitIndex_) {
       evt.getByToken(hitIndexToken_, hHitIndex);
     }
-    truth::LogicalGraphHitIndex const* hitIndex = hHitIndex.isValid() ? &(*hHitIndex) : nullptr;
+    std::optional<truth::SubgraphHitView> hitIndexView;
+    if (hHitIndex.isValid())
+      hitIndexView.emplace(*hHitIndex);
+    truth::SubgraphHitView* hitIndex = hitIndexView ? &(*hitIndexView) : nullptr;
 
     const std::vector<float> recHitEnergies = collectRecHitEnergies(evt);
 

--- a/PhysicsTools/TruthInfo/plugins/TruthLogicalGraphDumper.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthLogicalGraphDumper.cc
@@ -592,9 +592,9 @@ public:
 
       const bool hasHitInfo = hitIndex != nullptr && i < hitIndex->nParticles();
 
-      const auto directHits = hasHitInfo ? hitIndex->directHits(truth::HitChannel::HGCalCalo, i)
+      const auto directHits = hasHitInfo ? hitIndex->directHits(truth::HitChannel::Calo, i)
                                          : std::span<const truth::LogicalGraphHitIndex::Hit>();
-      const auto subgraphHits = hasHitInfo ? hitIndex->subgraphHits(truth::HitChannel::HGCalCalo, i)
+      const auto subgraphHits = hasHitInfo ? hitIndex->subgraphHits(truth::HitChannel::Calo, i)
                                            : std::span<const truth::LogicalGraphHitIndex::Hit>();
 
       const HitSummary directSummary = hasHitInfo ? summarizeHits(directHits, recHitEnergies) : HitSummary();

--- a/PhysicsTools/TruthInfo/plugins/TruthLogicalGraphProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthLogicalGraphProducer.cc
@@ -323,12 +323,15 @@ public:
             cfg.getParameter<edm::ParameterSet>("postProcessing").getParameter<bool>("dropHitlessSimSubgraphs")),
         postProcessor_(truth::TruthLogicalGraphPostProcessor::configFromPSet(
             cfg.getParameter<edm::ParameterSet>("postProcessing"))) {
-    // The hitless-subgraph pruning needs to know which SimTracks left a calo or
-    // tracker sim-hit; consume the same collections the hit-index producer uses.
+    // The hitless-subgraph pruning needs to know which SimTracks left a sim-hit;
+    // consume the same collections the hit-index producer uses, on every channel it
+    // indexes. A channel missing here is silently turned into deleted truth.
     if (dropHitlessSimSubgraphs_) {
       for (auto const& tag : cfg.getParameter<std::vector<edm::InputTag>>("simHitCollections"))
         caloSimHitTokens_.push_back(consumes<std::vector<PCaloHit>>(tag));
       for (auto const& tag : cfg.getParameter<std::vector<edm::InputTag>>("trackerSimHitCollections"))
+        trackerSimHitTokens_.push_back(consumes<edm::PSimHitContainer>(tag));
+      for (auto const& tag : cfg.getParameter<std::vector<edm::InputTag>>("muonSimHitCollections"))
         trackerSimHitTokens_.push_back(consumes<edm::PSimHitContainer>(tag));
     }
 
@@ -377,6 +380,18 @@ public:
         ->setComment(
             "Tracker PSimHit collections used only to decide which SimTracks left a hit, for the "
             "postProcessing.dropHitlessSimSubgraphs pruning. Matched to particles via PSimHit::trackId().");
+
+    desc.add<std::vector<edm::InputTag>>("muonSimHitCollections",
+                                         {edm::InputTag("g4SimHits", "MuonDTHits"),
+                                          edm::InputTag("g4SimHits", "MuonCSCHits"),
+                                          edm::InputTag("g4SimHits", "MuonRPCHits"),
+                                          edm::InputTag("g4SimHits", "MuonGEMHits"),
+                                          edm::InputTag("g4SimHits", "MuonME0Hits")})
+        ->setComment(
+            "Muon-chamber PSimHit collections, same role as trackerSimHitCollections. Needed because the "
+            "hit index carries a Muon channel: a particle whose only hits are in the chambers, for instance "
+            "a punch-through secondary born past the calorimeters, would otherwise be pruned as hitless and "
+            "leave those indexed hits with no node.");
 
     desc.add<edm::ParameterSetDescription>("postProcessing", truth::TruthLogicalGraphPostProcessor::psetDescription())
         ->setComment("Logical graph post-processing configuration.");

--- a/PhysicsTools/TruthInfo/plugins/TruthLogicalGraphProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthLogicalGraphProducer.cc
@@ -688,6 +688,13 @@ public:
           if (nodeId < raw.genEventOfNode().size())
             p.genEvent = raw.genEventOfNode()[nodeId];
 
+          // The sub-event a particle belongs to must come from whichever side it has. A
+          // GEN-only particle has no SIM side to inherit it from, and eventId 0 means the
+          // signal interaction, so leaving it at the default silently promotes every
+          // pileup particle without a SimTrack to signal.
+          if (p.eventId == 0)
+            p.eventId = raw.nodeEventId(nodeId);
+
           if (p.pdgId == 0)
             p.pdgId = raw.nodePdgId(nodeId);
 
@@ -773,6 +780,11 @@ public:
 
           if (nodeId < raw.genEventOfNode().size())
             v.genEvent = raw.genEventOfNode()[nodeId];
+
+          // Same as for particles: a GEN-only vertex has no SIM side to take the
+          // sub-event id from, and the default reads as the signal interaction.
+          if (v.eventId == 0)
+            v.eventId = raw.nodeEventId(nodeId);
 
           if (haveGenPayload) {
             const int barcode = static_cast<int>(ref.key);

--- a/PhysicsTools/TruthInfo/python/customiseTruthMixedReco.py
+++ b/PhysicsTools/TruthInfo/python/customiseTruthMixedReco.py
@@ -1,50 +1,86 @@
-"""RECO-side customise for the pileup truth chain: build the merged (signal+pileup)
-logical graph from the MixingModule accumulator's raw TruthGraph (label mix) and
-resolve its SimHit associations against the mixed rechits. Pairs with
-mixedTruthGraphCustomize.addTruthGraphAccumulator at DIGI, giving a pileup-aware
-truth graph at RECO."""
+# Original author: Felice Pantaleo (CERN) <felice.pantaleo@cern.ch>
+# Part of the MC-truth-graph prototype - under heavy development, not yet open
+# to external contributions (see PhysicsTools/TruthInfo/README.md).
+
+"""RECO-step customise for the pileup truth chain in a split production.
+
+The stage-independent truth (logical graph + UNRESOLVED per-particle per-cell hit
+index + raw graph TruthGraph_mix) is built at the DIGI step by
+mixedTruthGraphCustomize.customiseTruthDigi, where the merged signal+pileup simHits
+are live, and arrives here through the DIGI-RAW input file. This step:
+
+  1. drops the signal-only truth (re)build that the enableTruth validation would
+     otherwise schedule at RECO (truthGraphProducer, truthLogicalGraphProducer,
+     detIdToRecHitMapProducer, truthLogicalGraphHitIndexProducer). With those modules
+     gone, the branch validators' and association producers' empty-process InputTags
+     resolve to the mixed products from the DIGI-RAW input instead of a signal-only
+     rebuild;
+  2. repoints the branch validators' rawSrc to the mixed raw graph (TruthGraph_mix,
+     label 'mix'); the association producers carry no rawSrc;
+  3. re-persists the truth into the RECO-tier output at the requested verbosity level.
+
+No rebuild and no simHits are needed here: the shared-energy association
+(BranchHitAssociator) matches by DetId, so the unresolved index is sufficient, and
+no validator or associator reads recHitIndex."""
 
 import FWCore.ParameterSet.Config as cms
 
+from PhysicsTools.TruthInfo.truthEventContent_cff import setTruthEventContent
 
-def customise(process):
-    from PhysicsTools.TruthInfo.truthGraphValidation_cff import (
-        truthLogicalGraphProducer,
-        detIdToRecHitMapProducer,
-        truthLogicalGraphHitIndexProducer,
-    )
-    # The merged raw TruthGraph comes from the mixing accumulator, not the
-    # standalone truthGraphProducer.
-    process.truthLogicalGraphProducer = truthLogicalGraphProducer.clone(
-        src=cms.InputTag("mix"),
-        # The hitless-subgraph pruning decides which SimTracks left a calo hit; feed it
-        # the merged (signal+pileup) HGCal sim-hits, else every pileup subgraph looks
-        # hitless (its hits are in mix:mergedHGCHits, not the signal-only g4SimHits) and
-        # is pruned, leaving pileup branches empty. Matches the hit index below.
-        simHitCollections=cms.VInputTag(cms.InputTag('mix', 'mergedHGCHits')),
-    )
-    process.detIdToRecHitMapProducer = detIdToRecHitMapProducer
-    # The hit index also reads the RAW merged graph (for trackId->node); point it at mix.
-    process.truthLogicalGraphHitIndexProducer = truthLogicalGraphHitIndexProducer.clone(
-        rawSrc=cms.InputTag('mix'),
-        # Read the merged (signal+pileup) HGCal sim-hits from the accumulator, each
-        # tagged with its sub-event EncodedEventId, instead of the signal-only
-        # g4SimHits (which lack pileup at RECO).
-        simHitCollections=cms.VInputTag(cms.InputTag('mix', 'mergedHGCHits')),
-    )
+# The signal-only truth (re)build modules that enableTruth would schedule at RECO.
+# In the mixed production these are already built at DIGI, so they must not run here.
+_signalOnlyBuildModules = [
+    'truthGraphProducer',
+    'truthLogicalGraphProducer',
+    'detIdToRecHitMapProducer',
+    'truthLogicalGraphHitIndexProducer',
+]
 
-    process.truthMixedRecoPath = cms.Path(
-        process.truthLogicalGraphProducer
-        + process.detIdToRecHitMapProducer
-        + process.truthLogicalGraphHitIndexProducer
-    )
-    process.schedule.append(process.truthMixedRecoPath)
+# Branch validators that read the raw graph via rawSrc (the association producers do
+# not); repointed to the mixed raw graph.
+_rawSrcConsumers = [
+    'branchHGCalValidator',
+    'branchTrackingValidator',
+]
 
-    for out in process.outputModules_().values():
-        out.outputCommands.extend([
-            "keep *_truthLogicalGraphProducer_*_*",
-        ])
-        # The hit index is an intermediate graph footprint, regenerable from the graph
-        # plus mix:mergedHGCHits; persisting it costs ~9.7 MB/event (subgraph-hit CSR
-        # over every retained pileup particle), so it is kept out of the event content.
+
+def _detachModule(process, name):
+    """Remove a module from every sequence/path/endpath/task and detach it from the
+    process, so it is neither scheduled nor an on-demand current-process product and
+    its label resolves to the input file's product."""
+    if not hasattr(process, name):
+        return
+    module = getattr(process, name)
+    containers = []
+    for accessor in ('sequences', 'paths', 'endpaths', 'tasks', 'finalpaths'):
+        holder = getattr(process, accessor, None)
+        if holder is not None:
+            containers.extend(holder.values())
+    for container in containers:
+        try:
+            container.remove(module)
+        except Exception:
+            pass
+    delattr(process, name)
+
+
+def customiseValidation(process):
+    """Point the RECO-side enableTruth validation at the DIGI-built mixed truth."""
+    for name in _signalOnlyBuildModules:
+        _detachModule(process, name)
+    for name in _rawSrcConsumers:
+        if hasattr(process, name):
+            getattr(process, name).rawSrc = cms.InputTag('mix')
+    return process
+
+
+def customiseContent(process, level='compact', includeTrackingHits=True):
+    """Persist the mixed truth into the RECO-tier output at the given level."""
+    return setTruthEventContent(process, level=level, includeTrackingHits=includeTrackingHits)
+
+
+def customise(process, level='compact', includeTrackingHits=True):
+    """RECO-step entry point: repoint validation to the mixed truth and persist it."""
+    process = customiseValidation(process)
+    process = customiseContent(process, level=level, includeTrackingHits=includeTrackingHits)
     return process

--- a/PhysicsTools/TruthInfo/python/mixedTruthGraphCustomize.py
+++ b/PhysicsTools/TruthInfo/python/mixedTruthGraphCustomize.py
@@ -123,13 +123,6 @@ def buildCompactTruthAtDigi(process, includeTrackingHits=True):
         truthLogicalGraphHitIndexProducer,
     )
 
-    # Logical graph from the mixed raw graph; the hitless-subgraph pruning reads the
-    # merged HGCal sim-hits (else every pileup subgraph looks hitless and is pruned).
-    process.truthLogicalGraphProducer = truthLogicalGraphProducer.clone(
-        src=cms.InputTag("mix"),
-        simHitCollections=cms.VInputTag(cms.InputTag("mix", "mergedHGCHits")),
-    )
-
     # Calorimeter simHits for the Calo channel: the merged (signal+pileup)
     # products the accumulator wrote, one per calo family for the per-collection
     # DetId relabelling (HGCAL unpack, HCAL HcalHitRelabeller, ECAL none).
@@ -145,6 +138,15 @@ def buildCompactTruthAtDigi(process, includeTrackingHits=True):
         subdetectors = ["Calo", "Tracker", "Muon"]
         trackerSimHits = cms.VInputTag(cms.InputTag("mix", "mergedTrackerHits"))
         muonSimHits = cms.VInputTag(cms.InputTag("mix", "mergedMuonHits"))
+
+    # Logical graph from the mixed raw graph. The hitless-subgraph pruning reads the
+    # same merged collections as the index below: a calorimeter or a sub-event left
+    # out here has its particles pruned as hitless even though they do carry hits.
+    process.truthLogicalGraphProducer = truthLogicalGraphProducer.clone(
+        src=cms.InputTag("mix"),
+        simHitCollections=caloSimHits,
+        trackerSimHitCollections=trackerSimHits,
+    )
 
     process.truthLogicalGraphHitIndexProducer = truthLogicalGraphHitIndexProducer.clone(
         src=cms.InputTag("truthLogicalGraphProducer"),
@@ -200,6 +202,9 @@ def customiseTruthReduced(process):
     idx = process.truthLogicalGraphHitIndexProducer
     idx.subdetectors = cms.vstring("Calo", "Muon")
     idx.trackerSimHitCollections = cms.VInputTag()
+    # The pruning's detector scope stays equal to the index's, otherwise it prunes on
+    # tracker hits that are no longer accumulated.
+    process.truthLogicalGraphProducer.trackerSimHitCollections = cms.VInputTag()
     return process
 
 

--- a/PhysicsTools/TruthInfo/python/mixedTruthGraphCustomize.py
+++ b/PhysicsTools/TruthInfo/python/mixedTruthGraphCustomize.py
@@ -146,6 +146,7 @@ def buildCompactTruthAtDigi(process, includeTrackingHits=True):
         src=cms.InputTag("mix"),
         simHitCollections=caloSimHits,
         trackerSimHitCollections=trackerSimHits,
+        muonSimHitCollections=muonSimHits,
     )
 
     process.truthLogicalGraphHitIndexProducer = truthLogicalGraphHitIndexProducer.clone(

--- a/PhysicsTools/TruthInfo/python/mixedTruthGraphCustomize.py
+++ b/PhysicsTools/TruthInfo/python/mixedTruthGraphCustomize.py
@@ -86,6 +86,7 @@ def addTruthGraphAccumulator(process,
         pileupBunchCrossings=cms.vint32(*pileupBunchCrossings),
         collapsePileupGen=cms.bool(collapsePileupGen),
         collapseSignalGen=cms.bool(False),
+        collapseGenShower=cms.bool(True),
         # Prototype energy-budget closure: sum per-cell HGCal energy over ALL bunch
         # crossings (in-time + out-of-time) into cellTotalEnergy/cellTotalDetId, so
         # "untracked" energy (out-of-time pileup + dropped in-time) can be measured

--- a/PhysicsTools/TruthInfo/python/mixedTruthGraphCustomize.py
+++ b/PhysicsTools/TruthInfo/python/mixedTruthGraphCustomize.py
@@ -34,7 +34,8 @@ def addMixedTruthGraph(process):
 def addTruthGraphAccumulator(process,
                              pileupBunchCrossings=(0,),
                              collapsePileupGen=True,
-                             includeTrackingHits=False):
+                             includeTrackingHits=True,
+                             computeCellEnergyBudget=False):
     """Phase-B (B1): register TruthGraphAccumulator inside the MixingModule.
 
     The accumulator builds the mixed (signal + pileup) raw TruthGraph from the
@@ -42,11 +43,11 @@ def addTruthGraphAccumulator(process,
     pileup (bx 0) is included; pass pileupBunchCrossings to widen. The mixed graph
     is kept in the output as TruthGraph_mix__<process>.
 
-    By default the accumulator captures only the CALORIMETER sim-hits (HGCAL plus
-    barrel ECAL/HCAL). The tracking detectors (tracker, muon chambers, MTD) are the
-    largest sim-hit family at PU200 and dominate the event size (the merged tracker
-    PSimHits alone are tens of MB/event), so they are OFF by default. Pass
-    includeTrackingHits=True for a full-detector truth graph.
+    By default (includeTrackingHits=True) the accumulator captures the full detector
+    (calo + tracker + muon + MTD). Pass includeTrackingHits=False for a calo-only
+    graph (HGCAL plus barrel ECAL/HCAL): the tracker is the largest sim-hit family at
+    PU200 and dominates the event size (the merged tracker PSimHits alone are tens of
+    MB/event), so dropping it is the main cost lever.
     """
     def tags(*names):
         return cms.VInputTag(*[cms.InputTag("g4SimHits", n) for n in names])
@@ -85,20 +86,133 @@ def addTruthGraphAccumulator(process,
         pileupBunchCrossings=cms.vint32(*pileupBunchCrossings),
         collapsePileupGen=cms.bool(collapsePileupGen),
         collapseSignalGen=cms.bool(False),
+        # Prototype energy-budget closure: sum per-cell HGCal energy over ALL bunch
+        # crossings (in-time + out-of-time) into cellTotalEnergy/cellTotalDetId, so
+        # "untracked" energy (out-of-time pileup + dropped in-time) can be measured
+        # as total minus the in-time truth-branch energy.
+        computeCellEnergyBudget=cms.bool(computeCellEnergyBudget),
     )
 
-    for out in process.outputModules_().values():
-        out.outputCommands.append("keep TruthGraph_mix_*_*")
-        # The merged sim-hit collections are the union of signal + all kept pileup hits,
-        # and must bridge a split DIGI->RECO job (the pileup hits are gone after mixing;
-        # the RECO customise does not re-keep them). Drop these lines for a single-job
-        # DIGI+RECO where the hit index is built in the same process.
-        out.outputCommands.append("keep *_mix_mergedHGCHits_*")
-        out.outputCommands.append("keep *_mix_mergedEcalHits_*")
-        out.outputCommands.append("keep *_mix_mergedHcalHits_*")
-        if includeTrackingHits:
-            out.outputCommands.append("keep *_mix_mergedTrackerHits_*")
-            out.outputCommands.append("keep *_mix_mergedMuonHits_*")
-            out.outputCommands.append("keep *_mix_mergedMtdHits_*")
+    # Persistence is owned by truthEventContent_cff (the compact/full verbosity
+    # levels), applied via customiseTruthDigi. The accumulator products
+    # (TruthGraph_mix, mix:merged*Hits) are kept only at the 'full' level; the
+    # compact default persists the graph + unresolved index built below instead.
+    return process
 
+
+def buildCompactTruthAtDigi(process, includeTrackingHits=True):
+    """Build the stage-independent truth right after mixing, where the merged
+    signal+pileup simHits are live: the logical graph plus an UNRESOLVED
+    per-particle per-cell hit index.
+
+    The index is built with recHitMap="" (recHitIndex left invalid) because the
+    shared-energy association (BranchHitAssociator) matches by DetId, not by
+    recHitIndex. The same unresolved index therefore serves any later stage (L1,
+    HLT, offline RECO) that exposes its reco objects as (DetId, fraction), and the
+    bulky merged simHits never have to cross the DIGI->RECO boundary in the compact
+    content.
+
+    Channels: Calo (plus Tracker and Muon under includeTrackingHits) are pure
+    simHit reads and are built here. MTD is intentionally left out: its index needs
+    the reco Mtd cluster associations, which are RECO-stage products, so it cannot be
+    filled at DIGI (muon/MTD recHit linking is follow-up work in any case).
+    """
+    from Validation.Configuration.truthPrevalidation_cff import (
+        truthLogicalGraphProducer,
+        truthLogicalGraphHitIndexProducer,
+    )
+
+    # Logical graph from the mixed raw graph; the hitless-subgraph pruning reads the
+    # merged HGCal sim-hits (else every pileup subgraph looks hitless and is pruned).
+    process.truthLogicalGraphProducer = truthLogicalGraphProducer.clone(
+        src=cms.InputTag("mix"),
+        simHitCollections=cms.VInputTag(cms.InputTag("mix", "mergedHGCHits")),
+    )
+
+    # Calorimeter simHits for the Calo channel: the merged (signal+pileup)
+    # products the accumulator wrote, one per calo family for the per-collection
+    # DetId relabelling (HGCAL unpack, HCAL HcalHitRelabeller, ECAL none).
+    caloSimHits = cms.VInputTag(
+        cms.InputTag("mix", "mergedHGCHits"),
+        cms.InputTag("mix", "mergedEcalHits"),
+        cms.InputTag("mix", "mergedHcalHits"),
+    )
+    subdetectors = ["Calo"]
+    trackerSimHits = cms.VInputTag()
+    muonSimHits = cms.VInputTag()
+    if includeTrackingHits:
+        subdetectors = ["Calo", "Tracker", "Muon"]
+        trackerSimHits = cms.VInputTag(cms.InputTag("mix", "mergedTrackerHits"))
+        muonSimHits = cms.VInputTag(cms.InputTag("mix", "mergedMuonHits"))
+
+    process.truthLogicalGraphHitIndexProducer = truthLogicalGraphHitIndexProducer.clone(
+        src=cms.InputTag("truthLogicalGraphProducer"),
+        rawSrc=cms.InputTag("mix"),
+        recHitMap=cms.InputTag(""),   # UNRESOLVED: association is by DetId
+        subdetectors=cms.vstring(*subdetectors),
+        simHitCollections=caloSimHits,
+        trackerSimHitCollections=trackerSimHits,
+        muonSimHitCollections=muonSimHits,
+    )
+
+    process.truthCompactBuildPath = cms.Path(
+        process.truthLogicalGraphProducer
+        + process.truthLogicalGraphHitIndexProducer
+    )
+    if process.schedule is not None:
+        process.schedule.append(process.truthCompactBuildPath)
+
+    return process
+
+
+def customiseTruthDigi(process,
+                       level='compact',
+                       pileupBunchCrossings=(0,),
+                       collapsePileupGen=True,
+                       includeTrackingHits=True):
+    """DIGI-step entry point for the pileup-aware truth graph: register the
+    accumulator, build the compact stage-independent truth (graph + unresolved hit
+    index) where the merged simHits are live, and apply the event-content level.
+
+    level='compact' (default) persists the logical graph, the unresolved index and
+    the raw graph; level='full' also keeps the merged simHits (for off-geometry
+    re-association, e.g. L1)."""
+    process = addTruthGraphAccumulator(process,
+                                       pileupBunchCrossings=pileupBunchCrossings,
+                                       collapsePileupGen=collapsePileupGen,
+                                       includeTrackingHits=includeTrackingHits)
+    process = buildCompactTruthAtDigi(process, includeTrackingHits=includeTrackingHits)
+
+    from PhysicsTools.TruthInfo.truthEventContent_cff import setTruthEventContent
+    process = setTruthEventContent(process, level=level, includeTrackingHits=includeTrackingHits)
+    return process
+
+
+def customiseTruthReduced(process):
+    """Reduced variant: drop the Tracker channel from the DIGI-built truth, leaving
+    calo (HGCal + ECAL + HCAL) + MTD + muon. The default scope
+    (truthGraphMixedDigi_cff) is the full detector; apply this at the DIGI step for a
+    cost-sensitive production that does not need track-based candidate matching (the
+    tracker is the largest sim-hit family and dominates the DIGI cost)."""
+    acc = process.mix.digitizers.truthGraph
+    acc.trackerHits = cms.VInputTag()
+    idx = process.truthLogicalGraphHitIndexProducer
+    idx.subdetectors = cms.vstring("Calo", "Muon")
+    idx.trackerSimHitCollections = cms.VInputTag()
+    return process
+
+
+def customiseTruthDigiEnergyBudget(process):
+    """Prototype entry point: customiseTruthDigi plus the per-cell all-bunch-crossing
+    HGCal energy budget (cellTotalEnergy/cellTotalDetId products), for measuring the
+    out-of-time / untracked calorimeter energy fraction at pileup. The accumulator
+    logs allBx/inTime/untracked per event."""
+    process = customiseTruthDigi(process)
+    process.mix.digitizers.truthGraph.computeCellEnergyBudget = cms.bool(True)
+    for out in process.outputModules_().values():
+        out.outputCommands.extend([
+            'keep *_mix_cellTotalDetId_*',
+            'keep *_mix_cellTotalEnergy_*',
+            'keep *_mix_cellInTimeEnergy_*',
+        ])
     return process

--- a/PhysicsTools/TruthInfo/python/truthEventContent_cff.py
+++ b/PhysicsTools/TruthInfo/python/truthEventContent_cff.py
@@ -1,0 +1,95 @@
+# Original author: Felice Pantaleo (CERN) <felice.pantaleo@cern.ch>
+# Part of the MC-truth-graph prototype - under heavy development, not yet open
+# to external contributions (see PhysicsTools/TruthInfo/README.md).
+
+# Event content for the MC-truth graph, with two verbosity levels.
+#
+# The stage-independent truth is built once at the mixing/DIGI step, where the
+# merged signal+pileup simHits are live, as a logical graph plus a per-particle
+# per-cell sim-energy hit index. The index is built UNRESOLVED (recHitMap="")
+# because the shared-energy association (BranchHitAssociator) matches by DetId,
+# not by recHitIndex: it keys the inverted index and the per-cell total-sim-energy
+# denominator on DetId, so the same unresolved index serves any stage (L1, HLT,
+# offline RECO) that later exposes its reco objects as (DetId, fraction). The
+# recHitIndex field stays a convenience pointer, filled on demand only where a
+# consumer wants index->recHit navigation.
+#
+#   compact (default): the logical graph, the unresolved hit index, and the raw
+#     merged graph (TruthGraph_mix). The index is both the fraction numerator
+#     (per-particle per-cell energy) and, summed over all particles per cell, the
+#     denominator; correct hits-and-fractions shared energy at any stage whose
+#     rechits share the cell-level DetId space. The raw graph is small (~3 MB/ev)
+#     and is kept because the branch validators consume it (rawSrc, for the
+#     trackId->particle map) and it lets the logical graph / index be rebuilt
+#     offline.
+#
+#     INVARIANT: the persisted index must stay COMPLETE - every hit-leaving
+#     contributor present, no pdgId pruning. The per-cell denominator is the sum
+#     of the index hit energies over all particles; drop contributors and every
+#     surviving fraction is biased high. Do not "optimize" the index by pruning it
+#     to interesting species without also persisting a separate all-contributor
+#     per-cell total map.
+#
+#   full: compact + the merged simHits (all contributors). The only level that
+#     rebuilds the association at a DIFFERENT granularity (e.g. L1 trigger cells)
+#     or with a different metric, because it keeps the raw deposits with trackId +
+#     eventId. Adds the merged simHit cost (calo, plus tracking under
+#     includeTrackingHits).
+
+import FWCore.ParameterSet.Config as cms
+
+# The compact, stage-independent truth: the physics graph, the unresolved
+# per-particle per-cell footprint, and the raw merged CSR graph (needed by the
+# branch validators' rawSrc and for offline rebuild; ~3 MB/ev).
+_truthGraphKeep = [
+    'keep *_truthLogicalGraphProducer_*_*',
+    'keep *_truthLogicalGraphHitIndexProducer_*_*',
+    'keep TruthGraph_mix_*_*',
+]
+
+
+def _truthSimHitsKeep(includeTrackingHits):
+    """The merged (signal+pileup) simHits kept only at the 'full' level, so the
+    numerator/denominator can be rebuilt at a different granularity. Calo always;
+    tracking (tracker + muon + MTD) only when the accumulator captured it."""
+    keep = [
+        'keep *_mix_mergedHGCHits_*',
+        'keep *_mix_mergedEcalHits_*',
+        'keep *_mix_mergedHcalHits_*',
+    ]
+    if includeTrackingHits:
+        keep += [
+            'keep *_mix_mergedTrackerHits_*',
+            'keep *_mix_mergedMuonHits_*',
+            'keep *_mix_mergedMtdHits_*',
+        ]
+    return keep
+
+
+# The default analysis-tier content.
+truthContentCompact = cms.untracked.vstring(_truthGraphKeep)
+
+
+def truthContentFull(includeTrackingHits=True):
+    """The 'full' content: compact + merged simHits."""
+    return cms.untracked.vstring(_truthGraphKeep + _truthSimHitsKeep(includeTrackingHits))
+
+
+def truthEventContent(level='compact', includeTrackingHits=True):
+    """Return the output commands for a truth verbosity level.
+    level='compact' (default) or 'full'."""
+    if level == 'compact':
+        return cms.untracked.vstring(truthContentCompact)
+    if level == 'full':
+        return truthContentFull(includeTrackingHits)
+    raise ValueError("unknown truth event-content level %r; choose 'compact' or 'full'" % level)
+
+
+def setTruthEventContent(process, level='compact', includeTrackingHits=True):
+    """Append a truth verbosity level to every output module in the process.
+    level='compact' (default, ~O(10) MB/ev: graph + unresolved hit index) or
+    'full' (adds raw graph + merged simHits for off-geometry re-association)."""
+    commands = truthEventContent(level, includeTrackingHits)
+    for out in process.outputModules_().values():
+        out.outputCommands.extend(commands)
+    return process

--- a/PhysicsTools/TruthInfo/python/truthGraphMixedDigi_cff.py
+++ b/PhysicsTools/TruthInfo/python/truthGraphMixedDigi_cff.py
@@ -62,9 +62,17 @@ from Validation.Configuration.truthPrevalidation_cff import (
     truthLogicalGraphHitIndexProducer as _truthLogicalGraphHitIndexProducer,
 )
 
+# The hitless-subgraph pruning must see every detector the hit index reads, and read
+# the merged (signal+pileup) products: a calorimeter or a sub-event left out here has
+# its particles pruned as hitless even though the index would have given them hits.
 truthLogicalGraphProducer = _truthLogicalGraphProducer.clone(
     src=cms.InputTag("mix"),
-    simHitCollections=cms.VInputTag(cms.InputTag("mix", "mergedHGCHits")),
+    simHitCollections=cms.VInputTag(
+        cms.InputTag("mix", "mergedHGCHits"),
+        cms.InputTag("mix", "mergedEcalHits"),
+        cms.InputTag("mix", "mergedHcalHits"),
+    ),
+    trackerSimHitCollections=cms.VInputTag(cms.InputTag("mix", "mergedTrackerHits")),
 )
 
 truthLogicalGraphHitIndexProducer = _truthLogicalGraphHitIndexProducer.clone(

--- a/PhysicsTools/TruthInfo/python/truthGraphMixedDigi_cff.py
+++ b/PhysicsTools/TruthInfo/python/truthGraphMixedDigi_cff.py
@@ -73,6 +73,7 @@ truthLogicalGraphProducer = _truthLogicalGraphProducer.clone(
         cms.InputTag("mix", "mergedHcalHits"),
     ),
     trackerSimHitCollections=cms.VInputTag(cms.InputTag("mix", "mergedTrackerHits")),
+    muonSimHitCollections=cms.VInputTag(cms.InputTag("mix", "mergedMuonHits")),
 )
 
 truthLogicalGraphHitIndexProducer = _truthLogicalGraphHitIndexProducer.clone(

--- a/PhysicsTools/TruthInfo/python/truthGraphMixedDigi_cff.py
+++ b/PhysicsTools/TruthInfo/python/truthGraphMixedDigi_cff.py
@@ -46,8 +46,10 @@ truthGraphAccumulator = cms.PSet(
     muonHits=_tags("MuonDTHits", "MuonCSCHits", "MuonRPCHits", "MuonGEMHits", "MuonME0Hits"),
     mtdHits=_tags("FastTimerHitsBarrel", "FastTimerHitsEndcap"),
     pileupBunchCrossings=cms.vint32(0),   # in-time pileup for the per-particle graph
-    collapsePileupGen=cms.bool(True),
-    collapseSignalGen=cms.bool(False),
+    collapsePileupGen=cms.bool(True),    # pileup keeps stable GEN particles only
+    collapseSignalGen=cms.bool(False),   # signal keeps the full HepMC decay chain, which
+                                         # selection presets seed on
+
     computeCellEnergyBudget=cms.bool(False),  # prototype energy-budget map, off by default
 )
 

--- a/PhysicsTools/TruthInfo/python/truthGraphMixedDigi_cff.py
+++ b/PhysicsTools/TruthInfo/python/truthGraphMixedDigi_cff.py
@@ -49,6 +49,8 @@ truthGraphAccumulator = cms.PSet(
     collapsePileupGen=cms.bool(True),    # pileup keeps stable GEN particles only
     collapseSignalGen=cms.bool(False),   # signal keeps the full HepMC decay chain, which
                                          # selection presets seed on
+    collapseGenShower=cms.bool(True),    # contract the parton shower and the intermediate
+                                         # resonance copies out of that chain, keeping ancestry
 
     computeCellEnergyBudget=cms.bool(False),  # prototype energy-budget map, off by default
 )

--- a/PhysicsTools/TruthInfo/python/truthGraphMixedDigi_cff.py
+++ b/PhysicsTools/TruthInfo/python/truthGraphMixedDigi_cff.py
@@ -1,0 +1,89 @@
+# Original author: Felice Pantaleo (CERN) <felice.pantaleo@cern.ch>
+# Part of the MC-truth-graph prototype - under heavy development, not yet open
+# to external contributions (see PhysicsTools/TruthInfo/README.md).
+
+# DIGI-step pileup-aware truth, wired under the enableTruth modifier: the
+# TruthGraphAccumulator (registered in the MixingModule digitizers) builds the
+# merged signal+pileup raw TruthGraph during mixing, then the logical graph and an
+# UNRESOLVED per-particle per-cell hit index are built right after mixing, where the
+# merged simHits are live. recHitMap="" leaves the index unresolved because the
+# shared-energy association matches by DetId, so the merged simHits never have to
+# cross the DIGI->RECO boundary.
+#
+# DEFAULT SCOPE: full detector - calo (HGCal + ECAL + HCAL) + MTD + muon + tracker.
+# Track-based candidate matching (a TICLCandidate is two-channel: calo shared energy
+# plus tracker shared hits) needs the tracker channel, so it is in the default. The
+# tracker is the largest sim-hit family and the dominant cost, so the reduced variant
+# (mixedTruthGraphCustomize.customiseTruthReduced) drops it for cost-sensitive runs,
+# leaving calo + MTD + muon. MTD sim-hits are captured here; the MTD channel of the
+# hit index is resolved at RECO (it needs reco MTD cluster associations).
+
+import FWCore.ParameterSet.Config as cms
+
+
+def _tags(*names):
+    return cms.VInputTag(*[cms.InputTag("g4SimHits", n) for n in names])
+
+
+# Accumulator PSet added to the mixing digitizers under enableTruth (digitizers_cfi).
+truthGraphAccumulator = cms.PSet(
+    accumulatorType=cms.string("TruthGraphAccumulator"),
+    simTracks=cms.InputTag("g4SimHits"),
+    simVertices=cms.InputTag("g4SimHits"),
+    genEventHepMC3=cms.InputTag("generatorSmeared"),
+    genEventHepMC=cms.InputTag("generatorSmeared"),
+    caloHits=_tags("HGCHitsEE", "HGCHitsHEfront", "HGCHitsHEback"),
+    ecalHits=_tags("EcalHitsEB"),
+    hcalHits=_tags("HcalHits"),
+    trackerHits=_tags(
+        "TrackerHitsPixelBarrelLowTof", "TrackerHitsPixelBarrelHighTof",
+        "TrackerHitsPixelEndcapLowTof", "TrackerHitsPixelEndcapHighTof",
+        "TrackerHitsTIBLowTof", "TrackerHitsTIBHighTof",
+        "TrackerHitsTIDLowTof", "TrackerHitsTIDHighTof",
+        "TrackerHitsTOBLowTof", "TrackerHitsTOBHighTof",
+        "TrackerHitsTECLowTof", "TrackerHitsTECHighTof",
+    ),   # full detector by default; customiseTruthReduced empties this
+    muonHits=_tags("MuonDTHits", "MuonCSCHits", "MuonRPCHits", "MuonGEMHits", "MuonME0Hits"),
+    mtdHits=_tags("FastTimerHitsBarrel", "FastTimerHitsEndcap"),
+    pileupBunchCrossings=cms.vint32(0),   # in-time pileup for the per-particle graph
+    collapsePileupGen=cms.bool(True),
+    collapseSignalGen=cms.bool(False),
+    computeCellEnergyBudget=cms.bool(False),  # prototype energy-budget map, off by default
+)
+
+# The post-mixing build: logical graph + unresolved hit index from the mixed raw
+# graph (label mix) and the accumulator's merged simHits.
+from Validation.Configuration.truthPrevalidation_cff import (
+    truthLogicalGraphProducer as _truthLogicalGraphProducer,
+    truthLogicalGraphHitIndexProducer as _truthLogicalGraphHitIndexProducer,
+)
+
+truthLogicalGraphProducer = _truthLogicalGraphProducer.clone(
+    src=cms.InputTag("mix"),
+    simHitCollections=cms.VInputTag(cms.InputTag("mix", "mergedHGCHits")),
+)
+
+truthLogicalGraphHitIndexProducer = _truthLogicalGraphHitIndexProducer.clone(
+    src=cms.InputTag("truthLogicalGraphProducer"),
+    rawSrc=cms.InputTag("mix"),
+    recHitMap=cms.InputTag(""),   # UNRESOLVED: association is by DetId
+    # HCAL simulation DetIds are in packed test numbering; HcalHitRelabeller converts
+    # them to the reco HcalDetIds the association matches on. ECAL barrel and the Run4
+    # HGCAL geometries carry reco DetIds already, so only the HCAL switch is set here.
+    doHcalRelabelling=cms.bool(True),
+    subdetectors=cms.vstring("Calo", "Muon", "Tracker"),  # full; MTD resolved at RECO
+    simHitCollections=cms.VInputTag(
+        cms.InputTag("mix", "mergedHGCHits"),
+        cms.InputTag("mix", "mergedEcalHits"),
+        cms.InputTag("mix", "mergedHcalHits"),
+    ),
+    trackerSimHitCollections=cms.VInputTag(cms.InputTag("mix", "mergedTrackerHits")),  # customiseTruthReduced empties this
+    muonSimHitCollections=cms.VInputTag(cms.InputTag("mix", "mergedMuonHits")),
+)
+
+# Task so the producers run at DIGI on demand (triggered by the output keeps); added
+# to pdigiTask under enableTruth in Configuration/StandardSequences/Digi_cff.
+truthGraphMixedDigiTask = cms.Task(
+    truthLogicalGraphProducer,
+    truthLogicalGraphHitIndexProducer,
+)

--- a/PhysicsTools/TruthInfo/python/truthGraphValidation_cff.py
+++ b/PhysicsTools/TruthInfo/python/truthGraphValidation_cff.py
@@ -10,13 +10,11 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
-# Reuse the producer chain already defined for the prevalidation.
-from Validation.Configuration.truthPrevalidation_cff import (
-    truthGraphProducer,
-    truthLogicalGraphProducer,
-    detIdToRecHitMapProducer,
-    truthLogicalGraphHitIndexProducer,
-)
+# The logical graph and hit index are built at DIGI (mixing accumulator chain) under
+# enableTruth and arrive at RECO through the input. The associators/validators below
+# consume them by DetId via string InputTags, so the signal-only build producers are
+# intentionally NOT imported here: importing them would attach them to the RECO
+# process and shadow the DIGI-built products.
 
 # TICL-style Branch <-> calo-truth association maps (best-matched branch first),
 # restricted to the interesting particles via interestingPdgIds (empty = all).
@@ -32,7 +30,7 @@ truthBranchCaloAssociationProducer = cms.EDProducer(
 branchHGCalValidator = DQMEDAnalyzer(
     "BranchHGCalValidator",
     src=cms.InputTag("truthLogicalGraphProducer"),
-    rawSrc=cms.InputTag("truthGraphProducer"),
+    rawSrc=cms.InputTag("mix"),  # merged raw graph, built at DIGI by the accumulator
     hitIndex=cms.InputTag("truthLogicalGraphHitIndexProducer"),
     caloParticles=cms.InputTag("mix", "MergedCaloTruth"),
     simClusters=cms.InputTag("mix", "MergedCaloTruth"),
@@ -67,7 +65,7 @@ truthBranchTrackingAssociationProducer = cms.EDProducer(
 branchTrackingValidator = DQMEDAnalyzer(
     "BranchTrackingValidator",
     src=cms.InputTag("truthLogicalGraphProducer"),
-    rawSrc=cms.InputTag("truthGraphProducer"),
+    rawSrc=cms.InputTag("mix"),  # merged raw graph, built at DIGI by the accumulator
     hitIndex=cms.InputTag("truthLogicalGraphHitIndexProducer"),
     tracks=cms.InputTag("generalTracks"),
     clusterTPMap=cms.InputTag("truthTpClusterProducer"),
@@ -132,28 +130,23 @@ branchTracksterRecoValidator = DQMEDAnalyzer(
 # branchHGCalValidator, TrackingParticle via branchTrackingValidator - both verified
 # meaningful). Append to a validation sequence with the calo truth, the reco tracks
 # and the tracker digi sim-links available.
-truthGraphValidationSequence = cms.Sequence(
-    truthGraphProducer
-    + truthLogicalGraphProducer
-    + detIdToRecHitMapProducer
-    + truthLogicalGraphHitIndexProducer
-    + truthBranchCaloAssociationProducer
-    + truthTpClusterProducer
-    + truthBranchTrackingAssociationProducer
-    + branchHGCalValidator
-    + branchTrackingValidator
-)
+# (The standalone all-in-one truthGraphValidationSequence, which bundled the
+# signal-only build producers with the analyzers for the test/ single-file drivers,
+# is removed: the build now happens at DIGI, and bundling it here would attach the
+# signal-only producers to the RECO process.)
 
 # Split views for wiring into the release validation: the EDProducers (truth graph,
 # hit index, association maps) run in the prevalidation Path, the DQM analyzers in
 # the validation EndPath. truthGraphValidationSequence (above) keeps both together
 # for the standalone single-file drivers in test/.
+# Under enableTruth the logical graph and the hit index are built at the DIGI step
+# by the mixing accumulator chain (PhysicsTools/TruthInfo/truthGraphMixedDigi_cff),
+# and arrive at RECO through the input file. So the RECO prevalidation runs only the
+# reco-side association producers: src=truthLogicalGraphProducer /
+# hitIndex=truthLogicalGraphHitIndexProducer resolve (empty process) to the
+# DIGI-built products, and the validators' rawSrc points at the mixed graph (mix).
 truthGraphValidationProducers = cms.Sequence(
-    truthGraphProducer
-    + truthLogicalGraphProducer
-    + detIdToRecHitMapProducer
-    + truthLogicalGraphHitIndexProducer
-    + truthBranchCaloAssociationProducer
+    truthBranchCaloAssociationProducer
     + truthTpClusterProducer
     + truthBranchTrackingAssociationProducer
 )

--- a/PhysicsTools/TruthInfo/src/BranchHitAssociator.cc
+++ b/PhysicsTools/TruthInfo/src/BranchHitAssociator.cc
@@ -88,8 +88,22 @@ namespace truth {
 
     std::vector<LogicalGraphHitIndex::Hit> scratch;
     for (const uint32_t root : roots_) {
-      if (root < rootHitSlotOfRoot_.size())
-        rootHitSlotOfRoot_[root] = static_cast<uint32_t>(rootHitOffsets_.size() - 1);
+      if (root >= rootHitSlotOfRoot_.size())
+        continue;
+
+      // A root whose subgraph is a single one-slot range owns nothing but its own direct
+      // hits, and the builder already sorted and summed those per detId before writing
+      // them, so the persisted span is usable as it stands. Skipping the copy is what
+      // keeps the all-roots case affordable: leaves are most of the graph, and copying
+      // every one of them would rebuild in memory the aggregate this layout exists to
+      // not store.
+      const auto ranges = hitIndex_->subgraphRanges(root);
+      if (ranges.size() == 1 && ranges[0].slotCount == 1) {
+        rootHitSlotOfRoot_[root] = kPersistedSpan;
+        continue;
+      }
+
+      rootHitSlotOfRoot_[root] = static_cast<uint32_t>(rootHitOffsets_.size() - 1);
 
       scratch.clear();
       hitIndex_->appendSubgraphHits(channel_, root, scratch);
@@ -129,6 +143,8 @@ namespace truth {
     const uint32_t slot = rootHitSlotOfRoot_[rootId];
     if (slot == kNoRoot)
       return {};
+    if (slot == kPersistedSpan)
+      return hitIndex_->subgraphHits(channel_, rootId);
     const uint32_t begin = rootHitOffsets_[slot];
     const uint32_t end = rootHitOffsets_[slot + 1];
     return std::span<const LogicalGraphHitIndex::Hit>(rootHitStorage_.data() + begin, end - begin);

--- a/PhysicsTools/TruthInfo/src/BranchHitAssociator.cc
+++ b/PhysicsTools/TruthInfo/src/BranchHitAssociator.cc
@@ -44,6 +44,8 @@ namespace truth {
       }
     }
 
+    buildRootHits();
+
     // Inverted index detId -> candidate roots, from each candidate's subgraph
     // hits. Built as a flat (detId, root) list, sorted, then packed CSR-style so
     // lookups are a binary search plus a contiguous root span (no hashing).
@@ -76,8 +78,60 @@ namespace truth {
     }
   }
 
+  void BranchHitAssociator::buildRootHits() {
+    if (!hitIndex_->sharedSubgraphStore())
+      return;
+
+    rootHitSlotOfRoot_.assign(hitIndex_->nParticles(), kNoRoot);
+    rootHitOffsets_.reserve(roots_.size() + 1);
+    rootHitOffsets_.push_back(0);
+
+    std::vector<LogicalGraphHitIndex::Hit> scratch;
+    for (const uint32_t root : roots_) {
+      if (root < rootHitSlotOfRoot_.size())
+        rootHitSlotOfRoot_[root] = static_cast<uint32_t>(rootHitOffsets_.size() - 1);
+
+      scratch.clear();
+      hitIndex_->appendSubgraphHits(channel_, root, scratch);
+
+      // Same rule the materialised layout applies when it aggregates: sort by detId
+      // and sum the energies of the entries that share one, so the merge-join sees a
+      // single ascending entry per cell. The valid recHit index wins over the invalid
+      // sentinel, which sorts last.
+      std::sort(scratch.begin(), scratch.end(), [](auto const& a, auto const& b) {
+        if (a.detId != b.detId)
+          return a.detId < b.detId;
+        return a.recHitIndex < b.recHitIndex;
+      });
+      std::size_t w = 0;
+      for (std::size_t r = 0; r < scratch.size(); ++r) {
+        if (w > 0 && scratch[w - 1].detId == scratch[r].detId) {
+          scratch[w - 1].energy += scratch[r].energy;
+          if (scratch[w - 1].recHitIndex == LogicalGraphHitIndex::Hit::kInvalidRecHitIndex)
+            scratch[w - 1].recHitIndex = scratch[r].recHitIndex;
+        } else {
+          scratch[w++] = scratch[r];
+        }
+      }
+      scratch.resize(w);
+
+      rootHitStorage_.insert(rootHitStorage_.end(), scratch.begin(), scratch.end());
+      rootHitOffsets_.push_back(static_cast<uint32_t>(rootHitStorage_.size()));
+    }
+  }
+
   std::span<const LogicalGraphHitIndex::Hit> BranchHitAssociator::rootHits(uint32_t rootId) const {
-    return hitIndex_->subgraphHits(channel_, rootId);
+    if (!hitIndex_->sharedSubgraphStore())
+      return hitIndex_->subgraphHits(channel_, rootId);
+
+    if (rootId >= rootHitSlotOfRoot_.size())
+      return {};
+    const uint32_t slot = rootHitSlotOfRoot_[rootId];
+    if (slot == kNoRoot)
+      return {};
+    const uint32_t begin = rootHitOffsets_[slot];
+    const uint32_t end = rootHitOffsets_[slot + 1];
+    return std::span<const LogicalGraphHitIndex::Hit>(rootHitStorage_.data() + begin, end - begin);
   }
 
   std::span<const uint32_t> BranchHitAssociator::rootsForCell(uint32_t detId) const {

--- a/PhysicsTools/TruthInfo/src/GenGraphBuild.cc
+++ b/PhysicsTools/TruthInfo/src/GenGraphBuild.cc
@@ -206,10 +206,12 @@ namespace truth {
     return gb;
   }
 
-  void collapseGenShower(GenBuild& gb, std::unordered_set<int> const& simContinuedBarcodes) {
+  bool collapseGenShower(GenBuild& gb, std::unordered_set<int> const& simContinuedBarcodes) {
     const uint32_t nPart = static_cast<uint32_t>(gb.partBarcodes.size());
     if (nPart == 0)
-      return;
+      return true;
+
+    const bool statusFlagsAvailable = !gb.particleStatusFlagsByBarcode.empty();
 
     std::unordered_map<int, uint32_t> indexOfBarcode;
     indexOfBarcode.reserve(nPart * 2);
@@ -352,6 +354,8 @@ namespace truth {
     gb.particleBarcodeByIndex = std::move(particleBarcodeByIndex);
     gb.vtxToPart = std::move(vtxToPart);
     gb.partToVtx = std::move(partToVtx);
+
+    return statusFlagsAvailable;
   }
 
 }  // namespace truth

--- a/PhysicsTools/TruthInfo/src/GenGraphBuild.cc
+++ b/PhysicsTools/TruthInfo/src/GenGraphBuild.cc
@@ -1,0 +1,145 @@
+// Original author: Felice Pantaleo (CERN) <felice.pantaleo@cern.ch>
+
+#include <unordered_set>
+
+#include "DataFormats/HepMCCandidate/interface/GenStatusFlags.h"
+#include "PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h"
+#include "PhysicsTools/TruthInfo/interface/GenGraphBuild.h"
+
+#include "HepMC/GenEvent.h"
+#include "HepMC/GenParticle.h"
+#include "HepMC/GenVertex.h"
+#include "HepMC3/GenEvent.h"
+#include "HepMC3/GenParticle.h"
+#include "HepMC3/GenVertex.h"
+
+namespace truth {
+
+  GenBuild buildFromHepMC2(HepMC::GenEvent const& ev) {
+    GenBuild gb;
+
+    std::unordered_set<int> seenV;
+    std::unordered_set<int> seenP;
+
+    gb.particlePdgIdByBarcode.reserve(ev.particles_size() * 2);
+    gb.particleStatusByBarcode.reserve(ev.particles_size() * 2);
+    gb.particleBarcodeByIndex.reserve(ev.particles_size());
+
+    for (auto v = ev.vertices_begin(); v != ev.vertices_end(); ++v) {
+      if (*v == nullptr)
+        continue;
+
+      const int vbc = (*v)->barcode();
+
+      if (seenV.insert(vbc).second)
+        gb.vtxBarcodes.push_back(vbc);
+
+      for (auto po = (*v)->particles_out_const_begin(); po != (*v)->particles_out_const_end(); ++po) {
+        if (*po == nullptr)
+          continue;
+
+        const int pbc = (*po)->barcode();
+
+        if (seenP.insert(pbc).second)
+          gb.partBarcodes.push_back(pbc);
+
+        gb.vtxToPart.emplace_back(vbc, pbc);
+      }
+
+      for (auto pi = (*v)->particles_in_const_begin(); pi != (*v)->particles_in_const_end(); ++pi) {
+        if (*pi == nullptr)
+          continue;
+
+        const int pbc = (*pi)->barcode();
+
+        if (seenP.insert(pbc).second)
+          gb.partBarcodes.push_back(pbc);
+
+        gb.partToVtx.emplace_back(pbc, vbc);
+      }
+    }
+
+    MCTruthHelper<HepMC::GenParticle> mcTruthHelper;
+    for (auto p = ev.particles_begin(); p != ev.particles_end(); ++p) {
+      if (*p == nullptr)
+        continue;
+
+      const int pbc = (*p)->barcode();
+
+      gb.particleBarcodeByIndex.push_back(pbc);
+      gb.particlePdgIdByBarcode.emplace(pbc, (*p)->pdg_id());
+      gb.particleStatusByBarcode.emplace(pbc, static_cast<int16_t>((*p)->status()));
+
+      reco::GenStatusFlags flags;
+      mcTruthHelper.fillGenStatusFlags(**p, flags);
+      gb.particleStatusFlagsByBarcode.emplace(pbc, static_cast<uint16_t>(flags.flags_.to_ulong()));
+
+      if (seenP.insert(pbc).second)
+        gb.partBarcodes.push_back(pbc);
+    }
+
+    return gb;
+  }
+
+  GenBuild buildFromHepMC3(HepMC3::GenEvent const& ev) {
+    GenBuild gb;
+
+    std::unordered_set<int> seenV;
+    std::unordered_set<int> seenP;
+
+    gb.particlePdgIdByBarcode.reserve(ev.particles().size() * 2);
+    gb.particleStatusByBarcode.reserve(ev.particles().size() * 2);
+    gb.particleBarcodeByIndex.reserve(ev.particles().size());
+
+    for (auto const& vptr : ev.vertices()) {
+      if (!vptr)
+        continue;
+
+      const int vbc = vptr->id();
+
+      if (seenV.insert(vbc).second)
+        gb.vtxBarcodes.push_back(vbc);
+
+      for (auto const& po : vptr->particles_out()) {
+        if (!po)
+          continue;
+
+        const int pbc = po->id();
+
+        if (seenP.insert(pbc).second)
+          gb.partBarcodes.push_back(pbc);
+
+        gb.vtxToPart.emplace_back(vbc, pbc);
+      }
+
+      for (auto const& pi : vptr->particles_in()) {
+        if (!pi)
+          continue;
+
+        const int pbc = pi->id();
+
+        if (seenP.insert(pbc).second)
+          gb.partBarcodes.push_back(pbc);
+
+        gb.partToVtx.emplace_back(pbc, vbc);
+      }
+    }
+
+    for (auto const& pptr : ev.particles()) {
+      if (!pptr)
+        continue;
+
+      const int pbc = pptr->id();
+
+      gb.particleBarcodeByIndex.push_back(pbc);
+      gb.particlePdgIdByBarcode.emplace(pbc, pptr->pid());
+      gb.particleStatusByBarcode.emplace(pbc, static_cast<int16_t>(pptr->status()));
+
+      if (seenP.insert(pbc).second)
+        gb.partBarcodes.push_back(pbc);
+    }
+
+    return gb;
+  }
+
+}  // namespace truth

--- a/PhysicsTools/TruthInfo/src/GenGraphBuild.cc
+++ b/PhysicsTools/TruthInfo/src/GenGraphBuild.cc
@@ -1,5 +1,8 @@
 // Original author: Felice Pantaleo (CERN) <felice.pantaleo@cern.ch>
 
+#include <algorithm>
+#include <cstdlib>
+#include <limits>
 #include <unordered_set>
 
 #include "DataFormats/HepMCCandidate/interface/GenStatusFlags.h"
@@ -12,6 +15,67 @@
 #include "HepMC3/GenEvent.h"
 #include "HepMC3/GenParticle.h"
 #include "HepMC3/GenVertex.h"
+
+namespace {
+
+  constexpr uint16_t kIsHardProcess = 1u << reco::GenStatusFlags::kIsHardProcess;
+  constexpr uint16_t kIsLastCopy = 1u << reco::GenStatusFlags::kIsLastCopy;
+
+  // Sentinel for "this particle has no production vertex in the record", which is the
+  // case for the incoming beam particles.
+  constexpr int kNoVertex = std::numeric_limits<int>::min();
+
+  // Shower bookkeeping objects rather than particles reconstruction can be asked
+  // about: partons, diquarks, Pythia strings and clusters, and the beam/system
+  // pseudoparticles. Their last copy carries no physics of its own.
+  [[nodiscard]] bool isShowerObject(int32_t pdgId) {
+    const int32_t id = std::abs(pdgId);
+    if (id >= 1 && id <= 6)
+      return true;
+    if (id == 21)
+      return true;
+    if (id >= 91 && id <= 94)  // cluster, string and the other hadronization placeholders
+      return true;
+    if (id == 990)  // pomeron
+      return true;
+    if (id >= 1000 && id <= 9999 && (id / 10) % 10 == 0 && (id / 100) % 10 != 0)  // diquarks, e.g. 2101, 2203
+      return true;
+    if (id >= 9900000 && id < 1000000000)  // generator-internal states such as 9922212, below the nuclei codes
+      return true;
+    return false;
+  }
+
+  template <typename V>
+  [[nodiscard]] V lookup(std::unordered_map<int, V> const& map, int key, V fallback) {
+    const auto it = map.find(key);
+    return it != map.end() ? it->second : fallback;
+  }
+
+  [[nodiscard]] bool keepGenParticle(truth::GenBuild const& gb,
+                                     int barcode,
+                                     std::unordered_set<int> const& simContinuedBarcodes) {
+    if (simContinuedBarcodes.count(barcode) != 0)
+      return true;
+    if (lookup(gb.particleStatusByBarcode, barcode, static_cast<int16_t>(0)) == 1)
+      return true;
+    const uint16_t flags = lookup(gb.particleStatusFlagsByBarcode, barcode, static_cast<uint16_t>(0));
+    if ((flags & kIsHardProcess) != 0)
+      return true;
+    return (flags & kIsLastCopy) != 0 && !isShowerObject(lookup(gb.particlePdgIdByBarcode, barcode, int32_t{0}));
+  }
+
+  void sortUnique(std::vector<uint32_t>& v) {
+    std::sort(v.begin(), v.end());
+    v.erase(std::unique(v.begin(), v.end()), v.end());
+  }
+
+  template <typename V>
+  void pruneMap(std::unordered_map<int, V>& map, std::unordered_set<int> const& keptBarcodes) {
+    for (auto it = map.begin(); it != map.end();)
+      it = (keptBarcodes.count(it->first) == 0) ? map.erase(it) : std::next(it);
+  }
+
+}  // namespace
 
 namespace truth {
 
@@ -140,6 +204,154 @@ namespace truth {
     }
 
     return gb;
+  }
+
+  void collapseGenShower(GenBuild& gb, std::unordered_set<int> const& simContinuedBarcodes) {
+    const uint32_t nPart = static_cast<uint32_t>(gb.partBarcodes.size());
+    if (nPart == 0)
+      return;
+
+    std::unordered_map<int, uint32_t> indexOfBarcode;
+    indexOfBarcode.reserve(nPart * 2);
+    for (uint32_t i = 0; i < nPart; ++i)
+      indexOfBarcode.emplace(gb.partBarcodes[i], i);
+
+    std::vector<int> prodVertexOf(nPart, kNoVertex);
+    for (auto const& [vbc, pbc] : gb.vtxToPart) {
+      const auto it = indexOfBarcode.find(pbc);
+      if (it != indexOfBarcode.end() && prodVertexOf[it->second] == kNoVertex)
+        prodVertexOf[it->second] = vbc;
+    }
+
+    std::unordered_map<int, std::vector<uint32_t>> incomingOf;
+    incomingOf.reserve(gb.vtxBarcodes.size() * 2);
+    for (auto const& [pbc, vbc] : gb.partToVtx) {
+      const auto it = indexOfBarcode.find(pbc);
+      if (it != indexOfBarcode.end())
+        incomingOf[vbc].push_back(it->second);
+    }
+
+    const std::vector<uint32_t> noParents;
+    auto parentsOf = [&](uint32_t i) -> std::vector<uint32_t> const& {
+      if (prodVertexOf[i] == kNoVertex)
+        return noParents;
+      const auto it = incomingOf.find(prodVertexOf[i]);
+      return it != incomingOf.end() ? it->second : noParents;
+    };
+
+    std::vector<uint8_t> keep(nPart, 0);
+    for (uint32_t i = 0; i < nPart; ++i)
+      keep[i] = keepGenParticle(gb, gb.partBarcodes[i], simContinuedBarcodes) ? 1 : 0;
+
+    // Nearest surviving ancestors of every particle, over the parent relation (the
+    // particles incoming to its production vertex). Iterative and memoized; a node
+    // still being computed is skipped, so a malformed record with a cycle terminates.
+    std::vector<std::vector<uint32_t>> nearestKept(nPart);
+    std::vector<uint8_t> state(nPart, 0);  // 0 = new, 1 = in progress, 2 = done
+    std::vector<uint32_t> stack;
+
+    for (uint32_t seed = 0; seed < nPart; ++seed) {
+      if (state[seed] == 2)
+        continue;
+      stack.push_back(seed);
+
+      while (!stack.empty()) {
+        const uint32_t i = stack.back();
+
+        if (state[i] == 2) {
+          stack.pop_back();
+          continue;
+        }
+
+        if (state[i] == 0) {
+          state[i] = 1;
+          if (keep[i] != 0) {
+            nearestKept[i].push_back(i);
+            state[i] = 2;
+            stack.pop_back();
+            continue;
+          }
+          for (const uint32_t parent : parentsOf(i)) {
+            if (state[parent] == 0)
+              stack.push_back(parent);
+          }
+          continue;
+        }
+
+        for (const uint32_t parent : parentsOf(i)) {
+          if (state[parent] == 2)
+            nearestKept[i].insert(nearestKept[i].end(), nearestKept[parent].begin(), nearestKept[parent].end());
+        }
+        sortUnique(nearestKept[i]);
+        state[i] = 2;
+        stack.pop_back();
+      }
+    }
+
+    // A vertex survives when it still produces a survivor. A survivor with no
+    // production vertex keeps the record's own topology: it had no incoming edge
+    // before the collapse either.
+    std::unordered_set<int> keptVertices;
+    std::vector<std::pair<int, int>> vtxToPart;
+    for (uint32_t i = 0; i < nPart; ++i) {
+      if (keep[i] == 0 || prodVertexOf[i] == kNoVertex)
+        continue;
+      keptVertices.insert(prodVertexOf[i]);
+      vtxToPart.emplace_back(prodVertexOf[i], gb.partBarcodes[i]);
+    }
+
+    // The surviving vertex inherits the nearest surviving ancestors of everything that
+    // fed it, which is the contraction: the collapsed chain becomes one edge. A vertex
+    // left without any is a root, and the callers attach the GenEvent node to it.
+    std::vector<std::pair<int, int>> partToVtx;
+    std::vector<uint32_t> ancestors;
+    for (const int vbc : gb.vtxBarcodes) {
+      if (keptVertices.count(vbc) == 0)
+        continue;
+      const auto it = incomingOf.find(vbc);
+      if (it == incomingOf.end())
+        continue;
+      ancestors.clear();
+      for (const uint32_t parent : it->second)
+        ancestors.insert(ancestors.end(), nearestKept[parent].begin(), nearestKept[parent].end());
+      sortUnique(ancestors);
+      for (const uint32_t a : ancestors) {
+        if (prodVertexOf[a] != vbc)  // a vertex must not become its own ancestor
+          partToVtx.emplace_back(gb.partBarcodes[a], vbc);
+      }
+    }
+
+    std::unordered_set<int> keptBarcodes;
+    keptBarcodes.reserve(nPart * 2);
+    std::vector<int> partBarcodes;
+    for (uint32_t i = 0; i < nPart; ++i) {
+      if (keep[i] == 0)
+        continue;
+      partBarcodes.push_back(gb.partBarcodes[i]);
+      keptBarcodes.insert(gb.partBarcodes[i]);
+    }
+
+    std::vector<int> vtxBarcodes;
+    for (const int vbc : gb.vtxBarcodes) {
+      if (keptVertices.count(vbc) != 0)
+        vtxBarcodes.push_back(vbc);
+    }
+
+    std::vector<int> particleBarcodeByIndex;
+    for (const int pbc : gb.particleBarcodeByIndex) {
+      if (keptBarcodes.count(pbc) != 0)
+        particleBarcodeByIndex.push_back(pbc);
+    }
+
+    pruneMap(gb.particlePdgIdByBarcode, keptBarcodes);
+    pruneMap(gb.particleStatusByBarcode, keptBarcodes);
+    pruneMap(gb.particleStatusFlagsByBarcode, keptBarcodes);
+
+    gb.partBarcodes = std::move(partBarcodes);
+    gb.vtxBarcodes = std::move(vtxBarcodes);
+    gb.particleBarcodeByIndex = std::move(particleBarcodeByIndex);
+    gb.vtxToPart = std::move(vtxToPart);
+    gb.partToVtx = std::move(partToVtx);
   }
 
 }  // namespace truth

--- a/PhysicsTools/TruthInfo/src/LogicalGraphHitIndexBuilder.cc
+++ b/PhysicsTools/TruthInfo/src/LogicalGraphHitIndexBuilder.cc
@@ -10,8 +10,11 @@
 
 namespace truth {
 
-  LogicalGraphHitIndexBuilder::LogicalGraphHitIndexBuilder(uint32_t nParticles)
-      : nParticles_(nParticles), children_(nParticles) {
+  LogicalGraphHitIndexBuilder::LogicalGraphHitIndexBuilder(uint32_t nParticles, bool sharedSubgraphStore)
+      : nParticles_(nParticles),
+        sharedSubgraphStore_(sharedSubgraphStore),
+        children_(nParticles),
+        hasSimTrack_(nParticles, 0) {
     for (auto& channel : directHits_)
       channel.resize(nParticles);
   }
@@ -21,6 +24,7 @@ namespace truth {
       return;
 
     trackIdToParticle_[simKey(eventId, trackId)] = particleId;
+    hasSimTrack_[particleId] = 1;
   }
 
   void LogicalGraphHitIndexBuilder::addParticleChild(uint32_t parentParticleId, uint32_t childParticleId) {
@@ -133,7 +137,221 @@ namespace truth {
     }
   }
 
+  bool LogicalGraphHitIndexBuilder::buildDfsOrder(std::vector<uint32_t>& slotToParticle,
+                                                  std::vector<uint32_t>& dfsPos,
+                                                  std::vector<uint32_t>& subtreeCount) const {
+    slotToParticle.clear();
+    slotToParticle.reserve(nParticles_);
+    dfsPos.assign(nParticles_, 0);
+    subtreeCount.assign(nParticles_, 1);
+
+    // A particle's SIM parent is the one parent that also has a SimTrack. Particles
+    // without one are roots: the SIM primaries, and the GEN-only nodes, which carry no
+    // hits and so become single-slot trees here.
+    //
+    // A subtree is only a contiguous run of slots when the hit-carrying particles form
+    // a forest. A particle with two SimTrack parents would sit under one of them and be
+    // missing from the other's run, so the layout cannot represent it and the caller
+    // falls back to the materialised one.
+    std::vector<uint32_t> simParent(nParticles_, kNoParent);
+    std::vector<std::vector<uint32_t>> simChildren(nParticles_);
+    bool isForest = true;
+    for (uint32_t parent = 0; parent < nParticles_; ++parent) {
+      if (hasSimTrack_[parent] == 0)
+        continue;
+      for (const uint32_t child : children_[parent]) {
+        if (child >= nParticles_ || hasSimTrack_[child] == 0)
+          continue;
+        if (simParent[child] != kNoParent) {
+          isForest = false;
+          continue;
+        }
+        simParent[child] = parent;
+        simChildren[parent].push_back(child);
+      }
+    }
+    if (!isForest)
+      return false;
+
+    std::vector<uint8_t> seen(nParticles_, 0);
+    std::vector<std::pair<uint32_t, bool>> stack;
+
+    auto visitTree = [&](uint32_t root) {
+      stack.emplace_back(root, false);
+      while (!stack.empty()) {
+        const auto [particleId, expanded] = stack.back();
+        stack.pop_back();
+
+        if (expanded) {
+          subtreeCount[particleId] = static_cast<uint32_t>(slotToParticle.size()) - dfsPos[particleId];
+          continue;
+        }
+        if (seen[particleId] != 0)
+          continue;
+
+        seen[particleId] = 1;
+        dfsPos[particleId] = static_cast<uint32_t>(slotToParticle.size());
+        slotToParticle.push_back(particleId);
+
+        // Pushed before the children, so it is popped once they have all been placed
+        // and the subtree size is the slots consumed since.
+        stack.emplace_back(particleId, true);
+        for (const uint32_t child : simChildren[particleId]) {
+          if (seen[child] == 0)
+            stack.emplace_back(child, false);
+        }
+      }
+    };
+
+    for (uint32_t particleId = 0; particleId < nParticles_; ++particleId) {
+      if (simParent[particleId] == kNoParent)
+        visitTree(particleId);
+    }
+
+    // Anything left is in a parentage cycle, which a well-formed graph does not have.
+    // Giving it its own tree keeps every particle addressable.
+    for (uint32_t particleId = 0; particleId < nParticles_; ++particleId) {
+      if (seen[particleId] == 0)
+        visitTree(particleId);
+    }
+
+    return true;
+  }
+
   LogicalGraphHitIndex LogicalGraphHitIndexBuilder::finish() {
+    usedSharedStore_ = sharedSubgraphStore_;
+    if (sharedSubgraphStore_)
+      return finishShared();
+
+    return finishMaterialised();
+  }
+
+  void LogicalGraphHitIndexBuilder::buildSubgraphRanges(std::vector<uint32_t> const& dfsPos,
+                                                        std::vector<uint32_t> const& subtreeCount,
+                                                        std::vector<uint32_t>& rangeOffsets,
+                                                        std::vector<SlotRange>& ranges) const {
+    // A particle that carries hits is a node of the SIM tree, so its subgraph is the
+    // single run of slots its subtree occupies. A GEN-only particle is a node of the
+    // GEN DAG above that tree: it owns no slots of its own, and its subgraph is the
+    // union of the runs of the SIM particles below it, merged where they touch.
+    std::vector<std::vector<SlotRange>> perParticle(nParticles_);
+    std::vector<uint8_t> state(nParticles_, 0);  // 0 = new, 1 = in progress, 2 = done
+    std::vector<uint32_t> stack;
+
+    auto mergeSorted = [](std::vector<SlotRange>& runs) {
+      std::sort(
+          runs.begin(), runs.end(), [](SlotRange const& a, SlotRange const& b) { return a.firstSlot < b.firstSlot; });
+      std::size_t w = 0;
+      for (std::size_t r = 0; r < runs.size(); ++r) {
+        if (w > 0 && runs[r].firstSlot <= runs[w - 1].firstSlot + runs[w - 1].slotCount) {
+          const uint32_t end =
+              std::max(runs[w - 1].firstSlot + runs[w - 1].slotCount, runs[r].firstSlot + runs[r].slotCount);
+          runs[w - 1].slotCount = end - runs[w - 1].firstSlot;
+        } else {
+          runs[w++] = runs[r];
+        }
+      }
+      runs.resize(w);
+    };
+
+    for (uint32_t seed = 0; seed < nParticles_; ++seed) {
+      if (state[seed] == 2)
+        continue;
+      stack.push_back(seed);
+
+      while (!stack.empty()) {
+        const uint32_t particleId = stack.back();
+
+        if (state[particleId] == 2) {
+          stack.pop_back();
+          continue;
+        }
+
+        if (state[particleId] == 0) {
+          state[particleId] = 1;
+          // A hit-carrying particle terminates the descent: its own subtree run
+          // already covers everything below it.
+          if (hasSimTrack_[particleId] != 0) {
+            perParticle[particleId].push_back(SlotRange{dfsPos[particleId], subtreeCount[particleId]});
+            state[particleId] = 2;
+            stack.pop_back();
+            continue;
+          }
+          for (const uint32_t child : children_[particleId]) {
+            if (child < nParticles_ && state[child] == 0)
+              stack.push_back(child);
+          }
+          continue;
+        }
+
+        // Second visit: every child that could be resolved has been. A child still in
+        // progress is a cycle, which a well-formed graph does not have, and is skipped.
+        auto& runs = perParticle[particleId];
+        for (const uint32_t child : children_[particleId]) {
+          if (child < nParticles_ && state[child] == 2)
+            runs.insert(runs.end(), perParticle[child].begin(), perParticle[child].end());
+        }
+        mergeSorted(runs);
+        state[particleId] = 2;
+        stack.pop_back();
+      }
+    }
+
+    rangeOffsets.clear();
+    rangeOffsets.reserve(nParticles_ + 1);
+    rangeOffsets.push_back(0);
+    ranges.clear();
+    for (uint32_t particleId = 0; particleId < nParticles_; ++particleId) {
+      auto const& runs = perParticle[particleId];
+      ranges.insert(ranges.end(), runs.begin(), runs.end());
+      rangeOffsets.push_back(static_cast<uint32_t>(ranges.size()));
+    }
+  }
+
+  LogicalGraphHitIndex LogicalGraphHitIndexBuilder::finishShared() {
+    std::vector<uint32_t> slotToParticle;
+    std::vector<uint32_t> dfsPos;
+    std::vector<uint32_t> subtreeCount;
+    if (!buildDfsOrder(slotToParticle, dfsPos, subtreeCount)) {
+      usedSharedStore_ = false;
+      return finishMaterialised();
+    }
+
+    std::vector<uint32_t> rangeOffsets;
+    std::vector<SlotRange> ranges;
+    buildSubgraphRanges(dfsPos, subtreeCount, rangeOffsets, ranges);
+
+    std::vector<LogicalGraphHitIndex::Channel> channels(kNumHitChannels);
+
+    for (std::size_t ch = 0; ch < kNumHitChannels; ++ch) {
+      if (!channelTouched_[ch])
+        continue;
+
+      auto& direct = directHits_[ch];
+      for (auto& hits : direct)
+        coalesce(hits);
+
+      auto& out = channels[ch];
+      out.dfsOffsets.reserve(slotToParticle.size() + 1);
+      out.dfsOffsets.push_back(0);
+
+      std::size_t total = 0;
+      for (auto const& hits : direct)
+        total += hits.size();
+      out.directHits.reserve(total);
+
+      for (const uint32_t particleId : slotToParticle) {
+        auto const& hits = direct[particleId];
+        out.directHits.insert(out.directHits.end(), hits.begin(), hits.end());
+        out.dfsOffsets.push_back(static_cast<uint32_t>(out.directHits.size()));
+      }
+    }
+
+    return LogicalGraphHitIndex(
+        nParticles_, std::move(channels), std::move(dfsPos), std::move(rangeOffsets), std::move(ranges));
+  }
+
+  LogicalGraphHitIndex LogicalGraphHitIndexBuilder::finishMaterialised() {
     std::vector<LogicalGraphHitIndex::Channel> channels(kNumHitChannels);
 
     for (std::size_t ch = 0; ch < kNumHitChannels; ++ch) {

--- a/PhysicsTools/TruthInfo/src/LogicalGraphHitIndexBuilder.cc
+++ b/PhysicsTools/TruthInfo/src/LogicalGraphHitIndexBuilder.cc
@@ -137,6 +137,47 @@ namespace truth {
     }
   }
 
+  std::vector<uint8_t> LogicalGraphHitIndexBuilder::closureReachesSimTrack() const {
+    std::vector<uint8_t> reaches(nParticles_, 0);
+    std::vector<uint8_t> state(nParticles_, 0);  // 0 = new, 1 = in progress, 2 = done
+    std::vector<uint32_t> stack;
+
+    for (uint32_t seed = 0; seed < nParticles_; ++seed) {
+      if (state[seed] == 2)
+        continue;
+      stack.push_back(seed);
+
+      while (!stack.empty()) {
+        const uint32_t particleId = stack.back();
+
+        if (state[particleId] == 2) {
+          stack.pop_back();
+          continue;
+        }
+
+        if (state[particleId] == 0) {
+          state[particleId] = 1;
+          for (const uint32_t child : children_[particleId]) {
+            if (child < nParticles_ && state[child] == 0)
+              stack.push_back(child);
+          }
+          continue;
+        }
+
+        // Second visit: a child still in progress is a cycle and contributes nothing.
+        uint8_t value = hasSimTrack_[particleId];
+        for (const uint32_t child : children_[particleId]) {
+          if (child < nParticles_ && state[child] == 2 && reaches[child] != 0)
+            value = 1;
+        }
+        reaches[particleId] = value;
+        state[particleId] = 2;
+        stack.pop_back();
+      }
+    }
+    return reaches;
+  }
+
   bool LogicalGraphHitIndexBuilder::buildDfsOrder(std::vector<uint32_t>& slotToParticle,
                                                   std::vector<uint32_t>& dfsPos,
                                                   std::vector<uint32_t>& subtreeCount) const {
@@ -153,6 +194,10 @@ namespace truth {
     // a forest. A particle with two SimTrack parents would sit under one of them and be
     // missing from the other's run, so the layout cannot represent it and the caller
     // falls back to the materialised one.
+    // Whether a particle's descendant closure contains anything that carries hits. Used
+    // below to reject the one topology the tree cannot represent.
+    const std::vector<uint8_t> reachesSim = closureReachesSimTrack();
+
     std::vector<uint32_t> simParent(nParticles_, kNoParent);
     std::vector<std::vector<uint32_t>> simChildren(nParticles_);
     bool isForest = true;
@@ -160,8 +205,18 @@ namespace truth {
       if (hasSimTrack_[parent] == 0)
         continue;
       for (const uint32_t child : children_[parent]) {
-        if (child >= nParticles_ || hasSimTrack_[child] == 0)
+        if (child >= nParticles_)
           continue;
+        if (hasSimTrack_[child] == 0) {
+          // A GEN-only child that still has hit-carrying descendants would put them
+          // outside this parent's subtree run, since the tree is built from
+          // hasSimTrack-to-hasSimTrack edges only, and the parent's subgraph would come
+          // back short. No current sample does this, because a SIM-continued GEN
+          // particle is a status 1 leaf, but nothing enforces it.
+          if (reachesSim[child] != 0)
+            isForest = false;
+          continue;
+        }
         if (simParent[child] != kNoParent) {
           isForest = false;
           continue;

--- a/PhysicsTools/TruthInfo/src/LogicalGraphHitIndexBuilder.cc
+++ b/PhysicsTools/TruthInfo/src/LogicalGraphHitIndexBuilder.cc
@@ -164,10 +164,16 @@ namespace truth {
           continue;
         }
 
-        // Second visit: a child still in progress is a cycle and contributes nothing.
+        // Second visit. A child still in progress is a cycle, and what lies beyond it is
+        // unknown at this point, so it must count as REACHING: memoizing 0 here would be
+        // wrong whenever the cycle has an exit to a SimTrack, and this function guards
+        // the layout, so it over-approximates. The cost of a false positive is a
+        // fallback to the materialised layout, which is always correct.
         uint8_t value = hasSimTrack_[particleId];
         for (const uint32_t child : children_[particleId]) {
-          if (child < nParticles_ && state[child] == 2 && reaches[child] != 0)
+          if (child >= nParticles_)
+            continue;
+          if (state[child] == 1 || (state[child] == 2 && reaches[child] != 0))
             value = 1;
         }
         reaches[particleId] = value;

--- a/PhysicsTools/TruthInfo/src/SubgraphHitView.cc
+++ b/PhysicsTools/TruthInfo/src/SubgraphHitView.cc
@@ -1,0 +1,55 @@
+// Original author: Felice Pantaleo (CERN) <felice.pantaleo@cern.ch>
+// Part of the MC-truth-graph prototype - under heavy development, not yet open
+// to external contributions (see PhysicsTools/TruthInfo/README.md).
+
+#include "PhysicsTools/TruthInfo/interface/SubgraphHitView.h"
+
+#include <algorithm>
+
+namespace truth {
+
+  std::span<const SubgraphHitView::Hit> SubgraphHitView::subgraphHits(HitChannel channel, uint32_t particleId) {
+    if (!hitIndex_->sharedSubgraphStore())
+      return hitIndex_->subgraphHits(channel, particleId);
+
+    const auto ranges = hitIndex_->subgraphRanges(particleId);
+    if (ranges.empty())
+      return {};
+
+    // A single one-slot range is one particle's own direct hits, which the builder
+    // already sorted and summed per detId.
+    if (ranges.size() == 1 && ranges[0].slotCount == 1)
+      return hitIndex_->rangeHits(channel, ranges[0]);
+
+    const uint64_t cacheKey = key(channel, particleId);
+    const auto found = cached_.find(cacheKey);
+    if (found != cached_.end())
+      return found->second;
+
+    std::vector<Hit> hits;
+    hitIndex_->appendSubgraphHits(channel, particleId, hits);
+
+    // The same rule LogicalGraphHitIndexBuilder::coalesce applies: sort by detId, sum
+    // the energies that share one, and keep the valid recHit index, which sorts first
+    // because the invalid sentinel is UINT32_MAX.
+    std::sort(hits.begin(), hits.end(), [](Hit const& a, Hit const& b) {
+      if (a.detId != b.detId)
+        return a.detId < b.detId;
+      return a.recHitIndex < b.recHitIndex;
+    });
+    std::size_t w = 0;
+    for (std::size_t r = 0; r < hits.size(); ++r) {
+      if (w > 0 && hits[w - 1].detId == hits[r].detId) {
+        hits[w - 1].energy += hits[r].energy;
+        if (hits[w - 1].recHitIndex == Hit::kInvalidRecHitIndex)
+          hits[w - 1].recHitIndex = hits[r].recHitIndex;
+      } else {
+        hits[w++] = hits[r];
+      }
+    }
+    hits.resize(w);
+
+    return cached_.emplace(cacheKey, std::move(hits)).first->second;
+  }
+
+}  // namespace truth

--- a/PhysicsTools/TruthInfo/test/BranchHitAssociator_t.cpp
+++ b/PhysicsTools/TruthInfo/test/BranchHitAssociator_t.cpp
@@ -29,10 +29,10 @@ namespace {
     b.setSimTrackForParticle(0, 0, 100);
     b.setSimTrackForParticle(1, 0, 101);
     b.addParticleChild(0, 1);
-    b.addHit(truth::HitChannel::HGCalCalo, 0, 100, 10, 1.0f, 0);
-    b.addHit(truth::HitChannel::HGCalCalo, 0, 100, 11, 1.0f, 0);
-    b.addHit(truth::HitChannel::HGCalCalo, 0, 101, 11, 1.0f, 0);
-    b.addHit(truth::HitChannel::HGCalCalo, 0, 101, 12, 2.0f, 0);
+    b.addHit(truth::HitChannel::Calo, 0, 100, 10, 1.0f, 0);
+    b.addHit(truth::HitChannel::Calo, 0, 100, 11, 1.0f, 0);
+    b.addHit(truth::HitChannel::Calo, 0, 101, 11, 1.0f, 0);
+    b.addHit(truth::HitChannel::Calo, 0, 101, 12, 2.0f, 0);
     return b.finish();
   }
 
@@ -43,7 +43,7 @@ namespace {
     b.setSimTrackForParticle(0, 0, 100);
     b.setSimTrackForParticle(1, 0, 101);
     b.addParticleChild(0, 1);
-    b.addHit(truth::HitChannel::HGCalCalo, 0, 100, 10, 1.0f, 0);  // calo channel
+    b.addHit(truth::HitChannel::Calo, 0, 100, 10, 1.0f, 0);  // calo channel
     b.addHit(truth::HitChannel::Tracker, 0, 100, 20, 1.0f);
     b.addHit(truth::HitChannel::Tracker, 0, 100, 21, 1.0f);
     b.addHit(truth::HitChannel::Tracker, 0, 101, 21, 1.0f);
@@ -145,7 +145,7 @@ void TestBranchHitAssociator::testTrackerChannel() {
   CPPUNIT_ASSERT(assoc.bestBranches(caloReco).empty());
   // ...and a calo associator ignores the tracker cells.
   truth::BranchHitAssociator caloAssoc(
-      index, {}, truth::BranchHitAssociator::Metric::SharedHits, truth::HitChannel::HGCalCalo);
+      index, {}, truth::BranchHitAssociator::Metric::SharedHits, truth::HitChannel::Calo);
   CPPUNIT_ASSERT(caloAssoc.bestBranches(reco).empty());
 }
 
@@ -159,7 +159,7 @@ void TestBranchHitAssociator::testEmptyRootsMatchNothingWhenRestricted() {
   truth::BranchHitAssociator restricted(index,
                                         {},
                                         truth::BranchHitAssociator::Metric::SharedEnergy,
-                                        truth::HitChannel::HGCalCalo,
+                                        truth::HitChannel::Calo,
                                         /*emptyRootsMeansAll=*/false);
   std::vector<truth::RecoHit> reco{{10, 1.0f, 1.0f}, {11, 2.0f, 1.0f}, {12, 2.0f, 1.0f}};
   CPPUNIT_ASSERT(restricted.bestBranches(reco).empty());

--- a/PhysicsTools/TruthInfo/test/BuildFile.xml
+++ b/PhysicsTools/TruthInfo/test/BuildFile.xml
@@ -23,6 +23,12 @@
   <use name="cppunit"/>
 </bin>
 
+<bin name="GenGraphBuild_t" file="GenGraphBuild_t.cpp">
+  <use name="PhysicsTools/TruthInfo"/>
+  <use name="DataFormats/HepMCCandidate"/>
+  <use name="cppunit"/>
+</bin>
+
 <bin name="BranchSelector_t" file="BranchSelector_t.cpp">
   <use name="PhysicsTools/TruthInfo"/>
   <use name="SimDataFormats/TruthInfo"/>

--- a/PhysicsTools/TruthInfo/test/GenGraphBuild_t.cpp
+++ b/PhysicsTools/TruthInfo/test/GenGraphBuild_t.cpp
@@ -134,6 +134,7 @@ class TestGenGraphBuild : public CppUnit::TestFixture {
   CPPUNIT_TEST(testContractedAncestry);
   CPPUNIT_TEST(testNoOrphans);
   CPPUNIT_TEST(testSimContinuationKeeps);
+  CPPUNIT_TEST(testNoStatusFlagsReportsDegraded);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -141,6 +142,7 @@ public:
   void testContractedAncestry();
   void testNoOrphans();
   void testSimContinuationKeeps();
+  void testNoStatusFlagsReportsDegraded();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestGenGraphBuild);
@@ -260,4 +262,18 @@ void TestGenGraphBuild::testSimContinuationKeeps() {
   for (int pbc : gb.partBarcodes) {
     CPPUNIT_ASSERT((reachable.count(pbc) != 0) == (pbc != 11));
   }
+}
+
+// Without packed status flags the isHardProcess and isLastCopy rules are dead: the
+// collapse must SAY so, and the keep set degrades to SIM-continued plus status 1.
+void TestGenGraphBuild::testNoStatusFlagsReportsDegraded() {
+  auto gb = buildRecord();
+  gb.particleStatusFlagsByBarcode.clear();
+
+  CPPUNIT_ASSERT(!truth::collapseGenShower(gb, std::unordered_set<int>{6}));
+
+  const std::vector<int> expected = {6, 9, 10};
+  std::vector<int> kept = gb.partBarcodes;
+  std::sort(kept.begin(), kept.end());
+  CPPUNIT_ASSERT(kept == expected);
 }

--- a/PhysicsTools/TruthInfo/test/GenGraphBuild_t.cpp
+++ b/PhysicsTools/TruthInfo/test/GenGraphBuild_t.cpp
@@ -1,0 +1,228 @@
+// Original author: Felice Pantaleo (CERN) <felice.pantaleo@cern.ch>
+// Part of the MC-truth-graph prototype - under heavy development, not yet open
+// to external contributions (see PhysicsTools/TruthInfo/README.md).
+
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
+#include "cppunit/extensions/HelperMacros.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <unordered_set>
+#include <vector>
+
+#include "DataFormats/HepMCCandidate/interface/GenStatusFlags.h"
+#include "PhysicsTools/TruthInfo/interface/GenGraphBuild.h"
+
+namespace {
+
+  constexpr uint16_t kHardProcess = 1u << reco::GenStatusFlags::kIsHardProcess;
+  constexpr uint16_t kLastCopy = 1u << reco::GenStatusFlags::kIsLastCopy;
+
+  // A hand-built GEN record with the two things the collapse has to handle, plus a
+  // re-convergent branch. Vertex barcodes are negative, particle barcodes positive,
+  // as HepMC2 writes them.
+  //
+  //   V-1: (nothing in)          -> 1 g   status 21, hard process
+  //                              -> 2 g   status 21, hard process
+  //   V-2: 1,2 in                -> 3 H   status 22, hard process        (first copy)
+  //   V-3: 3 in                  -> 4 H   status 44                      (intermediate copy)
+  //   V-4: 4 in                  -> 5 H   status 62, last copy           (last copy)
+  //   V-5: 5 in                  -> 6 b   status 71                      (shower parton)
+  //                              -> 7 bbar status 71                     (shower parton)
+  //   V-6: 6,7 in                -> 8 string 92                          (shower object)
+  //   V-7: 8 in                  -> 9  pi+ status 1
+  //                              -> 10 pi- status 1
+  //
+  // Kept: 1, 2 (hard process), 3 (hard process), 5 (last copy of a resonance), 9, 10
+  // (stable). Collapsed: 4 (intermediate copy), 6, 7 (partons), 8 (string).
+  truth::GenBuild buildRecord() {
+    truth::GenBuild gb;
+
+    struct Particle {
+      int barcode;
+      int32_t pdgId;
+      int16_t status;
+      uint16_t flags;
+      int prodVertex;
+      int endVertex;  // 0 = none
+    };
+
+    const std::vector<Particle> particles = {
+        {1, 21, 21, kHardProcess, -1, -2},
+        {2, 21, 21, kHardProcess, -1, -2},
+        {3, 25, 22, kHardProcess, -2, -3},
+        {4, 25, 44, 0, -3, -4},
+        {5, 25, 62, kLastCopy, -4, -5},
+        {6, 5, 71, kLastCopy, -5, -6},
+        {7, -5, 71, kLastCopy, -5, -6},
+        {8, 92, 92, kLastCopy, -6, -7},
+        {9, 211, 1, kLastCopy, -7, 0},
+        {10, -211, 1, kLastCopy, -7, 0},
+    };
+
+    for (int vbc = -1; vbc >= -7; --vbc)
+      gb.vtxBarcodes.push_back(vbc);
+
+    for (auto const& p : particles) {
+      gb.partBarcodes.push_back(p.barcode);
+      gb.particleBarcodeByIndex.push_back(p.barcode);
+      gb.particlePdgIdByBarcode.emplace(p.barcode, p.pdgId);
+      gb.particleStatusByBarcode.emplace(p.barcode, p.status);
+      gb.particleStatusFlagsByBarcode.emplace(p.barcode, p.flags);
+      gb.vtxToPart.emplace_back(p.prodVertex, p.barcode);
+      if (p.endVertex != 0)
+        gb.partToVtx.emplace_back(p.barcode, p.endVertex);
+    }
+
+    return gb;
+  }
+
+  bool hasVertexToParticle(truth::GenBuild const& gb, int vbc, int pbc) {
+    return std::find(gb.vtxToPart.begin(), gb.vtxToPart.end(), std::make_pair(vbc, pbc)) != gb.vtxToPart.end();
+  }
+
+  bool hasParticleToVertex(truth::GenBuild const& gb, int pbc, int vbc) {
+    return std::find(gb.partToVtx.begin(), gb.partToVtx.end(), std::make_pair(pbc, vbc)) != gb.partToVtx.end();
+  }
+
+  bool contains(std::vector<int> const& v, int x) { return std::find(v.begin(), v.end(), x) != v.end(); }
+
+  // Every kept particle must be reachable from the source vertices, which are the ones
+  // with no incoming particle: that is where the callers attach the GenEvent node.
+  std::unordered_set<int> reachableParticles(truth::GenBuild const& gb) {
+    std::unordered_set<int> withIncoming;
+    for (auto const& [pbc, vbc] : gb.partToVtx)
+      withIncoming.insert(vbc);
+
+    std::vector<int> vertexStack;
+    for (int vbc : gb.vtxBarcodes) {
+      if (withIncoming.count(vbc) == 0)
+        vertexStack.push_back(vbc);
+    }
+
+    std::unordered_set<int> seenParticles;
+    std::unordered_set<int> seenVertices(vertexStack.begin(), vertexStack.end());
+    while (!vertexStack.empty()) {
+      const int vbc = vertexStack.back();
+      vertexStack.pop_back();
+      for (auto const& [from, pbc] : gb.vtxToPart) {
+        if (from != vbc || !seenParticles.insert(pbc).second)
+          continue;
+        for (auto const& [pFrom, to] : gb.partToVtx) {
+          if (pFrom == pbc && seenVertices.insert(to).second)
+            vertexStack.push_back(to);
+        }
+      }
+    }
+    return seenParticles;
+  }
+
+}  // namespace
+
+class TestGenGraphBuild : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(TestGenGraphBuild);
+  CPPUNIT_TEST(testKeptSet);
+  CPPUNIT_TEST(testContractedAncestry);
+  CPPUNIT_TEST(testNoOrphans);
+  CPPUNIT_TEST(testSimContinuationKeeps);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void testKeptSet();
+  void testContractedAncestry();
+  void testNoOrphans();
+  void testSimContinuationKeeps();
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestGenGraphBuild);
+
+// The keep rule survives exactly the hard process, the last copy of the resonance and
+// the stable particles; the intermediate copy, the shower partons and the string go.
+void TestGenGraphBuild::testKeptSet() {
+  auto gb = buildRecord();
+  truth::collapseGenShower(gb, {});
+
+  const std::vector<int> expected = {1, 2, 3, 5, 9, 10};
+  std::vector<int> kept = gb.partBarcodes;
+  std::sort(kept.begin(), kept.end());
+  CPPUNIT_ASSERT(kept == expected);
+
+  CPPUNIT_ASSERT(gb.particlePdgIdByBarcode.size() == expected.size());
+  CPPUNIT_ASSERT(gb.particleStatusByBarcode.size() == expected.size());
+  CPPUNIT_ASSERT(gb.particleStatusFlagsByBarcode.size() == expected.size());
+  CPPUNIT_ASSERT(gb.particleBarcodeByIndex.size() == expected.size());
+
+  // A vertex survives only if it still produces a survivor: V-6 produced the string
+  // only, so it is bypassed.
+  CPPUNIT_ASSERT(contains(gb.vtxBarcodes, -1));
+  CPPUNIT_ASSERT(contains(gb.vtxBarcodes, -2));
+  CPPUNIT_ASSERT(contains(gb.vtxBarcodes, -4));
+  CPPUNIT_ASSERT(contains(gb.vtxBarcodes, -7));
+  CPPUNIT_ASSERT(!contains(gb.vtxBarcodes, -3));
+  CPPUNIT_ASSERT(!contains(gb.vtxBarcodes, -6));
+}
+
+// Ancestry is contracted, not cut: the resonance last copy hangs off the hard-process
+// copy, and the stable particles hang off the last copy, through real vertices.
+void TestGenGraphBuild::testContractedAncestry() {
+  auto gb = buildRecord();
+  truth::collapseGenShower(gb, {});
+
+  // 3 (hard process H) -> V-4 -> 5 (last copy H), the intermediate copy 4 gone.
+  CPPUNIT_ASSERT(hasParticleToVertex(gb, 3, -4));
+  CPPUNIT_ASSERT(hasVertexToParticle(gb, -4, 5));
+
+  // 5 -> V-7 -> 9, 10, the two partons and the string gone.
+  CPPUNIT_ASSERT(hasParticleToVertex(gb, 5, -7));
+  CPPUNIT_ASSERT(hasVertexToParticle(gb, -7, 9));
+  CPPUNIT_ASSERT(hasVertexToParticle(gb, -7, 10));
+
+  // The two incoming partons still meet at the hard vertex.
+  CPPUNIT_ASSERT(hasParticleToVertex(gb, 1, -2));
+  CPPUNIT_ASSERT(hasParticleToVertex(gb, 2, -2));
+  CPPUNIT_ASSERT(hasVertexToParticle(gb, -2, 3));
+
+  // No edge may refer to a particle or a vertex that is gone.
+  for (auto const& [vbc, pbc] : gb.vtxToPart) {
+    CPPUNIT_ASSERT(contains(gb.vtxBarcodes, vbc));
+    CPPUNIT_ASSERT(contains(gb.partBarcodes, pbc));
+  }
+  for (auto const& [pbc, vbc] : gb.partToVtx) {
+    CPPUNIT_ASSERT(contains(gb.partBarcodes, pbc));
+    CPPUNIT_ASSERT(contains(gb.vtxBarcodes, vbc));
+  }
+}
+
+void TestGenGraphBuild::testNoOrphans() {
+  auto before = buildRecord();
+  const auto reachableBefore = reachableParticles(before);
+
+  auto after = buildRecord();
+  truth::collapseGenShower(after, {});
+  const auto reachableAfter = reachableParticles(after);
+
+  CPPUNIT_ASSERT(reachableAfter.size() == after.partBarcodes.size());
+  for (int pbc : after.partBarcodes) {
+    CPPUNIT_ASSERT(reachableAfter.count(pbc) != 0);
+    CPPUNIT_ASSERT(reachableBefore.count(pbc) != 0);
+  }
+}
+
+// A SimTrack continuing a particle keeps it whatever its status and flags say, and the
+// contraction then routes through it.
+void TestGenGraphBuild::testSimContinuationKeeps() {
+  auto gb = buildRecord();
+  truth::collapseGenShower(gb, std::unordered_set<int>{6});
+
+  CPPUNIT_ASSERT(contains(gb.partBarcodes, 6));
+  CPPUNIT_ASSERT(!contains(gb.partBarcodes, 7));
+
+  CPPUNIT_ASSERT(hasParticleToVertex(gb, 5, -5));
+  CPPUNIT_ASSERT(hasVertexToParticle(gb, -5, 6));
+
+  // 9 and 10 now have two nearest surviving ancestors, 6 and the last copy 5, because
+  // only one of the two partons survived.
+  CPPUNIT_ASSERT(hasParticleToVertex(gb, 6, -7));
+  CPPUNIT_ASSERT(hasParticleToVertex(gb, 5, -7));
+  CPPUNIT_ASSERT(reachableParticles(gb).size() == gb.partBarcodes.size());
+}

--- a/PhysicsTools/TruthInfo/test/GenGraphBuild_t.cpp
+++ b/PhysicsTools/TruthInfo/test/GenGraphBuild_t.cpp
@@ -149,7 +149,8 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestGenGraphBuild);
 // the stable particles; the intermediate copy, the shower partons and the string go.
 void TestGenGraphBuild::testKeptSet() {
   auto gb = buildRecord();
-  truth::collapseGenShower(gb, {});
+  // buildRecord() sets packed status flags, so the flag-based keep rules are live.
+  CPPUNIT_ASSERT(truth::collapseGenShower(gb, {}));
 
   const std::vector<int> expected = {1, 2, 3, 5, 9, 10, 11};
   std::vector<int> kept = gb.partBarcodes;
@@ -175,7 +176,8 @@ void TestGenGraphBuild::testKeptSet() {
 // copy, and the stable particles hang off the last copy, through real vertices.
 void TestGenGraphBuild::testContractedAncestry() {
   auto gb = buildRecord();
-  truth::collapseGenShower(gb, {});
+  // buildRecord() sets packed status flags, so the flag-based keep rules are live.
+  CPPUNIT_ASSERT(truth::collapseGenShower(gb, {}));
 
   // 3 (hard process H) -> V-4 -> 5 (last copy H), the intermediate copy 4 gone.
   CPPUNIT_ASSERT(hasParticleToVertex(gb, 3, -4));
@@ -212,7 +214,7 @@ void TestGenGraphBuild::testNoOrphans() {
   const auto reachableBefore = reachableParticles(before);
 
   auto after = buildRecord();
-  truth::collapseGenShower(after, {});
+  CPPUNIT_ASSERT(truth::collapseGenShower(after, {}));
   const auto reachableAfter = reachableParticles(after);
 
   for (int pbc : after.partBarcodes) {
@@ -239,7 +241,7 @@ void TestGenGraphBuild::testNoOrphans() {
 // contraction then routes through it.
 void TestGenGraphBuild::testSimContinuationKeeps() {
   auto gb = buildRecord();
-  truth::collapseGenShower(gb, std::unordered_set<int>{6});
+  CPPUNIT_ASSERT(truth::collapseGenShower(gb, std::unordered_set<int>{6}));
 
   CPPUNIT_ASSERT(contains(gb.partBarcodes, 6));
   CPPUNIT_ASSERT(!contains(gb.partBarcodes, 7));

--- a/PhysicsTools/TruthInfo/test/GenGraphBuild_t.cpp
+++ b/PhysicsTools/TruthInfo/test/GenGraphBuild_t.cpp
@@ -48,6 +48,8 @@ namespace {
     };
 
     const std::vector<Particle> particles = {
+        // A beam proton, as HepMC2 writes it: last copy, and NO production vertex.
+        {11, 2212, 4, kLastCopy, 0, -1},
         {1, 21, 21, kHardProcess, -1, -2},
         {2, 21, 21, kHardProcess, -1, -2},
         {3, 25, 22, kHardProcess, -2, -3},
@@ -69,7 +71,8 @@ namespace {
       gb.particlePdgIdByBarcode.emplace(p.barcode, p.pdgId);
       gb.particleStatusByBarcode.emplace(p.barcode, p.status);
       gb.particleStatusFlagsByBarcode.emplace(p.barcode, p.flags);
-      gb.vtxToPart.emplace_back(p.prodVertex, p.barcode);
+      if (p.prodVertex != 0)
+        gb.vtxToPart.emplace_back(p.prodVertex, p.barcode);
       if (p.endVertex != 0)
         gb.partToVtx.emplace_back(p.barcode, p.endVertex);
     }
@@ -99,6 +102,12 @@ namespace {
       if (withIncoming.count(vbc) == 0)
         vertexStack.push_back(vbc);
     }
+
+    // Mirror the callers: when no vertex is a source, the GenEvent node is attached to
+    // every vertex instead. A collider record always lands here, because the beam
+    // particles give the first vertex an incoming particle.
+    if (vertexStack.empty())
+      vertexStack.assign(gb.vtxBarcodes.begin(), gb.vtxBarcodes.end());
 
     std::unordered_set<int> seenParticles;
     std::unordered_set<int> seenVertices(vertexStack.begin(), vertexStack.end());
@@ -142,7 +151,7 @@ void TestGenGraphBuild::testKeptSet() {
   auto gb = buildRecord();
   truth::collapseGenShower(gb, {});
 
-  const std::vector<int> expected = {1, 2, 3, 5, 9, 10};
+  const std::vector<int> expected = {1, 2, 3, 5, 9, 10, 11};
   std::vector<int> kept = gb.partBarcodes;
   std::sort(kept.begin(), kept.end());
   CPPUNIT_ASSERT(kept == expected);
@@ -193,6 +202,11 @@ void TestGenGraphBuild::testContractedAncestry() {
   }
 }
 
+// The contraction must not COST reachability: a survivor that the source vertices could
+// reach before must still be reachable after. It cannot be asked to do better than the
+// record it is given. A beam particle has no production vertex in the HepMC record, so
+// nothing points at it and it is unreachable before the collapse as well; measured on
+// ttbar as exactly 2 unreachable GenParticles per event both before and after.
 void TestGenGraphBuild::testNoOrphans() {
   auto before = buildRecord();
   const auto reachableBefore = reachableParticles(before);
@@ -201,11 +215,24 @@ void TestGenGraphBuild::testNoOrphans() {
   truth::collapseGenShower(after, {});
   const auto reachableAfter = reachableParticles(after);
 
-  CPPUNIT_ASSERT(reachableAfter.size() == after.partBarcodes.size());
   for (int pbc : after.partBarcodes) {
-    CPPUNIT_ASSERT(reachableAfter.count(pbc) != 0);
-    CPPUNIT_ASSERT(reachableBefore.count(pbc) != 0);
+    if (reachableBefore.count(pbc) != 0) {
+      CPPUNIT_ASSERT(reachableAfter.count(pbc) != 0);
+    }
   }
+
+  // Everything the collapse kept and could reach is reachable, so the only survivors
+  // outside the reachable set are the ones the record itself never attached.
+  for (int pbc : after.partBarcodes) {
+    if (reachableAfter.count(pbc) == 0) {
+      CPPUNIT_ASSERT(reachableBefore.count(pbc) == 0);
+    }
+  }
+
+  // The beam particle of buildRecord() is exactly that case, so this test would pass
+  // vacuously if it ever stopped being kept.
+  CPPUNIT_ASSERT(contains(after.partBarcodes, 11));
+  CPPUNIT_ASSERT(reachableBefore.count(11) == 0);
 }
 
 // A SimTrack continuing a particle keeps it whatever its status and flags say, and the
@@ -224,5 +251,11 @@ void TestGenGraphBuild::testSimContinuationKeeps() {
   // only one of the two partons survived.
   CPPUNIT_ASSERT(hasParticleToVertex(gb, 6, -7));
   CPPUNIT_ASSERT(hasParticleToVertex(gb, 5, -7));
-  CPPUNIT_ASSERT(reachableParticles(gb).size() == gb.partBarcodes.size());
+
+  // Every survivor is reachable except the beam particle, which the record itself leaves
+  // without a production vertex. See testNoOrphans.
+  const auto reachable = reachableParticles(gb);
+  for (int pbc : gb.partBarcodes) {
+    CPPUNIT_ASSERT((reachable.count(pbc) != 0) == (pbc != 11));
+  }
 }

--- a/PhysicsTools/TruthInfo/test/LogicalGraphHitIndexBuilder_t.cpp
+++ b/PhysicsTools/TruthInfo/test/LogicalGraphHitIndexBuilder_t.cpp
@@ -26,6 +26,7 @@ class TestLogicalGraphHitIndexBuilder : public CppUnit::TestFixture {
   CPPUNIT_TEST(testSharedStoreKeepsEachHitOnce);
   CPPUNIT_TEST(testSharedStoreFallsBackWhenNotAForest);
   CPPUNIT_TEST(testSharedStoreFallsBackAcrossAGenOnlyChild);
+  CPPUNIT_TEST(testSharedStoreFallsBackAcrossAGenOnlyCycle);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -35,6 +36,7 @@ public:
   void testSharedStoreKeepsEachHitOnce();
   void testSharedStoreFallsBackWhenNotAForest();
   void testSharedStoreFallsBackAcrossAGenOnlyChild();
+  void testSharedStoreFallsBackAcrossAGenOnlyCycle();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestLogicalGraphHitIndexBuilder);
@@ -203,6 +205,35 @@ void TestLogicalGraphHitIndexBuilder::testSharedStoreFallsBackAcrossAGenOnlyChil
   CPPUNIT_ASSERT(!index.sharedSubgraphStore());
 
   // The grandparent still sees both cells, which is what the fallback protects.
+  auto sub = index.subgraphHits(truth::HitChannel::Calo, 0);
+  CPPUNIT_ASSERT_EQUAL(std::size_t(2), sub.size());
+  CPPUNIT_ASSERT_EQUAL(uint32_t(10), sub[0].detId);
+  CPPUNIT_ASSERT_EQUAL(uint32_t(20), sub[1].detId);
+}
+
+// A GEN-only CYCLE between the hit-carrying parent and a hit-carrying descendant. The
+// closure walk must not memoize "reaches nothing" for a cycle member whose exit leads to
+// a SimTrack: a child still being computed counts as reaching, so the guard fires and the
+// builder falls back rather than answer a subgraph short of the descendant's hits.
+void TestLogicalGraphHitIndexBuilder::testSharedStoreFallsBackAcrossAGenOnlyCycle() {
+  truth::LogicalGraphHitIndexBuilder builder(4, /*sharedSubgraphStore=*/true);
+  builder.setSimTrackForParticle(0, 0, 100);
+  // particles 1 and 2 are GEN-only and form a cycle; the exit from 1 reaches particle 3.
+  builder.setSimTrackForParticle(3, 0, 103);
+  builder.addParticleChild(0, 2);
+  builder.addParticleChild(1, 2);
+  builder.addParticleChild(1, 3);
+  builder.addParticleChild(2, 1);
+
+  builder.addHit(truth::HitChannel::Calo, 0, 100, 10, 1.0f, 0);
+  builder.addHit(truth::HitChannel::Calo, 0, 103, 20, 2.0f, 1);
+
+  const auto index = builder.finish();
+
+  CPPUNIT_ASSERT(!builder.usedSharedStore());
+  CPPUNIT_ASSERT(!index.sharedSubgraphStore());
+
+  // The parent still sees the descendant's cell through the cycle.
   auto sub = index.subgraphHits(truth::HitChannel::Calo, 0);
   CPPUNIT_ASSERT_EQUAL(std::size_t(2), sub.size());
   CPPUNIT_ASSERT_EQUAL(uint32_t(10), sub[0].detId);

--- a/PhysicsTools/TruthInfo/test/LogicalGraphHitIndexBuilder_t.cpp
+++ b/PhysicsTools/TruthInfo/test/LogicalGraphHitIndexBuilder_t.cpp
@@ -25,6 +25,7 @@ class TestLogicalGraphHitIndexBuilder : public CppUnit::TestFixture {
   CPPUNIT_TEST(testSubgraphDiamondCountsSharedDescendantOnce);
   CPPUNIT_TEST(testSharedStoreKeepsEachHitOnce);
   CPPUNIT_TEST(testSharedStoreFallsBackWhenNotAForest);
+  CPPUNIT_TEST(testSharedStoreFallsBackAcrossAGenOnlyChild);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -33,6 +34,7 @@ public:
   void testSubgraphDiamondCountsSharedDescendantOnce();
   void testSharedStoreKeepsEachHitOnce();
   void testSharedStoreFallsBackWhenNotAForest();
+  void testSharedStoreFallsBackAcrossAGenOnlyChild();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestLogicalGraphHitIndexBuilder);
@@ -178,4 +180,31 @@ void TestLogicalGraphHitIndexBuilder::testSharedStoreFallsBackWhenNotAForest() {
     CPPUNIT_ASSERT_EQUAL(std::size_t(1), sub.size());
     CPPUNIT_ASSERT_DOUBLES_EQUAL(2.0, sub[0].energy, 1e-6);
   }
+}
+
+// A hit-carrying particle whose child carries no hits but whose grandchild does. The tree
+// is built from hasSimTrack-to-hasSimTrack edges, so the grandchild would land outside the
+// grandparent's subtree run and its hits would go missing from that subgraph. finish()
+// must fall back rather than answer short.
+void TestLogicalGraphHitIndexBuilder::testSharedStoreFallsBackAcrossAGenOnlyChild() {
+  truth::LogicalGraphHitIndexBuilder builder(3, /*sharedSubgraphStore=*/true);
+  builder.setSimTrackForParticle(0, 0, 100);
+  // particle 1 is GEN-only: no SimTrack, so it never carries hits itself.
+  builder.setSimTrackForParticle(2, 0, 102);
+  builder.addParticleChild(0, 1);
+  builder.addParticleChild(1, 2);
+
+  builder.addHit(truth::HitChannel::Calo, 0, 100, 10, 1.0f, 0);
+  builder.addHit(truth::HitChannel::Calo, 0, 102, 20, 2.0f, 1);
+
+  const auto index = builder.finish();
+
+  CPPUNIT_ASSERT(!builder.usedSharedStore());
+  CPPUNIT_ASSERT(!index.sharedSubgraphStore());
+
+  // The grandparent still sees both cells, which is what the fallback protects.
+  auto sub = index.subgraphHits(truth::HitChannel::Calo, 0);
+  CPPUNIT_ASSERT_EQUAL(std::size_t(2), sub.size());
+  CPPUNIT_ASSERT_EQUAL(uint32_t(10), sub[0].detId);
+  CPPUNIT_ASSERT_EQUAL(uint32_t(20), sub[1].detId);
 }

--- a/PhysicsTools/TruthInfo/test/LogicalGraphHitIndexBuilder_t.cpp
+++ b/PhysicsTools/TruthInfo/test/LogicalGraphHitIndexBuilder_t.cpp
@@ -13,7 +13,7 @@
 // These tests lock in the layout property the Branch view relies on: a particle's
 // subgraph hits are a single contiguous std::span, sorted by detId, deduplicated
 // by detId with energy accumulated across the whole subtree. That makes a
-// Subtree branch's hits == subgraphHits(truth::HitChannel::HGCalCalo, root) with zero gather, and orders them
+// Subtree branch's hits == subgraphHits(truth::HitChannel::Calo, root) with zero gather, and orders them
 // for merge-join matching against reco objects.
 class TestLogicalGraphHitIndexBuilder : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(TestLogicalGraphHitIndexBuilder);
@@ -37,15 +37,15 @@ void TestLogicalGraphHitIndexBuilder::testSubgraphHitsAreSortedContiguousAndAccu
   builder.setSimTrackForParticle(1, 0, 101);
   builder.addParticleChild(0, 1);
 
-  builder.addHit(truth::HitChannel::HGCalCalo, 0, 100, /*detId=*/10, /*energy=*/1.0f, /*recHitIndex=*/0);
-  builder.addHit(truth::HitChannel::HGCalCalo, 0, 100, /*detId=*/5, /*energy=*/2.0f, /*recHitIndex=*/1);
+  builder.addHit(truth::HitChannel::Calo, 0, 100, /*detId=*/10, /*energy=*/1.0f, /*recHitIndex=*/0);
+  builder.addHit(truth::HitChannel::Calo, 0, 100, /*detId=*/5, /*energy=*/2.0f, /*recHitIndex=*/1);
   builder.addHit(
-      truth::HitChannel::HGCalCalo, 0, 101, /*detId=*/10, /*energy=*/3.0f, /*recHitIndex=*/0);  // same detId as parent
-  builder.addHit(truth::HitChannel::HGCalCalo, 0, 101, /*detId=*/20, /*energy=*/1.5f, /*recHitIndex=*/2);
+      truth::HitChannel::Calo, 0, 101, /*detId=*/10, /*energy=*/3.0f, /*recHitIndex=*/0);  // same detId as parent
+  builder.addHit(truth::HitChannel::Calo, 0, 101, /*detId=*/20, /*energy=*/1.5f, /*recHitIndex=*/2);
 
   auto index = builder.finish();
 
-  auto sub = index.subgraphHits(truth::HitChannel::HGCalCalo, 0);
+  auto sub = index.subgraphHits(truth::HitChannel::Calo, 0);
   // subtree of 0 = {5, 10, 20}, with detId 10 accumulated across parent+child.
   CPPUNIT_ASSERT_EQUAL(std::size_t(3), sub.size());
   CPPUNIT_ASSERT_EQUAL(uint32_t(5), sub[0].detId);
@@ -58,7 +58,7 @@ void TestLogicalGraphHitIndexBuilder::testSubgraphHitsAreSortedContiguousAndAccu
     CPPUNIT_ASSERT(sub[i - 1].detId < sub[i].detId);
 
   // child subtree is just its own hits.
-  auto subChild = index.subgraphHits(truth::HitChannel::HGCalCalo, 1);
+  auto subChild = index.subgraphHits(truth::HitChannel::Calo, 1);
   CPPUNIT_ASSERT_EQUAL(std::size_t(2), subChild.size());
   CPPUNIT_ASSERT_EQUAL(uint32_t(10), subChild[0].detId);
   CPPUNIT_ASSERT_EQUAL(uint32_t(20), subChild[1].detId);
@@ -67,12 +67,12 @@ void TestLogicalGraphHitIndexBuilder::testSubgraphHitsAreSortedContiguousAndAccu
 void TestLogicalGraphHitIndexBuilder::testDirectHitsAreSortedByDetId() {
   truth::LogicalGraphHitIndexBuilder builder(1);
   builder.setSimTrackForParticle(0, 0, 7);
-  builder.addHit(truth::HitChannel::HGCalCalo, 0, 7, 30, 1.0f, 0);
-  builder.addHit(truth::HitChannel::HGCalCalo, 0, 7, 3, 1.0f, 1);
-  builder.addHit(truth::HitChannel::HGCalCalo, 0, 7, 17, 1.0f, 2);
+  builder.addHit(truth::HitChannel::Calo, 0, 7, 30, 1.0f, 0);
+  builder.addHit(truth::HitChannel::Calo, 0, 7, 3, 1.0f, 1);
+  builder.addHit(truth::HitChannel::Calo, 0, 7, 17, 1.0f, 2);
 
   auto index = builder.finish();
-  auto direct = index.directHits(truth::HitChannel::HGCalCalo, 0);
+  auto direct = index.directHits(truth::HitChannel::Calo, 0);
   CPPUNIT_ASSERT_EQUAL(std::size_t(3), direct.size());
   CPPUNIT_ASSERT_EQUAL(uint32_t(3), direct[0].detId);
   CPPUNIT_ASSERT_EQUAL(uint32_t(17), direct[1].detId);
@@ -94,11 +94,11 @@ void TestLogicalGraphHitIndexBuilder::testSubgraphDiamondCountsSharedDescendantO
   builder.addParticleChild(1, 3);
   builder.addParticleChild(2, 3);
 
-  builder.addHit(truth::HitChannel::HGCalCalo, 0, 103, /*detId=*/50, /*energy=*/2.0f, /*recHitIndex=*/0);
+  builder.addHit(truth::HitChannel::Calo, 0, 103, /*detId=*/50, /*energy=*/2.0f, /*recHitIndex=*/0);
 
   auto index = builder.finish();
 
-  auto sub = index.subgraphHits(truth::HitChannel::HGCalCalo, 0);
+  auto sub = index.subgraphHits(truth::HitChannel::Calo, 0);
   CPPUNIT_ASSERT_EQUAL(std::size_t(1), sub.size());
   CPPUNIT_ASSERT_EQUAL(uint32_t(50), sub[0].detId);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(2.0, sub[0].energy, 1e-6);  // counted once, not 4.0

--- a/PhysicsTools/TruthInfo/test/LogicalGraphHitIndexBuilder_t.cpp
+++ b/PhysicsTools/TruthInfo/test/LogicalGraphHitIndexBuilder_t.cpp
@@ -8,6 +8,9 @@
 #include <cstdint>
 
 #include "SimDataFormats/TruthInfo/interface/LogicalGraphHitIndex.h"
+#include <map>
+#include <vector>
+
 #include "PhysicsTools/TruthInfo/interface/LogicalGraphHitIndexBuilder.h"
 
 // These tests lock in the layout property the Branch view relies on: a particle's
@@ -20,19 +23,23 @@ class TestLogicalGraphHitIndexBuilder : public CppUnit::TestFixture {
   CPPUNIT_TEST(testSubgraphHitsAreSortedContiguousAndAccumulated);
   CPPUNIT_TEST(testDirectHitsAreSortedByDetId);
   CPPUNIT_TEST(testSubgraphDiamondCountsSharedDescendantOnce);
+  CPPUNIT_TEST(testSharedStoreKeepsEachHitOnce);
+  CPPUNIT_TEST(testSharedStoreFallsBackWhenNotAForest);
   CPPUNIT_TEST_SUITE_END();
 
 public:
   void testSubgraphHitsAreSortedContiguousAndAccumulated();
   void testDirectHitsAreSortedByDetId();
   void testSubgraphDiamondCountsSharedDescendantOnce();
+  void testSharedStoreKeepsEachHitOnce();
+  void testSharedStoreFallsBackWhenNotAForest();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestLogicalGraphHitIndexBuilder);
 
 void TestLogicalGraphHitIndexBuilder::testSubgraphHitsAreSortedContiguousAndAccumulated() {
   // particle 0 (track 100) -> child particle 1 (track 101)
-  truth::LogicalGraphHitIndexBuilder builder(2);
+  truth::LogicalGraphHitIndexBuilder builder(2, /*sharedSubgraphStore=*/false);
   builder.setSimTrackForParticle(0, 0, 100);
   builder.setSimTrackForParticle(1, 0, 101);
   builder.addParticleChild(0, 1);
@@ -65,7 +72,7 @@ void TestLogicalGraphHitIndexBuilder::testSubgraphHitsAreSortedContiguousAndAccu
 }
 
 void TestLogicalGraphHitIndexBuilder::testDirectHitsAreSortedByDetId() {
-  truth::LogicalGraphHitIndexBuilder builder(1);
+  truth::LogicalGraphHitIndexBuilder builder(1, /*sharedSubgraphStore=*/false);
   builder.setSimTrackForParticle(0, 0, 7);
   builder.addHit(truth::HitChannel::Calo, 0, 7, 30, 1.0f, 0);
   builder.addHit(truth::HitChannel::Calo, 0, 7, 3, 1.0f, 1);
@@ -84,7 +91,7 @@ void TestLogicalGraphHitIndexBuilder::testSubgraphDiamondCountsSharedDescendantO
   // 0 along two distinct paths; its hit must contribute to subgraphHits(0) exactly
   // once. (Regression: the old recursive child-subgraph merge summed it once per
   // path, since coalesce() sums equal detIds, doubling the energy.)
-  truth::LogicalGraphHitIndexBuilder builder(4);
+  truth::LogicalGraphHitIndexBuilder builder(4, /*sharedSubgraphStore=*/false);
   builder.setSimTrackForParticle(0, 0, 100);
   builder.setSimTrackForParticle(1, 0, 101);
   builder.setSimTrackForParticle(2, 0, 102);
@@ -102,4 +109,73 @@ void TestLogicalGraphHitIndexBuilder::testSubgraphDiamondCountsSharedDescendantO
   CPPUNIT_ASSERT_EQUAL(std::size_t(1), sub.size());
   CPPUNIT_ASSERT_EQUAL(uint32_t(50), sub[0].detId);
   CPPUNIT_ASSERT_DOUBLES_EQUAL(2.0, sub[0].energy, 1e-6);  // counted once, not 4.0
+}
+
+// The shared layout stores every hit exactly once and answers a subgraph as a range of
+// that one store, so the range carries the same per-cell energy as the materialised
+// aggregate once the caller sums the entries that share a detId.
+void TestLogicalGraphHitIndexBuilder::testSharedStoreKeepsEachHitOnce() {
+  auto build = [](bool shared) {
+    truth::LogicalGraphHitIndexBuilder builder(2, shared);
+    builder.setSimTrackForParticle(0, 0, 100);
+    builder.setSimTrackForParticle(1, 0, 101);
+    builder.addParticleChild(0, 1);
+    builder.addHit(truth::HitChannel::Calo, 0, 100, 10, 1.0f, 0);
+    builder.addHit(truth::HitChannel::Calo, 0, 100, 5, 2.0f, 1);
+    builder.addHit(truth::HitChannel::Calo, 0, 101, 10, 3.0f, 0);
+    builder.addHit(truth::HitChannel::Calo, 0, 101, 20, 1.5f, 2);
+    return builder.finish();
+  };
+
+  const auto materialised = build(false);
+  const auto shared = build(true);
+
+  CPPUNIT_ASSERT(!materialised.sharedSubgraphStore());
+  CPPUNIT_ASSERT(shared.sharedSubgraphStore());
+
+  // Four hits went in. The materialised layout also keeps a second, aggregated copy;
+  // the shared one keeps no duplicate storage at all.
+  auto const& sharedChannel = shared.channel(truth::HitChannel::Calo);
+  CPPUNIT_ASSERT_EQUAL(std::size_t(4), sharedChannel.directHits.size());
+  CPPUNIT_ASSERT(sharedChannel.subgraphHits.empty());
+  CPPUNIT_ASSERT(!materialised.channel(truth::HitChannel::Calo).subgraphHits.empty());
+
+  // Same physics content for the root's subgraph: detId 10 sums parent and child.
+  std::vector<truth::LogicalGraphHitIndex::Hit> hits;
+  shared.appendSubgraphHits(truth::HitChannel::Calo, 0, hits);
+  std::map<uint32_t, float> summed;
+  for (auto const& hit : hits)
+    summed[hit.detId] += hit.energy;
+
+  CPPUNIT_ASSERT_EQUAL(std::size_t(3), summed.size());
+  CPPUNIT_ASSERT_DOUBLES_EQUAL(2.0, summed[5], 1e-6);
+  CPPUNIT_ASSERT_DOUBLES_EQUAL(4.0, summed[10], 1e-6);
+  CPPUNIT_ASSERT_DOUBLES_EQUAL(1.5, summed[20], 1e-6);
+}
+
+// A hit-carrying particle with two hit-carrying parents cannot be one contiguous run
+// under either of them, so finish() must fall back rather than answer a short subgraph.
+void TestLogicalGraphHitIndexBuilder::testSharedStoreFallsBackWhenNotAForest() {
+  truth::LogicalGraphHitIndexBuilder builder(4, /*sharedSubgraphStore=*/true);
+  builder.setSimTrackForParticle(0, 0, 100);
+  builder.setSimTrackForParticle(1, 0, 101);
+  builder.setSimTrackForParticle(2, 0, 102);
+  builder.setSimTrackForParticle(3, 0, 103);
+  builder.addParticleChild(0, 1);
+  builder.addParticleChild(0, 2);
+  builder.addParticleChild(1, 3);
+  builder.addParticleChild(2, 3);
+  builder.addHit(truth::HitChannel::Calo, 0, 103, 50, 2.0f, 0);
+
+  const auto index = builder.finish();
+
+  CPPUNIT_ASSERT(!builder.usedSharedStore());
+  CPPUNIT_ASSERT(!index.sharedSubgraphStore());
+
+  // Both parents of 3 still see its hit, which is what the fallback buys.
+  for (const uint32_t root : {0u, 1u, 2u}) {
+    auto sub = index.subgraphHits(truth::HitChannel::Calo, root);
+    CPPUNIT_ASSERT_EQUAL(std::size_t(1), sub.size());
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(2.0, sub[0].energy, 1e-6);
+  }
 }

--- a/SimDataFormats/TruthInfo/interface/LogicalGraphHitIndex.h
+++ b/SimDataFormats/TruthInfo/interface/LogicalGraphHitIndex.h
@@ -20,10 +20,10 @@ namespace truth {
   // outer by detector radius. The value is the channel index and must stay stable;
   // code refers to channels by name, never by literal index.
   enum class HitChannel : uint8_t {
-    Tracker = 0,    // tracker PSimHits, energy = energyLoss, no recHit link
-    MTD = 1,        // MIP timing layer (BTL/ETL)
-    HGCalCalo = 2,  // calorimeter PCaloHits, recHit-mapped via the DetId->RecHit map
-    Muon = 3        // muon chambers (DT/CSC/RPC/GEM)
+    Tracker = 0,  // tracker PSimHits, energy = energyLoss, no recHit link
+    MTD = 1,      // MIP timing layer (BTL/ETL)
+    Calo = 2,  // all calorimeter PCaloHits (HGCAL endcap + ECAL barrel + HCAL), recHit-mapped via the DetId->RecHit map
+    Muon = 3   // muon chambers (DT/CSC/RPC/GEM)
   };
   inline constexpr std::size_t kNumHitChannels = 4;
 

--- a/SimDataFormats/TruthInfo/interface/LogicalGraphHitIndex.h
+++ b/SimDataFormats/TruthInfo/interface/LogicalGraphHitIndex.h
@@ -39,15 +39,39 @@ namespace truth {
       [[nodiscard]] bool hasRecHit() const { return recHitIndex != kInvalidRecHitIndex; }
     };
 
-    // One detector channel: per-particle direct hits and subgraph-aggregated hits,
-    // each stored CSR-style (offsets index into the flat hit storage). Empty when
-    // the channel is not filled. Members are public so the dictionary and the
-    // associator's flat scans can reach them directly.
+    // One detector channel. Two storage layouts exist, and which one an index carries
+    // is a property of the data, not of the reading job: sharedSubgraphStore() reports
+    // it and the accessors below handle both, so an index written either way reads back
+    // correctly.
+    //
+    //   materialised: directOffsets/directHits hold each particle's own hits, and
+    //       subgraphOffsets/subgraphHits hold a second, coalesced copy of every
+    //       descendant's hits under each ancestor. A hit is stored once per ancestor
+    //       that contains it. Written by every index that predates the shared layout.
+    //
+    //   shared (the default): dfsOffsets/directHits hold each hit exactly once, ordered
+    //       so that a particle's descendants occupy the slots right after it. A subgraph
+    //       is then a set of ranges of that single store and costs no hit storage at
+    //       all. The hits of a range are in tree order rather than detId order and
+    //       repeat a detId hit by several descendants, so a consumer that needs per-cell
+    //       energies coalesces them.
+    //
+    // Members are public so the dictionary and the associator's flat scans can reach
+    // them directly.
     struct Channel {
       std::vector<uint32_t> directOffsets;
       std::vector<Hit> directHits;
       std::vector<uint32_t> subgraphOffsets;
       std::vector<Hit> subgraphHits;
+      std::vector<uint32_t> dfsOffsets;
+    };
+
+    // A run of consecutive DFS slots. Particles that carry hits own exactly one, their
+    // own subtree. A GEN-only particle owns as many as it takes to cover the SIM
+    // subtrees below it: the GEN half is a DAG, so its descendants are not one run.
+    struct SlotRange {
+      uint32_t firstSlot = 0;
+      uint32_t slotCount = 0;
     };
 
     LogicalGraphHitIndex() = default;
@@ -55,28 +79,96 @@ namespace truth {
     LogicalGraphHitIndex(uint32_t nParticles, std::vector<Channel> channels)
         : nParticles_(nParticles), channels_(std::move(channels)) {}
 
+    LogicalGraphHitIndex(uint32_t nParticles,
+                         std::vector<Channel> channels,
+                         std::vector<uint32_t> dfsPos,
+                         std::vector<uint32_t> rangeOffsets,
+                         std::vector<SlotRange> ranges)
+        : nParticles_(nParticles),
+          channels_(std::move(channels)),
+          dfsPos_(std::move(dfsPos)),
+          rangeOffsets_(std::move(rangeOffsets)),
+          ranges_(std::move(ranges)) {}
+
+    // True when the shared layout is in use. The DFS slot of a particle and the ranges
+    // its subgraph covers are properties of the tree, so they are stored once for the
+    // whole index rather than per channel.
+    [[nodiscard]] bool sharedSubgraphStore() const { return !dfsPos_.empty(); }
+    [[nodiscard]] std::vector<uint32_t> const& dfsPos() const { return dfsPos_; }
+
+    // The slot ranges a particle's subgraph covers. Empty in the materialised layout.
+    [[nodiscard]] std::span<const SlotRange> subgraphRanges(uint32_t particleId) const {
+      if (particleId + 1 >= rangeOffsets_.size())
+        return {};
+      const auto begin = rangeOffsets_[particleId];
+      const auto end = rangeOffsets_[particleId + 1];
+      return std::span<const SlotRange>(ranges_.data() + begin, end - begin);
+    }
+
+    // The hits of one slot range in a channel.
+    [[nodiscard]] std::span<const Hit> rangeHits(HitChannel channel, SlotRange range) const {
+      Channel const* channelData = channelOrNull(channel);
+      if (channelData == nullptr || range.slotCount == 0)
+        return {};
+      if (range.firstSlot + range.slotCount >= channelData->dfsOffsets.size())
+        return {};
+      const auto begin = channelData->dfsOffsets[range.firstSlot];
+      const auto end = channelData->dfsOffsets[range.firstSlot + range.slotCount];
+      return std::span<const Hit>(channelData->directHits.data() + begin, end - begin);
+    }
+
     [[nodiscard]] uint32_t nParticles() const { return nParticles_; }
     [[nodiscard]] static constexpr std::size_t nChannels() { return kNumHitChannels; }
 
     // Direct hits of a particle in a channel (the hits on its own SimTrack).
     [[nodiscard]] std::span<const Hit> directHits(HitChannel channel, uint32_t particleId) const {
       Channel const* channelData = channelOrNull(channel);
-      if (channelData == nullptr || particleId + 1 >= channelData->directOffsets.size())
+      if (channelData == nullptr)
+        return {};
+      if (sharedSubgraphStore()) {
+        if (particleId >= dfsPos_.size())
+          return {};
+        return rangeHits(channel, SlotRange{dfsPos_[particleId], 1});
+      }
+      if (particleId + 1 >= channelData->directOffsets.size())
         return {};
       const auto begin = channelData->directOffsets[particleId];
       const auto end = channelData->directOffsets[particleId + 1];
       return std::span<const Hit>(channelData->directHits.data() + begin, end - begin);
     }
 
-    // Subgraph hits of a particle in a channel (its own hits plus those of every
-    // logical descendant), coalesced and sorted by detId.
+    // A particle's own hits plus those of every descendant, as one span. Coalesced and
+    // sorted by detId in the materialised layout. In the shared layout this is valid
+    // only for a particle whose subgraph is a single range, which is every particle
+    // that carries hits; a GEN-only particle spans several ranges and returns empty
+    // here, so a consumer that must handle those iterates subgraphRanges instead.
     [[nodiscard]] std::span<const Hit> subgraphHits(HitChannel channel, uint32_t particleId) const {
       Channel const* channelData = channelOrNull(channel);
-      if (channelData == nullptr || particleId + 1 >= channelData->subgraphOffsets.size())
+      if (channelData == nullptr)
+        return {};
+      if (sharedSubgraphStore()) {
+        const auto ranges = subgraphRanges(particleId);
+        return ranges.size() == 1 ? rangeHits(channel, ranges[0]) : std::span<const Hit>{};
+      }
+      if (particleId + 1 >= channelData->subgraphOffsets.size())
         return {};
       const auto begin = channelData->subgraphOffsets[particleId];
       const auto end = channelData->subgraphOffsets[particleId + 1];
       return std::span<const Hit>(channelData->subgraphHits.data() + begin, end - begin);
+    }
+
+    // Append a particle's subgraph hits, whichever layout is in use. The only accessor
+    // that is correct for every particle in both layouts.
+    void appendSubgraphHits(HitChannel channel, uint32_t particleId, std::vector<Hit>& out) const {
+      if (!sharedSubgraphStore()) {
+        const auto span = subgraphHits(channel, particleId);
+        out.insert(out.end(), span.begin(), span.end());
+        return;
+      }
+      for (auto const& range : subgraphRanges(particleId)) {
+        const auto span = rangeHits(channel, range);
+        out.insert(out.end(), span.begin(), span.end());
+      }
     }
 
     [[nodiscard]] bool hasChannel(HitChannel channel) const {
@@ -98,6 +190,12 @@ namespace truth {
 
     uint32_t nParticles_ = 0;
     std::vector<Channel> channels_;  // size kNumHitChannels when built
+
+    // Non-empty only in the shared layout: the DFS slot of each particle, and the slot
+    // ranges of each particle's subgraph, CSR-style.
+    std::vector<uint32_t> dfsPos_;
+    std::vector<uint32_t> rangeOffsets_;
+    std::vector<SlotRange> ranges_;
   };
 
 }  // namespace truth

--- a/SimDataFormats/TruthInfo/src/classes_def.xml
+++ b/SimDataFormats/TruthInfo/src/classes_def.xml
@@ -27,17 +27,23 @@
   <class name="std::vector<truth::VertexData>"/>
   <class name="edm::Wrapper<truth::Graph>"/>
 
-  <class name="truth::LogicalGraphHitIndex" ClassVersion="3">
+  <class name="truth::LogicalGraphHitIndex" ClassVersion="4">
+    <version ClassVersion="4" checksum="1362593623"/>
     <version ClassVersion="3" checksum="1046280499"/>
   </class>
   <class name="truth::LogicalGraphHitIndex::Hit" ClassVersion="3">
     <version ClassVersion="3" checksum="611807671"/>
   </class>
   <class name="std::vector<truth::LogicalGraphHitIndex::Hit>"/>
-  <class name="truth::LogicalGraphHitIndex::Channel" ClassVersion="3">
+  <class name="truth::LogicalGraphHitIndex::Channel" ClassVersion="4">
+    <version ClassVersion="4" checksum="2575462028"/>
     <version ClassVersion="3" checksum="1904217884"/>
   </class>
   <class name="std::vector<truth::LogicalGraphHitIndex::Channel>"/>
+  <class name="truth::LogicalGraphHitIndex::SlotRange" ClassVersion="3">
+    <version ClassVersion="3" checksum="558917159"/>
+  </class>
+  <class name="std::vector<truth::LogicalGraphHitIndex::SlotRange>"/>
   <class name="edm::Wrapper<truth::LogicalGraphHitIndex>"/>
 
   <!-- The ticl::AssociationMap<mapWithSharedEnergyAndScore> (raw-index variant) and

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -348,9 +348,11 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         CheckTrack = cms.untracked.bool(False),
         EndPrintTrackID = cms.int32(0),
         # Reattach SimVertices whose parent SimTrack was dropped (PersistencyEmin) to
-        # the nearest stored ancestor so SimVertex::parentIndex never orphans. Off by
-        # default; enabled by the enableTruth process modifier (truth-graph workflows).
-        ReconnectDroppedAncestors = cms.bool(False)
+        # the nearest stored ancestor so SimVertex::parentIndex never orphans. On
+        # unconditionally: it is a general SimVertex-connectivity correctness fix, it
+        # does not change the detector sim-hits, and it is essentially free (measured
+        # ~0% SIM CPU, no output-size growth).
+        ReconnectDroppedAncestors = cms.bool(True)
     ),
     SteppingAction = cms.PSet(
         common_MCtruth,
@@ -823,14 +825,10 @@ fixLongLivedSleptonSim.toModify( g4SimHits,
 ## threshold the intermediate low-energy ancestors are dropped and the production
 ## SimVertex of a stored secondary gets parentIndex = -1, fragmenting the truth
 ## graph into components disconnected from the generator. ReconnectDroppedAncestors
-## (a baseline TrackingAction parameter, default False above) reattaches each such
+## (a baseline TrackingAction parameter, now default True above) reattaches each such
 ## vertex to its nearest stored ancestor, so SimVertex::parentIndex always resolves
 ## (no orphans) without the SimTrack/SimVertex multiplicity blow-up of
-## PersistencyEmin = 0 - the dropped intermediate nodes are collapsed into shortcut
+## PersistencyEmin = 0: the dropped intermediate nodes are collapsed into shortcut
 ## edges (measured ~65% fewer SimTracks than PersistencyEmin = 0, same
-## one-component-per-event connectivity). Enabled only under enableTruth.
-##
-from Configuration.ProcessModifiers.enableTruth_cff import enableTruth
-enableTruth.toModify( g4SimHits,
-                      TrackingAction = dict(ReconnectDroppedAncestors = True)
-)
+## one-component-per-event connectivity). It is on unconditionally (no process
+## modifier needed): a general connectivity fix, detector-neutral, essentially free.

--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -142,3 +142,15 @@ premix_stage1.toModify(theDigitizersValid, _customizePremixStage1)
 def _loadPremixStage2Aliases(process):
     process.load("SimGeneral.MixingModule.aliases_PreMix_cfi")
 modifyDigitizers_loadPremixStage2Aliases = premix_stage2.makeProcessModifier(_loadPremixStage2Aliases)
+
+# Pileup-aware MC-truth graph: register the TruthGraphAccumulator in the mixing
+# digitizers under enableTruth (Phase-2 HGCal only). It builds the merged
+# signal+pileup raw TruthGraph during mixing; the logical graph + hit index are then
+# built right after mixing (Configuration/StandardSequences/Digi_cff).
+from Configuration.ProcessModifiers.enableTruth_cff import enableTruth
+from PhysicsTools.TruthInfo.truthGraphMixedDigi_cff import truthGraphAccumulator as _truthGraphAccumulator
+for _theDigis in (theDigitizers, theDigitizersValid):
+    (enableTruth & phase2_hgcal).toModify(_theDigis, truthGraph=_truthGraphAccumulator)
+    # Premixing has no raw pileup g4SimHits for the accumulator to read, so drop it
+    # under premix even if enableTruth is on (applied after, so it wins by code order).
+    premix_stage2.toModify(_theDigis, truthGraph=None)

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -67,12 +67,14 @@ globalPrevalidation = cms.Sequence(
 )
 
 from Configuration.ProcessModifiers.enableTruth_cff import enableTruth
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 # The truth Branch validation is wired into the baseCommon{PreValidation,Validation}
 # sequences below (after they are defined): the monolithic globalPrevalidation /
 # globalValidation are NOT in the Phase-2 autoValidation assembly, so attaching there
-# would silently never run for the Run4 (.88) truth workflows. These imports make the
-# modules visible for labelling when the process loads this cff (import * idiom).
-from Validation.Configuration.truthPrevalidation_cff import *
+# would silently never run for the Run4 truth workflows. The truth graph + hit index
+# are built at DIGI (mixing accumulator chain) under enableTruth, so truthPrevalidation
+# is deliberately NOT imported here (importing its signal-only build producers would
+# attach them to the RECO process and shadow the DIGI-built products).
 from PhysicsTools.TruthInfo.truthGraphValidation_cff import *
 
 # filter/producer "pre-" sequence for validation_preprod
@@ -141,21 +143,31 @@ from Validation.Configuration.me0SimValid_cff import *
 baseCommonPreValidation = cms.Sequence(cms.SequencePlaceholder("mix"))
 baseCommonValidation = cms.Sequence()
 
-# Branch performance-plot validation, gated by enableTruth (only the Run4 .88 truth
-# workflows). baseCommon{PreValidation,Validation} are part of the 'baseValidation'
+# Branch performance-plot validation, gated by enableTruth, which the Run4 eras apply
+# from Phase2C17I13M9 onwards (the .88 workflow variant applies it explicitly on top of
+# a non-truth era). baseCommon{PreValidation,Validation} are part of the 'baseValidation'
 # triplet that autoValidation['phase2Validation'] always schedules, so this is the
 # Phase-2 entry point: the truth-graph + association EDProducers run in the
 # prevalidation Path, the DQM analyzers in the validation EndPath. The matching
 # harvesting is attached to postValidation_common in postValidation_cff. The
 # reco-side eff/fake/merge/duplicate validators stay opt-in (antichain caveat, see
 # truthGraphValidation_cff).
+# premix_stage2 keeps enableTruth (it comes from the era) but the premixed pileup has
+# no raw pileup SimTracks, so the accumulator and the DIGI build are dropped and the
+# truth products do not exist downstream. Revert to the truth-free sequences there,
+# after the enableTruth lines, so the later statement wins.
+_baseCommonPreValidationNoTruth = baseCommonPreValidation.copy()
+_baseCommonValidationNoTruth = baseCommonValidation.copy()
+
 _baseCommonPreValidationWithTruth = baseCommonPreValidation.copy()
 _baseCommonPreValidationWithTruth += truthGraphValidationProducers
 enableTruth.toReplaceWith(baseCommonPreValidation, _baseCommonPreValidationWithTruth)
+premix_stage2.toReplaceWith(baseCommonPreValidation, _baseCommonPreValidationNoTruth)
 
 _baseCommonValidationWithTruth = baseCommonValidation.copy()
 _baseCommonValidationWithTruth += truthGraphValidationAnalyzers
 enableTruth.toReplaceWith(baseCommonValidation, _baseCommonValidationWithTruth)
+premix_stage2.toReplaceWith(baseCommonValidation, _baseCommonValidationNoTruth)
 
 # Tracking-only validation
 globalPrevalidationTrackingOnly = cms.Sequence(

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -79,15 +79,21 @@ postValidation_common = cms.Sequence()
 # enableTruth (Run4 .88 truth workflows). postValidation_common is the harvesting
 # member of the 'baseValidation' triplet that autoValidation['phase2Validation']
 # schedules - the counterpart of the baseCommon{PreValidation,Validation} hook in
-# globalValidation_cff. The .88 workflows therefore also apply enableTruth to the
-# HARVESTGlobal step (see Configuration/PyReleaseValidation). Import * so the
+# globalValidation_cff. The .88 workflow variant therefore also applies enableTruth to
+# the HARVESTGlobal step (see Configuration/PyReleaseValidation), and the Run4 eras
+# apply it to every step of their workflows. Import * so the
 # harvester modules are labelled when the process loads this cff; reco-side
 # harvesters stay opt-in (see truthGraphDQMHarvester_cff).
 from Configuration.ProcessModifiers.enableTruth_cff import enableTruth
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 from PhysicsTools.TruthInfo.truthGraphDQMHarvester_cff import *
+# premix_stage2 builds no truth products (see globalValidation_cff), so the harvesting
+# reverts to the truth-free sequence there; the later statement wins.
+_postValidationCommonNoTruth = postValidation_common.copy()
 _postValidationCommonWithTruth = postValidation_common.copy()
 _postValidationCommonWithTruth += truthGraphDQMHarvesting
 enableTruth.toReplaceWith(postValidation_common, _postValidationCommonWithTruth)
+premix_stage2.toReplaceWith(postValidation_common, _postValidationCommonNoTruth)
 
 postValidation_trackingOnly = cms.Sequence(
       postProcessorTrackSequenceTrackingOnly


### PR DESCRIPTION
Turns the pileup-aware MC-truth graph on for Run4, wired entirely under the `enableTruth` process modifier and added to the `Phase2C22I13M9` era (so `Phase2C26I13M9` and the `noMkFit` variants inherit it). No special workflow is needed.

The truth is built once, at the mixing/DIGI step, where the merged signal+pileup sim-hits are live: the `TruthGraphAccumulator` builds the merged raw graph during mixing, and the logical graph plus a per-particle per-cell hit index are built right after it. RECO consumes those products (the branch validators and association producers read them by `DetId`); it does not rebuild anything.

## Event-content levels

Two orthogonal choices. The first is the one that matters for cost; the second is an advanced
option for special downstream consumers.


### 1. Detector scope (the size/cost lever)

| Level | Channels captured + indexed | Use |
|---|---|---|
| **`default`: full detector** | Calo (HGCAL + ECAL barrel + HCAL), **Tracker**, **Muon**, **MTD** | Complete truth for **track-based** candidate matching: a `TICLCandidate` is two-channel (calo shared-energy plus tracker shared-hits), so full particle-flow / candidate-PID validation needs the tracker channel. |
| **`reduced`: calo + MTD + muon** | above **minus Tracker** | Cost-sensitive opt-out (`customiseTruthReduced`): drops the tracker, the largest sim-hit family, keeping the calorimeter + timing + muon truth a calo-only TICL study needs. |

The default is the **full detector**: it captures every channel a two-channel candidate metric needs.
`reduced` (`customiseTruthReduced`) drops only the tracker `PSimHit`s, which dominate the merged sim-hit volume, for a cheaper calo + MTD + muon truth. The calorimeter channel `HitChannel::Calo` holds all calorimetry (HGCAL endcap plus ECAL barrel and HCAL), keyed by DetId type.

### 2. Persistence of the per-cell footprint (advanced, orthogonal)

Every level persists the compact truth:

- `truthLogicalGraphProducer`, the navigable Particle-Vertex logical graph;
- `truthLogicalGraphHitIndexProducer`, the per-particle per-cell hit index, **unresolved** (`recHitMap=""`). It is keyed by `DetId`, which is what the shared-energy association matches on, so the same index serves L1, HLT and offline RECO; `recHitIndex` is resolved on demand per stage;
- `TruthGraph_mix`, the raw merged CSR graph (small; the branch validators consume it and it allows
  an offline rebuild).

An opt-in `+simHits` variant additionally keeps the merged sim-hits (`mix:merged*Hits`). It is the only variant that lets a consumer rebuild the association at a **different granularity** (e.g. L1 trigger cells) or with a different metric, at the cost of the raw sim-hit size. Not needed for standard calo/tracker shared-energy truth.

### Why the index is unresolved and DetId-keyed

The association layer (`BranchHitAssociator`) matches reco objects to truth branches by `DetId`, computing a hits-and-fractions shared energy with the **per-cell total sim energy as the denominator**. Because it is `DetId`-based, the DIGI-built index is stage-independent and the bulky merged sim-hits never have to cross the DIGI to RECO boundary in the default content. 

## Cost (measured)

A/B (truth off vs on), single-thread, rough and directional (2 to 3 events), not a production benchmark.

**GEN-SIM**: `g4SimHits.TrackingAction.ReconnectDroppedAncestors` is now a baseline default, on unconditionally (no longer gated by `enableTruth`). It is a general SimVertex-connectivity correctness fix, not truth-specific: it only fixes up `SimVertex::parentIndex` so nothing orphans.
Measured essentially free (TTbar: CPU ~0%, output size unchanged, peak RSS within noise). All the truth cost is at DIGI. Because every GEN-SIM now has this connectivity, no truth-specific MinBias pileup sample is needed.

**DIGI** (PU200, DIGI+L1 step), both content levels:

| Metric | `default` (full detector) | `reduced` (calo + MTD + muon) |
|---|---|---|
| Total CPU | **~+23%** | ~+8% |
| Peak RSS | +290 MB (+6%) | +247 MB (+5%) |
| DIGI-RAW size | **~+11.7 MB/ev (~17%)** | ~+9.5 MB/ev (~14%) |

(Muon is a ~1k hits/event family, so it does not move the calo + MTD numbers.)

DIGI-RAW breakdown for `reduced` (per event, compressed): hit index ~6.3 MB, raw graph ~2.8, logical
graph ~0.4. The tracker merge and its index channel are the bulk of the difference between the levels:
the default roughly triples the DIGI CPU delta versus reduced for about 2 MB/ev more output.

Per-module profiling: the truth build producers cost ~0.4 s/event (negligible). The entire cost is the accumulator's sim-hit merge inside the MixingModule. Sim-hit families merged per event at PU200 (full level, for reference): ECAL 1.9M, HGCal 0.56M, tracker 0.55M, MTD 0.12M, HCAL 40k, muon 1k.

It's excluded where it cannot work:

- **Premixing** (`premix_stage2`): premixed pileup carries no raw pileup `SimTrack`s, so the
  accumulator has nothing to build from. The accumulator and the build are dropped under premix.
- **FastSim**: no full-sim `g4SimHits`; the `fastSimPhase2` helper drops `enableTruth` from every FastSim era.

