### PR TITLE
TICL: initialise all TICLCandidate members and wrap phi in the track to trackster window

### DIFF
--- a/DataFormats/HGCalReco/interface/TICLCandidate.h
+++ b/DataFormats/HGCalReco/interface/TICLCandidate.h
@@ -43,7 +43,15 @@ namespace io_v1 {
           rawEnergy_(0.f) {}
 
     TICLCandidate(const edm::Ptr<reco::Track> trackPtr, const edm::Ptr<ticl::Trackster>& tracksterPtr)
-        : LeafCandidate(), tracksters_{}, trackPtrs_{}, time_(0.f), timeError_(-1.f) {
+        : LeafCandidate(),
+          tracksters_{},
+          trackPtrs_{},
+          idProbabilities_{},
+          time_(0.f),
+          timeError_(-1.f),
+          MTDtime_{0.f},
+          MTDtimeError_{-1.f},
+          rawEnergy_(0.f) {
       if (trackPtr.isNull() and tracksterPtr.isNull())
         throw cms::Exception("NullPointerError")
             << "TICLCandidate constructor: at least one between track and trackster must be valid";

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -1,3 +1,4 @@
+#include "DataFormats/Math/interface/deltaPhi.h"
 #include "RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h"
 #include "RecoHGCal/TICL/interface/TICLUtils.h"
 #include "RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h"
@@ -108,8 +109,9 @@ void GeneralInterpretationAlgo::findTrackstersInWindow(const edm::MultiSpan<Trac
         const auto &in_tile = tile[tile.globalBin(eta_i, (phi_i % TileConstants::nPhiBins))];
         for (const unsigned &t_i : in_tile) {
           // calculate actual distances of tracksters to the seed for a more accurate cut
+          const auto dPhi = reco::deltaPhi(tracksterPropPoints[t_i].Phi(), seed_phi);
           auto sep2 = (tracksterPropPoints[t_i].Eta() - seed_eta) * (tracksterPropPoints[t_i].Eta() - seed_eta) +
-                      (tracksterPropPoints[t_i].Phi() - seed_phi) * (tracksterPropPoints[t_i].Phi() - seed_phi);
+                      dPhi * dPhi;
           if (sep2 < delta2) {
             in_delta.push_back(t_i);
             // distances2.push_back(sep2);

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -110,8 +110,8 @@ void GeneralInterpretationAlgo::findTrackstersInWindow(const edm::MultiSpan<Trac
         for (const unsigned &t_i : in_tile) {
           // calculate actual distances of tracksters to the seed for a more accurate cut
           const auto dPhi = reco::deltaPhi(tracksterPropPoints[t_i].Phi(), seed_phi);
-          auto sep2 = (tracksterPropPoints[t_i].Eta() - seed_eta) * (tracksterPropPoints[t_i].Eta() - seed_eta) +
-                      dPhi * dPhi;
+          auto sep2 =
+              (tracksterPropPoints[t_i].Eta() - seed_eta) * (tracksterPropPoints[t_i].Eta() - seed_eta) + dPhi * dPhi;
           if (sep2 < delta2) {
             in_delta.push_back(t_i);
             // distances2.push_back(sep2);


### PR DESCRIPTION
### PR description:

Two independent defects in the TICL candidate stage, found while working on the HGCAL candidate reconstruction. Both are small and self-contained.

**1. `TICLCandidate`: the two-argument constructor leaves members indeterminate**

Its member-init list is

```cpp
: LeafCandidate(), tracksters_{}, trackPtrs_{}, time_(0.f), timeError_(-1.f)
```

which omits `idProbabilities_`, `MTDtime_`, `MTDtimeError_` and `rawEnergy_`. In the track-only branch (null trackster) none of the four is assigned afterwards either. `std::array<float, 8> idProbabilities_` has no default member initializer, so those eight floats are indeterminate and are written into an event product. The other two constructors of the same class already initialise all four.

The branch is reachable. In `TICLCandidateProducer`'s muon loop the trackster `Ptr` is default-constructed and only assigned when `muonInTrackIndices[iTrack] >= 0`:

```cpp
edm::Ptr<Trackster> tracksterPtr;
if (tracksterId >= 0) { tracksterPtr = ...; }
TICLCandidate muonCandidate(trackPtr, tracksterPtr);
```

so a muon track with no associated MIP trackster constructs a track-only candidate. `TICLCandidateValidator` then reads `idProbabilities()` to fill the candidate-type histogram.

**2. `GeneralInterpretationAlgo`: phi is not wrapped when measuring track to trackster separation**

`findTrackstersInWindow` subtracts the two phi values directly:

```cpp
auto sep2 = (eta_i - seed_eta) * (eta_i - seed_eta) + (phi_i - seed_phi) * (phi_i - seed_phi);
```

Across the +-pi seam two objects 0.01 rad apart give a separation of about 6.28 and fail the `delta_tk_ts_layer1` / `delta_tk_ts_interface` windows (0.02 and 0.03), so a track and its trackster are not linked there. Fixed with `reco::deltaPhi`.

Measured on a TTbar PU200 sample (Run4D122, 20 events, same input both legs): 39947 to 39950 final tracksters, consistent with the roughly 1 percent of the phi range those windows span.

Both changes compile cleanly. The first is a correctness fix with no intended change in behaviour where the members were already assigned; the second changes results only for track-trackster pairs straddling the phi seam.
