### PR TITLE
RecoEgamma: drop the TICLGeom ES producers from the HGC egamma PAT task

### DIFF
--- a/RecoEgamma/EgammaTools/python/slimmedEgammaHGC_cff.py
+++ b/RecoEgamma/EgammaTools/python/slimmedEgammaHGC_cff.py
@@ -5,12 +5,6 @@ from RecoEgamma.EgammaTools.hgcalElectronIDValueMap_cff import hgcalElectronIDVa
 from PhysicsTools.PatAlgos.PATElectronProducer_cfi import PATElectronProducer
 from PhysicsTools.PatAlgos.slimming.slimmedElectrons_cfi import slimmedElectrons
 from RecoLocalCalo.HGCalRecProducers.recHitMapProducer_cff import recHitMapProducer
-# TICLGeom SoA geometry EventSetup producers consumed by the HGCal electron and
-# photon ID (HGCalEgammaIDHelper); added to the task below so they are present
-# when this slimming runs in a standalone PAT job, not only when RECO is scheduled
-from RecoHGCal.TICL.TICLGeom_cff import (ticlGeomESProducer,
-                                         ticlGeomLookupESProducer,
-                                         ticlGeomLayersESProducer)
 
 hgcElectronID = hgcalElectronIDValueMap.clone(
     electrons = "cleanedEcalDrivenGsfElectronsHGC",
@@ -119,8 +113,5 @@ slimmedPhotonsHGCTask = cms.Task(
 slimmedEgammaHGCTask = cms.Task(
     recHitMapProducer,
     slimmedElectronsHGCTask,
-    slimmedPhotonsHGCTask,
-    ticlGeomESProducer,
-    ticlGeomLookupESProducer,
-    ticlGeomLayersESProducer
+    slimmedPhotonsHGCTask
 )


### PR DESCRIPTION
### PR description

Removes a leftover scheduling that broke the standalone PAT step. The HGCal e/gamma and tau ID host helpers (`HGCalEgammaIDHelper`, `EgammaPCAHelper`, `HGCalIsoCalculator`, and the isPhase2 branch of `PositionAtECalEntranceComputer`) were reverted to `hgcal::RecHitTools`, which consumes only `CaloGeometry`, so the miniAOD/PAT step no longer consumes the `@alpaka` TICLGeom EventSetup products. A standalone `-s PAT` job (the ProdLike step4) loads no Alpaka accelerator, so these producers were force-constructed and failed at EventProcessor construction. 
This removes the now-dead producer scheduling from `slimmedEgammaHGCTask`. RECO keeps its own scheduling of these producers via `hgcalLocalRecoTask`, so the combined RECO+PAT workflow is unaffected.

### PR validation

Built against the failing IB (`CMSSW_20_1_MULTIARCHSV4_X_2026-08-10-2300`, el9). `edmConfigDump` of the ProdLike D127 PAT config now schedules zero `TICLGeom*ESProducer@alpaka`, `hgcElectronID` is still scheduled and resolves `CaloGeometry`, and the process has no `ProcessAcceleratorAlpaka` (confirming a bare PAT job cannot host an `@alpaka` producer).