### PR TITLE
allocate CLUE's scratch using caching allocator 

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersAlgoWrapper.dev.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersAlgoWrapper.dev.cc
@@ -10,10 +10,23 @@
 
 #include "CLUEAlgoAlpaka.h"
 
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   using namespace cms::alpakatools;
   using namespace hgcal::constants;
+
+  namespace {
+    // CLUE's per-event scratch follows the same allocation policy as the rest of
+    // the reconstruction
+    struct ScratchAllocator {
+      template <typename TElem, typename TIdx, typename TQueue, typename TExtent>
+      ALPAKA_FN_HOST auto allocate(TQueue& queue, TExtent const& extent) const {
+        return cms::alpakatools::make_device_buffer<TElem[]>(queue, alpaka::getWidth(extent));
+      }
+    };
+  }  // namespace
 
   void HGCalLayerClustersAlgoWrapper::run(Queue& queue,
                                           const unsigned int size,
@@ -25,19 +38,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     CLUEAlgoAlpaka<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D, Queue, HGCalSiliconTilesConstants, kHGCalLayers> algoStandalone(
         queue, dc, kappa, outlierDeltaFactor, false);
 
-    algoStandalone.makeClustersCMSSW(size,
-                                     inputs.dim1().data(),
-                                     inputs.dim2().data(),
-                                     inputs.layer().data(),
-                                     inputs.energy().data(),
-                                     inputs.sigmaNoise().data(),
-                                     inputs.detid().data(),
-                                     outputs.rho().data(),
-                                     outputs.delta().data(),
-                                     outputs.nearestHigher().data(),
-                                     outputs.clusterIndex().data(),
-                                     outputs.isSeed().data(),
-                                     &outputs.numberOfClustersScalar());
+    algoStandalone.template makeClustersCMSSW<ScratchAllocator>(size,
+                                                                inputs.dim1().data(),
+                                                                inputs.dim2().data(),
+                                                                inputs.layer().data(),
+                                                                inputs.energy().data(),
+                                                                inputs.sigmaNoise().data(),
+                                                                inputs.detid().data(),
+                                                                outputs.rho().data(),
+                                                                outputs.delta().data(),
+                                                                outputs.nearestHigher().data(),
+                                                                outputs.clusterIndex().data(),
+                                                                outputs.isSeed().data(),
+                                                                &outputs.numberOfClustersScalar());
   }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE


### PR DESCRIPTION
`CLUEAlgoAlpaka::makeClustersCMSSW` allocated its three scratch buffers with `alpaka::allocAsyncBuf` on every event, so every event called `cudaMallocAsync`/`hipMallocAsync` directly, bypassing the allocator policy the rest of the reconstruction follows. This was the only module in the Phase-2 HGCAL alpaka path doing that. On ROCm it deadlocks. In `runTheMatrixAMD_W7900` for workflow `34434.404` the job hung on event 1 and was killed by the 9000 s timeout, with the main thread blocked in `pthread_mutex_lock` under `hipMallocAsync` (reached from `HGCalSoARecHitsLayerClustersProducer::produce` -> `CLUEAlgoAlpaka::makeClustersCMSSW` -> `alpaka::allocAsyncBuf`) while the `edm async pool` thread was blocked on the same lock under `hipEventSynchronize`, releasing the previous event's buffers.

clue 1.1.2 adds an allocation policy to `makeClustersCMSSW`, defaulted to the previous behaviour, so this passes one backed by `cms::alpakatools::make_device_buffer`.

