### PR TITLE
Do not have debug level MessageLogger in TauValidator

### DIFF
--- a/Validation/RecoTau/plugins/TauValidator.cc
+++ b/Validation/RecoTau/plugins/TauValidator.cc
@@ -16,7 +16,7 @@
 #include "DataFormats/TauReco/interface/TauDiscriminatorContainer.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <cstddef>


### PR DESCRIPTION
#### PR description:

This fixes a warning in the DBG IBs. The code can be uncommented for the case where someone wants to temporarily enable this.

#### PR validation:

Building in CMSSW_20_1_DBG_X_2026-08-17-2300 no longer issues the warning.

resolves https://github.com/cms-sw/framework-team/issues/2397