### PR TITLE
A bug fix for the use of Hcal pulse shapes from CMS database

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalPulseShapesEP.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalPulseShapesEP.cc
@@ -119,7 +119,8 @@ HcalPulseShapesEP::~HcalPulseShapesEP() {
 HcalPulseShapesEP::ReturnType HcalPulseShapesEP::produce(const HcalPulseShapeLookupRcd& rcd) {
   const HcalTopology& htopo = rcd.get(topoToken_);
   const CaloGeometry& geom = rcd.get(geomToken_);
-  const HcalPulseDelays& delays = rcd.get(delaysToken_);
+  HcalPulseDelays delays(rcd.get(delaysToken_));
+  delays.setTopo(&htopo);
   const HcalInterpolatedPulseMap& pulses = rcd.get(pulseMapToken_);
 
   // We need to create a LabeledShape object for each unique


### PR DESCRIPTION
This is a bug fix for using the Hcal pulse shapes from the database. The feature was originally developed for potential Run 3 rereco scenarios the in the PR https://github.com/cms-sw/cmssw/pull/49556. It is unclear if we will use this feature for Phase 2 developments, but I presume that we don't want this bug to stick around in the 20_1 either.

Normal matrix tests were run.

In addition to normal matrix tests, some private validation was performed in which the pulse shapes were written into a private database, and that database was used for Hcal rechit reconstruction. The tables are not yet in the CMS database because we need to validate them first, and to validate them we need the code to work.

This fix will need to be backported to 17_0
