### PR TITLE
Removed unused member variable from EcalUncalibratedRecHit

### DIFF
--- a/DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h
+++ b/DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h
@@ -67,7 +67,6 @@ private:
   float chi2_;            //< Chi2 of the pulse
   //< Out-Of-Time reconstructed amplitude, one for each active BX, from readout sample 0 to 9
   float OOTamplitudes_[EcalDataFrame::MAXSAMPLES];
-  float OOTchi2_;   //< Out-Of-Time Chi2
   uint32_t flags_;  //< flag to be propagated to RecHit
   uint32_t aux_;    //< aux word; first 8 bits contain time (jitter) error
   DetId id_;        //< Detector ID

--- a/DataFormats/EcalRecHit/src/classes_def.xml
+++ b/DataFormats/EcalRecHit/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-  <class name="EcalUncalibratedRecHit" ClassVersion="3">
+  <class name="EcalUncalibratedRecHit" ClassVersion="4">
+   <version ClassVersion="4" checksum="1554672449"/>
    <version ClassVersion="3" checksum="343844348"/>
   </class>
   <class name="std::vector<EcalUncalibratedRecHit>"/>


### PR DESCRIPTION
#### PR description:

This appears to be a left over from a change about 7 years ago where the OOT related variables were changed.

This was discovered while investigating the issue https://github.com/cms-sw/cmssw/issues/51640

#### PR validation:

Code compiles.

resolves https://github.com/cms-sw/framework-team/issues/2382