### PR TITLE
Replace deprecated tensorflow::Status with absl::Status for TF 2.21

### DIFF
--- a/PhysicsTools/TensorFlow/src/TensorFlow.cc
+++ b/PhysicsTools/TensorFlow/src/TensorFlow.cc
@@ -94,7 +94,7 @@ namespace tensorflow {
 
   MetaGraphDef* loadMetaGraphDef(const std::string& exportDir, const std::string& tag, Options& options) {
     // objects to load the graph
-    Status status;
+    absl::Status status;
     RunOptions runOptions;
     SavedModelBundle bundle;
 
@@ -118,7 +118,7 @@ namespace tensorflow {
 
   GraphDef* loadGraphDef(const std::string& pbFile) {
     // objects to load the graph
-    Status status;
+    absl::Status status;
 
     // load it
     GraphDef* graphDef = new GraphDef();
@@ -140,7 +140,7 @@ namespace tensorflow {
 
   Session* createSession(Options& options) {
     // objects to create the session
-    Status status;
+    absl::Status status;
 
     // create a new, empty session
     Session* session = nullptr;
@@ -166,7 +166,7 @@ namespace tensorflow {
     Session* session = createSession(options);
 
     // add the graph def from the meta graph
-    Status status;
+    absl::Status status;
     status = session->Create(metaGraphDef->graph_def());
     if (!status.ok()) {
       throw cms::Exception("InvalidMetaGraphDef")
@@ -219,7 +219,7 @@ namespace tensorflow {
     Session* session = createSession(options);
 
     // add the graph def
-    Status status;
+    absl::Status status;
     status = session->Create(*graphDef);
 
     // check for success
@@ -236,7 +236,7 @@ namespace tensorflow {
     }
 
     // close and delete the session
-    Status status = session->Close();
+    absl::Status status = session->Close();
     delete session;
 
     // reset the pointer
@@ -285,7 +285,7 @@ namespace tensorflow {
       return;
 
     // run and check the status
-    Status status = session->Run(runOptions, inputs, outputNames, {}, outputs, nullptr, threadPoolOptions);
+    absl::Status status = session->Run(runOptions, inputs, outputNames, {}, outputs, nullptr, threadPoolOptions);
     if (!status.ok()) {
       throw cms::Exception("InvalidRun") << "error while running session: " << status.ToString();
     }

--- a/PhysicsTools/TensorFlow/test/testGraphLoading.cc
+++ b/PhysicsTools/TensorFlow/test/testGraphLoading.cc
@@ -54,7 +54,7 @@ void testGraphLoading::test() {
   scale.scalar<float>()() = 1.0;
 
   std::vector<tensorflow::Tensor> outputs;
-  tensorflow::Status status = session->Run({{"input", input}, {"scale", scale}}, {"output"}, {}, &outputs);
+  absl::Status status = session->Run({{"input", input}, {"scale", scale}}, {"output"}, {}, &outputs);
   if (!status.ok()) {
     std::cout << status.ToString() << std::endl;
     CPPUNIT_ASSERT(false);

--- a/PhysicsTools/TensorFlow/test/testGraphLoadingCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testGraphLoadingCUDA.cc
@@ -75,7 +75,7 @@ process.add_(cms.Service('CUDAService'))
   scale.scalar<float>()() = 1.0;
 
   std::vector<tensorflow::Tensor> outputs;
-  tensorflow::Status status = session->Run({{"input", input}, {"scale", scale}}, {"output"}, {}, &outputs);
+  absl::Status status = session->Run({{"input", input}, {"scale", scale}}, {"output"}, {}, &outputs);
   if (!status.ok()) {
     std::cout << status.ToString() << std::endl;
     CPPUNIT_ASSERT(false);

--- a/PhysicsTools/TensorFlow/test/testHelloWorld.cc
+++ b/PhysicsTools/TensorFlow/test/testHelloWorld.cc
@@ -35,7 +35,7 @@ void testHelloWorld::test() {
   tensorflow::Backend backend = tensorflow::Backend::cpu;
 
   // object to load and run the graph / session
-  tensorflow::Status status;
+  absl::Status status;
   tensorflow::Options options{backend};
   tensorflow::RunOptions runOptions;
   tensorflow::SavedModelBundle bundle;

--- a/PhysicsTools/TensorFlow/test/testHelloWorldCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testHelloWorldCUDA.cc
@@ -55,7 +55,7 @@ process.add_(cms.Service('CUDAService'))
   tensorflow::Backend backend = tensorflow::Backend::cuda;
 
   // object to load and run the graph / session
-  tensorflow::Status status;
+  absl::Status status;
   tensorflow::Options options{backend};
   tensorflow::RunOptions runOptions;
   tensorflow::SavedModelBundle bundle;

--- a/PhysicsTools/TensorFlow/test/testMetaGraphLoading.cc
+++ b/PhysicsTools/TensorFlow/test/testMetaGraphLoading.cc
@@ -58,7 +58,7 @@ void testMetaGraphLoading::test() {
   scale.scalar<float>()() = 1.0;
 
   std::vector<tensorflow::Tensor> outputs;
-  tensorflow::Status status = session2->Run({{"input", input}, {"scale", scale}}, {"output"}, {}, &outputs);
+  absl::Status status = session2->Run({{"input", input}, {"scale", scale}}, {"output"}, {}, &outputs);
   if (!status.ok()) {
     std::cout << status.ToString() << std::endl;
     CPPUNIT_ASSERT(false);

--- a/PhysicsTools/TensorFlow/test/testMetaGraphLoadingCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testMetaGraphLoadingCUDA.cc
@@ -79,7 +79,7 @@ process.add_(cms.Service('CUDAService'))
   scale.scalar<float>()() = 1.0;
 
   std::vector<tensorflow::Tensor> outputs;
-  tensorflow::Status status = session2->Run({{"input", input}, {"scale", scale}}, {"output"}, {}, &outputs);
+  absl::Status status = session2->Run({{"input", input}, {"scale", scale}}, {"output"}, {}, &outputs);
   if (!status.ok()) {
     std::cout << status.ToString() << std::endl;
     CPPUNIT_ASSERT(false);

--- a/PhysicsTools/TensorFlow/test/testVisibleDevices.cc
+++ b/PhysicsTools/TensorFlow/test/testVisibleDevices.cc
@@ -46,7 +46,7 @@ void testVisibleDevices::test() {
   CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, options), cms::Exception);
 
   std::vector<tensorflow::DeviceAttributes> response;
-  tensorflow::Status status = session->ListDevices(&response);
+  absl::Status status = session->ListDevices(&response);
   CPPUNIT_ASSERT(status.ok());
 
   // If a single device is found, we assume that it's the CPU.

--- a/PhysicsTools/TensorFlow/test/testVisibleDevicesCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testVisibleDevicesCUDA.cc
@@ -69,7 +69,7 @@ process.add_(cms.Service('CUDAService'))
   CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, options), cms::Exception);
 
   std::vector<tensorflow::DeviceAttributes> response;
-  tensorflow::Status status = session->ListDevices(&response);
+  absl::Status status = session->ListDevices(&response);
   CPPUNIT_ASSERT(status.ok());
 
   // If a single device is found, we assume that it's the CPU.

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -25,7 +25,7 @@ namespace deep_tau {
         const std::string& graph_file = graph_entry.second;
         if (mem_mapped) {
           memmappedEnv_[entry_name] = std::make_unique<tensorflow::MemmappedEnv>(tensorflow::Env::Default());
-          const tensorflow::Status mmap_status = memmappedEnv_.at(entry_name)->InitializeFromFile(graph_file);
+          const absl::Status mmap_status = memmappedEnv_.at(entry_name)->InitializeFromFile(graph_file);
           if (!mmap_status.ok()) {
             throw cms::Exception("DeepTauCache: unable to initalize memmapped environment for ")
                 << graph_file << ". \n"
@@ -33,7 +33,7 @@ namespace deep_tau {
           }
 
           graphs_[entry_name] = std::make_unique<tensorflow::GraphDef>();
-          const tensorflow::Status load_graph_status =
+          const absl::Status load_graph_status =
               ReadBinaryProto(memmappedEnv_.at(entry_name).get(),
                               tensorflow::MemmappedFileSystem::kMemmappedPackageDefaultGraphDef,
                               graphs_.at(entry_name).get());

--- a/RecoTracker/PixelTrackFitting/interface/alpaka/RiemannFit.h
+++ b/RecoTracker/PixelTrackFitting/interface/alpaka/RiemannFit.h
@@ -608,7 +608,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::riemannFit {
 #endif
       {
         Eigen::Matrix<double, 1, 1> cm;
-        Eigen::Matrix<double, 1, 1> cm2;
+        // Eigen::Matrix<double, 1, 1> cm2;
         cm = mc.transpose() * vMat * mc;
         const double tempC2 = cm(0, 0);
         Matrix2Nd<N> tempVcsMat;


### PR DESCRIPTION
TF 2.21 marks tensorflow::Status as deprecated (ABSL_DEPRECATE_AND_INLINE), it is now an inline alias for absl::Status. Update PhysicsTools/TensorFlow, RecoTauTag/RecoTau, and RecoTracker/PixelTrackFitting to use absl::Status directly.