### PR TITLE
New D127 Inputs

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4706,7 +4706,7 @@ defaultDataSets['2025FS']='CMSSW_13_0_11-130X_mcRun3_2023_realistic_withEarly202
 defaultRun4Geometry = 'D127'
 defaultDataSets['Run4D110']='CMSSW_15_1_0_pre5-150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D110_noPU-v'
 defaultDataSets['Run4D121']='CMSSW_20_0_0_pre1-150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v'
-defaultDataSets['Run4D127']=''
+defaultDataSets['Run4D127']='CMSSW_20_0_0-150X_mcRun4_realistic_v1_STD_D127_GSOnly_noPU_Inputs-v'
 
 ## HIN
 defaultDataSets['2023HIN']='CCMSSW_14_1_0-PU_140X_mcRun3_2023_realistic_HI_v4_STD_2023HIN_PU-v'

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -130,8 +130,7 @@ if __name__ == '__main__':
             ###### MC (generated from scratch or from RelVals)
             # Phase2
             prefixDet+34.0,	# RelValTTbar_14TeV                     phase2_realistic_T35        ExtendedRun4D127         (Phase-2 baseline)
-            ######## FIXME: to be re-introduced when there is a PU library with the D127 geometry
-            #prefixDet+234.0,	# RelValTTbar_14TeV                     phase2_realistic_T35        ExtendedRun4D127         AVE_200_BX_25ns	(Phase-2 baseline with PU) 
+            prefixDet+234.0,	# RelValTTbar_14TeV                     phase2_realistic_T35        ExtendedRun4D127         AVE_200_BX_25ns	(Phase-2 baseline with PU) 
             prefixDet+34.911,	# TTbar_14TeV_TuneCP5                   phase2_realistic_T35        DD4hepExtendedRun4D127   DD4Hep (HLLHC14TeV BeamSpot)
             #prefixDet+234.999, # RelValTTbar_14TeV (PREMIX)            phase2_realistic_T35        ExtendedRun4D127         AVE_50_BX_25ns_m3p3 COMMENT: reads old format file
             prefixDet+96.0,     # RelValCloseByPGun_CE_E_Front_120um    phase2_realistic_T35        ExtendedRun4D127


### PR DESCRIPTION
#### PR description:

As easy as that. New GEN-SIM inputs for D127 release, [freshly produced](https://cms-pdmv-prod.web.cern.ch/relval/relvals?ticket=CMSSW_20_0_0__Run4_D127_pp_noPU_STD_Inputs_GSOnly-00002&page=0&limit=50). Reverting also https://github.com/cms-sw/cmssw/pull/51667.

#### PR validation:

Let's the bot do that.

