### PR TITLE
Optimize PV for OO UPC reco

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -216,6 +216,11 @@ from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen
     TkFilterParameters = dict(
         algorithm="filterWithThreshold",
         minSiliconLayersWithHits = 0,
+        maxDzError = 3.0,
         numTracksThreshold = cms.int32(3),
-    ))
+    ),
+    vertexCollections = {
+        0: dict(chi2cutoff = 4.0, minNdof = -1.1),
+        1: dict(chi2cutoff = 4.0, minNdof = -2.0),
+    })
 )


### PR DESCRIPTION
#### PR description:

This PR extends the maximum dZ error and |eta| to 3 used in the track selection for the primary vertex reconstruction in OO UPC reco, to improve PV reco efficiency for low pT tracks.

#### PR validation:

Tested with relvals 143.911,143.912

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: