### PR TITLE
[17.0.X] Update `GeneralPurposeVertexAnalyzer` and `PrimaryVertexMonitor` axes labels accordingly to track pT cut

### DIFF
--- a/Alignment/OfflineValidation/plugins/GeneralPurposeVertexAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/GeneralPurposeVertexAnalyzer.cc
@@ -247,7 +247,7 @@ void GeneralPurposeVertexAnalyzer::IPMonitoring::bookIPMonitor(const edm::Parame
                          //VarBin,
                          VarMin,
                          VarMax);
-  IPVsPhi_->SetXTitle("PV track (p_{T} > 1 GeV) #phi");
+  IPVsPhi_->SetXTitle(fmt::format("PV track (p_{{T}} > {} GeV) #phi", pTcut_).c_str());
   IPVsPhi_->SetYTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_).c_str());
 
   IPVsEta_ =
@@ -259,7 +259,7 @@ void GeneralPurposeVertexAnalyzer::IPMonitoring::bookIPMonitor(const edm::Parame
                          //VarBin,
                          VarMin,
                          VarMax);
-  IPVsEta_->SetXTitle("PV track (p_{T} > 1 GeV) #eta");
+  IPVsEta_->SetXTitle(fmt::format("PV track (p_{{T}} > {} GeV) #eta", pTcut_).c_str());
   IPVsEta_->SetYTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_).c_str());
 
   IPVsPt_ = gpVertexAnalyzer::makeProfileIfLog(
@@ -274,7 +274,7 @@ void GeneralPurposeVertexAnalyzer::IPMonitoring::bookIPMonitor(const edm::Parame
       VarMin,
       VarMax,
       "");
-  IPVsPt_->SetXTitle("PV track (p_{T} > 1 GeV) p_{T} [GeV]");
+  IPVsPt_->SetXTitle(fmt::format("PV track (p_{{T}} > {} GeV) p_{{T}} [GeV]", pTcut_).c_str());
   IPVsPt_->SetYTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_).c_str());
 
   IPErrVsPhi_ =
@@ -286,7 +286,7 @@ void GeneralPurposeVertexAnalyzer::IPMonitoring::bookIPMonitor(const edm::Parame
                          //VarBin,
                          0.,
                          (varname_.find("xy") != std::string::npos) ? 100. : 200.);
-  IPErrVsPhi_->SetXTitle("PV track (p_{T} > 1 GeV) #phi");
+  IPErrVsPhi_->SetXTitle(fmt::format("PV track (p_{{T}} > {} GeV) #phi", pTcut_).c_str());
   IPErrVsPhi_->SetYTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_).c_str());
 
   IPErrVsEta_ =
@@ -298,7 +298,7 @@ void GeneralPurposeVertexAnalyzer::IPMonitoring::bookIPMonitor(const edm::Parame
                          //VarBin,
                          0.,
                          (varname_.find("xy") != std::string::npos) ? 100. : 200.);
-  IPErrVsEta_->SetXTitle("PV track (p_{T} > 1 GeV) #eta");
+  IPErrVsEta_->SetXTitle(fmt::format("PV track (p_{{T}} > {} GeV) #eta", pTcut_).c_str());
   IPErrVsEta_->SetYTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_).c_str());
 
   IPErrVsPt_ = gpVertexAnalyzer::makeProfileIfLog(
@@ -313,7 +313,7 @@ void GeneralPurposeVertexAnalyzer::IPMonitoring::bookIPMonitor(const edm::Parame
       VarMin,
       VarMax,
       "");
-  IPErrVsPt_->SetXTitle("PV track (p_{T} > 1 GeV) p_{T} [GeV]");
+  IPErrVsPt_->SetXTitle(fmt::format("PV track (p_{{T}} > {} GeV) p_{{T}} [GeV]", pTcut_).c_str());
   IPErrVsPt_->SetYTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_).c_str());
 
   IPVsEtaVsPhi_ = fs->make<TProfile2D>(
@@ -328,8 +328,8 @@ void GeneralPurposeVertexAnalyzer::IPMonitoring::bookIPMonitor(const edm::Parame
       //VarBin,
       VarMin,
       VarMax);
-  IPVsEtaVsPhi_->SetXTitle("PV track (p_{T} > 1 GeV) #eta");
-  IPVsEtaVsPhi_->SetYTitle("PV track (p_{T} > 1 GeV) #phi");
+  IPVsEtaVsPhi_->SetXTitle(fmt::format("PV track (p_{{T}} > {} GeV) #eta", pTcut_).c_str());
+  IPVsEtaVsPhi_->SetYTitle(fmt::format("PV track (p_{{T}} > {} GeV) #phi", pTcut_).c_str());
   IPVsEtaVsPhi_->SetZTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_).c_str());
 
   IPErrVsEtaVsPhi_ = fs->make<TProfile2D>(
@@ -344,8 +344,8 @@ void GeneralPurposeVertexAnalyzer::IPMonitoring::bookIPMonitor(const edm::Parame
       // VarBin,
       0.,
       (varname_.find("xy") != std::string::npos) ? 100. : 200.);
-  IPErrVsEtaVsPhi_->SetXTitle("PV track (p_{T} > 1 GeV) #eta");
-  IPErrVsEtaVsPhi_->SetYTitle("PV track (p_{T} > 1 GeV) #phi");
+  IPErrVsEtaVsPhi_->SetXTitle(fmt::format("PV track (p_{{T}} > {} GeV) #eta", pTcut_).c_str());
+  IPErrVsEtaVsPhi_->SetYTitle(fmt::format("PV track (p_{{T}} > {} GeV) #phi", pTcut_).c_str());
   IPErrVsEtaVsPhi_->SetZTitle(
       fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_).c_str());
 }

--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
@@ -276,7 +276,7 @@ void PrimaryVertexMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
                                  VarMin,
                                  VarMax,
                                  "");
-  IPVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 1);
+  IPVsPhi_->setAxisTitle(fmt::format("PV track (p_{{T}} > {} GeV) #phi", pTcut_), 1);
   IPVsPhi_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_), 2);
 
   IPVsEta_ = iBooker.bookProfile(fmt::format("d{}VsEta_pt{}", varname_, pTcut_),
@@ -288,7 +288,7 @@ void PrimaryVertexMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
                                  VarMin,
                                  VarMax,
                                  "");
-  IPVsEta_->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
+  IPVsEta_->setAxisTitle(fmt::format("PV track (p_{{T}} > {} GeV) #eta", pTcut_), 1);
   IPVsEta_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_), 2);
 
   IPVsPt_ = pvMonitor::makeProfileIfLog(
@@ -303,7 +303,7 @@ void PrimaryVertexMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
       VarMin,
       VarMax,
       "");
-  IPVsPt_->setAxisTitle("PV track (p_{T} > 1 GeV) p_{T} [GeV]", 1);
+  IPVsPt_->setAxisTitle(fmt::format("PV track (p_{{T}} > {} GeV) p_{{T}} [GeV]", pTcut_), 1);
   IPVsPt_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_), 2);
 
   // IP error profiles
@@ -318,7 +318,7 @@ void PrimaryVertexMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
                           0.,
                           (varname_.find("xy") != std::string::npos) ? 100. : 200.,
                           "");
-  IPErrVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 1);
+  IPErrVsPhi_->setAxisTitle(fmt::format("PV track (p_{{T}} > {} GeV) #phi", pTcut_), 1);
   IPErrVsPhi_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_), 2);
 
   IPErrVsEta_ =
@@ -331,7 +331,7 @@ void PrimaryVertexMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
                           0.,
                           (varname_.find("xy") != std::string::npos) ? 100. : 200.,
                           "");
-  IPErrVsEta_->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
+  IPErrVsEta_->setAxisTitle(fmt::format("PV track (p_{{T}} > {} GeV) #eta", pTcut_), 1);
   IPErrVsEta_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_), 2);
 
   IPErrVsPt_ = pvMonitor::makeProfileIfLog(
@@ -346,7 +346,7 @@ void PrimaryVertexMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
       VarMin,
       VarMax,
       "");
-  IPErrVsPt_->setAxisTitle("PV track (p_{T} > 1 GeV) p_{T} [GeV]", 1);
+  IPErrVsPt_->setAxisTitle(fmt::format("PV track (p_{{T}} > {} GeV) p_{{T}} [GeV]", pTcut_), 1);
   IPErrVsPt_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_), 2);
 
   // 2D profiles
@@ -364,8 +364,8 @@ void PrimaryVertexMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
       VarMin,
       VarMax,
       "");
-  IPVsEtaVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
-  IPVsEtaVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 2);
+  IPVsEtaVsPhi_->setAxisTitle(fmt::format("PV track (p_{{T}} > {} GeV) #eta", pTcut_), 1);
+  IPVsEtaVsPhi_->setAxisTitle(fmt::format("PV track (p_{{T}} > {} GeV) #phi", pTcut_), 2);
   IPVsEtaVsPhi_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_), 3);
 
   IPErrVsEtaVsPhi_ = iBooker.bookProfile2D(
@@ -381,8 +381,8 @@ void PrimaryVertexMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
       0.,
       (varname_.find("xy") != std::string::npos) ? 100. : 200.,
       "");
-  IPErrVsEtaVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
-  IPErrVsEtaVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 2);
+  IPErrVsEtaVsPhi_->setAxisTitle(fmt::format("PV track (p_{{T}} > {} GeV) #eta", pTcut_), 1);
+  IPErrVsEtaVsPhi_->setAxisTitle(fmt::format("PV track (p_{{T}} > {} GeV) #phi", pTcut_), 2);
   IPErrVsEtaVsPhi_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_),
                                  3);
 }


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/51488
backport of https://github.com/cms-sw/cmssw/pull/51517

#### PR description:

From the original PR:

> While looking at the HLT/Vertexing plots in the DQM directory (i.e., HLT/Vertexing/hltPixelVertices/Alignment/dxyVsEta_pt10 https://cern.ch/7khox), we realized that the horizontal labels in the TProfiles produced by the GeneralPurposeVertexAnalyzer do indicate the default pT>1 GeV cut also for the plotted quantities related to tracks with pT>10 GeV cut.

> <img width="900" height="442" alt="image" src="https://github.com/user-attachments/assets/0f720b7e-b0e8-46a1-9bff-ef3e2b9c531d" />


#### PR validation:

See master PRs

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/51488 and https://github.com/cms-sw/cmssw/pull/51517 to CMSSW_17_0_X

Cc: @pietroGru 

