### PR TITLE
Make Worker only if module uses the transition

### DIFF
--- a/FWCore/Framework/interface/StreamSchedule.h
+++ b/FWCore/Framework/interface/StreamSchedule.h
@@ -227,18 +227,17 @@ namespace edm {
 
     /// returns the collection of pointers to workers
     AllWorkers const& allWorkersRuns() const { return workerManagerRuns_.allWorkers(); }
-    AllWorkers const& allWorkersLumisAndEvents() const { return workerManagerLumisAndEvents_.allWorkers(); }
+    AllWorkers const& allWorkersLumis() const { return workerManagerLumis_.allWorkers(); }
+    AllWorkers const& allWorkersEvents() const { return workerManagerEvents_.allWorkers(); }
 
-    AllWorkers const& unscheduledWorkersLumisAndEvents() const {
-      return workerManagerLumisAndEvents_.unscheduledWorkers();
-    }
+    AllWorkers const& unscheduledWorkersEvents() const { return workerManagerEvents_.unscheduledWorkers(); }
     unsigned int numberOfUnscheduledModules() const { return number_of_unscheduled_modules_; }
 
     StreamContext const& context() const { return streamContext_; }
 
   private:
     /// returns the action table
-    ExceptionToActionTable const& actionTable() const { return workerManagerLumisAndEvents_.actionTable(); }
+    ExceptionToActionTable const& actionTable() const { return workerManagerEvents_.actionTable(); }
 
     void resetAll();
 
@@ -267,7 +266,8 @@ namespace edm {
 
     std::vector<unsigned int> moduleBeginStreamFailed_;
     WorkerManager workerManagerRuns_;
-    WorkerManager workerManagerLumisAndEvents_;
+    WorkerManager workerManagerLumis_;
+    WorkerManager workerManagerEvents_;
     std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
 
     edm::propagate_const<TrigResPtr> results_;
@@ -341,7 +341,7 @@ namespace edm {
           // Caught exception is propagated via WaitingTaskHolder
           WorkerManager* workerManager = &workerManagerRuns_;
           if (T::branchType_ == InLumi) {
-            workerManager = &workerManagerLumisAndEvents_;
+            workerManager = &workerManagerLumis_;
           }
           CMS_SA_ALLOW try {
             preScheduleSignal<T>(&streamContext_);

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -327,7 +327,7 @@ namespace edm {
     // At this point all ProductDescriptions are created. Mark now the
     // ones of unscheduled workers to be on-demand.
     {
-      auto const& unsched = streamSchedules_[0]->unscheduledWorkersLumisAndEvents();
+      auto const& unsched = streamSchedules_[0]->unscheduledWorkersEvents();
       if (not unsched.empty()) {
         std::set<std::string> unscheduledModules;
         std::transform(unsched.begin(),

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -154,7 +154,8 @@ namespace edm {
                                  StreamID streamID,
                                  ProcessContext const* processContext)
       : workerManagerRuns_(modReg, areg, actions),
-        workerManagerLumisAndEvents_(modReg, areg, actions),
+        workerManagerLumis_(modReg, areg, actions),
+        workerManagerEvents_(modReg, areg, actions),
         actReg_(areg),
         results_(std::make_shared<HLTGlobalStatus>(paths.size())),
         results_inserter_(),
@@ -178,7 +179,7 @@ namespace edm {
     if (hasPath) {
       // the results inserter stands alone
       inserter->setTrigResultForStream(streamID.value(), results());
-      results_inserter_ = workerManagerLumisAndEvents_.getWorkerForModule(*inserter);
+      results_inserter_ = workerManagerEvents_.getWorkerForModule(*inserter);
     }
 
     // fill normal endpaths
@@ -190,11 +191,16 @@ namespace edm {
     }
 
     for (auto const* module : unscheduledModules) {
-      workerManagerLumisAndEvents_.addToUnscheduledWorkers(*module);
+      workerManagerEvents_.addToUnscheduledWorkers(*module);
     }
 
-    for (auto const& worker : allWorkersLumisAndEvents()) {
-      (void)workerManagerRuns_.getWorkerForModule(*worker->description());
+    for (auto const& worker : allWorkersEvents()) {
+      if (worker->wantsStreamLuminosityBlocks()) {
+        (void)workerManagerLumis_.getWorkerForModule(*worker->description());
+      }
+      if (worker->wantsStreamRuns()) {
+        (void)workerManagerRuns_.getWorkerForModule(*worker->description());
+      }
     }
 
   }  // StreamSchedule::StreamSchedule
@@ -239,7 +245,7 @@ namespace edm {
     }
 
     std::unordered_set<std::string> modulesToExclude(modulesToSkip.begin(), modulesToSkip.end());
-    for (auto w : allWorkersLumisAndEvents()) {
+    for (auto w : allWorkersEvents()) {
       if (modulesToExclude.end() != modulesToExclude.find(w->description()->moduleLabel())) {
         continue;
       }
@@ -416,7 +422,7 @@ namespace edm {
     PathWorkers tmpworkers;
     tmpworkers.reserve(iPath.size());
     for (auto const& module : iPath) {
-      tmpworkers.emplace_back(workerManagerLumisAndEvents_.getWorkerForModule(*module.description_),
+      tmpworkers.emplace_back(workerManagerEvents_.getWorkerForModule(*module.description_),
                               module.action_,
                               module.placeInPath_,
                               module.runConcurrently_);
@@ -425,7 +431,7 @@ namespace edm {
   }
 
   void StreamSchedule::fillTrigPath(PathInfo const& iPath, int bitpos, TrigResPtr trptr) {
-    auto workerPtr = workerManagerLumisAndEvents_.getWorkerForModule(*iPath.inserter_);
+    auto workerPtr = workerManagerEvents_.getWorkerForModule(*iPath.inserter_);
     pathStatusInserterWorkers_.emplace_back(workerPtr);
     if (iPath.modules_.empty()) {
       empty_trig_paths_.push_back(bitpos);
@@ -440,7 +446,7 @@ namespace edm {
   void StreamSchedule::fillEndPath(EndPathInfo const& iEndPath, int bitpos) {
     Worker* workerPtr = nullptr;
     if (iEndPath.inserter_) {
-      workerPtr = workerManagerLumisAndEvents_.getWorkerForModule(*iEndPath.inserter_);
+      workerPtr = workerManagerEvents_.getWorkerForModule(*iEndPath.inserter_);
       endPathStatusInserterWorkers_.emplace_back(workerPtr);
     }
     if (iEndPath.modules_.empty()) {
@@ -530,8 +536,13 @@ namespace edm {
         break;
       }
     }
-
-    for (auto const& worker : allWorkersLumisAndEvents()) {
+    for (auto const& worker : allWorkersEvents()) {
+      if (worker->description()->moduleLabel() == iLabel) {
+        iMod->replaceModuleFor(worker);
+        break;
+      }
+    }
+    for (auto const& worker : allWorkersLumis()) {
       if (worker->description()->moduleLabel() == iLabel) {
         iMod->replaceModuleFor(worker);
         break;
@@ -541,14 +552,15 @@ namespace edm {
 
   void StreamSchedule::deleteModule(std::string const& iLabel) {
     workerManagerRuns_.deleteModuleIfExists(iLabel);
-    workerManagerLumisAndEvents_.deleteModuleIfExists(iLabel);
+    workerManagerLumis_.deleteModuleIfExists(iLabel);
+    workerManagerEvents_.deleteModuleIfExists(iLabel);
   }
 
   std::vector<ModuleDescription const*> StreamSchedule::getAllModuleDescriptions() const {
     std::vector<ModuleDescription const*> result;
-    result.reserve(allWorkersLumisAndEvents().size());
+    result.reserve(allWorkersEvents().size());
 
-    for (auto const& worker : allWorkersLumisAndEvents()) {
+    for (auto const& worker : allWorkersEvents()) {
       ModuleDescription const* p = worker->description();
       result.push_back(p);
     }
@@ -576,8 +588,8 @@ namespace edm {
       // Data dependencies need to be set up before marking empty
       // (End)Paths complete in case something consumes the status of
       // the empty (EndPath)
-      workerManagerLumisAndEvents_.setupResolvers(ep);
-      workerManagerLumisAndEvents_.setupOnDemandSystem(info);
+      workerManagerEvents_.setupResolvers(ep);
+      workerManagerEvents_.setupOnDemandSystem(info);
 
       HLTPathStatus hltPathStatus(hlt::Pass, 0);
       for (int empty_trig_path : empty_trig_paths_) {
@@ -659,9 +671,8 @@ namespace edm {
       }
 
       ParentContext parentContext(&streamContext_);
-      workerManagerLumisAndEvents_
-          .processAccumulatorsAsync<OccurrenceTraits<EventPrincipal, TransitionActionStreamBegin>>(
-              hAllPathsDone, info, serviceToken, streamID_, parentContext, &streamContext_);
+      workerManagerEvents_.processAccumulatorsAsync<OccurrenceTraits<EventPrincipal, TransitionActionStreamBegin>>(
+          hAllPathsDone, info, serviceToken, streamID_, parentContext, &streamContext_);
     } catch (...) {
       iTask.doneWaiting(std::current_exception());
     }
@@ -885,7 +896,7 @@ namespace edm {
 
     fill_summary(trig_paths_, rep.trigPathSummaries, &fillPathSummary);
     fill_summary(end_paths_, rep.endPathSummaries, &fillPathSummary);
-    fill_summary(allWorkersLumisAndEvents(), rep.workerSummaries, &fillWorkerSummary);
+    fill_summary(allWorkersEvents(), rep.workerSummaries, &fillWorkerSummary);
   }
 
   void StreamSchedule::clearCounters() {
@@ -893,7 +904,7 @@ namespace edm {
     total_events_ = total_passed_ = 0;
     for_all(trig_paths_, std::bind(&Path::clearCounters, _1));
     for_all(end_paths_, std::bind(&Path::clearCounters, _1));
-    for_all(allWorkersLumisAndEvents(), std::bind(&Worker::clearCounters, _1));
+    for_all(allWorkersEvents(), std::bind(&Worker::clearCounters, _1));
   }
 
   void StreamSchedule::resetAll() { results_->reset(); }


### PR DESCRIPTION
#### PR description:

If a module doesn't process a stream Run or LuminosityBlock transition then we no longer make a Worker for that transition.

#### PR validation:

Code compiles and all framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/2378