### PR TITLE
Run 3 HBHE bad digi event filter

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
@@ -10,6 +10,7 @@ from RecoMET.METFilters.metFilters_cff import chargedHadronTrackResolutionFilter
 from RecoMET.METFilters.metFilters_cff import BadChargedCandidateFilter, BadPFMuonFilter, BadPFMuonDzFilter #2016 post-ICHEPversion
 from RecoMET.METFilters.metFilters_cff import BadChargedCandidateSummer16Filter, BadPFMuonSummer16Filter #2016 ICHEP version
 from RecoMET.METFilters.metFilters_cff import hfNoisyHitsFilter
+from RecoMET.METFilters.metFilters_cff import hcalBadDigiFilter
 
 # individual filters
 Flag_HBHENoiseFilter = cms.Path(HBHENoiseFilterResultProducer * HBHENoiseFilter)
@@ -37,6 +38,7 @@ Flag_BadChargedCandidateSummer16Filter = cms.Path(BadChargedCandidateSummer16Fil
 Flag_BadPFMuonSummer16Filter = cms.Path(BadPFMuonSummer16Filter)
 Flag_BadPFMuonDzFilter  = cms.Path(BadPFMuonDzFilter)
 Flag_hfNoisyHitsFilter  = cms.Path(hfNoisyHitsFilter)
+Flag_hcalBadDigiFilter  = cms.Path(hcalBadDigiFilter)
 
 # and the sub-filters
 Flag_trkPOG_manystripclus53X = cms.Path(~manystripclus53X)
@@ -103,6 +105,7 @@ metFilterPathsTask = cms.Task(
     BadPFMuonFilter,
     BadPFMuonDzFilter,
     hfNoisyHitsFilter,
+    hcalBadDigiFilter,
     BadChargedCandidateSummer16Filter,
     BadPFMuonSummer16Filter
 )

--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalRecAlgoESProducer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalRecAlgoESProducer.cc
@@ -141,11 +141,7 @@ void HcalRecAlgoESProducer::fillDescriptions(edm::ConfigurationDescriptions& des
                                                     "HSCP_ExpFit",
                                                     "ADCSaturationBit",
                                                     "HBHEIsolatedNoise",
-                                                    "AddedSimHcalNoise",
-                                                    "HBHERun3StuckADC",
-                                                    "HBHERun3repeatedADCblock",
-                                                    "HBHERun3BadCapId",
-                                                    "HBHERun3NonrotatingCapId"});
+                                                    "AddedSimHcalNoise"});
       temp2.addParameter<std::vector<std::string>>("ChannelStatus",
                                                    {
                                                        "HcalCellExcludeFromHBHENoiseSummary",
@@ -209,10 +205,9 @@ void HcalRecAlgoESProducer::fillDescriptions(edm::ConfigurationDescriptions& des
     }
     {
       edm::ParameterSet temp2;
-      temp2.addParameter<std::vector<std::string>>("RecHitFlags",
-                                                   {
-                                                       "",
-                                                   });
+      temp2.addParameter<std::vector<std::string>>(
+          "RecHitFlags",
+          {"HBHERun3StuckADC", "HBHERun3repeatedADCblock", "HBHERun3BadCapId", "HBHERun3NonrotatingCapId"});
       temp2.addParameter<std::vector<std::string>>("ChannelStatus",
                                                    {
                                                        "HcalCellHot",

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -32,11 +32,7 @@ run2_HCAL_2017.toModify(hcalRecAlgos,
     phase = 1,
     SeverityLevels = {
         2 : dict( RecHitFlags = ['HBHEIsolatedNoise',
-                                 'HFAnomalousHit',
-                                 'HBHERun3StuckADC',
-                                 'HBHERun3repeatedADCblock',
-                                 'HBHERun3BadCapId',
-                                 'HBHERun3NonrotatingCapId']
+                                 'HFAnomalousHit']
             ),
         3 : dict( RecHitFlags = ['HBHEHpdHitMultiplicity',  
                                  'HBHEFlatNoise', 
@@ -49,6 +45,11 @@ run2_HCAL_2017.toModify(hcalRecAlgos,
                                  'HFS8S1Ratio',  
                                  'HFPET', 
                                  'HFSignalAsymmetry']
+            ),
+        6 : dict( RecHitFlags = ['HBHERun3StuckADC',
+                                 'HBHERun3repeatedADCblock',
+                                 'HBHERun3BadCapId',
+                                 'HBHERun3NonrotatingCapId']
             ),
     },
     RecoveredRecHitBits = ['']

--- a/RecoMET/METFilters/plugins/BuildFile.xml
+++ b/RecoMET/METFilters/plugins/BuildFile.xml
@@ -15,6 +15,7 @@
   <use name="CondFormats/DataRecord"/>
   <use name="DataFormats/HcalRecHit"/>
   <use name="RecoJets/JetProducers"/>
+  <use name="RecoLocalCalo/HcalRecAlgos"/>
   <use name="root"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoMET/METFilters/plugins/HcalBadDigiFilter.cc
+++ b/RecoMET/METFilters/plugins/HcalBadDigiFilter.cc
@@ -1,0 +1,233 @@
+// -*- C++ -*-
+//
+// Package:    RecoMET/METFilters
+// Class:      HcalBadDigiFilter
+//
+/**\class HcalBadDigiFilter HcalBadDigiFilter.cc RecoMET/METFilters/plugins/HcalBadDigiFilter.cc
+
+ Description: Set/unset event flags depending on quality of HBHE digis and recHits.
+ Mainly needed for >=Run 3.
+ More info in https://gitlab.cern.ch/cmshcal/docs/-/work_items/315#note_11812610
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Vinay Hegde
+//         Created:  Thu, 02 Jul 2026 14:23:11 GMT
+//
+//
+
+// system include files
+#include <memory>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include "DataFormats/HcalDigi/interface/HcalUnpackerReport.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/METReco/interface/HcalPhase1FlagLabels.h"
+
+#include "CondFormats/HcalObjects/interface/HcalChannelStatus.h"
+
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelProperties.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalChannelPropertiesRecord.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+//
+// class declaration
+//
+
+using namespace edm;
+using namespace std;
+
+class HcalBadDigiFilter : public edm::stream::EDFilter<> {
+public:
+  explicit HcalBadDigiFilter(const edm::ParameterSet&);
+  bool clusteredChannels(const std::vector<DetId> detIds);
+  bool isBadRecHit(const uint32_t r_flag, const double r_energy);
+  vector<uint32_t> getFlagBits(vector<string>);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  EDGetTokenT<HcalUnpackerReport> unpackerReportLabel_;
+  EDGetTokenT<HBHERecHitCollection> hbheRecHitsLabel_;
+  ESGetToken<HcalTopology, HcalRecNumberingRecord> htopoToken_;
+  ESGetToken<HcalChannelPropertiesVec, HcalChannelPropertiesRecord> propertiesToken_;
+
+  const uint32_t maxBadChannels_;
+  const vector<string> listOfFlags_;
+  const vector<double> minRecHitEnergies_;
+  const bool useBadChannelsTopology_;
+  const bool debug_;
+  const vector<uint32_t> listOfFlagBits_;
+
+  Handle<HcalUnpackerReport> unpackerReportHandle_;
+  Handle<HBHERecHitCollection> hbheRecHitsHandle_;
+};
+
+HcalBadDigiFilter::HcalBadDigiFilter(const edm::ParameterSet& iConfig)
+    : unpackerReportLabel_(consumes<HcalUnpackerReport>(iConfig.getParameter<edm::InputTag>("unpackerReportLabel"))),
+      hbheRecHitsLabel_(consumes<HBHERecHitCollection>(iConfig.getParameter<edm::InputTag>("hbheRecHitsLabel"))),
+      htopoToken_(esConsumes<HcalTopology, HcalRecNumberingRecord>()),
+      propertiesToken_(esConsumes<HcalChannelPropertiesVec, HcalChannelPropertiesRecord>()),
+      maxBadChannels_(iConfig.getParameter<uint32_t>("maxBadChannels")),
+      listOfFlags_(iConfig.getParameter<std::vector<std::string>>("listOfFlags")),
+      minRecHitEnergies_(iConfig.getParameter<std::vector<double>>("minRecHitEnergies")),
+      useBadChannelsTopology_(iConfig.getParameter<bool>("useBadChannelsTopology")),
+      debug_(iConfig.getParameter<bool>("debug")),
+      listOfFlagBits_(getFlagBits(listOfFlags_)) {
+  if (listOfFlagBits_.size() != minRecHitEnergies_.size()) {
+    throw cms::Exception("Error") << "Length of minRecHitEnergies = " << minRecHitEnergies_.size()
+                                  << ", length of flags = " << listOfFlagBits_.size()
+                                  << ". These two should be the same.";
+  }
+}
+
+// ------------ method called on each new Event  ------------
+bool HcalBadDigiFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  iEvent.getByToken(unpackerReportLabel_, unpackerReportHandle_);
+  iEvent.getByToken(hbheRecHitsLabel_, hbheRecHitsHandle_);
+
+  set<DetId> detId_badChn;
+  int nBadChn_recHit = 0, nBadChn_unpacker = 0;
+  //first check recHit flags and collected bad channels list
+  const HBHERecHitCollection* HBHERecHits;
+  if (hbheRecHitsHandle_.isValid()) {
+    HBHERecHits = hbheRecHitsHandle_.product();
+    for (HBHERecHitCollection::const_iterator hbherechit = HBHERecHits->begin(); hbherechit != HBHERecHits->end();
+         hbherechit++) {
+      uint32_t r_flag = hbherechit->flags();
+      double r_energy = hbherechit->energy();
+      if (isBadRecHit(r_flag, r_energy)) {
+        const DetId id = hbherechit->detid();
+        detId_badChn.insert(id);
+        nBadChn_recHit++;
+      }
+    }
+  }
+  //now check unpacker report
+  if (unpackerReportHandle_.isValid()) {
+    for (vector<DetId>::const_iterator it = unpackerReportHandle_->bad_quality_begin();
+         it != unpackerReportHandle_->bad_quality_end();
+         ++it) {
+      detId_badChn.insert(it->rawId());
+      nBadChn_unpacker++;
+    }
+  }
+
+  if (detId_badChn.empty())
+    return true;  // for most events, this is the case.
+
+  //ignore channels that are already known as bad in DB, if they exist in detId_badChn list
+  const HcalTopology& htopo = iSetup.getData(htopoToken_);
+  const HcalChannelPropertiesVec& prop = iSetup.getData(propertiesToken_);
+  vector<DetId> detId_badChnupdated;
+  for (const auto& it : detId_badChn) {
+    const HcalDetId cell = HcalDetId(it);
+    const HcalSubdetector subdet = cell.subdet();
+    if (!(subdet == HcalSubdetector::HcalBarrel || subdet == HcalSubdetector::HcalEndcap))
+      continue;
+    const HcalChannelProperties& properties = prop.at(htopo.detId2denseId(cell));
+    if (properties.taggedBadByDb) {
+      continue;
+    }
+    detId_badChnupdated.push_back(it);
+  }
+
+  if (!detId_badChnupdated.empty() && debug_)
+    edm::LogInfo("HcalBadDigiFilter") << " nBad from unpacker:" << nBadChn_unpacker
+                                      << " nBad from recHits:" << nBadChn_recHit
+                                      << " nBad after DB check:" << detId_badChnupdated.size() << endl;
+
+  //decide whether to keep the event or not
+  if (detId_badChnupdated.size() > maxBadChannels_)
+    return false;
+  else if (useBadChannelsTopology_ && clusteredChannels(detId_badChnupdated))
+    return false;
+
+  return true;
+}
+
+// check if required flags are set
+bool HcalBadDigiFilter::isBadRecHit(const uint32_t r_flag, const double r_energy) {
+  for (size_t i = 0; i < listOfFlagBits_.size(); i++) {
+    if (((r_flag >> listOfFlagBits_[i]) & 1) && (r_energy > minRecHitEnergies_[i]))
+      return true;
+  }
+  return false;
+}
+
+vector<uint32_t> HcalBadDigiFilter::getFlagBits(vector<string> flagNames) {
+  vector<uint32_t> flagBits;
+  for (const auto& name : flagNames) {
+    if (name == "HBHERun3BadCapId")
+      flagBits.push_back(HcalPhase1FlagLabels::HBHERun3BadCapId);
+    else if (name == "HBHERun3NonrotatingCapId")
+      flagBits.push_back(HcalPhase1FlagLabels::HBHERun3NonrotatingCapId);
+    else if (name == "HBHERun3StuckADC")
+      flagBits.push_back(HcalPhase1FlagLabels::HBHERun3StuckADC);
+    else if (name == "HBHERun3repeatedADCblock")
+      flagBits.push_back(HcalPhase1FlagLabels::HBHERun3repeatedADCblock);
+    else
+      throw cms::Exception("Error") << "Couldn't find the bit index associated to this string: " << name;
+  }
+  return flagBits;
+}
+//Find how many channel are neighbors. If nNeighbors is > half of bad channels, they are considered as clustered
+bool HcalBadDigiFilter::clusteredChannels(const std::vector<DetId> detIds) {
+  uint32_t nNeighbors = 0;
+  const std::size_t nCells = detIds.size();
+  for (size_t i = 0; i < nCells; i++) {
+    HcalDetId hid = HcalDetId(detIds[i]);
+    const int ieta = hid.ieta();
+    const int iphi = hid.iphi();
+    const int idepth = hid.depth();
+
+    for (size_t j = i + 1; j < nCells; j++) {
+      HcalDetId hid2 = HcalDetId(detIds[j]);
+      if (hid == hid2)
+        continue;
+
+      const int jeta = hid2.ieta();
+      const int jphi = hid2.iphi();
+      const int jdepth = hid2.depth();
+      //usually bad channels come in alternate depths. So, use up to next-to-next neighbors in depth
+      if ((abs(ieta - jeta) <= 1) && (abs(iphi - jphi) <= 1) && (abs(idepth - jdepth) <= 2)) {
+        nNeighbors++;
+      }
+      if (nNeighbors > nCells / 2)
+        return true;
+    }
+  }
+  return false;
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void HcalBadDigiFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  desc.add<InputTag>("hbheRecHitsLabel", edm::InputTag("hbhereco"));
+  desc.add<InputTag>("unpackerReportLabel", edm::InputTag("hcalDigis"));
+  desc.add<bool>("debug", false);
+  desc.add<vector<string>>(
+      "listOfFlags", {"HBHERun3BadCapId", "HBHERun3NonrotatingCapId", "HBHERun3StuckADC", "HBHERun3repeatedADCblock"});
+  desc.add<vector<double>>("minRecHitEnergies", {-100., -100., 10., 10.});
+  desc.add<uint32_t>("maxBadChannels", 5);
+  desc.add<bool>("useBadChannelsTopology", false);
+  descriptions.addDefault(desc);
+}
+//define this as a plug-in
+DEFINE_FWK_MODULE(HcalBadDigiFilter);

--- a/RecoMET/METFilters/python/hcalBadDigiFilter_cfi.py
+++ b/RecoMET/METFilters/python/hcalBadDigiFilter_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+hcalBadDigiFilter = cms.EDFilter("HcalBadDigiFilter",
+                                unpackerReportLabel  = cms.InputTag("hcalDigis"),
+                                hbheRecHitsLabel = cms.InputTag("hbhereco"),
+                                debug = cms.bool(False),
+                                listOfFlags = cms.vstring('HBHERun3BadCapId',
+                                                          'HBHERun3NonrotatingCapId',
+                                                          'HBHERun3StuckADC',
+                                                          'HBHERun3repeatedADCblock',),
+                                minRecHitEnergies = cms.vdouble(-100., -100., 10., 10.), # in the same order as listOfFlags. < 0 means no cut
+                                maxBadChannels = cms.uint32(5),
+                                useBadChannelsTopology = cms.bool(False)
+)

--- a/RecoMET/METFilters/python/metFilters_cff.py
+++ b/RecoMET/METFilters/python/metFilters_cff.py
@@ -93,3 +93,6 @@ from RecoMET.METFilters.BadPFMuonDzFilter_cfi import *
 
 #HF noise filter 
 from RecoMET.METFilters.hfNoisyHitsFilter_cfi import *
+
+## Hcal Digi filters, for HBHE
+from RecoMET.METFilters.hcalBadDigiFilter_cfi import *


### PR DESCRIPTION
This PR is related to HCAL HBHE data in Run 3. It adds event flaggers if there are many channels in HCAL with bad RecHits or bad Digis. It also sets severity level to HCAL bad RecHits so that they are ingored in PF reconstruction. More details about the issues (Type A) can be found in https://gitlab.cern.ch/cmshcal/docs/-/work_items/315 (private HCAL repo) and [this talk](https://indico.cern.ch/event/1712463/contributions/7211448/attachments/3322716/5949294/Eventfilters2026D_HBHERun3_HcalDPG31Jul26.pdf).
Related PR for flagging RecHits: https://github.com/cms-sw/cmssw/pull/51094

Very high pT jets and high MET arising from HCAL noise is expected to be mitigated.

This PR aims at Run 3 re-reco and no immediate reason for back-porting or forward-porting.

 @abdoulline