### PR TITLE
py3.14: use function instead of lambda

### DIFF
--- a/Alignment/CommonAlignment/scripts/tkal_create_file_lists.py
+++ b/Alignment/CommonAlignment/scripts/tkal_create_file_lists.py
@@ -28,6 +28,10 @@ import Alignment.MillePedeAlignmentAlgorithm.mpslib.tools as mps_tools
 
 
 ################################################################################
+def ignore_sigint():
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
 def main(argv = None):
     """
     Main routine. Not called, if this module is loaded via `import`.
@@ -359,7 +363,7 @@ class FileListCreator(object):
                                else 1)
         pool = multiprocessing.Pool(
             processes = number_of_processes,
-            initializer = lambda: signal.signal(signal.SIGINT, signal.SIG_IGN))
+            initializer = ignore_sigint)
 
         print_msg("Requesting information for the following dataset(s):")
         for d in self._datasets: print_msg("\t"+d)


### PR DESCRIPTION
With Python 3.14 , `forkserver` is the default instead of `fork` for the Process() method (this is for starting a child process - https://docs.python.org/3/library/multiprocessing.html). With `fork`, one could pass objects that couldn't be pickled (lambdas, local functions, file handles, database connections) but with `forkserver`, everything must be pickleable. This PR proposes that we keep the python default and use a `function` (instead of `lambda) . This should fix the failing unit test in PY314 IB

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/raw/el9_amd64_gcc13/CMSSW_20_1_PY314_X_2026-08-10-1100/unitTestLogs/Alignment/CommonAlignment
```
Traceback (most recent call last):
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/cms/cmssw/CMSSW_20_1_PY314_X_2026-08-10-1100/bin/el9_amd64_gcc13/tkal_create_file_lists.py", line 1175, in <module>
    main()
    ~~~~^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/cms/cmssw/CMSSW_20_1_PY314_X_2026-08-10-1100/bin/el9_amd64_gcc13/tkal_create_file_lists.py", line 43, in main
    file_list_creator.create()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/cms/cmssw/CMSSW_20_1_PY314_X_2026-08-10-1100/bin/el9_amd64_gcc13/tkal_create_file_lists.py", line 119, in create
    self._request_dataset_information()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/cms/cmssw/CMSSW_20_1_PY314_X_2026-08-10-1100/bin/el9_amd64_gcc13/tkal_create_file_lists.py", line 360, in _request_dataset_information
    pool = multiprocessing.Pool(
        processes = number_of_processes,
        initializer = lambda: signal.signal(signal.SIGINT, signal.SIG_IGN))
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/external/python3/3.14.6-404cf4e3e2d3f8bed88fcf7e2a792b73/lib/python3.14/multiprocessing/context.py", line 119, in Pool
    return Pool(processes, initializer, initargs, maxtasksperchild,
                context=self.get_context())
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/external/python3/3.14.6-404cf4e3e2d3f8bed88fcf7e2a792b73/lib/python3.14/multiprocessing/pool.py", line 215, in __init__
    self._repopulate_pool()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/external/python3/3.14.6-404cf4e3e2d3f8bed88fcf7e2a792b73/lib/python3.14/multiprocessing/pool.py", line 306, in _repopulate_pool
    return self._repopulate_pool_static(self._ctx, self.Process,
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
                                        self._processes,
                                        ^^^^^^^^^^^^^^^^
    ...<3 lines>...
                                        self._maxtasksperchild,
                                        ^^^^^^^^^^^^^^^^^^^^^^^
                                        self._wrap_exception)
                                        ^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/external/python3/3.14.6-404cf4e3e2d3f8bed88fcf7e2a792b73/lib/python3.14/multiprocessing/pool.py", line 329, in _repopulate_pool_static
    w.start()
    ~~~~~~~^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/external/python3/3.14.6-404cf4e3e2d3f8bed88fcf7e2a792b73/lib/python3.14/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
                  ~~~~~~~~~~~^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/external/python3/3.14.6-404cf4e3e2d3f8bed88fcf7e2a792b73/lib/python3.14/multiprocessing/context.py", line 306, in _Popen
    return Popen(process_obj)
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/external/python3/3.14.6-404cf4e3e2d3f8bed88fcf7e2a792b73/lib/python3.14/multiprocessing/popen_forkserver.py", line 35, in __init__
    super().__init__(process_obj)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/external/python3/3.14.6-404cf4e3e2d3f8bed88fcf7e2a792b73/lib/python3.14/multiprocessing/popen_fork.py", line 20, in __init__
    self._launch(process_obj)
    ~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/external/python3/3.14.6-404cf4e3e2d3f8bed88fcf7e2a792b73/lib/python3.14/multiprocessing/popen_forkserver.py", line 47, in _launch
    reduction.dump(process_obj, buf)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/external/python3/3.14.6-404cf4e3e2d3f8bed88fcf7e2a792b73/lib/python3.14/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
_pickle.PicklingError: Can't pickle local object <function FileListCreator._request_dataset_information.<locals>.<lambda> at 0x149d886c9010>

```