### PR TITLE
Keep the HGCal e/gamma and tau ID host helpers on RecHitTools

### DIFF
--- a/RecoEgamma/EgammaTools/interface/EgammaPCAHelper.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaPCAHelper.h
@@ -20,7 +20,7 @@
 #include "RecoEgamma/EgammaTools/interface/Spot.h"
 #include "RecoEgamma/EgammaTools/interface/LongDeps.h"
 #include "RecoEgamma/EgammaTools/interface/ShowerDepth.h"
-#include "RecoLocalCalo/HGCalRecAlgos/interface/TICLGeomTools.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 #include "Math/Transform3D.h"
 #include <unordered_map>
 
@@ -46,7 +46,7 @@ namespace hgcal {
     void setHitMap(const std::unordered_map<DetId, const unsigned int> *hitMap);
     const std::unordered_map<DetId, const unsigned int> *getHitMap() { return hitMap_; }
 
-    void setRecHitTools(const ticlgeom::Tools *recHitTools);
+    void setRecHitTools(const hgcal::RecHitTools *recHitTools);
     void setRecHits(edm::Handle<HGCRecHitCollection> recHitHandleEE,
                     edm::Handle<HGCRecHitCollection> recHitHandleFH,
                     edm::Handle<HGCRecHitCollection> recHitHandleBH);
@@ -102,7 +102,7 @@ namespace hgcal {
 
     // helper
     std::unique_ptr<TPrincipal> pca_;
-    const ticlgeom::Tools *recHitTools_;
+    const hgcal::RecHitTools *recHitTools_;
     ShowerDepth showerDepth_;
 
     std::vector<const HGCRecHit *> hits_;

--- a/RecoEgamma/EgammaTools/interface/HGCalEgammaIDHelper.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalEgammaIDHelper.h
@@ -25,7 +25,6 @@
 
 #include "RecoEgamma/EgammaTools/interface/EgammaPCAHelper.h"
 #include "RecoEgamma/EgammaTools/interface/LongDeps.h"
-#include "RecoLocalCalo/HGCalRecAlgos/interface/TICLGeomTools.h"
 #include <vector>
 #include "HGCalIsoCalculator.h"
 
@@ -82,10 +81,8 @@ private:
   edm::EDGetTokenT<HGCRecHitCollection> recHitsFH_;
   edm::EDGetTokenT<HGCRecHitCollection> recHitsBH_;
   edm::EDGetTokenT<std::unordered_map<DetId, const unsigned int>> hitMap_;
-  edm::ESGetToken<TICLGeomHost, CaloGeometryRecord> ticlGeomToken_;
-  edm::ESGetToken<TICLGeomLookupHost, CaloGeometryRecord> ticlGeomLookupToken_;
-  edm::ESGetToken<TICLGeomLayersHost, CaloGeometryRecord> ticlGeomLayersToken_;
-  ticlgeom::Tools recHitTools_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometry_;
+  hgcal::RecHitTools recHitTools_;
   bool debug_;
 };
 

--- a/RecoEgamma/EgammaTools/interface/HGCalIsoCalculator.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalIsoCalculator.h
@@ -9,7 +9,7 @@
 #define RecoEgamma_EgammaTools_HGCalIsoCalculator_h
 
 #include "DataFormats/HGCRecHit/interface/HGCRecHitCollections.h"
-#include "RecoLocalCalo/HGCalRecAlgos/interface/TICLGeomTools.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
 
@@ -54,7 +54,7 @@ public:
 
   void setMinDeltaR(const float dr) { mindr2_ = dr * dr; }
 
-  void setRecHitTools(const ticlgeom::Tools* recHitTools) { rechittools_ = recHitTools; }
+  void setRecHitTools(const hgcal::RecHitTools* recHitTools) { rechittools_ = recHitTools; }
 
   void setNRings(const size_t nrings);
 
@@ -75,7 +75,7 @@ private:
 
   float dr2_, mindr2_;
 
-  const ticlgeom::Tools* rechittools_;
+  const hgcal::RecHitTools* rechittools_;
   edm::Handle<HGCRecHitCollection> recHitsEE_;
   edm::Handle<HGCRecHitCollection> recHitsFH_;
   edm::Handle<HGCRecHitCollection> recHitsBH_;

--- a/RecoEgamma/EgammaTools/python/slimmedEgammaHGC_cff.py
+++ b/RecoEgamma/EgammaTools/python/slimmedEgammaHGC_cff.py
@@ -5,6 +5,12 @@ from RecoEgamma.EgammaTools.hgcalElectronIDValueMap_cff import hgcalElectronIDVa
 from PhysicsTools.PatAlgos.PATElectronProducer_cfi import PATElectronProducer
 from PhysicsTools.PatAlgos.slimming.slimmedElectrons_cfi import slimmedElectrons
 from RecoLocalCalo.HGCalRecProducers.recHitMapProducer_cff import recHitMapProducer
+# TICLGeom SoA geometry EventSetup producers consumed by the HGCal electron and
+# photon ID (HGCalEgammaIDHelper); added to the task below so they are present
+# when this slimming runs in a standalone PAT job, not only when RECO is scheduled
+from RecoHGCal.TICL.TICLGeom_cff import (ticlGeomESProducer,
+                                         ticlGeomLookupESProducer,
+                                         ticlGeomLayersESProducer)
 
 hgcElectronID = hgcalElectronIDValueMap.clone(
     electrons = "cleanedEcalDrivenGsfElectronsHGC",
@@ -113,5 +119,8 @@ slimmedPhotonsHGCTask = cms.Task(
 slimmedEgammaHGCTask = cms.Task(
     recHitMapProducer,
     slimmedElectronsHGCTask,
-    slimmedPhotonsHGCTask
+    slimmedPhotonsHGCTask,
+    ticlGeomESProducer,
+    ticlGeomLookupESProducer,
+    ticlGeomLayersESProducer
 )

--- a/RecoEgamma/EgammaTools/src/EgammaPCAHelper.cc
+++ b/RecoEgamma/EgammaTools/src/EgammaPCAHelper.cc
@@ -45,7 +45,7 @@ void EGammaPCAHelper::setRecHits(edm::Handle<HGCRecHitCollection> recHitHandleEE
   }
 }
 
-void EGammaPCAHelper::setRecHitTools(const ticlgeom::Tools* recHitTools) {
+void EGammaPCAHelper::setRecHitTools(const hgcal::RecHitTools* recHitTools) {
   recHitTools_ = recHitTools;
   maxlayer_ = recHitTools_->lastLayerBH();
 }

--- a/RecoEgamma/EgammaTools/src/HGCalEgammaIDHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalEgammaIDHelper.cc
@@ -16,9 +16,7 @@ HGCalEgammaIDHelper::HGCalEgammaIDHelper(const edm::ParameterSet& iConfig, edm::
   recHitsFH_ = iC.consumes<HGCRecHitCollection>(fhRecHitInputTag_);
   recHitsBH_ = iC.consumes<HGCRecHitCollection>(bhRecHitInputTag_);
   hitMap_ = iC.consumes<std::unordered_map<DetId, const unsigned int>>(hitMapInputTag_);
-  ticlGeomToken_ = iC.esConsumes(edm::ESInputTag("", ""));
-  ticlGeomLookupToken_ = iC.esConsumes(edm::ESInputTag("", ""));
-  ticlGeomLayersToken_ = iC.esConsumes(edm::ESInputTag("", ""));
+  caloGeometry_ = iC.esConsumes();
   pcaHelper_.setdEdXWeights(dEdXWeights_);
   debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
 }
@@ -28,8 +26,7 @@ void HGCalEgammaIDHelper::eventInit(const edm::Event& iEvent, const edm::EventSe
   auto recHitHandleFH = iEvent.getHandle(recHitsFH_);
   auto recHitHandleBH = iEvent.getHandle(recHitsBH_);
 
-  recHitTools_.setGeometry(
-      iSetup.getData(ticlGeomToken_), iSetup.getData(ticlGeomLookupToken_), iSetup.getData(ticlGeomLayersToken_));
+  recHitTools_.setGeometry(iSetup.getData(caloGeometry_));
   pcaHelper_.setRecHitTools(&recHitTools_);
   isoHelper_.setRecHitTools(&recHitTools_);
   pcaHelper_.setHitMap(&iEvent.get(hitMap_));

--- a/RecoTauTag/RecoTau/BuildFile.xml
+++ b/RecoTauTag/RecoTau/BuildFile.xml
@@ -23,7 +23,6 @@
 <use name="PhysicsTools/JetMCUtils"/>
 <use name="CommonTools/Utils"/>
 <use name="CommonTools/BaseParticlePropagator"/>
-<use name="CondFormats/HGCalObjects"/>
 <use name="RecoLocalCalo/HGCalRecAlgos"/>
 <use name="roottmva"/>
 <use name="PhysicsTools/TensorFlow"/>

--- a/RecoTauTag/RecoTau/interface/PositionAtECalEntranceComputer.h
+++ b/RecoTauTag/RecoTau/interface/PositionAtECalEntranceComputer.h
@@ -17,7 +17,7 @@
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
-#include "RecoLocalCalo/HGCalRecAlgos/interface/TICLGeomTools.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
 class MagneticField;
 class IdealMagneticFieldRecord;
@@ -35,12 +35,10 @@ public:
 
 private:
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> bField_esToken_;
-  edm::ESGetToken<TICLGeomHost, CaloGeometryRecord> ticlGeom_esToken_;
-  edm::ESGetToken<TICLGeomLookupHost, CaloGeometryRecord> ticlGeomLookup_esToken_;
-  edm::ESGetToken<TICLGeomLayersHost, CaloGeometryRecord> ticlGeomLayers_esToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeo_esToken_;
   double bField_z_;
   bool isPhase2_;
-  ticlgeom::Tools recHitTools_;
+  hgcal::RecHitTools recHitTools_;
   float hgcalFace_z_;
   static constexpr float ecalBarrelEndcapEtaBorder_ = 1.479;
   static constexpr float hgcalHfEtaBorder_ = 3.0;

--- a/RecoTauTag/RecoTau/src/PositionAtECalEntranceComputer.cc
+++ b/RecoTauTag/RecoTau/src/PositionAtECalEntranceComputer.cc
@@ -9,26 +9,23 @@
 #include <cassert>
 
 PositionAtECalEntranceComputer::PositionAtECalEntranceComputer(edm::ConsumesCollector&& cc, bool isPhase2)
-    : PositionAtECalEntranceComputer(cc, isPhase2) {}
+    : bField_esToken_(cc.esConsumes<MagneticField, IdealMagneticFieldRecord>()),
+      caloGeo_esToken_(cc.esConsumes<CaloGeometry, CaloGeometryRecord>()),
+      bField_z_(-1.),
+      isPhase2_(isPhase2) {}
 
 PositionAtECalEntranceComputer::PositionAtECalEntranceComputer(edm::ConsumesCollector& cc, bool isPhase2)
-    : bField_esToken_(cc.esConsumes<MagneticField, IdealMagneticFieldRecord>()), bField_z_(-1.), isPhase2_(isPhase2) {
-  // the TICLGeom products exist only in Phase2, and only the Phase2 branch of
-  // beginEvent reads them, so consume them only there
-  if (isPhase2_) {
-    ticlGeom_esToken_ = cc.esConsumes(edm::ESInputTag("", ""));
-    ticlGeomLookup_esToken_ = cc.esConsumes(edm::ESInputTag("", ""));
-    ticlGeomLayers_esToken_ = cc.esConsumes(edm::ESInputTag("", ""));
-  }
-}
+    : bField_esToken_(cc.esConsumes<MagneticField, IdealMagneticFieldRecord>()),
+      caloGeo_esToken_(cc.esConsumes<CaloGeometry, CaloGeometryRecord>()),
+      bField_z_(-1.),
+      isPhase2_(isPhase2) {}
 
 PositionAtECalEntranceComputer::~PositionAtECalEntranceComputer() {}
 
 void PositionAtECalEntranceComputer::beginEvent(const edm::EventSetup& es) {
   bField_z_ = es.getData(bField_esToken_).inTesla(GlobalPoint(0., 0., 0.)).z();
   if (isPhase2_) {
-    recHitTools_.setGeometry(
-        es.getData(ticlGeom_esToken_), es.getData(ticlGeomLookup_esToken_), es.getData(ticlGeomLayers_esToken_));
+    recHitTools_.setGeometry(es.getData(caloGeo_esToken_));
     hgcalFace_z_ = recHitTools_.getPositionLayer(1).z();  // HGCal 1st layer
   }
 }


### PR DESCRIPTION
Follow-up to #51563 (RecHitTools -> ticlgeom::Tools migration).

The HGCal electron/photon ID (`HGCalEgammaIDHelper`, with `EgammaPCAHelper` and `HGCalIsoCalculator`) and the Phase-2 tau anti-electron discriminator (`PositionAtECalEntranceComputer`, `isPhase2=true`) also run in the miniAOD/PAT step. When PAT runs as its own job, e.g. the ProdLike workflows (RECO and PAT are separate `cmsRun` jobs), that process does not load the Alpaka accelerator, so consuming the `@alpaka` TICLGeom EventSetup products there fails at runtime. 

These are host-only, low-volume helpers (a handful of e/gamma/tau objects per event), so the SoA facade brings them nothing. This PR reverts them to `hgcal::RecHitTools`, which depends only on `CaloGeometry` and needs no accelerator, removing the dependency from every non-RECO step. The `ticlgeom::Tools` facade is kept in the hot RECO and device consumers where it pays off, and in `HGCalShowerShapeHelper`, which runs only in RECO and HLT (accelerator always present).
