### PR TITLE
Make Open MPI 5 use the same accelerator as CMSSW

### DIFF
--- a/Configuration/StandardSequences/python/Accelerators_cff.py
+++ b/Configuration/StandardSequences/python/Accelerators_cff.py
@@ -6,3 +6,7 @@ import FWCore.ParameterSet.Config as cms
 from HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA_cfi import ProcessAcceleratorCUDA
 from HeterogeneousCore.ROCmCore.ProcessAcceleratorROCm_cfi import ProcessAcceleratorROCm
 from HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi import ProcessAcceleratorAlpaka
+
+# Update the environment variables used by MPI to select the accelerator
+# backend
+from HeterogeneousCore.MPIServices.ProcessAcceleratorMPI_cfi import ProcessAcceleratorMPI

--- a/HeterogeneousCore/MPIServices/python/ProcessAcceleratorMPI.py
+++ b/HeterogeneousCore/MPIServices/python/ProcessAcceleratorMPI.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+import os
+
+class ProcessAcceleratorMPI(cms.ProcessAccelerator):
+    def __init__(self):
+        super(ProcessAcceleratorMPI, self).__init__()
+
+    def apply(self, process, accelerators):
+        # Open MPI supports a single accelerator backend, either CUDA or ROCm.
+        # What accelerator to use can be autodetected, or selected with the OMPI_MCA_accelerator
+        # environment variable.
+        # By default, the CMSSW environment disables accelerator support setting it to 'null'.
+
+        # Update the environment only if the MPIService is part of the configuration.
+        if not hasattr(process, "MPIService"):
+            return
+
+        # Select the Open MPI accelerator backend based on the CMSSW accelerator.
+        if "gpu-nvidia" in accelerators:
+            os.environ['OMPI_MCA_accelerator'] = 'cuda'
+        elif "gpu-amd" in accelerators:
+            os.environ['OMPI_MCA_accelerator'] = 'rocm'
+        else:
+            os.environ['OMPI_MCA_accelerator'] = 'null'
+
+
+# Ensure this module is kept in the configuration when dumping it
+cms.specialImportRegistry.registerSpecialImportForType(ProcessAcceleratorMPI, "from HeterogeneousCore.MPIServices.ProcessAcceleratorMPI import ProcessAcceleratorMPI")

--- a/HeterogeneousCore/MPIServices/python/ProcessAcceleratorMPI_cfi.py
+++ b/HeterogeneousCore/MPIServices/python/ProcessAcceleratorMPI_cfi.py
@@ -1,0 +1,3 @@
+from HeterogeneousCore.MPIServices.ProcessAcceleratorMPI import ProcessAcceleratorMPI as _ProcessAcceleratorMPI
+
+ProcessAcceleratorMPI = _ProcessAcceleratorMPI()


### PR DESCRIPTION
#### PR description:

Open MPI supports a single accelerator back-end, either CUDA or ROCm.
What accelerator to use can be autodetected, or selected with the `OMPI_MCA_accelerator` environment variable.

By default, the CMSSW environment disables accelerator support setting it to `'null'`.

If the `MPIService` is part of the configuration, set `OMPI_MCA_accelerator` to select the Open MPI accelerator back-end based on the CMSSW accelerator.

For more background information see the discussions at https://github.com/cms-sw/cmssw/issues/49332#issuecomment-3517942589 and https://github.com/cms-sw/cmssw/pull/50503#pullrequestreview-4968664921 .

#### PR validation:

None.