### PR TITLE
Rename HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1 to L1NN

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_LooseDeepTauPFTauHPS150_L1NN_eta2p1_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_LooseDeepTauPFTauHPS150_L1NN_eta2p1_cfi.py
@@ -19,7 +19,7 @@ from ..modules.hltAK4PFJetsForTaus_cfi import *
 from ..modules.hltHpsSelectedPFTauLooseTauWPDeepTau_cfi import *
 from ..modules.hltHpsPFTau150LooseTauWPDeepTau_cfi import *
 
-HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1 = cms.Path(
+HLT_LooseDeepTauPFTauHPS150_L1NN_eta2p1 = cms.Path(
     HLTBeginSequence 
     + hltL1SingleNNTau150                              
     + HLTRawToDigiSequence 

--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -126,7 +126,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Ele32_WPTight_Unseede
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Ele30_WPTight_L1Seeded_LooseDeepTauPFTauHPS30_eta2p1_CrossL1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_IsoMu24_FromL1TkMuon_cfi")
-fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_LooseDeepTauPFTauHPS150_L1NN_eta2p1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Mu37_Mu27_FromL1TkMuon_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Mu50_FromL1TkMuon_cfi")
@@ -327,7 +327,7 @@ fragment.schedule = cms.Schedule(*[
     fragment.HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1,
     fragment.HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1,
     fragment.HLT_Ele30_WPTight_L1Seeded_LooseDeepTauPFTauHPS30_eta2p1_CrossL1,
-    fragment.HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1,
+    fragment.HLT_LooseDeepTauPFTauHPS150_L1NN_eta2p1,
     ### Removed temporarily until final decision on L1T tau Phase-2
     #fragment.L1T_DoubleNNTau52,
     #fragment.L1T_SingleNNTau150,

--- a/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
@@ -124,7 +124,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Ele32_WPTight_L1Seede
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Ele30_WPTight_L1Seeded_LooseDeepTauPFTauHPS30_eta2p1_CrossL1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_IsoMu24_FromL1TkMuon_cfi")
-fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_LooseDeepTauPFTauHPS150_L1NN_eta2p1_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Mu37_Mu27_FromL1TkMuon_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Mu50_FromL1TkMuon_cfi")
@@ -289,7 +289,7 @@ fragment.schedule = cms.Schedule(*[
     fragment.HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1,
     fragment.HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1,
     fragment.HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1,
-    fragment.HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1,
+    fragment.HLT_LooseDeepTauPFTauHPS150_L1NN_eta2p1,
     
     ### Removed temporarily until final decision on L1T tau Phase-2
     #fragment.L1T_DoubleNNTau52,

--- a/Validation/HLTrigger/python/HLTGenValidation_cff.py
+++ b/Validation/HLTrigger/python/HLTGenValidation_cff.py
@@ -562,7 +562,7 @@ HLTGenValSourceTAU = cms.EDProducer("HLTGenValSource",
     hltPathsToCheck = cms.vstring(
         'HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1',
         'HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1',
-        'HLT_LooseDeepTauPFTauHPS150_L2NN_eta2p1'
+        'HLT_LooseDeepTauPFTauHPS150_L1NN_eta2p1'
     ),
     hltProcessName = cms.string('HLT'),
     objType = cms.string('tauHAD'),


### PR DESCRIPTION
The path is seeded by hltL1SingleNNTau150 (L1 NN Tau) and does not use L2TauTagNNProducer, so the "L2NN" label inherited from the Run3 naming convention was misleading. 
Rename the path and its cfi file accordingly, and update the references in HLT_75e33_cff, HLT_75e33_timing_cff and HLTGenValidation_cff.

[PR merged before ](https://github.com/cms-sw/cmssw/pull/49637)