### PR TITLE
Generalised Phase-2 GT filters, modelled after `HLTL1TSeed`

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltDoubleTkMuon157L1TkMuonFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltDoubleTkMuon157L1TkMuonFilter_cfi.py
@@ -1,5 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
-hltDoubleTkMuon157L1TkMuonFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pDoubleTkMuon15_7')
-)
+hltDoubleTkMuon157L1TkMuonFilter =  cms.EDFilter("HLTP2GTSingleObjectFilter",
+                                                 saveTags = cms.bool(True),
+                                                 l1GTAlgoBlockTag = cms.InputTag('l1tGTAlgoBlockProducer'),
+                                                 minN = cms.uint32(2),
+                                                 l1GTAlgos = cms.VPSet(
+                                                     cms.PSet(
+                                                         name = cms.string('pDoubleTkMuon15_7'),
+                                                         collection = cms.PSet(
+                                                             objectType = cms.string('GMTTkMuons'),
+                                                             minPt = cms.double(0),
+                                                             maxAbsEta = cms.double(9999.)
+                                                         )
+                                                     )
+                                                 ))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEGL1SeedsForDoubleEleIsolatedFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEGL1SeedsForDoubleEleIsolatedFilter_cfi.py
@@ -1,5 +1,64 @@
 import FWCore.ParameterSet.Config as cms
 
-hltEGL1SeedsForDoubleEleIsolatedFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pDoubleEGEle37_24 or pDoubleTkEle25_12 or pIsoTkEleEGEle22_12')
-)
+hltEGL1SeedsForDoubleEleIsolatedFilter = cms.EDFilter("HLTP2GTDoubleObjectFilter",
+                                                      l1GTAlgoBlockTag = cms.InputTag("l1tGTAlgoBlockProducer"),
+                                                      l1GTAlgos = cms.VPSet(
+                                                          cms.PSet(
+                                                              name = cms.string("pIsoTkEleEGEle22_12"),
+                                                              collection1 = cms.PSet(
+                                                                  objectType = cms.string("CL2Electrons"),
+                                                                  minPt      = cms.double(0.),
+                                                                  maxAbsEta  = cms.double(9999.),
+                                                              ),
+                                                              collection2 = cms.PSet(
+                                                                  objectType = cms.string("CL2Photons"),
+                                                                  minPt      = cms.double(0.),
+                                                                  maxAbsEta  = cms.double(9999.),
+                                                              ),
+                                                              minDR      = cms.double(0.0),
+                                                              maxDR      = cms.double(1e9),
+                                                              minDEta    = cms.double(-1.0),
+                                                              minDPhi    = cms.double(-1.0),
+                                                              minInvMass = cms.double(0.0),
+                                                              maxInvMass = cms.double(1e9),
+                                                          ),
+                                                          cms.PSet(
+                                                              name = cms.string("pDoubleEGEle37_24"),
+                                                              collection1 = cms.PSet(
+                                                                  objectType = cms.string("CL2Photons"),
+                                                                  minPt      = cms.double(0.),
+                                                                  maxAbsEta  = cms.double(9999.),
+                                                              ),
+                                                              collection2 = cms.PSet(
+                                                                  objectType = cms.string("CL2Photons"),
+                                                                  minPt      = cms.double(0.),
+                                                                  maxAbsEta  = cms.double(9999.),
+                                                              ),
+                                                              minDR      = cms.double(0.0),
+                                                              maxDR      = cms.double(1e9),
+                                                              minDEta    = cms.double(-1.0),
+                                                              minDPhi    = cms.double(-1.0),
+                                                              minInvMass = cms.double(0.0),
+                                                              maxInvMass = cms.double(1e9),
+                                                          ),
+                                                          cms.PSet(
+                                                              name = cms.string("pDoubleTkEle25_12"),
+                                                              collection1 = cms.PSet(
+                                                                  objectType = cms.string("CL2Electrons"),
+                                                                  minPt      = cms.double(0.),
+                                                                  maxAbsEta  = cms.double(9999.),
+                                                              ),
+                                                              collection2 = cms.PSet(
+                                                                  objectType = cms.string("CL2Electrons"),
+                                                                  minPt      = cms.double(0.),
+                                                                  maxAbsEta  = cms.double(9999.),
+                                                              ),
+                                                              minDR      = cms.double(0.0),
+                                                              maxDR      = cms.double(1e9),
+                                                              minDEta    = cms.double(-1.0),
+                                                              minDPhi    = cms.double(-1.0),
+                                                              minInvMass = cms.double(0.0),
+                                                              maxInvMass = cms.double(1e9),
+                                                          ),
+                                                      )
+                                                    )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEGL1SeedsForDoubleEleNonIsolatedFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEGL1SeedsForDoubleEleNonIsolatedFilter_cfi.py
@@ -1,5 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
-hltEGL1SeedsForDoubleEleNonIsolatedFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pDoubleEGEle37_24 or pDoubleTkEle25_12')
-)
+hltEGL1SeedsForDoubleEleNonIsolatedFilter =  cms.EDFilter("HLTP2GTSingleObjectFilter",
+                                                          saveTags = cms.bool(True),
+                                                          l1GTAlgoBlockTag = cms.InputTag('l1tGTAlgoBlockProducer'),
+                                                          minN = cms.uint32(2),
+                                                          l1GTAlgos = cms.VPSet(
+                                                              cms.PSet(
+                                                                  name = cms.string('pDoubleEGEle37_24'),
+                                                                  collection = cms.PSet(
+                                                                      objectType = cms.string('CL2Photons'),
+                                                                      minPt = cms.double(0),
+                                                                      maxAbsEta = cms.double(99999.)
+                                                                  )
+                                                              ),
+                                                              cms.PSet(
+                                                                  name = cms.string('pDoubleTkEle25_12'),
+                                                                  collection = cms.PSet(
+                                                                      objectType = cms.string('CL2Electrons'),
+                                                                      minPt = cms.double(0),
+                                                                      maxAbsEta = cms.double(99999.)
+                                                                  )
+                                                              )
+                                                          ))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEGL1SeedsForDoublePhotonIsolatedFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEGL1SeedsForDoublePhotonIsolatedFilter_cfi.py
@@ -1,5 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
-hltEGL1SeedsForDoublePhotonIsolatedFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pDoubleEGEle37_24 or pDoubleIsoTkPho22_12')
-)
+hltEGL1SeedsForDoublePhotonIsolatedFilter = cms.EDFilter("HLTP2GTSingleObjectFilter",
+                                                         saveTags = cms.bool(True),
+                                                         l1GTAlgoBlockTag = cms.InputTag('l1tGTAlgoBlockProducer'),
+                                                         minN = cms.uint32(2),
+                                                         l1GTAlgos = cms.VPSet(
+                                                             cms.PSet(
+                                                                 name = cms.string('pDoubleEGEle37_24'),
+                                                                 collection = cms.PSet(
+                                                                     objectType = cms.string('CL2Photons'),
+                                                                     minPt = cms.double(0),
+                                                                     maxAbsEta = cms.double(9999.)
+                                                                 )
+                                                             ),
+                                                             cms.PSet(
+                                                                 name = cms.string('pDoubleIsoTkPho22_12'),
+                                                                 collection = cms.PSet(
+                                                                     objectType = cms.string('CL2Photons'),
+                                                                     minPt = cms.double(0),
+                                                                     maxAbsEta = cms.double(9999.)
+                                                                 )
+                                                             ),
+                                                         ))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEGL1SeedsForSingleEleIsolatedFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEGL1SeedsForSingleEleIsolatedFilter_cfi.py
@@ -1,5 +1,32 @@
 import FWCore.ParameterSet.Config as cms
 
-hltEGL1SeedsForSingleEleIsolatedFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pSingleEGEle51 or pSingleTkEle36 or pSingleIsoTkEle28')
-)
+hltEGL1SeedsForSingleEleIsolatedFilter = cms.EDFilter("HLTP2GTSingleObjectFilter",
+                                                      saveTags = cms.bool(True),
+                                                      l1GTAlgoBlockTag = cms.InputTag('l1tGTAlgoBlockProducer'),
+                                                      minN = cms.uint32(1),
+                                                      l1GTAlgos = cms.VPSet(
+                                                          cms.PSet(
+                                                              name = cms.string('pSingleEGEle51'),
+                                                              collection = cms.PSet(
+                                                                  objectType = cms.string('CL2Photons'),
+                                                                  minPt = cms.double(0),
+                                                                  maxAbsEta = cms.double(9999.)
+                                                              )
+                                                          ),
+                                                          cms.PSet(
+                                                              name = cms.string('pSingleTkEle36'),
+                                                              collection = cms.PSet(
+                                                                  objectType = cms.string('CL2Electrons'),
+                                                                  minPt = cms.double(0),
+                                                                  maxAbsEta = cms.double(9999.)
+                                                              )
+                                                          ),
+                                                          cms.PSet(
+                                                              name = cms.string('pSingleIsoTkEle28'),
+                                                              collection = cms.PSet(
+                                                                  objectType = cms.string('CL2Electrons'),
+                                                                  minPt = cms.double(0),
+                                                                  maxAbsEta = cms.double(9999.)
+                                                              )
+                                                          )
+                                                      ))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEGL1SeedsForSingleEleNonIsolatedFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEGL1SeedsForSingleEleNonIsolatedFilter_cfi.py
@@ -1,5 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
-hltEGL1SeedsForSingleEleNonIsolatedFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pSingleEGEle51 or pSingleTkEle36')
-)
+hltEGL1SeedsForSingleEleNonIsolatedFilter = cms.EDFilter("HLTP2GTSingleObjectFilter",
+                                                         saveTags = cms.bool(True),
+                                                         l1GTAlgoBlockTag = cms.InputTag('l1tGTAlgoBlockProducer'),
+                                                         minN = cms.uint32(1),
+                                                         l1GTAlgos = cms.VPSet(
+                                                             cms.PSet(
+                                                                 name = cms.string('pSingleEGEle51'),
+                                                                 collection = cms.PSet(
+                                                                     objectType = cms.string('CL2Photons'),
+                                                                     minPt = cms.double(0),
+                                                                     maxAbsEta = cms.double(99999.)
+                                                                 )
+                                                             ),
+                                                             cms.PSet(
+                                                                 name = cms.string('pSingleTkEle36'),
+                                                                 collection = cms.PSet(
+                                                                     objectType = cms.string('CL2Electrons'),
+                                                                     minPt = cms.double(0),
+                                                                     maxAbsEta = cms.double(99999.)
+                                                                 )
+                                                             )
+                                                         ))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEGL1SeedsForSinglePhotonIsolatedFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEGL1SeedsForSinglePhotonIsolatedFilter_cfi.py
@@ -1,5 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
-hltEGL1SeedsForSinglePhotonIsolatedFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pSingleEGEle51 or pSingleIsoTkPho36')
-)
+hltEGL1SeedsForSinglePhotonIsolatedFilter = cms.EDFilter("HLTP2GTSingleObjectFilter",
+                                                         saveTags = cms.bool(True),
+                                                         l1GTAlgoBlockTag = cms.InputTag('l1tGTAlgoBlockProducer'),
+                                                         minN = cms.uint32(1),
+                                                         l1GTAlgos = cms.VPSet(
+                                                             cms.PSet(
+                                                                 name = cms.string('pSingleEGEle51'),
+                                                                 collection = cms.PSet(
+                                                                     objectType = cms.string('CL2Photons'),
+                                                                     minPt = cms.double(0),
+                                                                     maxAbsEta = cms.double(99999.)
+                                                                 )
+                                                             ),
+                                                             cms.PSet(
+                                                                 name = cms.string('pSingleIsoTkPho36'),
+                                                                 collection = cms.PSet(
+                                                                     objectType = cms.string('CL2Photons'),
+                                                                     minPt = cms.double(0),
+                                                                     maxAbsEta = cms.double(99999.)
+                                                                 )
+                                                             )
+                                                         ))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltL1SeedsForDoublePuppiJetBtagFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltL1SeedsForDoublePuppiJetBtagFilter_cfi.py
@@ -1,5 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
-hltL1SeedsForDoublePuppiJetBtagFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pDoublePuppiJet112_112')
-)
+hltL1SeedsForDoublePuppiJetBtagFilter = cms.EDFilter("HLTP2GTSingleObjectFilter",
+                                           saveTags = cms.bool(True),
+                                           l1GTAlgoBlockTag = cms.InputTag('l1tGTAlgoBlockProducer'),
+                                           minN = cms.uint32(2),
+                                           l1GTAlgos = cms.VPSet(
+                                               cms.PSet(
+                                                   name = cms.string('pDoublePuppiJet112_112'),
+                                                   collection = cms.PSet(
+                                                       objectType = cms.string('CL2JetsSC4'),
+                                                       minPt = cms.double(0),
+                                                       maxAbsEta = cms.double(9999.)
+                                                   )
+                                               )
+                                           ))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltL1SeedsForPuppiHTFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltL1SeedsForPuppiHTFilter_cfi.py
@@ -1,5 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
-hltL1SeedsForPuppiHTFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pPuppiHT450')
-)
+hltL1SeedsForPuppiHTFilter = cms.EDFilter("HLTP2GTSingleObjectFilter",
+                                          saveTags = cms.bool(True),
+                                          l1GTAlgoBlockTag = cms.InputTag('l1tGTAlgoBlockProducer'),
+                                          minN = cms.uint32(1),
+                                          l1GTAlgos = cms.VPSet(
+                                              cms.PSet(
+                                                  name = cms.string('pPuppiHT450'),
+                                                  collection = cms.PSet(
+                                                      objectType = cms.string('CL2HtSum'),
+                                                      minPt = cms.double(0),
+                                                      maxAbsEta = cms.double(9999.)
+                                                  )
+                                              )
+                                          ))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltL1SeedsForPuppiJetFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltL1SeedsForPuppiJetFilter_cfi.py
@@ -1,5 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
-hltL1SeedsForPuppiJetFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pSinglePuppiJet230')
-)
+hltL1SeedsForPuppiJetFilter = cms.EDFilter("HLTP2GTSingleObjectFilter",
+                                           saveTags = cms.bool(True),
+                                           l1GTAlgoBlockTag = cms.InputTag('l1tGTAlgoBlockProducer'),
+                                           minN = cms.uint32(1),
+                                           l1GTAlgos = cms.VPSet(
+                                               cms.PSet(
+                                                   name = cms.string('pSinglePuppiJet230'),
+                                                   collection = cms.PSet(
+                                                       objectType = cms.string('CL2JetsSC4'),
+                                                       minPt = cms.double(0),
+                                                       maxAbsEta = cms.double(2.4)
+                                                   )
+                                               )
+                                           ))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltL1SeedsForPuppiMETFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltL1SeedsForPuppiMETFilter_cfi.py
@@ -1,5 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
-hltL1SeedsForPuppiMETFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pPuppiMET200')
-)
+hltL1SeedsForPuppiMETFilter = cms.EDFilter("HLTP2GTSingleObjectFilter",
+                                           saveTags = cms.bool(True),
+                                           l1GTAlgoBlockTag = cms.InputTag('l1tGTAlgoBlockProducer'),
+                                           minN = cms.uint32(1),
+                                           l1GTAlgos = cms.VPSet(
+                                               cms.PSet(
+                                                   name = cms.string('pPuppiMET200'),
+                                                   collection = cms.PSet(
+                                                       objectType = cms.string('CL2EtSum'),
+                                                       minPt = cms.double(0),
+                                                       maxAbsEta = cms.double(9999.)
+                                                   )
+                                               )
+                                           ))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPuppiTauTkIsoEle45_22L1TkFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPuppiTauTkIsoEle45_22L1TkFilter_cfi.py
@@ -1,5 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
-hltPuppiTauTkIsoEle45_22L1TkFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pPuppiTauTkIsoEle45_22')
-)
+hltPuppiTauTkIsoEle45and22L1TkFilter = cms.EDFilter("HLTP2GTDoubleObjectFilter",
+                                                    l1GTAlgoBlockTag = cms.InputTag("l1tGTAlgoBlockProducer"),
+                                                    l1GTAlgos = cms.VPSet(
+                                                        cms.PSet(
+                                                            name = cms.string("pPuppiTauTkIsoEle45_22"),
+                                                            collection1 = cms.PSet(
+                                                                objectType = cms.string("CL2Electrons"),
+                                                                minPt      = cms.double(0.),
+                                                                maxAbsEta  = cms.double(9999.),
+                                                            ),
+                                                            collection2 = cms.PSet(
+                                                                objectType = cms.string("CL2Taus"),
+                                                                minPt      = cms.double(0.),
+                                                                maxAbsEta  = cms.double(9999.),
+                                                            ),
+                                                            minDR      = cms.double(0.0),
+                                                            maxDR      = cms.double(1e9),
+                                                            minDEta    = cms.double(-1.0),
+                                                            minDPhi    = cms.double(-1.0),
+                                                            minInvMass = cms.double(0.0),
+                                                            maxInvMass = cms.double(1e9),
+                                                        )
+                                                    )
+                                                  )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPuppiTauTkMuon4218L1TkFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPuppiTauTkMuon4218L1TkFilter_cfi.py
@@ -1,5 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
-hltPuppiTauTkMuon4218L1TkFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pPuppiTauTkMuon42_18')
-)
+hltPuppiTauTkMuon4218L1TkFilter = cms.EDFilter("HLTP2GTDoubleObjectFilter",
+                                               l1GTAlgoBlockTag = cms.InputTag("l1tGTAlgoBlockProducer"),
+                                               l1GTAlgos = cms.VPSet(
+                                                   cms.PSet(
+                                                       name = cms.string("pPuppiTauTkMuon42_18"),
+                                                       collection1 = cms.PSet(
+                                                           objectType = cms.string("CL2Taus"),
+                                                           minPt      = cms.double(0.),
+                                                           maxAbsEta  = cms.double(9999.),
+                                                       ),
+                                                       collection2 = cms.PSet(
+                                                           objectType = cms.string("GMTTkMuons"),
+                                                           minPt      = cms.double(0.),
+                                                           maxAbsEta  = cms.double(9999.),
+                                                       ),
+                                                       minDR      = cms.double(0.0),
+                                                       maxDR      = cms.double(1e9),
+                                                       minDEta    = cms.double(-1.0),
+                                                       minDPhi    = cms.double(-1.0),
+                                                       minInvMass = cms.double(0.0),
+                                                       maxInvMass = cms.double(1e9),
+                                                   )
+                                                 )
+                                              )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltSingleTkMuon22L1TkMuonFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltSingleTkMuon22L1TkMuonFilter_cfi.py
@@ -1,5 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
-hltSingleTkMuon22L1TkMuonFilter = cms.EDFilter("PathStatusFilter",
-    logicalExpression = cms.string('pSingleTkMuon22')
-)
+hltSingleTkMuon22L1TkMuonFilter =  cms.EDFilter("HLTP2GTSingleObjectFilter",
+                                                saveTags = cms.bool(True),
+                                                l1GTAlgoBlockTag = cms.InputTag('l1tGTAlgoBlockProducer'),
+                                                minN = cms.uint32(1),
+                                                l1GTAlgos = cms.VPSet(
+                                                    cms.PSet(
+                                                        name = cms.string('pSingleTkMuon22'),
+                                                        collection = cms.PSet(
+                                                            objectType = cms.string('GMTTkMuons'),
+                                                            minPt = cms.double(0),
+                                                            maxAbsEta = cms.double(9999.)
+                                                        )
+                                                    )
+                                                ))

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Ele30_WPTight_L1Seeded_LooseDeepTauPFTauHPS30_eta2p1_CrossL1_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Ele30_WPTight_L1Seeded_LooseDeepTauPFTauHPS30_eta2p1_CrossL1_cfi.py
@@ -54,7 +54,7 @@ from ..modules.hltEle30WPTightGsfTrackIsoL1SeededFilter_cfi import *
 
 HLT_Ele30_WPTight_L1Seeded_LooseDeepTauPFTauHPS30_eta2p1_CrossL1 = cms.Path( 
     HLTBeginSequence +
-    hltPuppiTauTkIsoEle45_22L1TkFilter +
+    hltPuppiTauTkIsoEle45and22L1TkFilter +
     HLTRawToDigiSequence +
     HLTLocalrecoSequence +
     HLTTICLLocalRecoSequence +

--- a/HLTrigger/HLTfilters/plugins/HLTP2GTDoubleObjectFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTP2GTDoubleObjectFilter.cc
@@ -1,0 +1,164 @@
+// HLT filter seeded by a Phase-2 GT double-object condition.
+// Mirrors l1tGTDoubleObjectCond: two collections (may be different types),
+// per-object kinematic cuts, and inter-object cuts (DeltaR, DeltaEta, DeltaPhi, m_inv).
+//
+// Example python config:
+//
+//   hltP2GTFilterIsoTkEleEGEle2212 = cms.EDFilter("HLTP2GTDoubleObjectFilter",
+//       l1GTAlgoBlockTag = cms.InputTag("l1tGTAlgoBlockProducer"),
+//       l1GTAlgos = cms.VPSet(
+//           cms.PSet(
+//               name = cms.string("pIsoTkEleEGEle22_12"),
+//               collection1 = cms.PSet(
+//                   objectType = cms.string("CL2Electrons"),
+//                   minPt      = cms.double(22.0),
+//                   maxAbsEta  = cms.double(2.4),
+//               ),
+//               collection2 = cms.PSet(
+//                   objectType = cms.string("CL2Photons"),
+//                   minPt      = cms.double(12.0),
+//                   maxAbsEta  = cms.double(2.4),
+//               ),
+//               minDR      = cms.double(0.1),
+//               maxDR      = cms.double(1e9),
+//               minDEta    = cms.double(-1.0),
+//               minDPhi    = cms.double(-1.0),
+//               minInvMass = cms.double(0.0),
+//               maxInvMass = cms.double(1e9),
+//           ),
+//       ),
+//   )
+//
+// Semantics:
+//   For each firing algo, iterate all ordered pairs (o1 in coll1, o2 in coll2).
+//   When collection1 and collection2 have the same objectType the pair (o1,o2)
+//   and (o2,o1) are both tested but a candidate can be accepted more than once —
+//   this matches the upstream L1 behaviour.  Set minDR > 0 to suppress
+//   self-pairs if both collections draw from the same physical list.
+//
+//   The filter passes if at least one valid pair is found across all algos.
+
+#include "HLTP2GTUtilities.h"
+
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "DataFormats/L1Trigger/interface/P2GTCandidate.h"
+#include "DataFormats/L1Trigger/interface/P2GTAlgoBlock.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include <string>
+#include <vector>
+
+class HLTP2GTDoubleObjectFilter : public HLTFilter {
+public:
+  explicit HLTP2GTDoubleObjectFilter(const edm::ParameterSet&);
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+  bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs&) const override;
+
+private:
+  struct AlgoConfig {
+    std::string algoName;
+    hltp2gt::CollectionSpec coll1;
+    hltp2gt::CollectionSpec coll2;
+    hltp2gt::PairCuts pairCuts;
+    AlgoConfig(const edm::ParameterSet& ps)
+        : algoName(ps.getParameter<std::string>("name")),
+          coll1(ps.getParameter<edm::ParameterSet>("collection1")),
+          coll2(ps.getParameter<edm::ParameterSet>("collection2")),
+          pairCuts(ps) {}
+  };
+
+  const edm::InputTag m_algoBlockTag;
+  const edm::EDGetTokenT<l1t::P2GTAlgoBlockMap> m_algoBlockToken;
+  std::vector<AlgoConfig> m_algos;
+};
+
+HLTP2GTDoubleObjectFilter::HLTP2GTDoubleObjectFilter(const edm::ParameterSet& iConfig)
+    : HLTFilter(iConfig),
+      m_algoBlockTag(iConfig.getParameter<edm::InputTag>("l1GTAlgoBlockTag")),
+      m_algoBlockToken(consumes<l1t::P2GTAlgoBlockMap>(m_algoBlockTag)) {
+  for (const auto& ps : iConfig.getParameter<std::vector<edm::ParameterSet>>("l1GTAlgos"))
+    m_algos.emplace_back(ps);
+}
+
+void HLTP2GTDoubleObjectFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<edm::InputTag>("l1GTAlgoBlockTag", edm::InputTag("l1tGTAlgoBlockProducer"));
+
+  edm::ParameterSetDescription algoDesc;
+  algoDesc.add<std::string>("name", "");
+
+  edm::ParameterSetDescription coll1Desc, coll2Desc;
+  hltp2gt::CollectionSpec::fillDescription(coll1Desc, "CL2Electrons");
+  hltp2gt::CollectionSpec::fillDescription(coll2Desc, "CL2Photons");
+  algoDesc.add<edm::ParameterSetDescription>("collection1", coll1Desc);
+  algoDesc.add<edm::ParameterSetDescription>("collection2", coll2Desc);
+
+  hltp2gt::PairCuts::fillDescription(algoDesc);
+
+  desc.addVPSet("l1GTAlgos", algoDesc, {});
+  descriptions.addWithDefaultLabel(desc);
+}
+
+bool HLTP2GTDoubleObjectFilter::hltFilter(edm::Event& iEvent,
+                                          const edm::EventSetup&,
+                                          trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  if (saveTags())
+    filterproduct.addCollectionTag(m_algoBlockTag);
+
+  if (m_algos.empty())
+    return false;
+
+  const auto& algoMap = iEvent.get(m_algoBlockToken);
+
+  // Collect matched refs separately per role so they carry the right type.
+  std::vector<l1t::P2GTCandidateRef> matched1, matched2;
+  edm::InputTag lastTag;
+
+  for (const auto& cfg : m_algos) {
+    auto it = algoMap.find(cfg.algoName);
+    if (it == algoMap.end() || !it->second.decisionBeforeBxMaskAndPrescale())
+      continue;
+
+    const auto& objs = it->second.trigObjects();
+
+    for (const auto& r1 : objs) {
+      if (!cfg.coll1.accepts(*r1))
+        continue;
+      for (const auto& r2 : objs) {
+        if (r1 == r2)
+          continue;
+        if (!cfg.coll2.accepts(*r2))
+          continue;
+        if (!cfg.pairCuts.accepts(*r1, *r2))
+          continue;
+
+        LogDebug("HLTP2GTDoubleObjectFilter")
+            << "  accepted pair: " << hltp2gt::objectTypeName(r1->objectType()) << " pT=" << r1->pt() << "  x  "
+            << hltp2gt::objectTypeName(r2->objectType()) << " pT=" << r2->pt();
+
+        if (saveTags()) {
+          hltp2gt::addCollectionTagOnce(r1, iEvent, filterproduct, lastTag);
+          hltp2gt::addCollectionTagOnce(r2, iEvent, filterproduct, lastTag);
+        }
+        matched1.push_back(r1);
+        matched2.push_back(r2);
+      }
+    }
+  }
+
+  for (const auto& ref : matched1)
+    filterproduct.addObject(hltp2gt::triggerTypeForP2GT(ref->objectType()), ref);
+  for (const auto& ref : matched2)
+    filterproduct.addObject(hltp2gt::triggerTypeForP2GT(ref->objectType()), ref);
+
+  const bool pass = !matched1.empty();
+  LogDebug("HLTP2GTDoubleObjectFilter") << "found " << matched1.size() << " pairs, result=" << pass;
+  return pass;
+}
+
+DEFINE_FWK_MODULE(HLTP2GTDoubleObjectFilter);

--- a/HLTrigger/HLTfilters/plugins/HLTP2GTDoubleObjectFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTP2GTDoubleObjectFilter.cc
@@ -126,11 +126,20 @@ bool HLTP2GTDoubleObjectFilter::hltFilter(edm::Event& iEvent,
 
     const auto& objs = it->second.trigObjects();
 
-    for (const auto& r1 : objs) {
+    for (std::size_t i = 0; i < objs.size(); ++i) {
+      const auto& r1 = objs[i];
       if (!cfg.coll1.accepts(*r1))
         continue;
-      for (const auto& r2 : objs) {
-        if (r1 == r2)
+      for (std::size_t j = 0; j < objs.size(); ++j) {
+        if (j == i)
+          continue;  // always skip self
+        const auto& r2 = objs[j];
+        // When r1 and r2 come from the same underlying product they are
+        // interchangeable as coll1/coll2 candidates, so (i,j) and (j,i)
+        // would be duplicates.  Enforce i < j in that case only.
+        // For refs from different products both orderings are distinct
+        // (e.g. barrel jet + forward jet) and must both be tested.
+        if (r1.id() == r2.id() && j < i)
           continue;
         if (!cfg.coll2.accepts(*r2))
           continue;

--- a/HLTrigger/HLTfilters/plugins/HLTP2GTSingleObjectFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTP2GTSingleObjectFilter.cc
@@ -1,0 +1,117 @@
+// HLT filter seeded by a Phase-2 GT single-object condition.
+// Mirrors l1tGTSingleObjectCond: one collection, per-object kinematic cuts.
+//
+// Example python config:
+//
+//   hltP2GTFilterCL2Taus = cms.EDFilter("HLTP2GTSingleObjectFilter",
+//       l1GTAlgoBlockTag = cms.InputTag("l1tGTAlgoBlockProducer"),
+//       minN = cms.uint32(2),
+//       l1GTAlgos = cms.VPSet(
+//           cms.PSet(
+//               name       = cms.string("pDoubleTau_Seed"),
+//               collection = cms.PSet(
+//                   objectType = cms.string("CL2Taus"),
+//                   minPt      = cms.double(35.0),
+//                   maxAbsEta  = cms.double(2.1),
+//               ),
+//           ),
+//       ),
+//   )
+
+#include "HLTP2GTUtilities.h"
+
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "DataFormats/L1Trigger/interface/P2GTCandidate.h"
+#include "DataFormats/L1Trigger/interface/P2GTAlgoBlock.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include <string>
+#include <vector>
+
+class HLTP2GTSingleObjectFilter : public HLTFilter {
+public:
+  explicit HLTP2GTSingleObjectFilter(const edm::ParameterSet&);
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+  bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs&) const override;
+
+private:
+  struct AlgoConfig {
+    std::string algoName;
+    hltp2gt::CollectionSpec collection;
+    AlgoConfig(const edm::ParameterSet& ps)
+        : algoName(ps.getParameter<std::string>("name")),
+          collection(ps.getParameter<edm::ParameterSet>("collection")) {}
+  };
+
+  const edm::InputTag m_algoBlockTag;
+  const edm::EDGetTokenT<l1t::P2GTAlgoBlockMap> m_algoBlockToken;
+  const unsigned int m_minN;
+  std::vector<AlgoConfig> m_algos;
+};
+
+HLTP2GTSingleObjectFilter::HLTP2GTSingleObjectFilter(const edm::ParameterSet& iConfig)
+    : HLTFilter(iConfig),
+      m_algoBlockTag(iConfig.getParameter<edm::InputTag>("l1GTAlgoBlockTag")),
+      m_algoBlockToken(consumes<l1t::P2GTAlgoBlockMap>(m_algoBlockTag)),
+      m_minN(iConfig.getParameter<unsigned int>("minN")) {
+  for (const auto& ps : iConfig.getParameter<std::vector<edm::ParameterSet>>("l1GTAlgos"))
+    m_algos.emplace_back(ps);
+}
+
+void HLTP2GTSingleObjectFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<edm::InputTag>("l1GTAlgoBlockTag", edm::InputTag("l1tGTAlgoBlockProducer"));
+  desc.add<unsigned int>("minN", 1);
+
+  edm::ParameterSetDescription algoDesc;
+  algoDesc.add<std::string>("name", "");
+  edm::ParameterSetDescription collDesc;
+  hltp2gt::CollectionSpec::fillDescription(collDesc, "CL2Taus");
+  algoDesc.add<edm::ParameterSetDescription>("collection", collDesc);
+
+  desc.addVPSet("l1GTAlgos", algoDesc, {});
+  descriptions.addWithDefaultLabel(desc);
+}
+
+bool HLTP2GTSingleObjectFilter::hltFilter(edm::Event& iEvent,
+                                          const edm::EventSetup&,
+                                          trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  if (saveTags())
+    filterproduct.addCollectionTag(m_algoBlockTag);
+
+  if (m_algos.empty())
+    return false;
+
+  const auto& algoMap = iEvent.get(m_algoBlockToken);
+
+  std::vector<l1t::P2GTCandidateRef> accepted;
+  edm::InputTag lastTag;
+
+  for (const auto& cfg : m_algos) {
+    auto it = algoMap.find(cfg.algoName);
+    if (it == algoMap.end() || !it->second.decisionBeforeBxMaskAndPrescale())
+      continue;
+
+    for (const auto& ref : it->second.trigObjects()) {
+      if (!cfg.collection.accepts(*ref))
+        continue;
+      if (saveTags())
+        hltp2gt::addCollectionTagOnce(ref, iEvent, filterproduct, lastTag);
+      accepted.push_back(ref);
+    }
+  }
+
+  for (const auto& ref : accepted)
+    filterproduct.addObject(hltp2gt::triggerTypeForP2GT(ref->objectType()), ref);
+
+  LogDebug("HLTP2GTSingleObjectFilter") << "accepted " << accepted.size() << " objects (minN=" << m_minN << ")";
+
+  return accepted.size() >= m_minN;
+}
+
+DEFINE_FWK_MODULE(HLTP2GTSingleObjectFilter);

--- a/HLTrigger/HLTfilters/plugins/HLTP2GTUtilities.h
+++ b/HLTrigger/HLTfilters/plugins/HLTP2GTUtilities.h
@@ -1,0 +1,300 @@
+// Shared utilities for HLTP2GT*Filter plugins.
+// Provides:
+//  - parseObjectType()           string -> l1t::P2GTCandidate::ObjectType
+//  - triggerTypeForP2GT()        ObjectType -> trigger::TriggerObjectType
+//  - objectTypeName()            ObjectType -> human-readable string (for logging)
+//  - CollectionSpec              per-collection kinematic requirements
+//  - PairCuts / TripleCuts       inter-object requirements
+//  - makeCollectionDescription() helper to build a sub-PSet description
+
+#ifndef HLTrigger_HLTfilters_HLTP2GTUtilities_h
+#define HLTrigger_HLTfilters_HLTP2GTUtilities_h
+
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "DataFormats/L1Trigger/interface/P2GTCandidate.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <cmath>
+#include <limits>
+#include <map>
+#include <string>
+
+namespace hltp2gt {
+
+  // ---------------------------------------------------------------------------
+  // String -> enum
+  // ---------------------------------------------------------------------------
+  inline l1t::P2GTCandidate::ObjectType parseObjectType(const std::string& name) {
+    using OT = l1t::P2GTCandidate::ObjectType;
+    static const std::map<std::string, OT> kTable = {
+        {"GCTNonIsoEg", OT::GCTNonIsoEg},
+        {"GCTIsoEg", OT::GCTIsoEg},
+        {"GCTJets", OT::GCTJets},
+        {"GCTTaus", OT::GCTTaus},
+        {"GCTHtSum", OT::GCTHtSum},
+        {"GCTEtSum", OT::GCTEtSum},
+        {"GMTSaPromptMuons", OT::GMTSaPromptMuons},
+        {"GMTSaDisplacedMuons", OT::GMTSaDisplacedMuons},
+        {"GMTTkMuons", OT::GMTTkMuons},
+        {"GMTTopo", OT::GMTTopo},
+        {"GTTPromptJets", OT::GTTPromptJets},
+        {"GTTDisplacedJets", OT::GTTDisplacedJets},
+        {"GTTPhiCandidates", OT::GTTPhiCandidates},
+        {"GTTRhoCandidates", OT::GTTRhoCandidates},
+        {"GTTBsCandidates", OT::GTTBsCandidates},
+        {"GTTHadronicTaus", OT::GTTHadronicTaus},
+        {"GTTPromptTracks", OT::GTTPromptTracks},
+        {"GTTDisplacedTracks", OT::GTTDisplacedTracks},
+        {"GTTPrimaryVert", OT::GTTPrimaryVert},
+        {"GTTPromptHtSum", OT::GTTPromptHtSum},
+        {"GTTDisplacedHtSum", OT::GTTDisplacedHtSum},
+        {"GTTEtSum", OT::GTTEtSum},
+        {"CL2JetsSC4", OT::CL2JetsSC4},
+        {"CL2JetsSC8", OT::CL2JetsSC8},
+        {"CL2Taus", OT::CL2Taus},
+        {"CL2Electrons", OT::CL2Electrons},
+        {"CL2Photons", OT::CL2Photons},
+        {"CL2HtSum", OT::CL2HtSum},
+        {"CL2EtSum", OT::CL2EtSum},
+    };
+    auto it = kTable.find(name);
+    if (it == kTable.end())
+      throw cms::Exception("Configuration") << "HLTP2GTFilter: unknown P2GT object type \"" << name << "\"";
+    return it->second;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Enum -> TriggerObjectType
+  // ---------------------------------------------------------------------------
+  inline trigger::TriggerObjectType triggerTypeForP2GT(l1t::P2GTCandidate::ObjectType ot) {
+    using OT = l1t::P2GTCandidate::ObjectType;
+    switch (ot) {
+      case OT::GCTNonIsoEg:
+        return trigger::TriggerL1NoIsoEG;
+      case OT::GCTIsoEg:
+        return trigger::TriggerL1IsoEG;
+      case OT::GCTJets:
+        return trigger::TriggerL1Jet;
+      case OT::GCTTaus:
+        return trigger::TriggerL1TauJet;
+      case OT::GCTHtSum:
+        return trigger::TriggerL1HTT;
+      case OT::GCTEtSum:
+        return trigger::TriggerL1ETT;
+      case OT::GMTSaPromptMuons:
+        return trigger::TriggerL1Mu;
+      case OT::GMTSaDisplacedMuons:
+        return trigger::TriggerL1Mu;
+      case OT::GMTTkMuons:
+        return trigger::TriggerL1Mu;
+      case OT::GMTTopo:
+        return trigger::TriggerL1Mu;
+      case OT::GTTPromptJets:
+        return trigger::TriggerL1Jet;
+      case OT::GTTDisplacedJets:
+        return trigger::TriggerL1Jet;
+      case OT::GTTPhiCandidates:
+        return trigger::TriggerL1Jet;
+      case OT::GTTRhoCandidates:
+        return trigger::TriggerL1Jet;
+      case OT::GTTBsCandidates:
+        return trigger::TriggerL1Jet;
+      case OT::GTTHadronicTaus:
+        return trigger::TriggerL1TauJet;
+      case OT::GTTPromptTracks:
+        return trigger::TriggerTrack;
+      case OT::GTTDisplacedTracks:
+        return trigger::TriggerTrack;
+      case OT::GTTPrimaryVert:
+        return trigger::TriggerL1Vertex;
+      case OT::GTTPromptHtSum:
+        return trigger::TriggerL1HTT;
+      case OT::GTTDisplacedHtSum:
+        return trigger::TriggerL1HTT;
+      case OT::GTTEtSum:
+        return trigger::TriggerL1ETT;
+      case OT::CL2JetsSC4:
+        return trigger::TriggerL1Jet;
+      case OT::CL2JetsSC8:
+        return trigger::TriggerL1Jet;
+      case OT::CL2Taus:
+        return trigger::TriggerL1Tau;
+      case OT::CL2Electrons:
+        return trigger::TriggerL1EG;
+      case OT::CL2Photons:
+        return trigger::TriggerL1EG;
+      case OT::CL2HtSum:
+        return trigger::TriggerL1HTT;
+      case OT::CL2EtSum:
+        return trigger::TriggerL1ETT;
+      default:
+        return trigger::TriggerCluster;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Enum -> name string (for LogDebug)
+  // ---------------------------------------------------------------------------
+  inline const char* objectTypeName(l1t::P2GTCandidate::ObjectType ot) {
+    using OT = l1t::P2GTCandidate::ObjectType;
+    switch (ot) {
+      case OT::GCTNonIsoEg:
+        return "GCTNonIsoEg";
+      case OT::GCTIsoEg:
+        return "GCTIsoEg";
+      case OT::GCTJets:
+        return "GCTJets";
+      case OT::GCTTaus:
+        return "GCTTaus";
+      case OT::GCTHtSum:
+        return "GCTHtSum";
+      case OT::GCTEtSum:
+        return "GCTEtSum";
+      case OT::GMTSaPromptMuons:
+        return "GMTSaPromptMuons";
+      case OT::GMTSaDisplacedMuons:
+        return "GMTSaDisplacedMuons";
+      case OT::GMTTkMuons:
+        return "GMTTkMuons";
+      case OT::GMTTopo:
+        return "GMTTopo";
+      case OT::GTTPromptJets:
+        return "GTTPromptJets";
+      case OT::GTTDisplacedJets:
+        return "GTTDisplacedJets";
+      case OT::GTTPhiCandidates:
+        return "GTTPhiCandidates";
+      case OT::GTTRhoCandidates:
+        return "GTTRhoCandidates";
+      case OT::GTTBsCandidates:
+        return "GTTBsCandidates";
+      case OT::GTTHadronicTaus:
+        return "GTTHadronicTaus";
+      case OT::GTTPromptTracks:
+        return "GTTPromptTracks";
+      case OT::GTTDisplacedTracks:
+        return "GTTDisplacedTracks";
+      case OT::GTTPrimaryVert:
+        return "GTTPrimaryVert";
+      case OT::GTTPromptHtSum:
+        return "GTTPromptHtSum";
+      case OT::GTTDisplacedHtSum:
+        return "GTTDisplacedHtSum";
+      case OT::GTTEtSum:
+        return "GTTEtSum";
+      case OT::CL2JetsSC4:
+        return "CL2JetsSC4";
+      case OT::CL2JetsSC8:
+        return "CL2JetsSC8";
+      case OT::CL2Taus:
+        return "CL2Taus";
+      case OT::CL2Electrons:
+        return "CL2Electrons";
+      case OT::CL2Photons:
+        return "CL2Photons";
+      case OT::CL2HtSum:
+        return "CL2HtSum";
+      case OT::CL2EtSum:
+        return "CL2EtSum";
+      default:
+        return "Unknown";
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Per-collection kinematic specification
+  // ---------------------------------------------------------------------------
+  struct CollectionSpec {
+    l1t::P2GTCandidate::ObjectType objectType;
+    double minPt;
+    double maxAbsEta;
+
+    CollectionSpec(const edm::ParameterSet& ps)
+        : objectType(parseObjectType(ps.getParameter<std::string>("objectType"))),
+          minPt(ps.getParameter<double>("minPt")),
+          maxAbsEta(ps.getParameter<double>("maxAbsEta")) {}
+
+    bool accepts(const l1t::P2GTCandidate& c) const {
+      return c.objectType() == objectType && c.pt() >= minPt && std::abs(c.eta()) <= maxAbsEta;
+    }
+
+    static void fillDescription(edm::ParameterSetDescription& desc, const std::string& defaultType = "CL2Taus") {
+      desc.add<std::string>("objectType", defaultType);
+      desc.add<double>("minPt", 0.0);
+      desc.add<double>("maxAbsEta", 1e9);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Inter-object cuts (used by double and triple filters)
+  // Negative minDR / minDEta / minDPhi / minInvMass means "no cut".
+  // ---------------------------------------------------------------------------
+  struct PairCuts {
+    double minDR2;  ///< squared, for speed
+    double maxDR2;
+    double minDEta;      ///< absolute value cut; negative = disabled
+    double minDPhi;      ///< absolute value cut; negative = disabled
+    double minInvMass2;  ///< squared
+    double maxInvMass2;
+
+    PairCuts(const edm::ParameterSet& ps)
+        : minDR2(std::pow(ps.getParameter<double>("minDR"), 2)),
+          maxDR2(std::pow(ps.getParameter<double>("maxDR"), 2)),
+          minDEta(ps.getParameter<double>("minDEta")),
+          minDPhi(ps.getParameter<double>("minDPhi")),
+          minInvMass2(std::pow(ps.getParameter<double>("minInvMass"), 2)),
+          maxInvMass2(std::pow(ps.getParameter<double>("maxInvMass"), 2)) {}
+
+    bool accepts(const l1t::P2GTCandidate& a, const l1t::P2GTCandidate& b) const {
+      const double deta = a.eta() - b.eta();
+      const double dphi = reco::deltaPhi(a.phi(), b.phi());
+      const double dr2 = deta * deta + dphi * dphi;
+      if (dr2 < minDR2 || dr2 > maxDR2)
+        return false;
+      if (minDEta >= 0 && std::abs(deta) < minDEta)
+        return false;
+      if (minDPhi >= 0 && std::abs(dphi) < minDPhi)
+        return false;
+      // Invariant mass (massless approximation: m² ≈ 2·pT·pT·(cosh(Δη)−cos(Δφ)))
+      const double m2 = 2.0 * a.pt() * b.pt() * (std::cosh(deta) - std::cos(dphi));
+      if (m2 < minInvMass2 || m2 > maxInvMass2)
+        return false;
+      return true;
+    }
+
+    static void fillDescription(edm::ParameterSetDescription& desc) {
+      desc.add<double>("minDR", 0.0);
+      desc.add<double>("maxDR", 1e9);
+      desc.add<double>("minDEta", -1.0);  // disabled
+      desc.add<double>("minDPhi", -1.0);  // disabled
+      desc.add<double>("minInvMass", 0.0);
+      desc.add<double>("maxInvMass", 1e9);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Register a collection tag in the filter product (deduplicating by ProductID)
+  // ---------------------------------------------------------------------------
+  inline void addCollectionTagOnce(const l1t::P2GTCandidateRef& ref,
+                                   edm::Event& iEvent,
+                                   trigger::TriggerFilterObjectWithRefs& fp,
+                                   edm::InputTag& lastTag) {
+    const auto& prov = iEvent.getStableProvenance(ref.id());
+    edm::InputTag tag(prov.moduleLabel(), prov.productInstanceName(), prov.processName());
+    if (tag.encode() != lastTag.encode()) {
+      fp.addCollectionTag(tag);
+      lastTag = tag;
+    }
+  }
+
+}  // namespace hltp2gt
+
+// deltaPhi is in DataFormats/Math
+#include "DataFormats/Math/interface/deltaPhi.h"
+
+#endif  // HLTrigger_HLTfilters_HLTP2GTUtilities_h


### PR DESCRIPTION
#### PR description:

Title says it:
- split Double vs Single collections filtering
- use `HLTP2GTDoubleObjectFilter` and `HLTP2GTSingleObjectFilter` in a bunch of filters at HLT instead of `PathStatusFilter` (which being e generic `EDFilter` and not a `HLTFilter` doesn't leave trace of the trigger candidate kinematics in the `TriggerEvent`)

#### PR validation:

`runTheMatrix.py -l ph2_hlt -i all --ibeos` runs fine.
Bitwise trigger results compatibility to be tested by the bot.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A