### PR TITLE
JetTester: add jpt jet type reading reco::JPTJetCollection

### DIFF
--- a/Validation/RecoJets/plugins/JetTester.cc
+++ b/Validation/RecoJets/plugins/JetTester.cc
@@ -27,9 +27,11 @@ JetTester::JetTester(const edm::ParameterSet& iConfig)
   isCaloJet = (std::string("calo") == JetType);        // <reco::CaloJetCollection>
   isPFJet = (std::string("pf") == JetType);            // <reco::PFJetCollection>
   isMiniAODJet = (std::string("miniaod") == JetType);  // <pat::JetCollection>
-  if (!isCaloJet && !isPFJet && !isMiniAODJet) {
+  isJPTJet = (std::string("jpt") == JetType);          // <reco::JPTJetCollection>
+
+  if (!isCaloJet && !isPFJet && !isMiniAODJet && !isJPTJet) {
     throw cms::Exception("Configuration")
-        << "Unknown jet type: " << JetType << "\nPlease use 'calo', 'pf', or 'miniaod'.";
+        << "Unknown jet type: " << JetType << "\nPlease use 'calo', 'pf', 'jpt', or 'miniaod'.";
   }
 
   if (!isMiniAODJet) {
@@ -44,6 +46,8 @@ JetTester::JetTester(const edm::ParameterSet& iConfig)
     pfJetsToken_ = consumes<reco::PFJetCollection>(mInputCollection);
   if (isMiniAODJet)
     patJetsToken_ = consumes<pat::JetCollection>(mInputCollection);
+  if (isJPTJet)
+    jptJetsToken_ = consumes<reco::JPTJetCollection>(mInputCollection);
   mInputGenCollection = iConfig.getParameter<edm::InputTag>("srcGen");
   genJetsToken_ = consumes<reco::GenJetCollection>(edm::InputTag(mInputGenCollection));
   evtToken_ = consumes<GenEventInfoProduct>(edm::InputTag("generator"));
@@ -1052,6 +1056,7 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
   edm::Handle<CaloJetCollection> caloJets;
   edm::Handle<PFJetCollection> pfJets;
   edm::Handle<pat::JetCollection> patJets;
+  edm::Handle<JPTJetCollection> jptJets;
 
   if (isCaloJet) {
     mEvent.getByToken(caloJetsToken_, caloJets);
@@ -1061,6 +1066,18 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
       recoJets.push_back((*caloJets)[ijet]);
       if (correctionIsValid) {
         auto jetCorrected = (*caloJets)[ijet];
+        jetCorrected.scaleEnergy(jetCorr->correction(jetCorrected));
+        corrJets.push_back(jetCorrected);
+      }
+    }
+  } else if (isJPTJet) {
+    mEvent.getByToken(jptJetsToken_, jptJets);
+    if (!jptJets.isValid())
+      return;
+    for (unsigned ijet = 0; ijet < jptJets->size(); ijet++) {
+      recoJets.push_back((*jptJets)[ijet]);
+      if (correctionIsValid) {
+        auto jetCorrected = (*jptJets)[ijet];
         jetCorrected.scaleEnergy(jetCorr->correction(jetCorrected));
         corrJets.push_back(jetCorrected);
       }

--- a/Validation/RecoJets/plugins/JetTester.h
+++ b/Validation/RecoJets/plugins/JetTester.h
@@ -69,6 +69,7 @@ private:
   edm::EDGetTokenT<std::vector<reco::Vertex>> pvToken_;
   edm::EDGetTokenT<reco::CaloJetCollection> caloJetsToken_;
   edm::EDGetTokenT<reco::PFJetCollection> pfJetsToken_;
+  edm::EDGetTokenT<reco::JPTJetCollection> jptJetsToken_;
   edm::EDGetTokenT<reco::GenJetCollection> genJetsToken_;
   edm::EDGetTokenT<GenEventInfoProduct> evtToken_;
   edm::EDGetTokenT<pat::JetCollection> patJetsToken_;
@@ -306,6 +307,7 @@ private:
   bool isCaloJet;
   bool isPFJet;
   bool isMiniAODJet;
+  bool isJPTJet;
   bool isHLT_;
 };
 

--- a/Validation/RecoJets/python/hltJetValidation_cff.py
+++ b/Validation/RecoJets/python/hltJetValidation_cff.py
@@ -39,3 +39,9 @@ hltJetAnalyzerAK4PFCHS = _hltJetTester.clone(
     src = "hltAK4PFCHSJets",
     JetCorrections = "hltAK4PFCHSJetCorrector_ForValidation",
 )
+
+hltJetAnalyzerAK4JPT = _hltJetTester.clone(
+    src = "hltJetPlusTrackZSPCorJetAntiKt4",
+    JetType = 'jpt',
+    JetCorrections = "",
+)


### PR DESCRIPTION
JetTester currently supports only 'calo', 'pf' and 'miniaod' jet types. There is no branch for reco::JPTJetCollection, so a JPT collection has to be validated as 'calo', which reads the reco::CaloJet collection that JetPlusTrackProducer writes alongside the JPT jets rather than the corrected jets themselves.

This adds an isJPTJet branch reading reco::JPTJetCollection, and switches hltJetAnalyzerAK4JPT to JetType = 'jpt'.

Effect on the Phase-2 HLT JPT collection (hltJetPlusTrackZSPCorJetAntiKt4, TTbar 200PU):
- before: 3 / 477 matched gen jets
- after: 398 / 477 matched gen jets

No change for calo, pf or miniaod collections.