### PR TITLE
Regional disabling of CSF in BPIX

### DIFF
--- a/RecoTracker/Configuration/python/customizeBPixShapeCSFRegions.py
+++ b/RecoTracker/Configuration/python/customizeBPixShapeCSFRegions.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+from HLTrigger.Configuration.common import esproducers_by_type
+
+def customizeNoBPixShapeCutL1Ends(process):
+    regions = cms.VPSet(
+        cms.PSet(modules = cms.vuint32(1, 2, 7, 8), # ladders are omitted == all ladders
+                 layers  = cms.vuint32(1)),
+    )
+    for prod in esproducers_by_type(process, 'ClusterShapeHitFilterESProducer'):
+        prod.noBPixShapeCutRegions = regions.copy()
+    return process
+
+def customizeBPixShapeCutL1CenterOnly(process):
+    regions = cms.VPSet(
+        cms.PSet(modules = cms.vuint32(1, 2, 3, 6, 7, 8), # ladders are omitted == all ladders
+                 layers  = cms.vuint32(1)),
+    )
+    for prod in esproducers_by_type(process, 'ClusterShapeHitFilterESProducer'):
+        prod.noBPixShapeCutRegions = regions.copy()
+    return process
+
+def customizeNoBPixShapeCutL1(process):
+    regions = cms.VPSet(
+        cms.PSet(layers  = cms.vuint32(1))
+    )
+    for prod in esproducers_by_type(process, 'ClusterShapeHitFilterESProducer'):
+        prod.noBPixShapeCutRegions = regions.copy()
+    return process

--- a/RecoTracker/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
@@ -17,6 +17,7 @@
 #include <utility>
 #include <unordered_map>
 #include <cstring>
+#include <vector>
 
 /*****************************************************************************/
 class PixelKeys {
@@ -155,8 +156,18 @@ public:
     const PixelGeomDetUnit* det;
     unsigned short part;
     unsigned short layer;
+    bool applyShapeCut;
     std::pair<float, float> drift;
     std::pair<float, float> cotangent;
+  };
+
+  // BPix region where the pixel shape cut is not applied.
+  // "layers" must not be empty
+  // empty "ladders" or "modules" means "any" on the specfied layer(s)
+  struct BPixShapeCutRegion {
+    std::vector<unsigned int> layers;
+    std::vector<unsigned int> ladders;
+    std::vector<unsigned int> modules;
   };
 
   struct StripData {
@@ -175,7 +186,8 @@ public:
                         const SiPixelLorentzAngle* theSiPixelLorentzAngle_,
                         const SiStripLorentzAngle* theSiStripLorentzAngle_,
                         const std::string& pixelShapeFile_,
-                        const std::string& pixelShapeFileL1_);
+                        const std::string& pixelShapeFileL1_,
+                        const std::vector<BPixShapeCutRegion>& noBPixShapeCutRegions_ = {});
 
   ~ClusterShapeHitFilter();
 
@@ -260,6 +272,7 @@ private:
   void loadPixelLimits(std::string const& file, PixelLimits* plim);
   void loadStripLimits();
   void fillPixelData();
+  bool isBPixShapeCutDisabled(DetId id) const;
   void fillStripData();
 
   std::pair<float, float> getCotangent(const PixelGeomDetUnit* pixelDet) const;
@@ -276,6 +289,8 @@ private:
 
   const SiPixelLorentzAngle* theSiPixelLorentzAngle;
   const SiStripLorentzAngle* theSiStripLorentzAngle;
+
+  const std::vector<BPixShapeCutRegion> noBPixShapeCutRegions;
 
   std::unordered_map<unsigned int, PixelData> pixelData;
   std::unordered_map<unsigned int, StripData> stripData;

--- a/RecoTracker/PixelLowPtUtilities/plugins/ClusterShapeHitFilterESProducer.cc
+++ b/RecoTracker/PixelLowPtUtilities/plugins/ClusterShapeHitFilterESProducer.cc
@@ -15,6 +15,7 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 class ClusterShapeHitFilterESProducer : public edm::ESProducer {
 public:
@@ -39,16 +40,37 @@ private:
 
   const std::string pixelShapeFile;
   const std::string pixelShapeFileL1;
+  const std::vector<ClusterShapeHitFilter::BPixShapeCutRegion> noBPixShapeCutRegions_;
   const float minGoodPixelCharge_, minGoodStripCharge_;
   const bool isPhase2_;
   const bool cutOnPixelCharge_, cutOnStripCharge_;
   const bool cutOnPixelShape_, cutOnStripShape_;
 };
 
+namespace {
+  std::vector<ClusterShapeHitFilter::BPixShapeCutRegion> getNoBPixShapeCutRegions(const edm::ParameterSet& iConfig) {
+    std::vector<ClusterShapeHitFilter::BPixShapeCutRegion> regions;
+    for (const auto& pset : iConfig.getParameter<std::vector<edm::ParameterSet>>("noBPixShapeCutRegions")) {
+      auto const& layers = pset.getParameter<std::vector<unsigned int>>("layers");
+      if (layers.empty())
+        throw cms::Exception("Configuration")
+            << "ClusterShapeHitFilterESProducer: empty 'layers' in a noBPixShapeCutRegions entry; at least one BPix "
+               "layer must be given, while empty 'ladders' and 'modules' mean 'any'";
+
+      regions.push_back({layers,
+                         pset.getParameter<std::vector<unsigned int>>("ladders"),
+                         pset.getParameter<std::vector<unsigned int>>("modules")});
+    }
+
+    return regions;
+  }
+}  // namespace
+
 /*****************************************************************************/
 ClusterShapeHitFilterESProducer::ClusterShapeHitFilterESProducer(const edm::ParameterSet& iConfig)
     : pixelShapeFile(iConfig.getParameter<std::string>("PixelShapeFile")),
       pixelShapeFileL1(iConfig.getParameter<std::string>("PixelShapeFileL1")),
+      noBPixShapeCutRegions_(getNoBPixShapeCutRegions(iConfig)),
       minGoodPixelCharge_(0),
       minGoodStripCharge_(clusterChargeCut(iConfig)),
       isPhase2_(iConfig.getParameter<bool>("isPhase2")),
@@ -87,7 +109,8 @@ ClusterShapeHitFilterESProducer::ReturnType ClusterShapeHitFilterESProducer::pro
                                                                                 &iRecord.get(pixelToken_),
                                                                                 theSiStripLorentzAngle,
                                                                                 pixelShapeFile,
-                                                                                pixelShapeFileL1));
+                                                                                pixelShapeFileL1,
+                                                                                noBPixShapeCutRegions_));
 
   aFilter->setShapeCuts(cutOnPixelShape_, cutOnStripShape_);
   aFilter->setChargeCuts(cutOnPixelCharge_, minGoodPixelCharge_, cutOnStripCharge_, minGoodStripCharge_);
@@ -103,6 +126,13 @@ void ClusterShapeHitFilterESProducer::fillDescriptions(edm::ConfigurationDescrip
   desc.add<bool>("isPhase2", false);
   desc.add<bool>("doPixelShapeCut", true);
   desc.add<bool>("doStripShapeCut", true);
+
+  edm::ParameterSetDescription region;
+  region.add<std::vector<unsigned int>>("layers");       // mandatory non-empty
+  region.add<std::vector<unsigned int>>("ladders", {});  // empty means all ladders for given layer(s)
+  region.add<std::vector<unsigned int>>("modules", {});  // empty means all modules for given layer(s)
+  desc.addVPSet("noBPixShapeCutRegions", region, {});
+
   desc.add<edm::ParameterSetDescription>("clusterChargeCut", getConfigurationDescription4CCC(CCC::kNone));
   descriptions.addWithDefaultLabel(desc);
 }

--- a/RecoTracker/PixelLowPtUtilities/src/ClusterShapeHitFilter.cc
+++ b/RecoTracker/PixelLowPtUtilities/src/ClusterShapeHitFilter.cc
@@ -23,10 +23,18 @@
 
 #include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
 
+#include <algorithm>
 #include <fstream>
 #include <cassert>
 
 using namespace std;
+
+namespace {
+  // an empty selection matches any value
+  bool matches(const std::vector<unsigned int>& values, unsigned int value) {
+    return values.empty() || std::find(values.begin(), values.end(), value) != values.end();
+  }
+}  // namespace
 
 /*****************************************************************************/
 ClusterShapeHitFilter::ClusterShapeHitFilter(const TrackerGeometry* theTracker_,
@@ -35,12 +43,14 @@ ClusterShapeHitFilter::ClusterShapeHitFilter(const TrackerGeometry* theTracker_,
                                              const SiPixelLorentzAngle* theSiPixelLorentzAngle_,
                                              const SiStripLorentzAngle* theSiStripLorentzAngle_,
                                              const std::string& pixelShapeFile_,
-                                             const std::string& pixelShapeFileL1_)
+                                             const std::string& pixelShapeFileL1_,
+                                             const std::vector<BPixShapeCutRegion>& noBPixShapeCutRegions_)
     : theTracker(theTracker_),
       theTkTopol(theTkTopol_),
       theMagneticField(theMagneticField_),
       theSiPixelLorentzAngle(theSiPixelLorentzAngle_),
-      theSiStripLorentzAngle(theSiStripLorentzAngle_) {
+      theSiStripLorentzAngle(theSiStripLorentzAngle_),
+      noBPixShapeCutRegions(noBPixShapeCutRegions_) {
   // Load pixel limits
   loadPixelLimits(pixelShapeFile_, pixelLimits);
   loadPixelLimits(pixelShapeFileL1_, pixelLimitsL1);
@@ -113,7 +123,18 @@ void ClusterShapeHitFilter::loadStripLimits() {
   LogTrace("MinBiasTracking|ClusterShapeHitFilter") << " [ClusterShapeHitFilter] strip-cluster-width filter loaded";
 }
 
+bool ClusterShapeHitFilter::isBPixShapeCutDisabled(DetId id) const {
+  for (auto const& region : noBPixShapeCutRegions)
+    if (matches(region.layers, theTkTopol->pxbLayer(id)) && matches(region.ladders, theTkTopol->pxbLadder(id)) &&
+        matches(region.modules, theTkTopol->pxbModule(id)))
+      return true;
+
+  return false;
+}
+
 void ClusterShapeHitFilter::fillPixelData() {
+  unsigned int nDisabled = 0;
+
   //barrel
   for (auto det : theTracker->detsPXB()) {
     // better not to fail..
@@ -123,8 +144,11 @@ void ClusterShapeHitFilter::fillPixelData() {
       pd.det = pixelDet;
       pd.part = 0;
       pd.layer = theTkTopol->pxbLayer(pixelDet->geographicalId());
+      pd.applyShapeCut = !isBPixShapeCutDisabled(pixelDet->geographicalId());
       pd.cotangent = getCotangent(pixelDet);
       pd.drift = getDrift(pixelDet);
+      if (!pd.applyShapeCut)
+        nDisabled++;
     }
   }
 
@@ -137,9 +161,14 @@ void ClusterShapeHitFilter::fillPixelData() {
     pd.det = pixelDet;
     pd.part = 1;
     pd.layer = 0;
+    pd.applyShapeCut = true;
     pd.cotangent = getCotangent(pixelDet);
     pd.drift = getDrift(pixelDet);
   }
+
+  if (!noBPixShapeCutRegions.empty())
+    edm::LogInfo("ClusterShapeHitFilter")
+        << " [ClusterShapeHitFilter] pixel shape cut disabled for " << nDisabled << " BPix modules";
 }
 
 void ClusterShapeHitFilter::fillStripData() {
@@ -292,6 +321,8 @@ bool ClusterShapeHitFilter::isCompatible(const SiPixelRecHit& recHit,
     return true;
 
   const PixelData& pd = getpd(recHit, ipd);
+  if (!pd.applyShapeCut)
+    return true;
 
   int part;
   ClusterData::ArrayType meas;


### PR DESCRIPTION
#### PR description:

This PR adds an option to disable cluster shape filtering in selected BPIX modules. The intention is to test if it would be beneficial (in Run 3) to have filtering only in parts of L1, although the implementation allows disabling the filter in other regions of BPIX as well. Three customizer functions (disabling the filter in half, most, and all of L1) are included.

#### PR validation:

 The `noBPixShapeCutRegions` parameter is empty by default so no changes in RECO are expected. Using the provided customizer functions reports the disabling of the expected number of modules in LogInfo. Standard `runTheMatrix` tests are running and results will be reported once they finish.
 
Update: runTheMatrix finished (mostly) successfully. The failed wfs seem to be related to not being able to open remote inputs files
```
42 37 36 31 22 1 1 1 1 1 1 tests passed, 12 4 0 0 0 0 0 0 0 0 0 failed
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backports are planned.
