### PR TITLE
Minor improvements to SiPixelRawDataError

### DIFF
--- a/DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h
+++ b/DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h
@@ -13,7 +13,7 @@
 
 #include "FWCore/Utilities/interface/typedefs.h"
 
-#include <string>
+#include <string_view>
 #include <cstdint>
 
 class SiPixelRawDataError {
@@ -33,22 +33,20 @@ public:
       cms_uint64_t errorWord64);  // function to allow user to input the error word (if 64-bit) after instantiation
   void setType(int errorType);    // function to allow user to input the error type after instantiation
   void setFedId(int fedId);       // function to allow user to input the fedID after instantiation
-  void setMessage();              // function to create an error message based on errorType
 
   inline cms_uint32_t getWord32() const { return errorWord32_; }  // the 32-bit word that contains the error information
   inline cms_uint64_t getWord64() const { return errorWord64_; }  // the 64-bit word that contains the error information
   inline int getType() const {
     return errorType_;
   }  // the number associated with the error type (26-31 for ROC number errors, 32-33 for calibration errors)
-  inline int getFedId() const { return fedId_; }                   // the fedId where the error occured
-  inline std::string getMessage() const { return errorMessage_; }  // the error message to be displayed with the error
+  inline int getFedId() const { return fedId_; }  // the fedId where the error occured
+  std::string_view getMessage() const;            // the error message to be displayed with the error
 
 private:
-  cms_uint32_t errorWord32_;
   cms_uint64_t errorWord64_;
+  cms_uint32_t errorWord32_;
   int errorType_;
   int fedId_;
-  std::string errorMessage_;
 };
 
 // Comparison operators

--- a/DataFormats/SiPixelRawData/src/SiPixelRawDataError.cc
+++ b/DataFormats/SiPixelRawData/src/SiPixelRawDataError.cc
@@ -15,14 +15,10 @@
 SiPixelRawDataError::SiPixelRawDataError() {}
 
 SiPixelRawDataError::SiPixelRawDataError(cms_uint32_t errorWord32, const int errorType, int fedId)
-    : errorWord32_(errorWord32), errorType_(errorType), fedId_(fedId) {
-  setMessage();
-}
+    : errorWord64_(0), errorWord32_(errorWord32), errorType_(errorType), fedId_(fedId) {}
 
 SiPixelRawDataError::SiPixelRawDataError(cms_uint64_t errorWord64, const int errorType, int fedId)
-    : errorWord64_(errorWord64), errorType_(errorType), fedId_(fedId) {
-  setMessage();
-}
+    : errorWord64_(errorWord64), errorWord32_(0), errorType_(errorType), fedId_(fedId) {}
 
 //Destructor
 
@@ -34,68 +30,65 @@ void SiPixelRawDataError::setWord32(cms_uint32_t errorWord32) { errorWord32_ = e
 
 void SiPixelRawDataError::setWord64(cms_uint64_t errorWord64) { errorWord64_ = errorWord64; }
 
-void SiPixelRawDataError::setType(int errorType) {
-  errorType_ = errorType;
-  setMessage();
-}
+void SiPixelRawDataError::setType(int errorType) { errorType_ = errorType; }
 
 void SiPixelRawDataError::setFedId(int fedId) { fedId_ = fedId; }
 
-void SiPixelRawDataError::setMessage() {
+std::string_view SiPixelRawDataError::getMessage() const {
   switch (errorType_) {
     case (25): {
-      errorMessage_ = "Error: Disabled FED channel (ROC=25)";
+      return "Error: Disabled FED channel (ROC=25)";
       break;
     }
     case (26): {
-      errorMessage_ = "Error: Gap word";
+      return "Error: Gap word";
       break;
     }
     case (27): {
-      errorMessage_ = "Error: Dummy word";
+      return "Error: Dummy word";
       break;
     }
     case (28): {
-      errorMessage_ = "Error: FIFO nearly full";
+      return "Error: FIFO nearly full";
       break;
     }
     case (29): {
-      errorMessage_ = "Error: Timeout";
+      return "Error: Timeout";
       break;
     }
     case (30): {
-      errorMessage_ = "Error: Trailer";
+      return "Error: Trailer";
       break;
     }
     case (31): {
-      errorMessage_ = "Error: Event number mismatch";
+      return "Error: Event number mismatch";
       break;
     }
     case (32): {
-      errorMessage_ = "Error: Invalid or missing header";
+      return "Error: Invalid or missing header";
       break;
     }
     case (33): {
-      errorMessage_ = "Error: Invalid or missing trailer";
+      return "Error: Invalid or missing trailer";
       break;
     }
     case (34): {
-      errorMessage_ = "Error: Size mismatch";
+      return "Error: Size mismatch";
       break;
     }
     case (35): {
-      errorMessage_ = "Error: Invalid channel";
+      return "Error: Invalid channel";
       break;
     }
     case (36): {
-      errorMessage_ = "Error: Invalid ROC number";
+      return "Error: Invalid ROC number";
       break;
     }
     case (37): {
-      errorMessage_ = "Error: Invalid dcol/pixel address";
+      return "Error: Invalid dcol/pixel address";
       break;
     }
     default:
-      errorMessage_ = "Error: Unknown error type";
+      return "Error: Unknown error type";
   };
 }

--- a/DataFormats/SiPixelRawData/src/classes_def.xml
+++ b/DataFormats/SiPixelRawData/src/classes_def.xml
@@ -1,7 +1,7 @@
 <lcgdict>
- <class name="SiPixelRawDataError" ClassVersion="3">
+ <class name="SiPixelRawDataError" ClassVersion="4">
+  <version ClassVersion="4" checksum="115097919"/>
   <version ClassVersion="3" checksum="3705435043"/>
-   <field name="errorMessage_" transient="true"/>
  </class>
  <class name="std::vector<SiPixelRawDataError>"/>
  <class name="edm::Wrapper<std::vector<SiPixelRawDataError> >"/>


### PR DESCRIPTION
#### PR description:

- initialize all variables
- removed storage of string error as can be determined via another stored variable.
- reordered member data to avoid unnecessary packing because of alignment needs.

found as part of investigation https://github.com/cms-sw/cmssw/issues/51640

#### PR validation:

Code compiles and runs.

resolves https://github.com/cms-sw/framework-team/issues/2384