### PR TITLE
Rename SimDataformats TICL associator as `TICLAssociationMap`

### DIFF
--- a/PhysicsTools/NanoAOD/interface/AssociationMapFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/AssociationMapFlatTableProducer.h
@@ -247,46 +247,50 @@ protected:
 
 // OneToOne, Fraction and Fraction with Score
 template <typename Source, typename Target>
-using AssociationMapOneToOneFraction =
-    ticl::AssociationMap<vector<ticl::AssociationElement<ticl::FractionType>>, std::vector<Source>, std::vector<Target>>;
+using AssociationMapOneToOneFraction = ticl::
+    TICLAssociationMap<vector<ticl::AssociationElement<ticl::FractionType>>, std::vector<Source>, std::vector<Target>>;
 
 template <typename Source, typename Target>
 using AssociationMapOneToOneFractionScore =
-    ticl::AssociationMap<vector<ticl::AssociationElement<std::pair<ticl::FractionType, float>>>,
-                         std::vector<Source>,
-                         std::vector<Target>>;
+    ticl::TICLAssociationMap<vector<ticl::AssociationElement<std::pair<ticl::FractionType, float>>>,
+                             std::vector<Source>,
+                             std::vector<Target>>;
 
 // OneToOne, SharedEnergy and SharedEnergy with Score
 template <typename Source, typename Target>
-using AssociationMapOneToOneSharedEnergy = ticl::
-    AssociationMap<vector<ticl::AssociationElement<ticl::SharedEnergyType>>, std::vector<Source>, std::vector<Target>>;
+using AssociationMapOneToOneSharedEnergy =
+    ticl::TICLAssociationMap<vector<ticl::AssociationElement<ticl::SharedEnergyType>>,
+                             std::vector<Source>,
+                             std::vector<Target>>;
 
 template <typename Source, typename Target>
 using AssociationMapOneToOneSharedEnergyScore =
-    ticl::AssociationMap<vector<ticl::AssociationElement<std::pair<ticl::SharedEnergyType, float>>>,
-                         std::vector<Source>,
-                         std::vector<Target>>;
+    ticl::TICLAssociationMap<vector<ticl::AssociationElement<std::pair<ticl::SharedEnergyType, float>>>,
+                             std::vector<Source>,
+                             std::vector<Target>>;
 
 // OneToMany, Fraction and Fraction with Score
 template <typename Source, typename Target>
-using AssociationMapOneToManyFraction =
-    ticl::AssociationMap<vector<vector<ticl::AssociationElement<ticl::FractionType>>>, vector<Source>, vector<Target>>;
+using AssociationMapOneToManyFraction = ticl::
+    TICLAssociationMap<vector<vector<ticl::AssociationElement<ticl::FractionType>>>, vector<Source>, vector<Target>>;
 
 template <typename Source, typename Target>
 using AssociationMapOneToManyFractionScore =
-    ticl::AssociationMap<vector<vector<ticl::AssociationElement<pair<ticl::FractionType, float>>>>,
-                         vector<Source>,
-                         vector<Target>>;
+    ticl::TICLAssociationMap<vector<vector<ticl::AssociationElement<pair<ticl::FractionType, float>>>>,
+                             vector<Source>,
+                             vector<Target>>;
 
 // OneToMany, SharedEnergy and SharedEnergy with Score
 template <typename Source, typename Target>
-using AssociationMapOneToManySharedEnergy = ticl::
-    AssociationMap<vector<vector<ticl::AssociationElement<ticl::SharedEnergyType>>>, vector<Source>, vector<Target>>;
+using AssociationMapOneToManySharedEnergy =
+    ticl::TICLAssociationMap<vector<vector<ticl::AssociationElement<ticl::SharedEnergyType>>>,
+                             vector<Source>,
+                             vector<Target>>;
 
 template <typename Source, typename Target>
 using AssociationMapOneToManySharedEnergyScore =
-    ticl::AssociationMap<vector<vector<ticl::AssociationElement<pair<ticl::SharedEnergyType, float>>>>,
-                         vector<Source>,
-                         vector<Target>>;
+    ticl::TICLAssociationMap<vector<vector<ticl::AssociationElement<pair<ticl::SharedEnergyType, float>>>>,
+                             vector<Source>,
+                             vector<Target>>;
 
 #endif

--- a/PhysicsTools/TruthInfo/plugins/TruthBranchCaloAssociationProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthBranchCaloAssociationProducer.cc
@@ -39,7 +39,7 @@
 
 namespace {
   // Raw-index AssociationMap (object index -> [(branch id, sharedEnergy, score)]).
-  using BranchAssociationMap = ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore>;
+  using BranchAssociationMap = ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore>;
 }  // namespace
 
 class TruthBranchCaloAssociationProducer : public edm::stream::EDProducer<> {

--- a/PhysicsTools/TruthInfo/plugins/TruthBranchTrackingAssociationProducer.cc
+++ b/PhysicsTools/TruthInfo/plugins/TruthBranchTrackingAssociationProducer.cc
@@ -44,7 +44,7 @@
 
 namespace {
   // Raw-index AssociationMap (object index -> [(branch id, sharedHits, score)]).
-  using BranchAssociationMap = ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore>;
+  using BranchAssociationMap = ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore>;
 }  // namespace
 
 class TruthBranchTrackingAssociationProducer : public edm::stream::EDProducer<> {

--- a/RecoHGCal/TICL/plugins/TICLDumper.cc
+++ b/RecoHGCal/TICL/plugins/TICLDumper.cc
@@ -65,8 +65,8 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
-using TracksterToTracksterMap =
-    ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster>>;
+using TracksterToTracksterMap = ticl::
+    TICLAssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster>>;
 // Helper class for geometry, magnetic field, etc
 class DetectorTools {
 public:

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/AllHitToTracksterAssociatorsProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/AllHitToTracksterAssociatorsProducer.cc
@@ -45,8 +45,8 @@ AllHitToTracksterAssociatorsProducerT<HIT>::AllHitToTracksterAssociatorsProducer
   }
 
   for (const auto& tracksterToken : tracksterCollectionTokens_) {
-    produces<ticl::AssociationMap<ticl::mapWithFraction>>("hitTo" + tracksterToken.first);
-    produces<ticl::AssociationMap<ticl::mapWithFraction>>(tracksterToken.first + "ToHit");
+    produces<ticl::TICLAssociationMap<ticl::mapWithFraction>>("hitTo" + tracksterToken.first);
+    produces<ticl::TICLAssociationMap<ticl::mapWithFraction>>(tracksterToken.first + "ToHit");
   }
 }
 
@@ -62,8 +62,8 @@ void AllHitToTracksterAssociatorsProducerT<HIT>::produce(edm::StreamID,
   if (!layer_clusters.isValid()) {
     edm::LogWarning("AllHitToTracksterAssociatorsProducer") << "Missing LayerCluster collection.";
     for (const auto& tracksterToken : tracksterCollectionTokens_) {
-      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), "hitTo" + tracksterToken.first);
-      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), tracksterToken.first + "ToHit");
+      iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(), "hitTo" + tracksterToken.first);
+      iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(), tracksterToken.first + "ToHit");
     }
     return;
   }
@@ -74,8 +74,8 @@ void AllHitToTracksterAssociatorsProducerT<HIT>::produce(edm::StreamID,
   if (!iEvent.getHandle(hitsToken_)) {
     edm::LogWarning("AllHitToTracksterAssociatorsProducer") << "Missing edm::RefProdVector<RecHitCollection>.";
     for (const auto& tracksterToken : tracksterCollectionTokens_) {
-      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), "hitTo" + tracksterToken.first);
-      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), tracksterToken.first + "ToHit");
+      iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(), "hitTo" + tracksterToken.first);
+      iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(), tracksterToken.first + "ToHit");
     }
     return;
   }
@@ -95,8 +95,8 @@ void AllHitToTracksterAssociatorsProducerT<HIT>::produce(edm::StreamID,
     LogDebug("HitToSimClusterCaloParticleAssociatorProducer")
         << "Only empty RecHitCollections found. Association maps will be empty.";
     for (const auto& tracksterToken : tracksterCollectionTokens_) {
-      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), "hitTo" + tracksterToken.first);
-      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), tracksterToken.first + "ToHit");
+      iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(), "hitTo" + tracksterToken.first);
+      iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(), tracksterToken.first + "ToHit");
     }
     return;
   }
@@ -108,13 +108,13 @@ void AllHitToTracksterAssociatorsProducerT<HIT>::produce(edm::StreamID,
     if (!tracksters.isValid()) {
       LogDebug("AllHitToTracksterAssociatorsProducer")
           << "Missing Tracksters for collection " << tracksterToken.first << ". Association maps will be empty.";
-      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), "hitTo" + tracksterToken.first);
-      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), tracksterToken.first + "ToHit");
+      iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(), "hitTo" + tracksterToken.first);
+      iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(), tracksterToken.first + "ToHit");
       continue;
     }
 
-    auto hitToTracksterMap = std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(rechitSpan.size());
-    auto tracksterToHitMap = std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(tracksters->size());
+    auto hitToTracksterMap = std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(rechitSpan.size());
+    auto tracksterToHitMap = std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(tracksters->size());
 
     for (unsigned int tracksterId = 0; tracksterId < tracksters->size(); ++tracksterId) {
       const auto& trackster = (*tracksters)[tracksterId];

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/AllLayerClusterToTracksterAssociatorsProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/AllLayerClusterToTracksterAssociatorsProducer.cc
@@ -40,9 +40,9 @@ AllLayerClusterToTracksterAssociatorsProducer::AllLayerClusterToTracksterAssocia
 
   // Produce separate association maps for each trackster collection using the trackster label
   for (const auto& tracksterToken : tracksterCollectionTokens_) {
-    produces<
-        ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster>>>(
-        tracksterToken.first);
+    produces<ticl::TICLAssociationMap<ticl::mapWithSharedEnergy,
+                                      std::vector<reco::CaloCluster>,
+                                      std::vector<ticl::Trackster>>>(tracksterToken.first);
   }
 }
 
@@ -58,9 +58,9 @@ void AllLayerClusterToTracksterAssociatorsProducer::produce(edm::StreamID,
   if (!layerClustersHandle.isValid()) {
     edm::LogWarning("MissingInput") << "Layer clusters collection not found. Producing empty maps.";
     for (const auto& tracksterToken : tracksterCollectionTokens_) {
-      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergy,
-                                                       std::vector<reco::CaloCluster>,
-                                                       std::vector<ticl::Trackster>>>(),
+      iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergy,
+                                                           std::vector<reco::CaloCluster>,
+                                                           std::vector<ticl::Trackster>>>(),
                  tracksterToken.first);
     }
     return;
@@ -71,16 +71,16 @@ void AllLayerClusterToTracksterAssociatorsProducer::produce(edm::StreamID,
     // If tracksters collection is missing, produce empty map and continue
     if (!trackstersHandle.isValid()) {
       LogDebug("MissingInput") << "Tracksters collection '" << tracksterToken.first << "' not found.";
-      iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergy,
-                                                       std::vector<reco::CaloCluster>,
-                                                       std::vector<ticl::Trackster>>>(),
+      iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergy,
+                                                           std::vector<reco::CaloCluster>,
+                                                           std::vector<ticl::Trackster>>>(),
                  tracksterToken.first);
       continue;
     }
 
     // Create association map
     auto lcToTracksterMap = std::make_unique<
-        ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster>>>(
+        ticl::TICLAssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster>>>(
         layerClustersHandle, trackstersHandle, iEvent);
 
     // Loop over tracksters

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/AllTracksterToSimTracksterAssociatorsByHitsProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/AllTracksterToSimTracksterAssociatorsByHitsProducer.cc
@@ -32,20 +32,20 @@ private:
 
   std::vector<std::pair<std::string, edm::EDGetTokenT<std::vector<ticl::Trackster>>>> tracksterCollectionTokens_;
   std::vector<std::pair<std::string, edm::EDGetTokenT<std::vector<ticl::Trackster>>>> simTracksterCollectionTokens_;
-  std::vector<std::pair<std::string, edm::EDGetTokenT<ticl::AssociationMap<ticl::mapWithFraction>>>>
+  std::vector<std::pair<std::string, edm::EDGetTokenT<ticl::TICLAssociationMap<ticl::mapWithFraction>>>>
       hitToTracksterMapTokens_;
-  std::vector<std::pair<std::string, edm::EDGetTokenT<ticl::AssociationMap<ticl::mapWithFraction>>>>
+  std::vector<std::pair<std::string, edm::EDGetTokenT<ticl::TICLAssociationMap<ticl::mapWithFraction>>>>
       tracksterToHitMapTokens_;
 
-  std::vector<std::pair<std::string, edm::EDGetTokenT<ticl::AssociationMap<ticl::mapWithFraction>>>>
+  std::vector<std::pair<std::string, edm::EDGetTokenT<ticl::TICLAssociationMap<ticl::mapWithFraction>>>>
       hitToSimTracksterMapTokens_;
-  std::vector<std::pair<std::string, edm::EDGetTokenT<ticl::AssociationMap<ticl::mapWithFraction>>>>
+  std::vector<std::pair<std::string, edm::EDGetTokenT<ticl::TICLAssociationMap<ticl::mapWithFraction>>>>
       simTracksterToHitMapTokens_;
 
   edm::EDGetTokenT<multiCollectionT> hitsToken_;
   edm::EDGetTokenT<std::vector<CaloParticle>> caloParticleToken_;
-  edm::EDGetTokenT<ticl::AssociationMap<ticl::mapWithFraction>> hitToSimClusterMapToken_;
-  edm::EDGetTokenT<ticl::AssociationMap<ticl::mapWithFraction>> hitToCaloParticleMapToken_;
+  edm::EDGetTokenT<ticl::TICLAssociationMap<ticl::mapWithFraction>> hitToSimClusterMapToken_;
+  edm::EDGetTokenT<ticl::TICLAssociationMap<ticl::mapWithFraction>> hitToCaloParticleMapToken_;
 };
 
 template <typename HIT>
@@ -53,9 +53,9 @@ AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::AllTracksterToSimTrac
     const edm::ParameterSet& pset)
     : hitsToken_(consumes<multiCollectionT>(pset.getParameter<edm::InputTag>("hits"))),
       caloParticleToken_(consumes<std::vector<CaloParticle>>(pset.getParameter<edm::InputTag>("caloParticles"))),
-      hitToSimClusterMapToken_(consumes<ticl::AssociationMap<ticl::mapWithFraction>>(
+      hitToSimClusterMapToken_(consumes<ticl::TICLAssociationMap<ticl::mapWithFraction>>(
           pset.getParameter<edm::InputTag>("hitToSimClusterMap"))),
-      hitToCaloParticleMapToken_(consumes<ticl::AssociationMap<ticl::mapWithFraction>>(
+      hitToCaloParticleMapToken_(consumes<ticl::TICLAssociationMap<ticl::mapWithFraction>>(
           pset.getParameter<edm::InputTag>("hitToCaloParticleMap"))) {
   const auto& tracksterCollections = pset.getParameter<std::vector<edm::InputTag>>("tracksterCollections");
 
@@ -67,9 +67,11 @@ AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::AllTracksterToSimTrac
     }
     tracksterCollectionTokens_.emplace_back(label, consumes<std::vector<ticl::Trackster>>(tag));
     hitToTracksterMapTokens_.emplace_back(
-        label, consumes<ticl::AssociationMap<ticl::mapWithFraction>>(edm::InputTag(allHitToTSAccoc, "hitTo" + label)));
+        label,
+        consumes<ticl::TICLAssociationMap<ticl::mapWithFraction>>(edm::InputTag(allHitToTSAccoc, "hitTo" + label)));
     tracksterToHitMapTokens_.emplace_back(
-        label, consumes<ticl::AssociationMap<ticl::mapWithFraction>>(edm::InputTag(allHitToTSAccoc, label + "ToHit")));
+        label,
+        consumes<ticl::TICLAssociationMap<ticl::mapWithFraction>>(edm::InputTag(allHitToTSAccoc, label + "ToHit")));
   }
 
   const auto& simTracksterCollections = pset.getParameter<std::vector<edm::InputTag>>("simTracksterCollections");
@@ -80,22 +82,24 @@ AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::AllTracksterToSimTrac
     }
     simTracksterCollectionTokens_.emplace_back(label, consumes<std::vector<ticl::Trackster>>(tag));
     hitToSimTracksterMapTokens_.emplace_back(
-        label, consumes<ticl::AssociationMap<ticl::mapWithFraction>>(edm::InputTag(allHitToTSAccoc, "hitTo" + label)));
+        label,
+        consumes<ticl::TICLAssociationMap<ticl::mapWithFraction>>(edm::InputTag(allHitToTSAccoc, "hitTo" + label)));
     simTracksterToHitMapTokens_.emplace_back(
-        label, consumes<ticl::AssociationMap<ticl::mapWithFraction>>(edm::InputTag(allHitToTSAccoc, label + "ToHit")));
+        label,
+        consumes<ticl::TICLAssociationMap<ticl::mapWithFraction>>(edm::InputTag(allHitToTSAccoc, label + "ToHit")));
   }
 
   // Produce separate association maps for each trackster-simTrackster combination
   for (const auto& tracksterToken : tracksterCollectionTokens_) {
     for (const auto& simTracksterToken : simTracksterCollectionTokens_) {
       std::string instanceLabel = tracksterToken.first + "To" + simTracksterToken.first;
-      produces<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                    std::vector<ticl::Trackster>,
-                                    std::vector<ticl::Trackster>>>(instanceLabel);
+      produces<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                        std::vector<ticl::Trackster>,
+                                        std::vector<ticl::Trackster>>>(instanceLabel);
       std::string reverseInstanceLabel = simTracksterToken.first + "To" + tracksterToken.first;
-      produces<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                    std::vector<ticl::Trackster>,
-                                    std::vector<ticl::Trackster>>>(reverseInstanceLabel);
+      produces<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                        std::vector<ticl::Trackster>,
+                                        std::vector<ticl::Trackster>>>(reverseInstanceLabel);
     }
   }
 }
@@ -111,13 +115,13 @@ void AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::produce(edm::Str
         << "Missing MultiRecHitCollection. Association maps will be empty.";
     for (const auto& tracksterToken : tracksterCollectionTokens_) {
       for (const auto& simTracksterToken : simTracksterCollectionTokens_) {
-        iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                         std::vector<ticl::Trackster>,
-                                                         std::vector<ticl::Trackster>>>(),
+        iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                             std::vector<ticl::Trackster>,
+                                                             std::vector<ticl::Trackster>>>(),
                    tracksterToken.first + "To" + simTracksterToken.first);
-        iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                         std::vector<ticl::Trackster>,
-                                                         std::vector<ticl::Trackster>>>(),
+        iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                             std::vector<ticl::Trackster>,
+                                                             std::vector<ticl::Trackster>>>(),
                    simTracksterToken.first + "To" + tracksterToken.first);
       }
     }
@@ -141,24 +145,24 @@ void AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::produce(edm::Str
 
     for (const auto& tracksterToken : tracksterCollectionTokens_) {
       for (const auto& simTracksterToken : simTracksterCollectionTokens_) {
-        iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                         std::vector<ticl::Trackster>,
-                                                         std::vector<ticl::Trackster>>>(),
+        iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                             std::vector<ticl::Trackster>,
+                                                             std::vector<ticl::Trackster>>>(),
                    tracksterToken.first + "To" + simTracksterToken.first);
-        iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                         std::vector<ticl::Trackster>,
-                                                         std::vector<ticl::Trackster>>>(),
+        iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                             std::vector<ticl::Trackster>,
+                                                             std::vector<ticl::Trackster>>>(),
                    simTracksterToken.first + "To" + tracksterToken.first);
       }
     }
     return;
   }
 
-  Handle<ticl::AssociationMap<ticl::mapWithFraction>> hitToSimClusterMapHandle;
+  Handle<ticl::TICLAssociationMap<ticl::mapWithFraction>> hitToSimClusterMapHandle;
   iEvent.getByToken(hitToSimClusterMapToken_, hitToSimClusterMapHandle);
   const auto& hitToSimClusterMap = *hitToSimClusterMapHandle;
 
-  Handle<ticl::AssociationMap<ticl::mapWithFraction>> hitToCaloParticleMapHandle;
+  Handle<ticl::TICLAssociationMap<ticl::mapWithFraction>> hitToCaloParticleMapHandle;
   iEvent.getByToken(hitToCaloParticleMapToken_, hitToCaloParticleMapHandle);
   const auto& hitToCaloParticleMap = *hitToCaloParticleMapHandle;
 
@@ -175,13 +179,13 @@ void AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::produce(edm::Str
       for (const auto& simTracksterToken : simTracksterCollectionTokens_) {
         Handle<std::vector<ticl::Trackster>> simTrackstersHandle;
 
-        iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                         std::vector<ticl::Trackster>,
-                                                         std::vector<ticl::Trackster>>>(),
+        iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                             std::vector<ticl::Trackster>,
+                                                             std::vector<ticl::Trackster>>>(),
                    tracksterToken.first + "To" + simTracksterToken.first);
-        iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                         std::vector<ticl::Trackster>,
-                                                         std::vector<ticl::Trackster>>>(),
+        iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                             std::vector<ticl::Trackster>,
+                                                             std::vector<ticl::Trackster>>>(),
                    simTracksterToken.first + "To" + tracksterToken.first);
       }
       continue;
@@ -190,7 +194,7 @@ void AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::produce(edm::Str
     const auto& recoTracksters = *recoTrackstersHandle;
 
     // Retrieve the correct HitToTracksterMap for the current trackster collection
-    Handle<ticl::AssociationMap<ticl::mapWithFraction>> hitToTracksterMapHandle;
+    Handle<ticl::TICLAssociationMap<ticl::mapWithFraction>> hitToTracksterMapHandle;
     auto tracksterMapTokenIter = std::find_if(
         hitToTracksterMapTokens_.begin(), hitToTracksterMapTokens_.end(), [&tracksterToken](const auto& pair) {
           return pair.first == tracksterToken.first;
@@ -201,7 +205,7 @@ void AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::produce(edm::Str
     const auto& hitToTracksterMap = *hitToTracksterMapHandle;
 
     // Retrieve the correct TracksterToHitMap for the current trackster collection
-    Handle<ticl::AssociationMap<ticl::mapWithFraction>> tracksterToHitMapHandle;
+    Handle<ticl::TICLAssociationMap<ticl::mapWithFraction>> tracksterToHitMapHandle;
     auto tracksterToHitMapTokenIter = std::find_if(
         tracksterToHitMapTokens_.begin(), tracksterToHitMapTokens_.end(), [&tracksterToken](const auto& pair) {
           return pair.first == tracksterToken.first;
@@ -222,13 +226,13 @@ void AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::produce(edm::Str
       iEvent.getByToken(simTracksterToken.second, simTrackstersHandle);
 
       if (!simTrackstersHandle.isValid()) {
-        iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                         std::vector<ticl::Trackster>,
-                                                         std::vector<ticl::Trackster>>>(),
+        iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                             std::vector<ticl::Trackster>,
+                                                             std::vector<ticl::Trackster>>>(),
                    tracksterToken.first + "To" + simTracksterToken.first);
-        iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                         std::vector<ticl::Trackster>,
-                                                         std::vector<ticl::Trackster>>>(),
+        iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                             std::vector<ticl::Trackster>,
+                                                             std::vector<ticl::Trackster>>>(),
                    simTracksterToken.first + "To" + tracksterToken.first);
         continue;
       }
@@ -236,7 +240,7 @@ void AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::produce(edm::Str
       const auto& simTracksters = *simTrackstersHandle;
 
       // Retrieve the correct HitToSimTracksterMap for the current simTrackster collection
-      Handle<ticl::AssociationMap<ticl::mapWithFraction>> hitToSimTracksterMapHandle;
+      Handle<ticl::TICLAssociationMap<ticl::mapWithFraction>> hitToSimTracksterMapHandle;
       auto simTracksterMapTokenIter =
           std::find_if(hitToSimTracksterMapTokens_.begin(),
                        hitToSimTracksterMapTokens_.end(),
@@ -247,7 +251,7 @@ void AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::produce(edm::Str
       const auto& hitToSimTracksterMap = *hitToSimTracksterMapHandle;
 
       // Retrieve the correct SimTracksterToHitMap for the current simTrackster collection
-      Handle<ticl::AssociationMap<ticl::mapWithFraction>> simTracksterToHitMapHandle;
+      Handle<ticl::TICLAssociationMap<ticl::mapWithFraction>> simTracksterToHitMapHandle;
       auto simTracksterToHitMapTokenIter =
           std::find_if(simTracksterToHitMapTokens_.begin(),
                        simTracksterToHitMapTokens_.end(),
@@ -258,13 +262,13 @@ void AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::produce(edm::Str
       const auto& simTracksterToHitMap = *simTracksterToHitMapHandle;
 
       // Create the association maps
-      auto tracksterToSimTracksterMap = std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                                              std::vector<ticl::Trackster>,
-                                                                              std::vector<ticl::Trackster>>>(
+      auto tracksterToSimTracksterMap = std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                                                  std::vector<ticl::Trackster>,
+                                                                                  std::vector<ticl::Trackster>>>(
           recoTrackstersHandle, simTrackstersHandle, iEvent);
-      auto simTracksterToTracksterMap = std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                                              std::vector<ticl::Trackster>,
-                                                                              std::vector<ticl::Trackster>>>(
+      auto simTracksterToTracksterMap = std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                                                  std::vector<ticl::Trackster>,
+                                                                                  std::vector<ticl::Trackster>>>(
           simTrackstersHandle, recoTrackstersHandle, iEvent);
 
       for (unsigned int tracksterIndex = 0; tracksterIndex < recoTracksters.size(); ++tracksterIndex) {
@@ -276,7 +280,7 @@ void AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::produce(edm::Str
         if (tracksterToHitMap.size() == 0)
           continue;
 
-        ticl::AssociationMap<ticl::mapWithFraction> hitToAssociatedSimTracksterMap(
+        ticl::TICLAssociationMap<ticl::mapWithFraction> hitToAssociatedSimTracksterMap(
             recoTracksterHitsAndFractions.size());
         std::vector<unsigned int> associatedSimTracksterIndices;
 
@@ -372,7 +376,7 @@ void AllTracksterToSimTracksterAssociatorsByHitsProducerT<HIT>::produce(edm::Str
         edm::Ref<std::vector<ticl::Trackster>> simTracksterRef(simTrackstersHandle, tracksterIndex);
         float simToRecoScoresDenominator = 0.f;
         const auto& simTracksterHitsAndFractions = simTracksterToHitMap[tracksterIndex];
-        ticl::AssociationMap<ticl::mapWithFraction> hitToAssociatedRecoTracksterMap(
+        ticl::TICLAssociationMap<ticl::mapWithFraction> hitToAssociatedRecoTracksterMap(
             simTracksterHitsAndFractions.size());
         std::vector<unsigned int> associatedRecoTracksterIndices;
         const auto& simTrackster = simTracksters[tracksterIndex];

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/AllTracksterToSimTracksterAssociatorsByLCsProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/AllTracksterToSimTracksterAssociatorsByLCsProducer.cc
@@ -25,15 +25,15 @@ private:
   std::vector<std::pair<std::string, edm::EDGetTokenT<std::vector<ticl::Trackster>>>> tracksterCollectionTokens_;
   std::vector<std::pair<std::string, edm::EDGetTokenT<std::vector<ticl::Trackster>>>> simTracksterCollectionTokens_;
   edm::EDGetTokenT<std::vector<reco::CaloCluster>> layerClustersToken_;
-  std::vector<std::pair<
-      std::string,
-      edm::EDGetTokenT<
-          ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster>>>>>
+  std::vector<std::pair<std::string,
+                        edm::EDGetTokenT<ticl::TICLAssociationMap<ticl::mapWithSharedEnergy,
+                                                                  std::vector<reco::CaloCluster>,
+                                                                  std::vector<ticl::Trackster>>>>>
       layerClusterToTracksterMapTokens_;
-  std::vector<std::pair<
-      std::string,
-      edm::EDGetTokenT<
-          ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster>>>>>
+  std::vector<std::pair<std::string,
+                        edm::EDGetTokenT<ticl::TICLAssociationMap<ticl::mapWithSharedEnergy,
+                                                                  std::vector<reco::CaloCluster>,
+                                                                  std::vector<ticl::Trackster>>>>>
       layerClusterToSimTracksterMapTokens_;
 };
 
@@ -51,9 +51,9 @@ AllTracksterToSimTracksterAssociatorsByLCsProducer::AllTracksterToSimTracksterAs
     tracksterCollectionTokens_.emplace_back(label, consumes<std::vector<ticl::Trackster>>(tag));
     layerClusterToTracksterMapTokens_.emplace_back(
         label,
-        consumes<ticl::AssociationMap<ticl::mapWithSharedEnergy,
-                                      std::vector<reco::CaloCluster>,
-                                      std::vector<ticl::Trackster>>>(edm::InputTag(allLCtoTSAccoc, label)));
+        consumes<ticl::TICLAssociationMap<ticl::mapWithSharedEnergy,
+                                          std::vector<reco::CaloCluster>,
+                                          std::vector<ticl::Trackster>>>(edm::InputTag(allLCtoTSAccoc, label)));
   }
 
   const auto& simTracksterCollections = pset.getParameter<std::vector<edm::InputTag>>("simTracksterCollections");
@@ -65,22 +65,22 @@ AllTracksterToSimTracksterAssociatorsByLCsProducer::AllTracksterToSimTracksterAs
     simTracksterCollectionTokens_.emplace_back(label, consumes<std::vector<ticl::Trackster>>(tag));
     layerClusterToSimTracksterMapTokens_.emplace_back(
         label,
-        consumes<ticl::AssociationMap<ticl::mapWithSharedEnergy,
-                                      std::vector<reco::CaloCluster>,
-                                      std::vector<ticl::Trackster>>>(edm::InputTag(allLCtoTSAccoc, label)));
+        consumes<ticl::TICLAssociationMap<ticl::mapWithSharedEnergy,
+                                          std::vector<reco::CaloCluster>,
+                                          std::vector<ticl::Trackster>>>(edm::InputTag(allLCtoTSAccoc, label)));
   }
 
   // Produce separate association maps for each trackster-simTrackster combination
   for (const auto& tracksterToken : tracksterCollectionTokens_) {
     for (const auto& simTracksterToken : simTracksterCollectionTokens_) {
       std::string instanceLabel = tracksterToken.first + "To" + simTracksterToken.first;
-      produces<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                    std::vector<ticl::Trackster>,
-                                    std::vector<ticl::Trackster>>>(instanceLabel);
+      produces<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                        std::vector<ticl::Trackster>,
+                                        std::vector<ticl::Trackster>>>(instanceLabel);
       std::string reverseInstanceLabel = simTracksterToken.first + "To" + tracksterToken.first;
-      produces<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                    std::vector<ticl::Trackster>,
-                                    std::vector<ticl::Trackster>>>(reverseInstanceLabel);
+      produces<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                        std::vector<ticl::Trackster>,
+                                        std::vector<ticl::Trackster>>>(reverseInstanceLabel);
     }
   }
 }
@@ -98,14 +98,14 @@ void AllTracksterToSimTracksterAssociatorsByLCsProducer::produce(edm::StreamID,
     edm::LogWarning("MissingInput") << "Layer clusters collection is invalid. Producing empty maps.";
     for (const auto& tracksterToken : tracksterCollectionTokens_) {
       for (const auto& simTracksterToken : simTracksterCollectionTokens_) {
-        iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                         std::vector<ticl::Trackster>,
-                                                         std::vector<ticl::Trackster>>>(),
+        iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                             std::vector<ticl::Trackster>,
+                                                             std::vector<ticl::Trackster>>>(),
                    tracksterToken.first + "To" + simTracksterToken.first);
 
-        iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                         std::vector<ticl::Trackster>,
-                                                         std::vector<ticl::Trackster>>>(),
+        iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                             std::vector<ticl::Trackster>,
+                                                             std::vector<ticl::Trackster>>>(),
                    simTracksterToken.first + "To" + tracksterToken.first);
       }
     }
@@ -121,14 +121,14 @@ void AllTracksterToSimTracksterAssociatorsByLCsProducer::produce(edm::StreamID,
     if (!recoTrackstersHandle.isValid()) {
       LogDebug("MissingInput") << "trackster collection " + tracksterToken.first + " not found. Producing empty maps.";
       for (const auto& simTracksterToken : simTracksterCollectionTokens_) {
-        iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                         std::vector<ticl::Trackster>,
-                                                         std::vector<ticl::Trackster>>>(),
+        iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                             std::vector<ticl::Trackster>,
+                                                             std::vector<ticl::Trackster>>>(),
                    tracksterToken.first + "To" + simTracksterToken.first);
 
-        iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                         std::vector<ticl::Trackster>,
-                                                         std::vector<ticl::Trackster>>>(),
+        iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                             std::vector<ticl::Trackster>,
+                                                             std::vector<ticl::Trackster>>>(),
                    simTracksterToken.first + "To" + tracksterToken.first);
       }
       continue;
@@ -137,7 +137,8 @@ void AllTracksterToSimTracksterAssociatorsByLCsProducer::produce(edm::StreamID,
     const auto& recoTracksters = *recoTrackstersHandle;
 
     // Retrieve the correct LayerClusterToTracksterMap for the current trackster collection
-    Handle<ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster>>>
+    Handle<
+        ticl::TICLAssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster>>>
         layerClusterToTracksterMapHandle;
     auto tracksterMapTokenIter =
         std::find_if(layerClusterToTracksterMapTokens_.begin(),
@@ -154,8 +155,9 @@ void AllTracksterToSimTracksterAssociatorsByLCsProducer::produce(edm::StreamID,
       const auto& simTracksters = *simTrackstersHandle;
 
       // Retrieve the correct LayerClusterToSimTracksterMap for the current simTrackster collection
-      Handle<
-          ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster>>>
+      Handle<ticl::TICLAssociationMap<ticl::mapWithSharedEnergy,
+                                      std::vector<reco::CaloCluster>,
+                                      std::vector<ticl::Trackster>>>
           layerClusterToSimTracksterMapHandle;
       auto simTracksterMapTokenIter =
           std::find_if(layerClusterToSimTracksterMapTokens_.begin(),
@@ -167,13 +169,13 @@ void AllTracksterToSimTracksterAssociatorsByLCsProducer::produce(edm::StreamID,
       const auto& layerClusterToSimTracksterMap = *layerClusterToSimTracksterMapHandle;
 
       // Create the association maps
-      auto tracksterToSimTracksterMap = std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                                              std::vector<ticl::Trackster>,
-                                                                              std::vector<ticl::Trackster>>>(
+      auto tracksterToSimTracksterMap = std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                                                  std::vector<ticl::Trackster>,
+                                                                                  std::vector<ticl::Trackster>>>(
           recoTrackstersHandle, simTrackstersHandle, iEvent);
-      auto simTracksterToTracksterMap = std::make_unique<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore,
-                                                                              std::vector<ticl::Trackster>,
-                                                                              std::vector<ticl::Trackster>>>(
+      auto simTracksterToTracksterMap = std::make_unique<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore,
+                                                                                  std::vector<ticl::Trackster>,
+                                                                                  std::vector<ticl::Trackster>>>(
           simTrackstersHandle, recoTrackstersHandle, iEvent);
 
       for (unsigned int tracksterIndex = 0; tracksterIndex < recoTracksters.size(); ++tracksterIndex) {
@@ -181,7 +183,7 @@ void AllTracksterToSimTracksterAssociatorsByLCsProducer::produce(edm::StreamID,
         edm::Ref<std::vector<ticl::Trackster>> recoTracksterRef(recoTrackstersHandle, tracksterIndex);
         const auto& layerClustersIds = recoTrackster.vertices();
         float recoToSimScoresDenominator = 0.f;
-        ticl::AssociationMap<ticl::mapWithSharedEnergy> layerClusterToAssociatedSimTracksterMap(
+        ticl::TICLAssociationMap<ticl::mapWithSharedEnergy> layerClusterToAssociatedSimTracksterMap(
             layerClustersIds.size());
         std::vector<unsigned int> associatedSimTracksterIndices;
         for (unsigned int i = 0; i < layerClustersIds.size(); ++i) {
@@ -254,7 +256,8 @@ void AllTracksterToSimTracksterAssociatorsByLCsProducer::produce(edm::StreamID,
         edm::Ref<std::vector<ticl::Trackster>> simTracksterRef(simTrackstersHandle, tracksterIndex);
         const auto& layerClustersIds = simTrackster.vertices();
         float simToRecoScoresDenominator = 0.f;
-        ticl::AssociationMap<ticl::mapWithSharedEnergy> layerClusterToAssociatedTracksterMap(layerClustersIds.size());
+        ticl::TICLAssociationMap<ticl::mapWithSharedEnergy> layerClusterToAssociatedTracksterMap(
+            layerClustersIds.size());
         std::vector<unsigned int> associatedRecoTracksterIndices;
         for (unsigned int i = 0; i < layerClustersIds.size(); ++i) {
           unsigned int layerClusterId = layerClustersIds[i];

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/HitToLayerClusterAssociatorProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/HitToLayerClusterAssociatorProducer.cc
@@ -21,7 +21,7 @@ HitToLayerClusterAssociatorProducerT<HIT>::HitToLayerClusterAssociatorProducerT(
   for (const auto &tag : hitsTags) {
     hitsTokens_.push_back(consumes<std::vector<HIT>>(tag));
   }
-  produces<ticl::AssociationMap<ticl::mapWithFraction>>("hitToLayerClusterMap");
+  produces<ticl::TICLAssociationMap<ticl::mapWithFraction>>("hitToLayerClusterMap");
 }
 
 template <typename HIT>
@@ -47,7 +47,7 @@ void HitToLayerClusterAssociatorProducerT<HIT>::produce(edm::StreamID,
   }
 
   // Create association map
-  auto hitToLayerClusterMap = std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(rechitSpan.size());
+  auto hitToLayerClusterMap = std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(rechitSpan.size());
 
   // Loop over layer clusters
   for (unsigned int lcId = 0; lcId < layer_clusters->size(); ++lcId) {

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/HitToSimClusterCaloParticleAssociatorProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/HitToSimClusterCaloParticleAssociatorProducer.cc
@@ -23,8 +23,8 @@ HitToSimClusterCaloParticleAssociatorProducerT<HIT>::HitToSimClusterCaloParticle
       caloParticleToken_(consumes<std::vector<CaloParticle>>(pset.getParameter<edm::InputTag>("caloParticles"))),
       hitMapToken_(consumes<std::unordered_map<DetId, const unsigned int>>(pset.getParameter<edm::InputTag>("hitMap"))),
       hitsToken_(consumes<multiCollectionT>(pset.getParameter<edm::InputTag>("hits"))) {
-  produces<ticl::AssociationMap<ticl::mapWithFraction>>("hitToSimClusterMap");
-  produces<ticl::AssociationMap<ticl::mapWithFraction>>("hitToCaloParticleMap");
+  produces<ticl::TICLAssociationMap<ticl::mapWithFraction>>("hitToSimClusterMap");
+  produces<ticl::TICLAssociationMap<ticl::mapWithFraction>>("hitToCaloParticleMap");
 }
 
 template <typename HIT>
@@ -46,8 +46,8 @@ void HitToSimClusterCaloParticleAssociatorProducerT<HIT>::produce(edm::StreamID,
     edm::LogWarning("HitToSimClusterCaloParticleAssociatorProducer")
         << "RecHitCollections is invalid.  Association maps will be empty.";
     // Store empty maps in the event
-    iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), "hitToSimClusterMap");
-    iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), "hitToCaloParticleMap");
+    iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(), "hitToSimClusterMap");
+    iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(), "hitToCaloParticleMap");
     return;
   }
 
@@ -66,14 +66,14 @@ void HitToSimClusterCaloParticleAssociatorProducerT<HIT>::produce(edm::StreamID,
     LogDebug("HitToSimClusterCaloParticleAssociatorProducer")
         << "RecHitCollection is empty. Association maps will be empty.";
     // Store empty maps in the event
-    iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), "hitToSimClusterMap");
-    iEvent.put(std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(), "hitToCaloParticleMap");
+    iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(), "hitToSimClusterMap");
+    iEvent.put(std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(), "hitToCaloParticleMap");
     return;
   }
 
   // Create association maps
-  auto hitToSimClusterMap = std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(rechitSpan.size());
-  auto hitToCaloParticleMap = std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(rechitSpan.size());
+  auto hitToSimClusterMap = std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(rechitSpan.size());
+  auto hitToCaloParticleMap = std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(rechitSpan.size());
 
   // Loop over caloParticles
   for (unsigned int cpId = 0; cpId < caloParticles.size(); ++cpId) {

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/HitToTracksterAssociatorProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/HitToTracksterAssociatorProducer.cc
@@ -25,8 +25,8 @@ HitToTracksterAssociatorProducerT<HIT>::HitToTracksterAssociatorProducerT(const 
   for (const auto &tag : hitsTags) {
     hitsTokens_.push_back(consumes<std::vector<HIT>>(tag));
   }
-  produces<ticl::AssociationMap<ticl::mapWithFraction>>("hitToTracksterMap");
-  produces<ticl::AssociationMap<ticl::mapWithFraction>>("tracksterToHitMap");
+  produces<ticl::TICLAssociationMap<ticl::mapWithFraction>>("hitToTracksterMap");
+  produces<ticl::TICLAssociationMap<ticl::mapWithFraction>>("tracksterToHitMap");
 }
 
 template <typename HIT>
@@ -55,8 +55,8 @@ void HitToTracksterAssociatorProducerT<HIT>::produce(edm::StreamID,
   }
 
   // Create association map
-  auto hitToTracksterMap = std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(rechitSpan.size());
-  auto tracksterToHitMap = std::make_unique<ticl::AssociationMap<ticl::mapWithFraction>>(tracksters->size());
+  auto hitToTracksterMap = std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(rechitSpan.size());
+  auto tracksterToHitMap = std::make_unique<ticl::TICLAssociationMap<ticl::mapWithFraction>>(tracksters->size());
 
   // Loop over tracksters
   for (unsigned int tracksterId = 0; tracksterId < tracksters->size(); ++tracksterId) {

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToTSAssociatorProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToTSAssociatorProducer.cc
@@ -19,7 +19,7 @@ LCToTSAssociatorProducer::LCToTSAssociatorProducer(const edm::ParameterSet &pset
       tracksterCollectionToken_(
           consumes<std::vector<ticl::Trackster>>(pset.getParameter<edm::InputTag>("tracksters"))) {
   produces<
-      ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster>>>();
+      ticl::TICLAssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster>>>();
 }
 
 LCToTSAssociatorProducer::~LCToTSAssociatorProducer() {}
@@ -40,7 +40,7 @@ void LCToTSAssociatorProducer::produce(edm::StreamID, edm::Event &iEvent, const 
 
   // Create association map
   auto lcToTracksterMap = std::make_unique<
-      ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster>>>(
+      ticl::TICLAssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::CaloCluster>, std::vector<ticl::Trackster>>>(
       layer_clusters, tracksters, iEvent);
 
   // Loop over tracksters

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/SimClusterToCaloParticleAssociatorProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/SimClusterToCaloParticleAssociatorProducer.cc
@@ -9,7 +9,7 @@
 SimClusterToCaloParticleAssociatorProducer::SimClusterToCaloParticleAssociatorProducer(const edm::ParameterSet &pset)
     : simClusterToken_(consumes<std::vector<SimCluster>>(pset.getParameter<edm::InputTag>("simClusters"))),
       caloParticleToken_(consumes<std::vector<CaloParticle>>(pset.getParameter<edm::InputTag>("caloParticles"))) {
-  produces<ticl::AssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle>>>(
+  produces<ticl::TICLAssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle>>>(
       "simClusterToCaloParticleMap");
 }
 
@@ -29,7 +29,7 @@ void SimClusterToCaloParticleAssociatorProducer::produce(edm::StreamID,
 
   // Create association map
   auto simClusterToCaloParticleMap = std::make_unique<
-      ticl::AssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle>>>(
+      ticl::TICLAssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle>>>(
       simClustersHandle, caloParticlesHandle, iEvent);
 
   // Loop over caloParticles

--- a/SimDataFormats/Associations/interface/TICLAssociationMap.h
+++ b/SimDataFormats/Associations/interface/TICLAssociationMap.h
@@ -152,9 +152,9 @@ namespace ticl {
   using oneToOneMapWithSharedEnergy = std::vector<AssociationElement<SharedEnergyType>>;
   using oneToOneMapWithSharedEnergyAndScore = std::vector<AssociationElement<std::pair<SharedEnergyType, float>>>;
 
-  // AssociationMap class templated on MapType
+  // TICLAssociationMap class templated on MapType
   template <typename MapType, typename Collection1 = void, typename Collection2 = void>
-  class AssociationMap {
+  class TICLAssociationMap {
   private:
     MapType map_;
 
@@ -173,13 +173,13 @@ namespace ticl {
     using V = typename Traits::ValueType;
     using Type = MapType;
     static constexpr bool is_one_to_one = Traits::is_one_to_one;
-    AssociationMap() : collectionRefProds() {}
+    TICLAssociationMap() : collectionRefProds() {}
 
     // Constructor for generic use
     template <typename C1 = Collection1,
               typename C2 = Collection2,
               typename std::enable_if_t<std::is_void_v<C1> && std::is_void_v<C2>, int> = 0>
-    AssociationMap(const unsigned int size1 = 0) {
+    TICLAssociationMap(const unsigned int size1 = 0) {
       map_.resize(size1);
     }
 
@@ -187,7 +187,7 @@ namespace ticl {
     template <typename C1 = Collection1,
               typename C2 = Collection2,
               typename std::enable_if_t<!std::is_void_v<C1> && !std::is_void_v<C2>, int> = 0>
-    AssociationMap(const edm::RefProd<C1>& id1, const edm::RefProd<C2>& id2, const edm::Event& event)
+    TICLAssociationMap(const edm::RefProd<C1>& id1, const edm::RefProd<C2>& id2, const edm::Event& event)
         : collectionRefProds(std::make_pair(id1, id2)) {
       resize(event);
     }
@@ -196,7 +196,7 @@ namespace ticl {
     template <typename C1 = Collection1,
               typename C2 = Collection2,
               typename std::enable_if_t<!std::is_void_v<C1> && !std::is_void_v<C2>, int> = 0>
-    AssociationMap(const edm::Handle<C1>& handle1, const edm::Handle<C2>& handle2, const edm::Event& event)
+    TICLAssociationMap(const edm::Handle<C1>& handle1, const edm::Handle<C2>& handle2, const edm::Event& event)
         : collectionRefProds(std::make_pair(edm::RefProd<C1>(handle1), edm::RefProd<C2>(handle2))) {
       resize(event);
     }
@@ -320,7 +320,7 @@ namespace ticl {
     const auto& at(unsigned int index1) const {
       const auto& elem = map_.at(index1);
       if (!elem.isValid()) {
-        throw std::out_of_range("Attempted to access an unset element in AssociationMap. Element index: " +
+        throw std::out_of_range("Attempted to access an unset element in TICLAssociationMap. Element index: " +
                                 std::to_string(index1));
       }
       return elem;
@@ -329,7 +329,7 @@ namespace ticl {
     auto& at(unsigned int index1) {
       auto& elem = map_.at(index1);
       if (!elem.isValid()) {
-        throw std::out_of_range("Attempted to access an unset element in AssociationMap. Element index: " +
+        throw std::out_of_range("Attempted to access an unset element in TICLAssociationMap. Element index: " +
                                 std::to_string(index1));
       }
       return elem;

--- a/SimDataFormats/Associations/src/classes_def.xml
+++ b/SimDataFormats/Associations/src/classes_def.xml
@@ -61,38 +61,38 @@
   <class name="std::pair<edm::RefProd<std::vector<reco::io_v1::CaloCluster> >,edm::RefProd<std::vector<ticl::Trackster> > >"/>
 
   <!-- For one-to-many map with FractionType -->
-  <class name="ticl::AssociationMap<ticl::mapWithFraction, std::vector<reco::io_v1::CaloCluster>, std::vector<ticl::Trackster> >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithFraction, std::vector<reco::io_v1::CaloCluster>, std::vector<ticl::Trackster> > >"/>
-  <class name="ticl::AssociationMap<ticl::mapWithFraction, void, void >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithFraction, void, void > >"/>
+  <class name="ticl::TICLAssociationMap<ticl::mapWithFraction, std::vector<reco::io_v1::CaloCluster>, std::vector<ticl::Trackster> >"/>
+  <class name="edm::Wrapper<ticl::TICLAssociationMap<ticl::mapWithFraction, std::vector<reco::io_v1::CaloCluster>, std::vector<ticl::Trackster> > >"/>
+  <class name="ticl::TICLAssociationMap<ticl::mapWithFraction, void, void >"/>
+  <class name="edm::Wrapper<ticl::TICLAssociationMap<ticl::mapWithFraction, void, void > >"/>
   <!-- For one-to-many map with FractionType and Score -->
-  <class name="ticl::AssociationMap<ticl::mapWithFractionAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster> >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithFractionAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster> > >"/>
-  <class name="ticl::AssociationMap<ticl::mapWithFractionAndScore, void, void >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithFractionAndScore, void, void > >"/>
+  <class name="ticl::TICLAssociationMap<ticl::mapWithFractionAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster> >"/>
+  <class name="edm::Wrapper<ticl::TICLAssociationMap<ticl::mapWithFractionAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster> > >"/>
+  <class name="ticl::TICLAssociationMap<ticl::mapWithFractionAndScore, void, void >"/>
+  <class name="edm::Wrapper<ticl::TICLAssociationMap<ticl::mapWithFractionAndScore, void, void > >"/>
   <!-- For one-to-one map with FractionType -->
-  <class name="ticl::AssociationMap<ticl::oneToOneMapWithFraction, std::vector<io_v1::SimCluster>, std::vector<io_v1::CaloParticle> >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::oneToOneMapWithFraction, std::vector<io_v1::SimCluster>, std::vector<io_v1::CaloParticle> > >"/>
-  <class name="ticl::AssociationMap<ticl::oneToOneMapWithFraction, void, void >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::oneToOneMapWithFraction, void, void > >"/>
+  <class name="ticl::TICLAssociationMap<ticl::oneToOneMapWithFraction, std::vector<io_v1::SimCluster>, std::vector<io_v1::CaloParticle> >"/>
+  <class name="edm::Wrapper<ticl::TICLAssociationMap<ticl::oneToOneMapWithFraction, std::vector<io_v1::SimCluster>, std::vector<io_v1::CaloParticle> > >"/>
+  <class name="ticl::TICLAssociationMap<ticl::oneToOneMapWithFraction, void, void >"/>
+  <class name="edm::Wrapper<ticl::TICLAssociationMap<ticl::oneToOneMapWithFraction, void, void > >"/>
 
   <!-- For one-to-many map with SharedEnergyType -->
-  <class name="ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::io_v1::CaloCluster>, std::vector<ticl::Trackster> >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::io_v1::CaloCluster>, std::vector<ticl::Trackster> > >"/>
-  <class name="ticl::AssociationMap<ticl::mapWithSharedEnergy, void, void >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithSharedEnergy, void, void > >"/>
+  <class name="ticl::TICLAssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::io_v1::CaloCluster>, std::vector<ticl::Trackster> >"/>
+  <class name="edm::Wrapper<ticl::TICLAssociationMap<ticl::mapWithSharedEnergy, std::vector<reco::io_v1::CaloCluster>, std::vector<ticl::Trackster> > >"/>
+  <class name="ticl::TICLAssociationMap<ticl::mapWithSharedEnergy, void, void >"/>
+  <class name="edm::Wrapper<ticl::TICLAssociationMap<ticl::mapWithSharedEnergy, void, void > >"/>
 
   <!-- For one-to-many map with SharedEnergyType and Score -->
-  <class name="ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster> >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster> > >"/>
-  <class name="ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, void, void >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, void, void > >"/>
+  <class name="ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster> >"/>
+  <class name="edm::Wrapper<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster> > >"/>
+  <class name="ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore, void, void >"/>
+  <class name="edm::Wrapper<ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore, void, void > >"/>
 
   <!-- For one-to-one map with SharedEnergyType -->
-  <class name="ticl::AssociationMap<ticl::oneToOneMapWithSharedEnergy, std::vector<io_v1::SimCluster>, std::vector<io_v1::CaloParticle> >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::oneToOneMapWithSharedEnergy, std::vector<io_v1::SimCluster>, std::vector<io_v1::CaloParticle> > >"/>
-  <class name="ticl::AssociationMap<ticl::oneToOneMapWithSharedEnergy, void, void >"/>
-  <class name="edm::Wrapper<ticl::AssociationMap<ticl::oneToOneMapWithSharedEnergy, void, void > >"/>
+  <class name="ticl::TICLAssociationMap<ticl::oneToOneMapWithSharedEnergy, std::vector<io_v1::SimCluster>, std::vector<io_v1::CaloParticle> >"/>
+  <class name="edm::Wrapper<ticl::TICLAssociationMap<ticl::oneToOneMapWithSharedEnergy, std::vector<io_v1::SimCluster>, std::vector<io_v1::CaloParticle> > >"/>
+  <class name="ticl::TICLAssociationMap<ticl::oneToOneMapWithSharedEnergy, void, void >"/>
+  <class name="edm::Wrapper<ticl::TICLAssociationMap<ticl::oneToOneMapWithSharedEnergy, void, void > >"/>
 
 
   <class name="reco::VertexSimToRecoCollection" >

--- a/Validation/HGCalValidation/interface/BarrelVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/BarrelVHistoProducerAlgo.h
@@ -199,10 +199,10 @@ class BarrelVHistoProducerAlgo {
 public:
   typedef dqm::legacy::DQMStore DQMStore;
   typedef dqm::legacy::MonitorElement MonitorElement;
-  using TracksterToTracksterMap =
-      ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster>>;
+  using TracksterToTracksterMap = ticl::
+      TICLAssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster>>;
   using SimClusterToCaloParticleMap =
-      ticl::AssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle>>;
+      ticl::TICLAssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle>>;
   enum validationType { byHits_CP = 0, byLCs, byLCs_CP, byHits };
 
   BarrelVHistoProducerAlgo(const edm::ParameterSet& pset);

--- a/Validation/HGCalValidation/interface/BarrelValidator.h
+++ b/Validation/HGCalValidation/interface/BarrelValidator.h
@@ -40,10 +40,10 @@ struct BarrelValidatorHistograms {
 class BarrelValidator : public DQMGlobalEDAnalyzer<BarrelValidatorHistograms> {
 public:
   using Histograms = BarrelValidatorHistograms;
-  using TracksterToTracksterMap =
-      ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster>>;
+  using TracksterToTracksterMap = ticl::
+      TICLAssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster>>;
   using SimClusterToCaloParticleMap =
-      ticl::AssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle>>;
+      ticl::TICLAssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle>>;
 
   /// Constructor
   BarrelValidator(const edm::ParameterSet& pset);

--- a/Validation/HGCalValidation/interface/HGCalValidator.h
+++ b/Validation/HGCalValidation/interface/HGCalValidator.h
@@ -48,10 +48,10 @@ struct HGCalValidatorHistograms {
 class HGCalValidator : public DQMGlobalEDAnalyzer<HGCalValidatorHistograms> {
 public:
   using Histograms = HGCalValidatorHistograms;
-  using TracksterToTracksterMap =
-      ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster>>;
+  using TracksterToTracksterMap = ticl::
+      TICLAssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster>>;
   using SimClusterToCaloParticleMap =
-      ticl::AssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle>>;
+      ticl::TICLAssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle>>;
 
   /// Constructor
   HGCalValidator(const edm::ParameterSet& pset);

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -254,10 +254,10 @@ class HGVHistoProducerAlgo {
 public:
   typedef dqm::legacy::DQMStore DQMStore;
   typedef dqm::legacy::MonitorElement MonitorElement;
-  using TracksterToTracksterMap =
-      ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster>>;
+  using TracksterToTracksterMap = ticl::
+      TICLAssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster>>;
   using SimClusterToCaloParticleMap =
-      ticl::AssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle>>;
+      ticl::TICLAssociationMap<ticl::oneToOneMapWithFraction, std::vector<SimCluster>, std::vector<CaloParticle>>;
   enum validationType { byHits_CP = 0, byLCs, byLCs_CP, byHits };
 
   HGVHistoProducerAlgo(const edm::ParameterSet& pset);

--- a/Validation/HGCalValidation/interface/TICLCandidateValidator.h
+++ b/Validation/HGCalValidation/interface/TICLCandidateValidator.h
@@ -23,8 +23,8 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 
 namespace ticl {
-  using TracksterToTracksterMap =
-      ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster>>;
+  using TracksterToTracksterMap = ticl::
+      TICLAssociationMap<ticl::mapWithSharedEnergyAndScore, std::vector<ticl::Trackster>, std::vector<ticl::Trackster>>;
 }
 
 struct TICLCandidateValidatorHistograms {

--- a/Validation/HGCalValidation/plugins/TracksterAssociationMaskProducer.cc
+++ b/Validation/HGCalValidation/plugins/TracksterAssociationMaskProducer.cc
@@ -26,12 +26,12 @@
 
 // using namespace ticl;
 using std::vector;
-using ticl::AssociationMap;
+using ticl::TICLAssociationMap;
 using ticl::Trackster;
 using ticl::TracksterCollection;
 
 using TracksterToTracksterMap =
-    ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, vector<ticl::Trackster>, vector<ticl::Trackster>>;
+    ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore, vector<ticl::Trackster>, vector<ticl::Trackster>>;
 
 class TracksterAssociationMaskProducer : public edm::stream::EDProducer<> {
 public:

--- a/Validation/HGCalValidation/plugins/TracksterSuperclusteringValidCandidateMaskProducer.cc
+++ b/Validation/HGCalValidation/plugins/TracksterSuperclusteringValidCandidateMaskProducer.cc
@@ -24,12 +24,12 @@
 
 // using namespace ticl;
 using std::vector;
-using ticl::AssociationMap;
+using ticl::TICLAssociationMap;
 using ticl::Trackster;
 using ticl::TracksterCollection;
 
 using TracksterToTracksterMap =
-    ticl::AssociationMap<ticl::mapWithSharedEnergyAndScore, vector<ticl::Trackster>, vector<ticl::Trackster>>;
+    ticl::TICLAssociationMap<ticl::mapWithSharedEnergyAndScore, vector<ticl::Trackster>, vector<ticl::Trackster>>;
 
 class TracksterSuperclusteringValidCandidateMaskProducer : public edm::stream::EDProducer<> {
 public:


### PR DESCRIPTION
#### PR description:
PR #49995 introduces a new heterogeneous Association Map under the `ticl` namespace. This PR renames the `ticl::AssociationMap` defined under `SimDataFormats/Associations` to avoid clashes inside TICL code.

FYI @waredjeb 
