### PR TITLE
Fix handling of an exception thrown from a source

### DIFF
--- a/FWCore/Framework/interface/SourceCoordinator.h
+++ b/FWCore/Framework/interface/SourceCoordinator.h
@@ -41,7 +41,7 @@ namespace edm {
     }
 
     void setSource(std::unique_ptr<InputSource> input) { input_ = std::move(input); }
-    void releaseSource() { input_ = nullptr; }
+    void releaseSource() { delete edm::get_underlying_safe(input_).release(); /*unique_ptr::op= is noexcept*/ }
     ProductRegistry const& productRegistry() const { return input_->productRegistry(); }
     void beginJob(ProductRegistry const&);
     void endJob();

--- a/FWCore/Framework/interface/SourceCoordinator.h
+++ b/FWCore/Framework/interface/SourceCoordinator.h
@@ -41,7 +41,9 @@ namespace edm {
     }
 
     void setSource(std::unique_ptr<InputSource> input) { input_ = std::move(input); }
-    void releaseSource() { delete edm::get_underlying_safe(input_).release(); /*unique_ptr::op= is noexcept*/ }
+    void releaseSource() {
+      delete edm::get_underlying_safe(input_).release(); /*unique_ptr::op= is noexcept*/  // NOLINT
+    }
     ProductRegistry const& productRegistry() const { return input_->productRegistry(); }
     void beginJob(ProductRegistry const&);
     void endJob();

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -596,16 +596,21 @@ namespace edm {
       //in case of an exception, make sure Services are available
       // during the following destructors
       auto expt = std::current_exception();
-      try {
-        espController_ = nullptr;
-        esp_ = nullptr;
-        schedule_ = nullptr;
-        sourceCoordinator_.releaseSource();
-        looper_ = nullptr;
-        actReg_ = nullptr;
-      } catch (...) {
-        // ignore any exceptions from destructors
-      }
+      auto noexception = [](auto&& f) {
+        try {
+          f();
+        } catch (...) {
+          // ignore any exception
+        }
+      };
+      // If an exception happens during assignment, terminate will be called anyway
+      espController_ = nullptr;
+      esp_ = nullptr;
+      schedule_ = nullptr;
+      noexception([&]() { sourceCoordinator_.releaseSource(); });
+      looper_ = nullptr;
+      actReg_ = nullptr;
+      ;
       std::rethrow_exception(expt);
     }
   }
@@ -615,12 +620,25 @@ namespace edm {
     ServiceToken token = getToken();
     ServiceRegistry::Operate op(token);
 
+    auto noexception = [](auto&& f) {
+      try {
+        f();
+      } catch (cms::Exception& ex) {
+        std::cerr << "Exception during EventProcessor destruction: " << ex.what() << std::endl;
+      } catch (std::exception& ex) {
+        std::cerr << "Exception during EventProcessor destruction: " << ex.what() << std::endl;
+      } catch (...) {
+        std::cerr << "Unknown exception during EventProcessor destruction" << std::endl;
+      }
+    };
+
     // manually destroy all these thing that may need the services around
     // propagate_const<T> has no reset() function
+    // If an exception happens during assignment, terminate will be called anyway
     espController_ = nullptr;
     esp_ = nullptr;
     schedule_ = nullptr;
-    sourceCoordinator_.releaseSource();
+    noexception([&]() { sourceCoordinator_.releaseSource(); });
     looper_ = nullptr;
     actReg_ = nullptr;
 
@@ -1680,7 +1698,7 @@ namespace edm {
                       *(status->lumiPrincipal()), status->eventSetupImpl(), &processContext_);
                 }) | then([this, status, iRunStatus](std::exception_ptr const* iException, auto holder) mutable {
                   if (not iRunStatus->globalEndRunHolder().hasTask()) {
-                    //endRun has already be run
+                    //endRun has already been run
                     assert(iException);
                     holder.doneWaiting(*iException);
                     return;

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -595,13 +595,18 @@ namespace edm {
     } catch (...) {
       //in case of an exception, make sure Services are available
       // during the following destructors
-      espController_ = nullptr;
-      esp_ = nullptr;
-      schedule_ = nullptr;
-      sourceCoordinator_.releaseSource();
-      looper_ = nullptr;
-      actReg_ = nullptr;
-      throw;
+      auto expt = std::current_exception();
+      try {
+        espController_ = nullptr;
+        esp_ = nullptr;
+        schedule_ = nullptr;
+        sourceCoordinator_.releaseSource();
+        looper_ = nullptr;
+        actReg_ = nullptr;
+      } catch (...) {
+        // ignore any exceptions from destructors
+      }
+      std::rethrow_exception(expt);
     }
   }
 
@@ -1202,6 +1207,7 @@ namespace edm {
                     //handle exception from readRunAsync
                     WaitingTaskHolder copyHolder(nextTask);
                     copyHolder.doneWaiting(*iException);
+                    runStatus->setStopBeforeProcessingRun(true);
                     releaseBeginRunResourcesAndResumeGlobalRunQueueAfterFailure(*runStatus);
                   }
                 }) |
@@ -1642,7 +1648,7 @@ namespace edm {
                   if (iException) {
                     //deal with possible failure from readLumiAsync
                     releaseLumiResourcesAfterFailure(*status);
-                    nextTask.doneWaiting(*iException);
+                    nextTask.presetTaskAsFailed(*iException);
                     endRunAsync(iRunStatus, std::nullopt, nextTask);
                     return;
                   }
@@ -1673,6 +1679,12 @@ namespace edm {
                   looper_->doBeginLuminosityBlock(
                       *(status->lumiPrincipal()), status->eventSetupImpl(), &processContext_);
                 }) | then([this, status, iRunStatus](std::exception_ptr const* iException, auto holder) mutable {
+                  if (not iRunStatus->globalEndRunHolder().hasTask()) {
+                    //endRun has already be run
+                    assert(iException);
+                    holder.doneWaiting(*iException);
+                    return;
+                  }
                   status->setGlobalEndRunHolder(iRunStatus->globalEndRunHolder());
 
                   if (iException) {

--- a/FWCore/Integration/plugins/ThrowingSource.cc
+++ b/FWCore/Integration/plugins/ThrowingSource.cc
@@ -85,12 +85,12 @@ namespace edm {
 
   void ThrowingSource::readLuminosityBlock_(LuminosityBlockPrincipal& lb) {
     if (whenToThrow_ == kReadLumi)
-      throw cms::Exception("TestThrow") << "ThrowingSource::beginLuminosityBlock";
+      throw cms::Exception("TestThrow") << "ThrowingSource::readLuminosityBlock_";
   }
 
   void ThrowingSource::readRun_(RunPrincipal& run) {
     if (whenToThrow_ == kReadRun)
-      throw cms::Exception("TestThrow") << "ThrowingSource::beginRun";
+      throw cms::Exception("TestThrow") << "ThrowingSource::readRun_";
   }
 
   std::shared_ptr<FileBlock> ThrowingSource::readFile_() {

--- a/FWCore/Integration/plugins/ThrowingSource.cc
+++ b/FWCore/Integration/plugins/ThrowingSource.cc
@@ -3,55 +3,61 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/InputSourceMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Sources/interface/ProducerSourceBase.h"
+#include "FWCore/Framework/interface/InputSource.h"
 #include "FWCore/Utilities/interface/Exception.h"
-
+#include "FWCore/Sources/interface/IDGeneratorSourceBase.h"
 namespace edm {
-  class ThrowingSource : public ProducerSourceBase {
+  class ThrowingSource final : public IDGeneratorSourceBase<InputSource> {
   public:
     explicit ThrowingSource(ParameterSet const&, InputSourceDescription const&);
-    ~ThrowingSource() noexcept(false) override;
+    ~ThrowingSource() noexcept(false) final;
 
-    void beginJob(ProductRegistry const&) override;
-    void endJob() override;
-    void beginLuminosityBlock(edm::LuminosityBlock&) override;
-    void beginRun(edm::Run&) override;
-    std::shared_ptr<edm::FileBlock> readFile_() override;
-    void closeFile_() override;
-    std::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_() override;
-    std::shared_ptr<edm::LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
-    void readEvent_(edm::EventPrincipal&) override;
+    void beginJob(ProductRegistry const&) final;
+    void endJob() final;
+    void readRun_(RunPrincipal& runPrincipal) final;
+    void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) final;
+    std::shared_ptr<edm::FileBlock> readFile_() final;
+    void closeFile_() final;
+    std::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_() final;
+    std::shared_ptr<edm::LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() final;
+    void readEvent_(edm::EventPrincipal&) final;
+
+    static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
     enum {
-      kDoNotThrow = 0,
-      kConstructor = 1,
-      kBeginJob = 2,
-      kBeginRun = 3,
-      kBeginLumi = 4,
-      kEndLumi = 5,
-      kEndRun = 6,
-      kEndJob = 7,
-      kGetNextItemType = 8,
-      kReadEvent = 9,
-      kReadLuminosityBlockAuxiliary = 10,
-      kReadRunAuxiliary = 11,
-      kReadFile = 12,
-      kCloseFile = 13,
-      kDestructor = 14
+      kDoNotThrow,
+      kConstructor,
+      kReadFile,
+      kBeginJob,
+      kGetNextItemType,
+      kReadRunAuxiliary,
+      kReadRun,
+      kReadLuminosityBlockAuxiliary,
+      kReadLumi,
+      kReadEvent,
+      kCloseFile,
+      kEndJob,
+      kDestructor
     };
-    bool setRunAndEventInfo(EventID& id, TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType) override;
-    void produce(Event&) override;
+    bool setRunAndEventInfo(EventID& id, TimeValue_t& time, edm::EventAuxiliary::ExperimentType& eType) final;
 
     // To test exception throws from sources
     int whenToThrow_;
   };
 
   ThrowingSource::ThrowingSource(ParameterSet const& pset, InputSourceDescription const& desc)
-      : ProducerSourceBase(pset, desc, false),
+      : IDGeneratorSourceBase<InputSource>(pset, desc, false),
         whenToThrow_(pset.getUntrackedParameter<int>("whenToThrow", kDoNotThrow)) {
     if (whenToThrow_ == kConstructor)
       throw cms::Exception("TestThrow") << "ThrowingSource constructor";
+  }
+
+  void ThrowingSource::fillDescriptions(ConfigurationDescriptions& descriptions) {
+    ParameterSetDescription desc;
+    IDGeneratorSourceBase<InputSource>::fillDescription(desc);
+    desc.addUntracked<int>("whenToThrow", kDoNotThrow);
+    descriptions.addDefault(desc);
   }
 
   ThrowingSource::~ThrowingSource() noexcept(false) {
@@ -59,9 +65,13 @@ namespace edm {
       throw cms::Exception("TestThrow") << "ThrowingSource destructor";
   }
 
-  bool ThrowingSource::setRunAndEventInfo(EventID&, TimeValue_t&, edm::EventAuxiliary::ExperimentType&) { return true; }
-
-  void ThrowingSource::produce(edm::Event&) {}
+  //Called from IDGeneratorSourceBase::getNextItemType
+  bool ThrowingSource::setRunAndEventInfo(EventID&, TimeValue_t&, edm::EventAuxiliary::ExperimentType&) {
+    if (whenToThrow_ == kGetNextItemType) {
+      throw cms::Exception("TestThrow") << "ThrowingSource::getNextItemType";
+    }
+    return true;
+  }
 
   void ThrowingSource::beginJob(edm::ProductRegistry const&) {
     if (whenToThrow_ == kBeginJob)
@@ -73,13 +83,13 @@ namespace edm {
       throw cms::Exception("TestThrow") << "ThrowingSource::endJob";
   }
 
-  void ThrowingSource::beginLuminosityBlock(LuminosityBlock& lb) {
-    if (whenToThrow_ == kBeginLumi)
+  void ThrowingSource::readLuminosityBlock_(LuminosityBlockPrincipal& lb) {
+    if (whenToThrow_ == kReadLumi)
       throw cms::Exception("TestThrow") << "ThrowingSource::beginLuminosityBlock";
   }
 
-  void ThrowingSource::beginRun(Run& run) {
-    if (whenToThrow_ == kBeginRun)
+  void ThrowingSource::readRun_(RunPrincipal& run) {
+    if (whenToThrow_ == kReadRun)
       throw cms::Exception("TestThrow") << "ThrowingSource::beginRun";
   }
 

--- a/FWCore/Integration/test/CatchCmsExceptionFromSource_cfg.py
+++ b/FWCore/Integration/test/CatchCmsExceptionFromSource_cfg.py
@@ -1,5 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
+import argparse
+parser = argparse.ArgumentParser(description='Test catching cms::Exception from source')
+parser.add_argument("--whenToThrow", type=int, default=0, help="When to throw an exception (0=do not throw, 1=constructor, 2=openFile, 3=beginJob, 4=getNextItemType, 5=readRunAuxiliary, 6=beginRun, 7=readLuminosityBlockAuxiliary, 8=beginLuminosityBlock, 9=readEvent, 10=closeFile, 11=endJob, 12=destructor)")
+args = parser.parse_args()
+
 process = cms.Process("TEST")
 
-process.source = cms.Source("ThrowingSource", whenToThrow = cms.untracked.int32(3))
+from FWCore.Integration.modules import ThrowingSource
+process.source = ThrowingSource(whenToThrow = args.whenToThrow)
+
+process.maxEvents.input = 1

--- a/FWCore/Integration/test/CatchCmsExceptiontest.sh
+++ b/FWCore/Integration/test/CatchCmsExceptiontest.sh
@@ -4,9 +4,21 @@ LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+function test_failure { 
+    if [ "$2" != "65" ]
+     then
+       echo $1: status $2; exit $2;
+    fi
+}
+
+
 cmsRun ${LOCAL_TEST_DIR}/CatchCmsExceptiontest_cfg.py &> CatchCmsException.log && die 'Failed in using CatchCmsException_cfg.py' 1
 
 grep -q WhatsItESProducer CatchCmsException.log || die 'Failed to find Producers name' $?
 
-#echo running cmsRun testSkipEvent_cfg.py
-#cmsRun ${LOCAL_TEST_DIR}/testSkipEvent_cfg.py &> testSkipEvent.log || die 'Failed in using testSkipEvent_cfg.py' $?
+#This is the case where the exception is not thrown, so the exit code should be 0
+cmsRun ${LOCAL_TEST_DIR}/CatchCmsExceptionFromSource_cfg.py --whenToThrow=0 || die 'Failed in using CatchCmsExceptionFromSource_cfg.py' $?
+
+for whenToThrow in $(seq 1 11); do
+  cmsRun ${LOCAL_TEST_DIR}/CatchCmsExceptionFromSource_cfg.py --whenToThrow=${whenToThrow}; test_failure "Failed in using CatchCmsExceptionFromSource_cfg.py --whenToThrow=${whenToThrow}" $?
+done

--- a/FWCore/Integration/test/CatchCmsExceptiontest.sh
+++ b/FWCore/Integration/test/CatchCmsExceptiontest.sh
@@ -5,8 +5,10 @@ LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 function die { echo $1: status $2 ;  exit $2; }
 
 function test_failure { 
-    if [ "$2" != "65" ]
-     then
+    if [ "$2" == "0" ]; then
+       echo $1: status $2; exit 1;
+    fi
+    if [ "$2" != "65" ]; then
        echo $1: status $2; exit $2;
     fi
 }
@@ -22,3 +24,6 @@ cmsRun ${LOCAL_TEST_DIR}/CatchCmsExceptionFromSource_cfg.py --whenToThrow=0 || d
 for whenToThrow in $(seq 1 11); do
   cmsRun ${LOCAL_TEST_DIR}/CatchCmsExceptionFromSource_cfg.py --whenToThrow=${whenToThrow}; test_failure "Failed in using CatchCmsExceptionFromSource_cfg.py --whenToThrow=${whenToThrow}" $?
 done
+
+#This is the case where the exception is not thrown, so the exit code should be 0
+cmsRun ${LOCAL_TEST_DIR}/CatchCmsExceptionFromSource_cfg.py --whenToThrow=12 || die 'Failed in using CatchCmsExceptionFromSource_cfg.py' $?


### PR DESCRIPTION
#### PR description:

- Extended the unit test and made it run
- Fix handling of exception from source within EventProcessor

#### PR validation:

Code compiles and new unit test succeeds.

resolves https://github.com/cms-sw/framework-team/issues/2404