### PR TITLE
Accurate MIP Scaling V19

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -124,6 +124,10 @@ protected:
   //noise level (used if scaleByDose=False)
   std::vector<float> noise_fC_;
 
+  //per-thickness MIP-charge scale for the ZS threshold
+  //indexed by cell.thickness-1 -> {HD120, LD200, LD300, HD200}
+  std::vector<float> mipChargeScale_;
+
   //charge collection efficiency (used if scaleByDose=False)
   std::vector<double> cce_;
 

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
@@ -176,10 +176,10 @@ void HGCDigitizerBase::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& coll,
       //note that in this legacy case, gainIdx is kept at 0, fixed
       cce = (cce_.empty() ? 1.f : cce_[cell.thickness - 1]);
       noiseWidth = cell.size * noise_fC_[cell.thickness - 1];
-      //cell.thickness (1,2,3 for 120,200,300um) doubles as the MIP-charge scale
-      //of the threshold; HD 200um sensors (cell.thickness==4) carry the MIP
-      //charge of a 200um sensor, not four times that of 120um
-      const int mipScaleFactor = (cell.thickness == 4) ? 2 : cell.thickness;
+      //approximate more accurately the scaling from different depletion thicknesses
+      //index by cell.thickness-1 -> {HD120, LD200, LD300, HD200}
+      static constexpr float kMipScale[4] = {1.0f, 1.6f, 2.5f, 1.6f};
+      const float mipScaleFactor = kMipScale[cell.thickness - 1];
       thrADC =
           thresholdFollowsMIP_
               ? std::floor(mipScaleFactor * cce * myFEelectronics_->getADCThreshold() / myFEelectronics_->getADClsb())

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
@@ -48,6 +48,12 @@ HGCDigitizerBase::HGCDigitizerBase(const edm::ParameterSet& ps)
   } else {
     noise_fC_.resize(4, 1.f);
   }
+
+  //per-thickness MIP-charge scale for the ZS threshold
+  //indexed by cell.thickness-1 -> {HD120, LD200, LD300, HD200})
+  const auto& mipScale = myCfg_.getParameter<std::vector<double>>("mipChargeScale");
+  mipChargeScale_ = std::vector<float>(mipScale.begin(), mipScale.end());
+
   if (myCfg_.existsAs<edm::ParameterSet>("ileakParam")) {
     scal_.setIleakParam(
         myCfg_.getParameter<edm::ParameterSet>("ileakParam").template getParameter<std::vector<double>>("ileakParam"));
@@ -176,10 +182,8 @@ void HGCDigitizerBase::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& coll,
       //note that in this legacy case, gainIdx is kept at 0, fixed
       cce = (cce_.empty() ? 1.f : cce_[cell.thickness - 1]);
       noiseWidth = cell.size * noise_fC_[cell.thickness - 1];
-      //approximate more accurately the scaling from different depletion thicknesses
-      //index by cell.thickness-1 -> {HD120, LD200, LD300, HD200}
-      static constexpr float kMipScale[4] = {1.0f, 1.6f, 2.5f, 1.6f};
-      const float mipScaleFactor = kMipScale[cell.thickness - 1];
+      //MIP-charge scale of the ZS threshold, per silicon thickness
+      const float mipScaleFactor = mipChargeScale_[cell.thickness - 1];
       thrADC =
           thresholdFollowsMIP_
               ? std::floor(mipScaleFactor * cce * myFEelectronics_->getADCThreshold() / myFEelectronics_->getADClsb())

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -189,6 +189,13 @@ hfnoseDigitizer = cms.PSet(
         )
     )
 
+# per-silicon-thickness MIP-charge scale of the ZS threshold {HD120, LD200, LD300, HD200}.
+#more accurate for V19
+for _dig in [hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer, hfnoseDigitizer]:
+    _dig.digiCfg.mipChargeScale = cms.vdouble(1.0, 2.0, 3.0, 2.0)
+phase2_hgcalV19.toModify(hgceeDigitizer.digiCfg, mipChargeScale = cms.vdouble(1.0, 1.6, 2.5, 1.6))
+phase2_hgcalV19.toModify(hgchefrontDigitizer.digiCfg, mipChargeScale = cms.vdouble(1.0, 1.6, 2.5, 1.6))
+
 # this bypasses the noise simulation
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 for _m in [hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer, hfnoseDigitizer]:


### PR DESCRIPTION
This PR slightly changes the MIP scaling for different depletion thicknesses

Should be tested on a D122 workflow (e.g. 34888.0)


Full validation here:
https://wredjeb.web.cern.ch/HGCAL/plots_D121_A_B/
D121
A: D122
B: D122 + this PR

Slight changes at DIGIs level, as expected. No other major changes in higher level quantities.

DIGIs: https://wredjeb.web.cern.ch/HGCAL/plots_D121_A_B/hlt/hlt_Digis/Occupancy_EE_zplus.png
LCs: https://wredjeb.web.cern.ch/HGCAL/plots_D121_A_B/hlt/hlt_Layer%20Clusters.html
Tracksters: https://wredjeb.web.cern.ch/HGCAL/plots_D121_A_B/hlt/hlt_Tracksters.html


Backport needed in CMSSW_20_0_X


@felicepantaleo @pfs FYI