### PR TITLE
Update unit tests for `edmTypeInfo`

### DIFF
--- a/DataFormats/PortableTestObjects/test/run_edmTypeInfo.sh
+++ b/DataFormats/PortableTestObjects/test/run_edmTypeInfo.sh
@@ -40,13 +40,25 @@ compare "${CMD}" "${EXPECTED}"
 
 # Run edmTypeInfo ALPAKA_ACCELERATOR_NAMESPACE::portabletest::TestDeviceCollection
 CMD="edmTypeInfo ALPAKA_ACCELERATOR_NAMESPACE::portabletest::TestDeviceCollection"
-EXPECTED='`alpaka_serial_sync::portabletest::TestDeviceCollection` does not resolve to any type known to ROOT
+EXPECTED='`alpaka_serial_sync::portabletest::TestDeviceCollection` does not resolve to any type known to ROOT'
+EXPECTED+='
 
-`alpaka_cuda_async::portabletest::TestDeviceCollection` resolves to `PortableDeviceCollection<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>,portabletest::TestSoALayout<128,false>,void>`
+'
+if scram tool info cuda >& /dev/null; then
+  EXPECTED+='`alpaka_cuda_async::portabletest::TestDeviceCollection` resolves to `PortableDeviceCollection<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>,portabletest::TestSoALayout<128,false>,void>`
   with friendly class name `alpakaDevCudaRt128falseportabletestTestSoALayoutvoidPortableDeviceCollection`
-  with type info `24PortableDeviceCollectionIN6alpaka19DevUniformCudaHipRtINS0_9ApiCudaRtEEEN12portabletest13TestSoALayoutILm128ELb0EEEvE`
+  with type info `24PortableDeviceCollectionIN6alpaka19DevUniformCudaHipRtINS0_9ApiCudaRtEEEN12portabletest13TestSoALayoutILm128ELb0EEEvE`'
+else
+  EXPECTED+='`alpaka_cuda_async::portabletest::TestDeviceCollection` does not resolve to any type known to ROOT'
+fi
+EXPECTED+='
 
-`alpaka_rocm_async::portabletest::TestDeviceCollection` resolves to `PortableDeviceCollection<alpaka::DevUniformCudaHipRt<alpaka::ApiHipRt>,portabletest::TestSoALayout<128,false>,void>`
+'
+if scram tool info rocm >& /dev/null; then
+  EXPECTED+='`alpaka_rocm_async::portabletest::TestDeviceCollection` resolves to `PortableDeviceCollection<alpaka::DevUniformCudaHipRt<alpaka::ApiHipRt>,portabletest::TestSoALayout<128,false>,void>`
   with friendly class name `alpakaDevHipRt128falseportabletestTestSoALayoutvoidPortableDeviceCollection`
   with type info `24PortableDeviceCollectionIN6alpaka19DevUniformCudaHipRtINS0_8ApiHipRtEEEN12portabletest13TestSoALayoutILm128ELb0EEEvE`'
+else
+  EXPECTED+='`alpaka_rocm_async::portabletest::TestDeviceCollection` does not resolve to any type known to ROOT'
+fi
 compare "${CMD}" "${EXPECTED}"


### PR DESCRIPTION
#### PR description:

Fix the heterogeneous unit tests for `edmTypeInfo` for builds where CUDA or ROCm are not available.

#### PR validation:

Unit test now passes on `el9_amd64_gcc16` which does not have CUDA.