### PR TITLE
Add HLT_DoubleMediumPFPuppiParTTauh30_eta2p1 path

### DIFF
--- a/DataFormats/BTauReco/interface/HLTParticleTransformerAK4Features.h
+++ b/DataFormats/BTauReco/interface/HLTParticleTransformerAK4Features.h
@@ -1,0 +1,80 @@
+#ifndef DataFormats_BTauReco_HLTParticleTransformerAK4Features_h
+#define DataFormats_BTauReco_HLTParticleTransformerAK4Features_h
+
+#include <vector>
+
+class HLTGlobalFeatures {
+public:
+  float jet_pt;
+  float jet_eta;
+  float jet_phi;
+  float jet_energy;
+};
+
+class HLTCpfCandidateFeatures {
+public:
+  float jet_pfcand_deta;
+  float jet_pfcand_dphi;
+  float jet_pfcand_pt_log;
+  float jet_pfcand_energy_log;
+  float jet_pfcand_charge;
+  float jet_pfcand_frompv;
+  float jet_pfcand_nlostinnerhits;
+  float jet_pfcand_track_chi2;
+  float jet_pfcand_track_qual;
+  float jet_pfcand_dz;
+  float jet_pfcand_dzsig;
+  float jet_pfcand_dxy;
+  float jet_pfcand_dxysig;
+  float jet_pfcand_etarel;
+  float jet_pfcand_pperp_ratio;
+  float jet_pfcand_ppara_ratio;
+  float jet_pfcand_trackjet_d3d;
+  float jet_pfcand_trackjet_d3dsig;
+  float jet_pfcand_trackjet_dist;
+  float jet_pfcand_trackjet_decayL;
+  float jet_pfcand_npixhits;
+  float jet_pfcand_nstriphits;
+  float jet_pfcand_highpurity;
+  float jet_pfcand_id;
+
+  float jet_pfcand_pt;
+  float jet_pfcand_eta;
+  float jet_pfcand_phi;
+  float jet_pfcand_energy;
+};
+
+class HLTVtxFeatures {
+public:
+  float jet_sv_deta;
+  float jet_sv_dphi;
+  float jet_sv_pt_log;
+  float jet_sv_mass;
+  float jet_sv_ntrack;
+  float jet_sv_chi2;
+  float jet_sv_dxy;
+  float jet_sv_dxysig;
+  float jet_sv_d3d;
+  float jet_sv_d3dsig;
+  float jet_sv_costhetasvpv;
+  float jet_sv_enratio;
+
+  float jet_sv_pt;
+  float jet_sv_eta;
+  float jet_sv_phi;
+  float jet_sv_energy;
+};
+
+namespace btagbtvdeep {
+
+  class HLTParticleTransformerAK4Features {
+  public:
+    bool is_filled = true;
+    HLTGlobalFeatures global_features;
+    std::vector<HLTCpfCandidateFeatures> cpf_candidates;
+    std::vector<HLTVtxFeatures> vtx_features;
+  };
+
+}  // namespace btagbtvdeep
+
+#endif

--- a/DataFormats/BTauReco/interface/HLTParticleTransformerAK4TagInfo.h
+++ b/DataFormats/BTauReco/interface/HLTParticleTransformerAK4TagInfo.h
@@ -1,0 +1,12 @@
+#ifndef DataFormats_BTauReco_HLTParticleTransformerAK4TagInfo_h
+#define DataFormats_BTauReco_HLTParticleTransformerAK4TagInfo_h
+
+#include "DataFormats/BTauReco/interface/HLTParticleTransformerAK4Features.h"
+#include "DataFormats/BTauReco/interface/FeaturesTagInfo.h"
+
+namespace reco {
+  typedef FeaturesTagInfo<btagbtvdeep::HLTParticleTransformerAK4Features> HLTParticleTransformerAK4TagInfo;
+  DECLARE_EDM_REFS(HLTParticleTransformerAK4TagInfo)
+}  // namespace reco
+
+#endif  // DataFormats_BTauReco_HLTParticleTransformerAK4TagInfo_h

--- a/DataFormats/BTauReco/src/classes.h
+++ b/DataFormats/BTauReco/src/classes.h
@@ -65,6 +65,8 @@
 #include "DataFormats/BTauReco/interface/DeepDoubleXTagInfo.h"
 #include "DataFormats/BTauReco/interface/ParticleTransformerAK4Features.h"
 #include "DataFormats/BTauReco/interface/ParticleTransformerAK4TagInfo.h"
+#include "DataFormats/BTauReco/interface/HLTParticleTransformerAK4Features.h"
+#include "DataFormats/BTauReco/interface/HLTParticleTransformerAK4TagInfo.h"
 #include "DataFormats/BTauReco/interface/UnifiedParticleTransformerAK4Features.h"
 #include "DataFormats/BTauReco/interface/UnifiedParticleTransformerAK4TagInfo.h"
 #include "DataFormats/BTauReco/interface/DeepBoostedJetTagInfo.h"

--- a/DataFormats/BTauReco/src/classes_def.xml
+++ b/DataFormats/BTauReco/src/classes_def.xml
@@ -433,6 +433,14 @@
   <class name="reco::ParticleTransformerAK4TagInfoRefVector"/>
   <class name="edm::Wrapper<reco::ParticleTransformerAK4TagInfoCollection>"/>
 
+  <class name="reco::HLTParticleTransformerAK4TagInfo"/>
+  <class name="reco::HLTParticleTransformerAK4TagInfoCollection"/>
+  <class name="reco::HLTParticleTransformerAK4TagInfoRef"/>
+  <class name="reco::HLTParticleTransformerAK4TagInfoFwdRef"/>
+  <class name="reco::HLTParticleTransformerAK4TagInfoRefProd"/>
+  <class name="reco::HLTParticleTransformerAK4TagInfoRefVector"/>
+  <class name="edm::Wrapper<reco::HLTParticleTransformerAK4TagInfoCollection>"/>
+
   <class name="reco::UnifiedParticleTransformerAK4TagInfo"/>
   <class name="reco::UnifiedParticleTransformerAK4TagInfoCollection"/>
   <class name="reco::UnifiedParticleTransformerAK4TagInfoRef"/>

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltDoublePFJets30ParTTauhTagMediumWPL2DoubleTau_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltDoublePFJets30ParTTauhTagMediumWPL2DoubleTau_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+hltDoublePFJets30ParTTauhTagMediumWPL2DoubleTau = cms.EDFilter( "TauTagFilter",
+    saveTags = cms.bool( True ),
+    nExpected = cms.int32( 2 ),
+    taus = cms.InputTag( "hltAK4PFPuppiJets" ),
+    tauTags = cms.InputTag( 'hltParticleTransformerDiscriminatorsJetTags','TauvsAll' ),
+    tauPtCorr = cms.InputTag( '','' ),
+    seeds = cms.InputTag( "hltL1P2GTTau" ),
+    seedTypes = cms.vint32( +84 ),
+    selection = cms.string( "0.11645" ),
+    minPt = cms.double( 30.0 ),
+    maxEta = cms.double( 2.1 ),
+    usePtCorr = cms.bool( False ),
+    matchWithSeeds = cms.bool( False ),
+    matchingdR = cms.double( 0.5 )
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPFJetForBtagSelector_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPFJetForBtagSelector_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+hltPFJetForBtagSelector = cms.EDFilter( "HLT1PFJet",
+    saveTags = cms.bool( True ),
+    inputTag = cms.InputTag( "hltAK4PFPuppiJets" ),
+    triggerType = cms.int32( 86 ),
+    MinE = cms.double( -1.0 ),
+    MinPt = cms.double( 30.0 ),
+    MinMass = cms.double( -1.0 ),
+    MaxMass = cms.double( -1.0 ),
+    MinEta = cms.double( -1.0 ),
+    MaxEta = cms.double( 2.1 ),
+    MinN = cms.int32( 1 )
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPFJetForBtag_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPFJetForBtag_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+hltPFJetForBtag = cms.EDProducer( "HLTPFJetCollectionProducer",
+    HLTObject = cms.InputTag( "hltPFJetForBtagSelector" ),
+    TriggerTypes = cms.vint32( 86 )
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleTransformerAK4TagInfos_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleTransformerAK4TagInfos_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+hltParticleTransformerAK4TagInfos = cms.EDProducer("HLTParticleTransformerAK4TagInfoProducer",
+    candidates = cms.InputTag("hltParticleFlowTmp"),
+    jet_radius = cms.double(0.4),
+    jets = cms.InputTag("hltAK4PFPuppiJets"),
+    mightGet = cms.optional.untracked.vstring,
+    min_candidate_pt = cms.double(0.1),
+    min_jet_pt = cms.double(5),
+    max_jet_eta = cms.double(2.1),
+    secondary_vertices = cms.InputTag("hltDeepInclusiveMergedVerticesPF"),
+    vertex_associator = cms.InputTag("hltPrimaryVertexAssociation","original"),
+    vertices = cms.InputTag("hltOfflinePrimaryVertices")
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleTransformerDiscriminatorsJetTags_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleTransformerDiscriminatorsJetTags_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+hltParticleTransformerDiscriminatorsJetTags = cms.EDProducer("BTagProbabilityToDiscriminator",
+    discriminators = cms.VPSet(
+      cms.PSet(name = cms.string("TauvsAll"),
+        numerator = cms.VInputTag('hltParticleTransformerONNXJetTags:probtaup',
+        'hltParticleTransformerONNXJetTags:probtaum'),
+        denominator = cms.VInputTag(
+            'hltParticleTransformerONNXJetTags:probb',
+            'hltParticleTransformerONNXJetTags:probg',
+            'hltParticleTransformerONNXJetTags:probtaup',
+            'hltParticleTransformerONNXJetTags:probtaum',
+            'hltParticleTransformerONNXJetTags:probc',
+            'hltParticleTransformerONNXJetTags:probuds'
+        )
+      )
+    )
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleTransformerONNXJetTags_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleTransformerONNXJetTags_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+hltParticleTransformerONNXJetTags = cms.EDProducer( "HLTParticleTransformerAK4ONNXJetTagsProducer",
+    src = cms.InputTag( "hltParticleTransformerAK4TagInfos" ),
+    model_path = cms.FileInPath( "RecoBTag/Combined/data/HLT/hltParticleTransformerAK4/hltParTAK4_CMSSW15_082026.onnx" ),
+    flav_names = cms.vstring(
+        "probb",
+        "probc",
+        "probuds",
+        "probg",
+        "probtaup",
+        "probtaum",
+    ),
+    input_names = cms.vstring(
+        "global",
+        "cpf",
+        "vtx",
+    ),
+    output_names = cms.vstring("output"),
+    mightGet = cms.optional.untracked.vstring,
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoubleMediumPFPuppiParTTauh30_eta2p1_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_DoubleMediumPFPuppiParTTauh30_eta2p1_cfi.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..sequences.HLTBeginSequence_cfi import *
+from ..sequences.HLTEndSequence_cfi import *
+from ..sequences.HLTAK4PFPuppiJetsReconstruction_cfi import *
+from ..sequences.HLTJetFlavourTagParticleTransformerSequencePF_cfi import *
+from ..modules.hltL1P2GTTau_cfi import *
+from ..sequences.HLTTICLLocalRecoSequence_cfi import *
+from ..sequences.HLTMuonsSequence_cfi import *
+from ..sequences.HLTParticleFlowSequence_cfi import *
+from ..sequences.HLTTrackingSequence_cfi import *
+from ..sequences.HLTLocalrecoSequence_cfi import *
+from ..sequences.HLTRawToDigiSequence_cfi import *
+from ..modules.hltDoublePFJets30ParTTauhTagMediumWPL2DoubleTau_cfi import *
+
+HLT_DoubleMediumPFPuppiParTTauh30_eta2p1 = cms.Path(
+    HLTBeginSequence +
+    hltL1P2GTTau +
+    HLTRawToDigiSequence +
+    HLTLocalrecoSequence +
+    HLTTICLLocalRecoSequence +
+    HLTTrackingSequence +
+    HLTMuonsSequence +
+    HLTParticleFlowSequence +
+    HLTAK4PFPuppiJetsReconstruction +
+    HLTJetFlavourTagParticleTransformerSequencePF +
+    hltDoublePFJets30ParTTauhTagMediumWPL2DoubleTau +
+    HLTEndSequence
+    )

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTJetFlavourTagParticleTransformerSequencePF_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTJetFlavourTagParticleTransformerSequencePF_cfi.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltDeepInclusiveMergedVerticesPF_cfi import *
+from ..modules.hltDeepInclusiveSecondaryVerticesPF_cfi import *
+from ..modules.hltDeepInclusiveVertexFinderPF_cfi import *
+from ..modules.hltPrimaryVertexAssociation_cfi import *
+from ..modules.hltDeepTrackVertexArbitratorPF_cfi import *
+from ..modules.hltPFJetForBtagSelector_cfi import *
+from ..modules.hltPFJetForBtag_cfi import *
+from ..modules.hltParticleTransformerAK4TagInfos_cfi import *
+from ..modules.hltParticleTransformerONNXJetTags_cfi import *
+from ..modules.hltParticleTransformerDiscriminatorsJetTags_cfi import *
+
+HLTJetFlavourTagParticleTransformerSequencePF = cms.Sequence( 
+    hltPFJetForBtagSelector + 
+    hltPFJetForBtag + 
+    hltDeepInclusiveVertexFinderPF + 
+    hltDeepInclusiveSecondaryVerticesPF + 
+    hltDeepTrackVertexArbitratorPF + 
+    hltDeepInclusiveMergedVerticesPF + 
+    hltPrimaryVertexAssociation + 
+    hltParticleTransformerAK4TagInfos + 
+    hltParticleTransformerONNXJetTags + 
+    hltParticleTransformerDiscriminatorsJetTags 
+    )

--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -109,6 +109,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltKFSmootherForRefi
 ### Paths
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/DST_PFScouting_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_DoubleMediumPFPuppiParTTauh30_eta2p1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Diphoton30_23_IsoCaloId_L1Seeded_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Diphoton30_23_IsoCaloId_Unseeded_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_DoubleEle23_12_Iso_L1Seeded_cfi")
@@ -325,12 +326,10 @@ fragment.schedule = cms.Schedule(*[
 
     fragment.HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1,
     fragment.HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1,
+    fragment.HLT_DoubleMediumPFPuppiParTTauh30_eta2p1,
     fragment.HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1,
     fragment.HLT_Ele30_WPTight_L1Seeded_LooseDeepTauPFTauHPS30_eta2p1_CrossL1,
     fragment.HLT_LooseDeepTauPFTauHPS150_L1NN_eta2p1,
-    ### Removed temporarily until final decision on L1T tau Phase-2
-    #fragment.L1T_DoubleNNTau52,
-    #fragment.L1T_SingleNNTau150,
 
     fragment.MC_JME,
     fragment.MC_BTV,

--- a/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
@@ -117,6 +117,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_DoubleEle23_12_Iso_L1
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_DoubleEle25_CaloIdL_PMS2_L1Seeded_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_DoubleMediumPFPuppiParTTauh30_eta2p1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Ele115_NonIso_L1Seeded_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Ele26_WP70_L1Seeded_cfi")
@@ -290,10 +291,7 @@ fragment.schedule = cms.Schedule(*[
     fragment.HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1,
     fragment.HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1,
     fragment.HLT_LooseDeepTauPFTauHPS150_L1NN_eta2p1,
-    
-    ### Removed temporarily until final decision on L1T tau Phase-2
-    #fragment.L1T_DoubleNNTau52,
-    #fragment.L1T_SingleNNTau150,
+    fragment.HLT_DoubleMediumPFPuppiParTTauh30_eta2p1,
 
     fragment.HLTriggerFinalPath,
     fragment.HLTAnalyzerEndpath,

--- a/HLTrigger/NGTScouting/python/hltTriggerObjects_cff.py
+++ b/HLTrigger/NGTScouting/python/hltTriggerObjects_cff.py
@@ -50,6 +50,7 @@ hltTriggerObjP4Table = cms.EDProducer(
         "HLT_Diphoton30_23_IsoCaloId_L1Seeded",
         "HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1",
         "HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1",
+        "HLT_DoubleMediumPFPuppiParTTauh30_eta2p1",
         "HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1",
         "HLT_Ele30_WPTight_L1Seeded_LooseDeepTauPFTauHPS30_eta2p1_CrossL1"
     ),

--- a/RecoBTag/FeatureTools/plugins/HLTParticleTransformerAK4TagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/HLTParticleTransformerAK4TagInfoProducer.cc
@@ -1,0 +1,412 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include "DataFormats/BTauReco/interface/HLTParticleTransformerAK4Features.h"
+#include "DataFormats/BTauReco/interface/HLTParticleTransformerAK4TagInfo.h"
+
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/IPTools/interface/IPTools.h"
+
+#include "RecoBTag/FeatureTools/interface/deep_helpers.h"
+
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+
+#include "RecoVertex/VertexTools/interface/VertexDistanceXY.h"
+#include "RecoVertex/VertexTools/interface/VertexDistance3D.h"
+
+#include <algorithm>
+#include <array>
+#include <vector>
+#include <cmath>
+
+#include "TVector3.h"
+
+class HLTParticleTransformerAK4TagInfoProducer : public edm::stream::EDProducer<> {
+public:
+  explicit HLTParticleTransformerAK4TagInfoProducer(const edm::ParameterSet&);
+  ~HLTParticleTransformerAK4TagInfoProducer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  typedef std::vector<reco::HLTParticleTransformerAK4TagInfo> TagInfoCollection;
+  typedef reco::VertexCompositePtrCandidateCollection SVCollection;
+  typedef reco::VertexCollection VertexCollection;
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  // Find a persistent edm::Ref to the candidate in the original collection.
+  edm::Ref<edm::View<reco::Candidate>> getPersistentCandidate(
+      const reco::Candidate* cand, const edm::Handle<edm::View<reco::Candidate>>& handle) const {
+    for (size_t idx = 0; idx < handle->size(); ++idx) {
+      if (&(handle->at(idx)) == cand) {
+        return edm::Ref<edm::View<reco::Candidate>>(handle, idx);
+      }
+    }
+    return edm::Ref<edm::View<reco::Candidate>>();
+  }
+
+  // Build a PackedCandidate with packed track properties.
+  static pat::PackedCandidate buildPackedCandidate(const reco::PFCandidate* cand,
+                                                   const reco::Track* track,
+                                                   int pvAssocQual,
+                                                   const reco::VertexRef& pv_ass,
+                                                   const reco::VertexRefProd& pvRefProd) {
+    constexpr float min_track_pt_property = 0.5f;
+    constexpr int min_valid_pixel_hits = 0;
+    constexpr int covarianceVersion = 1;
+    constexpr std::array<int, 5> covariancePackingSchemas = {{8, 264, 520, 776, 0}};
+
+    pat::PackedCandidate packed;
+    if (track) {
+      packed = pat::PackedCandidate(cand->polarP4(),
+                                    track->referencePoint(),
+                                    track->pt(),
+                                    track->eta(),
+                                    track->phi(),
+                                    cand->pdgId(),
+                                    pvRefProd,
+                                    pv_ass.key());
+      packed.setAssociationQuality(pat::PackedCandidate::PVAssociationQuality(pvAssocQual));
+      packed.setCovarianceVersion(covarianceVersion);
+
+      pat::PackedCandidate::LostInnerHits lostHits = pat::PackedCandidate::noLostInnerHits;
+      int nlost = track->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
+      if (nlost == 0) {
+        if (track->hitPattern().hasValidHitInPixelLayer(PixelSubdetector::SubDetector::PixelBarrel, 1))
+          lostHits = pat::PackedCandidate::validHitInFirstPixelBarrelLayer;
+      } else {
+        lostHits = (nlost == 1 ? pat::PackedCandidate::oneLostInnerHit : pat::PackedCandidate::moreLostInnerHits);
+      }
+      packed.setLostInnerHits(lostHits);
+      packed.setTrkAlgo(static_cast<uint8_t>(track->algo()), static_cast<uint8_t>(track->originalAlgo()));
+
+      const bool use_track_properties = track->pt() > min_track_pt_property;
+      if (use_track_properties) {
+        packed.setFirstHit(track->hitPattern().getHitPattern(reco::HitPattern::TRACK_HITS, 0));
+        if (std::abs(cand->pdgId()) == 22) {
+          packed.setTrackProperties(*track, covariancePackingSchemas[4], covarianceVersion);
+        } else if (track->hitPattern().numberOfValidPixelHits() > min_valid_pixel_hits) {
+          packed.setTrackProperties(*track, covariancePackingSchemas[0], covarianceVersion);
+        } else {
+          packed.setTrackProperties(*track, covariancePackingSchemas[1], covarianceVersion);
+        }
+      } else if (packed.pt() > min_track_pt_property) {
+        if (track->hitPattern().numberOfValidPixelHits() > 0) {
+          packed.setTrackProperties(*track, covariancePackingSchemas[2], covarianceVersion);
+        } else {
+          packed.setTrackProperties(*track, covariancePackingSchemas[3], covarianceVersion);
+        }
+      }
+      packed.setTrackHighPurity(cand->trackRef().isNonnull() && cand->trackRef()->quality(reco::Track::highPurity));
+    } else {
+      math::XYZPoint pv_ass_pos = pv_ass->position();
+      packed = pat::PackedCandidate(
+          cand->polarP4(), pv_ass_pos, cand->pt(), cand->eta(), cand->phi(), cand->pdgId(), pvRefProd, pv_ass.key());
+      packed.setAssociationQuality(pat::PackedCandidate::PVAssociationQuality(pat::PackedCandidate::UsedInFitTight));
+    }
+    return packed;
+  }
+
+  const double jet_radius_;
+  const double min_candidate_pt_;
+
+  const edm::EDGetTokenT<edm::View<reco::Jet>> jet_token_;
+  const edm::EDGetTokenT<VertexCollection> vtx_token_;
+  const edm::EDGetTokenT<SVCollection> sv_token_;
+  const edm::EDGetTokenT<edm::View<reco::Candidate>> candidateToken_;
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> track_builder_token_;
+
+  const double min_jet_pt_;
+  const double max_jet_eta_;
+
+  const bool fallback_vertex_association_;
+
+  const edm::EDGetTokenT<edm::Association<VertexCollection>> vertex_associator_token_;
+  const edm::EDGetTokenT<edm::ValueMap<int>> vertex_associator_quality_token_;
+};
+
+HLTParticleTransformerAK4TagInfoProducer::HLTParticleTransformerAK4TagInfoProducer(const edm::ParameterSet& iConfig)
+    : jet_radius_(iConfig.getParameter<double>("jet_radius")),
+      min_candidate_pt_(iConfig.getParameter<double>("min_candidate_pt")),
+      jet_token_(consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("jets"))),
+      vtx_token_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
+      sv_token_(consumes<SVCollection>(iConfig.getParameter<edm::InputTag>("secondary_vertices"))),
+      candidateToken_(consumes<edm::View<reco::Candidate>>(iConfig.getParameter<edm::InputTag>("candidates"))),
+      track_builder_token_(
+          esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"))),
+      min_jet_pt_(iConfig.getParameter<double>("min_jet_pt")),
+      max_jet_eta_(iConfig.getParameter<double>("max_jet_eta")),
+      fallback_vertex_association_(iConfig.getParameter<bool>("fallback_vertex_association")),
+      vertex_associator_token_(
+          consumes<edm::Association<VertexCollection>>(iConfig.getParameter<edm::InputTag>("vertex_associator"))),
+      vertex_associator_quality_token_(
+          consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("vertex_associator"))) {
+  produces<TagInfoCollection>();
+}
+
+void HLTParticleTransformerAK4TagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("jet_radius", 0.4);
+  desc.add<double>("min_candidate_pt", 0.95);
+  desc.add<edm::InputTag>("vertices", edm::InputTag("hltOfflinePrimaryVertices"));
+  desc.add<edm::InputTag>("secondary_vertices", edm::InputTag("hltInclusiveCandidateSecondaryVertices"));
+  desc.add<edm::InputTag>("jets", edm::InputTag("hltAK4PFPuppiJets"));
+  desc.add<edm::InputTag>("candidates", edm::InputTag("hltParticleFlowTmp"));
+  desc.add<double>("min_jet_pt", 15.0);
+  desc.add<double>("max_jet_eta", 2.5);
+  desc.add<bool>("fallback_vertex_association", false);
+  desc.add<edm::InputTag>("vertex_associator", edm::InputTag("hltPrimaryVertexAssociation", "original"));
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void HLTParticleTransformerAK4TagInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto output_tag_infos = std::make_unique<TagInfoCollection>();
+
+  edm::Handle<edm::View<reco::Jet>> jets;
+  iEvent.getByToken(jet_token_, jets);
+
+  edm::Handle<VertexCollection> vtxs;
+  iEvent.getByToken(vtx_token_, vtxs);
+  if (vtxs->empty()) {
+    iEvent.put(std::move(output_tag_infos));
+    return;
+  }
+  const auto& pv = vtxs->at(0);
+  std::unique_ptr<reco::VertexRefProd> PVRefProd = std::make_unique<reco::VertexRefProd>(vtxs);
+
+  edm::Handle<edm::View<reco::Candidate>> tracks;
+  iEvent.getByToken(candidateToken_, tracks);
+
+  edm::Handle<SVCollection> svs;
+  iEvent.getByToken(sv_token_, svs);
+
+  bool use_vertex_association = !fallback_vertex_association_;
+  edm::Handle<edm::ValueMap<int>> pvasq_value_map;
+  edm::Handle<edm::Association<VertexCollection>> pvas;
+  if (use_vertex_association) {
+    iEvent.getByToken(vertex_associator_quality_token_, pvasq_value_map);
+    iEvent.getByToken(vertex_associator_token_, pvas);
+    if (!pvasq_value_map.isValid() || !pvas.isValid())
+      use_vertex_association = false;
+  }
+
+  edm::ESHandle<TransientTrackBuilder> track_builder = iSetup.getHandle(track_builder_token_);
+
+  for (std::size_t jet_n = 0; jet_n < jets->size(); ++jet_n) {
+    edm::RefToBase<reco::Jet> jet_ref(jets, jet_n);
+    const auto& jet = jets->at(jet_n);
+
+    btagbtvdeep::HLTParticleTransformerAK4Features hltFeatures;
+    if (jet.pt() < min_jet_pt_ || std::abs(jet.eta()) > max_jet_eta_) {
+      hltFeatures.is_filled = false;
+      hltFeatures.global_features.jet_pt = 0.f;
+      hltFeatures.global_features.jet_eta = 0.f;
+      hltFeatures.global_features.jet_phi = 0.f;
+      hltFeatures.global_features.jet_energy = 0.f;
+    } else {
+      hltFeatures.is_filled = true;
+
+      // Fill secondary vertex features
+      {
+        SVCollection svs_sorted = *svs;
+        std::sort(svs_sorted.begin(), svs_sorted.end(), [&pv](const auto& sv1, const auto& sv2) {
+          return btagbtvdeep::sv_vertex_comparator(sv1, sv2, pv);
+        });
+
+        GlobalVector jet_vec(jet.px(), jet.py(), jet.pz());
+        for (const auto& sv : svs_sorted) {
+          if (reco::deltaR2(sv, jet) > (jet_radius_ * jet_radius_))
+            continue;
+
+          HLTVtxFeatures svfeat;
+          svfeat.jet_sv_pt = sv.pt();
+          svfeat.jet_sv_deta = sv.eta() - jet.eta();
+          svfeat.jet_sv_dphi = sv.phi() - jet.phi();
+          svfeat.jet_sv_eta = sv.eta();
+          svfeat.jet_sv_phi = sv.phi();
+          svfeat.jet_sv_energy = sv.energy();
+          svfeat.jet_sv_mass = sv.mass();
+          svfeat.jet_sv_ntrack = sv.numberOfDaughters();
+          svfeat.jet_sv_chi2 = sv.vertexNormalizedChi2();
+
+          reco::Vertex::CovarianceMatrix csv;
+          sv.fillVertexCovariance(csv);
+          reco::Vertex svtx(sv.vertex(), csv);
+
+          VertexDistanceXY dxy;
+          auto dxy_meas = dxy.signedDistance(svtx, pv, jet_vec);
+          svfeat.jet_sv_dxy = dxy_meas.value();
+          svfeat.jet_sv_dxysig = std::fabs(dxy_meas.significance());
+
+          VertexDistance3D d3d;
+          auto d3d_meas = d3d.signedDistance(svtx, pv, jet_vec);
+          svfeat.jet_sv_d3d = d3d_meas.value();
+          svfeat.jet_sv_d3dsig = std::fabs(d3d_meas.significance());
+          svfeat.jet_sv_pt_log = std::log(sv.pt());
+
+          const float cos_sv_pv = btagbtvdeep::vertexDdotP(sv, pv);
+          svfeat.jet_sv_costhetasvpv = cos_sv_pv;
+          svfeat.jet_sv_enratio = (jet.energy() > 0.f ? sv.energy() / jet.energy() : 0.f);
+
+          hltFeatures.vtx_features.push_back(svfeat);
+        }
+      }
+
+      // Collect and sort PF candidates by pt
+      std::vector<const reco::PFCandidate*> pfCandidates;
+      for (unsigned int i = 0; i < jet.numberOfDaughters(); ++i) {
+        const auto* cand = dynamic_cast<const reco::PFCandidate*>(jet.daughter(i));
+        if (!cand || cand->pt() < min_candidate_pt_)
+          continue;
+        pfCandidates.push_back(cand);
+      }
+
+      std::sort(pfCandidates.begin(), pfCandidates.end(), [](const reco::PFCandidate* a, const reco::PFCandidate* b) {
+        return a->pt() > b->pt();
+      });
+
+      hltFeatures.cpf_candidates.reserve(pfCandidates.size());
+
+      for (const auto* cand : pfCandidates) {
+        const reco::Track* track = cand->bestTrack();
+
+        // PV association
+        int pv_ass_quality = 0;
+        reco::VertexRef pv_ass(vtxs, 0);
+
+        if (use_vertex_association) {
+          edm::Ref<edm::View<reco::Candidate>> candRef = getPersistentCandidate(cand, tracks);
+          if (candRef.isNonnull() && pvas.isValid() && pvasq_value_map.isValid()) {
+            const reco::VertexRef& pv_orig = (*pvas)[candRef];
+            if (pv_orig.isNonnull())
+              pv_ass = pv_orig;
+            pv_ass_quality = (*pvasq_value_map)[candRef];
+          }
+        }
+
+        // Fallback: find closest PV by dz
+        if (!use_vertex_association && track && pv_ass.key() == 0) {
+          float z_dist = 99999.f;
+          int pv_pos = 0;
+          for (size_t iv = 0; iv < vtxs->size(); iv++) {
+            float dz = std::abs(track->dz((*vtxs)[iv].position()));
+            if (dz < z_dist) {
+              z_dist = dz;
+              pv_pos = iv;
+            }
+          }
+          pv_ass = reco::VertexRef(vtxs, pv_pos);
+        }
+
+        // Compute fromPV inline
+        int pvAssocQual;
+        if (track) {
+          pvAssocQual = static_cast<int>(btagbtvdeep::vtx_ass_from_pfcand(*cand, pv_ass_quality, pv_ass));
+        } else {
+          // Trackless candidates treated as UsedInFitTight
+          pvAssocQual = pat::PackedCandidate::UsedInFitTight;
+        }
+
+        // Build PackedCandidate to get packed track properties
+        pat::PackedCandidate packed_candidate = buildPackedCandidate(cand, track, pvAssocQual, pv_ass, *PVRefProd);
+        math::XYZPoint pv_ass_pos = pv_ass->position();
+
+        const reco::Track* packed_track = packed_candidate.bestTrack();
+        bool highPurity = packed_candidate.trackHighPurity();
+
+        // Fill features
+        HLTCpfCandidateFeatures feat;
+        feat.jet_pfcand_deta = jet.eta() - cand->eta();
+        feat.jet_pfcand_dphi = reco::deltaPhi(jet.phi(), cand->phi());
+        feat.jet_pfcand_pt_log = (cand->pt() > 0) ? std::log(cand->pt()) : 0;
+        feat.jet_pfcand_energy_log = (cand->energy() > 0) ? std::log(cand->energy()) : 0;
+        feat.jet_pfcand_charge = static_cast<float>(cand->charge());
+        feat.jet_pfcand_frompv = static_cast<float>(packed_candidate.fromPV());
+        feat.jet_pfcand_nlostinnerhits = packed_candidate.lostInnerHits();
+
+        if (packed_track) {
+          feat.jet_pfcand_track_chi2 = packed_track->normalizedChi2();
+          feat.jet_pfcand_track_qual = packed_track->qualityMask();
+          feat.jet_pfcand_dz = packed_candidate.dz(pv_ass_pos);
+          feat.jet_pfcand_dzsig = std::fabs(packed_candidate.dz(pv_ass_pos) / packed_candidate.dzError());
+          feat.jet_pfcand_dxy = packed_candidate.dxy(pv_ass_pos);
+          feat.jet_pfcand_dxysig = std::fabs(packed_candidate.dxy(pv_ass_pos) / packed_candidate.dxyError());
+          feat.jet_pfcand_npixhits = packed_candidate.numberOfPixelHits();
+          feat.jet_pfcand_nstriphits = packed_candidate.stripLayersWithMeasurement();
+        } else {
+          feat.jet_pfcand_track_chi2 = 0;
+          feat.jet_pfcand_track_qual = 0;
+          feat.jet_pfcand_dz = 0;
+          feat.jet_pfcand_dzsig = 0;
+          feat.jet_pfcand_dxy = 0;
+          feat.jet_pfcand_dxysig = 0;
+          feat.jet_pfcand_npixhits = 0;
+          feat.jet_pfcand_nstriphits = 0;
+        }
+
+        // etarel from candidate momentum
+        feat.jet_pfcand_etarel = reco::btau::etaRel(jet.momentum().Unit(), cand->momentum());
+
+        TVector3 jet_direction(jet.px(), jet.py(), jet.pz());
+        jet_direction = jet_direction.Unit();
+        TVector3 cand_direction(cand->px(), cand->py(), cand->pz());
+        float cand_mag = cand_direction.Mag();
+        feat.jet_pfcand_pperp_ratio = (cand_mag > 0) ? jet_direction.Perp(cand_direction) / cand_mag : 0;
+        feat.jet_pfcand_ppara_ratio = (cand_mag > 0) ? jet_direction.Dot(cand_direction) / cand_mag : 0;
+
+        // IP tools computed w.r.t. PV[0]
+        if (track) {
+          reco::TransientTrack tt = track_builder->build(*track);
+          GlobalVector jet_global_dir(jet.px(), jet.py(), jet.pz());
+
+          Measurement1D meas_ip3d = IPTools::signedImpactParameter3D(tt, jet_global_dir, pv).second;
+          Measurement1D meas_jetdist = IPTools::jetTrackDistance(tt, jet_global_dir, pv).second;
+          Measurement1D meas_decayL = IPTools::signedDecayLength3D(tt, jet_global_dir, pv).second;
+
+          feat.jet_pfcand_trackjet_d3d = meas_ip3d.value();
+          feat.jet_pfcand_trackjet_d3dsig = std::fabs(meas_ip3d.significance());
+          feat.jet_pfcand_trackjet_dist = -meas_jetdist.value();
+          feat.jet_pfcand_trackjet_decayL = meas_decayL.value();
+        } else {
+          feat.jet_pfcand_trackjet_d3d = 0;
+          feat.jet_pfcand_trackjet_d3dsig = 0;
+          feat.jet_pfcand_trackjet_dist = 0;
+          feat.jet_pfcand_trackjet_decayL = 0;
+        }
+        feat.jet_pfcand_highpurity = highPurity ? 1.f : 0.f;
+        feat.jet_pfcand_id = static_cast<float>(std::abs(cand->pdgId()));
+
+        feat.jet_pfcand_pt = cand->pt();
+        feat.jet_pfcand_eta = cand->eta();
+        feat.jet_pfcand_phi = cand->phi();
+        feat.jet_pfcand_energy = cand->energy();
+
+        hltFeatures.cpf_candidates.push_back(feat);
+      }
+
+      // Global features
+      hltFeatures.global_features.jet_pt = jet.pt();
+      hltFeatures.global_features.jet_eta = jet.eta();
+      hltFeatures.global_features.jet_phi = jet.phi();
+      hltFeatures.global_features.jet_energy = jet.energy();
+    }
+
+    output_tag_infos->emplace_back(reco::HLTParticleTransformerAK4TagInfo(hltFeatures, jet_ref));
+  }
+
+  iEvent.put(std::move(output_tag_infos));
+}
+
+DEFINE_FWK_MODULE(HLTParticleTransformerAK4TagInfoProducer);

--- a/RecoBTag/ONNXRuntime/plugins/HLTParticleTransformerAK4ONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/HLTParticleTransformerAK4ONNXJetTagsProducer.cc
@@ -1,0 +1,225 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/makeRefToBaseProdFrom.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/BTauReco/interface/JetTag.h"
+#include "DataFormats/BTauReco/interface/HLTParticleTransformerAK4Features.h"
+#include "DataFormats/BTauReco/interface/HLTParticleTransformerAK4TagInfo.h"
+
+#include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
+
+using namespace cms::Ort;
+
+class HLTParticleTransformerAK4ONNXJetTagsProducer : public edm::stream::EDProducer<edm::GlobalCache<ONNXRuntime>> {
+public:
+  explicit HLTParticleTransformerAK4ONNXJetTagsProducer(const edm::ParameterSet&, const ONNXRuntime*);
+  ~HLTParticleTransformerAK4ONNXJetTagsProducer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  static std::unique_ptr<ONNXRuntime> initializeGlobalCache(const edm::ParameterSet&);
+  static void globalEndJob(const ONNXRuntime*);
+
+private:
+  typedef std::vector<reco::HLTParticleTransformerAK4TagInfo> TagInfoCollection;
+  typedef reco::JetTagCollection JetTagCollection;
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  void make_inputs(const btagbtvdeep::HLTParticleTransformerAK4Features& features);
+  void get_input_sizes(const reco::HLTParticleTransformerAK4TagInfo& taginfo);
+
+  const edm::EDGetTokenT<TagInfoCollection> src_;
+  std::vector<std::string> flav_names_;
+  std::vector<std::string> input_names_;
+  std::vector<std::string> output_names_;
+
+  enum InputIndexes { kGlobalFeatures = 0, kCpfCandidates = 1, kVtxFeatures = 2 };
+
+  constexpr static size_t global_size_ = 4;
+  constexpr static unsigned n_max_cpf_candidates_ = 50;
+  constexpr static unsigned n_features_cpf_ = 28;
+  constexpr static unsigned n_max_sv_candidates_ = 5;
+  constexpr static unsigned n_features_sv_ = 16;
+
+  std::vector<std::vector<int64_t>> input_shapes_;
+
+  FloatArrays data_;
+};
+
+HLTParticleTransformerAK4ONNXJetTagsProducer::HLTParticleTransformerAK4ONNXJetTagsProducer(
+    const edm::ParameterSet& iConfig, const ONNXRuntime* cache)
+    : src_(consumes<TagInfoCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      flav_names_(iConfig.getParameter<std::vector<std::string>>("flav_names")),
+      input_names_(iConfig.getParameter<std::vector<std::string>>("input_names")),
+      output_names_(iConfig.getParameter<std::vector<std::string>>("output_names")) {
+  for (const auto& flav_name : flav_names_) {
+    produces<JetTagCollection>(flav_name);
+  }
+}
+
+void HLTParticleTransformerAK4ONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("hltParticleTransformerAK4TagInfos"));
+  desc.add<std::vector<std::string>>("input_names", {"global_features", "cpf_features", "vtx_features"});
+  desc.add<edm::FileInPath>(
+      "model_path",
+      edm::FileInPath("RecoBTag/Combined/data/HLT/hltParticleTransformerAK4/hltParTAK4_CMSSW15_082026.onnx"));
+  desc.add<std::vector<std::string>>("output_names", {"output"});
+  desc.add<std::vector<std::string>>("flav_names", {"probb", "probbb", "problepb"});
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+std::unique_ptr<ONNXRuntime> HLTParticleTransformerAK4ONNXJetTagsProducer::initializeGlobalCache(
+    const edm::ParameterSet& iConfig) {
+  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath());
+}
+
+void HLTParticleTransformerAK4ONNXJetTagsProducer::globalEndJob(const ONNXRuntime* cache) {}
+
+void HLTParticleTransformerAK4ONNXJetTagsProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<TagInfoCollection> tag_infos;
+  iEvent.getByToken(src_, tag_infos);
+
+  std::vector<std::unique_ptr<JetTagCollection>> output_tags;
+  if (!tag_infos->empty()) {
+    auto jet_ref = tag_infos->begin()->jet();
+    auto ref2prod = edm::makeRefToBaseProdFrom(jet_ref, iEvent);
+    for (std::size_t i = 0; i < flav_names_.size(); i++) {
+      output_tags.emplace_back(std::make_unique<JetTagCollection>(ref2prod));
+    }
+  } else {
+    for (std::size_t i = 0; i < flav_names_.size(); i++) {
+      output_tags.emplace_back(std::make_unique<JetTagCollection>());
+    }
+  }
+
+  for (unsigned jet_n = 0; jet_n < tag_infos->size(); ++jet_n) {
+    const auto& taginfo = (*tag_infos)[jet_n];
+    std::vector<float> outputs(flav_names_.size(), -1.0);
+    if (taginfo.features().is_filled) {
+      get_input_sizes(taginfo);
+
+      input_shapes_ = {{1, (int64_t)global_size_},
+                       {1, (int64_t)n_max_cpf_candidates_, (int64_t)n_features_cpf_},
+                       {1, (int64_t)n_max_sv_candidates_, (int64_t)n_features_sv_}};
+
+      outputs = globalCache()->run(input_names_, data_, input_shapes_, output_names_, 1)[0];
+      assert(outputs.size() == flav_names_.size());
+    }
+
+    const auto& jet_ref = taginfo.jet();
+    for (std::size_t flav_n = 0; flav_n < flav_names_.size(); flav_n++) {
+      (*(output_tags[flav_n]))[jet_ref] = outputs[flav_n];
+    }
+  }
+
+  for (std::size_t flav_n = 0; flav_n < flav_names_.size(); ++flav_n) {
+    iEvent.put(std::move(output_tags[flav_n]), flav_names_[flav_n]);
+  }
+}
+
+void HLTParticleTransformerAK4ONNXJetTagsProducer::get_input_sizes(
+    const reco::HLTParticleTransformerAK4TagInfo& taginfo) {
+  const auto& features = taginfo.features();
+
+  std::vector<unsigned int> input_sizes = {static_cast<unsigned int>(global_size_),
+                                           static_cast<unsigned int>(n_max_cpf_candidates_ * n_features_cpf_),
+                                           static_cast<unsigned int>(n_max_sv_candidates_ * n_features_sv_)};
+
+  data_.clear();
+  for (const auto& len : input_sizes) {
+    data_.emplace_back(len, 0);
+  }
+
+  make_inputs(features);
+}
+
+void HLTParticleTransformerAK4ONNXJetTagsProducer::make_inputs(
+    const btagbtvdeep::HLTParticleTransformerAK4Features& features) {
+  float* ptr = nullptr;
+  {
+    float* start = &data_[kGlobalFeatures][0];
+    ptr = start;
+    *ptr++ = features.global_features.jet_pt;
+    *ptr++ = features.global_features.jet_eta;
+    *ptr++ = features.global_features.jet_phi;
+    *ptr++ = features.global_features.jet_energy;
+    assert(ptr == start + global_size_);
+  }
+
+  {
+    for (std::size_t c_pf_n = 0; c_pf_n < std::min(features.cpf_candidates.size(), (std::size_t)n_max_cpf_candidates_);
+         c_pf_n++) {
+      ptr = &data_[kCpfCandidates][c_pf_n * n_features_cpf_];
+      const auto& cpf = features.cpf_candidates[c_pf_n];
+      float* start_cpf = ptr;
+
+      *ptr++ = cpf.jet_pfcand_deta;
+      *ptr++ = cpf.jet_pfcand_dphi;
+      *ptr++ = cpf.jet_pfcand_pt_log;
+      *ptr++ = cpf.jet_pfcand_energy_log;
+      *ptr++ = cpf.jet_pfcand_charge;
+      *ptr++ = cpf.jet_pfcand_frompv;
+      *ptr++ = cpf.jet_pfcand_nlostinnerhits;
+      *ptr++ = cpf.jet_pfcand_track_chi2;
+      *ptr++ = cpf.jet_pfcand_track_qual;
+      *ptr++ = cpf.jet_pfcand_dz;
+      *ptr++ = cpf.jet_pfcand_dzsig;
+      *ptr++ = cpf.jet_pfcand_dxy;
+      *ptr++ = cpf.jet_pfcand_dxysig;
+      *ptr++ = cpf.jet_pfcand_etarel;
+      *ptr++ = cpf.jet_pfcand_pperp_ratio;
+      *ptr++ = cpf.jet_pfcand_ppara_ratio;
+      *ptr++ = cpf.jet_pfcand_trackjet_d3d;
+      *ptr++ = cpf.jet_pfcand_trackjet_d3dsig;
+      *ptr++ = cpf.jet_pfcand_trackjet_dist;
+      *ptr++ = cpf.jet_pfcand_trackjet_decayL;
+      *ptr++ = cpf.jet_pfcand_npixhits;
+      *ptr++ = cpf.jet_pfcand_nstriphits;
+      *ptr++ = cpf.jet_pfcand_highpurity;
+      *ptr++ = cpf.jet_pfcand_id;
+      *ptr++ = cpf.jet_pfcand_pt;
+      *ptr++ = cpf.jet_pfcand_eta;
+      *ptr++ = cpf.jet_pfcand_phi;
+      *ptr++ = cpf.jet_pfcand_energy;
+
+      assert(ptr - start_cpf == static_cast<int>(n_features_cpf_));
+    }
+  }
+
+  {
+    assert(data_[kVtxFeatures].size() >= n_max_sv_candidates_ * n_features_sv_);
+    for (std::size_t sv_n = 0; sv_n < std::min(features.vtx_features.size(), (std::size_t)n_max_sv_candidates_);
+         sv_n++) {
+      ptr = &data_[kVtxFeatures][sv_n * n_features_sv_];
+      const auto& sv = features.vtx_features[sv_n];
+      float* start_sv = ptr;
+
+      *ptr++ = sv.jet_sv_deta;
+      *ptr++ = sv.jet_sv_dphi;
+      *ptr++ = sv.jet_sv_pt_log;
+      *ptr++ = sv.jet_sv_mass;
+      *ptr++ = sv.jet_sv_ntrack;
+      *ptr++ = sv.jet_sv_chi2;
+      *ptr++ = sv.jet_sv_dxy;
+      *ptr++ = sv.jet_sv_dxysig;
+      *ptr++ = sv.jet_sv_d3d;
+      *ptr++ = sv.jet_sv_d3dsig;
+      *ptr++ = sv.jet_sv_costhetasvpv;
+      *ptr++ = sv.jet_sv_enratio;
+      *ptr++ = sv.jet_sv_pt;
+      *ptr++ = sv.jet_sv_eta;
+      *ptr++ = sv.jet_sv_phi;
+      *ptr++ = sv.jet_sv_energy;
+
+      assert(ptr - start_sv == static_cast<int>(n_features_sv_));
+    }
+  }
+}
+
+DEFINE_FWK_MODULE(HLTParticleTransformerAK4ONNXJetTagsProducer);

--- a/Validation/HLTrigger/python/HLTGenValidation_cff.py
+++ b/Validation/HLTrigger/python/HLTGenValidation_cff.py
@@ -562,7 +562,8 @@ HLTGenValSourceTAU = cms.EDProducer("HLTGenValSource",
     hltPathsToCheck = cms.vstring(
         'HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1',
         'HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1',
-        'HLT_LooseDeepTauPFTauHPS150_L1NN_eta2p1'
+        'HLT_LooseDeepTauPFTauHPS150_L1NN_eta2p1',
+        'HLT_DoubleMediumPFPuppiParTTauh30_eta2p1'
     ),
     hltProcessName = cms.string('HLT'),
     objType = cms.string('tauHAD'),


### PR DESCRIPTION
#### PR description:

This PR introduces a new Phase-2 tau HLT path (HLT_DoubleMediumPFPuppiParTTauh30_eta2p1) based on a ParticleTransformer model. The model (+documentation) can be found in [this PR](https://github.com/cms-data/RecoBTag-Combined/pull/73) to the cms-data repository. It was developed to also be able to be used for b-tagging, but was not yet tested for this purpose - to illustrate this, the PR includes b- and c- discriminators, which are currently commented out. Most implementation choices were made to maintain compatibility with the existing tools used by the BTV group (most notably the [hltupler](https://gitlab.cern.ch/cms-btv/hltupler/) framework to produce the training ntuples).
Development progress and measurements were presented regularly in Tau internal meetings, e.g. [here](https://indico.cern.ch/event/1697900/contributions/7139864/attachments/3295080/5892805/ParT_DPSNote_v1.pdf) and [here](https://indico.cern.ch/event/1697959/contributions/7223199/attachments/3325785/5955985/HLT_ParT_progress_260810.pdf). 

The new model significantly outperforms the existing DeepTau model across all evaluated metrics - these are tau tagging efficiency, trigger rate and computational runtime. 

#### PR validation:
The standard tests have been run: 
- `scram b runtests use-ibeos`
- `runTheMatrix.py -l limited -i all --ibeos`

Model performance has been evaluated using the same sample composition as was used in the training, but with a different subgroup of the samples to ensure evaluation is done on events not used in the model training. 

To test this PR, the [PR](https://github.com/cms-data/RecoBTag-Combined/pull/73) to cms-data (mentioned above) containing the onnx model would need to be included. 