### PR TITLE
Added  ROOT dictionaries in DataFormats

### DIFF
--- a/DataFormats/BTauReco/src/classes_def.xml
+++ b/DataFormats/BTauReco/src/classes_def.xml
@@ -46,6 +46,8 @@
   <class name="reco::SecondaryVertexTagInfoRefVector"/>
   <class name="edm::Wrapper<reco::SecondaryVertexTagInfoCollection>"/>
 
+  <class name="reco::TemplatedSecondaryVertexTagInfo<reco::IPTagInfo<vector<edm::Ptr<reco::io_v1::Candidate> >,reco::io_v1::JetTagInfo>,reco::io_v1::VertexCompositePtrCandidate>"/>
+
   <class name="reco::TemplatedSecondaryVertexTagInfo<reco::CandIPTagInfo,reco::io_v1::VertexCompositePtrCandidate>::VertexData"/>
   <class name="std::vector<reco::CandSecondaryVertexTagInfo::VertexData>"/>
   <class name="reco::CandSecondaryVertexTagInfo"/>

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -59,6 +59,7 @@
 
   <class name="std::vector<reco::io_v1::Photon>"/>
   <class name="edm::Wrapper<std::vector<reco::io_v1::Photon> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<vector<reco::io_v1::Photon>,reco::io_v1::Photon>"/>
   <class name="edm::Ref<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon> >"/>
   <class name="std::vector<edm::Ref<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::Photon>,reco::io_v1::Photon> > >"/>
   <class name="edm::RefProd<std::vector<reco::io_v1::Photon> >"/>

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
 
+  <class name="std::vector<reco::io_v1::ElectronSeed::PMVars>"/>	
   <class name="edm::RefToBase<reco::io_v1::CaloCluster>"  rntupleStreamerMode="true"/>
   <class name="edm::reftobase::BaseHolder<reco::io_v1::CaloCluster>"/>
   <class name="edm::reftobase::IndirectHolder<reco::io_v1::CaloCluster>" />

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -1,6 +1,5 @@
 <lcgdict>
 
-  <class name="std::vector<reco::io_v1::ElectronSeed::PMVars>"/>	
   <class name="edm::RefToBase<reco::io_v1::CaloCluster>"  rntupleStreamerMode="true"/>
   <class name="edm::reftobase::BaseHolder<reco::io_v1::CaloCluster>"/>
   <class name="edm::reftobase::IndirectHolder<reco::io_v1::CaloCluster>" />
@@ -95,6 +94,7 @@
   </class>
 
   <class name="std::vector<reco::io_v1::ElectronSeed>"/>
+  <class name="std::vector<reco::io_v1::ElectronSeed::PMVars>"/>
   <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::ElectronSeed>,reco::io_v1::ElectronSeed>"/>
   <class name="edm::Ref<std::vector<reco::io_v1::ElectronSeed>,reco::io_v1::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::ElectronSeed>,reco::io_v1::ElectronSeed> >"/>
   <class name="edm::RefProd<std::vector<reco::io_v1::ElectronSeed> >"/>

--- a/DataFormats/HcalIsolatedTrack/src/classes_def.xml
+++ b/DataFormats/HcalIsolatedTrack/src/classes_def.xml
@@ -11,6 +11,7 @@
   <class name="reco::IsolatedPixelTrackCandidateRefProd"/>
   <class name="edm::Wrapper<reco::IsolatedPixelTrackCandidateCollection>"/>
   <class name="edm::reftobase::Holder<reco::io_v1::Candidate, edm::Ref<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate> > >" />
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate>"/>					  
   <class name="edm::Ref<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate> >"/>
   <class name="std::vector<edm::Ref<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::IsolatedPixelTrackCandidate>,reco::IsolatedPixelTrackCandidate> > >"/>
 

--- a/DataFormats/L1TCorrelator/src/classes_def.xml
+++ b/DataFormats/L1TCorrelator/src/classes_def.xml
@@ -13,6 +13,7 @@
   </class>
   <class name="std::vector<l1t::io_v1::TkEm>"/>
   <class name="edm::Wrapper<std::vector<l1t::io_v1::TkEm> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<l1t::io_v1::TkElectron>,l1t::io_v1::TkElectron>"/>
   <class name="edm::Ref<std::vector<l1t::io_v1::TkEm>,l1t::io_v1::TkEm,edm::refhelper::FindUsingAdvance<std::vector<l1t::io_v1::TkEm>,l1t::io_v1::TkEm> >"/>
   <class name="std::vector<edm::Ref<std::vector<l1t::io_v1::TkEm>,l1t::io_v1::TkEm,edm::refhelper::FindUsingAdvance<std::vector<l1t::io_v1::TkEm>,l1t::io_v1::TkEm> > >"/>
   <class name="edm::RefProd<l1t::TkEmCollection>" />

--- a/DataFormats/L1TCorrelator/src/classes_def.xml
+++ b/DataFormats/L1TCorrelator/src/classes_def.xml
@@ -13,7 +13,6 @@
   </class>
   <class name="std::vector<l1t::io_v1::TkEm>"/>
   <class name="edm::Wrapper<std::vector<l1t::io_v1::TkEm> >"/>
-  <class name="edm::refhelper::FindUsingAdvance<std::vector<l1t::io_v1::TkElectron>,l1t::io_v1::TkElectron>"/>
   <class name="edm::Ref<std::vector<l1t::io_v1::TkEm>,l1t::io_v1::TkEm,edm::refhelper::FindUsingAdvance<std::vector<l1t::io_v1::TkEm>,l1t::io_v1::TkEm> >"/>
   <class name="std::vector<edm::Ref<std::vector<l1t::io_v1::TkEm>,l1t::io_v1::TkEm,edm::refhelper::FindUsingAdvance<std::vector<l1t::io_v1::TkEm>,l1t::io_v1::TkEm> > >"/>
   <class name="edm::RefProd<l1t::TkEmCollection>" />
@@ -46,6 +45,7 @@
   </class>
   <class name="std::vector<l1t::io_v1::TkElectron>"/>
   <class name="edm::Wrapper<std::vector<l1t::io_v1::TkElectron> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<l1t::io_v1::TkElectron>,l1t::io_v1::TkElectron>"/>
   <class name="edm::Ref<std::vector<l1t::io_v1::TkElectron>,l1t::io_v1::TkElectron,edm::refhelper::FindUsingAdvance<std::vector<l1t::io_v1::TkElectron>,l1t::io_v1::TkElectron> >"/>
   <class name="std::vector<edm::Ref<std::vector<l1t::io_v1::TkElectron>,l1t::io_v1::TkElectron,edm::refhelper::FindUsingAdvance<std::vector<l1t::io_v1::TkElectron>,l1t::io_v1::TkElectron> > >"/>
   <class name="edm::RefProd<l1t::TkElectronCollection>" />

--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -76,6 +76,7 @@
   <class name="edm::Wrapper<L1MuKBMTCombinedStubCollection >"/>
 
  <class name="edm::Ref<L1MuKBMTCombinedStubCollection>" splitLevel="0"/>
+ <class name="std::vector<edm::Ref<L1MuKBMTCombinedStubCollection>>"/>	 
  <class name="edm::Wrapper<edm::Ref<L1MuKBMTCombinedStubCollection > >"/>
 
 

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -29,6 +29,8 @@
   <class name="l1t::RegionalOutput<l1t::PFCandidateCollection>" />
   <class name="edm::Wrapper<l1t::RegionalOutput<l1t::PFCandidateCollection>>" />
 
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<l1t::io_v1::PFJet>,l1t::io_v1::PFJet>"/>
+
   <class name="l1t::io_v1::PFJet"  ClassVersion="3">
         <version ClassVersion="3" checksum="1164493406"/>
   </class>

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -29,13 +29,12 @@
   <class name="l1t::RegionalOutput<l1t::PFCandidateCollection>" />
   <class name="edm::Wrapper<l1t::RegionalOutput<l1t::PFCandidateCollection>>" />
 
-  <class name="edm::refhelper::FindUsingAdvance<std::vector<l1t::io_v1::PFJet>,l1t::io_v1::PFJet>"/>
-
   <class name="l1t::io_v1::PFJet"  ClassVersion="3">
         <version ClassVersion="3" checksum="1164493406"/>
   </class>
   <class name="l1t::PFJetCollection" />
   <class name="edm::Wrapper<l1t::PFJetCollection>" />
+  <class name="edm::refhelper::FindUsingAdvance<std::vector<l1t::io_v1::PFJet>,l1t::io_v1::PFJet>"/>
   <class name="edm::Ref<l1t::PFJetCollection>" />
   <class name="edm::RefVector<l1t::PFJetCollection>" />
   <class name="std::vector<edm::Ref<std::vector<l1t::io_v1::PFJet>,l1t::io_v1::PFJet,edm::refhelper::FindUsingAdvance<std::vector<l1t::io_v1::PFJet>,l1t::io_v1::PFJet> > >" />

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -202,6 +202,7 @@
   <class name="edm::ValueMap<reco::PreIdRef>"/>
   <class name="std::vector<reco::PreIdRef>"/>
   <class name="edm::Wrapper<edm::ValueMap<reco::PreIdRef> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<vector<reco::io_v1::PreId>,reco::io_v1::PreId>" />
   <class name="edm::Ref<std::vector<reco::io_v1::PreId>,reco::io_v1::PreId,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::PreId>,reco::io_v1::PreId> >" />
 
   <class name="reco::PFBlockElementSuperCluster" ClassVersion="3">

--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -28,6 +28,9 @@
     <!-- <field name="fixed_" transient="true"/> -->
   </class>
 
+  <class name="std::pair<reco::isodeposit::Direction::Distance,float>"/>
+  <class name="std::map<reco::isodeposit::Direction::Distance,float>"/>
+
   <class name="std::vector<reco::io_v1::RecoChargedCandidate>"/>
   <class name="edm::Wrapper<std::vector<reco::io_v1::RecoChargedCandidate> >"/>
   <class name="edm::Ref<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate> >"/>

--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -28,9 +28,6 @@
     <!-- <field name="fixed_" transient="true"/> -->
   </class>
 
-  <class name="std::pair<reco::isodeposit::Direction::Distance,float>"/>
-  <class name="std::map<reco::isodeposit::Direction::Distance,float>"/>
-
   <class name="std::vector<reco::io_v1::RecoChargedCandidate>"/>
   <class name="edm::Wrapper<std::vector<reco::io_v1::RecoChargedCandidate> >"/>
   <class name="edm::Ref<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::io_v1::RecoChargedCandidate>,reco::io_v1::RecoChargedCandidate> >"/>
@@ -128,6 +125,9 @@
    <version ClassVersion="3" checksum="4179939266"/>
   </class>
   <class name="std::multimap<reco::io_v1::IsoDeposit::Direction::Distance,float>"/>
+
+  <class name="std::pair<reco::isodeposit::Direction::Distance,float>"/>
+  <class name="std::map<reco::isodeposit::Direction::Distance,float>"/>
 
   <class name="edm::ValueMap<reco::io_v1::IsoDeposit>::const_iterator">
     <field name="values_" transient="true"/>


### PR DESCRIPTION
This PR adds ROOT dictionary instantiations identified during the investigation of ROOT autoparsing and memory usage. The changes cover several DataFormats packages, including `BTauReco`, `EgammaCandidates`, `EgammaReco`, `HcalIsolatedTrack`, `L1TCorrelator`, `L1TMuon`, `L1TParticleFlow`,` ParticleFlowReco`, and `RecoCandidate`.
The goal is to provide the required dictionaries explicitly and avoid unnecessary runtime autoparsing.

Resolves https://github.com/cms-sw/framework-team/issues/2398