### PR TITLE
Patch: Remove hltPhase2PixelVertices from DST_HeterogeneousReco

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/paths/DST_HeterogeneousReco_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/DST_HeterogeneousReco_cfi.py
@@ -44,7 +44,6 @@ HLTPixelTrackingSequence = cms.Sequence(
     hltPhase2PixelTracksSoA
     + hltPhase2PixelTrackTorchHighPuritySelector
     + hltPhase2PixelTracks
-    + hltPhase2PixelVertices
     #+ hltExtendedPhase2PixelVerticesSoA # not yet ready
 )
 


### PR DESCRIPTION
#### PR description:

PR #51042 added the `hltPhase2PixelVertices` to [DST_HeterogeneousReco_cfi.py](https://github.com/cms-sw/cmssw/compare/master...EmanueleCoradin:fix-testHandWrittenPathMatchesTheMenu?expand=1#diff-ac26d05c11e85abe98c2d43f598a9565a542940b6303f31a8efd0e60fcee9707) but since it is not a heterogeneous module, it should not be included there.
As a result, it causes failures in the new `test_heterogeneousMenu` introduced by PR #51583 ([logs](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/raw/el9_amd64_gcc13/CMSSW_20_1_X_2026-08-04-2300/unitTestLogs/HLTrigger/Configuration)).

This PR should fix the issue. 