### PR TITLE
Add HTXSStage1p2Filter

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/HTXSFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/HTXSFilter.cc
@@ -47,6 +47,7 @@ HTXSFilter::~HTXSFilter() {
 // ------------ method called on each new Event  ------------
 bool HTXSFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
+  edm::LogWarning("HTXSFilter") << "HTXSFilter uses the (deprecated) Stage 1.1 flags to filter events. For Stage 1.2 flags, see HTXSStage1p2Filter." << std::endl;
   Handle<HTXS::HiggsClassification> cat;
   iEvent.getByToken(token_, cat);
   if (htxs_flags.empty()) {

--- a/GeneratorInterface/GenFilters/plugins/HTXSStage1p2Filter.cc
+++ b/GeneratorInterface/GenFilters/plugins/HTXSStage1p2Filter.cc
@@ -1,9 +1,9 @@
 // -*- C++ -*-
 //
-// Package:    HTXSFilter
-// Class:      HTXSFilter
+// Package:    HTXSStage1p2Filter
+// Class:      HTXSStage1p2Filter
 //
-/**\class HTXSFilter HTXSFilter.cc user/HTXSFilter/plugins/HTXSFilter.cc
+/**\class HTXSStage1p2Filter HTXSStage1p2Filter.cc user/HTXSStage1p2Filter/plugins/HTXSStage1p2Filter.cc
 
  Description: [one line class summary]
 
@@ -11,14 +11,14 @@
      [Notes on implementation]
 */
 //
-// Original Author:  Janek Bechtel
-//         Created:  Fri, 10 May 2019 14:30:15 GMT
+// Original Author:  Tom Runting
+//         Created:  Mon, 03 August 2024 09:29:16 GMT
 //
 //
 
 // system include files
 #include <memory>
-#include "GeneratorInterface/GenFilters/plugins/HTXSFilter.h"
+#include "GeneratorInterface/GenFilters/plugins/HTXSStage1p2Filter.h"
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -31,11 +31,11 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h"
 
-HTXSFilter::HTXSFilter(const edm::ParameterSet& iConfig)
+HTXSStage1p2Filter::HTXSStage1p2Filter(const edm::ParameterSet& iConfig)
     : token_(consumes<HTXS::HiggsClassification>(edm::InputTag("rivetProducerHTXS", "HiggsClassification"))),
       htxs_flags(iConfig.getUntrackedParameter("htxs_flags", std::vector<int>())) {}
 
-HTXSFilter::~HTXSFilter() {
+HTXSStage1p2Filter::~HTXSStage1p2Filter() {
   // do anything here that needs to be done at destruction time
   // (e.g. close files, deallocate resources etc.)
 }
@@ -45,19 +45,16 @@ HTXSFilter::~HTXSFilter() {
 //
 
 // ------------ method called on each new Event  ------------
-bool HTXSFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+bool HTXSStage1p2Filter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
-  edm::LogWarning("HTXSFilter") << "HTXSFilter uses the (deprecated) Stage 1.1 flags to filter events. For Stage 1.2 "
-                                   "flags, see HTXSStage1p2Filter."
-                                << std::endl;
   Handle<HTXS::HiggsClassification> cat;
   iEvent.getByToken(token_, cat);
   if (htxs_flags.empty()) {
-    edm::LogInfo("HTXSFilter") << "Selection of HTXS flags to filter is empty. Filtering will not be applied."
-                               << std::endl;
+    edm::LogInfo("HTXSStage1p2Filter") << "Selection of HTXS flags to filter is empty. Filtering will not be applied."
+                                       << std::endl;
     return true;
   }
-  if (std::find(htxs_flags.begin(), htxs_flags.end(), cat->stage1_1_cat_pTjet30GeV) != htxs_flags.end()) {
+  if (std::find(htxs_flags.begin(), htxs_flags.end(), cat->stage1_2_cat_pTjet30GeV) != htxs_flags.end()) {
     return true;
   } else {
     return false;
@@ -65,4 +62,4 @@ bool HTXSFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup
 }
 
 //define this as a plug-in
-DEFINE_FWK_MODULE(HTXSFilter);
+DEFINE_FWK_MODULE(HTXSStage1p2Filter);

--- a/GeneratorInterface/GenFilters/plugins/HTXSStage1p2Filter.h
+++ b/GeneratorInterface/GenFilters/plugins/HTXSStage1p2Filter.h
@@ -1,0 +1,55 @@
+#ifndef HTXSSTAGE1P2_FILTER_h
+#define HTXSSTAGE1P2_FILTER_h
+// -*- C++ -*-
+//
+// Package:    HTXSStage1p2Filter
+// Class:      HTXSStage1p2Filter
+//
+/**\class HTXSStage1p2Filter HTXSStage1p2Filter.cc user/HTXSStage1p2Filter/plugins/HTXSStage1p2Filter.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Tom Runting
+//         Created:  Mon, 03 August 2024 09:28:47 GMT
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h"
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+//
+// class decleration
+//
+namespace edm {
+  class HiggsClassification;
+}
+
+class HTXSStage1p2Filter : public edm::global::EDFilter<> {
+public:
+  explicit HTXSStage1p2Filter(const edm::ParameterSet&);
+  ~HTXSStage1p2Filter() override;
+
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+private:
+  // ----------member data ---------------------------
+
+  const edm::EDGetTokenT<HTXS::HiggsClassification> token_;
+  const std::vector<int> htxs_flags;
+};
+#endif


### PR DESCRIPTION
#### PR description:

Stage 1.1 was superseded a while ago - adding a deprecation warning to  `HTXSFilter` and introducing `HTXSStage1p2Filter` to allow filtering on HTXS Stage 1.2 categories

#### PR validation:

Builds + passes tests, produces expected output with a test fragment.
