### PR TITLE
[NGT] Add production vertex of GenParticles to NGT Scouting NanoAOD

### DIFF
--- a/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
+++ b/HLTrigger/NGTScouting/python/HLTNanoProducer_cff.py
@@ -4,6 +4,7 @@ from PhysicsTools.JetMCAlgos.AK4GenJetFlavourInfos_cfi import *
 from PhysicsTools.JetMCAlgos.HadronAndPartonSelector_cfi import *
 from PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.genparticles_cff import *
+from PhysicsTools.NanoAOD.genVertex_cff import *
 from PhysicsTools.NanoAOD.jetMC_cff import *
 from PhysicsTools.NanoAOD.taus_cff import *
 from PhysicsTools.PatAlgos.slimming.genParticles_cff import *
@@ -39,6 +40,7 @@ NanoGenTables = cms.Sequence(
     + prunedGenParticles
     + finalGenParticles
     + genParticleTable
+    + genVertexTable
     + genParticlesForJetsNoNu
     + ak4GenJetsNoNu
     + selectedHadronsAndPartonsForGenJetsFlavourInfos
@@ -155,6 +157,9 @@ def hltNanoCustomize(process):
         # process.genJetTable.cut = "pt > 10"
         # process.genJetFlavourTable.deltaR = 0.3
         process.genParticleTable.externalVariables = cms.PSet() # remove iso as external variable from PhysicsTools/NanoAOD/python/genparticles_cff.py:37 (hopefully temporarily)
+        process.genParticleTable.variables.vx = Var("vx", float, precision=10, doc="x coordinate of production vertex")
+        process.genParticleTable.variables.vy = Var("vy", float, precision=10, doc="y coordinate of production vertex")
+        process.genParticleTable.variables.vz = Var("vz", float, precision=16, doc="z coordinate of production vertex")
         process.NANOAODSIMoutput.outputCommands.append(
             "keep nanoaodFlatTable_*Table*_*_*"
         )


### PR DESCRIPTION
#### PR description:

Title says it all. 

The precision is chosen according to the precision that recoVertices are stored in.

#### PR validation:

I tested briefly by producing one NGT NanoAOD file for 20 TTbar events from relval samples:

```bash
cmsDriver.py step_2 -s L1P2GT,HLT:NGTScouting,VALIDATION:@hltValidation,NANO:@NGTScoutingVal \
  --mc --conditions auto:phase2_realistic_T35 --datatier NANOAODSIM \
  -n 20 --eventcontent NANOAODSIM --geometry ExtendedRun4D121 \
  --era Phase2C17I13M9 --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
  --filein /eos/cms/store/relval/CMSSW_20_0_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU-v1/2590000/0033230b-a131-453a-95c0-fe14d5027d1f.root \
  --fileout NanoAOD.root --process HLTX \
  --inputCommands="keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT" \
  --procModifiers ngtScouting
```

For any further testing the bot tests should be sufficienct.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.
