### PR TITLE
VertexAssociation: Added dependency for PackedCandidate

### DIFF
--- a/SimTracker/VertexAssociation/BuildFile.xml
+++ b/SimTracker/VertexAssociation/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="DataFormats/PatCandidates"/>
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/VertexReco"/>


### PR DESCRIPTION
Added dependency on `DataFormats/PatCandidates` for `PackedCandidate` needed in `SimTracker/VertexAssociation` . This should fix the link error for ASAN IBs
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc14/CMSSW_20_1_ASAN_X_2026-08-14-1100/SimTracker/VertexAssociation
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/el9_amd64_gcc14/external/gcc/14.3.1-724da22786638848892aa9ded8fcd995/bin/../lib/gcc/x86_64-redhat-linux-gnu/14.3.1/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: tmp/el9_amd64_gcc14/src/SimTracker/VertexAssociation/src/SimTrackerVertexAssociation/calculateVertexSharedTracks.cc.o: in function `(anonymous namespace)::extractTrackRefs(reco::io_v1::VertexCompositePtrCandidate const&)':
  calculateVertexSharedTracks.cc:(.text+0x851): undefined reference to `typeinfo for pat::io_v1::PackedCandidate'
```