### PR TITLE
fix typo in cmsTritonConfigTool

### DIFF
--- a/HeterogeneousCore/SonicTriton/scripts/cmsTritonConfigTool
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTritonConfigTool
@@ -194,7 +194,7 @@ def add_edit_args(parser, model_info):
             kwargs = dict(type=json.loads,
                 help="provide {} values in json format".format(field["type"])
             )
-            edit = edit_msg
+            editor = edit_msg
         action = group.add_argument(argname, **kwargs)
         if val_type is not None: action.val_type = val_type
         dests[action.dest] = editor


### PR DESCRIPTION
#### PR description:

This typo was noticed when trying to edit generic message fields like `dynamic_batching`.

#### PR validation:

The following command now works:
```
mkdir -p models/particlenet
cmsTritonConfigTool edit -c $CMSSW_RELEASE_BASE/external/el9_amd64_gcc13/data/RecoBTag/Combined/data/models/particlenet/config.pbtxt --copy models/particlenet --max-batch-size 500 --dynamic-batching '{"preferred_batch_size": [250]}'
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Maybe worth backporting, depending on usage in previous releases.