### PR TITLE
Remove no-op if-statement and corresponding TODO from calculateVertexSharedTracks.cc

### DIFF
--- a/SimTracker/VertexAssociation/interface/calculateVertexSharedTracks.h
+++ b/SimTracker/VertexAssociation/interface/calculateVertexSharedTracks.h
@@ -75,7 +75,7 @@ inline SharedTracksAndFractions calculateVertexSharedTracks(
 // reco::VertexCompositePtrCandidate overloads
 //
 // Track extraction from candidate daughters is done via dynamic_cast
-// (reco::PFCandidate on RECO/AOD, pat::PackedCandidate on MiniAOD).
+// (reco::PFCandidate on RECO/AOD).
 // Daughters from which no track can be recovered (neutral particles) are
 // excluded from both numerator and denominator — they carry no tracking
 // information and should not penalise the shared-track fraction.

--- a/SimTracker/VertexAssociation/src/VertexAssociatorByPositionAndTracks.cc
+++ b/SimTracker/VertexAssociation/src/VertexAssociatorByPositionAndTracks.cc
@@ -3,7 +3,6 @@
 #include <CLHEP/Units/SystemOfUnits.h>
 
 #include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
-#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 

--- a/SimTracker/VertexAssociation/src/calculateVertexSharedTracks.cc
+++ b/SimTracker/VertexAssociation/src/calculateVertexSharedTracks.cc
@@ -1,6 +1,5 @@
 #include "SimTracker/VertexAssociation/interface/calculateVertexSharedTracks.h"
 
-#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 
 // =============================================================================
@@ -10,25 +9,13 @@
 namespace {
 
   /// Extract a TrackRef from a reco::Candidate daughter.
-  /// Tries reco::PFCandidate (RECO/AOD) then pat::PackedCandidate (MiniAOD).
+  /// Tries reco::PFCandidate (RECO/AOD).
   /// Returns an invalid TrackRef for neutral or unresolvable daughters.
-  ///
-  /// Note on MiniAOD: pat::PackedCandidate::bestTrack() returns a raw pointer
-  /// to an embedded track that cannot be wrapped into a persistent TrackRef
-  /// usable by the standard track associators. Such daughters are therefore
-  /// treated as unresolvable and excluded from the shared-track calculation.
-  /// TODO: investigate transient TrackRef construction from packed track
-  /// collection to enable full track-content association on MiniAOD.
   reco::TrackRef extractTrackRef(const reco::Candidate &cand) {
     if (const auto *pfc = dynamic_cast<const reco::PFCandidate *>(&cand))
       return pfc->trackRef();
-
-    if (const auto *pkd = dynamic_cast<const pat::PackedCandidate *>(&cand)) {
-      (void)pkd;  // suppress unused-variable warning pending the TODO above
+    else
       return reco::TrackRef();
-    }
-
-    return reco::TrackRef();
   }
 
   /// Collect all recoverable TrackRefs from a VertexCompositePtrCandidate.


### PR DESCRIPTION
#### PR description:

Follow-up on https://github.com/cms-sw/cmssw/pull/51577#discussion_r3786014828 and https://github.com/cms-sw/cmssw/pull/51709#issuecomment-5314842735.

This PR removes a placeholder no-op if statement and the corresponding TODO as it is not really meaningful due to the MiniAOD file content which typically does not even provide all necessary objects to run the given function/association.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport.
