### PR TITLE
Remove JobFailure and PostESModuleRegistration signals as obsolete

### DIFF
--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -178,7 +178,6 @@ namespace evf {
     std::string makeInputLegendaJson();
 
     void preallocate(edm::service::SystemBounds const&);
-    void jobFailure();
     void preBeginJob(edm::ProcessContext const& pc);
 
     void preModuleBeginJob(edm::ModuleDescription const&);

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -206,7 +206,6 @@ namespace evf {
         totalEventsProcessed_(0),
         verbose_(iPS.getUntrackedParameter<bool>("verbose")) {
     reg.watchPreallocate(this, &FastMonitoringService::preallocate);  //receiving information on number of threads
-    reg.watchJobFailure(this, &FastMonitoringService::jobFailure);    //global
 
     reg.watchPreBeginJob(this, &FastMonitoringService::preBeginJob);
     reg.watchPreModuleBeginJob(this, &FastMonitoringService::preModuleBeginJob);  //global
@@ -468,8 +467,6 @@ namespace evf {
     }
     return false;
   }
-
-  void FastMonitoringService::jobFailure() { fmt_->m_data.macrostate_ = FastMonState::sError; }
 
   //new output module name is stream
   void FastMonitoringService::preModuleBeginJob(const edm::ModuleDescription& desc) {

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -93,9 +93,6 @@ namespace edm {
     void EventSetupProvider::add(std::shared_ptr<ESProductResolverProvider> iProvider) {
       assert(iProvider.get() != nullptr);
       dataProviders_->push_back(iProvider);
-      if (activityRegistry_) {
-        activityRegistry_->postESModuleRegistrationSignal_.emit(iProvider->description());
-      }
     }
 
     using RecordProviders = std::vector<std::shared_ptr<EventSetupRecordProvider>>;

--- a/FWCore/MessageService/plugins/MessageLogger.cc
+++ b/FWCore/MessageService/plugins/MessageLogger.cc
@@ -223,7 +223,6 @@ namespace edm {
       iRegistry.watchPostBeginJob(this, &MessageLogger::postBeginJob);
       iRegistry.watchPreEndJob(this, &MessageLogger::preEndJob);
       iRegistry.watchPostEndJob(this, &MessageLogger::postEndJob);
-      iRegistry.watchJobFailure(this, &MessageLogger::jobFailure);  // change log 14
 
       iRegistry.watchPreModuleConstruction(this, &MessageLogger::preModuleConstruction);
       iRegistry.watchPostModuleConstruction(this, &MessageLogger::postModuleConstruction);
@@ -973,13 +972,6 @@ namespace edm {
     }
 
     void MessageLogger::postEndJob() {
-      summarizeInJobReport();    // Put summary info into Job Rep  // change log 10
-      MessageLoggerQ::MLqSUM();  // trigger summary info.		// change log 9
-    }
-
-    void MessageLogger::jobFailure() {
-      MessageDrop* messageDrop = MessageDrop::instance();
-      messageDrop->setSinglet("jobFailure");
       summarizeInJobReport();    // Put summary info into Job Rep  // change log 10
       MessageLoggerQ::MLqSUM();  // trigger summary info.		// change log 9
     }

--- a/FWCore/ServiceRegistry/README.md
+++ b/FWCore/ServiceRegistry/README.md
@@ -130,4 +130,3 @@ occur when accessing data from `edm::Ref`-style objects. |
 | `PreStreamEarlyTermination` | - | Emitted when an exception is thrown from any stream transition. |
 | `PreGlobalEarlyTermination` | - | Emitted when an exception is thrown from any global transition. |
 | `PreSourceEarlyTermination` | - | Emitted when an external termination request is received. |
-| `JobFailure` | - | To be removed (only called from `FWCore/Services/test/servicesJobReport_t.cpp`) |

--- a/FWCore/ServiceRegistry/README.md
+++ b/FWCore/ServiceRegistry/README.md
@@ -27,7 +27,6 @@ The order of the signals in this list is an approximate order in which they woul
 | `PostServicesConstruction` | - | Emitted after all services have been constructed. |
 | `{Pre,Post}EventSetupModulesConstruction` | Yes | Emitted before and after constructing EventSetup modules. |
 | `{Pre,Post}ESModuleConstruction` | Yes | Emitted before and after constructing an EventSetup module (ESProducer or ESSource). |
-| `PostESModuleRegistration` | - | Emitted after an ESModule provider has been registered with the EventSetupProvider. |
 | `{Pre,Post}ModulesAndSourceConstruction` | Yes | Emitted before and after concurrent construction of the Source and the EDModules. |
 | `{Pre,Post}SourceConstruction` | Yes | Emitted before and after construction of the Source. |
 | `{Pre,Post}OpenFile` | Yes | `PoolSource`, `EmbeddedRootSource`, `RNTupleTempSource`, and `EmbeddedRNTupleTempSource` emit these signals  before and after opening a new input file (either primary or secondary). Note that the first signal may be emitted during the Source construction, and the later signals after the `BeginProcessing`. |

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -1297,13 +1297,6 @@ namespace edm {
     }
     AR_WATCH_USING_METHOD_1(watchPreSourceEarlyTermination)
 
-    /// signal is emitted if event processing or end-of-job
-    /// processing fails with an uncaught exception.
-    typedef signalslot::Signal<void()> JobFailure;
-    JobFailure jobFailureSignal_;
-    void watchJobFailure(JobFailure::slot_type const& iSlot) { jobFailureSignal_.connect_front(iSlot); }
-    AR_WATCH_USING_METHOD_0(watchJobFailure)
-
     // ---------- member functions ---------------------------
 
     ///forwards our signals to slots connected to iOther

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -190,14 +190,6 @@ namespace edm {
     }
     AR_WATCH_USING_METHOD_1(watchPostESModuleConstruction)
 
-    /// signal is emitted after the ESModule is registered with EventSetupProvider
-    using PostESModuleRegistration = signalslot::Signal<void(eventsetup::ComponentDescription const&)>;
-    PostESModuleRegistration postESModuleRegistrationSignal_;
-    void watchPostESModuleRegistration(PostESModuleRegistration::slot_type const& iSlot) {
-      postESModuleRegistrationSignal_.connect(iSlot);
-    }
-    AR_WATCH_USING_METHOD_1(watchPostESModuleRegistration)
-
     using PreModulesAndSourceConstruction = signalslot::Signal<void()>;
     /// signal is emitted before the parallel section to construct ED modules and source
     PreModulesAndSourceConstruction preModulesAndSourceConstructionSignal_;

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -222,7 +222,6 @@ namespace edm {
     preStreamEarlyTerminationSignal_.connect(std::cref(iOther.preStreamEarlyTerminationSignal_));
     preGlobalEarlyTerminationSignal_.connect(std::cref(iOther.preGlobalEarlyTerminationSignal_));
     preSourceEarlyTerminationSignal_.connect(std::cref(iOther.preSourceEarlyTerminationSignal_));
-    jobFailureSignal_.connect(std::cref(iOther.jobFailureSignal_));
   }
 
   void ActivityRegistry::copySlotsFrom(ActivityRegistry& iOther) {
@@ -395,6 +394,5 @@ namespace edm {
     copySlotsToFrom(preStreamEarlyTerminationSignal_, iOther.preStreamEarlyTerminationSignal_);
     copySlotsToFrom(preGlobalEarlyTerminationSignal_, iOther.preGlobalEarlyTerminationSignal_);
     copySlotsToFrom(preSourceEarlyTerminationSignal_, iOther.preSourceEarlyTerminationSignal_);
-    copySlotsToFromReverse(jobFailureSignal_, iOther.jobFailureSignal_);
   }
 }  // namespace edm

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -60,7 +60,6 @@ namespace edm {
     postEventSetupModulesConstructionSignal_.connect(std::cref(iOther.postEventSetupModulesConstructionSignal_));
     preESModuleConstructionSignal_.connect(std::cref(iOther.preESModuleConstructionSignal_));
     postESModuleConstructionSignal_.connect(std::cref(iOther.postESModuleConstructionSignal_));
-    postESModuleRegistrationSignal_.connect(std::cref(iOther.postESModuleRegistrationSignal_));
     preModulesAndSourceConstructionSignal_.connect(std::cref(iOther.preModulesAndSourceConstructionSignal_));
     postModulesAndSourceConstructionSignal_.connect(std::cref(iOther.postModulesAndSourceConstructionSignal_));
     preSourceConstructionSignal_.connect(std::cref(iOther.preSourceConstructionSignal_));
@@ -231,7 +230,6 @@ namespace edm {
     copySlotsToFromReverse(postEventSetupModulesConstructionSignal_, iOther.postEventSetupModulesConstructionSignal_);
     copySlotsToFrom(preESModuleConstructionSignal_, iOther.preESModuleConstructionSignal_);
     copySlotsToFromReverse(postESModuleConstructionSignal_, iOther.postESModuleConstructionSignal_);
-    copySlotsToFromReverse(postESModuleRegistrationSignal_, iOther.postESModuleRegistrationSignal_);
     copySlotsToFrom(preModulesAndSourceConstructionSignal_, iOther.preModulesAndSourceConstructionSignal_);
     copySlotsToFromReverse(postModulesAndSourceConstructionSignal_, iOther.postModulesAndSourceConstructionSignal_);
     copySlotsToFrom(preSourceConstructionSignal_, iOther.preSourceConstructionSignal_);

--- a/FWCore/Services/plugins/StallMonitor.cc
+++ b/FWCore/Services/plugins/StallMonitor.cc
@@ -293,7 +293,7 @@ StallMonitor::StallMonitor(ParameterSet const& iPS, ActivityRegistry& iRegistry)
     iRegistry.watchPreModuleWriteLumi(this, &StallMonitor::preModuleGlobalTransition);
     iRegistry.watchPostModuleWriteLumi(this, &StallMonitor::postModuleGlobalTransition);
 
-    iRegistry.postESModuleRegistrationSignal_.connect([this](auto const& iDescription) {
+    iRegistry.postESModuleConstructionSignal_.connect([this](auto const& iDescription) {
       if (esModuleLabels_.size() <= iDescription.id_) {
         esModuleLabels_.resize(iDescription.id_ + 1);
       }

--- a/FWCore/Services/src/JobReportService.cc
+++ b/FWCore/Services/src/JobReportService.cc
@@ -19,7 +19,6 @@ namespace edm {
 
     JobReportService::JobReportService(ParameterSet const&, ActivityRegistry& reg) : JobReport() {
       reg.watchPostEndJob(this, &JobReportService::postEndJob);
-      reg.watchJobFailure(this, &JobReportService::frameworkShutdownOnFailure);
 
       // We don't handle PreProcessEvent, because we have to know *which
       // input file* was the event read from. Only the InputSource that
@@ -32,24 +31,9 @@ namespace edm {
 
       // ... not yet implemented ...
 
-      // Maybe we should have a member function called from both
-      // postEndJob() and frameworkShutdownOnFailure(), so that common
-      // elements are reported through common code.
-
       //
       // Any files that are still open should be flushed to the report
       //
-      impl()->flushFiles();
-    }
-
-    void JobReportService::frameworkShutdownOnFailure() {
-      // Dump information to the MessageLogger's JobSummary
-      // about the files that aren't already closed,
-      // and whatever summary information is wanted.
-
-      // Maybe we should have a member function called from both
-      // postEndJob() and frameworkShutdownOnFailure(), so that common
-      // elements are reported through common code.
       impl()->flushFiles();
     }
 

--- a/FWCore/Services/test/servicesJobReport_t.cpp
+++ b/FWCore/Services/test/servicesJobReport_t.cpp
@@ -59,25 +59,11 @@ void work()
   areg.postEndJobSignal_();
 }
 
-void fail()
-{
-  // Make the service.
-  edm::ParameterSet ps;
-  edm::ActivityRegistry areg;
-
-  edm::service::JobReportService jrs(ps, areg);
-  std::vector<edm::JobReport::Token> inputTokens;
-  std::vector<edm::JobReport::Token> outputTokens;
-
-  areg.jobFailureSignal_();
-}
-
 int main()
 {
   int rc = -1;
   try {
       work();
-      fail();
       rc = 0;
   }
 

--- a/FWCore/Services/test/servicesJobReport_t.cpp
+++ b/FWCore/Services/test/servicesJobReport_t.cpp
@@ -3,12 +3,10 @@
 #include <string>
 #include <vector>
 
-
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Services/src/JobReportService.h"
 
-void work()
-{
+void work() {
   // Make the service.
   edm::ParameterSet ps;
   edm::ActivityRegistry areg;
@@ -23,57 +21,47 @@ void work()
   branchnames.push_back("branch_2_");
 
   for (int i = 0; i < 10; ++i) {
-      std::ostringstream oss;
-      oss << i;
-      std::string seq_tag = oss.str();
-      std::vector<std::string> localBranchNames(branchnames);
-      localBranchNames[0] += seq_tag;
-      localBranchNames[1] += seq_tag;
-      edm::JobReport::Token t = jrs.inputFileOpened("phys" + seq_tag,
-				    "log" + seq_tag,
-				    "cat" + seq_tag,
-				    "class" + seq_tag,
-				    "label" + seq_tag,
-				    localBranchNames);
-      inputTokens.push_back(t);
+    std::ostringstream oss;
+    oss << i;
+    std::string seq_tag = oss.str();
+    std::vector<std::string> localBranchNames(branchnames);
+    localBranchNames[0] += seq_tag;
+    localBranchNames[1] += seq_tag;
+    edm::JobReport::Token t = jrs.inputFileOpened(
+        "phys" + seq_tag, "log" + seq_tag, "cat" + seq_tag, "class" + seq_tag, "label" + seq_tag, localBranchNames);
+    inputTokens.push_back(t);
   }
-
 
   jrs.reportSkippedEvent(10001, 1002);
   jrs.reportSkippedEvent(10001, 1003);
   jrs.reportSkippedEvent(10001, 1004);
 
   try {
-      jrs.eventReadFromFile(24, 0, 0);
-      assert( "Failed to throw required exception" == 0);
+    jrs.eventReadFromFile(24, 0, 0);
+    assert("Failed to throw required exception" == 0);
+  } catch (edm::Exception& x) {
+    assert(x.categoryCode() == edm::errors::LogicError);
+  } catch (...) {
+    assert("Threw unexpected exception type" == 0);
   }
-  catch ( edm::Exception & x ) {
-      assert( x.categoryCode() == edm::errors::LogicError );
-  }
-  catch ( ... ) {
-      assert( "Threw unexpected exception type" == 0 );
-  }
-  
 
   // Fake the end-of-job
   areg.postEndJobSignal_();
 }
 
-int main()
-{
+int main() {
   int rc = -1;
   try {
-      work();
-      rc = 0;
+    work();
+    rc = 0;
   }
 
-  catch ( edm::Exception & x ) {
-      std::cerr << x << '\n';
-      rc = 1;
-  }
-  catch ( ... ) {
-      std::cerr << "Unknown exception caught\n";
-      rc = 2;
+  catch (edm::Exception& x) {
+    std::cerr << x << '\n';
+    rc = 1;
+  } catch (...) {
+    std::cerr << "Unknown exception caught\n";
+    rc = 2;
   }
   return rc;
 }

--- a/PerfTools/AllocMonitor/plugins/ModuleAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/ModuleAllocMonitor.cc
@@ -161,7 +161,7 @@ public:
         }
       });
 
-      iAR.watchPostESModuleRegistration([this](auto const& iDescription) {
+      iAR.watchPostESModuleConstruction([this](auto const& iDescription) {
         auto label = iDescription.label_;
         if (label.empty()) {
           label = iDescription.type_;

--- a/PerfTools/AllocMonitor/plugins/PhaseAllocMonitor.cc
+++ b/PerfTools/AllocMonitor/plugins/PhaseAllocMonitor.cc
@@ -145,7 +145,6 @@ public:
     REGISTER(PreCloseOutputFiles);
     REGISTER(PostCloseOutputFiles);
 
-    REGISTER(JobFailure);
     REGISTER(BeginProcessing);
     REGISTER(EndProcessing);
 


### PR DESCRIPTION
#### PR description:

This PR addresses https://github.com/cms-sw/cmssw/issues/51545#issuecomment-5051582158 by
- removing JobFailure signal that was not emitted except in one unit test
- removing PostESModuleRegistration signal that was substituted by PostESModuleConstruction signal

Resolves https://github.com/cms-sw/framework-team/issues/2377

#### PR validation:

Unit tests pass