### PR TITLE
[20_0_X] Re-align D12* Geometry Order to `master`

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -97,13 +97,13 @@ upgradeKeys['Run4'] = [
     'Run4D110FS',
     'Run4D110FSPU',
     'Run4D121FS',
-    'Run4D121FSPU',
-    'Run4D121GenOnly',
-    'Run4D121SimOnGen',
+    'Run4D121FSPU', 
     'Run4D126',
     'Run4D126PU',
     'Run4D127',
     'Run4D127PU',
+    'Run4D121GenOnly', 
+    'Run4D121SimOnGen',
 ]
 
 # pre-generation of WF numbers

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -130,7 +130,8 @@ if __name__ == '__main__':
             ###### MC (generated from scratch or from RelVals)
             # Phase2
             prefixDet+34.0,	# RelValTTbar_14TeV                     phase2_realistic_T35        ExtendedRun4D127         (Phase-2 baseline)
-            prefixDet+234.0,	# RelValTTbar_14TeV                     phase2_realistic_T35        ExtendedRun4D127         AVE_200_BX_25ns	(Phase-2 baseline with PU) 
+	    ### FIXME: to be re-enabled when the right PU library comes
+            #prefixDet+234.0,	# RelValTTbar_14TeV                     phase2_realistic_T35        ExtendedRun4D127         AVE_200_BX_25ns	(Phase-2 baseline with PU) 
             prefixDet+34.911,	# TTbar_14TeV_TuneCP5                   phase2_realistic_T35        DD4hepExtendedRun4D127   DD4Hep (HLLHC14TeV BeamSpot)
             #prefixDet+234.999, # RelValTTbar_14TeV (PREMIX)            phase2_realistic_T35        ExtendedRun4D127         AVE_50_BX_25ns_m3p3 COMMENT: reads old format file
             prefixDet+96.0,    # RelValCloseByPGun_CE_E_Front_120um    phase2_realistic_T35        ExtendedRun4D127


### PR DESCRIPTION
#### PR description:

This PR proposes a realignment of the 20_0_X order for `Run4D12*` geometries to the one used in `master`. Personally, I don't like this too much since it pushes D121 `GenOnly` and `SimOnGen` flavors to the bottom. But this is the less painful transition that allows us to keep the `37600` offset for D127 (the new baseline).

#### PR validation:

Let's the bot do this.
