### PR TITLE
Fixed D127 Inputs

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4706,7 +4706,7 @@ defaultDataSets['2025FS']='CMSSW_13_0_11-130X_mcRun3_2023_realistic_withEarly202
 defaultRun4Geometry = 'D127'
 defaultDataSets['Run4D110']='CMSSW_15_1_0_pre5-150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D110_noPU-v'
 defaultDataSets['Run4D121']='CMSSW_20_0_0_pre1-150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v'
-defaultDataSets['Run4D127']='CMSSW_20_0_0-150X_mcRun4_realistic_v1_STD_D127_GSOnly_noPU_Inputs-v'
+defaultDataSets['Run4D127']='CMSSW_20_0_0-150X_mcRun4_realistic_v1_D127_GSOnly_NewInputs-v'
 
 ## HIN
 defaultDataSets['2023HIN']='CCMSSW_14_1_0-PU_140X_mcRun3_2023_realistic_HI_v4_STD_2023HIN_PU-v'


### PR DESCRIPTION
#### PR description:

A follow-up to https://github.com/cms-sw/cmssw/pull/51684 is needed because some samples (namely the TTbar ones) have a different `v*` in the dataset name due to the fact that the samples had to be resubmitted. In the resubmission process, the first partially completed samples have been stored and then invalidated. In the time between these two operations, the tests have run successfully, not showing this issue.   

The different `v` (`v2`) makes them "invisible". 

Long story short we were obliged to reproduce new GEN-SIM samples as inputs. 

This change is propagated to the [20_0_X] PR https://github.com/cms-sw/cmssw/pull/51685.