### PR TITLE
Update dictionary package assignment for TrackingVertex-reco::Vertex associations

### DIFF
--- a/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
+++ b/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
@@ -33,9 +33,16 @@ io_v = r"(io_v\d+::)?"
 equivDict = \
      [
          {'SelectorUtils': ['VersionedSelector']},
-         {'Associations': ['TTTrackTruthPair', 'edm::Wrapper.+edm::AssociationMap.+TrackingParticle', 'MtdSimLayerCluster.+TrackingParticle', 'TrackingParticle.+MtdSimLayerCluster',
+         {'Associations': ['TTTrackTruthPair',
+                           'edm::Wrapper.+edm::AssociationMap.+TrackingParticle',
+                           'MtdSimLayerCluster.+TrackingParticle',
+                           'TrackingParticle.+MtdSimLayerCluster',
                            '(TTClusterAssociationMap|TTStubAssociationMap|TTTrackAssociationMap|TrackingParticle).*Phase2TrackerDigi',
-                           '(TTStub|TTCluster|TTTrack).*Phase2TrackerDigi.*TrackingParticle']},
+                           '(TTStub|TTCluster|TTTrack).*Phase2TrackerDigi.*TrackingParticle',
+                           'reco::VertexToTrackingVertexAssociator',
+                           f'TrackingVertex.*reco::{io_v}Vertex',
+                           f'reco::{io_v}Vertex.*TrackingVertex',
+                           ]},
          {'TrajectoryState'         : ['TrajectoryStateOnSurface']},
          {'L1TrackTrigger'        : ['(TTStub|TTCluster|TTTrack).*Phase2TrackerDigi']},
          {'L1Scouting'            : ['l1ScoutingRun3::CaloTower.*']},


### PR DESCRIPTION
#### PR description:

Following https://github.com/cms-sw/cmssw/pull/51577#issuecomment-5280903317

Resolves https://github.com/cms-sw/framework-team/issues/2390

#### PR validation:

Running `duplicateReflexLibrarySearch.py --lostDefs` locally no longer shows the warnings.