### PR TITLE
py3.14: explicitly pass the args.source instead of use of global args

### DIFF
--- a/DQMServices/Components/scripts/dqm-plot
+++ b/DQMServices/Components/scripts/dqm-plot
@@ -992,6 +992,7 @@ class DQMPlotter:
         rebin=None,
         clamp_yerrors=False,
         multiply_x_values=None,
+        source=None,
     ):
         """
         Create comparison plot with ratio panel.
@@ -1118,8 +1119,8 @@ class DQMPlotter:
         ax_main.set_ylabel(ylabel, fontsize=label_size if ytitle_fontsize is None else ytitle_fontsize)
 
         ha = "right"
-        # args.source is None in --operation mode; guard before indexing it.
-        if args.source and "KindOfSignalPV" in args.source[0][0]:
+        # source is None in --operation mode; guard before indexing it.
+        if source and "KindOfSignalPV" in source[0][0]:
             if rebin != None:
                 bin_labels = ['PV not Reco', 'PV Reco\nas Leading', 'PV Reco\nnot as Leading']
                 ha = "center"
@@ -2026,4 +2027,5 @@ if __name__ == "__main__":
         multiply_x_values=args.multiply_x_values,
         hline=args.hline,
         debug=args.debug,
+        source=args.source,
     )

--- a/DQMServices/Components/test/test_fastHaddMerge.py
+++ b/DQMServices/Components/test/test_fastHaddMerge.py
@@ -64,7 +64,7 @@ class FileProducer(object):
             h = f.Get(histo.folder_+'/'+histo.name_)
             h.SetDirectory(0)
             assert h
-            m = re.match('(.*)Entr.*_(\d+)$', h.GetName())
+            m = re.match(r'(.*)Entr.*_(\d+)$', h.GetName())
             assert m.groups()
             assert h.GetEntries() == word2num[m.group(1)] * self.numFiles_
             assert h.GetMean() == float(m.group(2))


### PR DESCRIPTION
This fixes the failing unit test for PY314 IBs where a global variable `args` is not visible in sub-tasks [a]

[a] https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el9_amd64_gcc13/CMSSW_20_1_PY314_X_2026-08-10-1100/unitTestLogs/DQMServices/Components#/
```
Error in task 0: name 'args' is not defined

Error in task 1: name 'args' is not defined

Error in task 2: name 'args' is not defined
Error in process_histogram_task: name 'args' is not defined
Error in process_histogram_task: name 'args' is not defined
Error in process_histogram_task: name 'args' is not defined
Error in process_histogram_task: name 'args' is not defined
Error in process_histogram_task: name 'args' is not defined
Error in process_histogram_task: name 'args' is not defined
```