### PR TITLE
Updating the TICL offline NanoAOD

### DIFF
--- a/DPGAnalysis/HGCalNanoAOD/plugins/BuildFile.xml
+++ b/DPGAnalysis/HGCalNanoAOD/plugins/BuildFile.xml
@@ -5,6 +5,9 @@
 <use name="DataFormats/NanoAOD"/>
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="DataFormats/StdDictionaries"/>
+<use name="DataFormats/TrackReco"/>
+<use name="DataFormats/MuonReco"/>
+<use name="RecoParticleFlow/PFProducer"/>
 <use name="SimDataFormats/CaloAnalysis"/>
 <use name="FWCore/Common"/>
 <use name="FWCore/Framework"/>

--- a/DPGAnalysis/HGCalNanoAOD/plugins/SimTracksterTableProducer.cc
+++ b/DPGAnalysis/HGCalNanoAOD/plugins/SimTracksterTableProducer.cc
@@ -48,6 +48,7 @@ private:
     const size_t nSimTracksters = simTrackstersHandle.isValid() ? simTrackstersHandle->size() : 0;
 
     static constexpr float default_value = std::numeric_limits<float>::quiet_NaN();
+    static constexpr int default_int_value = -1;
 
     std::vector<float> boundaryX(nSimTracksters, default_value);
     std::vector<float> boundaryY(nSimTracksters, default_value);
@@ -61,6 +62,8 @@ private:
     std::vector<float> simTime(nSimTracksters, default_value);
     std::vector<float> genPt(nSimTracksters, default_value);
     std::vector<float> mass(nSimTracksters, default_value);
+    std::vector<int> caloParticleIdx(nSimTracksters, default_int_value);
+    std::vector<int> isPU(nSimTracksters, default_int_value);
 
     if ((simTrackstersHandle.isValid() && caloParticlesHandle.isValid() && simClustersHandle.isValid() &&
          cpToSCMapHandle.isValid()) ||
@@ -71,7 +74,7 @@ private:
       const auto& cpToSCMap = *cpToSCMapHandle;
 
       //utility lambda for filling vectors
-      auto fillVectors = [&](const auto& obj, size_t iSim, float time) {
+      auto fillVectors = [&](const auto& obj, size_t iSim, float time, int cpIdx) {
         const auto& simTrack = obj.g4Tracks()[0];
         const auto caloPt = obj.pt();
         const auto simHitSumEnergy = obj.simEnergy();
@@ -90,6 +93,12 @@ private:
         simEnergy[iSim] = simHitSumEnergy;
         genPt[iSim] = caloPt;
         mass[iSim] = caloMass;
+
+        // PU flag: a non-zero event/bunch-crossing on the
+        // seed g4Track means the CaloParticle/SimCluster came from a pileup interaction.
+        isPU[iSim] = (simTrack.eventId().event() != 0 || simTrack.eventId().bunchCrossing() != 0) ? 1 : 0;
+
+        caloParticleIdx[iSim] = cpIdx;
       };
 
       for (size_t iSim = 0; iSim < simTracksters.size(); ++iSim) {
@@ -97,19 +106,22 @@ private:
         float time = default_value;
 
         if (simT.seedID() == caloParticlesHandle.id()) {
+          const int cpIdx = static_cast<int>(simT.seedIndex());
           const auto& cp = caloParticles[simT.seedIndex()];
           time = cp.simTime();
-          fillVectors(cp, iSim, time);
+          fillVectors(cp, iSim, time, cpIdx);
         } else {
           const auto& sc = simClusters[simT.seedIndex()];
+          int cpIdx = default_int_value;
           //SCtoCP map not availalbe, use CPtoSC map instead
-          for (const auto& [cpIdx, scVec] : cpToSCMap) {
+          for (const auto& [cpIdxCandidate, scVec] : cpToSCMap) {
             if (std::ranges::find(scVec, simT.seedIndex()) != scVec.end()) {
-              time = caloParticles[cpIdx].simTime();
+              cpIdx = static_cast<int>(cpIdxCandidate);
+              time = caloParticles[cpIdxCandidate].simTime();
               break;  //dont need to check further
             }
           }
-          fillVectors(sc, iSim, time);
+          fillVectors(sc, iSim, time, cpIdx);
         }
       }
     }
@@ -125,7 +137,7 @@ private:
     simTrackstersTable->addColumn<float>(
         "boundaryEta", boundaryEta, "CaloVolume boundary pseudorapidity of associated Simobject", precision_);
     simTrackstersTable->addColumn<float>(
-        "boundaryPhi", boundaryEta, "CaloVolume boundary phi of associated Simobject", precision_);
+        "boundaryPhi", boundaryPhi, "CaloVolume boundary phi of associated Simobject", precision_);
     simTrackstersTable->addColumn<float>(
         "boundaryPx", boundaryPx, "X component of momentum at CaloVolume boundary of associated Simobject", precision_);
     simTrackstersTable->addColumn<float>(
@@ -135,6 +147,10 @@ private:
     simTrackstersTable->addColumn<float>("simTime", simTime, "Sim-Time of simulated object [ns]", precision_);
     simTrackstersTable->addColumn<float>("genPt", genPt, "Gen-pT associated with SimObject", precision_);
     simTrackstersTable->addColumn<float>("mass", mass, "mass associated with SimObject", precision_);
+    simTrackstersTable->addColumn<int>(
+        "caloParticleIdx", caloParticleIdx, "Index of the parent CaloParticle in the CaloParticle collection");
+    simTrackstersTable->addColumn<int>(
+        "isPU", isPU, "PU flag of the associated Simobject: 1 = pileup (non-zero event/bx), 0 = otherwise");
 
     event.put(std::move(simTrackstersTable), tableName_);
   }

--- a/DPGAnalysis/HGCalNanoAOD/plugins/SimTracksterTableProducer.cc
+++ b/DPGAnalysis/HGCalNanoAOD/plugins/SimTracksterTableProducer.cc
@@ -63,7 +63,7 @@ private:
     std::vector<float> genPt(nSimTracksters, default_value);
     std::vector<float> mass(nSimTracksters, default_value);
     std::vector<int> caloParticleIdx(nSimTracksters, default_int_value);
-    std::vector<int> isPU(nSimTracksters, default_int_value);
+    std::vector<int8_t> isPU(nSimTracksters, default_int_value);
 
     if ((simTrackstersHandle.isValid() && caloParticlesHandle.isValid() && simClustersHandle.isValid() &&
          cpToSCMapHandle.isValid()) ||

--- a/DPGAnalysis/HGCalNanoAOD/plugins/TICLCandidateExtraTableProducer.cc
+++ b/DPGAnalysis/HGCalNanoAOD/plugins/TICLCandidateExtraTableProducer.cc
@@ -30,15 +30,14 @@ public:
         tracksters_token_(consumes<std::vector<ticl::Trackster>>(params.getParameter<edm::InputTag>("tracksters"))),
         tracks_token_(consumes<std::vector<reco::Track>>(params.getParameter<edm::InputTag>("tracks"))),
         hasLinkedTracksters_(params.existsAs<edm::InputTag>("linkedTracksters")),
-        linkedTracksters_token_(
-            hasLinkedTracksters_ ? consumes<std::vector<std::vector<unsigned int>>>(
-                                        params.getParameter<edm::InputTag>("linkedTracksters"))
-                                  : edm::EDGetTokenT<std::vector<std::vector<unsigned int>>>()),
+        linkedTracksters_token_(hasLinkedTracksters_ ? consumes<std::vector<std::vector<unsigned int>>>(
+                                                           params.getParameter<edm::InputTag>("linkedTracksters"))
+                                                     : edm::EDGetTokenT<std::vector<std::vector<unsigned int>>>()),
         hasPUInfo_(params.existsAs<edm::InputTag>("caloParticles") &&
                    params.existsAs<edm::InputTag>("caloParticleToSimClustersMap")),
-        caloParticles_token_(hasPUInfo_ ? consumes<std::vector<CaloParticle>>(
-                                               params.getParameter<edm::InputTag>("caloParticles"))
-                                         : edm::EDGetTokenT<std::vector<CaloParticle>>()),
+        caloParticles_token_(
+            hasPUInfo_ ? consumes<std::vector<CaloParticle>>(params.getParameter<edm::InputTag>("caloParticles"))
+                       : edm::EDGetTokenT<std::vector<CaloParticle>>()),
         caloParticleToSimClustersMap_token_(
             hasPUInfo_ ? consumes<std::map<uint, std::vector<uint>>>(
                              params.getParameter<edm::InputTag>("caloParticleToSimClustersMap"))
@@ -126,8 +125,8 @@ public:
     // linkedTracksters (pre-merge trackster links)
     if (hasLinkedTracksters_) {
       out->addColumn<uint16_t>("nLinkedTracksters",
-                                std::vector<uint16_t>(table_size, 0),
-                                "Number of Tracksters linked to candidate before final linking/merging");
+                               std::vector<uint16_t>(table_size, 0),
+                               "Number of Tracksters linked to candidate before final linking/merging");
 
       auto linkedTable = std::make_unique<nanoaod::FlatTable>(0, "linkedTracksters", false, false);
       std::vector<uint32_t> emptyLinkedIdx;
@@ -157,12 +156,12 @@ public:
       iEvent.put(std::move(gsfTrackIdxsTable), this->name_ + "GsfTrackIdxs");
     }
 
-    // isPU (sim candidates only); 
+    // isPU (sim candidates only);
     if (hasPUInfo_) {
       out->addColumn<int>("isPU",
-                           std::vector<int>(table_size, -1),
-                           "PU flag of the candidate's parent CaloParticle: 1 = pileup (non-zero event/bx), 0 = "
-                           "otherwise, -1 = unresolved");
+                          std::vector<int>(table_size, -1),
+                          "PU flag of the candidate's parent CaloParticle: 1 = pileup (non-zero event/bx), 0 = "
+                          "otherwise, -1 = unresolved");
     }
 
     if (out->nColumns() > 0) {
@@ -361,7 +360,7 @@ public:
         }
       }
 
-      // linked tracksters (pre-merge links), 
+      // linked tracksters (pre-merge links),
       // linkedTracksters[i] holds the trackster indices linked to candidate i
       // before the final linking/merging step. Not available/meaningful for sim candidates.
       if (hasLinkedTracksters_ && linkedTracksters_h.isValid() && i < linkedTracksters_h->size()) {
@@ -390,7 +389,7 @@ public:
       }
 
       // isPU: resolve the parent CaloParticle from the first constituent Trackster's
-      // seedID/seedIndex, then read its g4Track eventId/bunchCrossing 
+      // seedID/seedIndex, then read its g4Track eventId/bunchCrossing
       if (hasPUInfo_) {
         int puFlag = -1;
         if (caloParticles_h.isValid() && cpToSCMap_h.isValid() && !children.empty()) {
@@ -460,9 +459,8 @@ public:
     // linkedTracksters output: count column on the main table + flattened sub-table.
     // Only emitted for instances configured with linkedTracksters (reco)
     if (hasLinkedTracksters_) {
-      out->addColumn<uint16_t>("nLinkedTracksters",
-                                linkedCounts,
-                                "Number of Tracksters linked to candidate before final linking/merging");
+      out->addColumn<uint16_t>(
+          "nLinkedTracksters", linkedCounts, "Number of Tracksters linked to candidate before final linking/merging");
 
       auto linkedTable =
           std::make_unique<nanoaod::FlatTable>(linkedTracksterIndices.size(), "linkedTracksters", false, false);
@@ -474,8 +472,7 @@ public:
     // Full track-index / GSF-track-index lists: count columns on the main table + flattened
     // sub-tables, always emitted (see constructor comment). Product names are prefixed with
     // this->name_ so the reco and sim module instances never collide.
-    out->addColumn<uint16_t>(
-        "nTrackIdxs", trackIdxCounts, "Number of generalTracks associated with candidate");
+    out->addColumn<uint16_t>("nTrackIdxs", trackIdxCounts, "Number of generalTracks associated with candidate");
     {
       auto trackIdxsTable =
           std::make_unique<nanoaod::FlatTable>(allTrackIndices.size(), this->name_ + "TrackIdxs", false, false);
@@ -484,8 +481,7 @@ public:
       iEvent.put(std::move(trackIdxsTable), this->name_ + "TrackIdxs");
     }
 
-    out->addColumn<uint16_t>(
-        "nGsfTrackIdxs", gsfTrackIdxCounts, "Number of GSFTracks associated with candidate");
+    out->addColumn<uint16_t>("nGsfTrackIdxs", gsfTrackIdxCounts, "Number of GSFTracks associated with candidate");
     {
       auto gsfTrackIdxsTable =
           std::make_unique<nanoaod::FlatTable>(allGsfTrackIndices.size(), this->name_ + "GsfTrackIdxs", false, false);
@@ -497,8 +493,10 @@ public:
     // isPU output: one scalar per candidate, directly on the extension table.
     // Only emitted for instances configured with caloParticles + caloParticleToSimClustersMap (sim).
     if (hasPUInfo_) {
-      out->addColumn<int>(
-          "isPU", isPU, "PU flag of the candidate's parent CaloParticle: 1 = pileup (non-zero event/bx), 0 = otherwise, -1 = unresolved");
+      out->addColumn<int>("isPU",
+                          isPU,
+                          "PU flag of the candidate's parent CaloParticle: 1 = pileup (non-zero event/bx), 0 = "
+                          "otherwise, -1 = unresolved");
     }
 
     if (out->nColumns() > 0) {
@@ -519,8 +517,7 @@ public:
     desc.add<edm::InputTag>("tracksters", edm::InputTag("ticlTrackstersCLUE3DHigh"));
     desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
     desc.addOptional<edm::InputTag>("linkedTracksters")
-        ->setComment(
-            "Pre-merge/pre-linking Trackster links (reco TICLCandidates only, e.g. ");
+        ->setComment("Pre-merge/pre-linking Trackster links (reco TICLCandidates only, e.g. ");
     desc.addOptional<edm::InputTag>("caloParticles")
         ->setComment(
             "CaloParticle collection (sim candidates only), used together with "

--- a/DPGAnalysis/HGCalNanoAOD/plugins/TICLCandidateExtraTableProducer.cc
+++ b/DPGAnalysis/HGCalNanoAOD/plugins/TICLCandidateExtraTableProducer.cc
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <map>
 #include "PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h"
 #include "DataFormats/HGCalReco/interface/TICLCandidate.h"
 #include "DataFormats/HGCalReco/interface/Trackster.h"
@@ -16,11 +18,7 @@
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-
-//
-// One-to-many: TICLCandidate -> linked Tracksters
-// Or SimTICLCandidate --> SimTracksters
-//
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
 
 class TICLCandidateExtraTableProducer : public SimpleFlatTableProducerBase<TICLCandidate, std::vector<TICLCandidate>> {
 public:
@@ -31,6 +29,21 @@ public:
       : SimpleFlatTableProducerBase<TICLCandidate, std::vector<TICLCandidate>>(params),
         tracksters_token_(consumes<std::vector<ticl::Trackster>>(params.getParameter<edm::InputTag>("tracksters"))),
         tracks_token_(consumes<std::vector<reco::Track>>(params.getParameter<edm::InputTag>("tracks"))),
+        hasLinkedTracksters_(params.existsAs<edm::InputTag>("linkedTracksters")),
+        linkedTracksters_token_(
+            hasLinkedTracksters_ ? consumes<std::vector<std::vector<unsigned int>>>(
+                                        params.getParameter<edm::InputTag>("linkedTracksters"))
+                                  : edm::EDGetTokenT<std::vector<std::vector<unsigned int>>>()),
+        hasPUInfo_(params.existsAs<edm::InputTag>("caloParticles") &&
+                   params.existsAs<edm::InputTag>("caloParticleToSimClustersMap")),
+        caloParticles_token_(hasPUInfo_ ? consumes<std::vector<CaloParticle>>(
+                                               params.getParameter<edm::InputTag>("caloParticles"))
+                                         : edm::EDGetTokenT<std::vector<CaloParticle>>()),
+        caloParticleToSimClustersMap_token_(
+            hasPUInfo_ ? consumes<std::map<uint, std::vector<uint>>>(
+                             params.getParameter<edm::InputTag>("caloParticleToSimClustersMap"))
+                       : edm::EDGetTokenT<std::map<uint, std::vector<uint>>>()),
+        produceGeneralTrackBoundary_(params.getParameter<bool>("produceGeneralTrackBoundary")),
         detector_(params.getParameter<std::string>("detector")),
         propName_(params.getParameter<std::string>("propagator")),
         geometry_token_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
@@ -38,6 +51,27 @@ public:
         propagator_token_(esConsumes<Propagator, TrackingComponentsRecord>(edm::ESInputTag("", propName_))),
         hdc_token_(esConsumes<HGCalDDDConstants, IdealGeometryRecord>(
             edm::ESInputTag("", (detector_ == "HFNose") ? "HGCalHFNoseSensitive" : "HGCalEESensitive"))) {
+    // Only declare/emit the linkedTracksters product for instances that actually have it
+    // configured (reco TICLCandidates). Otherwise, two module instances of this same class
+    // (reco + sim) would both try to produce a main FlatTable literally named
+    // "linkedTracksters", which NanoAOD's output module rejects as "multiple main tables".
+    if (hasLinkedTracksters_) {
+      produces<nanoaod::FlatTable>("linkedTracksters");
+    }
+
+    // Full track-index / GSF-track-index lists per candidate (all tracks, not just the first
+    // via trackPtr()/gsftrackPtr()). Always produced by every instance; the product name is
+    // prefixed with this->name_ ("TICLCandidates"/"SimTICLCandidates") so the two module
+    // instances never collide on the same product name.
+    produces<nanoaod::FlatTable>(this->name_ + "TrackIdxs");
+    produces<nanoaod::FlatTable>(this->name_ + "GsfTrackIdxs");
+
+    // GeneralTrack HGCal-boundary extension: independent of TICLCandidate linking, one row per
+    // track in the full tracks collection. Optional enable on exactly one module instance.
+    if (produceGeneralTrackBoundary_) {
+      produces<nanoaod::FlatTable>("trackBoundary");
+    }
+
     if (params.existsAs<edm::ParameterSet>("collectionVariables")) {
       edm::ParameterSet const& collectionVarsPSet = params.getParameter<edm::ParameterSet>("collectionVariables");
       for (const auto& coltablename : collectionVarsPSet.getParameterNamesForType<edm::ParameterSet>()) {
@@ -89,6 +123,48 @@ public:
       iEvent.put(std::move(outcoltable), coltable.name + "Table");
     }
 
+    // linkedTracksters (pre-merge trackster links)
+    if (hasLinkedTracksters_) {
+      out->addColumn<uint16_t>("nLinkedTracksters",
+                                std::vector<uint16_t>(table_size, 0),
+                                "Number of Tracksters linked to candidate before final linking/merging");
+
+      auto linkedTable = std::make_unique<nanoaod::FlatTable>(0, "linkedTracksters", false, false);
+      std::vector<uint32_t> emptyLinkedIdx;
+      linkedTable->addColumn<uint32_t>("tracksterIndex", emptyLinkedIdx, "Index of linked Trackster");
+      linkedTable->setDoc("Tracksters linked to candidate before final linking/merging");
+      iEvent.put(std::move(linkedTable), "linkedTracksters");
+    }
+
+    // Full track-index / GSF-track-index lists per candidate
+    out->addColumn<uint16_t>(
+        "nTrackIdxs", std::vector<uint16_t>(table_size, 0), "Number of generalTracks associated with candidate");
+    {
+      auto trackIdxsTable = std::make_unique<nanoaod::FlatTable>(0, this->name_ + "TrackIdxs", false, false);
+      std::vector<uint32_t> emptyIdx;
+      trackIdxsTable->addColumn<uint32_t>("trackIndex", emptyIdx, "Index of associated generalTrack");
+      trackIdxsTable->setDoc("Full list of generalTrack indices associated with the candidate");
+      iEvent.put(std::move(trackIdxsTable), this->name_ + "TrackIdxs");
+    }
+
+    out->addColumn<uint16_t>(
+        "nGsfTrackIdxs", std::vector<uint16_t>(table_size, 0), "Number of GSFTracks associated with candidate");
+    {
+      auto gsfTrackIdxsTable = std::make_unique<nanoaod::FlatTable>(0, this->name_ + "GsfTrackIdxs", false, false);
+      std::vector<uint32_t> emptyIdx;
+      gsfTrackIdxsTable->addColumn<uint32_t>("trackIndex", emptyIdx, "Index of associated GSFTrack");
+      gsfTrackIdxsTable->setDoc("Full list of GSFTrack indices associated with the candidate");
+      iEvent.put(std::move(gsfTrackIdxsTable), this->name_ + "GsfTrackIdxs");
+    }
+
+    // isPU (sim candidates only); 
+    if (hasPUInfo_) {
+      out->addColumn<int>("isPU",
+                           std::vector<int>(table_size, -1),
+                           "PU flag of the candidate's parent CaloParticle: 1 = pileup (non-zero event/bx), 0 = "
+                           "otherwise, -1 = unresolved");
+    }
+
     if (out->nColumns() > 0) {
       out->setDoc(this->doc_);
       iEvent.put(std::move(out));
@@ -104,6 +180,56 @@ public:
     const auto& propagator = iSetup.getData(propagator_token_);
 
     const auto firstDisk = ticl::utils::buildHGCalFirstDisks(hgcons, geom);
+
+    // GeneralTrack HGCal-boundary extension: computed independently of TICLCandidate/Trackster
+    // validity, for every track in the full tracks collection, so it always matches
+    // GeneralTrack's own row count exactly. Handled first and unconditionally so the declared
+    // product is always put(), regardless of what happens with candidates below.
+    if (produceGeneralTrackBoundary_) {
+      const auto& allTracks_h = iEvent.getHandle(tracks_token_);
+      const size_t nAllTracks = allTracks_h.isValid() ? allTracks_h->size() : 0;
+      auto trackBoundaryTable =
+          std::make_unique<nanoaod::FlatTable>(nAllTracks, "GeneralTrack", /*singleton*/ false, /*extension*/ true);
+      std::vector<float> hgcal_x(nAllTracks), hgcal_y(nAllTracks), hgcal_z(nAllTracks);
+      std::vector<float> hgcal_eta(nAllTracks), hgcal_phi(nAllTracks);
+      std::vector<float> hgcal_px(nAllTracks), hgcal_py(nAllTracks), hgcal_pz(nAllTracks);
+
+      if (allTracks_h.isValid()) {
+        const auto& allTracks = *allTracks_h;
+        for (size_t i = 0; i < allTracks.size(); ++i) {
+          const auto& track = allTracks[i];
+          int iSide = int(track.eta() > 0);
+          const auto& fts = trajectoryStateTransform::outerFreeState(track, &bfield);
+          const auto& tsos = propagator.propagate(fts, firstDisk[iSide]->surface());
+          if (tsos.isValid()) {
+            const auto& globalPos = tsos.globalPosition();
+            const auto& globalMom = tsos.globalMomentum();
+            hgcal_x[i] = globalPos.x();
+            hgcal_y[i] = globalPos.y();
+            hgcal_z[i] = globalPos.z();
+            hgcal_eta[i] = globalPos.eta();
+            hgcal_phi[i] = globalPos.phi();
+            hgcal_px[i] = globalMom.x();
+            hgcal_py[i] = globalMom.y();
+            hgcal_pz[i] = globalMom.z();
+          } else {
+            hgcal_x[i] = hgcal_y[i] = hgcal_z[i] = kInvalidBoundaryValue;
+            hgcal_eta[i] = hgcal_phi[i] = kInvalidBoundaryValue;
+            hgcal_px[i] = hgcal_py[i] = hgcal_pz[i] = kInvalidBoundaryValue;
+          }
+        }
+      }
+
+      trackBoundaryTable->addColumn<float>("hgcal_x", hgcal_x, "Track X position at HGCal boundary");
+      trackBoundaryTable->addColumn<float>("hgcal_y", hgcal_y, "Track Y position at HGCal boundary");
+      trackBoundaryTable->addColumn<float>("hgcal_z", hgcal_z, "Track Z position at HGCal boundary");
+      trackBoundaryTable->addColumn<float>("hgcal_eta", hgcal_eta, "Track eta at HGCal boundary");
+      trackBoundaryTable->addColumn<float>("hgcal_phi", hgcal_phi, "Track phi at HGCal boundary");
+      trackBoundaryTable->addColumn<float>("hgcal_px", hgcal_px, "Track Px at HGCal boundary");
+      trackBoundaryTable->addColumn<float>("hgcal_py", hgcal_py, "Track Py at HGCal boundary");
+      trackBoundaryTable->addColumn<float>("hgcal_pz", hgcal_pz, "Track Pz at HGCal boundary");
+      iEvent.put(std::move(trackBoundaryTable), "trackBoundary");
+    }
 
     if (!prod.isValid() && this->skipNonExistingSrc_) {
       writeEmptyTables(iEvent, 0);
@@ -124,6 +250,30 @@ public:
     }
     const auto& tracks = *tracks_h;
 
+    // linkedTracksters (pre-merge trackster links) is only meaningful for reco TICLCandidates;
+    // it's an optional parameter so sim configurations can simply omit it.
+    edm::Handle<std::vector<std::vector<unsigned int>>> linkedTracksters_h;
+    if (hasLinkedTracksters_) {
+      linkedTracksters_h = iEvent.getHandle(linkedTracksters_token_);
+      if (!linkedTracksters_h.isValid() && this->skipNonExistingSrc_) {
+        writeEmptyTables(iEvent, prod->size());
+        return;
+      }
+    }
+
+    // isPU (sim candidates only): resolved via the seedID/seedIndex of the candidate's first
+    // constituent Trackster, same CaloParticle-resolution logic as SimTracksterTableProducer,
+    edm::Handle<std::vector<CaloParticle>> caloParticles_h;
+    edm::Handle<std::map<uint, std::vector<uint>>> cpToSCMap_h;
+    if (hasPUInfo_) {
+      caloParticles_h = iEvent.getHandle(caloParticles_token_);
+      cpToSCMap_h = iEvent.getHandle(caloParticleToSimClustersMap_token_);
+      if ((!caloParticles_h.isValid() || !cpToSCMap_h.isValid()) && this->skipNonExistingSrc_) {
+        writeEmptyTables(iEvent, prod->size());
+        return;
+      }
+    }
+
     const auto& candidates = *prod;
     const size_t table_size = candidates.size();
 
@@ -138,7 +288,25 @@ public:
     std::vector<float> track_boundaryEta, track_boundaryPhi;
     std::vector<float> track_boundaryPx, track_boundaryPy, track_boundaryPz;
 
-    for (const auto& cand : candidates) {
+    std::vector<uint16_t> linkedCounts;
+    linkedCounts.reserve(table_size);
+    std::vector<uint32_t> linkedTracksterIndices;
+
+    std::vector<uint16_t> trackIdxCounts;
+    trackIdxCounts.reserve(table_size);
+    std::vector<uint32_t> allTrackIndices;
+
+    std::vector<uint16_t> gsfTrackIdxCounts;
+    gsfTrackIdxCounts.reserve(table_size);
+    std::vector<uint32_t> allGsfTrackIndices;
+
+    std::vector<int> isPU;
+    if (hasPUInfo_) {
+      isPU.reserve(table_size);
+    }
+
+    for (size_t i = 0; i < candidates.size(); ++i) {
+      const auto& cand = candidates[i];
       const auto& children = cand.tracksters();
       counts.push_back(children.size());
       coltablesize += children.size();
@@ -147,13 +315,13 @@ public:
         tracksterKeys.push_back(t.key());
 
         // get the trackster and its track indices
-        const auto& trackster = tracksters[t.key()];
+        const auto& trackster = tracksters.at(t.key());
         const auto& trackIdxs = trackster.trackIdxs();
 
         if (!trackIdxs.empty()) {
           // for now, only one track
           const auto trackIdx = trackIdxs[0];
-          const auto& track = tracks[trackIdx];
+          const auto& track = tracks.at(trackIdx);
 
           int iSide = int(track.eta() > 0);
           const auto& fts = trajectoryStateTransform::outerFreeState(track, &bfield);
@@ -192,6 +360,70 @@ public:
           track_boundaryPz.push_back(kInvalidBoundaryValue);
         }
       }
+
+      // linked tracksters (pre-merge links), 
+      // linkedTracksters[i] holds the trackster indices linked to candidate i
+      // before the final linking/merging step. Not available/meaningful for sim candidates.
+      if (hasLinkedTracksters_ && linkedTracksters_h.isValid() && i < linkedTracksters_h->size()) {
+        const auto& linked = (*linkedTracksters_h)[i];
+        linkedCounts.push_back(linked.size());
+        for (auto idx : linked) {
+          linkedTracksterIndices.push_back(idx);
+        }
+      } else {
+        linkedCounts.push_back(0);
+      }
+
+      // Full track-index / GSF-track-index lists (all tracks, not just the first via
+      // trackPtr()/gsftrackPtr()). cand.trackPtrs()/gsfTrackPtrs() are Ptrs into whatever
+      // collection the candidate was built against -- key() gives the row index directly.
+      const auto& candTrackPtrs = cand.trackPtrs();
+      trackIdxCounts.push_back(candTrackPtrs.size());
+      for (const auto& tp : candTrackPtrs) {
+        allTrackIndices.push_back(tp.key());
+      }
+
+      const auto& candGsfTrackPtrs = cand.gsfTrackPtrs();
+      gsfTrackIdxCounts.push_back(candGsfTrackPtrs.size());
+      for (const auto& gp : candGsfTrackPtrs) {
+        allGsfTrackIndices.push_back(gp.key());
+      }
+
+      // isPU: resolve the parent CaloParticle from the first constituent Trackster's
+      // seedID/seedIndex, then read its g4Track eventId/bunchCrossing 
+      if (hasPUInfo_) {
+        int puFlag = -1;
+        if (caloParticles_h.isValid() && cpToSCMap_h.isValid() && !children.empty()) {
+          const auto& firstTrackster = tracksters[children[0].key()];
+          const auto& caloParticles = *caloParticles_h;
+          const auto& cpToSCMap = *cpToSCMap_h;
+
+          const CaloParticle* cp = nullptr;
+          if (firstTrackster.seedID() == caloParticles_h.id()) {
+            const auto seedIdx = firstTrackster.seedIndex();
+            if (seedIdx >= 0 && static_cast<size_t>(seedIdx) < caloParticles.size()) {
+              cp = &caloParticles[seedIdx];
+            }
+          } else {
+            const auto seedIdx = firstTrackster.seedIndex();
+            for (const auto& [cpIdx, scVec] : cpToSCMap) {
+              if (seedIdx >= 0 &&
+                  std::find(scVec.begin(), scVec.end(), static_cast<unsigned int>(seedIdx)) != scVec.end()) {
+                if (static_cast<size_t>(cpIdx) < caloParticles.size()) {
+                  cp = &caloParticles[cpIdx];
+                }
+                break;
+              }
+            }
+          }
+
+          if (cp && !cp->g4Tracks().empty()) {
+            const auto& simTrack = cp->g4Tracks()[0];
+            puFlag = (simTrack.eventId().event() != 0 || simTrack.eventId().bunchCrossing() != 0) ? 1 : 0;
+          }
+        }
+        isPU.push_back(puFlag);
+      }
     }
 
     for (const auto& coltable : coltables_) {
@@ -225,6 +457,50 @@ public:
       iEvent.put(std::move(outcoltable), coltable.name + "Table");
     }
 
+    // linkedTracksters output: count column on the main table + flattened sub-table.
+    // Only emitted for instances configured with linkedTracksters (reco)
+    if (hasLinkedTracksters_) {
+      out->addColumn<uint16_t>("nLinkedTracksters",
+                                linkedCounts,
+                                "Number of Tracksters linked to candidate before final linking/merging");
+
+      auto linkedTable =
+          std::make_unique<nanoaod::FlatTable>(linkedTracksterIndices.size(), "linkedTracksters", false, false);
+      linkedTable->addColumn<uint32_t>("tracksterIndex", linkedTracksterIndices, "Index of linked Trackster");
+      linkedTable->setDoc("Tracksters linked to candidate before final linking/merging");
+      iEvent.put(std::move(linkedTable), "linkedTracksters");
+    }
+
+    // Full track-index / GSF-track-index lists: count columns on the main table + flattened
+    // sub-tables, always emitted (see constructor comment). Product names are prefixed with
+    // this->name_ so the reco and sim module instances never collide.
+    out->addColumn<uint16_t>(
+        "nTrackIdxs", trackIdxCounts, "Number of generalTracks associated with candidate");
+    {
+      auto trackIdxsTable =
+          std::make_unique<nanoaod::FlatTable>(allTrackIndices.size(), this->name_ + "TrackIdxs", false, false);
+      trackIdxsTable->addColumn<uint32_t>("trackIndex", allTrackIndices, "Index of associated generalTrack");
+      trackIdxsTable->setDoc("Full list of generalTrack indices associated with the candidate");
+      iEvent.put(std::move(trackIdxsTable), this->name_ + "TrackIdxs");
+    }
+
+    out->addColumn<uint16_t>(
+        "nGsfTrackIdxs", gsfTrackIdxCounts, "Number of GSFTracks associated with candidate");
+    {
+      auto gsfTrackIdxsTable =
+          std::make_unique<nanoaod::FlatTable>(allGsfTrackIndices.size(), this->name_ + "GsfTrackIdxs", false, false);
+      gsfTrackIdxsTable->addColumn<uint32_t>("trackIndex", allGsfTrackIndices, "Index of associated GSFTrack");
+      gsfTrackIdxsTable->setDoc("Full list of GSFTrack indices associated with the candidate");
+      iEvent.put(std::move(gsfTrackIdxsTable), this->name_ + "GsfTrackIdxs");
+    }
+
+    // isPU output: one scalar per candidate, directly on the extension table.
+    // Only emitted for instances configured with caloParticles + caloParticleToSimClustersMap (sim).
+    if (hasPUInfo_) {
+      out->addColumn<int>(
+          "isPU", isPU, "PU flag of the candidate's parent CaloParticle: 1 = pileup (non-zero event/bx), 0 = otherwise, -1 = unresolved");
+    }
+
     if (out->nColumns() > 0) {
       out->setDoc(this->doc_);
       iEvent.put(std::move(out));
@@ -242,8 +518,26 @@ public:
 
     desc.add<edm::InputTag>("tracksters", edm::InputTag("ticlTrackstersCLUE3DHigh"));
     desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
+    desc.addOptional<edm::InputTag>("linkedTracksters")
+        ->setComment(
+            "Pre-merge/pre-linking Trackster links (reco TICLCandidates only, e.g. ");
+    desc.addOptional<edm::InputTag>("caloParticles")
+        ->setComment(
+            "CaloParticle collection (sim candidates only), used together with "
+            "caloParticleToSimClustersMap to compute the isPU column. Omit for reco candidates.");
+    desc.addOptional<edm::InputTag>("caloParticleToSimClustersMap")
+        ->setComment(
+            "CaloParticle-to-SimCluster index map (sim candidates only), e.g. the unlabeled product from "
+            "SimTrackstersProducer (same module as the simTracksters src). Required together with "
+            "caloParticles to compute the isPU column. Omit for reco candidates.");
     desc.add<std::string>("detector", "HGCAL");
     desc.add<std::string>("propagator", "PropagatorWithMaterial");
+    desc.add<bool>("produceGeneralTrackBoundary", false)
+        ->setComment(
+            "If true, also emit an extension of the GeneralTrack table with HGCal-boundary "
+            "propagated position/momentum for every track in the tracks collection (unconditional, "
+            "not restricted to candidate-linked tracks), mirroring TICLDumper's track_hgcal_* branches. "
+            "Enable on exactly one module instance to avoid duplicate GeneralTrack extensions.");
 
     edm::ParameterSetDescription coltable;
     coltable.add<std::string>("name", "hltTiclCandidate");
@@ -272,6 +566,12 @@ protected:
 
   const edm::EDGetTokenT<std::vector<ticl::Trackster>> tracksters_token_;
   const edm::EDGetTokenT<std::vector<reco::Track>> tracks_token_;
+  const bool hasLinkedTracksters_;
+  const edm::EDGetTokenT<std::vector<std::vector<unsigned int>>> linkedTracksters_token_;
+  const bool hasPUInfo_;
+  const edm::EDGetTokenT<std::vector<CaloParticle>> caloParticles_token_;
+  const edm::EDGetTokenT<std::map<uint, std::vector<uint>>> caloParticleToSimClustersMap_token_;
+  const bool produceGeneralTrackBoundary_;
   const std::string detector_;
   const std::string propName_;
   const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometry_token_;

--- a/DPGAnalysis/HGCalNanoAOD/plugins/TrackMuonInfoProducer.cc
+++ b/DPGAnalysis/HGCalNanoAOD/plugins/TrackMuonInfoProducer.cc
@@ -1,0 +1,104 @@
+// TrackMuonInfoProducer.cc
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h"
+
+class TrackMuonInfoProducer : public edm::global::EDProducer<> {
+public:
+  explicit TrackMuonInfoProducer(const edm::ParameterSet& cfg)
+      : tracksToken_(consumes<std::vector<reco::Track>>(cfg.getParameter<edm::InputTag>("tracks"))),
+        muonsToken_(consumes<reco::MuonCollection>(cfg.getParameter<edm::InputTag>("muons"))) {
+    produces<edm::ValueMap<int>>("isMuon");
+    produces<edm::ValueMap<int>>("isTrackerMuon");
+    produces<edm::ValueMap<int>>("muonDtHits");
+    produces<edm::ValueMap<int>>("muonCscHits");
+    produces<edm::ValueMap<int>>("muonType");
+  }
+
+  void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup&) const override {
+    edm::Handle<std::vector<reco::Track>> tracksH;
+    evt.getByToken(tracksToken_, tracksH);
+    edm::Handle<reco::MuonCollection> muonsH;
+    evt.getByToken(muonsToken_, muonsH);
+
+    const auto& tracks = *tracksH;
+    const auto& muons = *muonsH;
+
+    std::vector<int> isMuonV; isMuonV.reserve(tracks.size());
+    std::vector<int> isTrackerMuonV; isTrackerMuonV.reserve(tracks.size());
+    std::vector<int> muonDtV; muonDtV.reserve(tracks.size());
+    std::vector<int> muonCscV; muonCscV.reserve(tracks.size());
+    std::vector<int> muonTypeV; muonTypeV.reserve(tracks.size());
+
+    for (size_t i = 0; i < tracks.size(); ++i) {
+      reco::TrackRef tref(tracksH, i);
+      int muId = -1;
+      for (size_t im = 0; im < muons.size(); ++im) {
+        if (muons[im].track().isNonnull() && muons[im].track() == tref) { muId = (int)im; break; }
+      }
+      if (muId == -1) {
+        isMuonV.push_back(-1);
+        isTrackerMuonV.push_back(-1);
+        muonDtV.push_back(-1);
+        muonCscV.push_back(-1);
+        muonTypeV.push_back(-1);
+      } else {
+        reco::MuonRef mref(muonsH, muId);
+        bool ismu = PFMuonAlgo::isMuon(mref);
+        isMuonV.push_back(ismu ? 1 : 0);
+        isTrackerMuonV.push_back((*muonsH)[muId].isTrackerMuon() ? 1 : 0);
+        int dtHits = 0, cscHits = 0;
+        if (mref->standAloneMuon().isNonnull()) {
+          auto st = mref->standAloneMuon();
+          dtHits = st->hitPattern().numberOfValidMuonDTHits();
+          cscHits = st->hitPattern().numberOfValidMuonCSCHits();
+        }
+        muonDtV.push_back(dtHits);
+        muonCscV.push_back(cscHits);
+        muonTypeV.push_back(mref->type());
+      }
+    }
+
+    auto vm_isMuon = std::make_unique<edm::ValueMap<int>>();
+    edm::ValueMap<int>::Filler f_isMuon(*vm_isMuon);
+    f_isMuon.insert(tracksH, isMuonV.begin(), isMuonV.end()); f_isMuon.fill();
+    evt.put(std::move(vm_isMuon), "isMuon");
+
+    auto vm_isTracker = std::make_unique<edm::ValueMap<int>>();
+    edm::ValueMap<int>::Filler f_isTracker(*vm_isTracker);
+    f_isTracker.insert(tracksH, isTrackerMuonV.begin(), isTrackerMuonV.end()); f_isTracker.fill();
+    evt.put(std::move(vm_isTracker), "isTrackerMuon");
+
+    auto vm_dt = std::make_unique<edm::ValueMap<int>>();
+    edm::ValueMap<int>::Filler f_dt(*vm_dt);
+    f_dt.insert(tracksH, muonDtV.begin(), muonDtV.end()); f_dt.fill();
+    evt.put(std::move(vm_dt), "muonDtHits");
+
+    auto vm_csc = std::make_unique<edm::ValueMap<int>>();
+    edm::ValueMap<int>::Filler f_csc(*vm_csc);
+    f_csc.insert(tracksH, muonCscV.begin(), muonCscV.end()); f_csc.fill();
+    evt.put(std::move(vm_csc), "muonCscHits");
+
+    auto vm_type = std::make_unique<edm::ValueMap<int>>();
+    edm::ValueMap<int>::Filler f_type(*vm_type);
+    f_type.insert(tracksH, muonTypeV.begin(), muonTypeV.end()); f_type.fill();
+    evt.put(std::move(vm_type), "muonType");
+  }
+
+private:
+  const edm::EDGetTokenT<std::vector<reco::Track>> tracksToken_;
+  const edm::EDGetTokenT<reco::MuonCollection> muonsToken_;
+};
+
+DEFINE_FWK_MODULE(TrackMuonInfoProducer);

--- a/DPGAnalysis/HGCalNanoAOD/plugins/TrackMuonInfoProducer.cc
+++ b/DPGAnalysis/HGCalNanoAOD/plugins/TrackMuonInfoProducer.cc
@@ -35,17 +35,25 @@ public:
     const auto& tracks = *tracksH;
     const auto& muons = *muonsH;
 
-    std::vector<int> isMuonV; isMuonV.reserve(tracks.size());
-    std::vector<int> isTrackerMuonV; isTrackerMuonV.reserve(tracks.size());
-    std::vector<int> muonDtV; muonDtV.reserve(tracks.size());
-    std::vector<int> muonCscV; muonCscV.reserve(tracks.size());
-    std::vector<int> muonTypeV; muonTypeV.reserve(tracks.size());
+    std::vector<int> isMuonV;
+    isMuonV.reserve(tracks.size());
+    std::vector<int> isTrackerMuonV;
+    isTrackerMuonV.reserve(tracks.size());
+    std::vector<int> muonDtV;
+    muonDtV.reserve(tracks.size());
+    std::vector<int> muonCscV;
+    muonCscV.reserve(tracks.size());
+    std::vector<int> muonTypeV;
+    muonTypeV.reserve(tracks.size());
 
     for (size_t i = 0; i < tracks.size(); ++i) {
       reco::TrackRef tref(tracksH, i);
       int muId = -1;
       for (size_t im = 0; im < muons.size(); ++im) {
-        if (muons[im].track().isNonnull() && muons[im].track() == tref) { muId = (int)im; break; }
+        if (muons[im].track().isNonnull() && muons[im].track() == tref) {
+          muId = (int)im;
+          break;
+        }
       }
       if (muId == -1) {
         isMuonV.push_back(-1);
@@ -72,27 +80,32 @@ public:
 
     auto vm_isMuon = std::make_unique<edm::ValueMap<int>>();
     edm::ValueMap<int>::Filler f_isMuon(*vm_isMuon);
-    f_isMuon.insert(tracksH, isMuonV.begin(), isMuonV.end()); f_isMuon.fill();
+    f_isMuon.insert(tracksH, isMuonV.begin(), isMuonV.end());
+    f_isMuon.fill();
     evt.put(std::move(vm_isMuon), "isMuon");
 
     auto vm_isTracker = std::make_unique<edm::ValueMap<int>>();
     edm::ValueMap<int>::Filler f_isTracker(*vm_isTracker);
-    f_isTracker.insert(tracksH, isTrackerMuonV.begin(), isTrackerMuonV.end()); f_isTracker.fill();
+    f_isTracker.insert(tracksH, isTrackerMuonV.begin(), isTrackerMuonV.end());
+    f_isTracker.fill();
     evt.put(std::move(vm_isTracker), "isTrackerMuon");
 
     auto vm_dt = std::make_unique<edm::ValueMap<int>>();
     edm::ValueMap<int>::Filler f_dt(*vm_dt);
-    f_dt.insert(tracksH, muonDtV.begin(), muonDtV.end()); f_dt.fill();
+    f_dt.insert(tracksH, muonDtV.begin(), muonDtV.end());
+    f_dt.fill();
     evt.put(std::move(vm_dt), "muonDtHits");
 
     auto vm_csc = std::make_unique<edm::ValueMap<int>>();
     edm::ValueMap<int>::Filler f_csc(*vm_csc);
-    f_csc.insert(tracksH, muonCscV.begin(), muonCscV.end()); f_csc.fill();
+    f_csc.insert(tracksH, muonCscV.begin(), muonCscV.end());
+    f_csc.fill();
     evt.put(std::move(vm_csc), "muonCscHits");
 
     auto vm_type = std::make_unique<edm::ValueMap<int>>();
     edm::ValueMap<int>::Filler f_type(*vm_type);
-    f_type.insert(tracksH, muonTypeV.begin(), muonTypeV.end()); f_type.fill();
+    f_type.insert(tracksH, muonTypeV.begin(), muonTypeV.end());
+    f_type.fill();
     evt.put(std::move(vm_type), "muonType");
   }
 

--- a/DPGAnalysis/HGCalNanoAOD/python/HGCalNanoAOD_cff.py
+++ b/DPGAnalysis/HGCalNanoAOD/python/HGCalNanoAOD_cff.py
@@ -5,6 +5,9 @@ from DPGAnalysis.HGCalNanoAOD.hgcalTracksters_cfi import *
 from DPGAnalysis.HGCalNanoAOD.hgcalTICLCandidates_cfi import *
 from DPGAnalysis.HGCalNanoAOD.hgcalTICLSuperClusters_cfi import *
 from DPGAnalysis.HGCalNanoAOD.hgcalLayerClusters_cfi import *
+from DPGAnalysis.HGCalNanoAOD.hgcalGeneralTracks_cfi import *
+from DPGAnalysis.HGCalNanoAOD.hgcalGSFTracks_cfi import *
+from DPGAnalysis.HGCalNanoAOD.hgcalGen_cfi import *
 
 ######################################
 # Offline HGCAL NanoAOD Tables
@@ -14,6 +17,8 @@ OfflineHGCalTables = cms.Sequence(
     hgcalTrackstersTableSequence
     + ticlCandidateTable
     + ticlCandidateExtraTable
+    + hgcalGeneralTracksTableSequence
+    + hgcalGSFTracksTableSequence
 )
 
 # Store additional validation objects 
@@ -23,6 +28,7 @@ OfflineHGCalValidationTables = cms.Sequence(
     + ticlSimCandidateTable
     + ticlSimCandidateExtraTable
     + hgcalLayerClustersTableSequence
+    + hgcalGenSequence
 )
 
 ######################################

--- a/DPGAnalysis/HGCalNanoAOD/python/hgcalGSFTracks_cfi.py
+++ b/DPGAnalysis/HGCalNanoAOD/python/hgcalGSFTracks_cfi.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import *
+
+# GSF Tracks table for NanoAOD 
+gsfTracksTable = cms.EDProducer(
+    "SimpleGsfTrackFlatTableProducer",
+    skipNonExistingSrc=cms.bool(True),
+    src=cms.InputTag("electronGsfTracks"),
+    cut=cms.string(""),
+    name=cms.string("GSFTrack"),
+    doc=cms.string("GSF tracks"),
+    extension=cms.bool(False),
+    variables=cms.PSet(
+        # Basic kinematics 
+        pt=Var("pt()", "float", doc="GSF track p_T [GeV]"),
+        p=Var("p()", "float", doc="GSF track momentum magnitude [GeV]"),
+        eta=Var("eta()", "float", doc="GSF track pseudorapidity"),
+        phi=Var("phi()", "float", doc="GSF track phi angle [rad]"),
+        charge=Var("charge()", "int", doc="GSF track charge"),
+        
+        # Position 
+        vx=Var("vx()", "float", doc="GSF track vertex x [cm]"),
+        vy=Var("vy()", "float", doc="GSF track vertex y [cm]"),
+        vz=Var("vz()", "float", doc="GSF track vertex z [cm]"),
+        
+        nhits=Var("recHitsSize()", "int", doc="GSF track nHits"),
+        ptMode=Var("ptMode()", "float", doc="GSF track p_T Mode [GeV]"),
+        ptModeError=Var("ptModeError()", "float", doc="GSF track p_T Mode Error"),
+        pxMode=Var("pxMode()", "float", doc="GSF track px Mode [GeV]"),
+	pyMode=Var("pyMode()", "float", doc="GSF track py Mode [GeV]"),
+	pzMode=Var("pzMode()", "float", doc="GSF track pz Mode [GeV]"),
+        pMode=Var("pMode()", "float", doc="GSF track momentum Mode [GeV]"),
+        etaMode=Var("etaMode()", "float", doc="GSF track Mode pseudorapidity"),
+        etaModeError=Var("etaModeError()", "float", doc="GSF track Mode pseudorapidity Error"),
+        phiMode=Var("phiMode()", "float", doc="GSF track phi angle Mode [rad]"),
+        phiModeError=Var("phiModeError()", "float", doc="GSF track phi angle Mode Error"),
+        chargeMode=Var("chargeMode()", "int", doc="GSF track charge Mode"),
+        lambdaMode=Var("lambdaMode()", "float", doc="GSF track lambda Mode"),
+        lambdaModeError=Var("lambdaModeError()", "float", doc="GSF track lambda Mode Error"),
+        thetaMode=Var("thetaMode()", "float", doc="GSF track theta Mode"),
+        thetaModeError=Var("thetaModeError()", "float", doc="GSF track theta Mode Error"),
+        qoverpMode=Var("qoverpMode()", "float", doc="GSF track qoverp Mode"),
+        qoverpModeError=Var("qoverpModeError()", "float", doc="GSF track qoverp Mode Error"),
+        
+    ),
+)
+
+# Sequence for gsf tracks
+hgcalGSFTracksTableSequence = cms.Sequence(gsfTracksTable)

--- a/DPGAnalysis/HGCalNanoAOD/python/hgcalGen_cfi.py
+++ b/DPGAnalysis/HGCalNanoAOD/python/hgcalGen_cfi.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.nano_cff import nanoMetadata
+
+# GenParticles table 
+hgcalGenPartTable = cms.EDProducer(
+    "SimpleGenParticleFlatTableProducer",
+    skipNonExistingSrc=cms.bool(True),
+    src=cms.InputTag("genParticles"),
+    cut=cms.string("status==1 && pt > 0.5"),  # stable gen particles with pT > 0.5
+    name=cms.string("HGCalGenPart"),
+    doc=cms.string("Gen particles for HGCAL studies"),
+    singleton=cms.bool(False),
+    variables=cms.PSet(
+        pt=Var("pt", "float", doc="gen particle pT"),
+        eta=Var("eta", "float", doc="gen particle eta"),
+        phi=Var("phi", "float", doc="gen particle phi"),
+        mass=Var("mass", "float", doc="gen particle mass"),
+        pdgId=Var("pdgId", "int", doc="gen particle PDG ID"),
+        status=Var("status", "int", doc="gen particle status"),
+        energy=Var("energy", "float", doc="gen particle energy"),
+        vx=Var("vx", "float", doc="gen particle vx"),
+        vy=Var("vy", "float", doc="gen particle vy"),
+        vz=Var("vz", "float", doc="gen particle vz"),
+    ),
+)
+
+hgcalGenSequence = cms.Sequence(hgcalGenPartTable)

--- a/DPGAnalysis/HGCalNanoAOD/python/hgcalGen_cfi.py
+++ b/DPGAnalysis/HGCalNanoAOD/python/hgcalGen_cfi.py
@@ -9,7 +9,7 @@ hgcalGenPartTable = cms.EDProducer(
     src=cms.InputTag("genParticles"),
     cut=cms.string("status==1 && pt > 0.5"),  # stable gen particles with pT > 0.5
     name=cms.string("HGCalGenPart"),
-    doc=cms.string("Gen particles for HGCAL studies"),
+    doc=cms.string("Gen particles information"),
     singleton=cms.bool(False),
     variables=cms.PSet(
         pt=Var("pt", "float", doc="gen particle pT"),

--- a/DPGAnalysis/HGCalNanoAOD/python/hgcalGeneralTracks_cfi.py
+++ b/DPGAnalysis/HGCalNanoAOD/python/hgcalGeneralTracks_cfi.py
@@ -1,0 +1,53 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import *
+
+trackMuonInfo = cms.EDProducer("TrackMuonInfoProducer",
+    tracks = cms.InputTag("generalTracks"),
+    muons  = cms.InputTag("muons")
+)
+
+# General Tracks table for NanoAOD 
+generalTracksTable = cms.EDProducer(
+    "SimpleTrackFlatTableProducer",
+    skipNonExistingSrc=cms.bool(True),
+    src=cms.InputTag("generalTracks"),
+    cut=cms.string(""),
+    name=cms.string("GeneralTrack"),
+    doc=cms.string("General reconstructed tracks"),
+    extension=cms.bool(False),
+    variables=cms.PSet(
+        # Basic kinematics
+        pt=Var("pt()", "float", doc="track p_T [GeV]"),
+        p=Var("p()", "float", doc="track momentum magnitude [GeV]"),
+        eta=Var("eta()", "float", doc="track pseudorapidity"),
+        phi=Var("phi()", "float", doc="track phi angle [rad]"),
+        charge=Var("charge()", "int", doc="track charge"),
+        trackLambda=Var("lambda()", "float", doc="track lambda"),
+        
+        # Position 
+        vx=Var("vx()", "float", doc="track vertex x [cm]"),
+        vy=Var("vy()", "float", doc="track vertex y [cm]"),
+        vz=Var("vz()", "float", doc="track vertex z [cm]"),
+        
+        # Quality metrics
+        nhits=Var("numberOfValidHits()", "uint16", doc="number of valid hits"),
+        missingOuterHits=Var("missingOuterHits()", "uint8", doc="number of missing outer hits"),
+        
+        # Error parameters 
+        ptErr=Var("ptError()", "float", doc="track p_T error [GeV]"),
+        etaErr=Var("etaError()", "float", doc="track eta error"),
+        phiErr=Var("phiError()", "float", doc="track phi error"),
+        lambdaErr=Var("lambdaError()", "float", doc="track lambda error"),
+        qoverpErr=Var("qoverpError()", "float", doc="q/p error"),
+    ),
+    externalVariables = cms.PSet(
+        isMuon = ExtVar(cms.InputTag("trackMuonInfo", "isMuon"),"int", doc="1 if PFMuonAlgo::isMuon, 0 otherwise, -1 if no muon"),
+        isTrackerMuon = ExtVar(cms.InputTag("trackMuonInfo", "isTrackerMuon"),"int", doc="1 if tracker muon, -1 if no muon"),
+        muon_dt_hits = ExtVar(cms.InputTag("trackMuonInfo", "muonDtHits"),"int", doc="ST muon DT hits (-1 if no muon)"),
+        muon_csc_hits = ExtVar(cms.InputTag("trackMuonInfo", "muonCscHits"), "int", doc="ST muon CSC hits (-1 if no muon)"),
+        muon_type = ExtVar(cms.InputTag("trackMuonInfo", "muonType"), "int", doc="muon type (-1 if no muon)"),
+    )
+)
+
+# Sequence for general tracks
+hgcalGeneralTracksTableSequence = cms.Sequence(trackMuonInfo + generalTracksTable)

--- a/DPGAnalysis/HGCalNanoAOD/python/hgcalTICLCandidates_cfi.py
+++ b/DPGAnalysis/HGCalNanoAOD/python/hgcalTICLCandidates_cfi.py
@@ -49,6 +49,7 @@ ticlCandidateTable = cms.EDProducer(
     ),
 )
 
+
 # SimTICLCandidates for validation
 ticlSimCandidateTable = cms.EDProducer(
     "TICLCandidateTableProducer",
@@ -91,18 +92,24 @@ ticlSimCandidateTable = cms.EDProducer(
         MTDtimeError=Var("MTDtimeError", "float",
                          doc="Trackster associated MTD time error, meaningful only for offline reconstruction"),
         trackIdx=Var("trackPtr().key", "int",
-                     doc="Index of generalTrack associated with TICLCandidate")
+                     doc="Index of generalTrack associated with SimTICLCandidate"),
+        gsftrackIdx=Var("gsftrackPtr().key", "int",
+                        doc="Index of GSFTrack associated with SimTICLCandidate"),
+
     ),
 )
 
 # Extra tables for linking tracksters to candidates
 ticlCandidateExtraTable = cms.EDProducer(
     "TICLCandidateExtraTableProducer",
+    skipNonExistingSrc=cms.bool(True),
     src=cms.InputTag("ticlCandidate"),
     name=cms.string("TICLCandidates"),
     doc=cms.string("TICLCandidates extra table with linked Tracksters"),
     tracksters=cms.InputTag("ticlCandidate"),
     tracks=cms.InputTag("generalTracks"),
+    linkedTracksters=cms.InputTag("ticlCandidate", "linkedTracksters"),
+    produceGeneralTrackBoundary=cms.bool(True),
     detector=cms.string("HGCAL"),
     propagator=cms.string("PropagatorWithMaterial"),
     collectionVariables=cms.PSet(
@@ -118,11 +125,14 @@ ticlCandidateExtraTable = cms.EDProducer(
 
 ticlSimCandidateExtraTable = cms.EDProducer(
     "TICLCandidateExtraTableProducer",
+    skipNonExistingSrc=cms.bool(True),
     src=cms.InputTag("ticlSimTracksters"),
     name=cms.string("SimTICLCandidates"),
     doc=cms.string("TICLCandidates extra table with linked Tracksters"),
     tracksters=cms.InputTag("ticlSimTracksters"),
     tracks=cms.InputTag("generalTracks"),
+    caloParticles=cms.InputTag("mix", "MergedCaloTruth"),
+    caloParticleToSimClustersMap=cms.InputTag("ticlSimTracksters"),
     detector=cms.string("HGCAL"),
     propagator=cms.string("PropagatorWithMaterial"),
     collectionVariables=cms.PSet(
@@ -135,4 +145,3 @@ ticlSimCandidateExtraTable = cms.EDProducer(
         ),
     ),
 )
-

--- a/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
+++ b/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
@@ -92,7 +92,7 @@ namespace ticl {
                                 std::vector<Trackster>& resultTracksters,
                                 std::vector<int>& resultCandidate,
                                 std::vector<bool>& maskedTracksters,
-				std::vector<std::vector<unsigned int>> &linkedResultTracksters) = 0;
+                                std::vector<std::vector<unsigned int>>& linkedResultTracksters) = 0;
 
     virtual void initialize(const HGCalDDDConstants* hgcons,
                             const ticlgeom::Tools rhtools,

--- a/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
+++ b/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
@@ -91,7 +91,8 @@ namespace ticl {
                                 edm::Handle<MtdHostCollection> inputTiming_h,
                                 std::vector<Trackster>& resultTracksters,
                                 std::vector<int>& resultCandidate,
-                                std::vector<bool>& maskedTracksters) = 0;
+                                std::vector<bool>& maskedTracksters,
+				std::vector<std::vector<unsigned int>> &linkedResultTracksters) = 0;
 
     virtual void initialize(const HGCalDDDConstants* hgcons,
                             const ticlgeom::Tools rhtools,

--- a/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.cc
@@ -333,7 +333,7 @@ void GNNInterpretationAlgo::makeCandidates(const Inputs& input,
                                            std::vector<Trackster>& resultTracksters,
                                            std::vector<int>& resultCandidate,
                                            std::vector<bool>& maskedTracksters,
-					   std::vector<std::vector<unsigned int>> &linkedResultTracksters) {
+                                           std::vector<std::vector<unsigned int>>& linkedResultTracksters) {
   const auto& tracks = *input.tracksHandle;
   const auto& maskTracks = input.maskedTracks;
   const auto& tracksters = input.tracksters;
@@ -527,7 +527,7 @@ void GNNInterpretationAlgo::makeCandidates(const Inputs& input,
   }
   // Build output tracksters
   linkedResultTracksters.reserve(input.tracksters.size());
-  
+
   for (unsigned trkId = 0; trkId < trackToTracksters.size(); ++trkId) {
     if (trackToTracksters[trkId].empty())
       continue;

--- a/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.cc
@@ -332,7 +332,8 @@ void GNNInterpretationAlgo::makeCandidates(const Inputs& input,
                                            edm::Handle<MtdHostCollection> inputTiming_h,
                                            std::vector<Trackster>& resultTracksters,
                                            std::vector<int>& resultCandidate,
-                                           std::vector<bool>& maskedTracksters) {
+                                           std::vector<bool>& maskedTracksters,
+					   std::vector<std::vector<unsigned int>> &linkedResultTracksters) {
   const auto& tracks = *input.tracksHandle;
   const auto& maskTracks = input.maskedTracks;
   const auto& tracksters = input.tracksters;
@@ -525,7 +526,8 @@ void GNNInterpretationAlgo::makeCandidates(const Inputs& input,
     }
   }
   // Build output tracksters
-
+  linkedResultTracksters.reserve(input.tracksters.size());
+  
   for (unsigned trkId = 0; trkId < trackToTracksters.size(); ++trkId) {
     if (trackToTracksters[trkId].empty())
       continue;
@@ -545,13 +547,15 @@ void GNNInterpretationAlgo::makeCandidates(const Inputs& input,
                               1.f);
 
       resultTracksters.push_back(std::move(merged));
+      linkedResultTracksters.push_back(trackToTracksters[trkId]);
     }
   }
 
   // Add unlinked tracksters
-  for (unsigned i = 0; i < tracksters.size(); ++i) {
-    if (tracksterAvailable[i])
-      resultTracksters.push_back(tracksters[i]);
+  for (auto iTrackster = 0u; iTrackster < input.tracksters.size(); iTrackster++) {
+    if (tracksterAvailable[iTrackster])
+      resultTracksters.push_back(tracksters[iTrackster]);
+    linkedResultTracksters.push_back({iTrackster});
   }
 }
 

--- a/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.h
@@ -44,7 +44,8 @@ namespace ticl {
                         edm::Handle<MtdHostCollection> inputTiming_h,
                         std::vector<Trackster> &resultTracksters,
                         std::vector<int> &resultCandidate,
-                        std::vector<bool> &maskedTracksters) override;
+                        std::vector<bool> &maskedTracksters,
+			std::vector<std::vector<unsigned int>> &linkedResultTracksters) override;
 
     void initialize(const HGCalDDDConstants *hgcons,
                     const ticlgeom::Tools rhtools,

--- a/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.h
@@ -45,7 +45,7 @@ namespace ticl {
                         std::vector<Trackster> &resultTracksters,
                         std::vector<int> &resultCandidate,
                         std::vector<bool> &maskedTracksters,
-			std::vector<std::vector<unsigned int>> &linkedResultTracksters) override;
+                        std::vector<std::vector<unsigned int>> &linkedResultTracksters) override;
 
     void initialize(const HGCalDDDConstants *hgcons,
                     const ticlgeom::Tools rhtools,

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -198,7 +198,7 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
                                                std::vector<Trackster> &resultTracksters,
                                                std::vector<int> &resultCandidate,
                                                std::vector<bool> &maskedTracksters,
-					       std::vector<std::vector<unsigned int>> &linkedResultTracksters) {
+                                               std::vector<std::vector<unsigned int>> &linkedResultTracksters) {
   bool useMTDTiming = inputTiming_h.isValid();
   const auto tkH = input.tracksHandle;
   const auto maskTracks = input.maskedTracks;
@@ -380,7 +380,7 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
         auto tracksterId = trackstersInTrackIndices[iTrack][0];
         resultCandidate[iTrack] = resultTracksters.size();
         resultTracksters.push_back(input.tracksters[tracksterId]);
-	linkedResultTracksters.push_back(trackstersInTrackIndices[iTrack]);
+        linkedResultTracksters.push_back(trackstersInTrackIndices[iTrack]);
       } else {
         // in this case mergeTracksters() clears the pid probabilities and the regressed energy is not set
         // TODO: fix probabilities when CNN will be splitted

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -197,7 +197,8 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
                                                edm::Handle<MtdHostCollection> inputTiming_h,
                                                std::vector<Trackster> &resultTracksters,
                                                std::vector<int> &resultCandidate,
-                                               std::vector<bool> &maskedTracksters) {
+                                               std::vector<bool> &maskedTracksters,
+					       std::vector<std::vector<unsigned int>> &linkedResultTracksters) {
   bool useMTDTiming = inputTiming_h.isValid();
   const auto tkH = input.tracksHandle;
   const auto maskTracks = input.maskedTracks;
@@ -372,13 +373,14 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
     }
     trackstersInTrackIndices[i] = chargedCandidate;
   }
-
+  linkedResultTracksters.reserve(input.tracksters.size());
   for (size_t iTrack = 0; iTrack < trackstersInTrackIndices.size(); iTrack++) {
     if (!trackstersInTrackIndices[iTrack].empty()) {
       if (trackstersInTrackIndices[iTrack].size() == 1) {
         auto tracksterId = trackstersInTrackIndices[iTrack][0];
         resultCandidate[iTrack] = resultTracksters.size();
         resultTracksters.push_back(input.tracksters[tracksterId]);
+	linkedResultTracksters.push_back(trackstersInTrackIndices[iTrack]);
       } else {
         // in this case mergeTracksters() clears the pid probabilities and the regressed energy is not set
         // TODO: fix probabilities when CNN will be splitted
@@ -398,12 +400,14 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
         else
           resultTracksters.back().setIdProbability(ticl::Trackster::ParticleType::electron, 1.f);
       }
+      linkedResultTracksters.push_back(trackstersInTrackIndices[iTrack]);
     }
   }
 
-  for (size_t iTrackster = 0; iTrackster < input.tracksters.size(); iTrackster++) {
+  for (auto iTrackster = 0u; iTrackster < input.tracksters.size(); iTrackster++) {
     if (chargedMask[iTrackster]) {
       resultTracksters.push_back(input.tracksters[iTrackster]);
+      linkedResultTracksters.push_back({iTrackster});
     }
   }
 };

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
@@ -22,7 +22,7 @@ namespace ticl {
                         std::vector<Trackster> &resultTracksters,
                         std::vector<int> &resultCandidate,
                         std::vector<bool> &maskedTracksters,
-			std::vector<std::vector<unsigned int>> &linkedResultTracksters) override;
+                        std::vector<std::vector<unsigned int>> &linkedResultTracksters) override;
 
     void initialize(const HGCalDDDConstants *hgcons,
                     const ticlgeom::Tools rhtools,

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
@@ -21,7 +21,8 @@ namespace ticl {
                         edm::Handle<MtdHostCollection> inputTiming_h,
                         std::vector<Trackster> &resultTracksters,
                         std::vector<int> &resultCandidate,
-                        std::vector<bool> &maskedTracksters) override;
+                        std::vector<bool> &maskedTracksters,
+			std::vector<std::vector<unsigned int>> &linkedResultTracksters) override;
 
     void initialize(const HGCalDDDConstants *hgcons,
                     const ticlgeom::Tools rhtools,

--- a/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.cc
@@ -44,7 +44,8 @@ void MuonInterpretationAlgo::makeCandidates(const Inputs &input,
                                             edm::Handle<MtdHostCollection> /*inputTiming_h*/,
                                             std::vector<Trackster> &resultTracksters,
                                             std::vector<int> &resultCandidate,
-                                            std::vector<bool> &maskedTracksters) {
+                                            std::vector<bool> &maskedTracksters,
+					    std::vector<std::vector<unsigned int>> &linkedResultTracksters) {
   const auto &tracks = *input.tracksHandle;
   const auto &maskTracks = input.maskedTracks;
   const auto &tracksters = input.tracksters;

--- a/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.cc
@@ -45,7 +45,7 @@ void MuonInterpretationAlgo::makeCandidates(const Inputs &input,
                                             std::vector<Trackster> &resultTracksters,
                                             std::vector<int> &resultCandidate,
                                             std::vector<bool> &maskedTracksters,
-					    std::vector<std::vector<unsigned int>> &linkedResultTracksters) {
+                                            std::vector<std::vector<unsigned int>> &linkedResultTracksters) {
   const auto &tracks = *input.tracksHandle;
   const auto &maskTracks = input.maskedTracks;
   const auto &tracksters = input.tracksters;

--- a/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.h
@@ -44,7 +44,7 @@ namespace ticl {
                         std::vector<Trackster> &resultTracksters,
                         std::vector<int> &resultCandidate,
                         std::vector<bool> &maskedTracksters,
-			std::vector<std::vector<unsigned int>> &linkedResultTracksters) override;
+                        std::vector<std::vector<unsigned int>> &linkedResultTracksters) override;
 
     void initialize(const HGCalDDDConstants *hgcons,
                     const ticlgeom::Tools rhtools,

--- a/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.h
@@ -43,7 +43,8 @@ namespace ticl {
                         edm::Handle<MtdHostCollection> inputTiming_h,
                         std::vector<Trackster> &resultTracksters,
                         std::vector<int> &resultCandidate,
-                        std::vector<bool> &maskedTracksters) override;
+                        std::vector<bool> &maskedTracksters,
+			std::vector<std::vector<unsigned int>> &linkedResultTracksters) override;
 
     void initialize(const HGCalDDDConstants *hgcons,
                     const ticlgeom::Tools rhtools,

--- a/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
@@ -210,7 +210,7 @@ TICLCandidateProducer::TICLCandidateProducer(const edm::ParameterSet &ps, const 
 
   produces<std::vector<TICLCandidate>>();
   produces<std::vector<std::vector<unsigned int>>>("linkedTracksters");
-  
+
   // New trackster collection after linking
   produces<std::vector<Trackster>>();
 
@@ -397,7 +397,7 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
                                                                        tracks_h,
                                                                        generalTrackMask);
   generalInterpretationAlgo_->makeCandidates(
-					     input, inputTiming_h, *resultTracksters, trackstersInTrackIndices, maskedInputTracksters, *linkedResultTracksters);
+      input, inputTiming_h, *resultTracksters, trackstersInTrackIndices, maskedInputTracksters, *linkedResultTracksters);
 
   assignPCAtoTracksters(*resultTracksters,
                         layerClusters,
@@ -413,7 +413,7 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
   std::vector<bool> maskTracksters(resultTracksters->size(), true);
   edm::OrphanHandle<std::vector<Trackster>> resultTracksters_h = evt.put(std::move(resultTracksters));
   auto linkedTracksters = std::make_unique<std::vector<std::vector<unsigned int>>>();
-  
+
   // Muon candidates: energy from the track momentum (pdgId 13), attaching the MIP
   // trackster the muon pass associated (if any) and masking it so it is not re-emitted.
   for (size_t iTrack = 0; iTrack < tracks.size(); ++iTrack) {
@@ -442,7 +442,7 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
       if (tracksterId != -1 and !maskTracksters.empty()) {
         auto tracksterPtr = edm::Ptr<Trackster>(resultTracksters_h, tracksterId);
         TICLCandidate chargedCandidate(trackPtr, tracksterPtr);
-	linkedTracksters->push_back((*linkedResultTracksters)[tracksterId]);
+        linkedTracksters->push_back((*linkedResultTracksters)[tracksterId]);
         resultCandidates->push_back(chargedCandidate);
         maskTracksters[tracksterId] = false;
       }

--- a/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
@@ -209,7 +209,8 @@ TICLCandidateProducer::TICLCandidateProducer(const edm::ParameterSet &ps, const 
   }
 
   produces<std::vector<TICLCandidate>>();
-
+  produces<std::vector<std::vector<unsigned int>>>("linkedTracksters");
+  
   // New trackster collection after linking
   produces<std::vector<Trackster>>();
 
@@ -376,7 +377,7 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
   // muon), or a rejection (kMuonRejected: the trajectory points to a shower).
   std::vector<bool> maskedInputTracksters(generalTrackstersSpan.size(), false);
   muonInterpretationAlgo_->makeCandidates(
-      muonInput, inputTiming_h, *resultTracksters, muonInTrackIndices, maskedInputTracksters);
+      muonInput, inputTiming_h, *resultTracksters, muonInTrackIndices, maskedInputTracksters, *linkedResultTracksters);
 
   // A track the muon pass rejected is not a muon: route it back to the general pass so
   // it is reconstructed there (and no muon candidate is built for it below).
@@ -396,7 +397,7 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
                                                                        tracks_h,
                                                                        generalTrackMask);
   generalInterpretationAlgo_->makeCandidates(
-      input, inputTiming_h, *resultTracksters, trackstersInTrackIndices, maskedInputTracksters);
+					     input, inputTiming_h, *resultTracksters, trackstersInTrackIndices, maskedInputTracksters, *linkedResultTracksters);
 
   assignPCAtoTracksters(*resultTracksters,
                         layerClusters,
@@ -411,7 +412,8 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
 
   std::vector<bool> maskTracksters(resultTracksters->size(), true);
   edm::OrphanHandle<std::vector<Trackster>> resultTracksters_h = evt.put(std::move(resultTracksters));
-
+  auto linkedTracksters = std::make_unique<std::vector<std::vector<unsigned int>>>();
+  
   // Muon candidates: energy from the track momentum (pdgId 13), attaching the MIP
   // trackster the muon pass associated (if any) and masking it so it is not re-emitted.
   for (size_t iTrack = 0; iTrack < tracks.size(); ++iTrack) {
@@ -440,6 +442,7 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
       if (tracksterId != -1 and !maskTracksters.empty()) {
         auto tracksterPtr = edm::Ptr<Trackster>(resultTracksters_h, tracksterId);
         TICLCandidate chargedCandidate(trackPtr, tracksterPtr);
+	linkedTracksters->push_back((*linkedResultTracksters)[tracksterId]);
         resultCandidates->push_back(chargedCandidate);
         maskTracksters[tracksterId] = false;
       }
@@ -452,6 +455,7 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
       edm::Ptr<Trackster> tracksterPtr(resultTracksters_h, iTrackster);
       edm::Ptr<reco::Track> trackPtr;
       TICLCandidate neutralCandidate(trackPtr, tracksterPtr);
+      linkedTracksters->push_back((*linkedResultTracksters)[iTrackster]);
       resultCandidates->push_back(neutralCandidate);
     }
   }
@@ -511,6 +515,7 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
   assignTimeToCandidates(*resultCandidates, tracks_h, inputTimingView, getPathLength);
 
   evt.put(std::move(resultCandidates));
+  evt.put(std::move(linkedTracksters), "linkedTracksters");
 }
 
 template <typename F>


### PR DESCRIPTION
This PR adds more information to the offline TICL NanoAOD, with features aimed at improving TICL performance studies, especially for general tracks and GSF tracks for PF interpretation.
It also adds:
- GEN information for SIM-vs-GEN validation.
- The indices of the tracksters forming each TICLCandidate. This vector was already declared but not filled, so it is now properly filled and stored in the NanoAOD.
- A flag indicating whether a SimCandidate originates from PU (1) or not (0). This is normally 0 unless SIM from PU is enabled, in which case the flag becomes useful.

The PR has been tested with the relevant workflows and runs smoothly for 34506.213 and 34706.213.