### PR TITLE
Fix `defaultDatasets` for `Run4D127`

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4706,7 +4706,7 @@ defaultDataSets['2025FS']='CMSSW_13_0_11-130X_mcRun3_2023_realistic_withEarly202
 defaultRun4Geometry = 'D127'
 defaultDataSets['Run4D110']='CMSSW_15_1_0_pre5-150X_mcRun4_realistic_v1_STD_RegeneratedGS_Run4D110_noPU-v'
 defaultDataSets['Run4D121']='CMSSW_20_0_0_pre1-150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v'
-defaultDataSets['Run4D127']='CMSSW_20_0_0-150X_mcRun4_realistic_v1_D127_GSOnly_NewInputs-v'
+defaultDataSets['Run4D127']='CMSSW_20_0_0-150X_mcRun4_realistic_v1_D127_GSOnly-v'
 
 ## HIN
 defaultDataSets['2023HIN']='CCMSSW_14_1_0-PU_140X_mcRun3_2023_realistic_HI_v4_STD_2023HIN_PU-v'


### PR DESCRIPTION
As discussed in https://github.com/cms-sw/cmssw/issues/51722, the supposedly D127 input samples have run instead with D126 geometry.  New samples [are running](https://cms-pdmv-prod.web.cern.ch/relval/relvals?ticket=CMSSW_20_0_0__Run4_D127_pp_noPU_STD_Inputs_GSOnly-00004&page=0&limit=50&shown=2099199) and are starting to come out. 

This PR makes the `defaultDatasets` for `Run4D127` point to them. 

Keeping it a draft until `MinBias` and `TTbar` are done.

Just to be safe: taking one random sample [already produced](https://cmsweb.cern.ch/das/request?instance=prod/global&input=config+dataset%3D%2FRelValWToLNu_14TeV%2FCMSSW_20_0_0-150X_mcRun4_realistic_v1_D127GSOnly-v1%2FGEN-SIM) the config [here](https://cmsweb.cern.ch/couchdb/reqmgr_config_cache/718fcb14d4df910949dfd71ae9c5be7f/configFile) uses

```
process.load('Configuration.Geometry.GeometryExtendedRun4D127Reco_cff')
process.load('Configuration.Geometry.GeometryExtendedRun4D127_cff')
```
