### PR TITLE
[NGT] Set minHits for secondary vertexing with pixel tracks to 5

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltDeepInclusiveVertexFinderPF_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltDeepInclusiveVertexFinderPF_cfi.py
@@ -36,3 +36,6 @@ hltDeepInclusiveVertexFinderPF = cms.EDProducer("InclusiveCandidateVertexFinder"
         smoothing = cms.bool(True)
     )
 )
+
+from Configuration.ProcessModifiers.ngtScouting_cff import ngtScouting
+ngtScouting.toModify(hltDeepInclusiveVertexFinderPF, minHits = 5)


### PR DESCRIPTION
### PR description:

This PR changes the minimum number of hit requirement for the secondary vertexing in NGT scouting (`ngtScouting` procModifier) to 5. 

**Motivation** behind this: 
The default value for HLT is 8 hits, however using `ngtScouting` pixel tracks are replacing the full HLT tracks. Since those are built from only 7 tracker layers in the barrel region, the efficiency of SVs drops heavily for a large phase-space. 

**Study** on better settings for that value:
Test with `minHits` set to 4, 5, 6, 7 and the default 8.

**Results**
[**Plots here**](https://jaschulz.web.cern.ch/Plots/NGT/SecondaryVertexingPhase2HLT/IVFStudies/StudyNHits/?search=). Overall, the efficiency drops naturally the more hits you require:
- 4 hits: highest overall efficiency
- **5 hits: almost identical to 4 hit efficiency**
- 6 hits: small efficiency loss compared to 4 hits
- 7 hits: significant loss (definitely not acceptable)
- 8 hits (default): no sense in the barrel as we only have 7 layers $\to$ almost full loss of efficiency in barrel
We chose 5 hits for now as the loss is very small compared to 4 hits. But in general, any of 4, 5, or 6 are reasonable choices.

<img height="300" alt="grafik" src="https://github.com/user-attachments/assets/3e490ce6-c5c7-44a6-9e26-54b82ee79a57" />
<img height="300" alt="grafik" src="https://github.com/user-attachments/assets/c20deda4-2359-4e27-8645-9a114b30d3a5" />


### PR validation:

Bot tests should be sufficient as the change is minimal and purely python configuration.

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.
