### PR TITLE
New arbitration definition to optimize ME0 tracker muon reconstruction

### DIFF
--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -399,6 +399,7 @@ namespace reco {
                      int muonSubdetId,
                      ArbitrationType type = SegmentAndTrackArbitration,
                      bool includeSegmentError = true) const;
+      float dDphiDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
       /// get (best) segment information
       /// If no segment returns 999999
       float segmentX(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;

--- a/DataFormats/MuonReco/interface/MuonChamberMatch.h
+++ b/DataFormats/MuonReco/interface/MuonChamberMatch.h
@@ -30,6 +30,7 @@ namespace reco {
       DetId id;       // chamber ID
 
       int nDigisInRange;  // # of DT/CSC digis in the chamber close-by to the propagated track
+      float dPhidZ;       // dPhi/dZ of the track
 
       int detector() const { return id.subdetId(); }
       int station() const;

--- a/DataFormats/MuonReco/interface/MuonSegmentMatch.h
+++ b/DataFormats/MuonReco/interface/MuonSegmentMatch.h
@@ -31,6 +31,12 @@ namespace reco {
       static const unsigned int BelongsToTrackByClusClean = 1 << 23;  // won cluster sharing cleaning
       // won any arbitration cleaning type, including defaults
       static const unsigned int BelongsToTrackByCleaning = 1 << 24;
+      // best combined delta x and delta dphidz in single muon chamber
+      static const unsigned int BestInChamberByDX_DPhiDZ = 1 << 25;
+      // best combined delta x and delta dphidz in single muon station
+      static const unsigned int BestInStationByDX_DPhiDZ = 1 << 26;
+      // best combined delta x and delta dphidz of multiple muons
+      static const unsigned int BelongsToTrackByDX_DPhiDZ = 1 << 27;
 
       float x;            // X position of the matched segment
       float y;            // Y position of the matched segment
@@ -44,6 +50,7 @@ namespace reco {
       bool hasZed_;       // contains local y information (only relevant for segments in DT)
       bool hasPhi_;       // contains local x information (only relevant for segments in DT)
 
+      float dPhidZ;  // dPhi/dZ of the matched segment (only relevant for segments in GEM)
       bool isMask(unsigned int flag = Arbitrated) const { return (mask & flag) == flag; }
       void setMask(unsigned int flag) { mask |= flag; }
       float t0;
@@ -52,7 +59,7 @@ namespace reco {
       CSCSegmentRef cscSegmentRef;
       GEMSegmentRef gemSegmentRef;
       ME0SegmentRef me0SegmentRef;
-      MuonSegmentMatch() : x(0), y(0), xErr(0), yErr(0), dXdZ(0), dYdZ(0), dXdZErr(0), dYdZErr(0) {}
+      MuonSegmentMatch() : x(0), y(0), xErr(0), yErr(0), dXdZ(0), dYdZ(0), dXdZErr(0), dYdZErr(0), dPhidZ(0) {}
 
       bool hasZed() const { return hasZed_; }
       bool hasPhi() const { return hasPhi_; }

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -69,8 +69,8 @@ int Muon::numberOfMatches(ArbitrationType type) const {
     }
     if (type == GEMSegmentAndTrackArbitration) {
       for (auto& segmentMatch : chamberMatch.gemMatches) {
-        if (segmentMatch.isMask(MuonSegmentMatch::BestInChamberByDR) &&
-            segmentMatch.isMask(MuonSegmentMatch::BelongsToTrackByDR)) {
+        if (segmentMatch.isMask(MuonSegmentMatch::BestInChamberByDX_DPhiDZ) &&
+            segmentMatch.isMask(MuonSegmentMatch::BelongsToTrackByDX_DPhiDZ)) {
           matches++;
           break;
         }
@@ -429,13 +429,23 @@ std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> Muon::pair(
   for (std::vector<const MuonChamberMatch*>::const_iterator chamberMatch = chambers.begin();
        chamberMatch != chambers.end();
        chamberMatch++) {
-    if ((*chamberMatch)->segmentMatches.empty())
+    // Select the appropriate segment match vector based on detector type
+    const std::vector<MuonSegmentMatch>* segmentMatchesPtr = nullptr;
+    if ((*chamberMatch)->detector() == MuonSubdetId::GEM) {
+      segmentMatchesPtr = &((*chamberMatch)->gemMatches);
+    } else if ((*chamberMatch)->detector() == MuonSubdetId::ME0) {
+      segmentMatchesPtr = &((*chamberMatch)->me0Matches);
+    } else {
+      segmentMatchesPtr = &((*chamberMatch)->segmentMatches);
+    }
+
+    if (segmentMatchesPtr->empty())
       continue;
     if (type == NoArbitration)
-      return std::make_pair(*chamberMatch, &((*chamberMatch)->segmentMatches.front()));
+      return std::make_pair(*chamberMatch, &(segmentMatchesPtr->front()));
 
-    for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch = (*chamberMatch)->segmentMatches.begin();
-         segmentMatch != (*chamberMatch)->segmentMatches.end();
+    for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch = segmentMatchesPtr->begin();
+         segmentMatch != segmentMatchesPtr->end();
          segmentMatch++) {
       if (type == SegmentArbitration)
         if (segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR))
@@ -448,6 +458,10 @@ std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> Muon::pair(
         if (segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR) &&
             segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR) &&
             segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByCleaning))
+          return std::make_pair(*chamberMatch, &(*segmentMatch));
+      if (type == GEMSegmentAndTrackArbitration)
+        if (segmentMatch->isMask(MuonSegmentMatch::BestInChamberByDX_DPhiDZ) &&
+            segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDX_DPhiDZ))
           return std::make_pair(*chamberMatch, &(*segmentMatch));
     }
   }
@@ -553,6 +567,18 @@ float Muon::pullDyDz(int station, int muonSubdetId, ArbitrationType type, bool i
     return (chamberSegmentPair.first->dYdZ - chamberSegmentPair.second->dYdZ) /
            sqrt(std::pow(chamberSegmentPair.first->dYdZErr, 2) + std::pow(chamberSegmentPair.second->dYdZErr, 2));
   return (chamberSegmentPair.first->dYdZ - chamberSegmentPair.second->dYdZ) / chamberSegmentPair.first->dYdZErr;
+}
+
+float Muon::dDphiDz(int station, int muonSubdetId, ArbitrationType type) const {
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasPhi())
+    return 999999;
+  if (chamberSegmentPair.first->dPhidZ == 9999 || chamberSegmentPair.second->dPhidZ == 9999)
+    return 999999;
+  return chamberSegmentPair.first->dPhidZ - chamberSegmentPair.second->dPhidZ;
 }
 
 float Muon::segmentX(int station, int muonSubdetId, ArbitrationType type) const {

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -48,10 +48,12 @@ initial version number of a class which has never been stored before.
    <version ClassVersion="3" checksum="2031556424"/>
   </class>
   <class name="std::vector<reco::HcalMuonRecHit>"/>
-  <class name="reco::io_v1::MuonChamberMatch" ClassVersion="3">
+  <class name="reco::io_v1::MuonChamberMatch" ClassVersion="4">
+   <version ClassVersion="4" checksum="660442457"/>
    <version ClassVersion="3" checksum="2011871712"/>
   </class>
-  <class name="reco::io_v1::MuonSegmentMatch" ClassVersion="3">
+  <class name="reco::io_v1::MuonSegmentMatch" ClassVersion="4">
+    <version ClassVersion="4" checksum="2912227325"/>
     <version ClassVersion="3" checksum="2116957468"/>
   </class>
   <class name="reco::MuonRPCHitMatch" ClassVersion="3">

--- a/RecoMuon/MuonIdentification/interface/MuonArbitrationMethods.h
+++ b/RecoMuon/MuonIdentification/interface/MuonArbitrationMethods.h
@@ -11,7 +11,11 @@
 /// functor predicate for standard library sort algorithm
 struct SortMuonSegmentMatches {
   /// constructor takes arbitration type
-  SortMuonSegmentMatches(unsigned int flag) { flag_ = flag; }
+  SortMuonSegmentMatches(unsigned int flag, double dx_norm = 0.45, double dDphiDz_norm = 0.00003) {
+    flag_ = flag;
+    dx_norm_ = dx_norm;
+    dDphiDz_norm_ = dDphiDz_norm;
+  }
   /// sorts vector of pairs of chamber and segment pointers
   bool operator()(std::pair<reco::MuonChamberMatch*, reco::MuonSegmentMatch*> p1,
                   std::pair<reco::MuonChamberMatch*, reco::MuonSegmentMatch*> p2) {
@@ -42,11 +46,40 @@ struct SortMuonSegmentMatches {
       return sqrt(pow(sm1->dXdZ - cm1->dXdZ, 2) + pow(sm1->dYdZ - cm1->dYdZ, 2)) <
              sqrt(pow(sm2->dXdZ - cm2->dXdZ, 2) + pow(sm2->dYdZ - cm2->dYdZ, 2));
     }
+    if (flag_ == reco::MuonSegmentMatch::BestInChamberByDX_DPhiDZ ||
+        flag_ == reco::MuonSegmentMatch::BestInStationByDX_DPhiDZ ||
+        flag_ == reco::MuonSegmentMatch::BelongsToTrackByDX_DPhiDZ) {
+      if (fabs(sm1->y - cm1->y) > 3 * sqrt(pow(sm1->yErr, 2) + pow(cm1->yErr, 2))) {
+        // Bad segment: Dy too large
+        return false;
+      }
+      double dx1 = sm1->x - cm1->x;
+      double dDphiDz1 = sm1->dPhidZ - cm1->dPhidZ;
+      double dx2 = sm2->x - cm2->x;
+      double dDphiDz2 = sm2->dPhidZ - cm2->dPhidZ;
+
+      // normalization factors to make dx and dDPhidZ comparable
+      // obtained from the distribution in the noPU scenario
+      double dx_norm = dx_norm_;
+      double dDphiDz_norm = dDphiDz_norm_;
+
+      double pull_x1 = std::abs(dx1 / dx_norm);
+      double pull_dDphiDz1 = std::abs(dDphiDz1 / dDphiDz_norm);
+      double pull_x2 = std::abs(dx2 / dx_norm);
+      double pull_dDphiDz2 = std::abs(dDphiDz2 / dDphiDz_norm);
+
+      double D1 = pull_x1 * pull_x1 + pull_dDphiDz1 * pull_dDphiDz1;
+      double D2 = pull_x2 * pull_x2 + pull_dDphiDz2 * pull_dDphiDz2;
+
+      return D1 < D2;
+    }
 
     return false;  // is this appropriate? fix this
   }
 
   unsigned int flag_;
+  double dx_norm_;
+  double dDphiDz_norm_;
 };
 
 #endif

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -42,6 +42,7 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
   produces<reco::MuonTimeExtraMap>("dt");
   produces<reco::MuonTimeExtraMap>("csc");
 
+  globalGeomToken_ = esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>();
   minPt_ = iConfig.getParameter<double>("minPt");
   minP_ = iConfig.getParameter<double>("minP");
   minPCaloMuon_ = iConfig.getParameter<double>("minPCaloMuon");
@@ -77,6 +78,9 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
   caloCut_ = iConfig.getParameter<double>("minCaloCompatibility");  //CaloMuons
   arbClean_ = iConfig.getParameter<bool>("runArbitrationCleaner");  // muon mesh
   isPhase2_ = iConfig.getParameter<bool>("isPhase2");
+
+  dxNorm_ = iConfig.getParameter<double>("dxNorm");
+  dDphiDzNorm_ = iConfig.getParameter<double>("dDphiDzNorm");
 
   // Load TrackDetectorAssociator parameters
   const edm::ParameterSet parameters = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
@@ -856,6 +860,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent,
                                 reco::Muon& aMuon,
                                 TrackDetectorAssociator::Direction direction) {
   LogTrace("MuonIdentification") << "RecoMuon/MuonIdProducer :: fillMuonId";
+  auto const& propagator = iSetup.getData(propagatorToken_);
 
   // perform track - detector association
   const reco::Track* track = nullptr;
@@ -934,6 +939,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent,
     const auto& lErr = chamber.tState.localError();
     const auto& lPos = chamber.tState.localPosition();
     const auto& lDir = chamber.tState.localDirection();
+    const auto& gPos = chamber.tState.globalPosition();
 
     const auto& localError = lErr.positionError();
     matchedChamber.x = lPos.x();
@@ -952,6 +958,28 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent,
     matchedChamber.edgeY = chamber.localDistanceY;
 
     matchedChamber.id = chamber.id;
+
+    // dummy default values for DT CSC and RPC
+    matchedChamber.dPhidZ = 9999;
+
+    // Fill dPhidZ only for ME0
+    if (chamber.id.subdetId() == MuonSubdetId::GEM && GEMDetId(chamber.id.rawId()).station() == 0) {
+      const GEMDetId me0id(chamber.id);
+      GEMDetId layer1Id(me0id.region(), me0id.ring(), me0id.station(), 1, me0id.chamber(), me0id.ieta());
+      const GeomDet* layer1 = gemgeom->idToDet(layer1Id);
+      if (!layer1)
+        continue;  // check null pointer
+      auto tsos_layer1 = propagator.propagate(chamber.tState, layer1->surface());
+      if (!tsos_layer1.isValid())
+        continue;
+
+      GlobalPoint gPos_l1 = tsos_layer1.globalPosition();
+      float dphi = reco::deltaPhi(gPos_l1.phi().value(), gPos.phi().value());
+      float dz = gPos_l1.z() - gPos.z();
+      float dphi_dz = (fabs(dz) > 1e-6) ? dphi / dz : 9999;
+
+      matchedChamber.dPhidZ = dphi_dz;
+    }
 
     if (fillShowerDigis_ && fillMatching_) {
       theShowerDigiFiller_->fill(matchedChamber);
@@ -983,6 +1011,42 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent,
       matchedSegment.me0SegmentRef = segment.me0SegmentRef;
       matchedSegment.hasZed_ = segment.hasZed;
       matchedSegment.hasPhi_ = segment.hasPhi;
+
+      // dummy default values for DT CSC and RPC
+      matchedSegment.dPhidZ = 9999;
+      if (segment.gemSegmentRef.isNonnull() && gemgeom) {
+        const auto& recHits = segment.gemSegmentRef->specificRecHits();
+        if (recHits.size() >= 2) {
+          int minL = 99, maxL = -99;
+          GlobalPoint gpFirst, gpLast;
+          GlobalError geFirst, geLast;
+          ErrorFrameTransformer transformer;
+
+          for (const auto& rh : recHits) {
+            GEMDetId id(rh.geographicalId());
+            if (const auto* det = gemgeom->idToDet(id)) {
+              int layer = id.layer();
+              if (layer < minL) {
+                minL = layer;
+                gpFirst = det->surface().toGlobal(rh.localPosition());
+                geFirst = transformer.transform(rh.localPositionError(), det->surface());
+              }
+              if (layer > maxL) {
+                maxL = layer;
+                gpLast = det->surface().toGlobal(rh.localPosition());
+                geLast = transformer.transform(rh.localPositionError(), det->surface());
+              }
+            }
+          }
+
+          if (minL < 99 && maxL > -99) {
+            double dz = gpLast.z() - gpFirst.z();
+            double dphi = reco::deltaPhi(gpLast.phi().value(), gpFirst.phi().value());
+            matchedSegment.dPhidZ = (std::abs(dz) > 1e-6) ? dphi / dz : 0.0;
+          }
+        }
+      }
+
       // test segment
       bool matchedX = false;
       bool matchedY = false;
@@ -1260,6 +1324,7 @@ void MuonIdProducer::fillArbitrationInfo(reco::MuonCollection* pOutputMuons, uns
             arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDR);
             arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDX);
             arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::Arbitrated);
+            arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDX_DPhiDZ);
           } else {
             sort(arbitrationPairs.begin(),
                  arbitrationPairs.end(),
@@ -1277,6 +1342,10 @@ void MuonIdProducer::fillArbitrationInfo(reco::MuonCollection* pOutputMuons, uns
                  arbitrationPairs.end(),
                  SortMuonSegmentMatches(reco::MuonSegmentMatch::BelongsToTrackByDX));
             arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDX);
+            sort(arbitrationPairs.begin(),
+                 arbitrationPairs.end(),
+                 SortMuonSegmentMatches(reco::MuonSegmentMatch::BelongsToTrackByDX_DPhiDZ, dxNorm_, dDphiDzNorm_));
+            arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDX_DPhiDZ);
             for (auto& ap : arbitrationPairs) {
               ap.second->setMask(reco::MuonSegmentMatch::Arbitrated);
             }
@@ -1307,6 +1376,7 @@ void MuonIdProducer::fillArbitrationInfo(reco::MuonCollection* pOutputMuons, uns
         chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDXSlope);
         chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDR);
         chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDX);
+        chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDX_DPhiDZ);
       } else {
         sort(chamberPairs.begin(),
              chamberPairs.end(),
@@ -1324,6 +1394,10 @@ void MuonIdProducer::fillArbitrationInfo(reco::MuonCollection* pOutputMuons, uns
              chamberPairs.end(),
              SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInChamberByDX));
         chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDX);
+        sort(chamberPairs.begin(),
+             chamberPairs.end(),
+             SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInChamberByDX_DPhiDZ, dxNorm_, dDphiDzNorm_));
+        chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDX_DPhiDZ);
       }
     }  // chamberIter1
 
@@ -1354,6 +1428,7 @@ void MuonIdProducer::fillArbitrationInfo(reco::MuonCollection* pOutputMuons, uns
           stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDXSlope);
           stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDR);
           stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDX);
+          stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDX_DPhiDZ);
         } else {
           sort(stationPairs.begin(),
                stationPairs.end(),
@@ -1371,6 +1446,10 @@ void MuonIdProducer::fillArbitrationInfo(reco::MuonCollection* pOutputMuons, uns
                stationPairs.end(),
                SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInStationByDX));
           stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDX);
+          sort(stationPairs.begin(),
+               stationPairs.end(),
+               SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInStationByDX_DPhiDZ, dxNorm_, dDphiDzNorm_));
+          stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDX_DPhiDZ);
         }
       }
     }
@@ -1565,6 +1644,8 @@ void MuonIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   descCalo.add<int>("MaxSeverityHB", 9);
   descCalo.add<int>("MaxSeverityHE", 9);
   desc.add<edm::ParameterSetDescription>("CaloExtractorPSet", descCalo);
+  desc.add<double>("dxNorm", 0.45);
+  desc.add<double>("dDphiDzNorm", 0.00003);
 
   descriptions.addDefault(desc);
 }

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -61,7 +61,10 @@
 #include "RecoMuon/MuonIdentification/interface/MuonIdTruthInfo.h"
 #include "RecoMuon/MuonIdentification/interface/MuonArbitrationMethods.h"
 #include "DataFormats/Common/interface/ValueMap.h"
+
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
+#include "DataFormats/GEMRecHit/interface/GEMRecHit.h"
+#include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
 
 class MuonMesh;
 class MuonKinkFinder;
@@ -227,6 +230,9 @@ private:
 
   bool isPhase2_;
   bool debugWithTruthMatching_;
+
+  double dxNorm_;
+  double dDphiDzNorm_;
 
   edm::Handle<reco::TrackCollection> innerTrackCollectionHandle_;
   edm::Handle<reco::TrackCollection> outerTrackCollectionHandle_;

--- a/RecoMuon/MuonIdentification/plugins/MuonRefProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonRefProducer.cc
@@ -50,6 +50,8 @@ MuonRefProducer::MuonRefProducer(const edm::ParameterSet& iConfig) {
     arbitrationType_ = reco::Muon::SegmentArbitration;
   else if (arbitrationType == "SegmentAndTrackArbitration")
     arbitrationType_ = reco::Muon::SegmentAndTrackArbitration;
+  else if (arbitrationType == "GEMSegmentAndTrackArbitration")
+    arbitrationType_ = reco::Muon::GEMSegmentAndTrackArbitration;
   else {
     edm::LogWarning("MuonIdentification")
         << "Unknown arbitration type is requested: " << arbitrationType << "\nUsing the default one";

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -92,7 +92,10 @@ muons1stStep = cms.EDProducer("MuonIdProducer",
     ),
 
     # tracker muon arbitration
-    arbitrateTrackerMuons = cms.bool(True)
+    arbitrateTrackerMuons = cms.bool(True),
+    # normalization parameter for ME0 tracker muon arbitration
+    dxNorm = cms.double(0.45),
+    dDphiDzNorm = cms.double(0.00003)
 )
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM


### PR DESCRIPTION
#### PR description:

The goal of this PR is to optimize tracker muon reconstruction in the ME0 station ($2.0 < |\eta| < 2.8$). 

The ME0 station is characterized by fine segmentation in the $\phi$ direction and coarse segmentation in $\eta$. The standard arbitration procedure to find the best track-segment matching relies on $\Delta R = \sqrt{(\Delta X)^2 + (\Delta Y)^2}$; however, this approach limits efficiency for tracker muons in ME0 due to the limited precision of the $\Delta Y$ information.

To address this, the strategy introduced in this PR refines the track-segment matching selection through:
* A loose cut on $\Delta Y$, ensuring that matched tracks and segments belong to the same $\eta$ partition or adjacent ones.
* A discrimination metric that selects the closest pairs based on the two most precise observables provided by ME0 chambers:
  
 $$\mathrm{Metric} = \left(\frac{\Delta X}{\sigma_{\Delta X}}\right)^2 + \left(\frac{\Delta(d\phi/dz)}{\sigma_{\Delta(d\phi/dz)}}\right)^2$$

This new strategy results in an increased average reconstruction efficiency and significantly improves its uniformity across the entire ME0 acceptance [1]. The full study is documented [here](https://indico.cern.ch/event/1638450/#15-phase-2-studies-with-me0-re).

Additional Details
* Since the ME0 segment reconstruction algorithm uses $X$ coordinates, $d\phi/dz$ is computed using the furthest hits of the segment within the station.
* Two normalization factors, derived from distributions in the no-PU scenario [2], are introduced to make the two components of the discrimination metric comparable.  

[1]  
<p align="center">
  <img src="https://github.com/user-attachments/assets/35e3cda9-5bb2-48bf-a215-d8b3af0bee68" width="50%">
</p>

[2]
<p align="center">
  <img src="https://github.com/user-attachments/assets/548264e9-9032-405c-a3f4-457bedc3b2fa" width="48%">
  <img src="https://github.com/user-attachments/assets/8e48e511-ad98-4b54-b768-adea9758b6d6" width="48%">
</p>

#### PR validation:
The PR was validated with the suggested basic battery of tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No need to be backported
