### PR TITLE
backport 20_0_X - enable ReconnectDroppedAncestors by default

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -348,9 +348,11 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         CheckTrack = cms.untracked.bool(False),
         EndPrintTrackID = cms.int32(0),
         # Reattach SimVertices whose parent SimTrack was dropped (PersistencyEmin) to
-        # the nearest stored ancestor so SimVertex::parentIndex never orphans. Off by
-        # default; enabled by the enableTruth process modifier (truth-graph workflows).
-        ReconnectDroppedAncestors = cms.bool(False)
+        # the nearest stored ancestor so SimVertex::parentIndex never orphans. On
+        # unconditionally: it is a general SimVertex-connectivity correctness fix, it
+        # does not change the detector sim-hits, and it is essentially free (measured
+        # ~0% SIM CPU, no output-size growth).
+        ReconnectDroppedAncestors = cms.bool(True)
     ),
     SteppingAction = cms.PSet(
         common_MCtruth,
@@ -823,14 +825,10 @@ fixLongLivedSleptonSim.toModify( g4SimHits,
 ## threshold the intermediate low-energy ancestors are dropped and the production
 ## SimVertex of a stored secondary gets parentIndex = -1, fragmenting the truth
 ## graph into components disconnected from the generator. ReconnectDroppedAncestors
-## (a baseline TrackingAction parameter, default False above) reattaches each such
+## (a baseline TrackingAction parameter, now default True above) reattaches each such
 ## vertex to its nearest stored ancestor, so SimVertex::parentIndex always resolves
 ## (no orphans) without the SimTrack/SimVertex multiplicity blow-up of
-## PersistencyEmin = 0 - the dropped intermediate nodes are collapsed into shortcut
+## PersistencyEmin = 0: the dropped intermediate nodes are collapsed into shortcut
 ## edges (measured ~65% fewer SimTracks than PersistencyEmin = 0, same
-## one-component-per-event connectivity). Enabled only under enableTruth.
-##
-from Configuration.ProcessModifiers.enableTruth_cff import enableTruth
-enableTruth.toModify( g4SimHits,
-                      TrackingAction = dict(ReconnectDroppedAncestors = True)
-)
+## one-component-per-event connectivity). It is on unconditionally (no process
+## modifier needed): a general connectivity fix, detector-neutral, essentially free.


### PR DESCRIPTION
TrackingAction reattaches each dropped-ancestor SimVertex to its nearest stored ancestor, giving one connected SimTrack/SimVertex component per event. It is a general connectivity fix, detector-neutral and free in SIM CPU and output size, so it is on for every sample rather than gated by a process modifier.

@Moanwar asked me to make this PR for the summer production. Your decision to merge it or not if you think it might be useful to make the GEN-SIM of the production "truth graph"-ready, to be reprocessed later. 
It's not a back port of the full https://github.com/cms-sw/cmssw/pull/51562 , but only of the single line of code that fixes the broken simulation history. 

@cms-sw/ppd-l2 @bainbrid @mtosi @Moanwar 