### PR TITLE
Add ECAL Phase 2 development workflows with APD spikes

### DIFF
--- a/Configuration/ProcessModifiers/python/ecal_addspikes_cff.py
+++ b/Configuration/ProcessModifiers/python/ecal_addspikes_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is to add APD spike signals to the simulated ECAL barrel digis
+ecal_addspikes =  cms.Modifier()

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -96,9 +96,10 @@ The offsets currently in use are:
 * 0.24: 0 Tesla (Run-2, Run-3)
 * 0.31: Photon energy corrections with DRN architecture
 * 0.61: ECAL `phase2_ecal_devel` era, on CPU
-* 0.612: ECAL `phase2_ecal_devel` era, with automatic offload to GPU if available
+* 0.612: ECAL `phase2_ecal_devel` era, with Alpaka reconstruction
 * 0.6199: ECAL `phase2_ecal_devel` era, on CPU and with premixing stage1+stage2
-* 0.61299: ECAL `phase2_ecal_devel` era, with automatic offload to GPU if available and premixing stage1+stage2
+* 0.61299: ECAL `phase2_ecal_devel` era, with Alpaka reconstruction and premixing stage1+stage2
+* 0.622: ECAL `phase2_ecal_devel` era, with APD spike signals mixed into the ECAL digis and Alpaka reconstruction.
 * 0.631: ECAL component-method based digis
 * 0.632: ECAL component-method based finely-sampled waveforms
 * 0.633: ECAL phase2 Trigger Primitive

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2391,6 +2391,21 @@ upgradeWFs['ecalDevelAlpaka'] = UpgradeWorkflow_ecalDevel(
     offset = 0.612,
 )
 
+# ECAL Phase 2 workflow with APD spikes added to the digis and reconstruction with Alpaka
+upgradeWFs['ecalDevelSpikesAlpaka'] = UpgradeWorkflow_ecalDevel(
+    digi = {
+        '--procModifiers': 'ecal_addspikes',
+        '--custom_conditions': 'EcalSimPulseShapes_TB2025_v1,EcalSimPulseShapeRcd,frontier://FrontierProd/CMS_CONDITIONS'
+    },
+    reco = {
+        '--procModifiers': 'alpaka',
+        '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
+        '--custom_conditions': 'EcalSimPulseShapes_TB2025_v1,EcalSimPulseShapeRcd,frontier://FrontierProd/CMS_CONDITIONS'
+    },
+    suffix = '_ecalDevelSpikesAlpaka',
+    offset = 0.622,
+)
+
 # ECAL Phase 2 workflow with Alpaka reconstruction and PU from premix
 class UpgradeWorkflowPremix_ecalDevel(UpgradeWorkflow):
     def __init__(self, digi = {}, reco = {}, harvest = {}, **kwargs):

--- a/SimCalorimetry/EcalSimProducers/python/apdSimParameters_cff.py
+++ b/SimCalorimetry/EcalSimProducers/python/apdSimParameters_cff.py
@@ -14,3 +14,5 @@ apd_sim_parameters = cms.PSet(
     apdNonlParms    = cms.vdouble( 1.48, -3.75, 1.81, 1.26, 2.0, 45, 1.0 )
 )
 
+from Configuration.ProcessModifiers.ecal_addspikes_cff import ecal_addspikes
+ecal_addspikes.toModify(apd_sim_parameters, apdAddToBarrel = True)


### PR DESCRIPTION
#### PR description:

This PR adds new ECAL Phase 2 development workflows for which APD spikes are mixed into the ECAL digis during the ECAL electronics simulation.
The suffix for the workflows is (*.622).
A new modifier `ecal_addspikes` was added that controls the mixing of the spikes.
The workflow uses pulse shapes (scintillation and spike) derived from the 2025 TB data.

The new workflows are otherwise identical to the *.612 ones.

This is intended for the tuning and validation of the ECAL TP spike tagging algorithm.
No changes to the normal Phase 2 MC are expected.

#### PR validation:

Passes the new 34434.622 workflow.
