### PR TITLE
reuse identical logical volumes in HGCAL

### DIFF
--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedFineCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedFineCassette.cc
@@ -19,8 +19,10 @@
 #include "Geometry/HGCalCommonData/interface/HGCalWaferType.h"
 
 #include <cmath>
+#include <map>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <unordered_set>
 #include <vector>
 
@@ -478,6 +480,8 @@ struct HGCalMixRotatedFineCassette {
                    int absType,
                    bool fine) {
     cms::DDNamespace ns(ctxt, e, true);
+    int placementCopy(-1);
+    // Use unique temporary copy numbers for a shared volume; restore the original name and copy number after placement.
 
     // Make the top part first
     for (unsigned int ly = 0; ly < layerTypeTop_.size(); ++ly) {
@@ -578,10 +582,7 @@ struct HGCalMixRotatedFineCassette {
 #endif
           std::string name = namesTop_[ii] + "L" + std::to_string(copy) + "F" + std::to_string(k);
           ++k;
-          dd4hep::Solid solid = dd4hep::Tube(r1, r2, hthickl, phi1, phi2);
-          ns.addSolidNS(ns.prepend(name), solid);
-          dd4hep::Volume glog1 = dd4hep::Volume(solid.name(), solid, matter1);
-          ns.addVolumeNS(glog1);
+          dd4hep::Volume glog1 = topVolume(ns, name, matter1, r1, r2, hthickl, phi1, phi2);
 #ifdef EDM_ML_DEBUG
           edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: " << glog1.name() << " Tubs made of "
                                         << matter1.name() << " of dimensions " << cms::convert2mm(r1) << ", "
@@ -589,7 +590,9 @@ struct HGCalMixRotatedFineCassette {
                                         << convertRadToDeg(phi1) << ", " << convertRadToDeg(phi2);
 #endif
           dd4hep::Position tran(0, 0, zpos);
-          glog.placeVolume(glog1, copy, tran);
+          auto placed = glog.placeVolume(glog1, placementCopy--, tran);
+          placed->SetName((ns.prepend(name) + "_" + std::to_string(copy)).c_str());
+          placed->SetNumber(copy);
 #ifdef EDM_ML_DEBUG
           edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Position " << glog1.name() << " number "
                                         << copy << " in " << glog.name() << " at (0,0," << cms::convert2mm(zpos)
@@ -694,10 +697,7 @@ struct HGCalMixRotatedFineCassette {
 #endif
         std::string name = namesTop_[ii] + "L" + std::to_string(copy) + "F" + std::to_string(k);
         ++k;
-        dd4hep::Solid solid = dd4hep::Tube(r1, r2, hthickl, phi1, phi2);
-        ns.addSolidNS(ns.prepend(name), solid);
-        dd4hep::Volume glog1 = dd4hep::Volume(solid.name(), solid, matter1);
-        ns.addVolumeNS(glog1);
+        dd4hep::Volume glog1 = topVolume(ns, name, matter1, r1, r2, hthickl, phi1, phi2);
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: " << glog1.name() << " Tubs made of "
                                       << matter1.name() << " of dimensions " << cms::convert2mm(r1) << ", "
@@ -705,7 +705,9 @@ struct HGCalMixRotatedFineCassette {
                                       << convertRadToDeg(phi1) << ", " << convertRadToDeg(phi2);
 #endif
         dd4hep::Position tran(0, 0, zpos);
-        glog.placeVolume(glog1, copy, tran);
+        auto placed = glog.placeVolume(glog1, placementCopy--, tran);
+        placed->SetName((ns.prepend(name) + "_" + std::to_string(copy)).c_str());
+        placed->SetNumber(copy);
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedFineCassette: Position " << glog1.name() << " number "
                                       << copy << " in " << glog.name() << " at (0,0," << cms::convert2mm(zpos)
@@ -873,6 +875,25 @@ struct HGCalMixRotatedFineCassette {
     }
   }
 
+  dd4hep::Volume topVolume(cms::DDNamespace& ns,
+                           const std::string& name,
+                           const dd4hep::Material& material,
+                           double r1,
+                           double r2,
+                           double halfThickness,
+                           double phi1,
+                           double phi2) {
+    auto [entry, inserted] =
+        topVolumes_.try_emplace(std::make_tuple(std::string(material.name()), r1, r2, halfThickness, phi1, phi2));
+    if (inserted) {
+      dd4hep::Solid solid = dd4hep::Tube(r1, r2, halfThickness, phi1, phi2);
+      ns.addSolidNS(ns.prepend(name), solid);
+      entry->second = dd4hep::Volume(solid.name(), solid, material);
+      ns.addVolumeNS(entry->second);
+    }
+    return entry->second;
+  }
+
   void testCassetteShift() {
     for (unsigned int k = 0; k < layers_.size(); ++k) {
       int layer = k + 1;
@@ -959,7 +980,9 @@ struct HGCalMixRotatedFineCassette {
   std::vector<double> cassetteShiftScnt_;  // Shifts of the cassetes for scintillators
   std::string nameSpace_;                  // Namespace of this and ALL sub-parts
   std::unordered_set<int> copies_;         // List of copy #'s
-  int forFireworks_;                       // 0 for standard run 1 for fireworks
+  // Reuse top passive volumes with identical material and shape.
+  std::map<std::tuple<std::string, double, double, double, double, double>, dd4hep::Volume> topVolumes_;
+  int forFireworks_;  // 0 for standard run 1 for fireworks
   double alpha_, cosAlpha_;
   static constexpr double tol0_ = 0.0001 * dd4hep::mm;
   static constexpr double tol1_ = 0.01 * dd4hep::mm;

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWaferFullRotated.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWaferFullRotated.cc
@@ -13,6 +13,8 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include <map>
+#include <tuple>
 
 //#define EDM_ML_DEBUG
 
@@ -87,6 +89,9 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
   double RM2 = rM / sqrt3;
   const int nFine(nCells), nCoarse(nCells);
   HGCalCell wafer(waferSize, nFine, nCoarse);
+  // Passive layers have no sensitive detector and can share identical volumes.
+  std::map<std::tuple<std::string, std::vector<double>, std::vector<double>, double, double>, dd4hep::Volume>
+      passiveLayers;
   for (unsigned int k = 0; k < tag.size(); ++k) {
     // First the mother
     std::vector<double> xM = {rM, 0, -rM, -rM, 0, rM};
@@ -128,24 +133,32 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
           zw[0] = -0.5 * layerThick[i];
           zw[1] = 0.5 * layerThick[i];
         }
-        std::string layerName = layerNames[i] + tag[k] + waferTag;
-#ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: Layer " << l << ": " << i << ":" << layerName << " "
-                                      << layerSizeOff[i] << " r " << r2 << ":" << R2;
-#endif
-        solid = dd4hep::ExtrudedPolygon(xL, yL, zw, zx, zy, scale);
-        ns.addSolidNS(ns.prepend(layerName), solid);
         matter = ns.material(materials[i]);
-        glogs[i] = dd4hep::Volume(solid.name(), solid, matter);
-        ns.addVolumeNS(glogs[i]);
+        std::string layerName = layerNames[i] + tag[k] + waferTag;
+        auto key = std::make_tuple(materials[i], xL, yL, zw[0], zw[1]);
+        auto found = passiveLayers.find(key);
+        if ((layerType[i] <= 0) && (found != passiveLayers.end())) {
+          glogs[i] = found->second;
+        } else {
 #ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: " << solid.name() << " extruded polygon made of "
-                                      << materials[i] << " z|x|y|s (0) " << zw[0] << ":" << zx[0] << ":" << zy[0] << ":"
-                                      << scale[0] << " z|x|y|s (1) " << zw[1] << ":" << zx[1] << ":" << zy[1] << ":"
-                                      << scale[1] << " and " << xL.size() << " edges";
-        for (unsigned int kk = 0; kk < xL.size(); ++kk)
-          edm::LogVerbatim("HGCalGeom") << "[" << kk << "] " << xL[kk] << ":" << yL[kk];
+          edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: Layer " << l << ": " << i << ":" << layerName
+                                        << " " << layerSizeOff[i] << " r " << r2 << ":" << R2;
 #endif
+          solid = dd4hep::ExtrudedPolygon(xL, yL, zw, zx, zy, scale);
+          ns.addSolidNS(ns.prepend(layerName), solid);
+          glogs[i] = dd4hep::Volume(solid.name(), solid, matter);
+          ns.addVolumeNS(glogs[i]);
+          if (layerType[i] <= 0)
+            passiveLayers.emplace(std::move(key), glogs[i]);
+#ifdef EDM_ML_DEBUG
+          edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: " << solid.name() << " extruded polygon made of "
+                                        << materials[i] << " z|x|y|s (0) " << zw[0] << ":" << zx[0] << ":" << zy[0]
+                                        << ":" << scale[0] << " z|x|y|s (1) " << zw[1] << ":" << zx[1] << ":" << zy[1]
+                                        << ":" << scale[1] << " and " << xL.size() << " edges";
+          for (unsigned int kk = 0; kk < xL.size(); ++kk)
+            edm::LogVerbatim("HGCalGeom") << "[" << kk << "] " << xL[kk] << ":" << yL[kk];
+#endif
+        }
       }
       dd4hep::Position tran0(0, 0, (zi + 0.5 * layerThick[i]));
       glogM.placeVolume(glogs[i], copyNumber[i], tran0);

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWaferPartialRotated.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWaferPartialRotated.cc
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include <map>
+#include <tuple>
 
 //#define EDM_ML_DEBUG
 
@@ -82,6 +84,10 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
 #endif
   static constexpr double tol = 0.00001 * dd4hep::mm;
 
+  // Passive layers have no sensitive detector and can share identical volumes.
+  std::map<std::tuple<std::string, std::vector<double>, std::vector<double>, double, double>, dd4hep::Volume>
+      passiveLayers;
+
   // Loop over all types
   for (unsigned int k = 0; k < tags.size(); ++k) {
     for (unsigned int m = 0; m < placementIndex.size(); ++m) {
@@ -140,24 +146,31 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
             zw[0] = -0.5 * layerThick[i];
             zw[1] = 0.5 * layerThick[i];
           }
-          solid = dd4hep::ExtrudedPolygon(xL, yL, zw, zx, zy, scale);
-          std::string lname = layerNames[i] + placementIndexTags[m] + waferTag + tags[k];
-          ns.addSolidNS(ns.prepend(lname), solid);
           matter = ns.material(materials[i]);
-          glogs[i] = dd4hep::Volume(solid.name(), solid, matter);
-          ns.addVolumeNS(glogs[i]);
+          std::string lname = layerNames[i] + placementIndexTags[m] + waferTag + tags[k];
+          auto key = std::make_tuple(materials[i], xL, yL, zw[0], zw[1]);
+          auto found = passiveLayers.find(key);
+          if ((layerType[i] <= 0) && (found != passiveLayers.end())) {
+            glogs[i] = found->second;
+          } else {
+            solid = dd4hep::ExtrudedPolygon(xL, yL, zw, zx, zy, scale);
+            ns.addSolidNS(ns.prepend(lname), solid);
+            glogs[i] = dd4hep::Volume(solid.name(), solid, matter);
+            ns.addVolumeNS(glogs[i]);
+            if (layerType[i] <= 0)
+              passiveLayers.emplace(std::move(key), glogs[i]);
 #ifdef EDM_ML_DEBUG
-          edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferPartialRotated: " << solid.name()
-                                        << " extruded polygon made of " << materials[i] << " z|x|y|s (0) "
-                                        << cms::convert2mm(zw[0]) << ":" << cms::convert2mm(zx[0]) << ":"
-                                        << cms::convert2mm(zy[0]) << ":" << scale[0] << " z|x|y|s (1) "
-                                        << cms::convert2mm(zw[1]) << ":" << cms::convert2mm(zx[1]) << ":"
-                                        << cms::convert2mm(zy[1]) << ":" << scale[1] << " partial " << partialTypes[k]
-                                        << " placement index " << placementIndex[m] << " and " << xM.size() << " edges";
-          for (unsigned int j = 0; j < xL.size(); ++j)
             edm::LogVerbatim("HGCalGeom")
-                << "[" << j << "] " << cms::convert2mm(xL[j]) << ":" << cms::convert2mm(yL[j]);
+                << "DDHGCalWaferPartialRotated: " << solid.name() << " extruded polygon made of " << materials[i]
+                << " z|x|y|s (0) " << cms::convert2mm(zw[0]) << ":" << cms::convert2mm(zx[0]) << ":"
+                << cms::convert2mm(zy[0]) << ":" << scale[0] << " z|x|y|s (1) " << cms::convert2mm(zw[1]) << ":"
+                << cms::convert2mm(zx[1]) << ":" << cms::convert2mm(zy[1]) << ":" << scale[1] << " partial "
+                << partialTypes[k] << " placement index " << placementIndex[m] << " and " << xM.size() << " edges";
+            for (unsigned int j = 0; j < xL.size(); ++j)
+              edm::LogVerbatim("HGCalGeom")
+                  << "[" << j << "] " << cms::convert2mm(xL[j]) << ":" << cms::convert2mm(yL[j]);
 #endif
+          }
         }
         if ((layerType[i] > 0) && (senseType >= 0)) {
           std::string sname = senseName + placementIndexTags[m] + waferTag + tags[k];


### PR DESCRIPTION
#### PR description:

This PR reuses identical logical volumes and solids in the construction of the HGCAL. As mentioned in [this thread](https://github.com/cms-sw/cmssw/issues/51567#issuecomment-5127893527), currently a significant fraction of volumes are identical duplicates. By caching and reusing them, the total amount of logical volumes and solids can be significantly reduced:

The baseline D127 ( T35+C27+M17+I21+O10+F9) has 26,299 logical volumes, 26,233 solids, and 59,038 placements.
With this PR, they are reduced:
| Saved LV | Saved solids | Remaining LV | Remaining solids |
|---:|---:|---:|---:|
| 9,138 (34.75%) | 9,138 (34.83%) | 17,161 | 17,095 |

Placements are identical, the de-duplicated LVs are just placed more often.

#### Performance tests:

These are performance tests with the resulting geometry in VecGeom using the `BVHNavigationBenchmark`. Note that this does **not** translate to any performance claims on CMSSW, neither for run time nor memory usage, but it will certainly help the GPU simulations with AdePT (no tests with AdePT were done yet):

| Metric | Baseline | PR | Improvement |
|---|---:|---:|---:|
| Logical volumes | 26,299 | 17,161 | **34.75%** |
| Host navigator initialization | 5.637 s | 3.678 s | **34.75%** |
| GPU geometry transfer | 13.020 s | 10.427 s | **19.92%** |
| Total GPU setup | 13.229 s | 10.637 s | **19.59%** |
| Complete benchmark wall time | 20.996 s | 16.146 s | **23.10%** |
| Maximum host RSS | 1,030.65 MiB | 906.00 MiB | **124.65 MiB / 12.09%** |

In CMSSW, with single threaded runs (MT runs are not reproducible and have a larger run-to-run fluctuation, so a lot of events would be needed to make any claims), the run time is unchanged. The memory improves slightly:

| Metric | Baseline | PR | Change |
|---|---:|---:|---:|
| Wall time | 241.96 ± 0.60 s | 242.05 ± 2.61 s | +0.04% |
| Maximum RSS (`time -v`) | 2,676.82 ± 1.85 MiB | 2,648.91 ± 0.82 MiB | **−27.91 MiB (−1.04%)** |
| CMSSW peak RSS | 2,670.94 ± 3.14 MiB | 2,643.76 ± 3.46 MiB | **−27.19 MiB (−1.02%)** |
| End-of-job RSS | 2,461.31 ± 6.57 MiB | 2,433.42 ± 3.55 MiB | **−27.88 MiB (−1.13%)** |

#### PR validation:

This PR does not change the geometry itself, it simply re-uses the same logical volumes more often.
Therefore, the physics results are bit-wise identical. This was tested using IB `CMSSW_20_1_X_2026-07-28-1100` on `el9_amd64_gcc14` using this script
[cms_d127_sim_cfg.py.txt](https://github.com/user-attachments/files/30541715/cms_d127_sim_cfg.py.txt)
running it with:
```
cmsRun cms_d127_dd4hep_sim_cfg.py nevents=20 nthreads=1 seed=51567
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Should be judged by experts

#### Further notes:
Assisted by Codex GPT 5.6 Sol