### PR TITLE
METAlgorithms: Cleanup dependency to avoid linking TF for GenMETProducer

### DIFF
--- a/RecoMET/METAlgorithms/BuildFile.xml
+++ b/RecoMET/METAlgorithms/BuildFile.xml
@@ -12,7 +12,6 @@
 <use name="Geometry/CaloTopology"/>
 <use name="Geometry/HcalTowerAlgo"/>
 <use name="Geometry/CSCGeometry"/>
-<use name="RecoEcal/EgammaCoreTools"/>
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="DataFormats/L1GlobalMuonTrigger"/>
 <use name="DataFormats/MuonReco"/>


### PR DESCRIPTION
This PR removes the unused `RecoEcal/EgammaCoreTools` dependency from `RecoMET/METAlgorithms`. `RecoEcal/EgammaCoreTools`  has dependency on [Tensorflow](https://github.com/cms-sw/cmssw/blob/master/RecoEcal/EgammaCoreTools/BuildFile.xml#L19). This cleanup means we should be able to build `GenMETProducer` plugin for `RISCV64` IBs.

Local tests shows that workflow `1.0/step1` which is failing in `RISCV64` IB [a] now runs fine [b]

[a] https://cmssdt.cern.ch/SDT/cgi-bin/logreader/fc42_riscv64_gcc15/CMSSW_20_1_X_2026-07-30-2300/pyRelValMatrixLogs/run/1.0_ProdMinBias/step1_ProdMinBias.log#/
```
----- Begin Fatal Exception 01-Aug-2026 08:29:24 CEST-----------------------
An exception of category 'PluginNotFound' occurred while
   [0] Constructing the EventProcessor
Exception Message:
Unable to find plugin 'GenMETProducer' in category 'CMS EDM Framework Module'. Please check spelling of name.
----- End Fatal Exception -------------------------------------------------
```

[b]
```
1.0_ProdMinBias Step0-PASSED Step1-FAILED Step2-NOTRUN  - time date Wed Aug  5 16:20:52 2026-date Wed Aug  5 16:16:26 2026; exit: 0 256 0
1 0 0 tests passed, 0 1 0 failed
....
....
# FastJet is provided without warranty under the GNU GPL v2 or higher.  
# It uses T. Chan's closest pair algorithm, S. Fortune's Voronoi code
# and 3rd party plugin jet algorithms. See COPYING file for details.
#--------------------------------------------------------------------------
Begin processing the 2nd record. Run 1, Event 2, LumiSection 1 on stream 0 at 05-Aug-2026 16:20:00.192 CEST
Begin processing the 3rd record. Run 1, Event 3, LumiSection 1 on stream 0 at 05-Aug-2026 16:20:08.788 CEST
Begin processing the 4th record. Run 1, Event 4, LumiSection 1 on stream 0 at 05-Aug-2026 16:20:08.795 CEST
Begin processing the 5th record. Run 1, Event 5, LumiSection 1 on stream 0 at 05-Aug-2026 16:20:17.767 CEST
Begin processing the 6th record. Run 1, Event 6, LumiSection 1 on stream 0 at 05-Aug-2026 16:20:20.425 CEST
Begin processing the 7th record. Run 1, Event 7, LumiSection 1 on stream 0 at 05-Aug-2026 16:20:22.120 CEST
 PYTHIA Warning in SimpleSpaceShower::pT2nextQCD: weight above unity
Begin processing the 8th record. Run 1, Event 8, LumiSection 1 on stream 0 at 05-Aug-2026 16:20:29.113 CEST
Begin processing the 9th record. Run 1, Event 9, LumiSection 1 on stream 0 at 05-Aug-2026 16:20:32.619 CEST
Begin processing the 10th record. Run 1, Event 10, LumiSection 1 on stream 0 at 05-Aug-2026 16:20:38.095 CEST

```