### PR TITLE
Reuse the REntry when doing prompt read in RNTupleTempSource

### DIFF
--- a/FWIO/RNTupleTempInput/src/RootRNTuple.cc
+++ b/FWIO/RNTupleTempInput/src/RootRNTuple.cc
@@ -181,16 +181,21 @@ namespace edm::rntuple_temp {
       std::unordered_map<unsigned int, std::unique_ptr<edm::WrapperBase>>& iFields) const {
     LogTrace("IOTrace").format("RootRNTuple::getEntryForAllBranches() begin for entry {}", entryNumber_);
     oneapi::tbb::this_task_arena::isolate([&]() {
-      auto entry = reader_->GetModel().CreateEntry();
+      if (not promptReadEntry_) {
+        //we delay create call to here as doing it in construction before RootFile
+        // fills all EventIDs lead to reading of entire Event rather than just the EventAux.
+        promptReadEntry_ = reader_->GetModel().CreateEntry();
+      }
+
       for (auto& iField : iFields) {
         auto const& prod = branches_.find(iField.first);
         if (prod == nullptr or not prod->valid()) {
           continue;
         }
         iField.second = prod->newWrapper();
-        entry->BindRawPtr(prod->token(), reinterpret_cast<void*>(iField.second.get()));
+        promptReadEntry_->BindRawPtr(prod->token(), reinterpret_cast<void*>(iField.second.get()));
       }
-      reader_->LoadEntry(entryNumber_, *entry);
+      reader_->LoadEntry(entryNumber_, *promptReadEntry_);
     });
     LogTrace("IOTrace").format("RootRNTuple::getEntryForAllBranches() end for entry {}", entryNumber_);
   }

--- a/FWIO/RNTupleTempInput/src/RootRNTuple.h
+++ b/FWIO/RNTupleTempInput/src/RootRNTuple.h
@@ -210,6 +210,8 @@ namespace edm::rntuple_temp {
     unsigned long treeAutoFlush_ = 0;
     bool promptRead_;
     std::unique_ptr<RootDelayedReaderBase> rootDelayedReader_;
+    //set in getEntryForAllBranches which is protected by source serialization
+    CMS_SA_ALLOW mutable std::unique_ptr<ROOT::REntry> promptReadEntry_;
     std::variant<std::monostate,
                  ROOT::RNTupleView<edm::EventAuxiliary>,
                  ROOT::RNTupleView<edm::LuminosityBlockAuxiliary>,


### PR DESCRIPTION
#### PR description:

This re-uses the same REntry for each read of an Event when prompt reading is used.

#### PR validation:

Code compiles. Framework unit test succeed.

resolves https://github.com/cms-sw/framework-team/issues/2359