### PR TITLE
Fix PyTorchAlpaka Policy

### DIFF
--- a/PhysicsTools/PyTorchAlpaka/interface/TensorHandle.h
+++ b/PhysicsTools/PyTorchAlpaka/interface/TensorHandle.h
@@ -54,6 +54,23 @@ namespace cms::torch::alpakatools::detail {
     bool is_scalar_;
   };
 
+  inline size_t num_spanned_elements(const Dims& dims,
+                                     const int total_size,
+                                     const size_t alignment,
+                                     const size_t bytes) {
+    // Returns the number of memory elements spanned by the tensor.
+
+    if (dims.volume() == 0 || dims.batch_size() == 0)
+      return 0;
+    if (dims.is_scalar())
+      return 1;
+
+    const auto padded_column_size = static_cast<size_t>(num_elements_per_column(total_size, alignment, bytes));
+    const auto offset_to_last_column = static_cast<size_t>(dims.volume() - 1) * padded_column_size;
+
+    return offset_to_last_column + static_cast<size_t>(dims.batch_size());
+  }
+
   template <typename TQueue>
     requires alpaka::isQueue<TQueue>
   class ITensorHandle {
@@ -94,7 +111,7 @@ namespace cms::torch::alpakatools::detail {
           data_(data),
           total_size_(total_size),
           dims_(batch_size, dims, is_scalar),
-          policy_(data, dims_.volume() * num_elements_per_column(total_size, alignment, bytes)) {
+          policy_(data, num_spanned_elements(dims_, total_size_, alignment_, bytes_)) {
       init_sizes();
       init_strides();
     }


### PR DESCRIPTION
#### PR description:

This PR proposes a solution to the overflow reported in issue #51614 when running batched `PyTorchAlpaka` inference in `testPyTorchAlpakaTestSerialSync`.

For a batched tensor, `TensorCollection` advances the input pointer to the beginning of the selected batch. However, `TensorHandle` previously instructed `Policy` to copy the full tensor storage extent, as if the pointer still referred to the beginning of the SoA memory block.

When the pointer was shifted to a later batch, this caused the copy to extend past the end of the original allocation. The additional copied elements were outside the storage span addressed by the PyTorch tensor, so the inference results remained correct despite the invalid read.

This PR introduces `num_spanned_elements()`, which computes the correct contiguous memory span required by the tensor. The calculated extent is then passed to `Policy`, preventing the out-of-bounds copy.