### PR TITLE
Add NanoAOD pass-through example for Rucio stage-out

### DIFF
--- a/PhysicsTools/NanoAODTools/crab/rucio_passthrough/PSet.py
+++ b/PhysicsTools/NanoAODTools/crab/rucio_passthrough/PSet.py
@@ -1,0 +1,17 @@
+# this fake PSET is needed for local test and for crab to figure the output
+# filename you do not need to edit it unless you want to do a local test using
+# a different input file than the one marked below
+import FWCore.ParameterSet.Config as cms
+process = cms.Process('NANO')
+process.source = cms.Source(
+    "PoolSource",
+    fileNames=cms.untracked.vstring(),
+    # lumisToProcess=cms.untracked.VLuminosityBlockRange("254231:1-254231:24")
+)
+process.source.fileNames = [
+    '../../../NanoAOD/test/lzma.root'  # you can change only this line
+]
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(10))
+process.output = cms.OutputModule("PoolOutputModule",
+                                  fileName=cms.untracked.string('tree.root'))
+process.out = cms.EndPath(process.output)

--- a/PhysicsTools/NanoAODTools/crab/rucio_passthrough/README.md
+++ b/PhysicsTools/NanoAODTools/crab/rucio_passthrough/README.md
@@ -1,0 +1,69 @@
+# NanoAOD pass-through with CRAB and Rucio
+
+This setup submits NanoAOD files to CRAB and writes every input event and branch
+to a new output file without applying a selection or running an analysis module.
+Its purpose is to let CRAB stage the resulting files out through Rucio, including
+NanoAOD-derived ROOT files that cannot be opened by `cmsRun` because they do not
+contain the complete EDM metadata.
+
+See the CRAB documentation for the general
+[Rucio stage-out model](https://cmscrab-userguide.docs.cern.ch/rucio-stageout/rucio-stageout.html)
+and the [Rucio stage-out tutorial](https://cmscrab-userguide.docs.cern.ch/rucio-stageout/tutorial.html).
+
+## How it works
+
+- `PSet.py` is a dummy CMSSW configuration used by CRAB to discover the expected
+  `tree.root` output. It is not the processing payload.
+- `crab_script.sh` installs the shipped CMSSW Python area in the worker-node
+  environment and starts the payload with Python 3.
+- `crab_script.py` runs the NanoAODTools `PostProcessor` with no cut and no
+  modules. This selects its full-clone path, preserves the run/luminosity trees,
+  and writes a framework job report for CRAB.
+- With `fwkJobReport=True`, NanoAODTools merges the per-input clones into the
+  final `tree.root` using `haddnano.py`.
+
+The output is a logical clone of the NanoAOD content, not a byte-for-byte copy of
+the original ROOT file.
+
+## Configure and submit
+
+Start from `crab_cfg.py` and update at least:
+
+- `General.requestName`
+- `Data.inputDataset` and, if needed, `Data.inputDBS`
+- the job splitting and units
+- `Data.outputDatasetTag`
+- `Site.storageSite`
+
+The Rucio destination is enabled by the `/rucio/` component in
+`Data.outLFNDirBase`:
+
+```python
+config.Data.outLFNDirBase = '/store/user/rucio/%s/NanoPost' % (
+    getUsernameFromSiteDB())
+```
+
+The user needs sufficient Rucio quota at `Site.storageSite`. Keep
+`Data.publication = False` for NanoAOD-derived files without complete EDM
+metadata; CRAB still creates Rucio containers for the staged output.
+
+After setting up the CRAB client and proxy, submit from this directory:
+
+```console
+crab submit -c crab_cfg.py
+```
+
+Use `crab status` to follow both job execution and the asynchronous Rucio
+transfer. Once transfers begin, it reports the transfer container and its Rucio
+rule.
+
+## Important details
+
+- The payload must use `python3`. In current CMSSW EL8 environments, bare
+  `python` is the system Python 2 interpreter and cannot load NanoAODTools.
+- Do not set `maxEntries=-1`. NanoAODTools does not use the `cmsRun` convention
+  where `-1` means all events. Omit `maxEntries` to process the complete input.
+- `cmsRun` is deliberately not used. A `PoolSource` requires EDM `MetaData` and
+  `ParameterSets` trees, which may be absent from postprocessed NanoAOD files.
+- `modules=[]` is sufficient for pass-through operation; a custom module whose
+  `analyze` method only returns `True` is unnecessary.

--- a/PhysicsTools/NanoAODTools/crab/rucio_passthrough/crab_cfg.py
+++ b/PhysicsTools/NanoAODTools/crab/rucio_passthrough/crab_cfg.py
@@ -1,0 +1,33 @@
+from WMCore.Configuration import Configuration
+from CRABClient.UserUtilities import config, getUsernameFromSiteDB
+
+config = Configuration()
+
+config.section_("General")
+config.General.requestName = 'NanoPost1'
+config.General.transferLogs = True
+config.section_("JobType")
+config.JobType.pluginName = 'Analysis'
+config.JobType.psetName = 'PSet.py'
+config.JobType.scriptExe = 'crab_script.sh'
+config.JobType.inputFiles = ['crab_script.py']
+config.JobType.sendPythonFolder = True
+config.section_("Data")
+config.Data.inputDataset = '/DYJetsToLL_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17NanoAOD-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/NANOAODSIM'
+#config.Data.inputDBS = 'phys03'
+config.Data.inputDBS = 'global'
+config.Data.splitting = 'FileBased'
+#config.Data.splitting = 'EventAwareLumiBased'
+config.Data.unitsPerJob = 2
+config.Data.totalUnits = 10
+
+config.Data.outLFNDirBase = '/store/user/rucio/%s/NanoPost' % (
+    getUsernameFromSiteDB())
+config.Data.publication = False
+config.Data.outputDatasetTag = 'NanoTestPost'
+config.section_("Site")
+config.Site.storageSite = "T2_DE_DESY"
+
+#config.Site.storageSite = "T2_CH_CERN"
+# config.section_("User")
+#config.User.voGroup = 'dcms'

--- a/PhysicsTools/NanoAODTools/crab/rucio_passthrough/crab_script.py
+++ b/PhysicsTools/NanoAODTools/crab/rucio_passthrough/crab_script.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import PostProcessor
+
+# this takes care of converting the input files from CRAB
+from PhysicsTools.NanoAODTools.postprocessing.utils.crabhelper import inputFiles, runsAndLumis
+
+p = PostProcessor(".",
+                  inputFiles(),
+                  modules=[],
+                  provenance=True,
+                  fwkJobReport=True,
+                  jsonInput=runsAndLumis())
+p.run()
+
+print("DONE")

--- a/PhysicsTools/NanoAODTools/crab/rucio_passthrough/crab_script.sh
+++ b/PhysicsTools/NanoAODTools/crab/rucio_passthrough/crab_script.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#this is not meant to be run locally
+#
+echo Check if TTY
+if [ "`tty`" != "not a tty" ]; then
+  echo "YOU SHOULD NOT RUN THIS IN INTERACTIVE, IT DELETES YOUR LOCAL FILES"
+else
+
+echo "ENV..................................."
+env
+echo "VOMS"
+voms-proxy-info -all
+echo "CMSSW BASE, python path, pwd"
+echo $CMSSW_BASE
+echo $PYTHON_PATH
+echo $PWD
+rm -rf $CMSSW_BASE/lib/
+rm -rf $CMSSW_BASE/src/
+rm -rf $CMSSW_BASE/module/
+rm -rf $CMSSW_BASE/python/
+mv lib $CMSSW_BASE/lib
+mv src $CMSSW_BASE/src
+mv module $CMSSW_BASE/module
+mv python $CMSSW_BASE/python
+
+echo Found Proxy in: $X509_USER_PROXY
+python3 crab_script.py "$1"
+fi


### PR DESCRIPTION
## Summary

- add a self-contained `PhysicsTools/NanoAODTools/crab/rucio_passthrough` example
- use NanoAODTools' full-clone path (`modules=[]`) instead of an empty custom module
- run the CRAB payload with Python 3 and generate `tree.root` plus `FrameworkJobReport.xml`
- configure `/store/user/rucio/<account>/...` stage-out and document the workflow and limitations

## Motivation

The CRAB Rucio stage-out tutorial currently demonstrates an EDM input processed with `cmsRun`. NanoAOD-derived ROOT files may no longer contain the EDM `MetaData` and `ParameterSets` trees required by `PoolSource`, so they need a ROOT-level pass-through workflow. This example preserves the existing generic CRAB example and provides a separate copy-ready configuration for that use case.

## Validation

- Python syntax compilation for `PSet.py`, `crab_cfg.py`, and `crab_script.py`
- `bash -n crab_script.sh`
- end-to-end run in `CMSSW_15_0_17` under EL8 using a 14,780-event NanoAOD-derived input
- verified 14,780 events and 1,471 branches in the final `tree.root`
- verified creation of `FrameworkJobReport.xml`

A companion update to the CRAB user guide is being prepared for `docs/rucio-stageout/tutorial.md`.
