### PR TITLE
TICLGeom: do not schedule the @alpaka geometry ES producers in FastSim

### DIFF
--- a/RecoHGCal/TICL/python/TICLGeom_cff.py
+++ b/RecoHGCal/TICL/python/TICLGeom_cff.py
@@ -59,19 +59,10 @@ ticlGeomWithBarrelLookupESProducer = ticlGeomLookupESProducer.clone(
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
 phase2_hfnose.toModify(ticlGeomESProducer, detectors = ['HGCal', 'HFNose'])
 
-# These are @alpaka EventSetup producers, so they can only be scheduled in a
-# process that has the Alpaka backends loaded. Attach them only under the
-# phase2_hgcal era (which always sets up Alpaka), so they never leak into
-# FastSim, Run 2 or Run 3 processes that load the HGCal local reco cff.
-from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-
-
-def _addTICLGeomToReco(process):
-    process.ticlGeomESProducer = ticlGeomESProducer
-    process.ticlGeomLookupESProducer = ticlGeomLookupESProducer
-    process.ticlGeomLayersESProducer = ticlGeomLayersESProducer
-    process.ticlGeomWithBarrelESProducer = ticlGeomWithBarrelESProducer
-    process.ticlGeomWithBarrelLookupESProducer = ticlGeomWithBarrelLookupESProducer
-
-
-addTICLGeomToReco = phase2_hgcal.makeProcessModifier(_addTICLGeomToReco)
+# These are @alpaka EventSetup producers, so they must only reach a process that
+# loads the Alpaka accelerator. RecoLocalCalo/Configuration/hgcalLocalReco_cff
+# adds them to the HGCal reco Task, so their EventSetup modules are instantiated
+# only when that Task is scheduled, i.e. when HGCal local reco actually runs
+# (which is where the accelerator is present). Processes that only load the reco
+# sequence without scheduling it, such as FastSim or the tracker geometry dumps,
+# never instantiate them.

--- a/RecoLocalCalo/Configuration/python/hgcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hgcalLocalReco_cff.py
@@ -5,10 +5,14 @@ from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import *
 
 from RecoLocalCalo.HGCalRecProducers.recHitMapProducer_cff import recHitMapProducer
 
-# TICLGeom SoA geometry EventSetup producers (RecHitTools replacement); the
-# import registers a phase2_hgcal process modifier that attaches the @alpaka
-# producers, so they reach only Phase2 processes, never FastSim or Run 2/3
-from RecoHGCal.TICL.TICLGeom_cff import addTICLGeomToReco
+# TICLGeom SoA geometry EventSetup producers (RecHitTools replacement), added to
+# the HGCal reco Task so the @alpaka producers are instantiated only when the
+# Task is scheduled, never in FastSim or bare reco-loading configs
+from RecoHGCal.TICL.TICLGeom_cff import (ticlGeomESProducer,
+                                         ticlGeomLookupESProducer,
+                                         ticlGeomLayersESProducer,
+                                         ticlGeomWithBarrelESProducer,
+                                         ticlGeomWithBarrelLookupESProducer)
 
 # patch particle flow clusters for HGC into local reco sequence
 # (for now until global reco is going with some sort of clustering)
@@ -24,7 +28,12 @@ hgcalLocalRecoTask = cms.Task( HGCalUncalibRecHit,
                                        hgcalLayerClustersHSci,
                                        hgcalMergeLayerClusters,
                                        particleFlowRecHitHGC,
-                                       particleFlowClusterHGCal )
+                                       particleFlowClusterHGCal,
+                                       ticlGeomESProducer,
+                                       ticlGeomLookupESProducer,
+                                       ticlGeomLayersESProducer,
+                                       ticlGeomWithBarrelESProducer,
+                                       ticlGeomWithBarrelLookupESProducer )
 
 _hfnose_hgcalLocalRecoTask = hgcalLocalRecoTask.copy()
 _hfnose_hgcalLocalRecoTask.add(hgcalLayerClustersHFNose)


### PR DESCRIPTION
Phase2 FastSim is a `phase2_hgcal` process that loads no Alpaka backend and runs no HGCal reco, so scheduling the `@alpaka` TICLGeom EventSetup producers made the EventProcessor fail to find the plugin at construction. 