### PR TITLE
Fix ASAN build problem for SimTracker/VertexAssociation

### DIFF
--- a/SimTracker/VertexAssociation/BuildFile.xml
+++ b/SimTracker/VertexAssociation/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/VertexReco"/>
+<use name="DataFormats/PatCandidates"/>
 <use name="SimDataFormats/Associations"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimDataFormats/TrackingAnalysis"/>


### PR DESCRIPTION

#### PR description:

ASAN requires this library link with DataFormats/PatCandidates in order to resolve a vtable.

#### PR validation:

This built under CMSSW_20_1_ASAN_X_2026-08-17-2300

resolves https://github.com/cms-sw/framework-team/issues/2396