### PR TITLE
Add realistic TTCluster EDProducer

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTCluster.h
+++ b/DataFormats/L1TrackTrigger/interface/TTCluster.h
@@ -9,6 +9,8 @@
  *  \author Emmanuele Salvati
  *  \date   2013, Jul 12
  *
+ *  Simplified Ian Tomalin (2026)
+ *
  */
 
 #ifndef L1_TRACK_TRIGGER_CLUSTER_FORMAT_H
@@ -28,7 +30,8 @@ class TTCluster {
 public:
   /// Constructors
   TTCluster();
-  TTCluster(std::vector<T> aHits, DetId aDetId, unsigned int aStackMember, bool storeLocal);
+  TTCluster(const std::vector<T>& aHits, const DetId& aDetId, unsigned int aStackMember);
+  TTCluster(const DetId& aDetId, unsigned int aStackMember, const Phase2TrackerDigi& firstDigi, unsigned int width);
 
   /// Destructor
   ~TTCluster();
@@ -36,41 +39,52 @@ public:
   /// Data members:   getABC( ... )
   /// Helper methods: findABC( ... )
 
-  /// Hits in the Cluster
-  std::vector<T> getHits() const { return theHits; }
-  void setHits(std::vector<T> aHits) { theHits = aHits; }
-
-  /// Detector element
-  DetId getDetId() const { return theDetId; }
-  void setDetId(DetId aDetId) { theDetId = aDetId; }
+  /// Detector module & which of two sensors inside it.
+  const DetId& getDetId() const { return theDetId; }
   unsigned int getStackMember() const { return theStackMember; }
-  void setStackMember(unsigned int aStackMember) { theStackMember = aStackMember; }
 
-  /// Rows and columns to get rid of Digi collection
-  std::vector<int> findRows() const;
-  std::vector<int> findCols() const;
-  void setCoordinates(std::vector<int> a, std::vector<int> b) {
-    theRows = a;
-    theCols = b;
-  }
-  std::vector<int> getRows() const { return theRows; }
-  std::vector<int> getCols() const { return theCols; }
+  // In CMSSW, (rows,cols) are in (r-phi,r-z), whereas FE chip spec doc has
+  // opposite convention. These vectors have same size.
+  const std::vector<int>& getRows() const { return theRows; }
+  const std::vector<int>& getCols() const { return theCols; }
+
+  unsigned int getNumHits() const { return theRows.size(); }
 
   /// Cluster width
   unsigned int findWidth() const;
 
-  /// Single hit coordinates
-  /// Average cluster coordinates
+  /// First row (i.e. in r-phi) in cluster.
+  unsigned int findFirstRow() const;
+
+  // Encoded channel number of hit j in cluster.
+  uint16_t getChannel(unsigned int j) const {
+    assert(j < theRows.size());
+    // TO FIX: Take const here from Phase2TrackerDigi.
+    return theRows[j] | theCols[j] << 10;
+  }
+
+  /// Individual hit (i.e. digi) coordinates (in units of pitch)
   MeasurementPoint findHitLocalCoordinates(unsigned int hitIdx) const;
+  /// Twice inweighted centroid (in r-phi units of pitch)
+  unsigned int     twiceCentroid() {return (2*findFirstRow() + findWidth() - 1);}
+  /// Average cluster coordinates (in units of pitch)
   MeasurementPoint findAverageLocalCoordinates() const;
   MeasurementPoint findAverageLocalCoordinatesCentered() const;
+
+  bool operator==(const TTCluster<T>& other) const;
 
   /// Information
   std::string print(unsigned int i = 0) const;
 
 private:
+  /// Set rows and columns to get rid of Digi collection
+  /// Old code
+  void setRowsCols(const std::vector<T>& aHits);
+  /// New code -- knows clustering done only in r-phi
+  void setRowsCols(const Phase2TrackerDigi& firstDigi, unsigned int width);
+
+private:
   /// Data members
-  std::vector<T> theHits;
   DetId theDetId;
   unsigned int theStackMember;
 
@@ -86,32 +100,28 @@ private:
  *           in the source file.
  */
 
-/// Default Constructor
-/// NOTE: to be used with setSomething(...) methods
+/// Null Constructor
 template <typename T>
-TTCluster<T>::TTCluster() {
-  /// Set default data members
-  theHits.clear();
-  theDetId = 0;
-  theStackMember = 0;
+TTCluster<T>::TTCluster() : theDetId(0), theStackMember(0) {}
 
-  theRows.clear();
-  theCols.clear();
+/// Old Constructor
+template <typename T>
+TTCluster<T>::TTCluster(const std::vector<T>& aHits, const DetId& aDetId, unsigned int aStackMember)
+    : theDetId(aDetId), theStackMember(aStackMember) {
+  // Set theRows & theCols in cluster
+  this->setRowsCols(aHits);
 }
 
-/// Another Constructor
+/// New Constructor
 template <typename T>
-TTCluster<T>::TTCluster(std::vector<T> aHits, DetId aDetId, unsigned int aStackMember, bool storeLocal) {
-  /// Set data members
-  this->setHits(aHits);
-  this->setDetId(aDetId);
-  this->setStackMember(aStackMember);
-
-  theRows.clear();
-  theCols.clear();
-  if (storeLocal) {
-    this->setCoordinates(this->findRows(), this->findCols());
-  }
+TTCluster<T>::TTCluster(const DetId& aDetId,
+                        unsigned int aStackMember,
+                        const Phase2TrackerDigi& firstDigi,
+                        unsigned int width)
+    : theDetId(aDetId), theStackMember(aStackMember) {
+  // Set theRows & theCols in cluster
+  // FIX -- Replace theRows & theCols data members by firstDigi & width.
+  this->setRowsCols(firstDigi, width);
 }
 
 /// Destructor
@@ -120,36 +130,46 @@ TTCluster<T>::~TTCluster() {}
 
 /// Cluster width
 template <>
-unsigned int TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> >::findWidth() const;
+unsigned int TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi>>::findWidth() const;
 
 /// Single hit coordinates
 /// Average cluster coordinates
 template <>
-MeasurementPoint TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> >::findHitLocalCoordinates(
+MeasurementPoint TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi>>::findHitLocalCoordinates(
     unsigned int hitIdx) const;
 
 template <>
 MeasurementPoint
-TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> >::findAverageLocalCoordinates() const;
+TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi>>::findAverageLocalCoordinates() const;
 
-/// Operations with coordinates stored locally
 template <typename T>
-std::vector<int> TTCluster<T>::findRows() const {
-  std::vector<int> temp;
-  return temp;
+void TTCluster<T>::setRowsCols(const std::vector<T>& aHits) {}
+
+template <>
+void TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi>>::setRowsCols(
+    const std::vector<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi>>& aHits);
+
+/// Store coordinates locally -- New code -- knows clustering done only in r-phi
+template <typename T>
+void TTCluster<T>::setRowsCols(const Phase2TrackerDigi& firstDigi, unsigned int width) {
+  theRows.reserve(width);
+  theCols.reserve(width);
+
+  unsigned int firstRow = firstDigi.row();
+  unsigned int col = firstDigi.column();
+  for (unsigned int i = 0; i < width; i++) {
+    theRows.push_back(firstRow + i);
+    // FIX: Replace theCols data member with single number.
+    theCols.push_back(col);
+  }
 }
 
 template <typename T>
-std::vector<int> TTCluster<T>::findCols() const {
-  std::vector<int> temp;
-  return temp;
+bool TTCluster<T>::operator==(const TTCluster<T>& other) const {
+  bool same = (theRows == other.getRows() && theCols == other.getCols() && theDetId == other.getDetId() &&
+               theStackMember == other.getStackMember());
+  return same;
 }
-
-template <>
-std::vector<int> TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> >::findRows() const;
-
-template <>
-std::vector<int> TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> >::findCols() const;
 
 /// Information
 template <typename T>
@@ -163,7 +183,7 @@ std::string TTCluster<T>::print(unsigned int i) const {
   output << padding << "TTCluster:\n";
   padding += '\t';
   output << padding << "DetId: " << theDetId.rawId() << '\n';
-  output << padding << "member: " << theStackMember << ", cluster size: " << theHits.size() << '\n';
+  output << padding << "member: " << theStackMember << ", cluster size: " << this->getNumHits() << '\n';
   return output.str();
 }
 

--- a/DataFormats/L1TrackTrigger/interface/TTCluster.h
+++ b/DataFormats/L1TrackTrigger/interface/TTCluster.h
@@ -66,7 +66,7 @@ public:
   /// Individual hit (i.e. digi) coordinates (in units of pitch)
   MeasurementPoint findHitLocalCoordinates(unsigned int hitIdx) const;
   /// Twice inweighted centroid (in r-phi units of pitch)
-  unsigned int     twiceCentroid() {return (2*findFirstRow() + findWidth() - 1);}
+  unsigned int twiceCentroid() { return (2 * findFirstRow() + findWidth() - 1); }
   /// Average cluster coordinates (in units of pitch)
   MeasurementPoint findAverageLocalCoordinates() const;
   MeasurementPoint findAverageLocalCoordinatesCentered() const;

--- a/DataFormats/L1TrackTrigger/src/TTCluster.cc
+++ b/DataFormats/L1TrackTrigger/src/TTCluster.cc
@@ -1,28 +1,13 @@
-/*! \brief   Implementation of methods of TTCluster
- *  \details Here, in the source file, the methods which do depend
- *           on the specific type <T> that can fit the template.
- *
- *  \author Nicola Pozzobon
- *  \author Emmanuele Salvati
- *  \date   2013, Jul 12
- *
- */
 
 #include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
 
 /// Cluster width
 template <>
-unsigned int TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> >::findWidth() const {
+unsigned int TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi>>::findWidth() const {
   int rowMin = 99999999;
   int rowMax = 0;
   /// this is only the actual size in RPhi
-  for (unsigned int i = 0; i < theHits.size(); i++) {
-    int row = 0;
-    if (this->getRows().empty()) {
-      row = theHits[i]->row();
-    } else {
-      row = this->getRows()[i];
-    }
+  for (int row : theRows) {
     if (row < rowMin)
       rowMin = row;
     if (row > rowMax)
@@ -31,98 +16,68 @@ unsigned int TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2Trac
   return abs(rowMax - rowMin + 1);  /// This takes care of 1-Pixel clusters
 }
 
-/// Get hit local coordinates
+/// First row in cluster
 template <>
-MeasurementPoint TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> >::findHitLocalCoordinates(
+unsigned int TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi>>::findFirstRow() const {
+  int rowMin = 99999999;
+  for (int row : theRows) {
+    if (row < rowMin)
+      rowMin = row;
+  }
+  return rowMin;
+}
+
+/// Get individual hit (i.e. digi) local coordinates in units of pitch
+template <>
+MeasurementPoint TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi>>::findHitLocalCoordinates(
     unsigned int hitIdx) const {
   /// NOTE in this case, DO NOT add 0.5
   /// to get the center of the pixel
-  if (this->getRows().empty() || this->getCols().empty()) {
-    MeasurementPoint mp(theHits[hitIdx]->row(), theHits[hitIdx]->column());
-    return mp;
-  } else {
-    int row = this->getRows()[hitIdx];
-    int col = this->getCols()[hitIdx];
-    MeasurementPoint mp(row, col);
-    return mp;
-  }
+  assert(hitIdx < this->getNumHits());
+  int row = theRows[hitIdx];
+  int col = theCols[hitIdx];
+  return MeasurementPoint(row, col);
 }
 
-/// Unweighted average local cluster coordinates
+/// Unweighted average local cluster coordinates in units of pitch
 template <>
 MeasurementPoint
-TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> >::findAverageLocalCoordinates() const {
+TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi>>::findAverageLocalCoordinates() const {
+  const unsigned int numHits = this->getNumHits();
   double averageCol = 0.0;
   double averageRow = 0.0;
 
   /// Loop over the hits and calculate the average coordinates
-  if (!theHits.empty()) {
-    if (this->getRows().empty() || this->getCols().empty()) {
-      typename std::vector<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> >::const_iterator hitIter;
-      for (hitIter = theHits.begin(); hitIter != theHits.end(); hitIter++) {
-        averageCol += (*hitIter)->column();
-        averageRow += (*hitIter)->row();
-      }
-      averageCol /= theHits.size();
-      averageRow /= theHits.size();
-    } else {
-      for (unsigned int j = 0; j < theHits.size(); j++) {
-        averageCol += theCols[j];
-        averageRow += theRows[j];
-      }
-      averageCol /= theHits.size();
-      averageRow /= theHits.size();
-    }
+  for (unsigned int j = 0; j < numHits; j++) {
+    averageCol += theCols[j];
+    averageRow += theRows[j];
   }
+  averageCol /= numHits;
+  averageRow /= numHits;
   return MeasurementPoint(averageRow, averageCol);
 }
 
-/// Unweighted average local cluster coordinates, using center of the strips
+/// Unweighted average local cluster coordinates in units of pitch,
+/// offset by 0.5*pitch to centre of pixels/strips.
 template <>
 MeasurementPoint TTCluster<
-    edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> >::findAverageLocalCoordinatesCentered() const {
-  double averageCol = 0.0;
-  double averageRow = 0.0;
-
-  /// Loop over the hits and calculate the average coordinates
-  if (!theHits.empty()) {
-    if (this->getRows().empty() || this->getCols().empty()) {
-      typename std::vector<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> >::const_iterator hitIter;
-      for (hitIter = theHits.begin(); hitIter != theHits.end(); hitIter++) {
-        averageCol += (*hitIter)->column() + 0.5;
-        averageRow += (*hitIter)->row() + 0.5;
-      }
-      averageCol /= theHits.size();
-      averageRow /= theHits.size();
-    } else {
-      for (unsigned int j = 0; j < theHits.size(); j++) {
-        averageCol += theCols[j] + 0.5;
-        averageRow += theRows[j] + 0.5;
-      }
-      averageCol /= theHits.size();
-      averageRow /= theHits.size();
-    }
-  }
-  return MeasurementPoint(averageRow, averageCol);
+    edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi>>::findAverageLocalCoordinatesCentered() const {
+  MeasurementPoint mp = this->findAverageLocalCoordinates();
+  // Offset by 0.5*pitch
+  MeasurementPoint mp_shift(mp.x() + 0.5, mp.y() + 0.5);
+  return mp_shift;
 }
 
-/// Coordinates stored locally
+/// Store coordinates locally -- Old code
 template <>
-std::vector<int> TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> >::findRows() const {
-  std::vector<int> temp;
-  temp.reserve(theHits.size());
-  for (unsigned int i = 0; i < theHits.size(); i++) {
-    temp.push_back(theHits[i]->row());
-  }
-  return temp;
-}
+void TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi>>::setRowsCols(
+    const std::vector<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi>>& aHits) {
+  const unsigned int numHits = aHits.size();
+  theRows.reserve(numHits);
+  theCols.reserve(numHits);
 
-template <>
-std::vector<int> TTCluster<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> >::findCols() const {
-  std::vector<int> temp;
-  temp.reserve(theHits.size());
-  for (unsigned int i = 0; i < theHits.size(); i++) {
-    temp.push_back(theHits[i]->column());
+  for (unsigned int i = 0; i < numHits; i++) {
+    theRows.push_back(aHits[i]->row());
+    theCols.push_back(aHits[i]->column());
   }
-  return temp;
 }

--- a/L1Trigger/TrackTrigger/interface/TTClusterAlgorithmNew_official.h
+++ b/L1Trigger/TrackTrigger/interface/TTClusterAlgorithmNew_official.h
@@ -1,0 +1,66 @@
+#ifndef L1Trigger_TrackTrigger_TTClusterAlgorithmNew_official_h
+#define L1Trigger_TrackTrigger_TTClusterAlgorithmNew_official_h
+
+/*! \class   TTClusterAlgorithmNew_official
+ *  \brief   Class for "official" algorithm to be used
+ *           in TTClusterBuilderNew
+ *  \details This implements the algorithm in the FE electronics.
+ *           Clustering is done in 1D (in r-phi = rows).
+ *           Clusters exceeding a configured width are removed.
+ *
+ *           For PS-p sensors only, the algo has additional rules:
+ *             a) Clusters are split at MPA chip boundaries 
+ *                (120 strip multiples), as MPA has no lateral communication.
+ *             b) If two PS-p clusters in neighbouring columns (r-z) have 
+ *                the same row (r-phi) centroid, the one with higher column
+ *                number is vetoed.
+ *             c) If >= 3 PS-p clusters in neighbouring columns (r-z) have 
+ *                the same row (r-phi) centroid, all these clusters are 
+ *                vetoed.
+ *     
+ *           (The code is based on that of the offline cluster producer
+ *           Phase2TrackerCluserizer).
+ *
+ *  \author Ian Tomalin
+ *  \date Aug. 2026
+ */
+
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
+#include "DataFormats/DetId/interface/DetId.h"
+
+class TTClusterAlgorithmNew_official {
+public:
+  
+  TTClusterAlgorithmNew_official(unsigned int maxClusterWidth, bool enableClusterVetoes, const DetId& detId, bool upperSensor, bool isPSp) : maxClusterWidth_(maxClusterWidth), enableClusterVetoes_(enableClusterVetoes), detId_(detId), upperSensor_(upperSensor), isPSp_(isPSp) {} 
+
+  // Top-level of clustering algo
+  void clusterizeDetUnit(const edm::DetSet<Phase2TrackerDigi>& digis,
+                         TTClusterDetSetVec::FastFiller& clusters) const;
+
+private:
+
+  // Algo implmentation WITHOUT PS-p specific cluster vetoes
+  void algo(const edm::DetSet<Phase2TrackerDigi>& digis,
+            TTClusterDetSetVec::FastFiller& clusters) const;
+
+  // Algo implmentation WITH PS-p specific cluster vetoes
+  void algoWithVetoes(const edm::DetSet<Phase2TrackerDigi>& digis,
+            TTClusterDetSetVec::FastFiller& clusters) const;
+
+private:
+  // Clustering algo cfg
+  unsigned int maxClusterWidth_;
+  bool enableClusterVetoes_;
+  
+  // Info about this tracker module
+  DetId detId_;
+  bool upperSensor_;
+  bool isPSp_;
+};
+
+#endif

--- a/L1Trigger/TrackTrigger/interface/TTClusterAlgorithmNew_official.h
+++ b/L1Trigger/TrackTrigger/interface/TTClusterAlgorithmNew_official.h
@@ -25,7 +25,6 @@
  *  \date Aug. 2026
  */
 
-
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
@@ -35,28 +34,29 @@
 
 class TTClusterAlgorithmNew_official {
 public:
-  
-  TTClusterAlgorithmNew_official(unsigned int maxClusterWidth, bool enableClusterVetoes, const DetId& detId, bool upperSensor, bool isPSp) : maxClusterWidth_(maxClusterWidth), enableClusterVetoes_(enableClusterVetoes), detId_(detId), upperSensor_(upperSensor), isPSp_(isPSp) {} 
+  TTClusterAlgorithmNew_official(
+      unsigned int maxClusterWidth, bool enableClusterVetoes, const DetId& detId, bool upperSensor, bool isPSp)
+      : maxClusterWidth_(maxClusterWidth),
+        enableClusterVetoes_(enableClusterVetoes),
+        detId_(detId),
+        upperSensor_(upperSensor),
+        isPSp_(isPSp) {}
 
   // Top-level of clustering algo
-  void clusterizeDetUnit(const edm::DetSet<Phase2TrackerDigi>& digis,
-                         TTClusterDetSetVec::FastFiller& clusters) const;
+  void clusterizeDetUnit(const edm::DetSet<Phase2TrackerDigi>& digis, TTClusterDetSetVec::FastFiller& clusters) const;
 
 private:
-
   // Algo implmentation WITHOUT PS-p specific cluster vetoes
-  void algo(const edm::DetSet<Phase2TrackerDigi>& digis,
-            TTClusterDetSetVec::FastFiller& clusters) const;
+  void algo(const edm::DetSet<Phase2TrackerDigi>& digis, TTClusterDetSetVec::FastFiller& clusters) const;
 
   // Algo implmentation WITH PS-p specific cluster vetoes
-  void algoWithVetoes(const edm::DetSet<Phase2TrackerDigi>& digis,
-            TTClusterDetSetVec::FastFiller& clusters) const;
+  void algoWithVetoes(const edm::DetSet<Phase2TrackerDigi>& digis, TTClusterDetSetVec::FastFiller& clusters) const;
 
 private:
   // Clustering algo cfg
   unsigned int maxClusterWidth_;
   bool enableClusterVetoes_;
-  
+
   // Info about this tracker module
   DetId detId_;
   bool upperSensor_;

--- a/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.cc
@@ -57,7 +57,7 @@ void TTClusterBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
       edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>::FastFiller lowerOutputFiller(*ttClusterDSVForOutput,
                                                                                             lowerDetid);
       for (unsigned int i = 0; i < lowerHits.size(); i++) {
-        TTCluster<Ref_Phase2TrackerDigi_> temp(lowerHits.at(i), lowerDetid, 0, storeLocalCoord);
+        TTCluster<Ref_Phase2TrackerDigi_> temp(lowerHits.at(i), lowerDetid, 0);
         lowerOutputFiller.push_back(temp);
       }
       if (lowerOutputFiller.empty())
@@ -67,7 +67,7 @@ void TTClusterBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
       edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>::FastFiller upperOutputFiller(*ttClusterDSVForOutput,
                                                                                             upperDetid);
       for (unsigned int i = 0; i < upperHits.size(); i++) {
-        TTCluster<Ref_Phase2TrackerDigi_> temp(upperHits.at(i), upperDetid, 1, storeLocalCoord);
+        TTCluster<Ref_Phase2TrackerDigi_> temp(upperHits.at(i), upperDetid, 1);
         upperOutputFiller.push_back(temp);
       }
       if (upperOutputFiller.empty())

--- a/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.h
+++ b/L1Trigger/TrackTrigger/plugins/TTClusterBuilder.h
@@ -9,6 +9,8 @@
  *  \author Nicola Pozzobon
  *  \date   2013, Jul 12
  *
+ * NOTE (2026): This has now been replaced by TTClusterBuilderNew,
+ *              but will be kept for a while for validation purposes.
  */
 
 #ifndef L1_TRACK_TRIGGER_CLUSTER_BUILDER_H
@@ -55,7 +57,6 @@ private:
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomToken;
   std::vector<edm::EDGetTokenT<edm::DetSetVector<Phase2TrackerDigi> > > rawHitTokens;
   unsigned int ADCThreshold;
-  bool storeLocalCoord;
 
   /// Mandatory methods
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
@@ -76,7 +77,6 @@ private:
 template <typename T>
 TTClusterBuilder<T>::TTClusterBuilder(const edm::ParameterSet& iConfig) {
   ADCThreshold = iConfig.getParameter<unsigned int>("ADCThreshold");
-  storeLocalCoord = iConfig.getParameter<bool>("storeLocalCoord");
   theClusterFindingAlgoToken = esConsumes();
   tTopoToken = esConsumes<TrackerTopology, TrackerTopologyRcd>();
   tGeomToken = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();

--- a/L1Trigger/TrackTrigger/plugins/TTClusterBuilderNew.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTClusterBuilderNew.cc
@@ -1,0 +1,111 @@
+/*! \class TTClusterBuilderNew
+ *  \brief Plugin to create Tracker clusters for the Track-Trigger (TTClusters)
+ *         from digis.
+ *         This replaces the old TTClusterBuilder class. The algo it uses
+ *         corresponds to that in the FE chips.
+ *         (It is based on the code of the offline cluster producer
+ *          Phase2TrackerCluserizer).
+ *
+ *  \author Ian Tomalin
+ *  \date Aug. 2026
+ */
+
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+//#include "L1Trigger/TrackTrigger/interface/Phase2TrackerClusterizerSequentialAlgorithm.h"
+#include "L1Trigger/TrackTrigger/interface/TTClusterAlgorithmNew_official.h"
+
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/CommonTopologies/interface/PixelGeomDetUnit.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
+
+#include <vector>
+#include <memory>
+
+class TTClusterBuilderNew : public edm::stream::EDProducer<> {
+public:
+  explicit TTClusterBuilderNew(const edm::ParameterSet& conf);
+  ~TTClusterBuilderNew() override = default;
+  void produce(edm::Event& event, const edm::EventSetup& iSetup) override;
+
+private:
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomToken;  
+  edm::EDGetTokenT<edm::DetSetVector<Phase2TrackerDigi> > token_;
+
+  unsigned int maxClusterWidth_;
+  bool enableClusterVetoes_;
+};
+
+/*
+     * Initialise the producer
+     */
+
+TTClusterBuilderNew::TTClusterBuilderNew(edm::ParameterSet const& conf) {
+  tTopoToken = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+  tGeomToken = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
+  token_ = consumes<edm::DetSetVector<Phase2TrackerDigi> >(conf.getParameter<edm::InputTag>("src"));
+  // IRT CHECK: TrackerDTC uses a Token here. Why doesn't this?
+  produces<TTClusterDetSetVec>("ClusterInclusive");
+  maxClusterWidth_ = conf.getParameter<unsigned int>("maxClusterWidth");
+  enableClusterVetoes_ = conf.getParameter<bool>("enableClusterVetoes");
+}
+
+/*
+     * Clusterize the events
+     */
+
+void TTClusterBuilderNew::produce(edm::Event& event, const edm::EventSetup& iSetup) {
+
+  // Retrieve tracker topology from geometry
+  const TrackerTopology* const tTopo = &iSetup.getData(tTopoToken);
+  const TrackerGeometry* const tGeom = &iSetup.getData(tGeomToken);
+
+  // Get the Digis
+  edm::Handle<edm::DetSetVector<Phase2TrackerDigi> > digis;
+  event.getByToken(token_, digis);
+
+  auto outputClusters = std::make_unique<TTClusterDetSetVec>();
+  
+  // Loop over the tracker modules
+  for (const auto& DSViter : *digis) {
+    const DetId detId(DSViter.detId());
+    const bool upperSensor = not tTopo->isLower(detId);
+    const bool isPSp = (tGeom->getDetectorType(detId) == TrackerGeometry::ModuleType::Ph2PSP);    
+
+    // Define utility for adding clusters to output collection.
+    TTClusterDetSetVec::FastFiller clusters(*outputClusters, DSViter.detId());
+    
+    // Create & run clustering algorithm
+    //const Phase2TrackerClusterizerSequentialAlgorithm algo(maxClusterWidth_, detId, upperSensor, isPSp);
+    TTClusterAlgorithmNew_official algo(maxClusterWidth_, enableClusterVetoes_, detId, upperSensor, isPSp);    
+    
+    algo.clusterizeDetUnit(DSViter, clusters);
+    if (clusters.empty())
+      clusters.abort();
+  }
+
+  // Add the data to the output
+  outputClusters->shrink_to_fit();
+  event.put(std::move(outputClusters), "ClusterInclusive");
+}
+
+DEFINE_FWK_MODULE(TTClusterBuilderNew);

--- a/L1Trigger/TrackTrigger/plugins/TTClusterBuilderNew.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTClusterBuilderNew.cc
@@ -48,7 +48,7 @@ public:
 
 private:
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken;
-  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomToken;  
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomToken;
   edm::EDGetTokenT<edm::DetSetVector<Phase2TrackerDigi> > token_;
 
   unsigned int maxClusterWidth_;
@@ -74,7 +74,6 @@ TTClusterBuilderNew::TTClusterBuilderNew(edm::ParameterSet const& conf) {
      */
 
 void TTClusterBuilderNew::produce(edm::Event& event, const edm::EventSetup& iSetup) {
-
   // Retrieve tracker topology from geometry
   const TrackerTopology* const tTopo = &iSetup.getData(tTopoToken);
   const TrackerGeometry* const tGeom = &iSetup.getData(tGeomToken);
@@ -84,20 +83,20 @@ void TTClusterBuilderNew::produce(edm::Event& event, const edm::EventSetup& iSet
   event.getByToken(token_, digis);
 
   auto outputClusters = std::make_unique<TTClusterDetSetVec>();
-  
+
   // Loop over the tracker modules
   for (const auto& DSViter : *digis) {
     const DetId detId(DSViter.detId());
     const bool upperSensor = not tTopo->isLower(detId);
-    const bool isPSp = (tGeom->getDetectorType(detId) == TrackerGeometry::ModuleType::Ph2PSP);    
+    const bool isPSp = (tGeom->getDetectorType(detId) == TrackerGeometry::ModuleType::Ph2PSP);
 
     // Define utility for adding clusters to output collection.
     TTClusterDetSetVec::FastFiller clusters(*outputClusters, DSViter.detId());
-    
+
     // Create & run clustering algorithm
     //const Phase2TrackerClusterizerSequentialAlgorithm algo(maxClusterWidth_, detId, upperSensor, isPSp);
-    TTClusterAlgorithmNew_official algo(maxClusterWidth_, enableClusterVetoes_, detId, upperSensor, isPSp);    
-    
+    TTClusterAlgorithmNew_official algo(maxClusterWidth_, enableClusterVetoes_, detId, upperSensor, isPSp);
+
     algo.clusterizeDetUnit(DSViter, clusters);
     if (clusters.empty())
       clusters.abort();

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -55,14 +55,14 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::updateStubs(
       bool upperOK = false;
 
       for (clusterIter = lowerClusters.begin(); clusterIter != lowerClusters.end() && !lowerOK; ++clusterIter) {
-        if (clusterIter->getHits() == lowerClusterToBeReplaced->getHits()) {
+        if (*clusterIter == *lowerClusterToBeReplaced) {
           tempTTStub.addClusterRef(edmNew::makeRefTo(clusterHandle, clusterIter));
           lowerOK = true;
         }
       }
 
       for (clusterIter = upperClusters.begin(); clusterIter != upperClusters.end() && !upperOK; ++clusterIter) {
-        if (clusterIter->getHits() == upperClusterToBeReplaced->getHits()) {
+        if (*clusterIter == *upperClusterToBeReplaced) {
           tempTTStub.addClusterRef(edmNew::makeRefTo(clusterHandle, clusterIter));
           upperOK = true;
         }

--- a/L1Trigger/TrackTrigger/python/TTClusterNew_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTClusterNew_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+# This is the new clusterizer, that accurately emulates the FE chips,
+# unlike the old TTCluster_cfi.py one.
+
+TTClustersFromPhase2TrackerDigis = cms.EDProducer("TTClusterBuilderNew",
+    src = cms.InputTag('mix', 'Tracker'),
+    maxClusterWidth = cms.uint32(4),
+    # Enable vetoes used by MPA chips for clusters in PS-p sensors.
+    enableClusterVetoes = cms.bool(True)
+)                                                  
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(TTClustersFromPhase2TrackerDigis, rawHits = ["mixData:Tracker"])

--- a/L1Trigger/TrackTrigger/python/TTCluster_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTCluster_cfi.py
@@ -2,9 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 TTClustersFromPhase2TrackerDigis = cms.EDProducer("TTClusterBuilder_Phase2TrackerDigi_",
     rawHits = cms.VInputTag(cms.InputTag("mix","Tracker")),
-    ADCThreshold = cms.uint32(30),
-    storeLocalCoord = cms.bool(True), # if True, local coordinates (row and col)
-                                      # of each hit are stored in the cluster object
+    ADCThreshold = cms.uint32(30)
 )
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2

--- a/L1Trigger/TrackTrigger/python/TrackTrigger_cff.py
+++ b/L1Trigger/TrackTrigger/python/TrackTrigger_cff.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 #clusters
 from L1Trigger.TrackTrigger.TTClusterAlgorithmRegister_cfi import *
-from L1Trigger.TrackTrigger.TTCluster_cfi import *
+#from L1Trigger.TrackTrigger.TTCluster_cfi import *
+from L1Trigger.TrackTrigger.TTClusterNew_cfi import *
 
 #stubs
 from L1Trigger.TrackTrigger.TTStubAlgorithmRegister_cfi import *

--- a/L1Trigger/TrackTrigger/src/TTClusterAlgorithmNew_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTClusterAlgorithmNew_official.cc
@@ -1,0 +1,281 @@
+
+#include "L1Trigger/TrackTrigger/interface/TTClusterAlgorithmNew_official.h"
+
+#include <vector>
+
+//--- Top-level of clustering algo
+
+void TTClusterAlgorithmNew_official::clusterizeDetUnit(
+    const edm::DetSet<Phase2TrackerDigi>& digis,
+    TTClusterDetSetVec::FastFiller& clusters) const {
+
+  if (digis.empty())
+    return;
+  
+  if (enableClusterVetoes_ && isPSp_) {
+    this->algoWithVetoes(digis, clusters);
+  } else {
+    this->algo(digis, clusters);
+  }
+  
+}
+
+
+//--- Simple clustering algo matching that in all FE electronics,
+//--- except for case of PS-p sensors, where it misses the cluster vetoes.
+
+void TTClusterAlgorithmNew_official::algo(
+    const edm::DetSet<Phase2TrackerDigi>& digis,
+    TTClusterDetSetVec::FastFiller& clusters) const {
+
+  auto di = digis.begin();
+
+  unsigned int widthCluster = 1;
+  Phase2TrackerDigi firstDigi = *di;
+  auto previous = firstDigi;
+
+  ++di;
+
+  for (; di != digis.end(); ++di) {
+    auto digi = *di;
+
+#ifdef VERIFY_PH2_TK_CLUS
+    if (!(previous < digi))
+      std::cout << "not ordered " << previous << ' ' << digi << std::endl;
+#endif
+
+    constexpr unsigned int rowsPerMPA = 120;
+
+    const bool diffMPAchips = isPSp_ && (digi.row()/rowsPerMPA != previous.row()/rowsPerMPA);
+
+    if (digi - previous == 1 && not diffMPAchips) {
+      // Same column, adjacent row: extend the cluster (in r-phi).
+      ++widthCluster;
+      
+    } else {
+      
+      // Finish the current cluster.
+      
+      if (widthCluster <= maxClusterWidth_) {
+        clusters.push_back(TTCluster<Ref_Phase2TrackerDigi_>(detId_, upperSensor_, firstDigi, widthCluster));
+      }
+
+      // Start a new cluster.
+      firstDigi = digi;
+      widthCluster = 1;
+    }
+
+    previous = digi;
+  }
+
+  // Finish the final cluster.
+  if (widthCluster <= maxClusterWidth_) {
+    clusters.push_back(TTCluster<Ref_Phase2TrackerDigi_>(detId_, upperSensor_, firstDigi, widthCluster));
+  }
+}
+
+
+//--- Complex clustering algo matching that in all FE electronics.
+//--- It correctly describes the cluster vetoes of the PS-p sensors.
+//--- (It also gives correct results for PS-s and 2S sensors,
+//---  but for them, it is unnecessarily complex & CPU intensive.)
+
+void TTClusterAlgorithmNew_official::algoWithVetoes(
+    const edm::DetSet<Phase2TrackerDigi>& digis,
+    TTClusterDetSetVec::FastFiller& clusters) const {
+  
+  struct BufferedCluster {
+    TTCluster<Ref_Phase2TrackerDigi_> cluster;
+    unsigned int twiceCentroid;
+    bool veto = false;
+  };
+
+  struct BufferedColumn {
+    std::vector<BufferedCluster> clusters;
+    unsigned int ID = 99999; // number of the column
+  };
+
+  // These contain last three columns processed that contained clusters.
+  BufferedColumn twoColumnsAgo;
+  BufferedColumn previousColumn;
+  BufferedColumn currentColumn;
+  
+  //--------------------------------------------------------------------
+  
+  auto makeBufferedCluster = [&](const Phase2TrackerDigi& firstDigi,
+                                 unsigned int widthCluster) {
+    unsigned int firstRow = firstDigi.row();
+
+    // The centroid is:
+    //
+    //   firstRow + (widthCluster - 1) / 2
+    //
+    // Store twice the centroid so that half-integer centroids are
+    // compared exactly, without floating point.
+    unsigned int twiceCentroid = 2 * firstRow + widthCluster - 1;
+
+    return BufferedCluster{
+      TTCluster<Ref_Phase2TrackerDigi_>(detId_, upperSensor_, firstDigi, widthCluster),      
+      twiceCentroid
+    };
+  };
+
+  // Add clusters in a column to output collection
+  
+  auto outputColumn = [&](BufferedColumn& column) {
+    for (const auto& b : column.clusters) {
+      if (!b.veto)
+        clusters.push_back(b.cluster);
+    }
+  };
+  
+  // Compare the last two columns with the new column.
+  //
+  // A pair of equal centroid rows means that the cluster in the
+  // higher-numbered column is vetoed.
+  //
+  // Three equal centroid rows in consecutive columns means that
+  // all three clusters are vetoed.
+  auto processNewColumn = [&](BufferedColumn& oldest,
+                              BufferedColumn& previous,
+                              BufferedColumn& current) {
+
+    // Cluster veto logic is only used by the MPA chip (PS-p sensors).
+    //     b) If two PS-p clusters in neighbouring columns (r-z) have 
+    //        the same row (r-phi) centroid, the one with higher column
+    //         number is vetoed.
+    //     c) If >= 3 PS-p clusters in neighbouring columns (r-z) have 
+    //        the same row (r-phi) centroid, all these clusters are 
+    //        vetoed.
+
+    // Small complication -- PS-p modules have 32 columns, with 16
+    // read out by MPA chips at each end of module. The veto conditions
+    // only apply to columns read out from the same end.
+ 
+    
+    if (enableClusterVetoes_ && isPSp_) {
+
+      constexpr unsigned int numColsPerEnd = 16;
+      const bool currEnd = (current.ID  < numColsPerEnd);
+      const bool prevEnd = (previous.ID < numColsPerEnd);
+      const bool oldEnd  = (oldest.ID   < numColsPerEnd);
+      
+      // Identify clusters with same centroid position in neighbouring columns,
+      // using fact that within a row, clusters are ordered by position,
+      // so as to save CPU by not using a triple nested loop. 
+      
+      auto curr_clus = current.clusters.begin();
+      auto prev_clus = previous.clusters.begin();
+      auto old_clus  = oldest.clusters.begin();
+      if (current.ID == previous.ID + 1 && currEnd == prevEnd) {
+        // We have 2 neighbouring columns
+        while (curr_clus != current.clusters.end() && prev_clus != previous.clusters.end()) {
+          if (prev_clus->twiceCentroid < curr_clus->twiceCentroid) {
+            prev_clus++;
+          } else if (prev_clus->twiceCentroid > curr_clus->twiceCentroid) {
+            curr_clus++;
+          } else {
+            // Two-column veto: cluster furthest from module end vetoed.
+            if (currEnd) {
+              curr_clus->veto = true;
+            } else {
+              prev_clus->veto = true;
+            }
+              
+            if (current.ID == oldest.ID + 2 && currEnd == oldEnd) {
+              // We have 3 neighbouring columns
+              while (old_clus != oldest.clusters.end() &&
+                     old_clus->twiceCentroid < curr_clus->twiceCentroid) old_clus++;
+              
+              if (old_clus != oldest.clusters.end() &&
+                  old_clus->twiceCentroid == curr_clus->twiceCentroid) {
+                // Three-column veto: all three clusters are vetoed.
+                old_clus->veto = true;
+                prev_clus->veto = true;
+                // curr_clus already vetoed above.
+              }
+            }
+            curr_clus++;
+            prev_clus++;              
+          }
+        }
+      }   
+    }
+    
+    // -- OUTPUT CLUSTERS of oldest column, since no new column can veto them.
+    outputColumn(oldest);
+  };
+
+  //--------------------------------------------------------------------
+  
+  auto di = digis.begin();
+
+  unsigned int widthCluster = 1;
+  Phase2TrackerDigi firstDigi = *di;
+  auto previous = firstDigi;
+
+  currentColumn.ID = firstDigi.column();
+
+  ++di;
+
+  for (; di != digis.end(); ++di) {
+    auto digi = *di;
+
+#ifdef VERIFY_PH2_TK_CLUS
+    if (!(previous < digi))
+      std::cout << "not ordered " << previous << ' ' << digi << std::endl;
+#endif
+
+    constexpr unsigned int rowsPerMPA = 120;
+
+    const bool diffMPAchips = isPSp_ && (digi.row()/rowsPerMPA != previous.row()/rowsPerMPA);
+
+    if (digi - previous == 1 && not diffMPAchips) {
+      // Same column, adjacent row: extend the cluster (in r-phi).
+      ++widthCluster;
+      
+    } else {
+      
+      // Finish the current cluster.
+      
+      if (widthCluster <= maxClusterWidth_) {
+        currentColumn.clusters.push_back(makeBufferedCluster(firstDigi, widthCluster));
+      }
+
+      if (digi.column() != currentColumn.ID) {
+        // A complete column has just been constructed.
+        //
+        // Once we have three columns, the oldest one can be
+        // completely resolved.
+        processNewColumn(twoColumnsAgo, previousColumn, currentColumn);
+
+        twoColumnsAgo = std::move(previousColumn);
+        previousColumn = std::move(currentColumn);
+        
+        currentColumn.ID = digi.column();
+        currentColumn.clusters.clear();
+      }
+
+      // Start a new cluster.
+      firstDigi = digi;
+      widthCluster = 1;
+    }
+
+    previous = digi;
+  }
+
+  // Finish the final cluster.
+  if (widthCluster <= maxClusterWidth_) {
+    currentColumn.clusters.push_back(makeBufferedCluster(firstDigi, widthCluster));
+  }
+
+  // Since no new digis allowed There are no more columns, so we now trigger processing of a further column.
+
+  processNewColumn(twoColumnsAgo, previousColumn, currentColumn);
+
+  // -- OUTPUT CLUSTERS of final 2 columns, as not yet output,
+  // -- and no further columns can veto them.
+
+  outputColumn(previousColumn);  
+  outputColumn(currentColumn);  
+}

--- a/L1Trigger/TrackTrigger/src/TTClusterAlgorithmNew_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTClusterAlgorithmNew_official.cc
@@ -5,29 +5,23 @@
 
 //--- Top-level of clustering algo
 
-void TTClusterAlgorithmNew_official::clusterizeDetUnit(
-    const edm::DetSet<Phase2TrackerDigi>& digis,
-    TTClusterDetSetVec::FastFiller& clusters) const {
-
+void TTClusterAlgorithmNew_official::clusterizeDetUnit(const edm::DetSet<Phase2TrackerDigi>& digis,
+                                                       TTClusterDetSetVec::FastFiller& clusters) const {
   if (digis.empty())
     return;
-  
+
   if (enableClusterVetoes_ && isPSp_) {
     this->algoWithVetoes(digis, clusters);
   } else {
     this->algo(digis, clusters);
   }
-  
 }
-
 
 //--- Simple clustering algo matching that in all FE electronics,
 //--- except for case of PS-p sensors, where it misses the cluster vetoes.
 
-void TTClusterAlgorithmNew_official::algo(
-    const edm::DetSet<Phase2TrackerDigi>& digis,
-    TTClusterDetSetVec::FastFiller& clusters) const {
-
+void TTClusterAlgorithmNew_official::algo(const edm::DetSet<Phase2TrackerDigi>& digis,
+                                          TTClusterDetSetVec::FastFiller& clusters) const {
   auto di = digis.begin();
 
   unsigned int widthCluster = 1;
@@ -46,16 +40,15 @@ void TTClusterAlgorithmNew_official::algo(
 
     constexpr unsigned int rowsPerMPA = 120;
 
-    const bool diffMPAchips = isPSp_ && (digi.row()/rowsPerMPA != previous.row()/rowsPerMPA);
+    const bool diffMPAchips = isPSp_ && (digi.row() / rowsPerMPA != previous.row() / rowsPerMPA);
 
     if (digi - previous == 1 && not diffMPAchips) {
       // Same column, adjacent row: extend the cluster (in r-phi).
       ++widthCluster;
-      
+
     } else {
-      
       // Finish the current cluster.
-      
+
       if (widthCluster <= maxClusterWidth_) {
         clusters.push_back(TTCluster<Ref_Phase2TrackerDigi_>(detId_, upperSensor_, firstDigi, widthCluster));
       }
@@ -74,16 +67,13 @@ void TTClusterAlgorithmNew_official::algo(
   }
 }
 
-
 //--- Complex clustering algo matching that in all FE electronics.
 //--- It correctly describes the cluster vetoes of the PS-p sensors.
 //--- (It also gives correct results for PS-s and 2S sensors,
 //---  but for them, it is unnecessarily complex & CPU intensive.)
 
-void TTClusterAlgorithmNew_official::algoWithVetoes(
-    const edm::DetSet<Phase2TrackerDigi>& digis,
-    TTClusterDetSetVec::FastFiller& clusters) const {
-  
+void TTClusterAlgorithmNew_official::algoWithVetoes(const edm::DetSet<Phase2TrackerDigi>& digis,
+                                                    TTClusterDetSetVec::FastFiller& clusters) const {
   struct BufferedCluster {
     TTCluster<Ref_Phase2TrackerDigi_> cluster;
     unsigned int twiceCentroid;
@@ -92,18 +82,17 @@ void TTClusterAlgorithmNew_official::algoWithVetoes(
 
   struct BufferedColumn {
     std::vector<BufferedCluster> clusters;
-    unsigned int ID = 99999; // number of the column
+    unsigned int ID = 99999;  // number of the column
   };
 
   // These contain last three columns processed that contained clusters.
   BufferedColumn twoColumnsAgo;
   BufferedColumn previousColumn;
   BufferedColumn currentColumn;
-  
+
   //--------------------------------------------------------------------
-  
-  auto makeBufferedCluster = [&](const Phase2TrackerDigi& firstDigi,
-                                 unsigned int widthCluster) {
+
+  auto makeBufferedCluster = [&](const Phase2TrackerDigi& firstDigi, unsigned int widthCluster) {
     unsigned int firstRow = firstDigi.row();
 
     // The centroid is:
@@ -114,21 +103,19 @@ void TTClusterAlgorithmNew_official::algoWithVetoes(
     // compared exactly, without floating point.
     unsigned int twiceCentroid = 2 * firstRow + widthCluster - 1;
 
-    return BufferedCluster{
-      TTCluster<Ref_Phase2TrackerDigi_>(detId_, upperSensor_, firstDigi, widthCluster),      
-      twiceCentroid
-    };
+    return BufferedCluster{TTCluster<Ref_Phase2TrackerDigi_>(detId_, upperSensor_, firstDigi, widthCluster),
+                           twiceCentroid};
   };
 
   // Add clusters in a column to output collection
-  
+
   auto outputColumn = [&](BufferedColumn& column) {
     for (const auto& b : column.clusters) {
       if (!b.veto)
         clusters.push_back(b.cluster);
     }
   };
-  
+
   // Compare the last two columns with the new column.
   //
   // A pair of equal centroid rows means that the cluster in the
@@ -136,37 +123,32 @@ void TTClusterAlgorithmNew_official::algoWithVetoes(
   //
   // Three equal centroid rows in consecutive columns means that
   // all three clusters are vetoed.
-  auto processNewColumn = [&](BufferedColumn& oldest,
-                              BufferedColumn& previous,
-                              BufferedColumn& current) {
-
+  auto processNewColumn = [&](BufferedColumn& oldest, BufferedColumn& previous, BufferedColumn& current) {
     // Cluster veto logic is only used by the MPA chip (PS-p sensors).
-    //     b) If two PS-p clusters in neighbouring columns (r-z) have 
+    //     b) If two PS-p clusters in neighbouring columns (r-z) have
     //        the same row (r-phi) centroid, the one with higher column
     //         number is vetoed.
-    //     c) If >= 3 PS-p clusters in neighbouring columns (r-z) have 
-    //        the same row (r-phi) centroid, all these clusters are 
+    //     c) If >= 3 PS-p clusters in neighbouring columns (r-z) have
+    //        the same row (r-phi) centroid, all these clusters are
     //        vetoed.
 
     // Small complication -- PS-p modules have 32 columns, with 16
     // read out by MPA chips at each end of module. The veto conditions
     // only apply to columns read out from the same end.
- 
-    
-    if (enableClusterVetoes_ && isPSp_) {
 
+    if (enableClusterVetoes_ && isPSp_) {
       constexpr unsigned int numColsPerEnd = 16;
-      const bool currEnd = (current.ID  < numColsPerEnd);
+      const bool currEnd = (current.ID < numColsPerEnd);
       const bool prevEnd = (previous.ID < numColsPerEnd);
-      const bool oldEnd  = (oldest.ID   < numColsPerEnd);
-      
+      const bool oldEnd = (oldest.ID < numColsPerEnd);
+
       // Identify clusters with same centroid position in neighbouring columns,
       // using fact that within a row, clusters are ordered by position,
-      // so as to save CPU by not using a triple nested loop. 
-      
+      // so as to save CPU by not using a triple nested loop.
+
       auto curr_clus = current.clusters.begin();
       auto prev_clus = previous.clusters.begin();
-      auto old_clus  = oldest.clusters.begin();
+      auto old_clus = oldest.clusters.begin();
       if (current.ID == previous.ID + 1 && currEnd == prevEnd) {
         // We have 2 neighbouring columns
         while (curr_clus != current.clusters.end() && prev_clus != previous.clusters.end()) {
@@ -181,14 +163,13 @@ void TTClusterAlgorithmNew_official::algoWithVetoes(
             } else {
               prev_clus->veto = true;
             }
-              
+
             if (current.ID == oldest.ID + 2 && currEnd == oldEnd) {
               // We have 3 neighbouring columns
-              while (old_clus != oldest.clusters.end() &&
-                     old_clus->twiceCentroid < curr_clus->twiceCentroid) old_clus++;
-              
-              if (old_clus != oldest.clusters.end() &&
-                  old_clus->twiceCentroid == curr_clus->twiceCentroid) {
+              while (old_clus != oldest.clusters.end() && old_clus->twiceCentroid < curr_clus->twiceCentroid)
+                old_clus++;
+
+              if (old_clus != oldest.clusters.end() && old_clus->twiceCentroid == curr_clus->twiceCentroid) {
                 // Three-column veto: all three clusters are vetoed.
                 old_clus->veto = true;
                 prev_clus->veto = true;
@@ -196,18 +177,18 @@ void TTClusterAlgorithmNew_official::algoWithVetoes(
               }
             }
             curr_clus++;
-            prev_clus++;              
+            prev_clus++;
           }
         }
-      }   
+      }
     }
-    
+
     // -- OUTPUT CLUSTERS of oldest column, since no new column can veto them.
     outputColumn(oldest);
   };
 
   //--------------------------------------------------------------------
-  
+
   auto di = digis.begin();
 
   unsigned int widthCluster = 1;
@@ -228,16 +209,15 @@ void TTClusterAlgorithmNew_official::algoWithVetoes(
 
     constexpr unsigned int rowsPerMPA = 120;
 
-    const bool diffMPAchips = isPSp_ && (digi.row()/rowsPerMPA != previous.row()/rowsPerMPA);
+    const bool diffMPAchips = isPSp_ && (digi.row() / rowsPerMPA != previous.row() / rowsPerMPA);
 
     if (digi - previous == 1 && not diffMPAchips) {
       // Same column, adjacent row: extend the cluster (in r-phi).
       ++widthCluster;
-      
+
     } else {
-      
       // Finish the current cluster.
-      
+
       if (widthCluster <= maxClusterWidth_) {
         currentColumn.clusters.push_back(makeBufferedCluster(firstDigi, widthCluster));
       }
@@ -251,7 +231,7 @@ void TTClusterAlgorithmNew_official::algoWithVetoes(
 
         twoColumnsAgo = std::move(previousColumn);
         previousColumn = std::move(currentColumn);
-        
+
         currentColumn.ID = digi.column();
         currentColumn.clusters.clear();
       }
@@ -276,6 +256,6 @@ void TTClusterAlgorithmNew_official::algoWithVetoes(
   // -- OUTPUT CLUSTERS of final 2 columns, as not yet output,
   // -- and no further columns can veto them.
 
-  outputColumn(previousColumn);  
-  outputColumn(currentColumn);  
+  outputColumn(previousColumn);
+  outputColumn(currentColumn);
 }

--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
@@ -70,21 +70,19 @@ void TTClusterAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, co
       if (detid.subdetId() != StripSubdetector::TOB && detid.subdetId() != StripSubdetector::TID)
         continue;  // only run on OT
 
-      if (TTClusterHandle->find(detid) == TTClusterHandle->end())
+      const auto iter_clusDet = TTClusterHandle->find(detid);
+      if (iter_clusDet == TTClusterHandle->end())
         continue;
 
-      /// Get the DetSets of the Clusters
-      edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>> clusters = (*TTClusterHandle)[detid];
+      /// Get the DetSet of clusters in one tracker module
+      const edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>>& clusters = *iter_clusDet;
 
       for (auto contentIter = clusters.begin(); contentIter != clusters.end(); ++contentIter) {
         /// Make the reference to be put in the map
         TTClusterRef tempCluRef = edmNew::makeRefTo(TTClusterHandle, contentIter);
 
-        /// Prepare the maps wrt TTCluster
-        if (clusterToTrackingParticleVectorMap.find(tempCluRef) == clusterToTrackingParticleVectorMap.end()) {
-          std::vector<TrackingParticlePtr> tpVector;
-          clusterToTrackingParticleVectorMap.emplace(tempCluRef, tpVector);
-        }
+        // Add null entry for this cluster, if cluster is not already in map. And get iterator to clusters map entry.
+        auto iter_tempCluRefInMap = clusterToTrackingParticleVectorMap.try_emplace(tempCluRef).first;
 
         /// Get the PixelDigiSimLink
         /// Safety check added after new digitizer (Oct 2014)
@@ -92,29 +90,26 @@ void TTClusterAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, co
           /// Sensor is not found in DigiSimLink.
           /// Set MC truth to NULL for all hits in this sensor. Period.
 
-          /// Get the Digis and loop over them
-          std::vector<Ref_Phase2TrackerDigi_> theseHits = tempCluRef->getHits();
-          for (unsigned int i = 0; i < theseHits.size(); i++) {
-            /// No SimLink is found by definition
-            /// Then store NULL MC truth for all the digis
-            TrackingParticlePtr tempTPPtr;
-            clusterToTrackingParticleVectorMap.find(tempCluRef)->second.push_back(tempTPPtr);
-          }
+          /// Store a null TP in the map for each digi in the cluster.
+          unsigned int numHits = tempCluRef->getNumHits();
+          /// No SimLink is found. Then store null MC truth for each of the digis
+          const std::vector<TrackingParticlePtr> nullTPvec(numHits);
+          iter_tempCluRefInMap->second = nullTPvec;
 
           /// Go to the next sensor
           continue;
         }
 
-        edm::DetSet<PixelDigiSimLink> thisDigiSimLink = (*(thePixelDigiSimLinkHandle_))[detid];
+        const edm::DetSet<PixelDigiSimLink>& thisDigiSimLink = (*thePixelDigiSimLinkHandle_)[detid];
         edm::DetSet<PixelDigiSimLink>::const_iterator iterSimLink;
 
         /// Get the Digis and loop over them
-        std::vector<Ref_Phase2TrackerDigi_> theseHits = tempCluRef->getHits();
-        for (unsigned int i = 0; i < theseHits.size(); i++) {
+        unsigned int numHits = tempCluRef->getNumHits();
+        for (unsigned int i = 0; i < numHits; i++) {
           /// Loop over PixelDigiSimLink
           for (iterSimLink = thisDigiSimLink.data.begin(); iterSimLink != thisDigiSimLink.data.end(); iterSimLink++) {
             /// Find the link and, if there's not, skip
-            if (static_cast<int>(iterSimLink->channel()) != static_cast<int>(theseHits.at(i)->channel()))
+            if (static_cast<int>(iterSimLink->channel()) != static_cast<int>(tempCluRef->getChannel(i)))
               continue;
 
             /// Get SimTrack Id and type
@@ -122,35 +117,31 @@ void TTClusterAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, co
             EncodedEventId curSimEvId = iterSimLink->eventId();
 
             /// Prepare the SimTrack Unique ID
-            std::pair<unsigned int, EncodedEventId> thisUniqueId = std::make_pair(curSimTrkId, curSimEvId);
+            const std::pair<unsigned int, EncodedEventId> thisUniqueId(curSimTrkId, curSimEvId);
 
             /// Get the corresponding TrackingParticle
-            if (simTrackUniqueToTPMap.find(thisUniqueId) != simTrackUniqueToTPMap.end()) {
-              TrackingParticlePtr thisTrackingParticle = simTrackUniqueToTPMap.find(thisUniqueId)->second;
+            const auto iter_simTrackUniqueInMap = simTrackUniqueToTPMap.find(thisUniqueId);
+            if (iter_simTrackUniqueInMap != simTrackUniqueToTPMap.end()) {
+              const TrackingParticlePtr& thisTrackingParticle = iter_simTrackUniqueInMap->second;
 
               /// Store the TrackingParticle
-              clusterToTrackingParticleVectorMap.find(tempCluRef)->second.push_back(thisTrackingParticle);
+              iter_tempCluRefInMap->second.push_back(thisTrackingParticle);
 
-              /// Prepare the maps wrt TrackingParticle
-              if (trackingParticleToClusterVectorMap.find(thisTrackingParticle) ==
-                  trackingParticleToClusterVectorMap.end()) {
-                std::vector<TTClusterRef> clusterVector;
-                trackingParticleToClusterVectorMap.emplace(thisTrackingParticle, clusterVector);
-              }
-              trackingParticleToClusterVectorMap.find(thisTrackingParticle)
-                  ->second.push_back(tempCluRef);  /// Fill the auxiliary map
+              // Add null entry for this TP, if TP is not already in map. And get iterator to TP entry in map.
+              auto iter_thisTrackingParticleInMap =
+                  trackingParticleToClusterVectorMap.try_emplace(thisTrackingParticle).first;
+              iter_thisTrackingParticleInMap->second.push_back(tempCluRef);  /// Fill the auxiliary map
             } else {
               /// In case no TrackingParticle is found, store a NULL pointer
 
-              TrackingParticlePtr tempTPPtr;
-              clusterToTrackingParticleVectorMap.find(tempCluRef)->second.push_back(tempTPPtr);
+              const TrackingParticlePtr tempTPPtr;
+              iter_tempCluRefInMap->second.push_back(tempTPPtr);
             }
           }  /// End of loop over PixelDigiSimLink
         }  /// End of loop over all the hits composing the Cluster
 
         /// Check that the cluster has a non-NULL TP pointer
-        const std::vector<TrackingParticlePtr>& theseClusterTrackingParticlePtrs =
-            clusterToTrackingParticleVectorMap.find(tempCluRef)->second;
+        const std::vector<TrackingParticlePtr>& theseClusterTrackingParticlePtrs = iter_tempCluRefInMap->second;
         bool allOfThemAreNull = true;
         for (unsigned int tpi = 0; tpi < theseClusterTrackingParticlePtrs.size() && allOfThemAreNull; tpi++) {
           if (theseClusterTrackingParticlePtrs.at(tpi).isNull() == false)

--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
@@ -7,7 +7,9 @@
  *
  *  \author Nicola Pozzobon
  *  \date   2013, Jul 19
- *  (tidy up: Ian Tomalin, 2020)
+ *  (tidy up: Ian Tomalin, 2020 + 2026)
+ *
+ *  TO FIX: This code remains extremely CPU intensive.
  *
  */
 


### PR DESCRIPTION
#### PR description:

TTClusters are the EDProduct corresponding to the clusters made by the FE Tracker electronics, from which TTStubs and TTTracks (i.e. L1 tracks) are subsequently made. This PR resolves the following issues:

1) The old TTCluster EDProducer https://github.com/cms-sw/cmssw/blob/master/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_official.cc , called from TTClusterBuilder.cc, does cluster finding in 2D (both r-phi and r-z), whereas the electronics only does it in 1D (r-phi). Several other details of the algorithm are also incorrect.  

2) This PR therefore adds a new algorithm TTClusterAlgorithmNew_official.cc , based on detailed examination of the FE chip spec docs and talking to the FE chip designers. It is called from TTClusterBuilderNew.cc

3) The new clustering algorithm is made the default for MC production here https://github.com/cms-L1TK/cmssw/blob/ianFixTTClusProducer/L1Trigger/TrackTrigger/python/TrackTrigger_cff.py .

4) The EDProduct https://github.com/cms-L1TK/cmssw/blob/ianFixTTClusProducer/DataFormats/L1TrackTrigger/interface/TTCluster.h has been simplified . It used to store both Refs to the digis in the cluster and a vector of all channels in the cluster. This was duplicate info, so the Refs have been removed, which now resembles what is done for the offline clusters. (I've checked that CMSSW can still read MC containing the original products).

5) The "TrackingParticle (truth) - TTCluster" assocation is performed by https://github.com/cms-L1TK/cmssw/blob/ianFixTTClusProducer/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc . This used a ridiculous amount of CPU (6 times more than the whole of the L1 tracking). I've reduced its CPU by 30%.

#### PR validation:

Since 2D clusters could only be formed in the pixel sensors of the PS modules, and since these pixels are large in r-z, it was rare for 2D clusters to be made. The effect on performance is therefore tiny. The cluster rate & position resolution have been checked, as has the effect on the prompt L1 tracking.
