### PR TITLE
Fix the detector-only validation and the heavy-ion hit index after #51562

### DIFF
--- a/PhysicsTools/TruthInfo/plugins/LogicalGraphHitIndexProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/LogicalGraphHitIndexProducer.cc
@@ -331,6 +331,16 @@ void TruthLogicalGraphHitIndexProducer::produce(edm::StreamID, edm::Event& event
     fillMtdHits(event, builder);
 
   auto output = std::make_unique<truth::LogicalGraphHitIndex>(builder.finish());
+  if (sharedSubgraphStore_ && !builder.usedSharedStore()) {
+    // The materialised layout stores each hit once PER ANCESTOR, and on a large event
+    // that can exceed ROOT's 1 GiB single-object limit and kill the output module. The
+    // fallback was silent when that happened on heavy-ion events (cms-sw/cmssw#51638):
+    // the one symptom was a crash three modules away. Never fall back quietly.
+    edm::LogWarning("LogicalGraphHitIndexProducer")
+        << "shared subgraph store requested but the hit-carrying particles do not form a forest; "
+           "fell back to the MATERIALISED layout, which duplicates every hit per ancestor. On a "
+           "high-multiplicity event this can exceed ROOT's 1 GiB single-object limit at output.";
+  }
   event.put(std::move(output));
 }
 

--- a/PhysicsTools/TruthInfo/src/LogicalGraphHitIndexBuilder.cc
+++ b/PhysicsTools/TruthInfo/src/LogicalGraphHitIndexBuilder.cc
@@ -204,9 +204,24 @@ namespace truth {
     // below to reject the one topology the tree cannot represent.
     const std::vector<uint8_t> reachesSim = closureReachesSimTrack();
 
+    // The tree edge is hasSimTrack to NEAREST hit-carrying descendant, walking THROUGH
+    // any GEN-only nodes between them. A decay in flight puts a GEN-only record between
+    // two SIM particles, and central heavy-ion events do this at scale: 71 such bridges
+    // in one Hydjet event, none in pp samples. Treating the bridge as a forest violation
+    // sent every such event to the materialised fallback, whose per-ancestor hit
+    // duplication turned a 30 MB graph into an index above ROOT's 1 GiB single-object
+    // limit and killed the output module (cms-sw/cmssw#51638). The GEN-only bridge
+    // itself owns no slots, and its subgraph is the union of its descendants' runs,
+    // which buildSubgraphRanges already computes for every GEN-only node.
     std::vector<uint32_t> simParent(nParticles_, kNoParent);
     std::vector<std::vector<uint32_t>> simChildren(nParticles_);
     bool isForest = true;
+    std::vector<uint32_t> bridgeStack;
+    // Visited mask for the bridge walk, undone after each parent: GEN-only nodes can
+    // form a CYCLE (testSharedStoreFallsBackAcrossAGenOnlyCycle builds one), and a walk
+    // without the mask never terminates on it.
+    std::vector<uint8_t> bridgeSeen(nParticles_, 0);
+    std::vector<uint32_t> bridgeVisited;
     for (uint32_t parent = 0; parent < nParticles_; ++parent) {
       if (hasSimTrack_[parent] == 0)
         continue;
@@ -214,13 +229,41 @@ namespace truth {
         if (child >= nParticles_)
           continue;
         if (hasSimTrack_[child] == 0) {
-          // A GEN-only child that still has hit-carrying descendants would put them
-          // outside this parent's subtree run, since the tree is built from
-          // hasSimTrack-to-hasSimTrack edges only, and the parent's subgraph would come
-          // back short. No current sample does this, because a SIM-continued GEN
-          // particle is a status 1 leaf, but nothing enforces it.
-          if (reachesSim[child] != 0)
-            isForest = false;
+          if (reachesSim[child] == 0)
+            continue;
+          // Walk through the GEN-only bridge to its first hit-carrying descendants and
+          // attach them to this parent directly.
+          bridgeStack.push_back(child);
+          bridgeSeen[child] = 1;
+          bridgeVisited.push_back(child);
+          while (!bridgeStack.empty() && isForest) {
+            const uint32_t bridge = bridgeStack.back();
+            bridgeStack.pop_back();
+            for (const uint32_t below : children_[bridge]) {
+              if (below >= nParticles_)
+                continue;
+              if (hasSimTrack_[below] == 0) {
+                if (reachesSim[below] != 0 && bridgeSeen[below] == 0) {
+                  bridgeStack.push_back(below);
+                  bridgeSeen[below] = 1;
+                  bridgeVisited.push_back(below);
+                }
+                continue;
+              }
+              if (simParent[below] != kNoParent) {
+                // Reachable through two bridges or two parents: not a tree.
+                if (simParent[below] != parent)
+                  isForest = false;
+                continue;
+              }
+              simParent[below] = parent;
+              simChildren[parent].push_back(below);
+            }
+          }
+          bridgeStack.clear();
+          for (const uint32_t visited : bridgeVisited)
+            bridgeSeen[visited] = 0;
+          bridgeVisited.clear();
           continue;
         }
         if (simParent[child] != kNoParent) {

--- a/PhysicsTools/TruthInfo/test/LogicalGraphHitIndexBuilder_t.cpp
+++ b/PhysicsTools/TruthInfo/test/LogicalGraphHitIndexBuilder_t.cpp
@@ -189,6 +189,12 @@ void TestLogicalGraphHitIndexBuilder::testSharedStoreFallsBackWhenNotAForest() {
 // grandparent's subtree run and its hits would go missing from that subgraph. finish()
 // must fall back rather than answer short.
 void TestLogicalGraphHitIndexBuilder::testSharedStoreFallsBackAcrossAGenOnlyChild() {
+  // REQUIRED: a SIM to GEN-only to SIM sandwich stays on the SHARED store. This is a
+  // decay in flight, and central heavy-ion events carry it at scale: 71 bridges in one
+  // Hydjet event. Falling back to the materialised layout there duplicated every hit
+  // per ancestor and produced an index above ROOT's 1 GiB single-object limit
+  // (cms-sw/cmssw#51638). The bridge is walked through, so the grandparent's subgraph
+  // still sees everything below it and the GEN-only node keeps its own union view.
   truth::LogicalGraphHitIndexBuilder builder(3, /*sharedSubgraphStore=*/true);
   builder.setSimTrackForParticle(0, 0, 100);
   // particle 1 is GEN-only: no SimTrack, so it never carries hits itself.
@@ -201,14 +207,28 @@ void TestLogicalGraphHitIndexBuilder::testSharedStoreFallsBackAcrossAGenOnlyChil
 
   const auto index = builder.finish();
 
-  CPPUNIT_ASSERT(!builder.usedSharedStore());
-  CPPUNIT_ASSERT(!index.sharedSubgraphStore());
+  CPPUNIT_ASSERT(builder.usedSharedStore());
+  CPPUNIT_ASSERT(index.sharedSubgraphStore());
 
-  // The grandparent still sees both cells, which is what the fallback protects.
-  auto sub = index.subgraphHits(truth::HitChannel::Calo, 0);
-  CPPUNIT_ASSERT_EQUAL(std::size_t(2), sub.size());
-  CPPUNIT_ASSERT_EQUAL(uint32_t(10), sub[0].detId);
-  CPPUNIT_ASSERT_EQUAL(uint32_t(20), sub[1].detId);
+  // The grandparent sees both cells: its subtree run walked THROUGH the bridge.
+  {
+    auto sub = index.subgraphHits(truth::HitChannel::Calo, 0);
+    CPPUNIT_ASSERT_EQUAL(std::size_t(2), sub.size());
+    CPPUNIT_ASSERT_EQUAL(uint32_t(10), sub[0].detId);
+    CPPUNIT_ASSERT_EQUAL(uint32_t(20), sub[1].detId);
+  }
+  // The GEN-only bridge sees exactly its own descendant's cell.
+  {
+    auto sub = index.subgraphHits(truth::HitChannel::Calo, 1);
+    CPPUNIT_ASSERT_EQUAL(std::size_t(1), sub.size());
+    CPPUNIT_ASSERT_EQUAL(uint32_t(20), sub[0].detId);
+  }
+  // And the leaf sees itself alone.
+  {
+    auto sub = index.subgraphHits(truth::HitChannel::Calo, 2);
+    CPPUNIT_ASSERT_EQUAL(std::size_t(1), sub.size());
+    CPPUNIT_ASSERT_EQUAL(uint32_t(20), sub[0].detId);
+  }
 }
 
 // A GEN-only CYCLE between the hit-carrying parent and a hit-carrying descendant. The
@@ -230,10 +250,13 @@ void TestLogicalGraphHitIndexBuilder::testSharedStoreFallsBackAcrossAGenOnlyCycl
 
   const auto index = builder.finish();
 
-  CPPUNIT_ASSERT(!builder.usedSharedStore());
-  CPPUNIT_ASSERT(!index.sharedSubgraphStore());
+  // The bridge walk visits each GEN-only node once, so a cycle terminates and the SIM
+  // exit is attached under the one SIM parent: representable, so the SHARED store holds.
+  CPPUNIT_ASSERT(builder.usedSharedStore());
+  CPPUNIT_ASSERT(index.sharedSubgraphStore());
 
-  // The parent still sees the descendant's cell through the cycle.
+  // The parent still sees the descendant's cell through the cycle, which was always the
+  // required behaviour; only the layout that provides it changed.
   auto sub = index.subgraphHits(truth::HitChannel::Calo, 0);
   CPPUNIT_ASSERT_EQUAL(std::size_t(2), sub.size());
   CPPUNIT_ASSERT_EQUAL(uint32_t(10), sub[0].detId);

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -156,7 +156,13 @@ baseCommonValidation = cms.Sequence()
 # no raw pileup SimTracks, so the accumulator and the DIGI build are dropped and the
 # truth products do not exist downstream. Revert to the truth-free sequences there,
 # after the enableTruth lines, so the later statement wins.
-_baseCommonPreValidationNoTruth = baseCommonPreValidation.copy()
+# Public truth-free copy: the detector-only assemblies below must use THIS one. The
+# truth association producers consume generalTracks, the pixel clusters and the HGCal
+# and PF rechits, none of which a detector-only reconstruction makes, so attaching the
+# truth to baseCommonPreValidation itself would fail those workflows with
+# ProductNotFound at the first event.
+baseCommonPreValidationNoTruth = baseCommonPreValidation.copy()
+_baseCommonPreValidationNoTruth = baseCommonPreValidationNoTruth
 _baseCommonValidationNoTruth = baseCommonValidation.copy()
 
 _baseCommonPreValidationWithTruth = baseCommonPreValidation.copy()
@@ -207,8 +213,10 @@ globalValidationTaus = cms.Sequence(
 
 # ECAL local reconstruction
 globalPrevalidationECAL = cms.Sequence()
+# baseCommonPreValidationNoTruth, not baseCommonPreValidation: ECAL-only reconstruction
+# has no generalTracks and no HGCal rechits for the truth association to consume.
 globalPrevalidationECALOnly = cms.Sequence(
-      baseCommonPreValidation
+      baseCommonPreValidationNoTruth
     + globalPrevalidationECAL
 )
 
@@ -238,8 +246,9 @@ phase2_ecalTP_devel.toReplaceWith(ecalTPsValidationSequence, ecalTPsValidationSe
 # HCAL local reconstruction
 globalPrevalidationHCAL = cms.Sequence()
 
+# Same as the ECAL-only case above: no tracks, no truth association inputs.
 globalPrevalidationHCALOnly = cms.Sequence(
-      baseCommonPreValidation
+      baseCommonPreValidationNoTruth
     + globalPrevalidationHCAL
 )
 


### PR DESCRIPTION
Two fixes for regressions introduced by #51562, one per commit.

**Detector-only workflows fail with `ProductNotFound` (reported by @thomreis in #51562)**

The enableTruth attach on `baseCommonPreValidation` reached `globalPrevalidationECALOnly` and `globalPrevalidationHCALOnly`, whose reconstructions produce neither `generalTracks` nor the pixel clusters and calorimeter rechits the truth association producers consume, so workflows such as `34434.61` failed with `ProductNotFound` at the first event.

The two detector-only assemblies now use a truth-free copy of the base sequence. The standard workflows are untouched: `34434.0` keeps the three truth producers in prevalidation and both analyzers in validation. Verified: the unfixed IB reproduces the reported crash, and with the fix `34434.61` (ECAL only) and `34434.422` (HCAL only Alpaka) pass all four steps.

**Heavy-ion workflow 34551.85 fails with `FatalRootError` (fixes #51638)**

Not a big-event problem: on the failing central Hydjet event the logical graph is 35 MB and the raw graph 28 MB, but the hit index alone serialized above ROOT's 1 GiB single-object limit. The shared hit-index layout rejected any SIM particle whose GEN-only child has hit-carrying descendants (a decay in flight); central heavy-ion events produce 71 such bridges per event where pp samples produce none, and the silent fallback to the materialised layout duplicates every hit once per ancestor, which is what crossed 1 GiB and killed the output module three modules away.

The index tree edge is now SIM to nearest hit-carrying descendant, walking through GEN-only bridges with a visited mask so bridge cycles terminate. A particle reachable through two bridges or two parents still falls back, and the producer now emits a `LogWarning` whenever the shared layout was requested but not used, so any future fallback is visible instead of silent.

Measured on the failing event: the index goes from over 1 GiB to 20 MB and the shared layout holds. All 60 Hydjet events of the reproduction, including the nine that crashed, pass end to end; the bridge and cycle unit tests keep their content assertions unchanged and now assert the shared store; the two-SIM-parent fallback test is untouched.

### PR validation:

Reproduced both failures on the unfixed `CMSSW_20_1_X_2026-08-07-1100` IB, verified both fixes against the same inputs, `scram b runtests` in `PhysicsTools/TruthInfo` passes.
