### PR TITLE
Reduce GPU kernel spill due to the PixelTracking CA

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/alpaka/CACell.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CACell.h
@@ -220,6 +220,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                       int8_t* __restrict__ nLayers,
                                                       float* __restrict__ pt,
                                                       TmpTuple& tmpNtuplet,
+                                                      hindex_type* __restrict__ hits,
                                                       const unsigned int minHitsPerNtuplet,
                                                       const float preCurvature = kUninitializeCurvature) const {
       // the building process for a track ends if:
@@ -296,6 +297,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                                nLayers,
                                                                pt,
                                                                tmpNtuplet,
+                                                               hits,
                                                                minHitsPerNtuplet,
                                                                thisCurvature);
           }
@@ -307,7 +309,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           // if long enough save...
           if (nl >= minHitsPerNtuplet) {
             {
-              hindex_type hits[TrackerTraits::maxHitsOnTrack];  // maxHitsOnTracks takes fishbone hits into account
               uint32_t nh = 0U;
               uint32_t nfb = 0U;
               for (auto c : tmpNtuplet) {

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernelsImpl.h
@@ -771,6 +771,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
 
         if (doit) {
           typename Cell::TmpTuple stack;
+          typename Cell::hindex_type hits[TrackerTraits::maxHitsOnTrack];  // considering fishbone hits
 
           stack.reset();
           thisCell.template find_ntuplets<maxDepth>(acc,
@@ -787,6 +788,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
                                                     tracks_view.nLayers().data(),
                                                     tracks_view.pt().data(),
                                                     stack,
+                                                    hits,
                                                     params.minHitsPerNtuplet_);
           ALPAKA_ASSERT_ACC(stack.empty());
         }


### PR DESCRIPTION
#### PR description:

With the introduction of the new `cudaKernelStackBudget` tool in #51395, it was noted that the largest kernel spill in a typical Phase-2 configuration was due to the `find_ntuplets` kernel of the PixelTracking CA. This PR proposes a fix to significantly reduce the spill.
The kernel is templated on a `maxDepth` parameter (currently 12), which leads to the creation (and allocation in thread-local memory) of multiple copies of the kernel-local `hits` array after template unrolling. The fix instead passes the hits indexes array as a kernel argument removing the duplication entirely.

#### PR validation:

The code compiles and runs, producing identical result in a typical Phase-2 TTbar workflow (comparison plots [here](https://lferragi.web.cern.ch/plots/tracking_phase2/reduceCASpill/hltPhase2Pixel_hltAssociatorByHits/)).

Furthermore, the output of `cudaKernelStackBudget` changes significantly.
Before:
```
device 0: NVIDIA H100 NVL (compute capability 9.0, sm_90)
  max resident threads: 270336
  reservation (launched kernels): 301.1 MiB (315752448 B) = 270336 threads x 1168 B
      largest stack frame 1168 B in pluginRecoTrackerPixelSeedingPortableCudaAsync.so
      kernel: alpaka_cuda_async::caHitNtupletGeneratorKernels::Kernel_find_ntuplets<pixelTopology::Phase2OT>  [hltPhase2PixelTracksSoA]
      shared memory: 1024 B total = 1024 B static + 0 B dynamic
```
After:
```
device 0: NVIDIA H100 NVL (compute capability 9.0, sm_90)
  max resident threads: 270336
  reservation (launched kernels): 78.4 MiB (82182144 B) = 270336 threads x 304 B
      largest stack frame 304 B in pluginRecoLocalTrackerSiPixelClusterizerPluginsPortableCudaAsync.so
      kernel: alpaka_cuda_async::pixelClustering::FindClus<pixelTopology::Phase2>  [hltPhase2SiPixelClustersSoA]
      shared memory: 36752 B total = 36752 B static + 0 B dynamic
```
(`kernel_find_ntuplets` sits at 160 B STACK after)

The reduction in the largest stack frame is expect to show up as a meaningful reduction in the overall GPU memory usage during benchmarks (~220 MiB per job).