### PR TITLE
PY314: drop dxr unit test which uses deprecated cgi module

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -44,7 +44,6 @@
 <test name="import-cython" command="python3 -c 'import cython'"/>
 <test name="import-decorator" command="python3 -c 'import decorator'"/>
 <test name="import-docopt" command="python3 -c 'import docopt'"/>
-<test name="dxr-build"  command="dxr-build.py --help"/>
 <test name="import-enum" command="python3 -c 'import enum'"/>
 <test name="import-flake8" command="python3 -c 'import flake8'"/>
 <test name="import-funcsigs" command="python3 -c 'import funcsigs'"/>


### PR DESCRIPTION
DXR has been deprecated since few years now. This PR proposes to drop the unit tests for dxr which use `cgi` python module. Python 3.14 has removed `cgi` from the core library. 

With new version of Python and LLVM we will drop DXR from CMSSW distribution. 

https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el9_amd64_gcc13/CMSSW_20_1_PY314_X_2026-08-10-1100/unitTestLogs/PhysicsTools/PythonAnalysis#/2
```
===== Test "dxr-build" ====
Traceback (most recent call last):
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/week0/el9_amd64_gcc13/cms/cmssw/CMSSW_20_1_PY314_X_2026-08-10-1100/external/el9_amd64_gcc13/bin/dxr-build.py", line 9, in <module>
    from dxr.build import build_instance
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02954/el9_amd64_gcc13/external/py3-dxr/1.0.x-7ff81324a463bedc17be95eca7fd5375/lib/python3.14/site-packages/dxr/build.py", line 32, in <module>
    from dxr.query import filter_menu_items
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02954/el9_amd64_gcc13/external/py3-dxr/1.0.x-7ff81324a463bedc17be95eca7fd5375/lib/python3.14/site-packages/dxr/query.py", line 1, in <module>
    import cgi
ModuleNotFoundError: No module named 'cgi'

---> test dxr-build had ERRORS
```