### PR TITLE
MTD geometry: fast geographicalld rawId determination for BTLDetId

### DIFF
--- a/DataFormats/ForwardDetId/interface/BTLDetId.h
+++ b/DataFormats/ForwardDetId/interface/BTLDetId.h
@@ -219,6 +219,13 @@ namespace io_v1 {
 
     /** create a Geographical DetId for Tracking **/
     BTLDetId geographicalId(CrysLayout lay) const;
+
+    // provide the raw BTLDetId of a module given the raw BTLDetId of one of its crystals
+    // avoid using constructors, just replacing the crystal bit field with the default value assigned to the module
+    static inline uint32_t rawGeoId(uint32_t id, CrysLayout lay) {
+      return (lay == CrysLayout::v4) ? ((id & ~kBTLCrystalMask) | (kCrystalsPerModuleV2 & kBTLCrystalMask))
+                                     : ((id & ~kBTLoldCrystalMask) | (kCrystalsPerModuleV2 & kBTLoldCrystalMask));
+    }
   };
 
   std::ostream& operator<<(std::ostream&, const BTLDetId&);

--- a/Geometry/MTDGeometryBuilder/test/DD4hep_TestPixelTopology.cc
+++ b/Geometry/MTDGeometryBuilder/test/DD4hep_TestPixelTopology.cc
@@ -260,11 +260,18 @@ void DD4hep_TestPixelTopology::analyze(const edm::Event& iEvent, const edm::Even
         DetId theId, geoId;
         BTLDetId theIdBTL, modIdBTL;
         ETLDetId theIdETL, modIdETL;
+        uint32_t rawGeoId;
         if (isBarrel) {
           theIdBTL = btlNS_.getUnitID(thisN_);
           theId = theIdBTL;
           geoId = theIdBTL.geographicalId(MTDTopologyMode::crysLayoutFromTopoMode(pTP.product()->getMTDTopologyMode()));
           modIdBTL = geoId;
+          rawGeoId = BTLDetId::rawGeoId(theId.rawId(),
+                                        MTDTopologyMode::crysLayoutFromTopoMode(pTP.product()->getMTDTopologyMode()));
+          if (geoId.rawId() != rawGeoId) {
+            edm::LogVerbatim("DD4hep_TestPixelTopology")
+                << "DIFFERENCE geoId/rawGeoId " << geoId.rawId() << " " << rawGeoId;
+          }
         } else {
           theIdETL = etlNS_.getUnitID(thisN_);
           theId = theIdETL;


### PR DESCRIPTION

#### PR description:

Addition to ```BTLDetId``` of a static function to provide the ```rawId``` of the module given the ```rawId``` of one of its crystals. It helps to avoid the need to build explictely a ```BTLDetId``` and then call its ```geographicalId``` method, where another ```BTLDetId``` constructor is needed. USeful to speed up operations where only ```rawId```s are of interest.

#### PR validation:

The PR includes a sanity check in the ```Geometry/MTDGeometryBuilder``` unit test, that passes (no extra warning message is written out).