### PR TITLE
Changes for OO UPC reco

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -124,7 +124,7 @@ _photonDRN.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), patPhotonsD
 from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from PhysicsTools.PatAlgos.modules import DeDxEstimatorRekeyer
 dedxEstimator = DeDxEstimatorRekeyer()
-dedx_lfit.toModify(dedxEstimator, dedxEstimators = ["dedxPixelLikelihood", "dedxStripLikelihood", "dedxAllLikelihood"])
+dedx_lfit.toModify(dedxEstimator, dedxEstimators = ["dedxHarmonic2", "dedxPixelHarmonic2", "dedxPixelLikelihood", "dedxStripLikelihood", "dedxAllLikelihood"])
 dedx_lfit.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), dedxEstimator))
 
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc

--- a/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/trackerClusterCheck_cfi.py
@@ -43,3 +43,11 @@ from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
                MaxNumberOfPixelClusters = 10000,
                MaxNumberOfStripClusters = 30000
                )
+
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+(highBetaStar & run3_oxygen).toModify(trackerClusterCheck,
+               doClusterCheck=True,
+               cut = "strip < 200000 && pixel < 20000",
+               MaxNumberOfPixelClusters = 20000,
+               MaxNumberOfStripClusters = 200000
+               )

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -87,9 +87,10 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
          )
 )
 
+_TkClusParametersPP = offlinePrimaryVertices.TkClusParameters.clone()
+
 from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
-from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
-(highBetaStar & ~run3_oxygen).toModify(offlinePrimaryVertices,
+highBetaStar.toModify(offlinePrimaryVertices,
     TkClusParameters = dict(
         TkDAClusParameters = dict(
             Tmin = 4.0,
@@ -140,6 +141,8 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(offlinePrimaryVertices,
                         TkFilterParameters = dict(maxEta = 4.0))
 
+_offlinePrimaryVerticesPP = offlinePrimaryVertices.clone(TkClusParameters = _TkClusParametersPP)
+
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 (pp_on_XeXe_2017 | pp_on_AA).toModify(offlinePrimaryVertices,
@@ -163,7 +166,7 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
                )
 )
 
-(highBetaStar & ~run3_oxygen).toModify(offlinePrimaryVertices,
+highBetaStar.toModify(offlinePrimaryVertices,
      TkFilterParameters = dict(
          maxNormalizedChi2 = 80.0,
          minPixelLayersWithHits = 1,
@@ -180,7 +183,7 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 )
 
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
-(highBetaStar & run3_upc & ~run3_oxygen).toModify(offlinePrimaryVertices,
+(highBetaStar & run3_upc).toModify(offlinePrimaryVertices,
     TkFilterParameters = dict(
         algorithm="filterWithThreshold",
         maxNormalizedChi2 = 80.0,
@@ -206,4 +209,11 @@ from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
         0: dict(chi2cutoff = 4.0, minNdof = -1.1),
         1: dict(chi2cutoff = 4.0, minNdof = -2.0),
     }
+)
+
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+(highBetaStar & run3_oxygen).toReplaceWith(offlinePrimaryVertices, _offlinePrimaryVerticesPP.clone(
+    TkFilterParameters = dict(
+        minSiliconLayersWithHits = 0,
+    ))
 )

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -87,9 +87,10 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
          )
 )
 
+_TkClusParametersPP = offlinePrimaryVertices.TkClusParameters.clone()
+
 from Configuration.Eras.Modifier_highBetaStar_cff import highBetaStar
-from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
-(highBetaStar & ~run3_oxygen).toModify(offlinePrimaryVertices,
+highBetaStar.toModify(offlinePrimaryVertices,
     TkClusParameters = dict(
         TkDAClusParameters = dict(
             Tmin = 4.0,
@@ -140,6 +141,8 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(offlinePrimaryVertices,
                         TkFilterParameters = dict(maxEta = 4.0))
 
+_offlinePrimaryVerticesPP = offlinePrimaryVertices.clone(TkClusParameters = _TkClusParametersPP)
+
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 (pp_on_XeXe_2017 | pp_on_AA).toModify(offlinePrimaryVertices,
@@ -163,7 +166,7 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
                )
 )
 
-(highBetaStar & ~run3_oxygen).toModify(offlinePrimaryVertices,
+highBetaStar.toModify(offlinePrimaryVertices,
      TkFilterParameters = dict(
          maxNormalizedChi2 = 80.0,
          minPixelLayersWithHits = 1,
@@ -180,7 +183,7 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 )
 
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
-(highBetaStar & run3_upc & ~run3_oxygen).toModify(offlinePrimaryVertices,
+(highBetaStar & run3_upc).toModify(offlinePrimaryVertices,
     TkFilterParameters = dict(
         algorithm="filterWithThreshold",
         maxNormalizedChi2 = 80.0,
@@ -206,4 +209,13 @@ from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
         0: dict(chi2cutoff = 4.0, minNdof = -1.1),
         1: dict(chi2cutoff = 4.0, minNdof = -2.0),
     }
+)
+
+from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
+(highBetaStar & run3_oxygen).toReplaceWith(offlinePrimaryVertices, _offlinePrimaryVerticesPP.clone(
+    TkFilterParameters = dict(
+        algorithm="filterWithThreshold",
+        minSiliconLayersWithHits = 0,
+        numTracksThreshold = cms.int32(3),
+    ))
 )


### PR DESCRIPTION
#### PR description:

This PR adds the following changes for the rereco of the 2025 OO data using the UPC era:
- Relaxes the track selection in the primary vertex algorithm
- Relaxes the track cluster check
- Adds back the harmonic dEdx estimators in MiniAOD

@mandrenguyen

#### PR validation:

Tested with relvals 143.911,143.912

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported back to 15_0_X
