### PR TITLE
Add grid cosmic seeder for Phase-2 cosmic tracking

### DIFF
--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -47,9 +47,7 @@ from RecoEgamma.Configuration.RecoEgammaCosmics_cff import *
 # local reco
 trackerCosmicsTask = cms.Task(offlineBeamSpot,trackerlocalrecoTask,MeasurementTrackerEvent,tracksP5Task)
 
-# ugly hack: for the time being remove tracking (no Cosmics seeding in Phase-2) 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toReplaceWith(trackerCosmicsTask,trackerCosmicsTask.copyAndExclude([tracksP5Task]))
 
 trackerCosmics = cms.Sequence(trackerCosmicsTask)
 caloCosmicsTask = cms.Task(calolocalrecoTaskCosmics,ecalClustersCosmicsTask)

--- a/RecoLocalTracker/Configuration/python/RecoLocalTracker_Cosmics_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTracker_Cosmics_cff.py
@@ -21,7 +21,7 @@ from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import *
 _pixeltrackerlocalrecoTask_phase2 = pixeltrackerlocalrecoTask.copy()
 _pixeltrackerlocalrecoTask_phase2.add(siPhase2Clusters)
 _pixeltrackerlocalrecoTask_phase2.add(siPhase2RecHits)
-#_pixeltrackerlocalrecoTask_phase2.add(siPhase2VectorHits)
+_pixeltrackerlocalrecoTask_phase2.add(siPhase2VectorHits)
 phase2_tracker.toReplaceWith(pixeltrackerlocalrecoTask, _pixeltrackerlocalrecoTask_phase2)
 phase2_tracker.toReplaceWith(trackerlocalrecoTask, trackerlocalrecoTask.copyAndExclude([striptrackerlocalrecoTask]))
 

--- a/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
@@ -15,8 +15,10 @@ from RecoTracker.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
 
 #chi2 set to 40!!
 # CTF
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmicsP5_cff import *
 from RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cff import *
+from RecoTracker.SpecialSeedGenerators.CosmicGridTripletSeeder_cff import * 
 from RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cff import *
 combinedP5SeedsForCTF = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone(
     seedCollections   = ['combinatorialcosmicseedfinderP5',
@@ -41,17 +43,47 @@ from RecoTracker.FinalTrackSelectors.CTFFinalTrackSelectorP5_cff import *
 ckfTrackCandidatesP5LHCNavigation    = ckfTrackCandidatesP5.clone(NavigationSchool = 'SimpleNavigationSchool')
 ctfWithMaterialTracksP5LHCNavigation = ctfWithMaterialTracksCosmics.clone(src = "ckfTrackCandidatesP5LHCNavigation")
 
-ctftracksP5Task = cms.Task(combinatorialcosmicseedinglayersP5Task,
-                                  combinatorialcosmicseedfinderP5,
-                                  simpleCosmicBONSeedingLayers,
-                                  simpleCosmicBONSeeds,
-                                  combinedP5SeedsForCTF,
-                                  ckfTrackCandidatesP5,
-                                  ctfWithMaterialTracksCosmics,
-                                  ctfWithMaterialTracksP5,
-                                  ckfTrackCandidatesP5LHCNavigation,
-                                  ctfWithMaterialTracksP5LHCNavigation)
+
+
+ctfSeedsP5Task = cms.Task(combinatorialcosmicseedinglayersP5Task,
+                                  simpleCosmicBONSeeds)
+
+phase2SeedsP5Task = cms.Task(cosmicGridTripletSeeds)
+
+# in phase 2, we run the CTF on top of the grid seeder. 
+phase2_tracker.toReplaceWith(ctfSeedsP5Task,phase2SeedsP5Task)
+phase2_tracker.toModify(combinedP5SeedsForCTF,seedCollections   = ['cosmicGridTripletSeeds'])
+
+ctftracksP5Task = cms.Task( ctfSeedsP5Task,
+                            combinedP5SeedsForCTF,
+                            ckfTrackCandidatesP5, # CKF built from seeds
+                            ctfWithMaterialTracksCosmics, # these are TrackCandidatesP5 + CKF fit 
+                            ctfWithMaterialTracksP5,  # This is adding track selection on ctfWithMaterialTracksCosmics
+                            ckfTrackCandidatesP5LHCNavigation,    # this is the CKF candidates using the collision-style navigation
+                            ctfWithMaterialTracksP5LHCNavigation  # CKF candidates  using the collision-style navigation
+                        ) 
+
+# Copy of CTF on top of the grid seeder, used within Phase-1 for side-by-side validation 
+
+combinedP5SeedsForGrid = combinedP5SeedsForCTF.clone(seedCollections   = ['cosmicGridTripletSeeds'])
+gridTrackCandidatesP5 = ckfTrackCandidatesP5.clone(src = "combinedP5SeedsForGrid")
+gridWithMaterialTracksCosmics = ctfWithMaterialTracksCosmics.clone(src = "gridTrackCandidatesP5")
+gridWithMaterialTracksP5 = ctfWithMaterialTracksP5.clone(src = "gridWithMaterialTracksCosmics")
+gridTrackCandidatesP5LHCNavigation    = gridTrackCandidatesP5.clone(NavigationSchool = 'SimpleNavigationSchool')
+gridWithMaterialTracksP5LHCNavigation = gridWithMaterialTracksCosmics.clone(src = "gridTrackCandidatesP5LHCNavigation")
+
+gridtracksP5Task = cms.Task(       
+                            cosmicGridTripletSeeds,
+                            combinedP5SeedsForGrid,
+                            gridTrackCandidatesP5, # CKF built from seeds
+                            gridWithMaterialTracksCosmics, # these are TrackCandidatesP5 + CKF fit 
+                            gridWithMaterialTracksP5,  # This is adding track selection on ctfWithMaterialTracksCosmics
+                            gridTrackCandidatesP5LHCNavigation,    # this is the CKF candidates using the collision-style navigation
+                            gridWithMaterialTracksP5LHCNavigation # CKF candidates  using the collision-style navigation
+                        ) 
+
 ctftracksP5 = cms.Sequence(ctftracksP5Task)
+gridtracksP5 = cms.Sequence(gridtracksP5Task)
 
 from RecoTracker.FinalTrackSelectors.cosmicTrackSplitter_cfi import *
 cosmicTrackSplitting = RecoTracker.FinalTrackSelectors.cosmicTrackSplitter_cfi.cosmicTrackSplitter.clone(
@@ -81,6 +113,7 @@ from RecoTracker.DeDx.dedxEstimators_Cosmics_cff import *
 # (SK) keep rstracks commented out in case of resurrection
 tracksP5Task = cms.Task(cosmictracksP5Task,
                             ctftracksP5Task,
+                            gridtracksP5Task,
                             doAllCosmicdEdXEstimatorsTask,
                             siPixelClusterShapeCache)
 tracksP5 = cms.Sequence(tracksP5Task)

--- a/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
@@ -116,6 +116,7 @@ tracksP5Task = cms.Task(cosmictracksP5Task,
                             gridtracksP5Task,
                             doAllCosmicdEdXEstimatorsTask,
                             siPixelClusterShapeCache)
+phase2_tracker.toReplaceWith(tracksP5Task,tracksP5Task.copyAndExclude([cosmictracksP5Task, gridtracksP5Task, doAllCosmicdEdXEstimatorsTask, siPixelClusterShapeCache]))
 tracksP5 = cms.Sequence(tracksP5Task)
 tracksP5_wodEdX = tracksP5.copy()
 tracksP5_wodEdX.remove(doAllCosmicdEdXEstimators)

--- a/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
@@ -15,8 +15,10 @@ from RecoTracker.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
 
 #chi2 set to 40!!
 # CTF
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 from RecoTracker.SpecialSeedGenerators.CombinatorialSeedGeneratorForCosmicsP5_cff import *
 from RecoTracker.SpecialSeedGenerators.SimpleCosmicBONSeeder_cff import *
+from RecoTracker.SpecialSeedGenerators.CosmicGridTripletSeeder_cff import * 
 from RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cff import *
 combinedP5SeedsForCTF = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone(
     seedCollections   = ['combinatorialcosmicseedfinderP5',
@@ -41,17 +43,49 @@ from RecoTracker.FinalTrackSelectors.CTFFinalTrackSelectorP5_cff import *
 ckfTrackCandidatesP5LHCNavigation    = ckfTrackCandidatesP5.clone(NavigationSchool = 'SimpleNavigationSchool')
 ctfWithMaterialTracksP5LHCNavigation = ctfWithMaterialTracksCosmics.clone(src = "ckfTrackCandidatesP5LHCNavigation")
 
-ctftracksP5Task = cms.Task(combinatorialcosmicseedinglayersP5Task,
-                                  combinatorialcosmicseedfinderP5,
-                                  simpleCosmicBONSeedingLayers,
-                                  simpleCosmicBONSeeds,
-                                  combinedP5SeedsForCTF,
-                                  ckfTrackCandidatesP5,
-                                  ctfWithMaterialTracksCosmics,
-                                  ctfWithMaterialTracksP5,
-                                  ckfTrackCandidatesP5LHCNavigation,
-                                  ctfWithMaterialTracksP5LHCNavigation)
+
+
+ctfSeedsP5Task = cms.Task(      combinatorialcosmicseedinglayersP5Task,
+                                combinatorialcosmicseedfinderP5,
+                                simpleCosmicBONSeedingLayers,
+                                simpleCosmicBONSeeds)
+
+phase2SeedsP5Task = cms.Task(cosmicGridTripletSeeds)
+
+# in phase 2, we run the CTF on top of the grid seeder. 
+phase2_tracker.toReplaceWith(ctfSeedsP5Task,phase2SeedsP5Task)
+phase2_tracker.toModify(combinedP5SeedsForCTF,seedCollections   = ['cosmicGridTripletSeeds'])
+
+ctftracksP5Task = cms.Task( ctfSeedsP5Task,
+                            combinedP5SeedsForCTF,
+                            ckfTrackCandidatesP5, # CKF built from seeds
+                            ctfWithMaterialTracksCosmics, # these are TrackCandidatesP5 + CKF fit 
+                            ctfWithMaterialTracksP5,  # This is adding track selection on ctfWithMaterialTracksCosmics
+                            ckfTrackCandidatesP5LHCNavigation,    # this is the CKF candidates using the collision-style navigation
+                            ctfWithMaterialTracksP5LHCNavigation  # CKF candidates  using the collision-style navigation
+                        ) 
+
+# Copy of CTF on top of the grid seeder, used within Phase-1 for side-by-side validation 
+
+combinedP5SeedsForGrid = combinedP5SeedsForCTF.clone(seedCollections   = ['cosmicGridTripletSeeds'])
+gridTrackCandidatesP5 = ckfTrackCandidatesP5.clone(src = "combinedP5SeedsForGrid")
+gridWithMaterialTracksCosmics = ctfWithMaterialTracksCosmics.clone(src = "gridTrackCandidatesP5")
+gridWithMaterialTracksP5 = ctfWithMaterialTracksP5.clone(src = "gridWithMaterialTracksCosmics")
+gridTrackCandidatesP5LHCNavigation    = gridTrackCandidatesP5.clone(NavigationSchool = 'SimpleNavigationSchool')
+gridWithMaterialTracksP5LHCNavigation = gridWithMaterialTracksCosmics.clone(src = "gridTrackCandidatesP5LHCNavigation")
+
+gridtracksP5Task = cms.Task(       
+                            cosmicGridTripletSeeds,
+                            combinedP5SeedsForGrid,
+                            gridTrackCandidatesP5, # CKF built from seeds
+                            gridWithMaterialTracksCosmics, # these are TrackCandidatesP5 + CKF fit 
+                            gridWithMaterialTracksP5,  # This is adding track selection on ctfWithMaterialTracksCosmics
+                            gridTrackCandidatesP5LHCNavigation,    # this is the CKF candidates using the collision-style navigation
+                            gridWithMaterialTracksP5LHCNavigation # CKF candidates  using the collision-style navigation
+                        ) 
+
 ctftracksP5 = cms.Sequence(ctftracksP5Task)
+gridtracksP5 = cms.Sequence(gridtracksP5Task)
 
 from RecoTracker.FinalTrackSelectors.cosmicTrackSplitter_cfi import *
 cosmicTrackSplitting = RecoTracker.FinalTrackSelectors.cosmicTrackSplitter_cfi.cosmicTrackSplitter.clone(
@@ -81,8 +115,10 @@ from RecoTracker.DeDx.dedxEstimators_Cosmics_cff import *
 # (SK) keep rstracks commented out in case of resurrection
 tracksP5Task = cms.Task(cosmictracksP5Task,
                             ctftracksP5Task,
+                            gridtracksP5Task,
                             doAllCosmicdEdXEstimatorsTask,
                             siPixelClusterShapeCache)
+phase2_tracker.toReplaceWith(tracksP5Task,tracksP5Task.copyAndExclude([cosmictracksP5Task, gridtracksP5Task, doAllCosmicdEdXEstimatorsTask, siPixelClusterShapeCache]))
 tracksP5 = cms.Sequence(tracksP5Task)
 tracksP5_wodEdX = tracksP5.copy()
 tracksP5_wodEdX.remove(doAllCosmicdEdXEstimators)

--- a/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerP5_cff.py
@@ -45,8 +45,10 @@ ctfWithMaterialTracksP5LHCNavigation = ctfWithMaterialTracksCosmics.clone(src = 
 
 
 
-ctfSeedsP5Task = cms.Task(combinatorialcosmicseedinglayersP5Task,
-                                  simpleCosmicBONSeeds)
+ctfSeedsP5Task = cms.Task(      combinatorialcosmicseedinglayersP5Task,
+                                combinatorialcosmicseedfinderP5,
+                                simpleCosmicBONSeedingLayers,
+                                simpleCosmicBONSeeds)
 
 phase2SeedsP5Task = cms.Task(cosmicGridTripletSeeds)
 

--- a/RecoTracker/SpecialSeedGenerators/interface/CartesianSeedingGrid.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CartesianSeedingGrid.h
@@ -1,0 +1,142 @@
+#pragma once
+
+// system include files
+#include <vector>
+
+// user include files
+#include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
+
+
+/// Cartesian seeding grid, intended for cosmic track reconstruction.
+/// Collects space-points in an x-y-z binning in the global frame.
+/// In each bin, orders the hits by descending y.  
+/// Does not take ownership of the hits - user is responsible 
+/// for ensuring pointer validity and object lifetime. 
+class CartesianSeedingGrid{
+  public: 
+    /// @brief Constructor, taking the parameters of the (rectangular) bin grid. 
+    /// @param nBinsX: Number of bins in the global x coordinate 
+    /// @param xmin: Low edge of the first bin in global x 
+    /// @param xmax: Up edge of the last bin in global x 
+    /// @param nBinsY: Number of bins in the global y coordinate 
+    /// @param ymin: Low edge of the first bin in global y 
+    /// @param ymax: Up edge of the last bin in global y 
+    /// @param nBinsZ: Number of bins in the global z coordinate 
+    /// @param zmin: Low edge of the first bin in global z 
+    /// @param zmax: Up edge of the last bin in global z 
+    CartesianSeedingGrid (int nBinsX, double xmin, double xmax, int nBinsY, double ymin, double ymax,int nBinsZ, double zmin, double zmax );
+
+    /// @brief add a hit to the grid. Will be placed in a bin corresponding 
+    /// to the coordinates returned by its globalPosition(). 
+    /// @param h: Hit to be stored. 
+    void addHit(const BaseTrackerRecHit* h);
+
+    /// @brief convert a global x-coordinate to the corresponding bin index.
+    /// Under/overflows will be added to the first/last bins.
+    /// @param x global x coordinate value 
+    /// @return bin index in the x coordinate. 
+    inline int binX(double x) const {
+      return findBin(x,nBinsX_, xmin_, xmax_); 
+    }
+
+    /// @brief convert a global y-coordinate to the corresponding bin index.
+    /// Under/overflows will be added to the first/last bins.
+    /// @param y global y coordinate value 
+    /// @return bin index in the y coordinate. 
+    inline int binY(double y) const {
+      return findBin(y,nBinsY_, ymin_, ymax_); 
+    }
+    /// @brief convert a global z-coordinate to the corresponding bin index.
+    /// Under/overflows will be added to the first/last bins.
+    /// @param z global y coordinate value 
+    /// @return bin index in the z coordinate. 
+    inline int binZ(double z) const {
+      return findBin(z,nBinsZ_, zmin_, zmax_); 
+    }
+
+    /// @brief access (read-only) the hit content of one cell.
+    /// @param binX: The x-bin-index 
+    /// @param binY: The y-bin-index 
+    /// @param binZ: The z-bin-index 
+    /// @return the hits stored in cell (binX,binY,binZ), as a read-only reference 
+    const std::vector<const BaseTrackerRecHit*> & getHits(int binX, int binY, int binZ) const;
+
+    /// @brief sort the hits in each cell to be ordered descending in global y. 
+    /// Call this **after** filling the binning grid with all hits to be considered. 
+    void sort();
+
+    /// @brief helper function - maps 3D bin indices to our 1D vector. 
+    /// @param bx: index of the bin along x 
+    /// @param by: index of the bin along y 
+    /// @param bz: index of the bin along z
+    /// @return Index of the corresponding cell in our storage vector. 
+    int getBin(int bx, int by, int bz) const;
+
+    /// @brief getter for the number of bins along x. 
+    /// @return the number of bins along x 
+    inline int nBinsX() const {return nBinsX_;}
+
+    /// @brief getter for the number of bins along y. 
+    /// @return the number of bins along y
+    inline int nBinsY() const {return nBinsY_;}
+
+    /// @brief getter for the number of bins along z. 
+    /// @return the number of bins along z
+    inline int nBinsZ() const {return nBinsZ_;}
+
+
+    /// @brief getter for the starting coordinate of the x-binning 
+    /// @return the low edge of the first bin along x 
+    inline double xmin() const {return  xmin_;}
+    /// @brief getter for the end coordinate of the x-binning 
+    /// @return the up edge of the last bin along x 
+    inline double xmax() const {return  xmax_;}
+    /// @brief getter for the starting coordinate of the y-binning 
+    /// @return the low edge of the first bin along y 
+    inline double ymin() const {return  ymin_;}
+    /// @brief getter for the end coordinate of the y-binning 
+    /// @return the up edge of the last bin along y 
+    inline double ymax() const {return  ymax_;}
+    /// @brief getter for the starting coordinate of the z-binning 
+    /// @return the low edge of the first bin along z 
+    inline double zmin() const {return  zmin_;}
+    /// @brief getter for the end coordinate of the z-binning 
+    /// @return the up edge of the last bin along z 
+    inline double zmax() const {return  zmax_;}
+
+  private: 
+
+    /// @brief helper function to locate a bin. Will return the index of the bin in a 
+    /// (equidistant) binning of the interval [min,max] into nBins bins. 
+    /// Bins are indexed in "C-convention", meaning from 0 to nBins - 1. 
+    /// @param value: Value to translate to a bin index
+    /// @param nBins: Number of bins
+    /// @param min: Low edge of the binned interval
+    /// @param max: Up edge of the binned interval
+    /// @return Integer in the range [0, nBins-1] indicating the bin in which 
+    /// the passed value lies.  
+    /// Under/Overflow will be merged into the first / last bin. 
+    int findBin(double value, int nBins, double min, double max) const;
+
+    /// data members 
+
+    // x binning 
+    int nBinsX_;  /// number of bins on x axis
+    double xmin_; /// low edge of x axis
+    double xmax_; /// up edge of x axis 
+
+    // y binning  
+    int nBinsY_;  /// number of bins on y axis
+    double ymin_; /// low edge of y axis   
+    double ymax_; /// up edge of y axis 
+    
+    // z binning 
+    int nBinsZ_;  /// number of bins on z axis
+    double zmin_; /// low edge of z axis
+    double zmax_; /// up edge of z axis 
+
+    /// Data storage vector. Contains a vector of hits for each cell. 
+    /// Outer vector has size nBinsX_ * nBinsY_ * nBinsZ_, inner vector for 
+    /// each cell grows dynamically. 
+    std::vector<std::vector<const BaseTrackerRecHit*>> recHits_ = {};
+};

--- a/RecoTracker/SpecialSeedGenerators/interface/CartesianSeedingGrid.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CartesianSeedingGrid.h
@@ -6,137 +6,129 @@
 // user include files
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 
-
 /// Cartesian seeding grid, intended for cosmic track reconstruction.
 /// Collects space-points in an x-y-z binning in the global frame.
-/// In each bin, orders the hits by descending y.  
-/// Does not take ownership of the hits - user is responsible 
-/// for ensuring pointer validity and object lifetime. 
-class CartesianSeedingGrid{
-  public: 
-    /// @brief Constructor, taking the parameters of the (rectangular) bin grid. 
-    /// @param nBinsX: Number of bins in the global x coordinate 
-    /// @param xmin: Low edge of the first bin in global x 
-    /// @param xmax: Up edge of the last bin in global x 
-    /// @param nBinsY: Number of bins in the global y coordinate 
-    /// @param ymin: Low edge of the first bin in global y 
-    /// @param ymax: Up edge of the last bin in global y 
-    /// @param nBinsZ: Number of bins in the global z coordinate 
-    /// @param zmin: Low edge of the first bin in global z 
-    /// @param zmax: Up edge of the last bin in global z 
-    CartesianSeedingGrid (int nBinsX, double xmin, double xmax, int nBinsY, double ymin, double ymax,int nBinsZ, double zmin, double zmax );
+/// In each bin, orders the hits by descending y.
+/// Does not take ownership of the hits - user is responsible
+/// for ensuring pointer validity and object lifetime.
+class CartesianSeedingGrid {
+public:
+  /// @brief Constructor, taking the parameters of the (rectangular) bin grid.
+  /// @param nBinsX: Number of bins in the global x coordinate
+  /// @param xmin: Low edge of the first bin in global x
+  /// @param xmax: Up edge of the last bin in global x
+  /// @param nBinsY: Number of bins in the global y coordinate
+  /// @param ymin: Low edge of the first bin in global y
+  /// @param ymax: Up edge of the last bin in global y
+  /// @param nBinsZ: Number of bins in the global z coordinate
+  /// @param zmin: Low edge of the first bin in global z
+  /// @param zmax: Up edge of the last bin in global z
+  CartesianSeedingGrid(
+      int nBinsX, double xmin, double xmax, int nBinsY, double ymin, double ymax, int nBinsZ, double zmin, double zmax);
 
-    /// @brief add a hit to the grid. Will be placed in a bin corresponding 
-    /// to the coordinates returned by its globalPosition(). 
-    /// @param h: Hit to be stored. 
-    void addHit(const BaseTrackerRecHit* h);
+  /// @brief add a hit to the grid. Will be placed in a bin corresponding
+  /// to the coordinates returned by its globalPosition().
+  /// @param h: Hit to be stored.
+  void addHit(const BaseTrackerRecHit* h);
 
-    /// @brief convert a global x-coordinate to the corresponding bin index.
-    /// Under/overflows will be added to the first/last bins.
-    /// @param x global x coordinate value 
-    /// @return bin index in the x coordinate. 
-    inline int binX(double x) const {
-      return findBin(x,nBinsX_, xmin_, xmax_); 
-    }
+  /// @brief convert a global x-coordinate to the corresponding bin index.
+  /// Under/overflows will be added to the first/last bins.
+  /// @param x global x coordinate value
+  /// @return bin index in the x coordinate.
+  inline int binX(double x) const { return findBin(x, nBinsX_, xmin_, xmax_); }
 
-    /// @brief convert a global y-coordinate to the corresponding bin index.
-    /// Under/overflows will be added to the first/last bins.
-    /// @param y global y coordinate value 
-    /// @return bin index in the y coordinate. 
-    inline int binY(double y) const {
-      return findBin(y,nBinsY_, ymin_, ymax_); 
-    }
-    /// @brief convert a global z-coordinate to the corresponding bin index.
-    /// Under/overflows will be added to the first/last bins.
-    /// @param z global y coordinate value 
-    /// @return bin index in the z coordinate. 
-    inline int binZ(double z) const {
-      return findBin(z,nBinsZ_, zmin_, zmax_); 
-    }
+  /// @brief convert a global y-coordinate to the corresponding bin index.
+  /// Under/overflows will be added to the first/last bins.
+  /// @param y global y coordinate value
+  /// @return bin index in the y coordinate.
+  inline int binY(double y) const { return findBin(y, nBinsY_, ymin_, ymax_); }
+  /// @brief convert a global z-coordinate to the corresponding bin index.
+  /// Under/overflows will be added to the first/last bins.
+  /// @param z global y coordinate value
+  /// @return bin index in the z coordinate.
+  inline int binZ(double z) const { return findBin(z, nBinsZ_, zmin_, zmax_); }
 
-    /// @brief access (read-only) the hit content of one cell.
-    /// @param binX: The x-bin-index 
-    /// @param binY: The y-bin-index 
-    /// @param binZ: The z-bin-index 
-    /// @return the hits stored in cell (binX,binY,binZ), as a read-only reference 
-    const std::vector<const BaseTrackerRecHit*> & getHits(int binX, int binY, int binZ) const;
+  /// @brief access (read-only) the hit content of one cell.
+  /// @param binX: The x-bin-index
+  /// @param binY: The y-bin-index
+  /// @param binZ: The z-bin-index
+  /// @return the hits stored in cell (binX,binY,binZ), as a read-only reference
+  const std::vector<const BaseTrackerRecHit*>& getHits(int binX, int binY, int binZ) const;
 
-    /// @brief sort the hits in each cell to be ordered descending in global y. 
-    /// Call this **after** filling the binning grid with all hits to be considered. 
-    void sort();
+  /// @brief sort the hits in each cell to be ordered descending in global y.
+  /// Call this **after** filling the binning grid with all hits to be considered.
+  void sort();
 
-    /// @brief helper function - maps 3D bin indices to our 1D vector. 
-    /// @param bx: index of the bin along x 
-    /// @param by: index of the bin along y 
-    /// @param bz: index of the bin along z
-    /// @return Index of the corresponding cell in our storage vector. 
-    int getBin(int bx, int by, int bz) const;
+  /// @brief helper function - maps 3D bin indices to our 1D vector.
+  /// @param bx: index of the bin along x
+  /// @param by: index of the bin along y
+  /// @param bz: index of the bin along z
+  /// @return Index of the corresponding cell in our storage vector.
+  int getBin(int bx, int by, int bz) const;
 
-    /// @brief getter for the number of bins along x. 
-    /// @return the number of bins along x 
-    inline int nBinsX() const {return nBinsX_;}
+  /// @brief getter for the number of bins along x.
+  /// @return the number of bins along x
+  inline int nBinsX() const { return nBinsX_; }
 
-    /// @brief getter for the number of bins along y. 
-    /// @return the number of bins along y
-    inline int nBinsY() const {return nBinsY_;}
+  /// @brief getter for the number of bins along y.
+  /// @return the number of bins along y
+  inline int nBinsY() const { return nBinsY_; }
 
-    /// @brief getter for the number of bins along z. 
-    /// @return the number of bins along z
-    inline int nBinsZ() const {return nBinsZ_;}
+  /// @brief getter for the number of bins along z.
+  /// @return the number of bins along z
+  inline int nBinsZ() const { return nBinsZ_; }
 
+  /// @brief getter for the starting coordinate of the x-binning
+  /// @return the low edge of the first bin along x
+  inline double xmin() const { return xmin_; }
+  /// @brief getter for the end coordinate of the x-binning
+  /// @return the up edge of the last bin along x
+  inline double xmax() const { return xmax_; }
+  /// @brief getter for the starting coordinate of the y-binning
+  /// @return the low edge of the first bin along y
+  inline double ymin() const { return ymin_; }
+  /// @brief getter for the end coordinate of the y-binning
+  /// @return the up edge of the last bin along y
+  inline double ymax() const { return ymax_; }
+  /// @brief getter for the starting coordinate of the z-binning
+  /// @return the low edge of the first bin along z
+  inline double zmin() const { return zmin_; }
+  /// @brief getter for the end coordinate of the z-binning
+  /// @return the up edge of the last bin along z
+  inline double zmax() const { return zmax_; }
 
-    /// @brief getter for the starting coordinate of the x-binning 
-    /// @return the low edge of the first bin along x 
-    inline double xmin() const {return  xmin_;}
-    /// @brief getter for the end coordinate of the x-binning 
-    /// @return the up edge of the last bin along x 
-    inline double xmax() const {return  xmax_;}
-    /// @brief getter for the starting coordinate of the y-binning 
-    /// @return the low edge of the first bin along y 
-    inline double ymin() const {return  ymin_;}
-    /// @brief getter for the end coordinate of the y-binning 
-    /// @return the up edge of the last bin along y 
-    inline double ymax() const {return  ymax_;}
-    /// @brief getter for the starting coordinate of the z-binning 
-    /// @return the low edge of the first bin along z 
-    inline double zmin() const {return  zmin_;}
-    /// @brief getter for the end coordinate of the z-binning 
-    /// @return the up edge of the last bin along z 
-    inline double zmax() const {return  zmax_;}
+private:
+  /// @brief helper function to locate a bin. Will return the index of the bin in a
+  /// (equidistant) binning of the interval [min,max] into nBins bins.
+  /// Bins are indexed in "C-convention", meaning from 0 to nBins - 1.
+  /// @param value: Value to translate to a bin index
+  /// @param nBins: Number of bins
+  /// @param min: Low edge of the binned interval
+  /// @param max: Up edge of the binned interval
+  /// @return Integer in the range [0, nBins-1] indicating the bin in which
+  /// the passed value lies.
+  /// Under/Overflow will be merged into the first / last bin.
+  int findBin(double value, int nBins, double min, double max) const;
 
-  private: 
+  /// data members
 
-    /// @brief helper function to locate a bin. Will return the index of the bin in a 
-    /// (equidistant) binning of the interval [min,max] into nBins bins. 
-    /// Bins are indexed in "C-convention", meaning from 0 to nBins - 1. 
-    /// @param value: Value to translate to a bin index
-    /// @param nBins: Number of bins
-    /// @param min: Low edge of the binned interval
-    /// @param max: Up edge of the binned interval
-    /// @return Integer in the range [0, nBins-1] indicating the bin in which 
-    /// the passed value lies.  
-    /// Under/Overflow will be merged into the first / last bin. 
-    int findBin(double value, int nBins, double min, double max) const;
+  // x binning
+  int nBinsX_;   /// number of bins on x axis
+  double xmin_;  /// low edge of x axis
+  double xmax_;  /// up edge of x axis
 
-    /// data members 
+  // y binning
+  int nBinsY_;   /// number of bins on y axis
+  double ymin_;  /// low edge of y axis
+  double ymax_;  /// up edge of y axis
 
-    // x binning 
-    int nBinsX_;  /// number of bins on x axis
-    double xmin_; /// low edge of x axis
-    double xmax_; /// up edge of x axis 
+  // z binning
+  int nBinsZ_;   /// number of bins on z axis
+  double zmin_;  /// low edge of z axis
+  double zmax_;  /// up edge of z axis
 
-    // y binning  
-    int nBinsY_;  /// number of bins on y axis
-    double ymin_; /// low edge of y axis   
-    double ymax_; /// up edge of y axis 
-    
-    // z binning 
-    int nBinsZ_;  /// number of bins on z axis
-    double zmin_; /// low edge of z axis
-    double zmax_; /// up edge of z axis 
-
-    /// Data storage vector. Contains a vector of hits for each cell. 
-    /// Outer vector has size nBinsX_ * nBinsY_ * nBinsZ_, inner vector for 
-    /// each cell grows dynamically. 
-    std::vector<std::vector<const BaseTrackerRecHit*>> recHits_ = {};
+  /// Data storage vector. Contains a vector of hits for each cell.
+  /// Outer vector has size nBinsX_ * nBinsY_ * nBinsZ_, inner vector for
+  /// each cell grows dynamically.
+  std::vector<std::vector<const BaseTrackerRecHit*>> recHits_ = {};
 };

--- a/RecoTracker/SpecialSeedGenerators/interface/CartesianSeedingGrid.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CartesianSeedingGrid.h
@@ -1,0 +1,134 @@
+#pragma once
+
+// system include files
+#include <vector>
+
+// user include files
+#include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
+
+/// Cartesian seeding grid, intended for cosmic track reconstruction.
+/// Collects space-points in an x-y-z binning in the global frame.
+/// In each bin, orders the hits by descending y.
+/// Does not take ownership of the hits - user is responsible
+/// for ensuring pointer validity and object lifetime.
+class CartesianSeedingGrid {
+public:
+  /// @brief Constructor, taking the parameters of the (rectangular) bin grid.
+  /// @param nBinsX: Number of bins in the global x coordinate
+  /// @param xmin: Low edge of the first bin in global x
+  /// @param xmax: Up edge of the last bin in global x
+  /// @param nBinsY: Number of bins in the global y coordinate
+  /// @param ymin: Low edge of the first bin in global y
+  /// @param ymax: Up edge of the last bin in global y
+  /// @param nBinsZ: Number of bins in the global z coordinate
+  /// @param zmin: Low edge of the first bin in global z
+  /// @param zmax: Up edge of the last bin in global z
+  CartesianSeedingGrid(
+      int nBinsX, double xmin, double xmax, int nBinsY, double ymin, double ymax, int nBinsZ, double zmin, double zmax);
+
+  /// @brief add a hit to the grid. Will be placed in a bin corresponding
+  /// to the coordinates returned by its globalPosition().
+  /// @param h: Hit to be stored.
+  void addHit(const BaseTrackerRecHit* h);
+
+  /// @brief convert a global x-coordinate to the corresponding bin index.
+  /// Under/overflows will be added to the first/last bins.
+  /// @param x global x coordinate value
+  /// @return bin index in the x coordinate.
+  inline int binX(double x) const { return findBin(x, nBinsX_, xmin_, xmax_); }
+
+  /// @brief convert a global y-coordinate to the corresponding bin index.
+  /// Under/overflows will be added to the first/last bins.
+  /// @param y global y coordinate value
+  /// @return bin index in the y coordinate.
+  inline int binY(double y) const { return findBin(y, nBinsY_, ymin_, ymax_); }
+  /// @brief convert a global z-coordinate to the corresponding bin index.
+  /// Under/overflows will be added to the first/last bins.
+  /// @param z global y coordinate value
+  /// @return bin index in the z coordinate.
+  inline int binZ(double z) const { return findBin(z, nBinsZ_, zmin_, zmax_); }
+
+  /// @brief access (read-only) the hit content of one cell.
+  /// @param binX: The x-bin-index
+  /// @param binY: The y-bin-index
+  /// @param binZ: The z-bin-index
+  /// @return the hits stored in cell (binX,binY,binZ), as a read-only reference
+  const std::vector<const BaseTrackerRecHit*>& getHits(int binX, int binY, int binZ) const;
+
+  /// @brief sort the hits in each cell to be ordered descending in global y.
+  /// Call this **after** filling the binning grid with all hits to be considered.
+  void sort();
+
+  /// @brief helper function - maps 3D bin indices to our 1D vector.
+  /// @param bx: index of the bin along x
+  /// @param by: index of the bin along y
+  /// @param bz: index of the bin along z
+  /// @return Index of the corresponding cell in our storage vector.
+  int getBin(int bx, int by, int bz) const;
+
+  /// @brief getter for the number of bins along x.
+  /// @return the number of bins along x
+  inline int nBinsX() const { return nBinsX_; }
+
+  /// @brief getter for the number of bins along y.
+  /// @return the number of bins along y
+  inline int nBinsY() const { return nBinsY_; }
+
+  /// @brief getter for the number of bins along z.
+  /// @return the number of bins along z
+  inline int nBinsZ() const { return nBinsZ_; }
+
+  /// @brief getter for the starting coordinate of the x-binning
+  /// @return the low edge of the first bin along x
+  inline double xmin() const { return xmin_; }
+  /// @brief getter for the end coordinate of the x-binning
+  /// @return the up edge of the last bin along x
+  inline double xmax() const { return xmax_; }
+  /// @brief getter for the starting coordinate of the y-binning
+  /// @return the low edge of the first bin along y
+  inline double ymin() const { return ymin_; }
+  /// @brief getter for the end coordinate of the y-binning
+  /// @return the up edge of the last bin along y
+  inline double ymax() const { return ymax_; }
+  /// @brief getter for the starting coordinate of the z-binning
+  /// @return the low edge of the first bin along z
+  inline double zmin() const { return zmin_; }
+  /// @brief getter for the end coordinate of the z-binning
+  /// @return the up edge of the last bin along z
+  inline double zmax() const { return zmax_; }
+
+private:
+  /// @brief helper function to locate a bin. Will return the index of the bin in a
+  /// (equidistant) binning of the interval [min,max] into nBins bins.
+  /// Bins are indexed in "C-convention", meaning from 0 to nBins - 1.
+  /// @param value: Value to translate to a bin index
+  /// @param nBins: Number of bins
+  /// @param min: Low edge of the binned interval
+  /// @param max: Up edge of the binned interval
+  /// @return Integer in the range [0, nBins-1] indicating the bin in which
+  /// the passed value lies.
+  /// Under/Overflow will be merged into the first / last bin.
+  int findBin(double value, int nBins, double min, double max) const;
+
+  /// data members
+
+  // x binning
+  int nBinsX_;   /// number of bins on x axis
+  double xmin_;  /// low edge of x axis
+  double xmax_;  /// up edge of x axis
+
+  // y binning
+  int nBinsY_;   /// number of bins on y axis
+  double ymin_;  /// low edge of y axis
+  double ymax_;  /// up edge of y axis
+
+  // z binning
+  int nBinsZ_;   /// number of bins on z axis
+  double zmin_;  /// low edge of z axis
+  double zmax_;  /// up edge of z axis
+
+  /// Data storage vector. Contains a vector of hits for each cell.
+  /// Outer vector has size nBinsX_ * nBinsY_ * nBinsZ_, inner vector for
+  /// each cell grows dynamically.
+  std::vector<std::vector<const BaseTrackerRecHit*>> recHits_ = {};
+};

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicGridTripletSeeder.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicGridTripletSeeder.h
@@ -1,0 +1,209 @@
+#pragma once
+
+// system include files
+#include <cmath>
+#include <memory>
+#include <vector>
+
+// user include files
+#include "RecoTracker/SpecialSeedGenerators/interface/CartesianSeedingGrid.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/VectorHit2D.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "RecoTracker/PixelSeeding/interface/OrderedHitTriplet.h"
+#include "RecoTracker/TkSeedingLayers/interface/OrderedSeedingHits.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "RecoTracker/PixelSeeding/interface/OrderedHitTriplet.h"
+#include "RecoTracker/TkSeedGenerator/interface/FastHelix.h"
+#include "DataFormats/TrackerRecHit2D/interface/VectorHit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "TrackingTools/TrajectoryParametrization/interface/CartesianTrajectoryError.h"
+#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+
+#include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
+#include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
+
+/// Grid triplet seeder for cosmic muons.
+/// Intended as a very simple and robust seeder for initial
+/// Phase-2 alignment studies in a non-collision environment
+/// Forms triplets by connecting adjacent space-points in global y,
+/// using stubs in the strips to reduce combinatorics, and
+/// additionally binning the 3D space into cells and only
+/// using plausible cell combinations in the seeding.
+///
+/// Also compatible with Run-3 tracker, without reconfiguration.
+class CosmicGridTripletSeeder : public edm::stream::EDProducer<> {
+public:
+  explicit CosmicGridTripletSeeder(const edm::ParameterSet& par);
+  ~CosmicGridTripletSeeder() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
+
+private:
+  /// Encapsulated event state, for convenient passing between methods
+  /// and allowing for concurrent calls to the same producer instance
+  /// across multiple in-progress events.
+  struct TripletSeederEventState {
+    CartesianSeedingGrid grid;  /// the seeding grid
+    std::map<const VectorHit*, std::vector<const BaseTrackerRecHit*>>
+        vhConstituents;                               /// the reco hits comprising each of the vector hits in the grid
+    const MagneticField* magfield = nullptr;          /// cached magnetic field instance
+    const TrackerGeometry* tracker = nullptr;         /// cached tracking geometry
+    TkClonerImpl cloner;                              /// cloner, used in the final seed fitting
+    std::unique_ptr<KFUpdator> theUpdator = nullptr;  /// kalman updator
+    std::unique_ptr<PropagatorWithMaterial> thePropagatorAl = nullptr;  /// propagator - along momentum
+    std::unique_ptr<PropagatorWithMaterial> thePropagatorOp = nullptr;  /// propagator - opposite momentum
+  };
+
+  /// @brief load conditions required for the event
+  /// @param c: EventSetup instance
+  /// @return an event state instance with event-setup dependent members
+  /// initialised based on the passed argument
+  TripletSeederEventState initEventState(const edm::EventSetup& c) const;
+
+  /// @brief populate the seeding grid.
+  /// Will retrieve the hit collections and fill them into the seeding grid
+  /// contained within the event state.
+  /// @param e: Event to process
+  /// @param state: State instance to update - will get its grid and VH constituent members populated
+  /// @return status - true in case of success.
+  void populateGrid(const edm::Event& e, TripletSeederEventState& state) const;
+
+  /// @brief top-level triplet formation method.
+  /// Will loop over sets of adjacent cells and perform local triplet formation.
+  /// @param state: Event state to take the binned hits from
+  /// @param [out] found: Vector of triplets to push the found triplets into
+  void formTriplets(const TripletSeederEventState& state, std::vector<OrderedHitTriplet>& found) const;
+
+  /// @brief Triplet formation method for a given starting cell.
+  /// Will form triplets from hits in the given cell and its neighbours.
+  /// Results will be pushed into the "found" vector, and the "trackUsage"
+  /// multiset will count how often a given hit is used to enforce a maximum.
+  /// @param xBin: x-index of the cell to seed triplet formation
+  /// @param yBin: y-index of the cell to seed triplet formation
+  /// @param zBin: z-index of the cell to seed triplet formation
+  /// @param state: event state containing the hits and event information
+  /// @param [out] found: The list of triplets to push new candidates into
+  /// @param trackUsage: Counter for the number of triplets a given hit is used for.
+  void formTriplets(int xBin,
+                    int yBin,
+                    int zBin,
+                    const TripletSeederEventState& state,
+                    std::vector<OrderedHitTriplet>& found,
+                    std::unordered_multiset<const BaseTrackerRecHit*>& trackUsage) const;
+
+  /// @brief Triplet formation method for sets of hits to consider.
+  /// Will form triplets comprising one hit from topCands, one from centerCands, and one
+  /// from bottomCands, with the requirement for them to be ordered descending in y.
+  /// @param topCands: Candidates for the top (in global y) hit in the triplet
+  /// @param centerCands: Candidates for the middle (in global y) hit in the triplet
+  /// @param bottomCands: Candidates for the bottom (in global y) hit in the triplet
+  /// @param state: event state containing the hits and event information
+  /// @param [out] found: The list of triplets to push new candidates into
+  /// @param trackUsage: Counter for the number of triplets a given hit is used for.
+  void formTriplets(const std::vector<const BaseTrackerRecHit*>& topCands,
+                    const std::vector<const BaseTrackerRecHit*>& centerCands,
+                    const std::vector<const BaseTrackerRecHit*>& bottomCands,
+                    const TripletSeederEventState& state,
+                    std::vector<OrderedHitTriplet>& found,
+                    std::unordered_multiset<const BaseTrackerRecHit*>& trackUsage) const;
+
+  /// @brief Method apply quality cuts on a given triplet
+  /// Will check compatibility of points with a cosmic trajectory.
+  /// @param state: Event state, containing the required event info such as field.
+  /// @param triplet: The triplet to check
+  bool tripletOk(const TripletSeederEventState& state, const OrderedHitTriplet& triplet) const;
+
+  /// @brief Top-level method to fit the triplets into trajectorySeeds.
+  /// Will attempt, for each triplet, to check if it satisfies certain quality criteria and fit its
+  /// trajectory using a Kalman filter.
+  /// @param state: Event state, containing the required event info such as field, propagators and updator.
+  /// @param triplets: The set of triplets to fit
+  /// @param output seed collection to push the successfully fit candidates into.
+  void fitTriplets(const TripletSeederEventState& state,
+                   const std::vector<OrderedHitTriplet>& triplets,
+                   TrajectorySeedCollection& output) const;
+
+  /// @brief Method to attempt to fit a single triplet into a trajectorySeed.
+  /// Will attempt to check if it satisfies certain quality criteria and fit its
+  /// trajectory using a Kalman filter. In case of success, will push a candidate into
+  /// the output collection.
+  /// @param state: Event state, containing the required event info such as field, propagators and updator.
+  /// @param triplet: The triplet to fit
+  /// @param output seed collection to push the successfully fit candidates into.
+  /// @param seedPerSP: tracker to count accepted seeds using the same space-point
+  /// @param goUp: If true, will put the seed state on the surface of the uppermost space point. Else on the lowest.
+  /// @return a bool indicating the success of the operation
+  bool fitTriplet(const TripletSeederEventState& state,
+                  const OrderedHitTriplet& triplet,
+                  TrajectorySeedCollection& output,
+                  std::unordered_multiset<const TrackingRecHit*>& seedPerSP,
+                  bool goUp = false) const;
+
+  /// data dependencies
+  edm::EDGetTokenT<VectorHitCollection> vectorHitsToken_;                // vector hit collection
+  edm::EDGetTokenT<Phase2TrackerRecHit1DCollectionNew> otRecHitsToken_;  // strip hits in the outer tracker
+  edm::EDGetTokenT<SiStripMatchedRecHit2DCollection> matchedStripHitsToken_;
+  edm::EDGetTokenT<SiStripRecHit2DCollection> rPhiHitsToken_;
+  edm::EDGetTokenT<SiPixelRecHitCollection> pixelRecHitsToken_;  // pixel hits
+
+  /// condition dependencies
+
+  // B-field
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
+
+  // geometry
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerToken_;
+
+  // tools
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> ttrhBuilderToken_;
+
+  // config for enabling triplet writing
+  bool writeTriplets_ = false;
+
+  // config parameters for the seeding grid
+  int nGridBinsX_ = 1;
+  int nGridBinsY_ = 1;
+  int nGridBinsZ_ = 1;
+
+  double gridXmin_ = -120;
+  double gridXmax_ = 120;
+
+  double gridYmin_ = -120;
+  double gridYmax_ = 120;
+
+  double gridZmin_ = -280;
+  double gridZmax_ = 280;
+
+  // algorithm tuning options
+  double ptMin_ = 1.0;
+  std::size_t maxTripsPerSP_ = 24;  // max. triplets allowed per SP
+  std::size_t maxSeedsPerSP_ = 8;   // max. seeds allowed per SP
+  double slopeCompatForVH_ = 0.15;  // max. rel. difference in central dy/dx between triplet and vector hit estimate
+  bool tryBothDirections_ = true;   // try both extrapolation directions when fitting the seed or just "upwards"
+};

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicGridTripletSeeder.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicGridTripletSeeder.h
@@ -48,160 +48,162 @@
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 
-
-/// Grid triplet seeder for cosmic muons. 
-/// Intended as a very simple and robust seeder for initial 
+/// Grid triplet seeder for cosmic muons.
+/// Intended as a very simple and robust seeder for initial
 /// Phase-2 alignment studies in a non-collision environment
-/// Forms triplets by connecting adjacent space-points in global y, 
-/// using stubs in the strips to reduce combinatorics, and 
-/// additionally binning the 3D space into cells and only 
-/// using plausible cell combinations in the seeding.  
+/// Forms triplets by connecting adjacent space-points in global y,
+/// using stubs in the strips to reduce combinatorics, and
+/// additionally binning the 3D space into cells and only
+/// using plausible cell combinations in the seeding.
 ///
-/// Also compatible with Run-3 tracker, without reconfiguration. 
+/// Also compatible with Run-3 tracker, without reconfiguration.
 class CosmicGridTripletSeeder : public edm::stream::EDProducer<> {
 public:
-    explicit CosmicGridTripletSeeder(const edm::ParameterSet& par);
-    ~CosmicGridTripletSeeder() override = default;
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-    void produce(edm::Event &e, const edm::EventSetup &c) override;
+  explicit CosmicGridTripletSeeder(const edm::ParameterSet& par);
+  ~CosmicGridTripletSeeder() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
 
 private:
+  /// Encapsulated event state, for convenient passing between methods
+  /// and allowing for concurrent calls to the same producer instance
+  /// across multiple in-progress events.
+  struct TripletSeederEventState {
+    CartesianSeedingGrid grid;  /// the seeding grid
+    std::map<const VectorHit*, std::vector<const BaseTrackerRecHit*>>
+        vhConstituents;                               /// the reco hits comprising each of the vector hits in the grid
+    const MagneticField* magfield = nullptr;          /// cached magnetic field instance
+    const TrackerGeometry* tracker = nullptr;         /// cached tracking geometry
+    TkClonerImpl cloner;                              /// cloner, used in the final seed fitting
+    std::unique_ptr<KFUpdator> theUpdator = nullptr;  /// kalman updator
+    std::unique_ptr<PropagatorWithMaterial> thePropagatorAl = nullptr;  /// propagator - along momentum
+    std::unique_ptr<PropagatorWithMaterial> thePropagatorOp = nullptr;  /// propagator - opposite momentum
+  };
 
-    /// Encapsulated event state, for convenient passing between methods 
-    /// and allowing for concurrent calls to the same producer instance 
-    /// across multiple in-progress events. 
-    struct TripletSeederEventState{
-        CartesianSeedingGrid grid;  /// the seeding grid 
-        std::map<const VectorHit*, std::vector<const BaseTrackerRecHit*>> vhConstituents;  /// the reco hits comprising each of the vector hits in the grid  
-        const MagneticField *magfield = nullptr; /// cached magnetic field instance
-        const TrackerGeometry *tracker = nullptr; /// cached tracking geometry  
-        TkClonerImpl cloner;  /// cloner, used in the final seed fitting  
-        std::unique_ptr<KFUpdator> theUpdator = nullptr; /// kalman updator 
-        std::unique_ptr<PropagatorWithMaterial> thePropagatorAl = nullptr; /// propagator - along momentum 
-        std::unique_ptr<PropagatorWithMaterial> thePropagatorOp = nullptr; /// propagator - opposite momentum 
-    };
+  /// @brief load conditions required for the event
+  /// @param c: EventSetup instance
+  /// @return an event state instance with event-setup dependent members
+  /// initialised based on the passed argument
+  TripletSeederEventState initEventState(const edm::EventSetup& c) const;
 
-     /// @brief load conditions required for the event
-     /// @param c: EventSetup instance 
-     /// @return an event state instance with event-setup dependent members
-     /// initialised based on the passed argument 
-     TripletSeederEventState initEventState(const edm::EventSetup &c) const;
+  /// @brief populate the seeding grid.
+  /// Will retrieve the hit collections and fill them into the seeding grid
+  /// contained within the event state.
+  /// @param e: Event to process
+  /// @param state: State instance to update - will get its grid and VH constituent members populated
+  /// @return status - true in case of success.
+  void populateGrid(const edm::Event& e, TripletSeederEventState& state) const;
 
-     /// @brief populate the seeding grid. 
-     /// Will retrieve the hit collections and fill them into the seeding grid 
-     /// contained within the event state.  
-     /// @param e: Event to process
-     /// @param state: State instance to update - will get its grid and VH constituent members populated 
-     /// @return status - true in case of success. 
-     void populateGrid(const edm::Event& e, TripletSeederEventState & state) const;
-     
-     
-     /// @brief top-level triplet formation method. 
-     /// Will loop over sets of adjacent cells and perform local triplet formation. 
-     /// @param state: Event state to take the binned hits from
-     /// @param [out] found: Vector of triplets to push the found triplets into 
-     void formTriplets(const TripletSeederEventState & state, std::vector<OrderedHitTriplet> & found) const;
+  /// @brief top-level triplet formation method.
+  /// Will loop over sets of adjacent cells and perform local triplet formation.
+  /// @param state: Event state to take the binned hits from
+  /// @param [out] found: Vector of triplets to push the found triplets into
+  void formTriplets(const TripletSeederEventState& state, std::vector<OrderedHitTriplet>& found) const;
 
-     /// @brief Triplet formation method for a given starting cell. 
-     /// Will form triplets from hits in the given cell and its neighbours. 
-     /// Results will be pushed into the "found" vector, and the "trackUsage"
-     /// multiset will count how often a given hit is used to enforce a maximum. 
-     /// @param xBin: x-index of the cell to seed triplet formation 
-     /// @param yBin: y-index of the cell to seed triplet formation 
-     /// @param zBin: z-index of the cell to seed triplet formation 
-     /// @param state: event state containing the hits and event information
-     /// @param [out] found: The list of triplets to push new candidates into 
-     /// @param trackUsage: Counter for the number of triplets a given hit is used for.  
-     void formTriplets(int xBin, int yBin, int zBin, 
-                       const TripletSeederEventState & state,
-                       std::vector<OrderedHitTriplet> & found, 
-                       std::unordered_multiset<const BaseTrackerRecHit*> & trackUsage) const;
+  /// @brief Triplet formation method for a given starting cell.
+  /// Will form triplets from hits in the given cell and its neighbours.
+  /// Results will be pushed into the "found" vector, and the "trackUsage"
+  /// multiset will count how often a given hit is used to enforce a maximum.
+  /// @param xBin: x-index of the cell to seed triplet formation
+  /// @param yBin: y-index of the cell to seed triplet formation
+  /// @param zBin: z-index of the cell to seed triplet formation
+  /// @param state: event state containing the hits and event information
+  /// @param [out] found: The list of triplets to push new candidates into
+  /// @param trackUsage: Counter for the number of triplets a given hit is used for.
+  void formTriplets(int xBin,
+                    int yBin,
+                    int zBin,
+                    const TripletSeederEventState& state,
+                    std::vector<OrderedHitTriplet>& found,
+                    std::unordered_multiset<const BaseTrackerRecHit*>& trackUsage) const;
 
-     /// @brief Triplet formation method for sets of hits to consider. 
-     /// Will form triplets comprising one hit from topCands, one from centerCands, and one 
-     /// from bottomCands, with the requirement for them to be ordered descending in y. 
-     /// @param topCands: Candidates for the top (in global y) hit in the triplet
-     /// @param centerCands: Candidates for the middle (in global y) hit in the triplet
-     /// @param bottomCands: Candidates for the bottom (in global y) hit in the triplet
-     /// @param state: event state containing the hits and event information
-     /// @param [out] found: The list of triplets to push new candidates into 
-     /// @param trackUsage: Counter for the number of triplets a given hit is used for.  
-     void formTriplets(const std::vector<const BaseTrackerRecHit*> & topCands, 
-                       const std::vector<const BaseTrackerRecHit*> & centerCands, 
-                       const std::vector<const BaseTrackerRecHit*> & bottomCands, 
-                       const TripletSeederEventState & state,
-                       std::vector<OrderedHitTriplet> & found, 
-                       std::unordered_multiset<const BaseTrackerRecHit*> & trackUsage) const;
+  /// @brief Triplet formation method for sets of hits to consider.
+  /// Will form triplets comprising one hit from topCands, one from centerCands, and one
+  /// from bottomCands, with the requirement for them to be ordered descending in y.
+  /// @param topCands: Candidates for the top (in global y) hit in the triplet
+  /// @param centerCands: Candidates for the middle (in global y) hit in the triplet
+  /// @param bottomCands: Candidates for the bottom (in global y) hit in the triplet
+  /// @param state: event state containing the hits and event information
+  /// @param [out] found: The list of triplets to push new candidates into
+  /// @param trackUsage: Counter for the number of triplets a given hit is used for.
+  void formTriplets(const std::vector<const BaseTrackerRecHit*>& topCands,
+                    const std::vector<const BaseTrackerRecHit*>& centerCands,
+                    const std::vector<const BaseTrackerRecHit*>& bottomCands,
+                    const TripletSeederEventState& state,
+                    std::vector<OrderedHitTriplet>& found,
+                    std::unordered_multiset<const BaseTrackerRecHit*>& trackUsage) const;
 
+  /// @brief Method apply quality cuts on a given triplet
+  /// Will check compatibility of points with a cosmic trajectory.
+  /// @param state: Event state, containing the required event info such as field.
+  /// @param triplet: The triplet to check
+  bool tripletOk(const TripletSeederEventState& state, const OrderedHitTriplet& triplet) const;
 
-     /// @brief Method apply quality cuts on a given triplet
-     /// Will check compatibility of points with a cosmic trajectory. 
-     /// @param state: Event state, containing the required event info such as field. 
-     /// @param triplet: The triplet to check 
-     bool tripletOk(const TripletSeederEventState & state, const OrderedHitTriplet& triplet) const;
+  /// @brief Top-level method to fit the triplets into trajectorySeeds.
+  /// Will attempt, for each triplet, to check if it satisfies certain quality criteria and fit its
+  /// trajectory using a Kalman filter.
+  /// @param state: Event state, containing the required event info such as field, propagators and updator.
+  /// @param triplets: The set of triplets to fit
+  /// @param output seed collection to push the successfully fit candidates into.
+  void fitTriplets(const TripletSeederEventState& state,
+                   const std::vector<OrderedHitTriplet>& triplets,
+                   TrajectorySeedCollection& output) const;
 
+  /// @brief Method to attempt to fit a single triplet into a trajectorySeed.
+  /// Will attempt to check if it satisfies certain quality criteria and fit its
+  /// trajectory using a Kalman filter. In case of success, will push a candidate into
+  /// the output collection.
+  /// @param state: Event state, containing the required event info such as field, propagators and updator.
+  /// @param triplet: The triplet to fit
+  /// @param output seed collection to push the successfully fit candidates into.
+  /// @param seedPerSP: tracker to count accepted seeds using the same space-point
+  /// @param goUp: If true, will put the seed state on the surface of the uppermost space point. Else on the lowest.
+  /// @return a bool indicating the success of the operation
+  bool fitTriplet(const TripletSeederEventState& state,
+                  const OrderedHitTriplet& triplet,
+                  TrajectorySeedCollection& output,
+                  std::unordered_multiset<const TrackingRecHit*>& seedPerSP,
+                  bool goUp = false) const;
 
-     /// @brief Top-level method to fit the triplets into trajectorySeeds. 
-     /// Will attempt, for each triplet, to check if it satisfies certain quality criteria and fit its 
-     /// trajectory using a Kalman filter. 
-     /// @param state: Event state, containing the required event info such as field, propagators and updator. 
-     /// @param triplets: The set of triplets to fit 
-     /// @param output seed collection to push the successfully fit candidates into. 
-     void fitTriplets(const TripletSeederEventState & state, const std::vector<OrderedHitTriplet>& triplets, TrajectorySeedCollection & output) const;
-     
-     /// @brief Method to attempt to fit a single triplet into a trajectorySeed. 
-     /// Will attempt to check if it satisfies certain quality criteria and fit its 
-     /// trajectory using a Kalman filter. In case of success, will push a candidate into 
-     /// the output collection. 
-     /// @param state: Event state, containing the required event info such as field, propagators and updator. 
-     /// @param triplet: The triplet to fit 
-     /// @param output seed collection to push the successfully fit candidates into. 
-     /// @param seedPerSP: tracker to count accepted seeds using the same space-point 
-     /// @param goUp: If true, will put the seed state on the surface of the uppermost space point. Else on the lowest. 
-     /// @return a bool indicating the success of the operation 
-     bool fitTriplet(const TripletSeederEventState & state, const OrderedHitTriplet& triplet, TrajectorySeedCollection & output, std::unordered_multiset<const TrackingRecHit*> & seedPerSP, bool goUp = false) const;
+  /// data dependencies
+  edm::EDGetTokenT<VectorHitCollection> vectorHitsToken_;                // vector hit collection
+  edm::EDGetTokenT<Phase2TrackerRecHit1DCollectionNew> otRecHitsToken_;  // strip hits in the outer tracker
+  edm::EDGetTokenT<SiStripMatchedRecHit2DCollection> matchedStripHitsToken_;
+  edm::EDGetTokenT<SiStripRecHit2DCollection> rPhiHitsToken_;
+  edm::EDGetTokenT<SiPixelRecHitCollection> pixelRecHitsToken_;  // pixel hits
 
-     /// data dependencies 
-    edm::EDGetTokenT<VectorHitCollection> vectorHitsToken_;  // vector hit collection
-    edm::EDGetTokenT<Phase2TrackerRecHit1DCollectionNew> otRecHitsToken_;  // strip hits in the outer tracker
-    edm::EDGetTokenT<SiStripMatchedRecHit2DCollection> matchedStripHitsToken_;
-    edm::EDGetTokenT<SiStripRecHit2DCollection> rPhiHitsToken_;
-    edm::EDGetTokenT<SiPixelRecHitCollection> pixelRecHitsToken_;   // pixel hits
+  /// condition dependencies
 
-    /// condition dependencies 
+  // B-field
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
 
-    // B-field 
-    const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
+  // geometry
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerToken_;
 
-    // geometry
-    const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerToken_;
+  // tools
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> ttrhBuilderToken_;
 
-    // tools 
-    const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> ttrhBuilderToken_;
+  // config for enabling triplet writing
+  bool writeTriplets_ = false;
 
-    // config for enabling triplet writing
-    bool writeTriplets_ = false; 
+  // config parameters for the seeding grid
+  int nGridBinsX_ = 1;
+  int nGridBinsY_ = 1;
+  int nGridBinsZ_ = 1;
 
-    // config parameters for the seeding grid 
-    int nGridBinsX_ = 1;
-    int nGridBinsY_ = 1;
-    int nGridBinsZ_ = 1;
+  double gridXmin_ = -120;
+  double gridXmax_ = 120;
 
-    double gridXmin_ = -120; 
-    double gridXmax_ = 120; 
+  double gridYmin_ = -120;
+  double gridYmax_ = 120;
 
-    double gridYmin_ = -120; 
-    double gridYmax_ = 120; 
+  double gridZmin_ = -280;
+  double gridZmax_ = 280;
 
-    double gridZmin_ = -280; 
-    double gridZmax_ = 280; 
-
-    // algorithm tuning options
-    double ptMin_   = 1.0; 
-    std::size_t maxTripsPerSP_ = 24;     // max. triplets allowed per SP 
-    std::size_t maxSeedsPerSP_ = 8;      // max. seeds allowed per SP 
-    double slopeCompatForVH_ = 0.15;     // max. rel. difference in central dy/dx between triplet and vector hit estimate 
-    bool tryBothDirections_ = true;      // try both extrapolation directions when fitting the seed or just "upwards"
-
-
+  // algorithm tuning options
+  double ptMin_ = 1.0;
+  std::size_t maxTripsPerSP_ = 24;  // max. triplets allowed per SP
+  std::size_t maxSeedsPerSP_ = 8;   // max. seeds allowed per SP
+  double slopeCompatForVH_ = 0.15;  // max. rel. difference in central dy/dx between triplet and vector hit estimate
+  bool tryBothDirections_ = true;   // try both extrapolation directions when fitting the seed or just "upwards"
 };

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicGridTripletSeeder.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicGridTripletSeeder.h
@@ -1,0 +1,194 @@
+#pragma once
+
+// system include files
+#include <cmath>
+#include <memory>
+#include <vector>
+
+// user include files
+#include "RecoTracker/SpecialSeedGenerators/interface/CartesianSeedingGrid.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/VectorHit2D.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "RecoTracker/PixelSeeding/interface/OrderedHitTriplet.h"
+#include "RecoTracker/TkSeedingLayers/interface/OrderedSeedingHits.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "RecoTracker/PixelSeeding/interface/OrderedHitTriplet.h"
+#include "RecoTracker/TkSeedGenerator/interface/FastHelix.h"
+#include "DataFormats/TrackerRecHit2D/interface/VectorHit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "TrackingTools/TrajectoryParametrization/interface/CartesianTrajectoryError.h"
+#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+
+#include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
+#include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
+
+
+/// Grid triplet seeder for cosmic muons. 
+/// Intended as a very simple and robust seeder for initial 
+/// Phase-2 alignment studies in a non-collision environment
+/// Forms triplets by connecting adjacent space-points in global y, 
+/// using stubs in the strips to reduce combinatorics, and 
+/// additionally binning the 3D space into cells and only 
+/// using plausible cell combinations in the seeding.  
+///
+/// Also compatible with Run-3 tracker, without reconfiguration. 
+class CosmicGridTripletSeeder : public edm::stream::EDProducer<> {
+public:
+    explicit CosmicGridTripletSeeder(const edm::ParameterSet& par);
+    ~CosmicGridTripletSeeder() override = default;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+    void produce(edm::Event &e, const edm::EventSetup &c) override;
+
+private:
+
+    /// Encapsulated event state, for convenient passing between methods 
+    /// and allowing for concurrent calls to the same producer instance 
+    /// across multiple in-progress events. 
+    struct TripletSeederEventState{
+        CartesianSeedingGrid grid;  /// the seeding grid 
+        std::map<const VectorHit*, std::vector<const BaseTrackerRecHit*>> vhConstituents;  /// the reco hits comprising each of the vector hits in the grid  
+        const MagneticField *magfield = nullptr; /// cached magnetic field instance
+        const TrackerGeometry *tracker = nullptr; /// cached tracking geometry  
+        TkClonerImpl cloner;  /// cloner, used in the final seed fitting  
+        std::unique_ptr<KFUpdator> theUpdator = nullptr; /// kalman updator 
+        std::unique_ptr<PropagatorWithMaterial> thePropagatorAl = nullptr; /// propagator - along momentum 
+        std::unique_ptr<PropagatorWithMaterial> thePropagatorOp = nullptr; /// propagator - opposite momentum 
+    };
+
+     /// @brief load conditions required for the event
+     /// @param c: EventSetup instance 
+     /// @return an event state instance with event-setup dependent members
+     /// initialised based on the passed argument 
+     TripletSeederEventState initEventState(const edm::EventSetup &c) const;
+
+     /// @brief populate the seeding grid. 
+     /// Will retrieve the hit collections and fill them into the seeding grid 
+     /// contained within the event state.  
+     /// @param e: Event to process
+     /// @param state: State instance to update - will get its grid and VH constituent members populated 
+     /// @return status - true in case of success. 
+     void populateGrid(const edm::Event& e, TripletSeederEventState & state) const;
+     
+     
+     /// @brief top-level triplet formation method. 
+     /// Will loop over sets of adjacent cells and perform local triplet formation. 
+     /// @param state: Event state to take the binned hits from
+     /// @param [out] found: Vector of triplets to push the found triplets into 
+     void formTriplets(const TripletSeederEventState & state, std::vector<OrderedHitTriplet> & found) const;
+
+     /// @brief Triplet formation method for a given starting cell. 
+     /// Will form triplets from hits in the given cell and its neighbours. 
+     /// Results will be pushed into the "found" vector, and the "trackUsage"
+     /// multiset will count how often a given hit is used to enforce a maximum. 
+     /// @param xBin: x-index of the cell to seed triplet formation 
+     /// @param yBin: y-index of the cell to seed triplet formation 
+     /// @param zBin: z-index of the cell to seed triplet formation 
+     /// @param state: event state containing the hits and event information
+     /// @param [out] found: The list of triplets to push new candidates into 
+     /// @param trackUsage: Counter for the number of triplets a given hit is used for.  
+     void formTriplets(int xBin, int yBin, int zBin, 
+                       const TripletSeederEventState & state,
+                       std::vector<OrderedHitTriplet> & found, 
+                       std::unordered_multiset<const BaseTrackerRecHit*> & trackUsage) const;
+
+     /// @brief Triplet formation method for sets of hits to consider. 
+     /// Will form triplets comprising one hit from topCands, one from centerCands, and one 
+     /// from bottomCands, with the requirement for them to be ordered descending in y. 
+     /// @param topCands: Candidates for the top (in global y) hit in the triplet
+     /// @param centerCands: Candidates for the middle (in global y) hit in the triplet
+     /// @param bottomCands: Candidates for the bottom (in global y) hit in the triplet
+     /// @param state: event state containing the hits and event information
+     /// @param [out] found: The list of triplets to push new candidates into 
+     /// @param trackUsage: Counter for the number of triplets a given hit is used for.  
+     void formTriplets(const std::vector<const BaseTrackerRecHit*> & topCands, 
+                       const std::vector<const BaseTrackerRecHit*> & centerCands, 
+                       const std::vector<const BaseTrackerRecHit*> & bottomCands, 
+                       const TripletSeederEventState & state,
+                       std::vector<OrderedHitTriplet> & found, 
+                       std::unordered_multiset<const BaseTrackerRecHit*> & trackUsage) const;
+
+
+     /// @brief Top-level method to fit the triplets into trajectorySeeds. 
+     /// Will attempt, for each triplet, to check if it satisfies certain quality criteria and fit its 
+     /// trajectory using a Kalman filter. 
+     /// @param state: Event state, containing the required event info such as field, propagators and updator. 
+     /// @param triplets: The set of triplets to fit 
+     /// @param output seed collection to push the successfully fit candidates into. 
+     void fitTriplets(const TripletSeederEventState & state, const std::vector<OrderedHitTriplet>& triplets, TrajectorySeedCollection & output) const;
+     
+     /// @brief Method to attempt to fit a single triplet into a trajectorySeed. 
+     /// Will attempt to check if it satisfies certain quality criteria and fit its 
+     /// trajectory using a Kalman filter. In case of success, will push a candidate into 
+     /// the output collection. 
+     /// @param state: Event state, containing the required event info such as field, propagators and updator. 
+     /// @param triplet: The triplet to fit 
+     /// @param output seed collection to push the successfully fit candidates into. 
+     /// @return a bool indicating the success of the operation 
+     bool fitTriplet(const TripletSeederEventState & state, const OrderedHitTriplet& triplet, TrajectorySeedCollection & output) const;
+
+    /// helper borrowed from SimpleCosmicBONSeeder - possibly refactor into helper class for deployment
+    std::pair<GlobalVector, int> pqFromHelixFit(const GlobalPoint &inner,
+                                            const GlobalPoint &middle,
+                                            const GlobalPoint &outer,
+                                            const MagneticField* magfield) const; 
+
+     /// data dependencies 
+    edm::EDGetTokenT<VectorHitCollection> vectorHitsToken_;  // vector hit collection
+    edm::EDGetTokenT<Phase2TrackerRecHit1DCollectionNew> otRecHitsToken_;  // strip hits in the outer tracker
+    edm::EDGetTokenT<SiStripMatchedRecHit2DCollection> matchedStripHitsToken_;
+    edm::EDGetTokenT<SiStripRecHit2DCollection> rPhiHitsToken_;
+    edm::EDGetTokenT<SiPixelRecHitCollection> pixelRecHitsToken_;   // pixel hits
+
+    /// condition dependencies 
+
+    // B-field 
+    const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
+
+    // geometry
+    const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerToken_;
+
+    // tools 
+    const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> ttrhBuilderToken_;
+
+    // config parameters for the seeding grid 
+    int nGridBinsX_ = 1;
+    int nGridBinsY_ = 1;
+    int nGridBinsZ_ = 1;
+
+    double gridXmin_ = -120; 
+    double gridXmax_ = 120; 
+
+    double gridYmin_ = -120; 
+    double gridYmax_ = 120; 
+
+    double gridZmin_ = -280; 
+    double gridZmax_ = 280; 
+
+
+};

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicGridTripletSeeder.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicGridTripletSeeder.h
@@ -134,6 +134,13 @@ private:
                        std::unordered_multiset<const BaseTrackerRecHit*> & trackUsage) const;
 
 
+     /// @brief Method apply quality cuts on a given triplet
+     /// Will check compatibility of points with a cosmic trajectory. 
+     /// @param state: Event state, containing the required event info such as field. 
+     /// @param triplet: The triplet to check 
+     bool tripletOk(const TripletSeederEventState & state, const OrderedHitTriplet& triplet) const;
+
+
      /// @brief Top-level method to fit the triplets into trajectorySeeds. 
      /// Will attempt, for each triplet, to check if it satisfies certain quality criteria and fit its 
      /// trajectory using a Kalman filter. 
@@ -149,14 +156,10 @@ private:
      /// @param state: Event state, containing the required event info such as field, propagators and updator. 
      /// @param triplet: The triplet to fit 
      /// @param output seed collection to push the successfully fit candidates into. 
+     /// @param seedPerSP: tracker to count accepted seeds using the same space-point 
+     /// @param goUp: If true, will put the seed state on the surface of the uppermost space point. Else on the lowest. 
      /// @return a bool indicating the success of the operation 
-     bool fitTriplet(const TripletSeederEventState & state, const OrderedHitTriplet& triplet, TrajectorySeedCollection & output) const;
-
-    /// helper borrowed from SimpleCosmicBONSeeder - possibly refactor into helper class for deployment
-    std::pair<GlobalVector, int> pqFromHelixFit(const GlobalPoint &inner,
-                                            const GlobalPoint &middle,
-                                            const GlobalPoint &outer,
-                                            const MagneticField* magfield) const; 
+     bool fitTriplet(const TripletSeederEventState & state, const OrderedHitTriplet& triplet, TrajectorySeedCollection & output, std::unordered_multiset<const TrackingRecHit*> & seedPerSP, bool goUp = false) const;
 
      /// data dependencies 
     edm::EDGetTokenT<VectorHitCollection> vectorHitsToken_;  // vector hit collection
@@ -176,6 +179,9 @@ private:
     // tools 
     const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> ttrhBuilderToken_;
 
+    // config for enabling triplet writing
+    bool writeTriplets_ = false; 
+
     // config parameters for the seeding grid 
     int nGridBinsX_ = 1;
     int nGridBinsY_ = 1;
@@ -189,6 +195,13 @@ private:
 
     double gridZmin_ = -280; 
     double gridZmax_ = 280; 
+
+    // algorithm tuning options
+    double ptMin_   = 1.0; 
+    std::size_t maxTripsPerSP_ = 24;     // max. triplets allowed per SP 
+    std::size_t maxSeedsPerSP_ = 8;      // max. seeds allowed per SP 
+    double slopeCompatForVH_ = 0.15;     // max. rel. difference in central dy/dx between triplet and vector hit estimate 
+    bool tryBothDirections_ = true;      // try both extrapolation directions when fitting the seed or just "upwards"
 
 
 };

--- a/RecoTracker/SpecialSeedGenerators/python/CosmicGridTripletSeeder_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CosmicGridTripletSeeder_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+from RecoTracker.SpecialSeedGenerators.cosmicGridTripletSeeder_cfi import cosmicGridTripletSeeder 
+
+cosmicGridTripletSeeds = cosmicGridTripletSeeder.clone()

--- a/RecoTracker/SpecialSeedGenerators/python/CosmicGridTripletSeeder_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CosmicGridTripletSeeder_cff.py
@@ -1,2 +1,4 @@
-from RecoTracker.SpecialSeedGenerators.CosmicGridTripletSeeder_cfi import * 
-cosmicSeedingPhase2 = cms.Sequence(cosmicGridTripletSeeds)
+import FWCore.ParameterSet.Config as cms
+from RecoTracker.SpecialSeedGenerators.cosmicGridTripletSeeder_cfi import cosmicGridTripletSeeder 
+
+cosmicGridTripletSeeds = cosmicGridTripletSeeder.clone()

--- a/RecoTracker/SpecialSeedGenerators/python/CosmicGridTripletSeeder_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CosmicGridTripletSeeder_cff.py
@@ -1,0 +1,2 @@
+from RecoTracker.SpecialSeedGenerators.CosmicGridTripletSeeder_cfi import * 
+cosmicSeedingPhase2 = cms.Sequence(cosmicGridTripletSeeds)

--- a/RecoTracker/SpecialSeedGenerators/python/CosmicGridTripletSeeder_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CosmicGridTripletSeeder_cfi.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoTracker.SpecialSeedGenerators.cosmicGridTripletSeeder_cfi import cosmicGridTripletSeeder 
+cosmicGridTripletSeeds = cosmicGridTripletSeeder.clone(
+   vectorHits    = cms.untracked.InputTag("siPhase2VectorHits:accepted"),
+   OTRecHits = cms.untracked.InputTag("siPhase2RecHits"),
+   PixelRecHits = cms.untracked.InputTag("siPixelRecHits"),
+   TTRHBuilder = cms.string('WithTrackAngle'),
+   MagneticFieldRecord = cms.ESInputTag('', ''),
+   nGridX = cms.int32(1),
+   nGridY = cms.int32(1),
+   nGridZ = cms.int32(1)
+)

--- a/RecoTracker/SpecialSeedGenerators/python/CosmicGridTripletSeeder_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CosmicGridTripletSeeder_cfi.py
@@ -1,13 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.SpecialSeedGenerators.cosmicGridTripletSeeder_cfi import cosmicGridTripletSeeder 
-cosmicGridTripletSeeds = cosmicGridTripletSeeder.clone(
-   vectorHits    = cms.untracked.InputTag("siPhase2VectorHits:accepted"),
-   OTRecHits = cms.untracked.InputTag("siPhase2RecHits"),
-   PixelRecHits = cms.untracked.InputTag("siPixelRecHits"),
-   TTRHBuilder = cms.string('WithTrackAngle'),
-   MagneticFieldRecord = cms.ESInputTag('', ''),
-   nGridX = cms.int32(1),
-   nGridY = cms.int32(1),
-   nGridZ = cms.int32(1)
-)
+cosmicGridTripletSeeds = cosmicGridTripletSeeder.clone()

--- a/RecoTracker/SpecialSeedGenerators/python/CosmicGridTripletSeeder_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CosmicGridTripletSeeder_cfi.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from RecoTracker.SpecialSeedGenerators.cosmicGridTripletSeeder_cfi import cosmicGridTripletSeeder 
-cosmicGridTripletSeeds = cosmicGridTripletSeeder.clone()

--- a/RecoTracker/SpecialSeedGenerators/src/CartesianSeedingGrid.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CartesianSeedingGrid.cc
@@ -1,0 +1,38 @@
+#include "RecoTracker/SpecialSeedGenerators/interface/CartesianSeedingGrid.h"
+
+
+CartesianSeedingGrid::CartesianSeedingGrid (int nBinsX, double xmin, double xmax, int nBinsY, double ymin, double ymax,int nBinsZ, double zmin, double zmax ):
+    nBinsX_(nBinsX),
+    xmin_(xmin), 
+    xmax_(xmax), 
+    nBinsY_(nBinsY),
+    ymin_(ymin), 
+    ymax_(ymax), 
+    nBinsZ_(nBinsZ),
+    zmin_(zmin), 
+    zmax_(zmax){
+    recHits_.resize(nBinsX*nBinsY*nBinsZ);
+    }
+
+void CartesianSeedingGrid::addHit(const BaseTrackerRecHit* h){
+    recHits_.at(getBin(binX(h->globalPosition().x()), binY(h->globalPosition().y()), binZ(h->globalPosition().z()))).push_back(h);
+}
+
+const std::vector<const BaseTrackerRecHit*> & CartesianSeedingGrid::getHits(int binX, int binY, int binZ) const{
+    return recHits_.at(getBin(binX,binY,binZ));
+}
+
+void CartesianSeedingGrid::sort(){
+    for (auto & cell : recHits_){
+    std::sort(cell.begin(),cell.end(),[](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2){return h1->globalPosition().y() < h2->globalPosition().y(); });
+    }
+}
+
+int CartesianSeedingGrid::getBin(int bx, int by, int bz) const{
+    return bz + nBinsZ_ * (by + nBinsY_ * bx);
+}
+
+int CartesianSeedingGrid::findBin(double value, int nBins, double min, double max) const {
+    return std::clamp<int>(std::floor(( value- min) / (max - min) * nBins),0,nBins-1);
+}
+

--- a/RecoTracker/SpecialSeedGenerators/src/CartesianSeedingGrid.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CartesianSeedingGrid.cc
@@ -1,0 +1,38 @@
+#include "RecoTracker/SpecialSeedGenerators/interface/CartesianSeedingGrid.h"
+
+CartesianSeedingGrid::CartesianSeedingGrid(
+    int nBinsX, double xmin, double xmax, int nBinsY, double ymin, double ymax, int nBinsZ, double zmin, double zmax)
+    : nBinsX_(nBinsX),
+      xmin_(xmin),
+      xmax_(xmax),
+      nBinsY_(nBinsY),
+      ymin_(ymin),
+      ymax_(ymax),
+      nBinsZ_(nBinsZ),
+      zmin_(zmin),
+      zmax_(zmax) {
+  recHits_.resize(nBinsX * nBinsY * nBinsZ);
+}
+
+void CartesianSeedingGrid::addHit(const BaseTrackerRecHit* h) {
+  recHits_.at(getBin(binX(h->globalPosition().x()), binY(h->globalPosition().y()), binZ(h->globalPosition().z())))
+      .push_back(h);
+}
+
+const std::vector<const BaseTrackerRecHit*>& CartesianSeedingGrid::getHits(int binX, int binY, int binZ) const {
+  return recHits_.at(getBin(binX, binY, binZ));
+}
+
+void CartesianSeedingGrid::sort() {
+  for (auto& cell : recHits_) {
+    std::sort(cell.begin(), cell.end(), [](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2) {
+      return h1->globalPosition().y() < h2->globalPosition().y();
+    });
+  }
+}
+
+int CartesianSeedingGrid::getBin(int bx, int by, int bz) const { return bz + nBinsZ_ * (by + nBinsY_ * bx); }
+
+int CartesianSeedingGrid::findBin(double value, int nBins, double min, double max) const {
+  return std::clamp<int>(std::floor((value - min) / (max - min) * nBins), 0, nBins - 1);
+}

--- a/RecoTracker/SpecialSeedGenerators/src/CartesianSeedingGrid.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CartesianSeedingGrid.cc
@@ -1,38 +1,38 @@
 #include "RecoTracker/SpecialSeedGenerators/interface/CartesianSeedingGrid.h"
 
-
-CartesianSeedingGrid::CartesianSeedingGrid (int nBinsX, double xmin, double xmax, int nBinsY, double ymin, double ymax,int nBinsZ, double zmin, double zmax ):
-    nBinsX_(nBinsX),
-    xmin_(xmin), 
-    xmax_(xmax), 
-    nBinsY_(nBinsY),
-    ymin_(ymin), 
-    ymax_(ymax), 
-    nBinsZ_(nBinsZ),
-    zmin_(zmin), 
-    zmax_(zmax){
-    recHits_.resize(nBinsX*nBinsY*nBinsZ);
-    }
-
-void CartesianSeedingGrid::addHit(const BaseTrackerRecHit* h){
-    recHits_.at(getBin(binX(h->globalPosition().x()), binY(h->globalPosition().y()), binZ(h->globalPosition().z()))).push_back(h);
+CartesianSeedingGrid::CartesianSeedingGrid(
+    int nBinsX, double xmin, double xmax, int nBinsY, double ymin, double ymax, int nBinsZ, double zmin, double zmax)
+    : nBinsX_(nBinsX),
+      xmin_(xmin),
+      xmax_(xmax),
+      nBinsY_(nBinsY),
+      ymin_(ymin),
+      ymax_(ymax),
+      nBinsZ_(nBinsZ),
+      zmin_(zmin),
+      zmax_(zmax) {
+  recHits_.resize(nBinsX * nBinsY * nBinsZ);
 }
 
-const std::vector<const BaseTrackerRecHit*> & CartesianSeedingGrid::getHits(int binX, int binY, int binZ) const{
-    return recHits_.at(getBin(binX,binY,binZ));
+void CartesianSeedingGrid::addHit(const BaseTrackerRecHit* h) {
+  recHits_.at(getBin(binX(h->globalPosition().x()), binY(h->globalPosition().y()), binZ(h->globalPosition().z())))
+      .push_back(h);
 }
 
-void CartesianSeedingGrid::sort(){
-    for (auto & cell : recHits_){
-    std::sort(cell.begin(),cell.end(),[](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2){return h1->globalPosition().y() < h2->globalPosition().y(); });
-    }
+const std::vector<const BaseTrackerRecHit*>& CartesianSeedingGrid::getHits(int binX, int binY, int binZ) const {
+  return recHits_.at(getBin(binX, binY, binZ));
 }
 
-int CartesianSeedingGrid::getBin(int bx, int by, int bz) const{
-    return bz + nBinsZ_ * (by + nBinsY_ * bx);
+void CartesianSeedingGrid::sort() {
+  for (auto& cell : recHits_) {
+    std::sort(cell.begin(), cell.end(), [](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2) {
+      return h1->globalPosition().y() < h2->globalPosition().y();
+    });
+  }
 }
+
+int CartesianSeedingGrid::getBin(int bx, int by, int bz) const { return bz + nBinsZ_ * (by + nBinsY_ * bx); }
 
 int CartesianSeedingGrid::findBin(double value, int nBins, double min, double max) const {
-    return std::clamp<int>(std::floor(( value- min) / (max - min) * nBins),0,nBins-1);
+  return std::clamp<int>(std::floor((value - min) / (max - min) * nBins), 0, nBins - 1);
 }
-

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
@@ -1,0 +1,570 @@
+#include <Rtypes.h>
+#include <RtypesCore.h>
+#include <TAttLine.h>
+#include <TAttMarker.h>
+#include <TEllipse.h>
+#include <cmath>
+#include <memory>
+#include <set>
+#include <unordered_set>
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/SiStripDetId/interface/SiStripEnums.h"
+#include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/VectorHit.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/isFinite.h"
+#include "Geometry/CommonTopologies/interface/GeomDetEnumerators.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoTracker/PixelSeeding/interface/OrderedHitTriplet.h"
+#include "RecoTracker/TkSeedGenerator/interface/FastCircle.h"
+#include "RecoTracker/TkSeedGenerator/interface/FastHelix.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "RecoTracker/SpecialSeedGenerators/interface/CosmicGridTripletSeeder.h"
+
+CosmicGridTripletSeeder::CosmicGridTripletSeeder(const edm::ParameterSet& iConfig)
+    : vectorHitsToken_(mayConsume<VectorHitCollection>(iConfig.getUntrackedParameter<edm::InputTag>("vectorHits"))),
+      otRecHitsToken_(
+          mayConsume<Phase2TrackerRecHit1DCollectionNew>(iConfig.getUntrackedParameter<edm::InputTag>("OTRecHits"))),
+      matchedStripHitsToken_(mayConsume<SiStripMatchedRecHit2DCollection>(
+          iConfig.getUntrackedParameter<edm::InputTag>("matchedStripHits"))),
+      rPhiHitsToken_(mayConsume<SiStripRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("rPhiHits"))),
+      pixelRecHitsToken_(consumes(iConfig.getUntrackedParameter<edm::InputTag>("PixelRecHits"))),
+      magfieldToken_(esConsumes(iConfig.getParameter<edm::ESInputTag>("MagneticFieldRecord"))),
+      trackerToken_(esConsumes()),
+      ttrhBuilderToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("TTRHBuilder")))),
+      writeTriplets_(iConfig.getParameter<bool>("writeTriplets")),
+      nGridBinsX_(iConfig.getParameter<int>("nGridBinsX")),
+      nGridBinsY_(iConfig.getParameter<int>("nGridBinsY")),
+      nGridBinsZ_(iConfig.getParameter<int>("nGridBinsZ")),
+      gridXmin_(iConfig.getParameter<double>("gridXmin")),
+      gridXmax_(iConfig.getParameter<double>("gridXmax")),
+      gridYmin_(iConfig.getParameter<double>("gridYmin")),
+      gridYmax_(iConfig.getParameter<double>("gridYmax")),
+      gridZmin_(iConfig.getParameter<double>("gridZmin")),
+      gridZmax_(iConfig.getParameter<double>("gridZmax")),
+      maxTripsPerSP_(iConfig.getParameter<int>("maxTripsPerSP")),
+      maxSeedsPerSP_(iConfig.getParameter<int>("maxSeedsPerSP")),
+      slopeCompatForVH_(iConfig.getParameter<double>("slopeCompatForVH")),
+      tryBothDirections_(iConfig.getParameter<bool>("tryBothDirections")) {
+  produces<TrajectorySeedCollection>();
+  if (writeTriplets_) {
+    produces<edm::OwnVector<TrackingRecHit>>();
+  }
+}
+
+void CosmicGridTripletSeeder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<edm::InputTag>("vectorHits", edm::InputTag("siPhase2VectorHits:accepted"));
+  desc.addUntracked<edm::InputTag>("OTRecHits", edm::InputTag("siPhase2RecHits"));
+  desc.addUntracked<edm::InputTag>("matchedStripHits", edm::InputTag("siStripMatchedRecHits", "matchedRecHit"));
+  desc.addUntracked<edm::InputTag>("rPhiHits", edm::InputTag("siStripMatchedRecHits", "rphiRecHit"));
+  desc.addUntracked<edm::InputTag>("PixelRecHits", edm::InputTag("siPixelRecHits"));
+  desc.add<std::string>("TTRHBuilder", "WithTrackAngle");
+  desc.add<edm::ESInputTag>("MagneticFieldRecord", edm::ESInputTag("", ""));
+  desc.add<bool>("writeTriplets", false);
+  desc.add<int>("nGridBinsX", 1);
+  desc.add<int>("nGridBinsY", 1);
+  desc.add<int>("nGridBinsZ", 1);
+  desc.add<double>("gridXmin", -120);
+  desc.add<double>("gridXmax", 120);
+  desc.add<double>("gridYmin", -120);
+  desc.add<double>("gridYmax", 120);
+  desc.add<double>("gridZmin", -280);
+  desc.add<double>("gridZmax", 280);
+  desc.add<int>("maxTripsPerSP", 10);
+  desc.add<int>("maxSeedsPerSP", 8);
+  desc.add<double>("slopeCompatForVH", 0.15);
+  desc.add<bool>("tryBothDirections", true);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+CosmicGridTripletSeeder::TripletSeederEventState CosmicGridTripletSeeder::initEventState(
+    const edm::EventSetup& c) const {
+  auto magfield = &c.getData(magfieldToken_);
+  auto tracker = &c.getData(trackerToken_);
+  auto cloner = dynamic_cast<TkTransientTrackingRecHitBuilder const&>(c.getData(ttrhBuilderToken_)).cloner();
+  constexpr double g_muonMass = 0.1057;
+  return TripletSeederEventState{
+      CartesianSeedingGrid{
+          nGridBinsX_, gridXmin_, gridXmax_, nGridBinsY_, gridYmin_, gridYmax_, nGridBinsZ_, gridZmin_, gridZmax_},
+      {},
+      magfield,
+      tracker,
+      cloner,
+      std::make_unique<KFUpdator>(),
+      std::make_unique<PropagatorWithMaterial>(alongMomentum, g_muonMass, magfield),
+      std::make_unique<PropagatorWithMaterial>(oppositeToMomentum, g_muonMass, magfield)};
+}
+
+bool CosmicGridTripletSeeder::tripletOk(const TripletSeederEventState& state, const OrderedHitTriplet& trip) const {
+  // get the positions for triplet shape cleaning
+  Global3DPoint top = trip.inner()->globalPosition();
+  Global3DPoint middle = trip.middle()->globalPosition();
+  Global3DPoint bottom = trip.outer()->globalPosition();
+
+  // veto "zigzag" in z
+  if ((top.z() - middle.z()) * (middle.z() - bottom.z()) < 0 && std::abs(top.z() - bottom.z()) > 1.0)
+    return false;
+
+  // veto "zigzag" in x
+  if ((top.x() - middle.x()) * (middle.x() - bottom.x()) < 0 && std::abs(top.x() - bottom.x()) > 2.0)
+    return false;
+
+  // x-y slope consistency checks
+
+  // get the local x-y slopes between pairs of consecutive SP
+  double dxy_t = (top.x() - middle.x()) / (top.y() - middle.y());
+  double dxy_b = (middle.x() - bottom.x()) / (middle.y() - bottom.y());
+  // center point estimated as mean between the adjacent segments
+  double dxy_c = 0.5 * (dxy_t + dxy_b);
+  double dxy_vh_c = 0;
+  double dxy_vh_b = 0;
+  double dxy_vh_t = 0;
+
+  // and, for vector hits (only used in the barrel), the measured slopes
+  // on the hit itself
+  const VectorHit* topVH = dynamic_cast<const VectorHit*>(trip.inner());
+  if (topVH)
+    dxy_vh_t = topVH->globalDirectionVH().x() / topVH->globalDirectionVH().y();
+
+  const VectorHit* centerVH = dynamic_cast<const VectorHit*>(trip.middle());
+  if (centerVH)
+    dxy_vh_c = centerVH->globalDirectionVH().x() / centerVH->globalDirectionVH().y();
+
+  const VectorHit* bottomVH = dynamic_cast<const VectorHit*>(trip.outer());
+  if (bottomVH)
+    dxy_vh_b = bottomVH->globalDirectionVH().x() / bottomVH->globalDirectionVH().y();
+
+  // now we require consistency between the VH and the estimate from neighbouring SP
+  // for all cases where these are well-defined
+  if (topVH && std::abs(dxy_vh_t - dxy_t) > slopeCompatForVH_ * std::abs(std::max(dxy_vh_t, dxy_t)))
+    return false;
+  if (centerVH && std::abs(dxy_vh_c - dxy_c) > slopeCompatForVH_ * std::abs(std::max(dxy_vh_c, dxy_c)))
+    return false;
+  if (bottomVH && std::abs(dxy_vh_b - dxy_b) > slopeCompatForVH_ * std::abs(std::max(dxy_vh_b, dxy_b)))
+    return false;
+
+  // check curvature estimate
+  if (FastCircle(top, middle, bottom).rho() < 0.5 * ptMin_ / (0.003 * state.magfield->nominalValue())) {
+    return false;
+  }
+  return true;
+}
+
+void CosmicGridTripletSeeder::produce(edm::Event& e, const edm::EventSetup& c) {
+  // setup the event state object
+  TripletSeederEventState state = initEventState(c);
+
+  // populate the seeding grid
+  populateGrid(e, state);
+
+  // now form triplets
+  std::vector<OrderedHitTriplet> triplets;
+  formTriplets(state, triplets);
+
+  // book the trajectory seed collection
+  auto output = std::make_unique<TrajectorySeedCollection>();
+
+  // and fit the triplets
+  fitTriplets(state, triplets, *output);
+
+  // put our output on the store
+  e.put(std::move(output));
+  // optional triplet writing for debugging / perf validation
+  if (writeTriplets_) {
+    auto outtriplets = std::make_unique<edm::OwnVector<TrackingRecHit>>();
+    for (auto& trip : triplets) {
+      outtriplets->push_back(trip.inner()->cloneHit());
+      outtriplets->push_back(trip.middle()->cloneHit());
+      outtriplets->push_back(trip.outer()->cloneHit());
+    }
+    e.put(std::move(outtriplets));
+  }
+}
+
+void CosmicGridTripletSeeder::populateGrid(const edm::Event& iEvent,
+                                           CosmicGridTripletSeeder::TripletSeederEventState& state) const {
+  edm::Handle<VectorHitCollection> vectorHits;
+  edm::Handle<Phase2TrackerRecHit1DCollectionNew> otHitCollection;
+  edm::Handle<SiStripMatchedRecHit2DCollection> matchedStripHits;
+  edm::Handle<SiStripRecHit2DCollection> rPhiStripHits;
+  edm::Handle<SiPixelRecHitCollection> pixelHitCollection;
+
+  /// Treat the hit collections as optional, so that we can
+  /// run with both the Run-3 and the Phase-2 detectors.
+  bool hasOT = iEvent.getByToken(otRecHitsToken_, otHitCollection);
+  bool hasVec = iEvent.getByToken(vectorHitsToken_, vectorHits);
+  bool hasMatchedStrips = iEvent.getByToken(matchedStripHitsToken_, matchedStripHits);
+  bool hasRphiStrips = iEvent.getByToken(rPhiHitsToken_, rPhiStripHits);
+
+  /// Pixels should be around in all detector geometries.
+  bool hasPixels = iEvent.getByToken(pixelRecHitsToken_, pixelHitCollection);
+
+  std::set<const TrackingRecHit*> recHitsSeen{};
+  std::vector<const VectorHit*> vhSeen{};
+
+  /// step 1: Add the vector hits, and remember all raw hits associated to them
+  if (hasVec) {
+    LogDebug("CosmicGridTrupletSeeder") << "have Vec hits ";
+    for (auto detSet : *vectorHits) {
+      for (const VectorHit& vh : detSet) {
+        // Phase-2 endcap vector hits currently have directional information
+        // that can not be used directly - hence we skip these.
+        if (state.tracker->idToDet(vh.geographicalId())->subDetector() == GeomDetEnumerators::SubDetector::P2OTEC) {
+          continue;
+        }
+        state.grid.addHit(&vh);
+        vhSeen.push_back(&vh);
+      }
+    }
+  }
+
+  // Step 2 for phase-2 detector
+
+  // Add remaining OT hits, excluding those already on vector hits
+  if (hasOT) {
+    LogDebug("CosmicGridTrupletSeeder") << "have OT hits ";
+    for (auto ds : *otHitCollection) {
+      for (const auto& otHit : ds) {
+        bool unique = true;
+        for (const auto* vh : vhSeen) {
+          if (vh->sharesInput(&otHit, TrackingRecHit::some)) {
+            unique = false;
+            state.vhConstituents[vh].push_back(&otHit);
+            break;
+          }
+        }
+        if (!unique) {
+          continue;
+        }
+        state.grid.addHit(&otHit);
+        recHitsSeen.insert(&otHit);
+      }
+    }
+  }
+
+  // Step 2 for a phase-1 detector (two hit collections)
+
+  // phase-1 matched strip hits
+  if (hasMatchedStrips) {
+    LogDebug("CosmicGridTrupletSeeder") << "have matched hits ";
+    for (auto ds : *matchedStripHits) {
+      for (const auto& stripHit : ds) {
+        bool unique = true;
+        for (const auto* vh : vhSeen) {
+          if (vh->sharesInput(&stripHit, TrackingRecHit::some)) {
+            unique = false;
+            state.vhConstituents[vh].push_back(&stripHit);
+            break;
+          }
+        }
+        if (!unique) {
+          continue;
+        }
+        state.grid.addHit(&stripHit);
+        recHitsSeen.insert(&stripHit);
+      }
+    }
+  }
+
+  // phase-1 rphi strip hits
+  if (hasRphiStrips) {
+    LogDebug("CosmicGridTrupletSeeder") << "have rphi hits ";
+    for (auto ds : *rPhiStripHits) {
+      for (const auto& stripHit : ds) {
+        bool unique = true;
+        for (const auto* vh : vhSeen) {
+          if (vh->sharesInput(&stripHit, TrackingRecHit::some)) {
+            unique = false;
+            state.vhConstituents[vh].push_back(&stripHit);
+            break;
+          }
+        }
+        if (!unique) {
+          continue;
+        }
+        state.grid.addHit(&stripHit);
+        recHitsSeen.insert(&stripHit);
+      }
+    }
+  }
+
+  /// step 3: Add pixel hits if desired
+  if (hasPixels) {
+    LogDebug("CosmicGridTrupletSeeder") << "have Pixel hits ";
+    for (auto ds : *pixelHitCollection) {
+      for (const auto& pix : ds) {
+        state.grid.addHit(&pix);
+      }
+    }
+  }
+
+  // now sort all bins of the grid by descending global y.
+  state.grid.sort();
+}
+
+/// using the seeding grid, form triplets
+void CosmicGridTripletSeeder::formTriplets(const CosmicGridTripletSeeder::TripletSeederEventState& state,
+                                           std::vector<OrderedHitTriplet>& found) const {
+  std::unordered_multiset<const BaseTrackerRecHit*> trackUsage;
+  // loop downwards over the starting y bin, top to bottom
+  for (int yBin = state.grid.nBinsY() - 1; yBin >= 0; --yBin) {
+    // loop rectangularily over the x-z grid
+    for (int xBin = 0; xBin < state.grid.nBinsX(); ++xBin) {
+      for (int zBin = 0; zBin < state.grid.nBinsZ(); ++zBin) {
+        formTriplets(xBin, yBin, zBin, state, found, trackUsage);
+      }
+    }
+  }
+  // sort by y-location of the lower hit, fall-back to upper if same
+  std::sort(found.begin(), found.end(), [](const OrderedHitTriplet& t1, const OrderedHitTriplet& t2) {
+    double ylow1 = t1.outer()->globalPosition().y();
+    double ylow2 = t2.outer()->globalPosition().y();
+    double ytop1 = t1.inner()->globalPosition().y();
+    double ytop2 = t2.inner()->globalPosition().y();
+    return (ylow1 == ylow2 ? ytop1 > ytop2 : ylow1 > ylow2);
+  });
+}
+
+void CosmicGridTripletSeeder::formTriplets(int xBin,
+                                           int yBin,
+                                           int zBin,
+                                           const TripletSeederEventState& state,
+                                           std::vector<OrderedHitTriplet>& found,
+                                           std::unordered_multiset<const BaseTrackerRecHit*>& trackUsage) const {
+  const CartesianSeedingGrid& grid = state.grid;
+
+  const auto& topHits = grid.getHits(xBin, yBin, zBin);
+  // do not run triplet formation on empty cells.
+  if (topHits.empty())
+    return;
+
+  std::vector<const BaseTrackerRecHit*> hitCands;
+  hitCands.insert(hitCands.end(), topHits.begin(), topHits.end());
+
+  if (yBin > 0) {
+    for (int dxCenter = -1; dxCenter < 2; ++dxCenter) {
+      if (xBin + dxCenter < 0 || xBin + dxCenter >= grid.nBinsX())
+        continue;
+      for (int dzCenter = -1; dzCenter < 2; ++dzCenter) {
+        if (zBin + dzCenter < 0 || zBin + dzCenter >= grid.nBinsZ())
+          continue;
+        const auto& middleHits = grid.getHits(xBin + dxCenter, yBin - 1, zBin + dzCenter);
+        hitCands.insert(hitCands.end(), middleHits.begin(), middleHits.end());
+      }
+    }
+  }
+
+  std::sort(hitCands.begin(), hitCands.end(), [](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2) {
+    return h1->globalPosition().y() > h2->globalPosition().y();
+  });
+
+  formTriplets(topHits, hitCands, hitCands, state, found, trackUsage);
+}
+
+/// get the triplets for one particular cell combination
+void CosmicGridTripletSeeder::formTriplets(const std::vector<const BaseTrackerRecHit*>& topCands,
+                                           const std::vector<const BaseTrackerRecHit*>& centerCands,
+                                           const std::vector<const BaseTrackerRecHit*>& bottomCands,
+                                           const TripletSeederEventState& state,
+                                           std::vector<OrderedHitTriplet>& found,
+                                           std::unordered_multiset<const BaseTrackerRecHit*>& trackUsage) const {
+  for (const BaseTrackerRecHit* top : topCands) {
+    if (trackUsage.count(top) > maxTripsPerSP_)
+      continue;
+    const auto& gTop = top->globalPosition();
+
+    for (const BaseTrackerRecHit* center : centerCands) {
+      if (trackUsage.count(center) > maxTripsPerSP_)
+        continue;
+      const auto& gCenter = center->globalPosition();
+
+      if (gTop.y() < gCenter.y())
+        continue;
+      if (top->sameDetModule(*center))
+        continue;
+
+      for (const BaseTrackerRecHit* bottom : bottomCands) {
+        if (trackUsage.count(bottom) > maxTripsPerSP_)
+          continue;
+        const auto& gBottom = bottom->globalPosition();
+
+        if (top == bottom || center == bottom)
+          continue;
+        if (top->sameDetModule(*bottom) || center->sameDetModule(*bottom))
+          continue;
+        if (gCenter.y() < gBottom.y())
+          continue;
+
+        OrderedHitTriplet ps(top, center, bottom);
+        if (!tripletOk(state, ps))
+          continue;
+
+        trackUsage.insert(top);
+        trackUsage.insert(center);
+        trackUsage.insert(bottom);
+        found.push_back(ps);
+      }
+    }
+  }
+}
+/// fit the triplets with kalman into trajectory seeds
+void CosmicGridTripletSeeder::fitTriplets(const CosmicGridTripletSeeder::TripletSeederEventState& state,
+                                          const std::vector<OrderedHitTriplet>& triplets,
+                                          TrajectorySeedCollection& output) const {
+  std::unordered_multiset<const TrackingRecHit*> seedPerSP;
+  for (const OrderedHitTriplet& trip : triplets) {
+    if (seedPerSP.count(trip.inner()) >= maxSeedsPerSP_ || seedPerSP.count(trip.middle()) >= maxSeedsPerSP_ ||
+        seedPerSP.count(trip.outer()) >= maxSeedsPerSP_)
+      continue;
+    fitTriplet(state, trip, output, seedPerSP, true);
+    if (tryBothDirections_)
+      fitTriplet(state, trip, output, seedPerSP, false);
+  }
+}
+
+/// fit of a single triplet into a trajectory seed
+bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletSeederEventState& state,
+                                         const OrderedHitTriplet& triplet,
+                                         TrajectorySeedCollection& output,
+                                         std::unordered_multiset<const TrackingRecHit*>& seedPerSP,
+                                         bool goUp) const {
+  typedef TrajectoryStateOnSurface TSOS;
+
+  // arrange the triplet so that the hits appear in extrapolation order, with the *target hit* appearing first ("inner").
+  // NB: They initially come in the order "top - middle - bottom" (in global y) when passed to this method.
+  OrderedHitTriplet tripToUse = goUp ? triplet : OrderedHitTriplet{triplet.outer(), triplet.middle(), triplet.inner()};
+
+  // top SP
+  GlobalPoint target = state.tracker->idToDet((*(tripToUse.inner())).geographicalId())
+                           ->surface()
+                           .toGlobal((*(tripToUse.inner())).localPosition());
+
+  // middle SP
+  GlobalPoint middle = state.tracker->idToDet((*(tripToUse.middle())).geographicalId())
+                           ->surface()
+                           .toGlobal((*(tripToUse.middle())).localPosition());
+
+  // bottom SP
+  GlobalPoint start = state.tracker->idToDet((*(tripToUse.outer())).geographicalId())
+                          ->surface()
+                          .toGlobal((*(tripToUse.outer())).localPosition());
+
+  // Initial momentum estimate at the start point
+  // using the fast helix helper.
+  // Note: arg order of FastHelix is "outer middle vertex",
+  // so we will get a momentum pointing *up* when targeting the top SP,
+  // and pointing down when targeting the bottom SP.
+  FastHelix helix(target, middle, start, state.magfield->nominalValue(), state.magfield);
+
+  // extract momentum and charge - flip when needed to ensure a momentum
+  // pointing down (cosmic trajectory)
+  GlobalVector gv = (goUp ? -1 : 1) * helix.stateAtVertex().momentum();
+  float ch = (goUp ? -1 : 1) * helix.stateAtVertex().charge();
+
+  // initial cleaning.
+  float Mom = gv.mag();
+  if (Mom > 1000000 || edm::isNotFinite(Mom)) {
+    return false;
+  }
+  if (gv.perp() < 0.5 * ptMin_) {
+    return false;
+  }
+
+  // Next use a KF to refine the parameter estimate.
+  // Propagate from the start to the target, and track
+  // relation to the momentum direction.
+  const Propagator* propagator = goUp ? state.thePropagatorOp.get() : state.thePropagatorAl.get();
+
+  edm::OwnVector<TrackingRecHit> hits;
+  std::vector<const BaseTrackerRecHit*> seedHits;
+
+  // build our hit array in the order pointing towards the target ("inner")
+  for (const BaseTrackerRecHit* hit : {tripToUse.outer(), tripToUse.middle(), tripToUse.inner()}) {
+    const VectorHit* vh = dynamic_cast<const VectorHit*>(hit);
+    if (vh) {
+      auto found = state.vhConstituents.find(vh);
+      if (found != state.vhConstituents.end()) {
+        for (auto& component : found->second) {
+          seedHits.push_back(component);
+        }
+      } else {
+        edm::LogWarning("CosmicGridTripletSeeder")
+            << "Did not find any constitutents for a vector hit - are our inputs consistent?";
+        seedHits.push_back(hit);
+      }
+    } else {
+      seedHits.push_back(hit);
+    }
+  }
+  // re-sort, to account for the vector hit components being possibly out-of-order
+  std::sort(seedHits.begin(), seedHits.end(), [&](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2) {
+    return goUp ? h1->globalPosition().y() < h2->globalPosition().y()
+                : h1->globalPosition().y() > h2->globalPosition().y();
+  });
+
+  // starting parameters: Lowest point, estimated momentum from fast helix.
+  GlobalPoint updatedStartPos = seedHits.front()->globalPosition();
+  GlobalTrajectoryParameters Gtp(updatedStartPos, gv, int(ch), state.magfield);
+  FreeTrajectoryState CosmicSeed(Gtp, CurvilinearTrajectoryError(AlgebraicSymMatrix55(AlgebraicMatrixID())));
+  CosmicSeed.rescaleError(100);
+  TSOS propagated, updated;
+
+  // now incrementally propagate towards the target point
+  for (size_t ih = 0; ih < seedHits.size(); ++ih) {
+    if (ih == 0) {
+      propagated =
+          propagator->propagate(CosmicSeed, state.tracker->idToDet((*seedHits[ih]).geographicalId())->surface());
+    } else {
+      propagated = propagator->propagate(updated, state.tracker->idToDet((*seedHits[ih]).geographicalId())->surface());
+    }
+    // Phase-2 can result in cases with a "valid" state that has NaN values in the momentum.
+    // This occurs in rare cases when all hits on the seed are on non-stereo 2S OT sensors.
+    // The KF can not use these, so we bail out as for invalid propagations.
+    if (!propagated.isValid() || std::isnan(propagated.globalMomentum().mag())) {
+      return false;
+    }
+
+    // clone the hit based on the propagated state
+    SeedingHitSet::ConstRecHitPointer tthp = seedHits[ih];
+    auto newtth = static_cast<SeedingHitSet::RecHitPointer>(state.cloner(*tthp, propagated));
+    updated = state.theUpdator->update(propagated, *newtth);
+    hits.push_back(newtth);
+
+    if (!updated.isValid()) {
+      return false;
+    }
+  }
+
+  // some more cleaning
+  if (updated.globalMomentum().perp() < ptMin_) {
+    return false;
+  }
+  if (updated.globalMomentum().mag() < ptMin_) {
+    return false;
+  }
+
+  PTrajectoryStateOnDet const& PTraj =
+      trajectoryStateTransform::persistentState(updated, hits.back().geographicalId().rawId());
+
+  // and build the final seed.
+  output.push_back(TrajectorySeed(PTraj, hits, goUp ? oppositeToMomentum : alongMomentum));
+
+  if (output.size() > size_t(500)) {
+    output.clear();
+    edm::LogError("TooManySeeds") << "Found too many seeds, bailing out.\n";
+    return false;
+  }
+  seedPerSP.insert(triplet.inner());
+  seedPerSP.insert(triplet.middle());
+  seedPerSP.insert(triplet.outer());
+
+  return true;
+}

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
@@ -525,7 +525,10 @@ bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletS
     } else {
       propagated = propagator->propagate(updated, state.tracker->idToDet((*seedHits[ih]).geographicalId())->surface());
     }
-    if (!propagated.isValid()) {
+    // Phase-2 can result in cases with a "valid" state that has NaN values in the momentum.
+    // This occurs in rare cases when all hits on the seed are on non-stereo 2S OT sensors.
+    // The KF can not use these, so we bail out as for invalid propagations.
+    if (!propagated.isValid() || std::isnan(propagated.globalMomentum().mag())) {
       return false;
     }
 

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
@@ -1,0 +1,513 @@
+# include <Rtypes.h>
+#include <RtypesCore.h>
+#include <TAttLine.h>
+#include <TAttMarker.h>
+#include <TEllipse.h>
+#include <cmath>
+#include <memory>
+#include <set>
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/SiStripDetId/interface/SiStripEnums.h"
+#include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/VectorHit.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/isFinite.h"
+#include "Geometry/CommonTopologies/interface/GeomDetEnumerators.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoTracker/TkSeedGenerator/interface/FastHelix.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "RecoTracker/SpecialSeedGenerators/interface/CosmicGridTripletSeeder.h"
+
+//
+
+
+CosmicGridTripletSeeder::CosmicGridTripletSeeder(const edm::ParameterSet& iConfig)
+    : vectorHitsToken_(mayConsume<VectorHitCollection>(iConfig.getUntrackedParameter<edm::InputTag>("vectorHits"))),
+      otRecHitsToken_(mayConsume<Phase2TrackerRecHit1DCollectionNew>(iConfig.getUntrackedParameter<edm::InputTag>("OTRecHits"))),
+      matchedStripHitsToken_(mayConsume<SiStripMatchedRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("matchedStripHits"))),
+      rPhiHitsToken_(mayConsume<SiStripRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("rPhiHits"))),
+      // stereoHitsToken_(mayConsume<SiStripRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("stereoHits"))),
+      pixelRecHitsToken_(consumes(iConfig.getUntrackedParameter<edm::InputTag>("PixelRecHits"))),
+      magfieldToken_(esConsumes(iConfig.getParameter<edm::ESInputTag>("MagneticFieldRecord"))),
+      trackerToken_(esConsumes()),
+      ttrhBuilderToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("TTRHBuilder")))),
+      nGridBinsX_(iConfig.getParameter<int>("nGridBinsX")),
+      nGridBinsY_(iConfig.getParameter<int>("nGridBinsY")),
+      nGridBinsZ_(iConfig.getParameter<int>("nGridBinsZ")),
+      gridXmin_(iConfig.getParameter<double>("gridXmin")),
+      gridXmax_(iConfig.getParameter<double>("gridXmax")),
+      gridYmin_(iConfig.getParameter<double>("gridYmin")),
+      gridYmax_(iConfig.getParameter<double>("gridYmax")),
+      gridZmin_(iConfig.getParameter<double>("gridZmin")),
+      gridZmax_(iConfig.getParameter<double>("gridZmax")){
+  produces<TrajectorySeedCollection>();
+  produces<edm::OwnVector<TrackingRecHit>>();
+
+}
+
+void CosmicGridTripletSeeder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<edm::InputTag>("vectorHits", edm::InputTag("siPhase2VectorHits:accepted"));
+  desc.addUntracked<edm::InputTag>("OTRecHits", edm::InputTag("Phase2TrackerRecHits"));
+  desc.addUntracked<edm::InputTag>("matchedStripHits", edm::InputTag("siStripMatchedRecHits","matchedRecHit"));
+  desc.addUntracked<edm::InputTag>("rPhiHits", edm::InputTag("siStripMatchedRecHits","rphiRecHit"));
+  desc.addUntracked<edm::InputTag>("PixelRecHits", edm::InputTag("siPixelRecHits"));
+  desc.add<std::string>("TTRHBuilder", "WithTrackAngle");
+  desc.add<edm::ESInputTag>("MagneticFieldRecord", edm::ESInputTag("", ""));
+  desc.add<int>("nGridBinsX",1);
+  desc.add<int>("nGridBinsY",1);
+  desc.add<int>("nGridBinsZ",1);
+  desc.add<double>("gridXmin",-120);
+  desc.add<double>("gridXmax",120);
+  desc.add<double>("gridYmin",-120);
+  desc.add<double>("gridYmax",120);
+  desc.add<double>("gridZmin",-280);
+  desc.add<double>("gridZmax",280);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+std::pair<GlobalVector, int> CosmicGridTripletSeeder::pqFromHelixFit(const GlobalPoint& inner,
+                                                                     const GlobalPoint& middle,
+                                                                     const GlobalPoint& outer,
+                                                                     const MagneticField* magfield) const {
+  FastHelix helix(inner, middle, outer, magfield->nominalValue(), magfield);
+  FastCircle theCircle(inner, middle, outer);
+  double rho = theCircle.rho();
+  GlobalVector tesla = magfield->inTesla(middle);
+  double pt = 0.01 * rho * (0.3 * tesla.z());
+  double dx1 = outer.x() - theCircle.x0();
+  double dy1 = outer.y() - theCircle.y0();
+  double py = pt * dx1 / rho, px = -pt * dy1 / rho;
+  if (px * (middle.x() - outer.x()) + py * (middle.y() - outer.y()) < 0.) {
+    px *= -1.;
+    py *= -1.;
+  }
+  double dz = inner.z() - outer.z();
+  double sinphi = (dx1 * (inner.y() - theCircle.y0()) - dy1 * (inner.x() - theCircle.x0())) / (rho * rho);
+  double dphi = std::abs(std::asin(sinphi));
+  double pz = pt * dz / (dphi * rho);
+
+  int myq = ((theCircle.x0() * py - theCircle.y0() * px) / tesla.z()) > 0. ? +1 : -1;
+
+  return std::make_pair(GlobalVector(px, py, pz), myq);
+
+}
+
+CosmicGridTripletSeeder::TripletSeederEventState CosmicGridTripletSeeder::initEventState(const edm::EventSetup& c) const {
+  auto magfield = &c.getData(magfieldToken_);
+  auto tracker = &c.getData(trackerToken_);
+  auto cloner = dynamic_cast<TkTransientTrackingRecHitBuilder const&>(c.getData(ttrhBuilderToken_)).cloner();
+
+  return TripletSeederEventState{CartesianSeedingGrid{nGridBinsX_, gridXmin_, gridXmax_, nGridBinsY_, gridYmin_, gridYmax_, nGridBinsZ_, gridZmin_, gridZmax_},
+                                 {},
+                                 magfield,
+                                 tracker,
+                                 cloner,
+                                 std::make_unique<KFUpdator>(),
+                                 std::make_unique<PropagatorWithMaterial>(alongMomentum, 0.1057, magfield),
+                                 std::make_unique<PropagatorWithMaterial>(oppositeToMomentum, 0.1057, magfield)};
+}
+
+void CosmicGridTripletSeeder::produce(edm::Event& e, const edm::EventSetup& c) {
+  // setup the event state object
+  TripletSeederEventState state = initEventState(c);
+
+  // populate the seeding grid
+  populateGrid(e,state);
+
+  // now form triplets
+  std::vector<OrderedHitTriplet> triplets;
+  formTriplets(state, triplets);
+
+  // book the trajectory seed collection
+  auto output = std::make_unique<TrajectorySeedCollection>();
+  auto outtriplets = std::make_unique<edm::OwnVector<TrackingRecHit>>();
+
+  // and fit the triplets
+  fitTriplets(state, triplets, *output);
+
+  for (auto & trip : triplets){
+    outtriplets->push_back(trip.inner()->cloneHit()); 
+    outtriplets->push_back(trip.middle()->cloneHit()); 
+    outtriplets->push_back(trip.outer()->cloneHit()); 
+  }
+
+  // put our output on the store
+  e.put(std::move(output));
+  e.put(std::move(outtriplets));
+}
+
+void CosmicGridTripletSeeder::populateGrid(const edm::Event& iEvent, CosmicGridTripletSeeder::TripletSeederEventState & state) const {
+  edm::Handle<VectorHitCollection> vectorHits; 
+  edm::Handle<Phase2TrackerRecHit1DCollectionNew> otHitCollection; 
+  edm::Handle<SiStripMatchedRecHit2DCollection> matchedStripHits; 
+  edm::Handle<SiStripRecHit2DCollection> rPhiStripHits; 
+
+  /// Treat the hit collections as optional, so that we can
+  /// run with both the Run-3 and the Phase-2 detectors. 
+  bool hasOT = iEvent.getByToken(otRecHitsToken_, otHitCollection );
+  bool hasVec = iEvent.getByToken(vectorHitsToken_, vectorHits );
+  bool hasMatchedStrips = iEvent.getByToken(matchedStripHitsToken_, matchedStripHits );
+  bool hasRphiStrips = iEvent.getByToken(rPhiHitsToken_, rPhiStripHits );
+
+  /// Pixels should be around in all detector geometries. 
+  const SiPixelRecHitCollection & pixelHitCollection = iEvent.get(pixelRecHitsToken_);
+
+  std::set<const TrackingRecHit*> recHitsSeen{}; 
+  std::vector<const VectorHit*> vhSeen{}; 
+
+  /// step 1: Add the vector hits, and remember all raw hits associated to them 
+  if (hasVec){
+    for (auto detSet : *vectorHits){
+        for (const VectorHit & vh : detSet){
+          // Phase-2 endcap vector hits currently have directional information
+          // that can not be used directly - hence we skip these. 
+          if (state.tracker->idToDet(vh.geographicalId())->subDetector() == GeomDetEnumerators::SubDetector::P2OTEC){
+            continue; 
+          }
+          state.grid.addHit(&vh); 
+          vhSeen.push_back(&vh); 
+        }
+    }
+  }
+
+  // Step 2 for phase-2 detector
+
+  // Add remaining OT hits, excluding those already on vector hits 
+  if (hasOT){
+    for (auto  ds : *otHitCollection){
+        for (const auto & otHit : ds){
+          bool unique = true; 
+          for (const auto* vh : vhSeen){
+              if (vh->sharesInput(&otHit,TrackingRecHit::some)){
+                  unique = false; 
+                  state.vhConstituents[vh].push_back(&otHit);
+                  break; 
+              }
+          }
+          if (!unique){
+              continue; 
+          }
+          state.grid.addHit(&otHit); 
+          recHitsSeen.insert(&otHit); 
+        }
+    }
+  }
+
+  // Step 2 for a phase-1 detector (two hit collections)
+
+  // phase-1 matched strip hits
+  if (hasMatchedStrips){
+    for (auto  ds : *matchedStripHits){
+      for (const auto & stripHit : ds){
+        bool unique = true; 
+        for (const auto* vh : vhSeen){
+            if (vh->sharesInput(&stripHit,TrackingRecHit::some)){
+                unique = false; 
+                state.vhConstituents[vh].push_back(&stripHit);
+                break; 
+            }
+        }
+        if (!unique){
+            continue; 
+        }
+        state.grid.addHit(&stripHit); 
+        recHitsSeen.insert(&stripHit); 
+      }
+    }
+  } 
+
+  // phase-1 rphi strip hits 
+  if (hasRphiStrips){
+    for (auto  ds : *rPhiStripHits){
+      for (const auto & stripHit : ds){
+        bool unique = true; 
+        for (const auto* vh : vhSeen){
+            if (vh->sharesInput(&stripHit,TrackingRecHit::some)){
+                unique = false; 
+                state.vhConstituents[vh].push_back(&stripHit);
+                break; 
+            }
+        }
+        if (!unique){
+            continue; 
+        }
+        state.grid.addHit(&stripHit); 
+        recHitsSeen.insert(&stripHit); 
+      }
+    }
+  }
+
+  /// step 3: Add pixel hits if desired  
+  for (auto  ds : pixelHitCollection){
+      for (const auto & pix : ds){
+        state.grid.addHit(&pix); 
+      }
+  }
+
+  // now sort all bins of the grid by ascending global y.
+  state.grid.sort(); 
+
+}
+
+/// using the seeding grid, form triplets
+void CosmicGridTripletSeeder::formTriplets(const CosmicGridTripletSeeder::TripletSeederEventState & state, std::vector<OrderedHitTriplet> & found) const {
+    std::unordered_multiset<const BaseTrackerRecHit*> trackUsage; 
+    // loop downwards over the starting y bin, top to bottom 
+    for (int yBin = state.grid.nBinsY()-1; yBin >=0 ; --yBin){
+      // loop rectangularily over the x-z grid 
+      for (int xBin = 0; xBin < state.grid.nBinsX(); ++xBin){
+        for (int zBin = 0; zBin < state.grid.nBinsZ(); ++zBin){
+          const auto & topCandidates = state.grid.getHits(xBin,yBin,zBin); 
+          if (topCandidates.empty()) continue;         
+          formTriplets(xBin,yBin,zBin,state,found,trackUsage); 
+        }
+      }
+    }
+}
+
+void CosmicGridTripletSeeder::formTriplets(int xBin,
+                                           int yBin,
+                                           int zBin,
+                                           const TripletSeederEventState& state,
+                                           std::vector<OrderedHitTriplet>& found,
+                                           std::unordered_multiset<const BaseTrackerRecHit*>& trackUsage) const {
+  const CartesianSeedingGrid& grid = state.grid;
+
+  const auto& topHits = grid.getHits(xBin, yBin, zBin);
+
+  std::vector<const BaseTrackerRecHit *> hitCands; 
+  hitCands.insert(hitCands.end(),topHits.begin(), topHits.end() ); 
+
+  for (int dxCenter = -1; dxCenter < 2; ++dxCenter) {
+    if (xBin + dxCenter < 0 || xBin + dxCenter >= grid.nBinsX())
+      continue;
+    for (int dzCenter = -1; dzCenter < 2; ++dzCenter) {
+      if (zBin + dzCenter < 0 || zBin + dzCenter >= grid.nBinsZ())
+        continue;
+      // formTriplets(topHits, topHits, topHits, state, found, trackUsage);
+      if (yBin > 0){
+        const auto& middleHits = grid.getHits(xBin + dxCenter, yBin - 1, zBin + dzCenter);
+        hitCands.insert(hitCands.end(),middleHits.begin(), middleHits.end() ); 
+        // // formTriplets(topHits, topHits, middleHits, state, found, trackUsage);
+        // // formTriplets(topHits, middleHits, middleHits, state, found, trackUsage);
+        // for (int dxBottom = -1; dxBottom < 2; ++dxBottom) {
+        //   if (xBin + dxCenter + dxBottom < 0 || xBin + dxCenter + dxBottom >= grid.nBinsX())
+        //     continue;
+        //   if ((dxCenter < 0 && dxBottom > 0) || (dxCenter > 0 && dxBottom < 0))
+        //     continue;
+        //   for (int dzBottom = -1; dzBottom < 2; ++dzBottom) {
+        //     if (zBin + dzCenter + dzBottom < 0 || zBin + dzCenter + dzBottom >= grid.nBinsZ())
+        //       continue;
+        //     if ((dzCenter < 0 && dzBottom > 0) || (dzCenter > 0 && dzBottom < 0))
+        //       continue;
+        //     if (yBin > 1){
+        //       const auto& bottomHits = grid.getHits(xBin + dxCenter + dxBottom, yBin - 2, zBin + dzCenter + dzBottom);
+        //       formTriplets(topHits, middleHits, bottomHits, state, found, trackUsage);
+        //     }
+        //   }
+        // }
+      }
+    }
+  }
+  std::sort(hitCands.begin(),hitCands.end(),[](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2){return h1->globalPosition().y() < h2->globalPosition().y(); });
+  formTriplets(hitCands, hitCands, hitCands, state, found, trackUsage);
+}
+
+     /// get the triplets for one particular cell combination
+void CosmicGridTripletSeeder::formTriplets(const std::vector<const BaseTrackerRecHit*> & topCands, 
+                const std::vector<const BaseTrackerRecHit*> & centerCands, 
+                const std::vector<const BaseTrackerRecHit*> & bottomCands, 
+                const TripletSeederEventState & state,
+                std::vector<OrderedHitTriplet> & found, 
+                std::unordered_multiset<const BaseTrackerRecHit*> & trackUsage) const{
+
+  for (const BaseTrackerRecHit* top : topCands){
+    if (trackUsage.count(top) > 12) continue; 
+    const auto & gTop = top->globalPosition(); 
+    for (const BaseTrackerRecHit* center: centerCands){
+      const auto & gCenter = center->globalPosition(); 
+      if (trackUsage.count(center) > 12) continue; 
+      for (const BaseTrackerRecHit* bottom: bottomCands){
+        const auto & gBottom = bottom->globalPosition(); 
+        if (trackUsage.count(bottom) > 12) continue; 
+        if (center == top || top == bottom || center == bottom) continue; 
+        if (top->sameDetModule(*bottom) || top->sameDetModule(*center) || center->sameDetModule(*bottom)) continue; 
+        if (gCenter.y() > gTop.y()) continue;
+        if (gBottom.y() > gCenter.y()) continue;
+        // veto "zigzag" in z 
+        if ((gTop.z() - gCenter.z()) * (gCenter.z() - gBottom.z())  < 0 && std::abs(gTop.z() - gBottom.z() > 1.0)) continue;
+        // veto "zigzag" in x 
+        if ((gTop.x() - gCenter.x()) * (gCenter.x() - gBottom.x())  < 0 && std::abs(gTop.x() - gBottom.x() > 1.0)) continue;
+        const VectorHit* cenVH = dynamic_cast<const VectorHit*>(center); 
+        if (cenVH){
+          double dydx = 0.5 * ((gTop.y() - gCenter.y())/(gTop.x() - gCenter.x()) + (gCenter.y() - gBottom.y())/(gCenter.x() - gBottom.x())); 
+          double dydx_vh = cenVH->globalDirectionVH().y() / cenVH->globalDirectionVH().x();
+          std::cout << " dydx from trip "<<dydx<<" and from vh "<<dydx_vh<<std::endl; 
+        }
+
+        OrderedHitTriplet ps (top, center, bottom);
+        trackUsage.insert(top); 
+        trackUsage.insert(center); 
+        trackUsage.insert(bottom); 
+        found.push_back(ps); 
+      }
+    }
+  }
+}
+/// fit the triplets with kalman into trajectory seeds
+void CosmicGridTripletSeeder::fitTriplets(const CosmicGridTripletSeeder::TripletSeederEventState & state, const std::vector<OrderedHitTriplet>& triplets, TrajectorySeedCollection & output) const {
+    for (const OrderedHitTriplet & trip : triplets ) {
+      fitTriplet(state, trip, output); 
+    }
+}
+
+
+/// fit of a single triplet into a trajectory seed 
+bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletSeederEventState & state, const OrderedHitTriplet& triplet, TrajectorySeedCollection & output) const {
+  typedef TrajectoryStateOnSurface TSOS;
+
+
+    OrderedHitTriplet trip = triplet;  
+
+
+    GlobalPoint inner =
+        state.tracker->idToDet((*(trip.inner())).geographicalId())->surface().toGlobal((*(trip.inner())).localPosition());
+
+    GlobalPoint middle =
+        state.tracker->idToDet((*(trip.middle())).geographicalId())->surface().toGlobal((*(trip.middle())).localPosition());
+
+    GlobalPoint outer =
+        state.tracker->idToDet((*(trip.outer())).geographicalId())->surface().toGlobal((*(trip.outer())).localPosition());
+
+    if ((outer.y() - inner.y()) * outer.y() < 0) {
+      std::swap(inner, outer);
+      trip = OrderedHitTriplet(trip.outer(), trip.middle(), trip.inner());
+    }
+
+    // First use FastHelix out of the box
+    std::pair<GlobalVector, int> pq = pqFromHelixFit(inner, middle, outer, state.magfield);
+    GlobalVector gv = pq.first;
+    float ch = pq.second;
+    float Mom = sqrt(gv.x() * gv.x() + gv.y() * gv.y() + gv.z() * gv.z());
+
+    if (Mom > 1000000 || edm::isNotFinite(Mom)) {
+      return false;
+    }
+
+    if (gv.perp() < 0.5) {
+      return false;
+    }
+
+    const Propagator *propagator = nullptr;
+    if ((outer.y() - inner.y()) > 0) {
+      propagator = state.thePropagatorAl.get();
+    } else {
+      gv = -1 * gv;
+      ch = -1. * ch;
+      propagator = state.thePropagatorOp.get();
+    }
+
+    if ((gv.z() * (outer.z() - inner.z()) > 0) && (fabs(outer.z() - inner.z()) > 5) && (fabs(gv.z()) > .01)) {
+    }
+
+
+    edm::OwnVector<TrackingRecHit> hits;
+    std::vector<const BaseTrackerRecHit*> seedHits;
+    for (const BaseTrackerRecHit* hit : {trip.outer(), trip.middle(), trip.inner()}){
+      const VectorHit* vh = dynamic_cast<const VectorHit*>(hit);
+      if (vh){
+        auto found = state.vhConstituents.find(vh);
+        if (found != state.vhConstituents.end()){
+          for (auto & component : found->second){
+            seedHits.push_back(component);
+          }
+        }
+      }
+      else{
+        seedHits.push_back(hit);
+      }
+    }
+    std::sort(seedHits.begin(),seedHits.end(),[&](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2){
+      if (outer.y() > 0 ){
+        return h1->globalPosition().y() > h2->globalPosition().y();
+      }
+      else{
+        return h1->globalPosition().y() < h2->globalPosition().y();
+      }
+    }); 
+    outer = seedHits.front()->globalPosition(); 
+    GlobalTrajectoryParameters Gtp(outer, gv, int(ch), state.magfield);
+    FreeTrajectoryState CosmicSeed(Gtp, CurvilinearTrajectoryError(AlgebraicSymMatrix55(AlgebraicMatrixID())));
+    CosmicSeed.rescaleError(100);
+
+    TSOS propagated, updated;
+    bool fail = false;
+    for (size_t ih = 0; ih < seedHits.size(); ++ih) {
+      if (ih == 0) {
+        propagated = propagator->propagate(CosmicSeed, state.tracker->idToDet((*seedHits[ih]).geographicalId())->surface());
+      } else {
+        propagated = propagator->propagate(updated, state.tracker->idToDet((*seedHits[ih]).geographicalId())->surface());
+      }
+      if (!propagated.isValid()) {
+        fail = true;
+        break;
+      } else {
+      }
+      SeedingHitSet::ConstRecHitPointer tthp = seedHits[ih];
+      auto newtth = static_cast<SeedingHitSet::RecHitPointer>(state.cloner(*tthp, propagated));
+      updated = state.theUpdator->update(propagated, *newtth);
+      hits.push_back(newtth);
+      if (!updated.isValid()) {
+        fail = true;
+        break;
+      } else {
+      }
+    }
+    if (!fail && updated.isValid() && (updated.globalMomentum().perp() < 2.5)) {
+      fail = true;
+    }
+    if (!fail && updated.isValid() && (updated.globalMomentum().mag() < 2.5)) {
+      fail = true;
+    }
+    if (fail) return false; 
+    // if (!fail) {
+        // if (seedVerbosity_ > 2) {
+        //   std::cout << "Processing triplet "  << ", rescale error by " << rescaleError_
+        //             << ": state BEFORE rescaling " << updated;
+        //   std::cout << "    Cartesian error (X,P) before rescaling= \n"
+        //             << updated.cartesianError().matrix() << std::endl;
+        // }
+        // updated.rescaleError(100);
+      // }
+    //   if (true) {
+    //   std::cout << "Processed  triplet "  << ": success (saved as #" << output.size() << ") : " << inner << " + "
+    //             << middle << " + " << outer << std::endl;
+    //   std::cout << "    pt = " << updated.globalMomentum().perp() << "    eta = " << updated.globalMomentum().eta()
+    //             << "    phi = " << updated.globalMomentum().phi() << "    ch = " << updated.charge() << std::endl;
+    //   if (true) {
+    //     std::cout << "    State:" << updated;
+    //   } else {
+    //     std::cout << "    X  = " << updated.globalPosition() << ", P = " << updated.globalMomentum() << std::endl;
+    //   }
+    //   std::cout << "    Cartesian error (X,P) = \n" << updated.cartesianError().matrix() << std::endl;
+    // }   
+
+    PTrajectoryStateOnDet const &PTraj = trajectoryStateTransform::persistentState(
+        updated, hits.back().geographicalId().rawId());
+    output.push_back(TrajectorySeed(PTraj, hits, ((outer.y() - inner.y() > 0) ? alongMomentum : oppositeToMomentum)));
+
+    if (output.size() > size_t(500)) {
+      output.clear();
+      edm::LogError("TooManySeeds") << "Found too many seeds, bailing out.\n";
+      return false;
+    }
+    return true;
+
+}

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
@@ -238,7 +238,6 @@ void CosmicGridTripletSeeder::populateGrid(const edm::Event& iEvent,
           if (vh->sharesInput(&otHit, TrackingRecHit::some)) {
             unique = false;
             state.vhConstituents[vh].push_back(&otHit);
-            break;
           }
         }
         if (!unique) {

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
@@ -1,4 +1,4 @@
-# include <Rtypes.h>
+#include <Rtypes.h>
 #include <RtypesCore.h>
 #include <TAttLine.h>
 #include <TAttMarker.h>
@@ -30,8 +30,10 @@
 
 CosmicGridTripletSeeder::CosmicGridTripletSeeder(const edm::ParameterSet& iConfig)
     : vectorHitsToken_(mayConsume<VectorHitCollection>(iConfig.getUntrackedParameter<edm::InputTag>("vectorHits"))),
-      otRecHitsToken_(mayConsume<Phase2TrackerRecHit1DCollectionNew>(iConfig.getUntrackedParameter<edm::InputTag>("OTRecHits"))),
-      matchedStripHitsToken_(mayConsume<SiStripMatchedRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("matchedStripHits"))),
+      otRecHitsToken_(
+          mayConsume<Phase2TrackerRecHit1DCollectionNew>(iConfig.getUntrackedParameter<edm::InputTag>("OTRecHits"))),
+      matchedStripHitsToken_(mayConsume<SiStripMatchedRecHit2DCollection>(
+          iConfig.getUntrackedParameter<edm::InputTag>("matchedStripHits"))),
       rPhiHitsToken_(mayConsume<SiStripRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("rPhiHits"))),
       pixelRecHitsToken_(consumes(iConfig.getUntrackedParameter<edm::InputTag>("PixelRecHits"))),
       magfieldToken_(esConsumes(iConfig.getParameter<edm::ESInputTag>("MagneticFieldRecord"))),
@@ -47,105 +49,113 @@ CosmicGridTripletSeeder::CosmicGridTripletSeeder(const edm::ParameterSet& iConfi
       gridYmax_(iConfig.getParameter<double>("gridYmax")),
       gridZmin_(iConfig.getParameter<double>("gridZmin")),
       gridZmax_(iConfig.getParameter<double>("gridZmax")),
-      maxTripsPerSP_(iConfig.getParameter<int>("maxTripsPerSP")), 
-      maxSeedsPerSP_(iConfig.getParameter<int>("maxSeedsPerSP")), 
+      maxTripsPerSP_(iConfig.getParameter<int>("maxTripsPerSP")),
+      maxSeedsPerSP_(iConfig.getParameter<int>("maxSeedsPerSP")),
       slopeCompatForVH_(iConfig.getParameter<double>("slopeCompatForVH")),
-      tryBothDirections_(iConfig.getParameter<bool>("tryBothDirections")){
+      tryBothDirections_(iConfig.getParameter<bool>("tryBothDirections")) {
   produces<TrajectorySeedCollection>();
-  if (writeTriplets_){
+  if (writeTriplets_) {
     produces<edm::OwnVector<TrackingRecHit>>();
   }
-
 }
 
 void CosmicGridTripletSeeder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.addUntracked<edm::InputTag>("vectorHits", edm::InputTag("siPhase2VectorHits:accepted"));
   desc.addUntracked<edm::InputTag>("OTRecHits", edm::InputTag("siPhase2RecHits"));
-  desc.addUntracked<edm::InputTag>("matchedStripHits", edm::InputTag("siStripMatchedRecHits","matchedRecHit"));
-  desc.addUntracked<edm::InputTag>("rPhiHits", edm::InputTag("siStripMatchedRecHits","rphiRecHit"));
+  desc.addUntracked<edm::InputTag>("matchedStripHits", edm::InputTag("siStripMatchedRecHits", "matchedRecHit"));
+  desc.addUntracked<edm::InputTag>("rPhiHits", edm::InputTag("siStripMatchedRecHits", "rphiRecHit"));
   desc.addUntracked<edm::InputTag>("PixelRecHits", edm::InputTag("siPixelRecHits"));
   desc.add<std::string>("TTRHBuilder", "WithTrackAngle");
   desc.add<edm::ESInputTag>("MagneticFieldRecord", edm::ESInputTag("", ""));
-  desc.add<bool>("writeTriplets",false);
-  desc.add<int>("nGridBinsX",1);
-  desc.add<int>("nGridBinsY",1);
-  desc.add<int>("nGridBinsZ",1);
-  desc.add<double>("gridXmin",-120);
-  desc.add<double>("gridXmax",120);
-  desc.add<double>("gridYmin",-120);
-  desc.add<double>("gridYmax",120);
-  desc.add<double>("gridZmin",-280);
-  desc.add<double>("gridZmax",280);
-  desc.add<int>("maxTripsPerSP",10);
-  desc.add<int>("maxSeedsPerSP",8);
-  desc.add<double>("slopeCompatForVH",0.15);
-  desc.add<bool>("tryBothDirections",true);
+  desc.add<bool>("writeTriplets", false);
+  desc.add<int>("nGridBinsX", 1);
+  desc.add<int>("nGridBinsY", 1);
+  desc.add<int>("nGridBinsZ", 1);
+  desc.add<double>("gridXmin", -120);
+  desc.add<double>("gridXmax", 120);
+  desc.add<double>("gridYmin", -120);
+  desc.add<double>("gridYmax", 120);
+  desc.add<double>("gridZmin", -280);
+  desc.add<double>("gridZmax", 280);
+  desc.add<int>("maxTripsPerSP", 10);
+  desc.add<int>("maxSeedsPerSP", 8);
+  desc.add<double>("slopeCompatForVH", 0.15);
+  desc.add<bool>("tryBothDirections", true);
   descriptions.addWithDefaultLabel(desc);
 }
 
-CosmicGridTripletSeeder::TripletSeederEventState CosmicGridTripletSeeder::initEventState(const edm::EventSetup& c) const {
+CosmicGridTripletSeeder::TripletSeederEventState CosmicGridTripletSeeder::initEventState(
+    const edm::EventSetup& c) const {
   auto magfield = &c.getData(magfieldToken_);
   auto tracker = &c.getData(trackerToken_);
   auto cloner = dynamic_cast<TkTransientTrackingRecHitBuilder const&>(c.getData(ttrhBuilderToken_)).cloner();
   constexpr double g_muonMass = 0.1057;
-  return TripletSeederEventState{CartesianSeedingGrid{nGridBinsX_, gridXmin_, gridXmax_, nGridBinsY_, gridYmin_, gridYmax_, nGridBinsZ_, gridZmin_, gridZmax_},
-                                 {},
-                                 magfield,
-                                 tracker,
-                                 cloner,
-                                 std::make_unique<KFUpdator>(),
-                                 std::make_unique<PropagatorWithMaterial>(alongMomentum, g_muonMass, magfield),
-                                 std::make_unique<PropagatorWithMaterial>(oppositeToMomentum, g_muonMass, magfield)};
+  return TripletSeederEventState{
+      CartesianSeedingGrid{
+          nGridBinsX_, gridXmin_, gridXmax_, nGridBinsY_, gridYmin_, gridYmax_, nGridBinsZ_, gridZmin_, gridZmax_},
+      {},
+      magfield,
+      tracker,
+      cloner,
+      std::make_unique<KFUpdator>(),
+      std::make_unique<PropagatorWithMaterial>(alongMomentum, g_muonMass, magfield),
+      std::make_unique<PropagatorWithMaterial>(oppositeToMomentum, g_muonMass, magfield)};
 }
 
-bool CosmicGridTripletSeeder::tripletOk(const TripletSeederEventState & state, const OrderedHitTriplet& trip) const{
+bool CosmicGridTripletSeeder::tripletOk(const TripletSeederEventState& state, const OrderedHitTriplet& trip) const {
+  // get the positions for triplet shape cleaning
+  Global3DPoint top = trip.inner()->globalPosition();
+  Global3DPoint middle = trip.middle()->globalPosition();
+  Global3DPoint bottom = trip.outer()->globalPosition();
 
-    // get the positions for triplet shape cleaning 
-    Global3DPoint top = trip.inner()->globalPosition();
-    Global3DPoint middle = trip.middle()->globalPosition();
-    Global3DPoint bottom = trip.outer()->globalPosition();
+  // veto "zigzag" in z
+  if ((top.z() - middle.z()) * (middle.z() - bottom.z()) < 0 && std::abs(top.z() - bottom.z()) > 1.0)
+    return false;
 
-    // veto "zigzag" in z 
-    if ((top.z() - middle.z()) * (middle.z() - bottom.z())  < 0 && std::abs(top.z() - bottom.z()) > 1.0) return false;
+  // veto "zigzag" in x
+  if ((top.x() - middle.x()) * (middle.x() - bottom.x()) < 0 && std::abs(top.x() - bottom.x()) > 2.0)
+    return false;
 
-    // veto "zigzag" in x 
-    if ((top.x() - middle.x()) * (middle.x() - bottom.x())  < 0 && std::abs(top.x() - bottom.x()) > 2.0) return false;
+  // x-y slope consistency checks
 
-    // x-y slope consistency checks
+  // get the local x-y slopes between pairs of consecutive SP
+  double dxy_t = (top.x() - middle.x()) / (top.y() - middle.y());
+  double dxy_b = (middle.x() - bottom.x()) / (middle.y() - bottom.y());
+  // center point estimated as mean between the adjacent segments
+  double dxy_c = 0.5 * (dxy_t + dxy_b);
+  double dxy_vh_c = 0;
+  double dxy_vh_b = 0;
+  double dxy_vh_t = 0;
 
-    // get the local x-y slopes between pairs of consecutive SP 
-    double dxy_t = (top.x() - middle.x())/(top.y() - middle.y());  
-    double dxy_b = (middle.x() - bottom.x())/(middle.y() - bottom.y());
-    // center point estimated as mean between the adjacent segments 
-    double dxy_c = 0.5 * (dxy_t + dxy_b);
-    double dxy_vh_c = 0;
-    double dxy_vh_b = 0; 
-    double dxy_vh_t = 0; 
-        
-    // and, for vector hits (only used in the barrel), the measured slopes 
-    // on the hit itself 
-    const VectorHit* topVH = dynamic_cast<const VectorHit*>(trip.inner()); 
-    if (topVH) dxy_vh_t = topVH->globalDirectionVH().x() /  topVH->globalDirectionVH().y(); 
+  // and, for vector hits (only used in the barrel), the measured slopes
+  // on the hit itself
+  const VectorHit* topVH = dynamic_cast<const VectorHit*>(trip.inner());
+  if (topVH)
+    dxy_vh_t = topVH->globalDirectionVH().x() / topVH->globalDirectionVH().y();
 
-    const VectorHit* centerVH = dynamic_cast<const VectorHit*>(trip.middle()); 
-    if (centerVH) dxy_vh_c = centerVH->globalDirectionVH().x() /  centerVH->globalDirectionVH().y(); 
+  const VectorHit* centerVH = dynamic_cast<const VectorHit*>(trip.middle());
+  if (centerVH)
+    dxy_vh_c = centerVH->globalDirectionVH().x() / centerVH->globalDirectionVH().y();
 
-    const VectorHit* bottomVH = dynamic_cast<const VectorHit*>(trip.outer());
-    if (bottomVH) dxy_vh_b = bottomVH->globalDirectionVH().x() /  bottomVH->globalDirectionVH().y(); 
+  const VectorHit* bottomVH = dynamic_cast<const VectorHit*>(trip.outer());
+  if (bottomVH)
+    dxy_vh_b = bottomVH->globalDirectionVH().x() / bottomVH->globalDirectionVH().y();
 
-    // now we require consistency between the VH and the estimate from neighbouring SP 
-    // for all cases where these are well-defined 
-    if (topVH     && std::abs(dxy_vh_t - dxy_t) > slopeCompatForVH_ * std::abs(std::max(dxy_vh_t,dxy_t))) return false; 
-    if (centerVH  && std::abs(dxy_vh_c - dxy_c) > slopeCompatForVH_ * std::abs(std::max(dxy_vh_c,dxy_c))) return false; 
-    if (bottomVH  && std::abs(dxy_vh_b - dxy_b) > slopeCompatForVH_ * std::abs(std::max(dxy_vh_b,dxy_b))) return false; 
-    
-    // check curvature estimate 
-    if (FastCircle(top, middle, bottom).rho() < 0.5 * ptMin_ / (0.003 * state.magfield->nominalValue())){
-      return false; 
-    }
-    return true; 
+  // now we require consistency between the VH and the estimate from neighbouring SP
+  // for all cases where these are well-defined
+  if (topVH && std::abs(dxy_vh_t - dxy_t) > slopeCompatForVH_ * std::abs(std::max(dxy_vh_t, dxy_t)))
+    return false;
+  if (centerVH && std::abs(dxy_vh_c - dxy_c) > slopeCompatForVH_ * std::abs(std::max(dxy_vh_c, dxy_c)))
+    return false;
+  if (bottomVH && std::abs(dxy_vh_b - dxy_b) > slopeCompatForVH_ * std::abs(std::max(dxy_vh_b, dxy_b)))
+    return false;
 
+  // check curvature estimate
+  if (FastCircle(top, middle, bottom).rho() < 0.5 * ptMin_ / (0.003 * state.magfield->nominalValue())) {
+    return false;
+  }
+  return true;
 }
 
 void CosmicGridTripletSeeder::produce(edm::Event& e, const edm::EventSetup& c) {
@@ -153,7 +163,7 @@ void CosmicGridTripletSeeder::produce(edm::Event& e, const edm::EventSetup& c) {
   TripletSeederEventState state = initEventState(c);
 
   // populate the seeding grid
-  populateGrid(e,state);
+  populateGrid(e, state);
 
   // now form triplets
   std::vector<OrderedHitTriplet> triplets;
@@ -167,159 +177,160 @@ void CosmicGridTripletSeeder::produce(edm::Event& e, const edm::EventSetup& c) {
 
   // put our output on the store
   e.put(std::move(output));
-  // optional triplet writing for debugging / perf validation 
-  if (writeTriplets_){
+  // optional triplet writing for debugging / perf validation
+  if (writeTriplets_) {
     auto outtriplets = std::make_unique<edm::OwnVector<TrackingRecHit>>();
-    for (auto & trip : triplets){
-      outtriplets->push_back(trip.inner()->cloneHit()); 
-      outtriplets->push_back(trip.middle()->cloneHit()); 
-      outtriplets->push_back(trip.outer()->cloneHit()); 
+    for (auto& trip : triplets) {
+      outtriplets->push_back(trip.inner()->cloneHit());
+      outtriplets->push_back(trip.middle()->cloneHit());
+      outtriplets->push_back(trip.outer()->cloneHit());
     }
     e.put(std::move(outtriplets));
   }
 }
 
-void CosmicGridTripletSeeder::populateGrid(const edm::Event& iEvent, CosmicGridTripletSeeder::TripletSeederEventState & state) const {
-  edm::Handle<VectorHitCollection> vectorHits; 
-  edm::Handle<Phase2TrackerRecHit1DCollectionNew> otHitCollection; 
-  edm::Handle<SiStripMatchedRecHit2DCollection> matchedStripHits; 
-  edm::Handle<SiStripRecHit2DCollection> rPhiStripHits; 
-  edm::Handle<SiPixelRecHitCollection> pixelHitCollection; 
+void CosmicGridTripletSeeder::populateGrid(const edm::Event& iEvent,
+                                           CosmicGridTripletSeeder::TripletSeederEventState& state) const {
+  edm::Handle<VectorHitCollection> vectorHits;
+  edm::Handle<Phase2TrackerRecHit1DCollectionNew> otHitCollection;
+  edm::Handle<SiStripMatchedRecHit2DCollection> matchedStripHits;
+  edm::Handle<SiStripRecHit2DCollection> rPhiStripHits;
+  edm::Handle<SiPixelRecHitCollection> pixelHitCollection;
 
   /// Treat the hit collections as optional, so that we can
-  /// run with both the Run-3 and the Phase-2 detectors. 
-  bool hasOT = iEvent.getByToken(otRecHitsToken_, otHitCollection );
-  bool hasVec = iEvent.getByToken(vectorHitsToken_, vectorHits );
-  bool hasMatchedStrips = iEvent.getByToken(matchedStripHitsToken_, matchedStripHits );
-  bool hasRphiStrips = iEvent.getByToken(rPhiHitsToken_, rPhiStripHits );
+  /// run with both the Run-3 and the Phase-2 detectors.
+  bool hasOT = iEvent.getByToken(otRecHitsToken_, otHitCollection);
+  bool hasVec = iEvent.getByToken(vectorHitsToken_, vectorHits);
+  bool hasMatchedStrips = iEvent.getByToken(matchedStripHitsToken_, matchedStripHits);
+  bool hasRphiStrips = iEvent.getByToken(rPhiHitsToken_, rPhiStripHits);
 
-  /// Pixels should be around in all detector geometries. 
+  /// Pixels should be around in all detector geometries.
   bool hasPixels = iEvent.getByToken(pixelRecHitsToken_, pixelHitCollection);
 
-  std::set<const TrackingRecHit*> recHitsSeen{}; 
-  std::vector<const VectorHit*> vhSeen{}; 
+  std::set<const TrackingRecHit*> recHitsSeen{};
+  std::vector<const VectorHit*> vhSeen{};
 
-  /// step 1: Add the vector hits, and remember all raw hits associated to them 
-  if (hasVec){
-    LogDebug("CosmicGridTrupletSeeder")<< "have Vec hits "; 
-    for (auto detSet : *vectorHits){
-        for (const VectorHit & vh : detSet){
-          // Phase-2 endcap vector hits currently have directional information
-          // that can not be used directly - hence we skip these. 
-          if (state.tracker->idToDet(vh.geographicalId())->subDetector() == GeomDetEnumerators::SubDetector::P2OTEC){
-            continue; 
-          }
-          state.grid.addHit(&vh); 
-          vhSeen.push_back(&vh); 
+  /// step 1: Add the vector hits, and remember all raw hits associated to them
+  if (hasVec) {
+    LogDebug("CosmicGridTrupletSeeder") << "have Vec hits ";
+    for (auto detSet : *vectorHits) {
+      for (const VectorHit& vh : detSet) {
+        // Phase-2 endcap vector hits currently have directional information
+        // that can not be used directly - hence we skip these.
+        if (state.tracker->idToDet(vh.geographicalId())->subDetector() == GeomDetEnumerators::SubDetector::P2OTEC) {
+          continue;
         }
+        state.grid.addHit(&vh);
+        vhSeen.push_back(&vh);
+      }
     }
   }
 
   // Step 2 for phase-2 detector
 
-  // Add remaining OT hits, excluding those already on vector hits 
-  if (hasOT){
-    LogDebug("CosmicGridTrupletSeeder")<< "have OT hits "; 
-    for (auto  ds : *otHitCollection){
-        for (const auto & otHit : ds){
-          bool unique = true; 
-          for (const auto* vh : vhSeen){
-              if (vh->sharesInput(&otHit,TrackingRecHit::some)){
-                  unique = false; 
-                  state.vhConstituents[vh].push_back(&otHit);
-                  break; 
-              }
+  // Add remaining OT hits, excluding those already on vector hits
+  if (hasOT) {
+    LogDebug("CosmicGridTrupletSeeder") << "have OT hits ";
+    for (auto ds : *otHitCollection) {
+      for (const auto& otHit : ds) {
+        bool unique = true;
+        for (const auto* vh : vhSeen) {
+          if (vh->sharesInput(&otHit, TrackingRecHit::some)) {
+            unique = false;
+            state.vhConstituents[vh].push_back(&otHit);
+            break;
           }
-          if (!unique){
-              continue; 
-          }
-          state.grid.addHit(&otHit); 
-          recHitsSeen.insert(&otHit); 
         }
+        if (!unique) {
+          continue;
+        }
+        state.grid.addHit(&otHit);
+        recHitsSeen.insert(&otHit);
+      }
     }
   }
 
   // Step 2 for a phase-1 detector (two hit collections)
 
   // phase-1 matched strip hits
-  if (hasMatchedStrips){
-    LogDebug("CosmicGridTrupletSeeder")<< "have matched hits "; 
-    for (auto  ds : *matchedStripHits){
-      for (const auto & stripHit : ds){
-        bool unique = true; 
-        for (const auto* vh : vhSeen){
-            if (vh->sharesInput(&stripHit,TrackingRecHit::some)){
-                unique = false; 
-                state.vhConstituents[vh].push_back(&stripHit);
-                break; 
-            }
+  if (hasMatchedStrips) {
+    LogDebug("CosmicGridTrupletSeeder") << "have matched hits ";
+    for (auto ds : *matchedStripHits) {
+      for (const auto& stripHit : ds) {
+        bool unique = true;
+        for (const auto* vh : vhSeen) {
+          if (vh->sharesInput(&stripHit, TrackingRecHit::some)) {
+            unique = false;
+            state.vhConstituents[vh].push_back(&stripHit);
+            break;
+          }
         }
-        if (!unique){
-            continue; 
+        if (!unique) {
+          continue;
         }
-        state.grid.addHit(&stripHit); 
-        recHitsSeen.insert(&stripHit); 
-      }
-    }
-  } 
-
-  // phase-1 rphi strip hits 
-  if (hasRphiStrips){
-    LogDebug("CosmicGridTrupletSeeder")<< "have rphi hits "; 
-    for (auto  ds : *rPhiStripHits){
-      for (const auto & stripHit : ds){
-        bool unique = true; 
-        for (const auto* vh : vhSeen){
-            if (vh->sharesInput(&stripHit,TrackingRecHit::some)){
-                unique = false; 
-                state.vhConstituents[vh].push_back(&stripHit);
-                break; 
-            }
-        }
-        if (!unique){
-            continue; 
-        }
-        state.grid.addHit(&stripHit); 
-        recHitsSeen.insert(&stripHit); 
+        state.grid.addHit(&stripHit);
+        recHitsSeen.insert(&stripHit);
       }
     }
   }
 
-  /// step 3: Add pixel hits if desired  
-  if (hasPixels){
-    LogDebug("CosmicGridTrupletSeeder")<< "have Pixel hits "; 
-    for (auto  ds : *pixelHitCollection){
-        for (const auto & pix : ds){
-          state.grid.addHit(&pix); 
+  // phase-1 rphi strip hits
+  if (hasRphiStrips) {
+    LogDebug("CosmicGridTrupletSeeder") << "have rphi hits ";
+    for (auto ds : *rPhiStripHits) {
+      for (const auto& stripHit : ds) {
+        bool unique = true;
+        for (const auto* vh : vhSeen) {
+          if (vh->sharesInput(&stripHit, TrackingRecHit::some)) {
+            unique = false;
+            state.vhConstituents[vh].push_back(&stripHit);
+            break;
+          }
         }
+        if (!unique) {
+          continue;
+        }
+        state.grid.addHit(&stripHit);
+        recHitsSeen.insert(&stripHit);
+      }
+    }
+  }
+
+  /// step 3: Add pixel hits if desired
+  if (hasPixels) {
+    LogDebug("CosmicGridTrupletSeeder") << "have Pixel hits ";
+    for (auto ds : *pixelHitCollection) {
+      for (const auto& pix : ds) {
+        state.grid.addHit(&pix);
+      }
     }
   }
 
   // now sort all bins of the grid by descending global y.
-  state.grid.sort(); 
-
+  state.grid.sort();
 }
 
 /// using the seeding grid, form triplets
-void CosmicGridTripletSeeder::formTriplets(const CosmicGridTripletSeeder::TripletSeederEventState & state, std::vector<OrderedHitTriplet> & found) const {
-    std::unordered_multiset<const BaseTrackerRecHit*> trackUsage; 
-    // loop downwards over the starting y bin, top to bottom 
-    for (int yBin = state.grid.nBinsY()-1; yBin >=0 ; --yBin){
-      // loop rectangularily over the x-z grid 
-      for (int xBin = 0; xBin < state.grid.nBinsX(); ++xBin){
-        for (int zBin = 0; zBin < state.grid.nBinsZ(); ++zBin){
-          formTriplets(xBin,yBin,zBin,state,found,trackUsage); 
-        }
+void CosmicGridTripletSeeder::formTriplets(const CosmicGridTripletSeeder::TripletSeederEventState& state,
+                                           std::vector<OrderedHitTriplet>& found) const {
+  std::unordered_multiset<const BaseTrackerRecHit*> trackUsage;
+  // loop downwards over the starting y bin, top to bottom
+  for (int yBin = state.grid.nBinsY() - 1; yBin >= 0; --yBin) {
+    // loop rectangularily over the x-z grid
+    for (int xBin = 0; xBin < state.grid.nBinsX(); ++xBin) {
+      for (int zBin = 0; zBin < state.grid.nBinsZ(); ++zBin) {
+        formTriplets(xBin, yBin, zBin, state, found, trackUsage);
       }
     }
-    // sort by y-location of the lower hit, fall-back to upper if same 
-    std::sort(found.begin(),found.end(),[](const OrderedHitTriplet & t1, const OrderedHitTriplet & t2){
-      double ylow1 = t1.outer()->globalPosition().y();
-      double ylow2 = t2.outer()->globalPosition().y();
-      double ytop1 = t1.inner()->globalPosition().y();
-      double ytop2 = t2.inner()->globalPosition().y();
-      return (ylow1 == ylow2 ? ytop1 > ytop2 : ylow1 > ylow2); 
-    });
+  }
+  // sort by y-location of the lower hit, fall-back to upper if same
+  std::sort(found.begin(), found.end(), [](const OrderedHitTriplet& t1, const OrderedHitTriplet& t2) {
+    double ylow1 = t1.outer()->globalPosition().y();
+    double ylow2 = t2.outer()->globalPosition().y();
+    double ytop1 = t1.inner()->globalPosition().y();
+    double ytop2 = t2.inner()->globalPosition().y();
+    return (ylow1 == ylow2 ? ytop1 > ytop2 : ylow1 > ylow2);
+  });
 }
 
 void CosmicGridTripletSeeder::formTriplets(int xBin,
@@ -331,13 +342,14 @@ void CosmicGridTripletSeeder::formTriplets(int xBin,
   const CartesianSeedingGrid& grid = state.grid;
 
   const auto& topHits = grid.getHits(xBin, yBin, zBin);
-  // do not run triplet formation on empty cells. 
-  if (topHits.empty()) return; 
+  // do not run triplet formation on empty cells.
+  if (topHits.empty())
+    return;
 
-  std::vector<const BaseTrackerRecHit *> hitCands; 
-  hitCands.insert(hitCands.end(),topHits.begin(), topHits.end() ); 
+  std::vector<const BaseTrackerRecHit*> hitCands;
+  hitCands.insert(hitCands.end(), topHits.begin(), topHits.end());
 
-  if (yBin > 0){
+  if (yBin > 0) {
     for (int dxCenter = -1; dxCenter < 2; ++dxCenter) {
       if (xBin + dxCenter < 0 || xBin + dxCenter >= grid.nBinsX())
         continue;
@@ -345,190 +357,211 @@ void CosmicGridTripletSeeder::formTriplets(int xBin,
         if (zBin + dzCenter < 0 || zBin + dzCenter >= grid.nBinsZ())
           continue;
         const auto& middleHits = grid.getHits(xBin + dxCenter, yBin - 1, zBin + dzCenter);
-        hitCands.insert(hitCands.end(),middleHits.begin(), middleHits.end() ); 
+        hitCands.insert(hitCands.end(), middleHits.begin(), middleHits.end());
       }
     }
   }
 
-  std::sort(hitCands.begin(),hitCands.end(),[](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2){return h1->globalPosition().y() > h2->globalPosition().y(); });
+  std::sort(hitCands.begin(), hitCands.end(), [](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2) {
+    return h1->globalPosition().y() > h2->globalPosition().y();
+  });
 
   formTriplets(topHits, hitCands, hitCands, state, found, trackUsage);
 }
 
-     /// get the triplets for one particular cell combination
-void CosmicGridTripletSeeder::formTriplets(const std::vector<const BaseTrackerRecHit*> & topCands, 
-                const std::vector<const BaseTrackerRecHit*> & centerCands, 
-                const std::vector<const BaseTrackerRecHit*> & bottomCands, 
-                const TripletSeederEventState & state,
-                std::vector<OrderedHitTriplet> & found, 
-                std::unordered_multiset<const BaseTrackerRecHit*> & trackUsage) const{
-  for (const BaseTrackerRecHit* top : topCands){
-    if (trackUsage.count(top) >maxTripsPerSP_) continue; 
-    const auto & gTop = top->globalPosition(); 
+/// get the triplets for one particular cell combination
+void CosmicGridTripletSeeder::formTriplets(const std::vector<const BaseTrackerRecHit*>& topCands,
+                                           const std::vector<const BaseTrackerRecHit*>& centerCands,
+                                           const std::vector<const BaseTrackerRecHit*>& bottomCands,
+                                           const TripletSeederEventState& state,
+                                           std::vector<OrderedHitTriplet>& found,
+                                           std::unordered_multiset<const BaseTrackerRecHit*>& trackUsage) const {
+  for (const BaseTrackerRecHit* top : topCands) {
+    if (trackUsage.count(top) > maxTripsPerSP_)
+      continue;
+    const auto& gTop = top->globalPosition();
 
-    for (const BaseTrackerRecHit* center: centerCands){
-      if (trackUsage.count(center) >maxTripsPerSP_) continue; 
-      const auto & gCenter = center->globalPosition(); 
+    for (const BaseTrackerRecHit* center : centerCands) {
+      if (trackUsage.count(center) > maxTripsPerSP_)
+        continue;
+      const auto& gCenter = center->globalPosition();
 
-      if ( gTop.y()   < gCenter.y()) continue;
-      if (top->sameDetModule(*center)) continue; 
+      if (gTop.y() < gCenter.y())
+        continue;
+      if (top->sameDetModule(*center))
+        continue;
 
-      for (const BaseTrackerRecHit* bottom: bottomCands){
-        if (trackUsage.count(bottom) >maxTripsPerSP_) continue; 
-        const auto & gBottom = bottom->globalPosition(); 
+      for (const BaseTrackerRecHit* bottom : bottomCands) {
+        if (trackUsage.count(bottom) > maxTripsPerSP_)
+          continue;
+        const auto& gBottom = bottom->globalPosition();
 
-        if (top == bottom || center == bottom) continue; 
-        if (top->sameDetModule(*bottom) || center->sameDetModule(*bottom)) continue; 
-        if ( gCenter.y() < gBottom.y()) continue;
-        
-        OrderedHitTriplet ps (top, center, bottom);
-        if (!tripletOk(state,ps)) continue; 
+        if (top == bottom || center == bottom)
+          continue;
+        if (top->sameDetModule(*bottom) || center->sameDetModule(*bottom))
+          continue;
+        if (gCenter.y() < gBottom.y())
+          continue;
 
-        trackUsage.insert(top); 
-        trackUsage.insert(center); 
-        trackUsage.insert(bottom); 
-        found.push_back(ps); 
+        OrderedHitTriplet ps(top, center, bottom);
+        if (!tripletOk(state, ps))
+          continue;
+
+        trackUsage.insert(top);
+        trackUsage.insert(center);
+        trackUsage.insert(bottom);
+        found.push_back(ps);
       }
     }
   }
 }
 /// fit the triplets with kalman into trajectory seeds
-void CosmicGridTripletSeeder::fitTriplets(const CosmicGridTripletSeeder::TripletSeederEventState & state, const std::vector<OrderedHitTriplet>& triplets, TrajectorySeedCollection & output) const {
-    std::unordered_multiset<const TrackingRecHit*> seedPerSP;
-    for (const OrderedHitTriplet & trip : triplets ) {
-      if (   seedPerSP.count(trip.inner() ) >= maxSeedsPerSP_
-          || seedPerSP.count(trip.middle()) >= maxSeedsPerSP_
-          || seedPerSP.count(trip.outer() ) >= maxSeedsPerSP_
-      ) continue; 
-      fitTriplet(state, trip, output, seedPerSP, true); 
-      if (tryBothDirections_) fitTriplet(state, trip, output, seedPerSP,false); 
-    }
+void CosmicGridTripletSeeder::fitTriplets(const CosmicGridTripletSeeder::TripletSeederEventState& state,
+                                          const std::vector<OrderedHitTriplet>& triplets,
+                                          TrajectorySeedCollection& output) const {
+  std::unordered_multiset<const TrackingRecHit*> seedPerSP;
+  for (const OrderedHitTriplet& trip : triplets) {
+    if (seedPerSP.count(trip.inner()) >= maxSeedsPerSP_ || seedPerSP.count(trip.middle()) >= maxSeedsPerSP_ ||
+        seedPerSP.count(trip.outer()) >= maxSeedsPerSP_)
+      continue;
+    fitTriplet(state, trip, output, seedPerSP, true);
+    if (tryBothDirections_)
+      fitTriplet(state, trip, output, seedPerSP, false);
+  }
 }
 
-/// fit of a single triplet into a trajectory seed 
-bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletSeederEventState & state, const OrderedHitTriplet& triplet, TrajectorySeedCollection & output, std::unordered_multiset<const TrackingRecHit*> & seedPerSP, bool goUp) const {
+/// fit of a single triplet into a trajectory seed
+bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletSeederEventState& state,
+                                         const OrderedHitTriplet& triplet,
+                                         TrajectorySeedCollection& output,
+                                         std::unordered_multiset<const TrackingRecHit*>& seedPerSP,
+                                         bool goUp) const {
   typedef TrajectoryStateOnSurface TSOS;
 
-    // arrange the triplet so that the hits appear in extrapolation order, with the *target hit* appearing first ("inner"). 
-    // NB: They initially come in the order "top - middle - bottom" (in global y) when passed to this method. 
-    OrderedHitTriplet tripToUse = goUp ? triplet : OrderedHitTriplet{triplet.outer(), triplet.middle(), triplet.inner()}; 
+  // arrange the triplet so that the hits appear in extrapolation order, with the *target hit* appearing first ("inner").
+  // NB: They initially come in the order "top - middle - bottom" (in global y) when passed to this method.
+  OrderedHitTriplet tripToUse = goUp ? triplet : OrderedHitTriplet{triplet.outer(), triplet.middle(), triplet.inner()};
 
-    // top SP
-    GlobalPoint target =
-        state.tracker->idToDet((*(tripToUse.inner())).geographicalId())->surface().toGlobal((*(tripToUse.inner())).localPosition());
+  // top SP
+  GlobalPoint target = state.tracker->idToDet((*(tripToUse.inner())).geographicalId())
+                           ->surface()
+                           .toGlobal((*(tripToUse.inner())).localPosition());
 
-    // middle SP
-    GlobalPoint middle =
-        state.tracker->idToDet((*(tripToUse.middle())).geographicalId())->surface().toGlobal((*(tripToUse.middle())).localPosition());
+  // middle SP
+  GlobalPoint middle = state.tracker->idToDet((*(tripToUse.middle())).geographicalId())
+                           ->surface()
+                           .toGlobal((*(tripToUse.middle())).localPosition());
 
-    // bottom SP 
-    GlobalPoint start =
-        state.tracker->idToDet((*(tripToUse.outer())).geographicalId())->surface().toGlobal((*(tripToUse.outer())).localPosition());
+  // bottom SP
+  GlobalPoint start = state.tracker->idToDet((*(tripToUse.outer())).geographicalId())
+                          ->surface()
+                          .toGlobal((*(tripToUse.outer())).localPosition());
 
-    // Initial momentum estimate at the start point 
-    // using the fast helix helper.
-    // Note: arg order of FastHelix is "outer middle vertex",
-    // so we will get a momentum pointing *up* when targeting the top SP,
-    // and pointing down when targeting the bottom SP. 
-    FastHelix helix(target, middle, start, state.magfield->nominalValue(),state.magfield);
+  // Initial momentum estimate at the start point
+  // using the fast helix helper.
+  // Note: arg order of FastHelix is "outer middle vertex",
+  // so we will get a momentum pointing *up* when targeting the top SP,
+  // and pointing down when targeting the bottom SP.
+  FastHelix helix(target, middle, start, state.magfield->nominalValue(), state.magfield);
 
-    // extract momentum and charge - flip when needed to ensure a momentum 
-    // pointing down (cosmic trajectory)
-    GlobalVector  gv =  (goUp ? -1 : 1) * helix.stateAtVertex().momentum();  
-    float ch = (goUp ? -1 : 1) * helix.stateAtVertex().charge();
-    
-    // initial cleaning. 
-    float Mom = gv.mag();
-    if (Mom > 1000000 || edm::isNotFinite(Mom)) {
-      return false;
-    }
-    if (gv.perp() < 0.5 * ptMin_) {
-      return false;
-    }
+  // extract momentum and charge - flip when needed to ensure a momentum
+  // pointing down (cosmic trajectory)
+  GlobalVector gv = (goUp ? -1 : 1) * helix.stateAtVertex().momentum();
+  float ch = (goUp ? -1 : 1) * helix.stateAtVertex().charge();
 
-    // Next use a KF to refine the parameter estimate.
-    // Propagate from the start to the target, and track
-    // relation to the momentum direction. 
-    const Propagator *propagator = goUp ? state.thePropagatorOp.get() : state.thePropagatorAl.get();
+  // initial cleaning.
+  float Mom = gv.mag();
+  if (Mom > 1000000 || edm::isNotFinite(Mom)) {
+    return false;
+  }
+  if (gv.perp() < 0.5 * ptMin_) {
+    return false;
+  }
 
-    edm::OwnVector<TrackingRecHit> hits;
-    std::vector<const BaseTrackerRecHit*> seedHits;
+  // Next use a KF to refine the parameter estimate.
+  // Propagate from the start to the target, and track
+  // relation to the momentum direction.
+  const Propagator* propagator = goUp ? state.thePropagatorOp.get() : state.thePropagatorAl.get();
 
-    // build our hit array in the order pointing towards the target ("inner")
-    for (const BaseTrackerRecHit* hit :{tripToUse.outer(), tripToUse.middle(), tripToUse.inner()}){
-      const VectorHit* vh = dynamic_cast<const VectorHit*>(hit);
-      if (vh){
-        auto found = state.vhConstituents.find(vh);
-        if (found != state.vhConstituents.end()){
-          for (auto & component : found->second){
-            seedHits.push_back(component);
-          }
+  edm::OwnVector<TrackingRecHit> hits;
+  std::vector<const BaseTrackerRecHit*> seedHits;
+
+  // build our hit array in the order pointing towards the target ("inner")
+  for (const BaseTrackerRecHit* hit : {tripToUse.outer(), tripToUse.middle(), tripToUse.inner()}) {
+    const VectorHit* vh = dynamic_cast<const VectorHit*>(hit);
+    if (vh) {
+      auto found = state.vhConstituents.find(vh);
+      if (found != state.vhConstituents.end()) {
+        for (auto& component : found->second) {
+          seedHits.push_back(component);
         }
-        else{
-            edm::LogWarning("CosmicGridTripletSeeder")<< "Did not find any constitutents for a vector hit - are our inputs consistent?";
-            seedHits.push_back(hit);
-        }
-      }
-      else{
+      } else {
+        edm::LogWarning("CosmicGridTripletSeeder")
+            << "Did not find any constitutents for a vector hit - are our inputs consistent?";
         seedHits.push_back(hit);
       }
+    } else {
+      seedHits.push_back(hit);
     }
-    // re-sort, to account for the vector hit components being possibly out-of-order
-    std::sort(seedHits.begin(),seedHits.end(),[&](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2){
-        return goUp ? h1->globalPosition().y() < h2->globalPosition().y() : h1->globalPosition().y() > h2->globalPosition().y();
-    });
+  }
+  // re-sort, to account for the vector hit components being possibly out-of-order
+  std::sort(seedHits.begin(), seedHits.end(), [&](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2) {
+    return goUp ? h1->globalPosition().y() < h2->globalPosition().y()
+                : h1->globalPosition().y() > h2->globalPosition().y();
+  });
 
-    // starting parameters: Lowest point, estimated momentum from fast helix. 
-    GlobalPoint updatedStartPos = seedHits.front()->globalPosition(); 
-    GlobalTrajectoryParameters Gtp(updatedStartPos, gv, int(ch), state.magfield);
-    FreeTrajectoryState CosmicSeed(Gtp, CurvilinearTrajectoryError(AlgebraicSymMatrix55(AlgebraicMatrixID())));
-    CosmicSeed.rescaleError(100);
-    TSOS propagated, updated;
+  // starting parameters: Lowest point, estimated momentum from fast helix.
+  GlobalPoint updatedStartPos = seedHits.front()->globalPosition();
+  GlobalTrajectoryParameters Gtp(updatedStartPos, gv, int(ch), state.magfield);
+  FreeTrajectoryState CosmicSeed(Gtp, CurvilinearTrajectoryError(AlgebraicSymMatrix55(AlgebraicMatrixID())));
+  CosmicSeed.rescaleError(100);
+  TSOS propagated, updated;
 
-    // now incrementally propagate towards the target point
-    for (size_t ih = 0; ih < seedHits.size(); ++ih) {
-      if (ih == 0) {
-        propagated = propagator->propagate(CosmicSeed, state.tracker->idToDet((*seedHits[ih]).geographicalId())->surface());
-      } else {
-        propagated = propagator->propagate(updated, state.tracker->idToDet((*seedHits[ih]).geographicalId())->surface());
-      }
-      if (!propagated.isValid()) {
-        return false;
-      }
-
-      // clone the hit based on the propagated state 
-      SeedingHitSet::ConstRecHitPointer tthp = seedHits[ih];
-      auto newtth = static_cast<SeedingHitSet::RecHitPointer>(state.cloner(*tthp, propagated));
-      updated = state.theUpdator->update(propagated, *newtth);
-      hits.push_back(newtth);
-
-      if (!updated.isValid()) {
-        return false;
-      }
+  // now incrementally propagate towards the target point
+  for (size_t ih = 0; ih < seedHits.size(); ++ih) {
+    if (ih == 0) {
+      propagated =
+          propagator->propagate(CosmicSeed, state.tracker->idToDet((*seedHits[ih]).geographicalId())->surface());
+    } else {
+      propagated = propagator->propagate(updated, state.tracker->idToDet((*seedHits[ih]).geographicalId())->surface());
     }
-    
-    // some more cleaning
-    if (updated.globalMomentum().perp() < ptMin_) {
-      return false;
-    }
-    if (updated.globalMomentum().mag() < ptMin_) {
+    if (!propagated.isValid()) {
       return false;
     }
 
-    PTrajectoryStateOnDet const &PTraj = trajectoryStateTransform::persistentState(
-        updated, hits.back().geographicalId().rawId());
+    // clone the hit based on the propagated state
+    SeedingHitSet::ConstRecHitPointer tthp = seedHits[ih];
+    auto newtth = static_cast<SeedingHitSet::RecHitPointer>(state.cloner(*tthp, propagated));
+    updated = state.theUpdator->update(propagated, *newtth);
+    hits.push_back(newtth);
 
-    // and build the final seed. 
-    output.push_back(TrajectorySeed(PTraj, hits, goUp ? oppositeToMomentum : alongMomentum ));
-
-    if (output.size() > size_t(500)) {
-      output.clear();
-      edm::LogError("TooManySeeds") << "Found too many seeds, bailing out.\n";
+    if (!updated.isValid()) {
       return false;
     }
-    seedPerSP.insert(triplet.inner());
-    seedPerSP.insert(triplet.middle());
-    seedPerSP.insert(triplet.outer());
+  }
 
-    return true;
+  // some more cleaning
+  if (updated.globalMomentum().perp() < ptMin_) {
+    return false;
+  }
+  if (updated.globalMomentum().mag() < ptMin_) {
+    return false;
+  }
+
+  PTrajectoryStateOnDet const& PTraj =
+      trajectoryStateTransform::persistentState(updated, hits.back().geographicalId().rawId());
+
+  // and build the final seed.
+  output.push_back(TrajectorySeed(PTraj, hits, goUp ? oppositeToMomentum : alongMomentum));
+
+  if (output.size() > size_t(500)) {
+    output.clear();
+    edm::LogError("TooManySeeds") << "Found too many seeds, bailing out.\n";
+    return false;
+  }
+  seedPerSP.insert(triplet.inner());
+  seedPerSP.insert(triplet.middle());
+  seedPerSP.insert(triplet.outer());
+
+  return true;
 }

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
@@ -32,7 +32,6 @@ CosmicGridTripletSeeder::CosmicGridTripletSeeder(const edm::ParameterSet& iConfi
       otRecHitsToken_(mayConsume<Phase2TrackerRecHit1DCollectionNew>(iConfig.getUntrackedParameter<edm::InputTag>("OTRecHits"))),
       matchedStripHitsToken_(mayConsume<SiStripMatchedRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("matchedStripHits"))),
       rPhiHitsToken_(mayConsume<SiStripRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("rPhiHits"))),
-      // stereoHitsToken_(mayConsume<SiStripRecHit2DCollection>(iConfig.getUntrackedParameter<edm::InputTag>("stereoHits"))),
       pixelRecHitsToken_(consumes(iConfig.getUntrackedParameter<edm::InputTag>("PixelRecHits"))),
       magfieldToken_(esConsumes(iConfig.getParameter<edm::ESInputTag>("MagneticFieldRecord"))),
       trackerToken_(esConsumes()),
@@ -54,7 +53,7 @@ CosmicGridTripletSeeder::CosmicGridTripletSeeder(const edm::ParameterSet& iConfi
 void CosmicGridTripletSeeder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.addUntracked<edm::InputTag>("vectorHits", edm::InputTag("siPhase2VectorHits:accepted"));
-  desc.addUntracked<edm::InputTag>("OTRecHits", edm::InputTag("Phase2TrackerRecHits"));
+  desc.addUntracked<edm::InputTag>("OTRecHits", edm::InputTag("siPhase2RecHits"));
   desc.addUntracked<edm::InputTag>("matchedStripHits", edm::InputTag("siStripMatchedRecHits","matchedRecHit"));
   desc.addUntracked<edm::InputTag>("rPhiHits", edm::InputTag("siStripMatchedRecHits","rphiRecHit"));
   desc.addUntracked<edm::InputTag>("PixelRecHits", edm::InputTag("siPixelRecHits"));
@@ -164,6 +163,7 @@ void CosmicGridTripletSeeder::populateGrid(const edm::Event& iEvent, CosmicGridT
 
   /// step 1: Add the vector hits, and remember all raw hits associated to them 
   if (hasVec){
+    LogDebug("CosmicGridTrupletSeeder")<< "have Vec hits "; 
     for (auto detSet : *vectorHits){
         for (const VectorHit & vh : detSet){
           // Phase-2 endcap vector hits currently have directional information
@@ -181,6 +181,7 @@ void CosmicGridTripletSeeder::populateGrid(const edm::Event& iEvent, CosmicGridT
 
   // Add remaining OT hits, excluding those already on vector hits 
   if (hasOT){
+    LogDebug("CosmicGridTrupletSeeder")<< "have OT hits "; 
     for (auto  ds : *otHitCollection){
         for (const auto & otHit : ds){
           bool unique = true; 
@@ -204,6 +205,7 @@ void CosmicGridTripletSeeder::populateGrid(const edm::Event& iEvent, CosmicGridT
 
   // phase-1 matched strip hits
   if (hasMatchedStrips){
+    LogDebug("CosmicGridTrupletSeeder")<< "have matched hits "; 
     for (auto  ds : *matchedStripHits){
       for (const auto & stripHit : ds){
         bool unique = true; 
@@ -225,6 +227,7 @@ void CosmicGridTripletSeeder::populateGrid(const edm::Event& iEvent, CosmicGridT
 
   // phase-1 rphi strip hits 
   if (hasRphiStrips){
+    LogDebug("CosmicGridTrupletSeeder")<< "have rphi hits "; 
     for (auto  ds : *rPhiStripHits){
       for (const auto & stripHit : ds){
         bool unique = true; 
@@ -349,7 +352,7 @@ void CosmicGridTripletSeeder::formTriplets(const std::vector<const BaseTrackerRe
         if (cenVH){
           double dydx = 0.5 * ((gTop.y() - gCenter.y())/(gTop.x() - gCenter.x()) + (gCenter.y() - gBottom.y())/(gCenter.x() - gBottom.x())); 
           double dydx_vh = cenVH->globalDirectionVH().y() / cenVH->globalDirectionVH().x();
-          std::cout << " dydx from trip "<<dydx<<" and from vh "<<dydx_vh<<std::endl; 
+          LogDebug("CosmicGridTripletSeeder") << " dydx from trip "<<dydx<<" and from vh "<<dydx_vh;
         }
 
         OrderedHitTriplet ps (top, center, bottom);
@@ -368,14 +371,11 @@ void CosmicGridTripletSeeder::fitTriplets(const CosmicGridTripletSeeder::Triplet
     }
 }
 
-
 /// fit of a single triplet into a trajectory seed 
 bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletSeederEventState & state, const OrderedHitTriplet& triplet, TrajectorySeedCollection & output) const {
   typedef TrajectoryStateOnSurface TSOS;
 
-
     OrderedHitTriplet trip = triplet;  
-
 
     GlobalPoint inner =
         state.tracker->idToDet((*(trip.inner())).geographicalId())->surface().toGlobal((*(trip.inner())).localPosition());
@@ -385,26 +385,21 @@ bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletS
 
     GlobalPoint outer =
         state.tracker->idToDet((*(trip.outer())).geographicalId())->surface().toGlobal((*(trip.outer())).localPosition());
-
     if ((outer.y() - inner.y()) * outer.y() < 0) {
       std::swap(inner, outer);
       trip = OrderedHitTriplet(trip.outer(), trip.middle(), trip.inner());
     }
-
     // First use FastHelix out of the box
     std::pair<GlobalVector, int> pq = pqFromHelixFit(inner, middle, outer, state.magfield);
     GlobalVector gv = pq.first;
     float ch = pq.second;
     float Mom = sqrt(gv.x() * gv.x() + gv.y() * gv.y() + gv.z() * gv.z());
-
     if (Mom > 1000000 || edm::isNotFinite(Mom)) {
       return false;
     }
-
     if (gv.perp() < 0.5) {
       return false;
     }
-
     const Propagator *propagator = nullptr;
     if ((outer.y() - inner.y()) > 0) {
       propagator = state.thePropagatorAl.get();
@@ -413,10 +408,8 @@ bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletS
       ch = -1. * ch;
       propagator = state.thePropagatorOp.get();
     }
-
     if ((gv.z() * (outer.z() - inner.z()) > 0) && (fabs(outer.z() - inner.z()) > 5) && (fabs(gv.z()) > .01)) {
     }
-
 
     edm::OwnVector<TrackingRecHit> hits;
     std::vector<const BaseTrackerRecHit*> seedHits;
@@ -428,6 +421,10 @@ bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletS
           for (auto & component : found->second){
             seedHits.push_back(component);
           }
+        }
+        else{
+            edm::LogWarning("CosmicGridTripletSeeder")<< "Did not find any constitutents for a vector hit - are our inputs consistent?";
+            seedHits.push_back(hit);
         }
       }
       else{
@@ -441,12 +438,11 @@ bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletS
       else{
         return h1->globalPosition().y() < h2->globalPosition().y();
       }
-    }); 
+    });
     outer = seedHits.front()->globalPosition(); 
     GlobalTrajectoryParameters Gtp(outer, gv, int(ch), state.magfield);
     FreeTrajectoryState CosmicSeed(Gtp, CurvilinearTrajectoryError(AlgebraicSymMatrix55(AlgebraicMatrixID())));
     CosmicSeed.rescaleError(100);
-
     TSOS propagated, updated;
     bool fail = false;
     for (size_t ih = 0; ih < seedHits.size(); ++ih) {
@@ -498,16 +494,18 @@ bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletS
     //   }
     //   std::cout << "    Cartesian error (X,P) = \n" << updated.cartesianError().matrix() << std::endl;
     // }   
-
     PTrajectoryStateOnDet const &PTraj = trajectoryStateTransform::persistentState(
         updated, hits.back().geographicalId().rawId());
+    
     output.push_back(TrajectorySeed(PTraj, hits, ((outer.y() - inner.y() > 0) ? alongMomentum : oppositeToMomentum)));
+
 
     if (output.size() > size_t(500)) {
       output.clear();
       edm::LogError("TooManySeeds") << "Found too many seeds, bailing out.\n";
       return false;
     }
+
     return true;
 
 }

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicGridTripletSeeder.cc
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <memory>
 #include <set>
+#include <unordered_set>
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
@@ -15,17 +16,17 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/VectorHit.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 #include "FWCore/Utilities/interface/ESInputTag.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "Geometry/CommonTopologies/interface/GeomDetEnumerators.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoTracker/PixelSeeding/interface/OrderedHitTriplet.h"
+#include "RecoTracker/TkSeedGenerator/interface/FastCircle.h"
 #include "RecoTracker/TkSeedGenerator/interface/FastHelix.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "RecoTracker/SpecialSeedGenerators/interface/CosmicGridTripletSeeder.h"
-
-//
-
 
 CosmicGridTripletSeeder::CosmicGridTripletSeeder(const edm::ParameterSet& iConfig)
     : vectorHitsToken_(mayConsume<VectorHitCollection>(iConfig.getUntrackedParameter<edm::InputTag>("vectorHits"))),
@@ -36,6 +37,7 @@ CosmicGridTripletSeeder::CosmicGridTripletSeeder(const edm::ParameterSet& iConfi
       magfieldToken_(esConsumes(iConfig.getParameter<edm::ESInputTag>("MagneticFieldRecord"))),
       trackerToken_(esConsumes()),
       ttrhBuilderToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("TTRHBuilder")))),
+      writeTriplets_(iConfig.getParameter<bool>("writeTriplets")),
       nGridBinsX_(iConfig.getParameter<int>("nGridBinsX")),
       nGridBinsY_(iConfig.getParameter<int>("nGridBinsY")),
       nGridBinsZ_(iConfig.getParameter<int>("nGridBinsZ")),
@@ -44,9 +46,15 @@ CosmicGridTripletSeeder::CosmicGridTripletSeeder(const edm::ParameterSet& iConfi
       gridYmin_(iConfig.getParameter<double>("gridYmin")),
       gridYmax_(iConfig.getParameter<double>("gridYmax")),
       gridZmin_(iConfig.getParameter<double>("gridZmin")),
-      gridZmax_(iConfig.getParameter<double>("gridZmax")){
+      gridZmax_(iConfig.getParameter<double>("gridZmax")),
+      maxTripsPerSP_(iConfig.getParameter<int>("maxTripsPerSP")), 
+      maxSeedsPerSP_(iConfig.getParameter<int>("maxSeedsPerSP")), 
+      slopeCompatForVH_(iConfig.getParameter<double>("slopeCompatForVH")),
+      tryBothDirections_(iConfig.getParameter<bool>("tryBothDirections")){
   produces<TrajectorySeedCollection>();
-  produces<edm::OwnVector<TrackingRecHit>>();
+  if (writeTriplets_){
+    produces<edm::OwnVector<TrackingRecHit>>();
+  }
 
 }
 
@@ -59,6 +67,7 @@ void CosmicGridTripletSeeder::fillDescriptions(edm::ConfigurationDescriptions& d
   desc.addUntracked<edm::InputTag>("PixelRecHits", edm::InputTag("siPixelRecHits"));
   desc.add<std::string>("TTRHBuilder", "WithTrackAngle");
   desc.add<edm::ESInputTag>("MagneticFieldRecord", edm::ESInputTag("", ""));
+  desc.add<bool>("writeTriplets",false);
   desc.add<int>("nGridBinsX",1);
   desc.add<int>("nGridBinsY",1);
   desc.add<int>("nGridBinsZ",1);
@@ -68,49 +77,75 @@ void CosmicGridTripletSeeder::fillDescriptions(edm::ConfigurationDescriptions& d
   desc.add<double>("gridYmax",120);
   desc.add<double>("gridZmin",-280);
   desc.add<double>("gridZmax",280);
+  desc.add<int>("maxTripsPerSP",10);
+  desc.add<int>("maxSeedsPerSP",8);
+  desc.add<double>("slopeCompatForVH",0.15);
+  desc.add<bool>("tryBothDirections",true);
   descriptions.addWithDefaultLabel(desc);
-}
-
-std::pair<GlobalVector, int> CosmicGridTripletSeeder::pqFromHelixFit(const GlobalPoint& inner,
-                                                                     const GlobalPoint& middle,
-                                                                     const GlobalPoint& outer,
-                                                                     const MagneticField* magfield) const {
-  FastHelix helix(inner, middle, outer, magfield->nominalValue(), magfield);
-  FastCircle theCircle(inner, middle, outer);
-  double rho = theCircle.rho();
-  GlobalVector tesla = magfield->inTesla(middle);
-  double pt = 0.01 * rho * (0.3 * tesla.z());
-  double dx1 = outer.x() - theCircle.x0();
-  double dy1 = outer.y() - theCircle.y0();
-  double py = pt * dx1 / rho, px = -pt * dy1 / rho;
-  if (px * (middle.x() - outer.x()) + py * (middle.y() - outer.y()) < 0.) {
-    px *= -1.;
-    py *= -1.;
-  }
-  double dz = inner.z() - outer.z();
-  double sinphi = (dx1 * (inner.y() - theCircle.y0()) - dy1 * (inner.x() - theCircle.x0())) / (rho * rho);
-  double dphi = std::abs(std::asin(sinphi));
-  double pz = pt * dz / (dphi * rho);
-
-  int myq = ((theCircle.x0() * py - theCircle.y0() * px) / tesla.z()) > 0. ? +1 : -1;
-
-  return std::make_pair(GlobalVector(px, py, pz), myq);
-
 }
 
 CosmicGridTripletSeeder::TripletSeederEventState CosmicGridTripletSeeder::initEventState(const edm::EventSetup& c) const {
   auto magfield = &c.getData(magfieldToken_);
   auto tracker = &c.getData(trackerToken_);
   auto cloner = dynamic_cast<TkTransientTrackingRecHitBuilder const&>(c.getData(ttrhBuilderToken_)).cloner();
-
+  constexpr double g_muonMass = 0.1057;
   return TripletSeederEventState{CartesianSeedingGrid{nGridBinsX_, gridXmin_, gridXmax_, nGridBinsY_, gridYmin_, gridYmax_, nGridBinsZ_, gridZmin_, gridZmax_},
                                  {},
                                  magfield,
                                  tracker,
                                  cloner,
                                  std::make_unique<KFUpdator>(),
-                                 std::make_unique<PropagatorWithMaterial>(alongMomentum, 0.1057, magfield),
-                                 std::make_unique<PropagatorWithMaterial>(oppositeToMomentum, 0.1057, magfield)};
+                                 std::make_unique<PropagatorWithMaterial>(alongMomentum, g_muonMass, magfield),
+                                 std::make_unique<PropagatorWithMaterial>(oppositeToMomentum, g_muonMass, magfield)};
+}
+
+bool CosmicGridTripletSeeder::tripletOk(const TripletSeederEventState & state, const OrderedHitTriplet& trip) const{
+
+    // get the positions for triplet shape cleaning 
+    Global3DPoint top = trip.inner()->globalPosition();
+    Global3DPoint middle = trip.middle()->globalPosition();
+    Global3DPoint bottom = trip.outer()->globalPosition();
+
+    // veto "zigzag" in z 
+    if ((top.z() - middle.z()) * (middle.z() - bottom.z())  < 0 && std::abs(top.z() - bottom.z()) > 1.0) return false;
+
+    // veto "zigzag" in x 
+    if ((top.x() - middle.x()) * (middle.x() - bottom.x())  < 0 && std::abs(top.x() - bottom.x()) > 2.0) return false;
+
+    // x-y slope consistency checks
+
+    // get the local x-y slopes between pairs of consecutive SP 
+    double dxy_t = (top.x() - middle.x())/(top.y() - middle.y());  
+    double dxy_b = (middle.x() - bottom.x())/(middle.y() - bottom.y());
+    // center point estimated as mean between the adjacent segments 
+    double dxy_c = 0.5 * (dxy_t + dxy_b);
+    double dxy_vh_c = 0;
+    double dxy_vh_b = 0; 
+    double dxy_vh_t = 0; 
+        
+    // and, for vector hits (only used in the barrel), the measured slopes 
+    // on the hit itself 
+    const VectorHit* topVH = dynamic_cast<const VectorHit*>(trip.inner()); 
+    if (topVH) dxy_vh_t = topVH->globalDirectionVH().x() /  topVH->globalDirectionVH().y(); 
+
+    const VectorHit* centerVH = dynamic_cast<const VectorHit*>(trip.middle()); 
+    if (centerVH) dxy_vh_c = centerVH->globalDirectionVH().x() /  centerVH->globalDirectionVH().y(); 
+
+    const VectorHit* bottomVH = dynamic_cast<const VectorHit*>(trip.outer());
+    if (bottomVH) dxy_vh_b = bottomVH->globalDirectionVH().x() /  bottomVH->globalDirectionVH().y(); 
+
+    // now we require consistency between the VH and the estimate from neighbouring SP 
+    // for all cases where these are well-defined 
+    if (topVH     && std::abs(dxy_vh_t - dxy_t) > slopeCompatForVH_ * std::abs(std::max(dxy_vh_t,dxy_t))) return false; 
+    if (centerVH  && std::abs(dxy_vh_c - dxy_c) > slopeCompatForVH_ * std::abs(std::max(dxy_vh_c,dxy_c))) return false; 
+    if (bottomVH  && std::abs(dxy_vh_b - dxy_b) > slopeCompatForVH_ * std::abs(std::max(dxy_vh_b,dxy_b))) return false; 
+    
+    // check curvature estimate 
+    if (FastCircle(top, middle, bottom).rho() < 0.5 * ptMin_ / (0.003 * state.magfield->nominalValue())){
+      return false; 
+    }
+    return true; 
+
 }
 
 void CosmicGridTripletSeeder::produce(edm::Event& e, const edm::EventSetup& c) {
@@ -126,20 +161,22 @@ void CosmicGridTripletSeeder::produce(edm::Event& e, const edm::EventSetup& c) {
 
   // book the trajectory seed collection
   auto output = std::make_unique<TrajectorySeedCollection>();
-  auto outtriplets = std::make_unique<edm::OwnVector<TrackingRecHit>>();
 
   // and fit the triplets
   fitTriplets(state, triplets, *output);
 
-  for (auto & trip : triplets){
-    outtriplets->push_back(trip.inner()->cloneHit()); 
-    outtriplets->push_back(trip.middle()->cloneHit()); 
-    outtriplets->push_back(trip.outer()->cloneHit()); 
-  }
-
   // put our output on the store
   e.put(std::move(output));
-  e.put(std::move(outtriplets));
+  // optional triplet writing for debugging / perf validation 
+  if (writeTriplets_){
+    auto outtriplets = std::make_unique<edm::OwnVector<TrackingRecHit>>();
+    for (auto & trip : triplets){
+      outtriplets->push_back(trip.inner()->cloneHit()); 
+      outtriplets->push_back(trip.middle()->cloneHit()); 
+      outtriplets->push_back(trip.outer()->cloneHit()); 
+    }
+    e.put(std::move(outtriplets));
+  }
 }
 
 void CosmicGridTripletSeeder::populateGrid(const edm::Event& iEvent, CosmicGridTripletSeeder::TripletSeederEventState & state) const {
@@ -147,6 +184,7 @@ void CosmicGridTripletSeeder::populateGrid(const edm::Event& iEvent, CosmicGridT
   edm::Handle<Phase2TrackerRecHit1DCollectionNew> otHitCollection; 
   edm::Handle<SiStripMatchedRecHit2DCollection> matchedStripHits; 
   edm::Handle<SiStripRecHit2DCollection> rPhiStripHits; 
+  edm::Handle<SiPixelRecHitCollection> pixelHitCollection; 
 
   /// Treat the hit collections as optional, so that we can
   /// run with both the Run-3 and the Phase-2 detectors. 
@@ -156,7 +194,7 @@ void CosmicGridTripletSeeder::populateGrid(const edm::Event& iEvent, CosmicGridT
   bool hasRphiStrips = iEvent.getByToken(rPhiHitsToken_, rPhiStripHits );
 
   /// Pixels should be around in all detector geometries. 
-  const SiPixelRecHitCollection & pixelHitCollection = iEvent.get(pixelRecHitsToken_);
+  bool hasPixels = iEvent.getByToken(pixelRecHitsToken_, pixelHitCollection);
 
   std::set<const TrackingRecHit*> recHitsSeen{}; 
   std::vector<const VectorHit*> vhSeen{}; 
@@ -248,13 +286,16 @@ void CosmicGridTripletSeeder::populateGrid(const edm::Event& iEvent, CosmicGridT
   }
 
   /// step 3: Add pixel hits if desired  
-  for (auto  ds : pixelHitCollection){
-      for (const auto & pix : ds){
-        state.grid.addHit(&pix); 
-      }
+  if (hasPixels){
+    LogDebug("CosmicGridTrupletSeeder")<< "have Pixel hits "; 
+    for (auto  ds : *pixelHitCollection){
+        for (const auto & pix : ds){
+          state.grid.addHit(&pix); 
+        }
+    }
   }
 
-  // now sort all bins of the grid by ascending global y.
+  // now sort all bins of the grid by descending global y.
   state.grid.sort(); 
 
 }
@@ -267,12 +308,18 @@ void CosmicGridTripletSeeder::formTriplets(const CosmicGridTripletSeeder::Triple
       // loop rectangularily over the x-z grid 
       for (int xBin = 0; xBin < state.grid.nBinsX(); ++xBin){
         for (int zBin = 0; zBin < state.grid.nBinsZ(); ++zBin){
-          const auto & topCandidates = state.grid.getHits(xBin,yBin,zBin); 
-          if (topCandidates.empty()) continue;         
           formTriplets(xBin,yBin,zBin,state,found,trackUsage); 
         }
       }
     }
+    // sort by y-location of the lower hit, fall-back to upper if same 
+    std::sort(found.begin(),found.end(),[](const OrderedHitTriplet & t1, const OrderedHitTriplet & t2){
+      double ylow1 = t1.outer()->globalPosition().y();
+      double ylow2 = t2.outer()->globalPosition().y();
+      double ytop1 = t1.inner()->globalPosition().y();
+      double ytop2 = t2.inner()->globalPosition().y();
+      return (ylow1 == ylow2 ? ytop1 > ytop2 : ylow1 > ylow2); 
+    });
 }
 
 void CosmicGridTripletSeeder::formTriplets(int xBin,
@@ -284,43 +331,28 @@ void CosmicGridTripletSeeder::formTriplets(int xBin,
   const CartesianSeedingGrid& grid = state.grid;
 
   const auto& topHits = grid.getHits(xBin, yBin, zBin);
+  // do not run triplet formation on empty cells. 
+  if (topHits.empty()) return; 
 
   std::vector<const BaseTrackerRecHit *> hitCands; 
   hitCands.insert(hitCands.end(),topHits.begin(), topHits.end() ); 
 
-  for (int dxCenter = -1; dxCenter < 2; ++dxCenter) {
-    if (xBin + dxCenter < 0 || xBin + dxCenter >= grid.nBinsX())
-      continue;
-    for (int dzCenter = -1; dzCenter < 2; ++dzCenter) {
-      if (zBin + dzCenter < 0 || zBin + dzCenter >= grid.nBinsZ())
+  if (yBin > 0){
+    for (int dxCenter = -1; dxCenter < 2; ++dxCenter) {
+      if (xBin + dxCenter < 0 || xBin + dxCenter >= grid.nBinsX())
         continue;
-      // formTriplets(topHits, topHits, topHits, state, found, trackUsage);
-      if (yBin > 0){
+      for (int dzCenter = -1; dzCenter < 2; ++dzCenter) {
+        if (zBin + dzCenter < 0 || zBin + dzCenter >= grid.nBinsZ())
+          continue;
         const auto& middleHits = grid.getHits(xBin + dxCenter, yBin - 1, zBin + dzCenter);
         hitCands.insert(hitCands.end(),middleHits.begin(), middleHits.end() ); 
-        // // formTriplets(topHits, topHits, middleHits, state, found, trackUsage);
-        // // formTriplets(topHits, middleHits, middleHits, state, found, trackUsage);
-        // for (int dxBottom = -1; dxBottom < 2; ++dxBottom) {
-        //   if (xBin + dxCenter + dxBottom < 0 || xBin + dxCenter + dxBottom >= grid.nBinsX())
-        //     continue;
-        //   if ((dxCenter < 0 && dxBottom > 0) || (dxCenter > 0 && dxBottom < 0))
-        //     continue;
-        //   for (int dzBottom = -1; dzBottom < 2; ++dzBottom) {
-        //     if (zBin + dzCenter + dzBottom < 0 || zBin + dzCenter + dzBottom >= grid.nBinsZ())
-        //       continue;
-        //     if ((dzCenter < 0 && dzBottom > 0) || (dzCenter > 0 && dzBottom < 0))
-        //       continue;
-        //     if (yBin > 1){
-        //       const auto& bottomHits = grid.getHits(xBin + dxCenter + dxBottom, yBin - 2, zBin + dzCenter + dzBottom);
-        //       formTriplets(topHits, middleHits, bottomHits, state, found, trackUsage);
-        //     }
-        //   }
-        // }
       }
     }
   }
-  std::sort(hitCands.begin(),hitCands.end(),[](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2){return h1->globalPosition().y() < h2->globalPosition().y(); });
-  formTriplets(hitCands, hitCands, hitCands, state, found, trackUsage);
+
+  std::sort(hitCands.begin(),hitCands.end(),[](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2){return h1->globalPosition().y() > h2->globalPosition().y(); });
+
+  formTriplets(topHits, hitCands, hitCands, state, found, trackUsage);
 }
 
      /// get the triplets for one particular cell combination
@@ -330,32 +362,28 @@ void CosmicGridTripletSeeder::formTriplets(const std::vector<const BaseTrackerRe
                 const TripletSeederEventState & state,
                 std::vector<OrderedHitTriplet> & found, 
                 std::unordered_multiset<const BaseTrackerRecHit*> & trackUsage) const{
-
   for (const BaseTrackerRecHit* top : topCands){
-    if (trackUsage.count(top) > 12) continue; 
+    if (trackUsage.count(top) >maxTripsPerSP_) continue; 
     const auto & gTop = top->globalPosition(); 
-    for (const BaseTrackerRecHit* center: centerCands){
-      const auto & gCenter = center->globalPosition(); 
-      if (trackUsage.count(center) > 12) continue; 
-      for (const BaseTrackerRecHit* bottom: bottomCands){
-        const auto & gBottom = bottom->globalPosition(); 
-        if (trackUsage.count(bottom) > 12) continue; 
-        if (center == top || top == bottom || center == bottom) continue; 
-        if (top->sameDetModule(*bottom) || top->sameDetModule(*center) || center->sameDetModule(*bottom)) continue; 
-        if (gCenter.y() > gTop.y()) continue;
-        if (gBottom.y() > gCenter.y()) continue;
-        // veto "zigzag" in z 
-        if ((gTop.z() - gCenter.z()) * (gCenter.z() - gBottom.z())  < 0 && std::abs(gTop.z() - gBottom.z() > 1.0)) continue;
-        // veto "zigzag" in x 
-        if ((gTop.x() - gCenter.x()) * (gCenter.x() - gBottom.x())  < 0 && std::abs(gTop.x() - gBottom.x() > 1.0)) continue;
-        const VectorHit* cenVH = dynamic_cast<const VectorHit*>(center); 
-        if (cenVH){
-          double dydx = 0.5 * ((gTop.y() - gCenter.y())/(gTop.x() - gCenter.x()) + (gCenter.y() - gBottom.y())/(gCenter.x() - gBottom.x())); 
-          double dydx_vh = cenVH->globalDirectionVH().y() / cenVH->globalDirectionVH().x();
-          LogDebug("CosmicGridTripletSeeder") << " dydx from trip "<<dydx<<" and from vh "<<dydx_vh;
-        }
 
+    for (const BaseTrackerRecHit* center: centerCands){
+      if (trackUsage.count(center) >maxTripsPerSP_) continue; 
+      const auto & gCenter = center->globalPosition(); 
+
+      if ( gTop.y()   < gCenter.y()) continue;
+      if (top->sameDetModule(*center)) continue; 
+
+      for (const BaseTrackerRecHit* bottom: bottomCands){
+        if (trackUsage.count(bottom) >maxTripsPerSP_) continue; 
+        const auto & gBottom = bottom->globalPosition(); 
+
+        if (top == bottom || center == bottom) continue; 
+        if (top->sameDetModule(*bottom) || center->sameDetModule(*bottom)) continue; 
+        if ( gCenter.y() < gBottom.y()) continue;
+        
         OrderedHitTriplet ps (top, center, bottom);
+        if (!tripletOk(state,ps)) continue; 
+
         trackUsage.insert(top); 
         trackUsage.insert(center); 
         trackUsage.insert(bottom); 
@@ -366,54 +394,68 @@ void CosmicGridTripletSeeder::formTriplets(const std::vector<const BaseTrackerRe
 }
 /// fit the triplets with kalman into trajectory seeds
 void CosmicGridTripletSeeder::fitTriplets(const CosmicGridTripletSeeder::TripletSeederEventState & state, const std::vector<OrderedHitTriplet>& triplets, TrajectorySeedCollection & output) const {
+    std::unordered_multiset<const TrackingRecHit*> seedPerSP;
     for (const OrderedHitTriplet & trip : triplets ) {
-      fitTriplet(state, trip, output); 
+      if (   seedPerSP.count(trip.inner() ) >= maxSeedsPerSP_
+          || seedPerSP.count(trip.middle()) >= maxSeedsPerSP_
+          || seedPerSP.count(trip.outer() ) >= maxSeedsPerSP_
+      ) continue; 
+      fitTriplet(state, trip, output, seedPerSP, true); 
+      if (tryBothDirections_) fitTriplet(state, trip, output, seedPerSP,false); 
     }
 }
 
 /// fit of a single triplet into a trajectory seed 
-bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletSeederEventState & state, const OrderedHitTriplet& triplet, TrajectorySeedCollection & output) const {
+bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletSeederEventState & state, const OrderedHitTriplet& triplet, TrajectorySeedCollection & output, std::unordered_multiset<const TrackingRecHit*> & seedPerSP, bool goUp) const {
   typedef TrajectoryStateOnSurface TSOS;
 
-    OrderedHitTriplet trip = triplet;  
+    // arrange the triplet so that the hits appear in extrapolation order, with the *target hit* appearing first ("inner"). 
+    // NB: They initially come in the order "top - middle - bottom" (in global y) when passed to this method. 
+    OrderedHitTriplet tripToUse = goUp ? triplet : OrderedHitTriplet{triplet.outer(), triplet.middle(), triplet.inner()}; 
 
-    GlobalPoint inner =
-        state.tracker->idToDet((*(trip.inner())).geographicalId())->surface().toGlobal((*(trip.inner())).localPosition());
+    // top SP
+    GlobalPoint target =
+        state.tracker->idToDet((*(tripToUse.inner())).geographicalId())->surface().toGlobal((*(tripToUse.inner())).localPosition());
 
+    // middle SP
     GlobalPoint middle =
-        state.tracker->idToDet((*(trip.middle())).geographicalId())->surface().toGlobal((*(trip.middle())).localPosition());
+        state.tracker->idToDet((*(tripToUse.middle())).geographicalId())->surface().toGlobal((*(tripToUse.middle())).localPosition());
 
-    GlobalPoint outer =
-        state.tracker->idToDet((*(trip.outer())).geographicalId())->surface().toGlobal((*(trip.outer())).localPosition());
-    if ((outer.y() - inner.y()) * outer.y() < 0) {
-      std::swap(inner, outer);
-      trip = OrderedHitTriplet(trip.outer(), trip.middle(), trip.inner());
-    }
-    // First use FastHelix out of the box
-    std::pair<GlobalVector, int> pq = pqFromHelixFit(inner, middle, outer, state.magfield);
-    GlobalVector gv = pq.first;
-    float ch = pq.second;
-    float Mom = sqrt(gv.x() * gv.x() + gv.y() * gv.y() + gv.z() * gv.z());
+    // bottom SP 
+    GlobalPoint start =
+        state.tracker->idToDet((*(tripToUse.outer())).geographicalId())->surface().toGlobal((*(tripToUse.outer())).localPosition());
+
+    // Initial momentum estimate at the start point 
+    // using the fast helix helper.
+    // Note: arg order of FastHelix is "outer middle vertex",
+    // so we will get a momentum pointing *up* when targeting the top SP,
+    // and pointing down when targeting the bottom SP. 
+    FastHelix helix(target, middle, start, state.magfield->nominalValue(),state.magfield);
+
+    // extract momentum and charge - flip when needed to ensure a momentum 
+    // pointing down (cosmic trajectory)
+    GlobalVector  gv =  (goUp ? -1 : 1) * helix.stateAtVertex().momentum();  
+    float ch = (goUp ? -1 : 1) * helix.stateAtVertex().charge();
+    
+    // initial cleaning. 
+    float Mom = gv.mag();
     if (Mom > 1000000 || edm::isNotFinite(Mom)) {
       return false;
     }
-    if (gv.perp() < 0.5) {
+    if (gv.perp() < 0.5 * ptMin_) {
       return false;
     }
-    const Propagator *propagator = nullptr;
-    if ((outer.y() - inner.y()) > 0) {
-      propagator = state.thePropagatorAl.get();
-    } else {
-      gv = -1 * gv;
-      ch = -1. * ch;
-      propagator = state.thePropagatorOp.get();
-    }
-    if ((gv.z() * (outer.z() - inner.z()) > 0) && (fabs(outer.z() - inner.z()) > 5) && (fabs(gv.z()) > .01)) {
-    }
+
+    // Next use a KF to refine the parameter estimate.
+    // Propagate from the start to the target, and track
+    // relation to the momentum direction. 
+    const Propagator *propagator = goUp ? state.thePropagatorOp.get() : state.thePropagatorAl.get();
 
     edm::OwnVector<TrackingRecHit> hits;
     std::vector<const BaseTrackerRecHit*> seedHits;
-    for (const BaseTrackerRecHit* hit : {trip.outer(), trip.middle(), trip.inner()}){
+
+    // build our hit array in the order pointing towards the target ("inner")
+    for (const BaseTrackerRecHit* hit :{tripToUse.outer(), tripToUse.middle(), tripToUse.inner()}){
       const VectorHit* vh = dynamic_cast<const VectorHit*>(hit);
       if (vh){
         auto found = state.vhConstituents.find(vh);
@@ -431,20 +473,19 @@ bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletS
         seedHits.push_back(hit);
       }
     }
+    // re-sort, to account for the vector hit components being possibly out-of-order
     std::sort(seedHits.begin(),seedHits.end(),[&](const BaseTrackerRecHit* h1, const BaseTrackerRecHit* h2){
-      if (outer.y() > 0 ){
-        return h1->globalPosition().y() > h2->globalPosition().y();
-      }
-      else{
-        return h1->globalPosition().y() < h2->globalPosition().y();
-      }
+        return goUp ? h1->globalPosition().y() < h2->globalPosition().y() : h1->globalPosition().y() > h2->globalPosition().y();
     });
-    outer = seedHits.front()->globalPosition(); 
-    GlobalTrajectoryParameters Gtp(outer, gv, int(ch), state.magfield);
+
+    // starting parameters: Lowest point, estimated momentum from fast helix. 
+    GlobalPoint updatedStartPos = seedHits.front()->globalPosition(); 
+    GlobalTrajectoryParameters Gtp(updatedStartPos, gv, int(ch), state.magfield);
     FreeTrajectoryState CosmicSeed(Gtp, CurvilinearTrajectoryError(AlgebraicSymMatrix55(AlgebraicMatrixID())));
     CosmicSeed.rescaleError(100);
     TSOS propagated, updated;
-    bool fail = false;
+
+    // now incrementally propagate towards the target point
     for (size_t ih = 0; ih < seedHits.size(); ++ih) {
       if (ih == 0) {
         propagated = propagator->propagate(CosmicSeed, state.tracker->idToDet((*seedHits[ih]).geographicalId())->surface());
@@ -452,60 +493,42 @@ bool CosmicGridTripletSeeder::fitTriplet(const CosmicGridTripletSeeder::TripletS
         propagated = propagator->propagate(updated, state.tracker->idToDet((*seedHits[ih]).geographicalId())->surface());
       }
       if (!propagated.isValid()) {
-        fail = true;
-        break;
-      } else {
+        return false;
       }
+
+      // clone the hit based on the propagated state 
       SeedingHitSet::ConstRecHitPointer tthp = seedHits[ih];
       auto newtth = static_cast<SeedingHitSet::RecHitPointer>(state.cloner(*tthp, propagated));
       updated = state.theUpdator->update(propagated, *newtth);
       hits.push_back(newtth);
+
       if (!updated.isValid()) {
-        fail = true;
-        break;
-      } else {
+        return false;
       }
     }
-    if (!fail && updated.isValid() && (updated.globalMomentum().perp() < 2.5)) {
-      fail = true;
+    
+    // some more cleaning
+    if (updated.globalMomentum().perp() < ptMin_) {
+      return false;
     }
-    if (!fail && updated.isValid() && (updated.globalMomentum().mag() < 2.5)) {
-      fail = true;
+    if (updated.globalMomentum().mag() < ptMin_) {
+      return false;
     }
-    if (fail) return false; 
-    // if (!fail) {
-        // if (seedVerbosity_ > 2) {
-        //   std::cout << "Processing triplet "  << ", rescale error by " << rescaleError_
-        //             << ": state BEFORE rescaling " << updated;
-        //   std::cout << "    Cartesian error (X,P) before rescaling= \n"
-        //             << updated.cartesianError().matrix() << std::endl;
-        // }
-        // updated.rescaleError(100);
-      // }
-    //   if (true) {
-    //   std::cout << "Processed  triplet "  << ": success (saved as #" << output.size() << ") : " << inner << " + "
-    //             << middle << " + " << outer << std::endl;
-    //   std::cout << "    pt = " << updated.globalMomentum().perp() << "    eta = " << updated.globalMomentum().eta()
-    //             << "    phi = " << updated.globalMomentum().phi() << "    ch = " << updated.charge() << std::endl;
-    //   if (true) {
-    //     std::cout << "    State:" << updated;
-    //   } else {
-    //     std::cout << "    X  = " << updated.globalPosition() << ", P = " << updated.globalMomentum() << std::endl;
-    //   }
-    //   std::cout << "    Cartesian error (X,P) = \n" << updated.cartesianError().matrix() << std::endl;
-    // }   
+
     PTrajectoryStateOnDet const &PTraj = trajectoryStateTransform::persistentState(
         updated, hits.back().geographicalId().rawId());
-    
-    output.push_back(TrajectorySeed(PTraj, hits, ((outer.y() - inner.y() > 0) ? alongMomentum : oppositeToMomentum)));
 
+    // and build the final seed. 
+    output.push_back(TrajectorySeed(PTraj, hits, goUp ? oppositeToMomentum : alongMomentum ));
 
     if (output.size() > size_t(500)) {
       output.clear();
       edm::LogError("TooManySeeds") << "Found too many seeds, bailing out.\n";
       return false;
     }
+    seedPerSP.insert(triplet.inner());
+    seedPerSP.insert(triplet.middle());
+    seedPerSP.insert(triplet.outer());
 
     return true;
-
 }

--- a/RecoTracker/SpecialSeedGenerators/src/SealModules.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SealModules.cc
@@ -3,11 +3,13 @@
 #include "RecoTracker/SpecialSeedGenerators/interface/CosmicSeedGenerator.h"
 #include "RecoTracker/SpecialSeedGenerators/interface/CRackSeedGenerator.h"
 #include "RecoTracker/SpecialSeedGenerators/interface/SimpleCosmicBONSeeder.h"
+#include "RecoTracker/SpecialSeedGenerators/interface/CosmicGridTripletSeeder.h"
 
 DEFINE_FWK_MODULE(CtfSpecialSeedGenerator);
 DEFINE_FWK_MODULE(CosmicSeedGenerator);
 DEFINE_FWK_MODULE(CRackSeedGenerator);
 DEFINE_FWK_MODULE(SimpleCosmicBONSeeder);
+DEFINE_FWK_MODULE(CosmicGridTripletSeeder);
 
 #include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGeneratorFactory.h"
 #include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGenerator.h"


### PR DESCRIPTION
#### PR description:

This PR introduces a simple grid-seeder for cosmic muons in the tracker. It is compatible with both the Phase-1 and Phase-2 detectors, but intended for Phase-2, to unlock the currently missing cosmic reconstruction and allow alignment studies to proceed.

Changes: 
- add `CartesianSeedingGrid` class to model a rectangular binned space-point grid to aid seeding
- add `CosmicGridTripletSeeder` producer to produce triplet seeds from space points in the inner and outer tracker systems 
- add python configuration for the above
- re-enable the cosmic chain for Phase-2, and enable vector hit production 
- add a parallel cosmic chain using the grid seeder in Phase-1, for validation purposes. This can also be dropped in the PR if desired. 

Documentation:
- [Discussion of the implementation in this PR and downstream performance checks in Tracker DPG/POG meeting](https://indico.cern.ch/event/1717234/#45-update-on-phase-2-cosmic-se)
- [Discussion of advanced prototype in TrkPOG](https://indico.cern.ch/event/1709534/#6-status-update-on-cosmic-seed)
- [Initial presentation of the plan in Tracker DPG](https://indico.cern.ch/event/1628662/#40-update-on-phase-2-cosmic-tr)

#### PR validation:

- Efficiency validation on Phase-1 and Phase-2 cosmic MC using 25k events: In presentations above
- :heavy_check_mark: `scram b runtests`: runs `DQM/SiStripMonitorClient/testSiStripDQM_OfflineTkMap` / `DQM/SiStripMonitorClient/test_TreeAndTkMapProducer` / `Calibration/TkAlCaRecoProducers/testAlCaHarvesting`, all succeed
- :heavy_check_mark: `runTheMatrix.py -l limited -i all --ibeos`: Either succeeding or DAS errors

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
- no backport intended 

