### PR TITLE
Only make Worker for global transition if needed

### DIFF
--- a/FWCore/Framework/interface/GlobalSchedule.h
+++ b/FWCore/Framework/interface/GlobalSchedule.h
@@ -33,6 +33,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include <span>
 #include "boost/range/adaptor/reversed.hpp"
 
 namespace edm {
@@ -90,6 +91,22 @@ namespace edm {
     AllWorkers const& allWorkers() const { return workerManagers_[0].allWorkers(); }
 
   private:
+    std::span<WorkerManager> lumisManagers() {
+      return std::span<WorkerManager>(workerManagers_).subspan(0, numberOfConcurrentLumis_);
+    }
+    std::span<WorkerManager const> lumisManagers() const {
+      return std::span<WorkerManager const>(workerManagers_).subspan(0, numberOfConcurrentLumis_);
+    }
+    std::span<WorkerManager> runManagers() {
+      return std::span<WorkerManager>(workerManagers_).subspan(numberOfConcurrentLumis_, numberOfConcurrentRuns_);
+    }
+    std::span<WorkerManager const> runManagers() const {
+      return std::span<WorkerManager const>(workerManagers_).subspan(numberOfConcurrentLumis_, numberOfConcurrentRuns_);
+    }
+    std::span<WorkerManager> processBlockManagers() {
+      return std::span<WorkerManager>(workerManagers_)
+          .subspan(numberOfConcurrentLumis_ + numberOfConcurrentRuns_, numberOfConcurrentProcessBlocks_);
+    }
     /// returns the action table
     ExceptionToActionTable const& actionTable() const { return workerManagers_[0].actionTable(); }
 
@@ -104,6 +121,10 @@ namespace edm {
                          bool cleaningUpAfterException,
                          std::exception_ptr&);
 
+    //the order of the workerManagers_ is as follows:
+    // 0 to numberOfConcurrentLumis_-1: for the concurrent lumis
+    // numberOfConcurrentLumis_ to numberOfConcurrentLumis_ + numberOfConcurrentRuns_-1: for the concurrent runs
+    // numberOfConcurrentLumis_ + numberOfConcurrentRuns_ to numberOfConcurrentLumis_ + numberOfConcurrentRuns_ + numberOfConcurrentProcessBlocks_-1: for the concurrent process blocks
     std::vector<WorkerManager> workerManagers_;
     std::vector<unsigned int> beginJobFailedForModule_;
     std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
@@ -150,12 +171,15 @@ namespace edm {
         preScheduleSignal<T>(globalContext.get(), token);
 
         unsigned int managerIndex = principal.index();
+        std::span<WorkerManager> managers;
         if constexpr (T::branchType_ == InRun) {
-          managerIndex += numberOfConcurrentLumis_;
+          managers = runManagers();
         } else if constexpr (T::branchType_ == InProcess) {
-          managerIndex += (numberOfConcurrentLumis_ + numberOfConcurrentRuns_);
+          managers = processBlockManagers();
+        } else {
+          managers = lumisManagers();
         }
-        WorkerManager& workerManager = workerManagers_[managerIndex];
+        WorkerManager& workerManager = managers[managerIndex];
         workerManager.resetAll();
 
         ParentContext parentContext(globalContext.get());

--- a/FWCore/Framework/interface/GlobalSchedule.h
+++ b/FWCore/Framework/interface/GlobalSchedule.h
@@ -40,9 +40,6 @@ namespace edm {
   class ExceptionCollector;
   class PreallocationConfiguration;
   class ModuleRegistry;
-  class TriggerResultInserter;
-  class PathStatusInserter;
-  class EndPathStatusInserter;
 
   namespace maker {
     class ModuleHolder;
@@ -55,10 +52,7 @@ namespace edm {
     using WorkerPtr = std::shared_ptr<Worker>;
     using Wokers = std::vector<Worker*>;
 
-    GlobalSchedule(std::shared_ptr<TriggerResultInserter> inserter,
-                   std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
-                   std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
-                   std::shared_ptr<ModuleRegistry> modReg,
+    GlobalSchedule(std::shared_ptr<ModuleRegistry> modReg,
                    std::vector<edm::ModuleDescription const*> const& modulesToUse,
                    PreallocationConfiguration const& prealloc,
                    ExceptionToActionTable const& actions,

--- a/FWCore/Framework/interface/GlobalSchedule.h
+++ b/FWCore/Framework/interface/GlobalSchedule.h
@@ -49,9 +49,7 @@ namespace edm {
   class GlobalSchedule {
   public:
     using vstring = std::vector<std::string>;
-    using AllWorkers = std::vector<Worker*>;
     using WorkerPtr = std::shared_ptr<Worker>;
-    using Wokers = std::vector<Worker*>;
 
     GlobalSchedule(std::shared_ptr<ModuleRegistry> modReg,
                    std::vector<edm::ModuleDescription const*> const& modulesToUse,
@@ -70,14 +68,6 @@ namespace edm {
     void beginJob(ModuleRegistry&);
     void endJob(ExceptionCollector& collector, ModuleRegistry&);
 
-    /// Return a vector allowing const access to all the
-    /// ModuleDescriptions for this GlobalSchedule.
-
-    /// *** N.B. *** Ownership of the ModuleDescriptions is *not*
-    /// *** passed to the caller. Do not call delete on these
-    /// *** pointers!
-    std::vector<ModuleDescription const*> getAllModuleDescriptions() const;
-
     /// Return whether each output module has reached its maximum count.
     bool terminate() const;
 
@@ -87,8 +77,8 @@ namespace edm {
     /// Delete the module with label iLabel
     void deleteModule(std::string const& iLabel);
 
-    /// returns the collection of pointers to workers
-    AllWorkers const& allWorkers() const { return workerManagers_[0].allWorkers(); }
+    std::vector<Worker*> const& lumisWorkers() const { return lumisManagers()[0].allWorkers(); }
+    std::vector<Worker*> const& runWorkers() const { return runManagers()[0].allWorkers(); }
 
   private:
     std::span<WorkerManager> lumisManagers() {

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -286,7 +286,9 @@ namespace edm {
                                edm::ProductRegistry const& preg);
 
     /// returns the collection of pointers to workers
-    AllWorkers const& allWorkers() const;
+    AllWorkers const& allWorkersEvents() const;
+    AllWorkers const& allWorkersRun() const;
+    AllWorkers const& allWorkersLumis() const;
 
     ModuleRegistry const& moduleRegistry() const { return *moduleRegistry_; }
 

--- a/FWCore/Framework/interface/maker/ModuleHolder.h
+++ b/FWCore/Framework/interface/maker/ModuleHolder.h
@@ -59,6 +59,13 @@ namespace edm {
       virtual Type moduleType() const = 0;
       virtual Concurrency moduleConcurrencyType() const = 0;
 
+      virtual bool wantsProcessBlocks() const noexcept = 0;
+      virtual bool wantsInputProcessBlocks() const noexcept = 0;
+      virtual bool wantsGlobalRuns() const noexcept = 0;
+      virtual bool wantsGlobalLuminosityBlocks() const noexcept = 0;
+      virtual bool wantsStreamRuns() const noexcept = 0;
+      virtual bool wantsStreamLuminosityBlocks() const noexcept = 0;
+
       virtual void finishModuleInitialization(ModuleDescription const& iDesc,
                                               PreallocationConfiguration const& iPrealloc,
                                               SignallingProductRegistryFiller* iReg) = 0;
@@ -106,6 +113,13 @@ namespace edm {
       std::unique_ptr<Worker> makeWorker(ExceptionToActionTable const* actions) const final {
         return std::make_unique<edm::WorkerT<T>>(module(), moduleDescription(), actions);
       }
+
+      bool wantsProcessBlocks() const noexcept final { return m_mod->wantsProcessBlocks(); }
+      bool wantsInputProcessBlocks() const noexcept final { return m_mod->wantsInputProcessBlocks(); }
+      bool wantsGlobalRuns() const noexcept final { return m_mod->wantsGlobalRuns(); }
+      bool wantsGlobalLuminosityBlocks() const noexcept final { return m_mod->wantsGlobalLuminosityBlocks(); }
+      bool wantsStreamRuns() const noexcept final { return m_mod->wantsStreamRuns(); }
+      bool wantsStreamLuminosityBlocks() const noexcept final { return m_mod->wantsStreamLuminosityBlocks(); }
 
       static void finishModuleInitialization(T& iModule,
                                              ModuleDescription const& iDesc,

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -2183,7 +2183,7 @@ namespace edm {
     ex << "The framework is configured to use at least two streams, but the following modules\n"
        << "require synchronizing on LuminosityBlock boundaries:";
     bool found = false;
-    for (auto worker : schedule_->allWorkers()) {
+    for (auto worker : schedule_->allWorkersLumis()) {
       if (worker->wantsGlobalLuminosityBlocks() and worker->globalLuminosityBlocksQueue()) {
         found = true;
         ex << "\n  " << worker->description()->moduleName() << " " << worker->description()->moduleLabel();
@@ -2199,7 +2199,7 @@ namespace edm {
 
   void EventProcessor::warnAboutModulesRequiringRunSynchronization() const {
     std::unique_ptr<LogSystem> s;
-    for (auto worker : schedule_->allWorkers()) {
+    for (auto worker : schedule_->allWorkersRun()) {
       if (worker->wantsGlobalRuns() and worker->globalRunsQueue()) {
         if (not s) {
           s = std::make_unique<LogSystem>("ModulesSynchingOnRuns");

--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -26,16 +26,12 @@
 #include <sstream>
 
 namespace edm {
-  GlobalSchedule::GlobalSchedule(
-      std::shared_ptr<TriggerResultInserter> inserter,
-      std::vector<edm::propagate_const<std::shared_ptr<PathStatusInserter>>>& pathStatusInserters,
-      std::vector<edm::propagate_const<std::shared_ptr<EndPathStatusInserter>>>& endPathStatusInserters,
-      std::shared_ptr<ModuleRegistry> modReg,
-      std::vector<edm::ModuleDescription const*> const& iModulesToUse,
-      PreallocationConfiguration const& prealloc,
-      ExceptionToActionTable const& actions,
-      std::shared_ptr<ActivityRegistry> areg,
-      ProcessContext const* processContext)
+  GlobalSchedule::GlobalSchedule(std::shared_ptr<ModuleRegistry> modReg,
+                                 std::vector<edm::ModuleDescription const*> const& iModulesToUse,
+                                 PreallocationConfiguration const& prealloc,
+                                 ExceptionToActionTable const& actions,
+                                 std::shared_ptr<ActivityRegistry> areg,
+                                 ProcessContext const* processContext)
       : actReg_(areg),
         processContext_(processContext),
         numberOfConcurrentLumis_(prealloc.numberOfLuminosityBlocks()),
@@ -52,27 +48,6 @@ namespace edm {
         (void)wm.getWorkerForModule(*module);
       }
     }
-    if (inserter) {
-      for (auto& wm : workerManagers_) {
-        (void)wm.getWorkerForModule(*inserter);
-      }
-    }
-
-    for (auto& pathStatusInserter : pathStatusInserters) {
-      std::shared_ptr<PathStatusInserter> inserterPtr = get_underlying(pathStatusInserter);
-
-      for (auto& wm : workerManagers_) {
-        (void)wm.getWorkerForModule(*inserterPtr);
-      }
-    }
-
-    for (auto& endPathStatusInserter : endPathStatusInserters) {
-      std::shared_ptr<EndPathStatusInserter> inserterPtr = get_underlying(endPathStatusInserter);
-      for (auto& wm : workerManagers_) {
-        (void)wm.getWorkerForModule(*inserterPtr);
-      }
-    }
-
   }  // GlobalSchedule::GlobalSchedule
 
   void GlobalSchedule::beginJob(ModuleRegistry& modReg) {

--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -44,8 +44,22 @@ namespace edm {
     }
     for (auto const& module : iModulesToUse) {
       //side effect keeps this module around
-      for (auto& wm : workerManagers_) {
-        (void)wm.getWorkerForModule(*module);
+      auto mod = modReg->getExistingModule(module->moduleLabel());
+      assert(mod);
+      if (mod->wantsProcessBlocks() or mod->wantsInputProcessBlocks()) {
+        for (auto& wm : processBlockManagers()) {
+          (void)wm.getWorkerForModule(*module);
+        }
+      }
+      if (mod->wantsGlobalRuns()) {
+        for (auto& wm : runManagers()) {
+          (void)wm.getWorkerForModule(*module);
+        }
+      }
+      if (mod->wantsGlobalLuminosityBlocks()) {
+        for (auto& wm : lumisManagers()) {
+          (void)wm.getWorkerForModule(*module);
+        }
       }
     }
   }  // GlobalSchedule::GlobalSchedule
@@ -137,17 +151,6 @@ namespace edm {
     for (auto& wm : workerManagers_) {
       wm.deleteModuleIfExists(iLabel);
     }
-  }
-
-  std::vector<ModuleDescription const*> GlobalSchedule::getAllModuleDescriptions() const {
-    std::vector<ModuleDescription const*> result;
-    result.reserve(allWorkers().size());
-
-    for (auto const& worker : allWorkers()) {
-      ModuleDescription const* p = worker->description();
-      result.push_back(p);
-    }
-    return result;
   }
 
   void GlobalSchedule::handleException(GlobalContext const* globalContext,

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -403,7 +403,7 @@ namespace edm {
 
     if (wantSummary_) {
       std::vector<const ModuleDescription*> modDesc;
-      const auto& workers = allWorkers();
+      const auto& workers = allWorkersEvents();
       modDesc.reserve(workers.size());
 
       std::transform(workers.begin(),
@@ -926,7 +926,7 @@ namespace edm {
                               const SignallingProductRegistryFiller& iRegistry,
                               eventsetup::ESRecordsToProductResolverIndices const& iIndices) {
     Worker* found = nullptr;
-    for (auto const& worker : allWorkers()) {
+    for (auto const& worker : allWorkersEvents()) {
       if (worker->description()->moduleLabel() == iLabel) {
         found = worker;
         break;
@@ -994,7 +994,9 @@ namespace edm {
     moduleRegistry_->forAllModuleHolders([&](auto const* iHolder) { result.push_back(&iHolder->moduleDescription()); });
     return result;
   }
-  Schedule::AllWorkers const& Schedule::allWorkers() const { return globalSchedule_->allWorkers(); }
+  Schedule::AllWorkers const& Schedule::allWorkersEvents() const { return streamSchedules_[0]->allWorkersEvents(); }
+  Schedule::AllWorkers const& Schedule::allWorkersRun() const { return globalSchedule_->runWorkers(); }
+  Schedule::AllWorkers const& Schedule::allWorkersLumis() const { return globalSchedule_->lumisWorkers(); }
 
   void Schedule::convertCurrentProcessAlias(std::string const& processName) {
     moduleRegistry_->forAllModuleHolders([&](auto& iHolder) { iHolder->convertCurrentProcessAlias(processName); });

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -286,15 +286,8 @@ namespace edm {
                                                                                processContext));
     }
 
-    globalSchedule_ = std::make_unique<GlobalSchedule>(resultsInserter(),
-                                                       pathStatusInserters_,
-                                                       endPathStatusInserters_,
-                                                       moduleRegistrySharedPtr(),
-                                                       builder.allNeededModules_,
-                                                       prealloc,
-                                                       actions,
-                                                       areg,
-                                                       processContext);
+    globalSchedule_ = std::make_unique<GlobalSchedule>(
+        moduleRegistrySharedPtr(), builder.allNeededModules_, prealloc, actions, areg, processContext);
   }
 
   void Schedule::finishSetup(ParameterSet& proc_pset,


### PR DESCRIPTION
#### PR description:

The GlobalSchedule will now only make Workers for modules which have actions for the given transition.

#### PR validation:

Code compiles and framework unit tests pass.

resolves https://github.com/cms-sw/framework-team/issues/2379