### PR TITLE
[17_0_X] Add PbPb egamma regression

### DIFF
--- a/Configuration/ProcessModifiers/python/hiEGReg_cff.py
+++ b/Configuration/ProcessModifiers/python/hiEGReg_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+#modifier to enable egamma energy regression for heavy-ion data
+hiEGReg = cms.Modifier()

--- a/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_HIN_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_HIN_tools.py
@@ -10,7 +10,12 @@ def miniAODFromMiniAOD_customizeCommon(process):
     # Update egamma regression
     ###########################################################################
     def _updateEGRegression(process):
-        from RecoEgamma.EgammaTools.regressionModifier_cfi import regressionModifier
+        process.load('RecoHI.HiJetAlgos.PackedPFTowers_cfi')
+        from RecoHI.HiJetAlgos.hiPuRhoProducer_cfi import hiPuRhoProducer
+        process.hiRhoForEGReg = hiPuRhoProducer.clone(src = 'PackedPFTowers')
+        task.add(process.PackedPFTowers)
+        task.add(process.hiRhoForEGReg)
+        from RecoEgamma.EgammaTools.regressionModifier_cfi import regressionModifierHIN as regressionModifier
         for obj in ['Electron','Photon']:
             setattr(process,f'slimmed{obj}s',cms.EDProducer(f"Modified{obj}Producer",
                 src = cms.InputTag(f'slimmed{obj}s::@skipCurrentProcess'),
@@ -19,8 +24,9 @@ def miniAODFromMiniAOD_customizeCommon(process):
             task.add(getattr(process,f'slimmed{obj}s'))
             cols.append(f'slimmed{obj}s')
 
+    from Configuration.ProcessModifiers.hiEGReg_cff import hiEGReg
     from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
-    pp_on_PbPb_run3.toModify(process, _updateEGRegression)
+    (hiEGReg & pp_on_PbPb_run3).toModify(process, _updateEGRegression)
 
     ###########################################################################
     # Add secondary vertex

--- a/RecoEcal/Configuration/python/RecoEcal_cff.py
+++ b/RecoEcal/Configuration/python/RecoEcal_cff.py
@@ -39,3 +39,8 @@ _ecalClustersHITask = ecalClustersTask.copy()
 _ecalClustersHITask.add(islandClusteringTask)
 for e in [pA_2016, peripheralPbPb, pp_on_AA, pp_on_XeXe_2017, ppRef_2017]:
     e.toReplaceWith(ecalClustersTask, _ecalClustersHITask)
+
+from Configuration.ProcessModifiers.hiEGReg_cff import hiEGReg
+from RecoHI.HiJetAlgos.hiPuRhoProducer_cfi import hiPuRhoProducer as _hiPuRho
+hiRhoForEGReg = _hiPuRho.clone(src = 'towerMaker')
+hiEGReg.toReplaceWith(ecalClustersTask, ecalClustersTask.copyAndAdd(hiRhoForEGReg))

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -34,3 +34,11 @@ from Configuration.Eras.Modifier_run3_egamma_cff import run3_egamma
     uncertaintyKeyEB = 'pfscecal_ebUncertainty_offline_v2',
     regressionKeyEE  = 'pfscecal_eeCorrection_offline_v2',
     uncertaintyKeyEE = 'pfscecal_eeUncertainty_offline_v2'))
+
+from Configuration.ProcessModifiers.hiEGReg_cff import hiEGReg
+hiEGReg.toModify(particleFlowSuperClusterECAL, regressionConfig = dict(
+    rhoMaps = ["hiRhoForEGReg:mapEtaEdges", "hiRhoForEGReg:mapToRho"],
+    regressionKeyEB  = 'pfscecal_EBCorrection_HIN_offline',
+    uncertaintyKeyEB = 'pfscecal_EBUncertainty_HIN_offline',
+    regressionKeyEE  = 'pfscecal_EECorrection_HIN_offline',
+    uncertaintyKeyEE = 'pfscecal_EEUncertainty_HIN_offline'))

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -285,3 +285,52 @@ from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_low
 )
 
 egamma_lowPt_exclusive.toReplaceWith(regressionModifier,regressionModifier103XLowPtPho)
+
+# Regression for heavy-ion data
+regressionModifierHIN = regressionModifierRun3.clone(
+    rhoMaps = ["hiRhoForEGReg:mapEtaEdges", "hiRhoForEGReg:mapToRho"],
+    eleRegs = dict(
+        ecalOnlyMean = dict(
+            ebLowEtForestName = cms.ESInputTag("", "electron_eb_ecalOnly_HIN_1To500_0p2To2_mean"),
+            ebHighEtForestName = cms.ESInputTag("", "electron_eb_ecalOnly_HIN_1To500_0p2To2_mean"),
+            eeLowEtForestName = cms.ESInputTag("", "electron_ee_ecalOnly_HIN_1To500_0p2To2_mean"),
+            eeHighEtForestName = cms.ESInputTag("", "electron_ee_ecalOnly_HIN_1To500_0p2To2_mean"),
+        ),
+        ecalOnlySigma = dict(
+            ebLowEtForestName = cms.ESInputTag("", "electron_eb_ecalOnly_HIN_1To500_0p0002To0p5_sigma"),
+            ebHighEtForestName = cms.ESInputTag("", "electron_eb_ecalOnly_HIN_1To500_0p0002To0p5_sigma"),
+            eeLowEtForestName = cms.ESInputTag("", "electron_ee_ecalOnly_HIN_1To500_0p0002To0p5_sigma"),
+            eeHighEtForestName = cms.ESInputTag("", "electron_ee_ecalOnly_HIN_1To500_0p0002To0p5_sigma"),
+        ),
+        epComb = dict(
+            ecalTrkRegressionConfig = dict(
+                ebLowEtForestName = cms.ESInputTag("", 'electron_eb_ecalTrk_HIN_1To500_0p2To2_mean'),
+                ebHighEtForestName = cms.ESInputTag("", 'electron_eb_ecalTrk_HIN_1To500_0p2To2_mean'),
+                eeLowEtForestName = cms.ESInputTag("", 'electron_ee_ecalTrk_HIN_1To500_0p2To2_mean'),
+                eeHighEtForestName = cms.ESInputTag("", 'electron_ee_ecalTrk_HIN_1To500_0p2To2_mean'),
+            ),
+            ecalTrkRegressionUncertConfig = dict(
+                ebLowEtForestName = cms.ESInputTag("", 'electron_eb_ecalTrk_HIN_1To500_0p0002To0p5_sigma'),
+                ebHighEtForestName = cms.ESInputTag("", 'electron_eb_ecalTrk_HIN_1To500_0p0002To0p5_sigma'),
+                eeLowEtForestName = cms.ESInputTag("", 'electron_ee_ecalTrk_HIN_1To500_0p0002To0p5_sigma'),
+                eeHighEtForestName = cms.ESInputTag("", 'electron_ee_ecalTrk_HIN_1To500_0p0002To0p5_sigma'),
+            )
+        )
+    ),
+    phoRegs = dict(
+        ecalOnlyMean = dict(
+            ebLowEtForestName = cms.ESInputTag("", "photon_eb_ecalOnly_HIN_10To500_0p2To2_mean"),
+            ebHighEtForestName = cms.ESInputTag("", "photon_eb_ecalOnly_HIN_10To500_0p2To2_mean"),
+            eeLowEtForestName = cms.ESInputTag("", "photon_ee_ecalOnly_HIN_10To500_0p2To2_mean"),
+            eeHighEtForestName = cms.ESInputTag("", "photon_ee_ecalOnly_HIN_10To500_0p2To2_mean"),
+        ),
+        ecalOnlySigma = dict(
+            ebLowEtForestName = cms.ESInputTag("", "photon_eb_ecalOnly_HIN_10To500_0p0002To0p5_sigma"),
+            ebHighEtForestName = cms.ESInputTag("", "photon_eb_ecalOnly_HIN_10To500_0p0002To0p5_sigma"),
+            eeLowEtForestName = cms.ESInputTag("", "photon_ee_ecalOnly_HIN_10To500_0p0002To0p5_sigma"),
+            eeHighEtForestName = cms.ESInputTag("", "photon_ee_ecalOnly_HIN_10To500_0p0002To0p5_sigma"),
+        )
+    )
+)
+from Configuration.ProcessModifiers.hiEGReg_cff import hiEGReg
+hiEGReg.toReplaceWith(regressionModifier,regressionModifierHIN)


### PR DESCRIPTION
#### PR description:

This PR adds the Run3 PbPb egamma regression presented to the EGM POG in [slides](https://indico.cern.ch/event/1701989/contributions/7191006/attachments/3315881/5935478/PbPb%20Run3%20EG%20regression-1.pdf) . A process modifier hiEGReg is created to enable this regression.

@mandrenguyen 

#### PR validation:

Tested with relvals 141.401,142.401,143.401,144.401
No changes expected for any other workflow

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: