### PR TITLE
configure MPISender via type and input tag instead of pattern

### DIFF
--- a/HeterogeneousCore/MPICore/plugins/MPISender.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISender.cc
@@ -42,7 +42,6 @@ public:
   MPISender(edm::ParameterSet const& config)
       : upstream_(consumes<MPIToken>(config.getParameter<edm::InputTag>("upstream"))),
         token_(produces<MPIToken>()),
-        patterns_(edm::productPatterns(config.getParameter<std::vector<std::string>>("products"))),
         instance_(config.getParameter<int32_t>("instance")),
         buffer_(std::make_unique<TBufferFile>(TBuffer::kWrite)),
         metadata_size_(0),
@@ -54,58 +53,26 @@ public:
       throw cms::Exception("InvalidValue") << "Invalid MPISender instance value, please use a value between 1 and 255";
     }
 
-    products_.resize(patterns_.size());
-
     if (not activity_.label().empty()) {
       activityToken_ = consumes<edm::PathStateToken>(activity_);
     }
 
-    callWhenNewProductsRegistered([this](edm::ProductDescription const& product) {
-      static const std::string_view kPathStatus("edm::PathStatus");
-      static const std::string_view kEndPathStatus("edm::EndPathStatus");
+    auto const& products = config.getParameter<std::vector<edm::ParameterSet>>("products");
+    products_.reserve(products.size());
+    for (auto const& product : products) {
+      auto const& type = product.getParameter<std::string>("type");
+      auto const& input_tag = product.getParameter<edm::InputTag>("name");
+      Entry entry;
+      entry.type = edm::TypeWithDict::byName(type);
+      entry.wrappedType = edm::TypeWithDict::byName("edm::Wrapper<" + type + ">");
+      entry.token = this->consumes(edm::TypeToGet{edm::TypeID{entry.type.typeInfo()}, edm::PRODUCT_TYPE}, input_tag);
 
-      // std::cout << "MPISender: considering product " << product.friendlyClassName() << '_'
-      //           << product.moduleLabel() << '_' << product.productInstanceName() << '_' << product.processName()
-      //           << " of type " << product.unwrappedType().name() << " branch type " << product.branchType() << "\n";
+      LogDebug("MPISender") << "send product \"" << input_tag.label() << '_' << input_tag.instance() << '_'
+                            << input_tag.process() << "\" of type \"" << entry.type.name()
+                            << "\" over MPI channel instance " << instance_;
 
-      switch (product.branchType()) {
-        case edm::InEvent:
-          if (product.className() == kPathStatus or product.className() == kEndPathStatus)
-            return;
-          for (size_t pattern_index = 0; pattern_index < patterns_.size(); pattern_index++) {
-            if (patterns_[pattern_index].match(product)) {
-              Entry entry;
-              entry.type = product.unwrappedType();
-              entry.wrappedType = product.wrappedType();
-              // TODO move this to EDConsumerBase::consumes() ?
-              entry.token = this->consumes(
-                  edm::TypeToGet{product.unwrappedTypeID(), edm::PRODUCT_TYPE},
-                  edm::InputTag{product.moduleLabel(), product.productInstanceName(), product.processName()});
-
-              LogDebug("MPISender") << "send product \"" << product.friendlyClassName() << '_' << product.moduleLabel()
-                                    << '_' << product.productInstanceName() << '_' << product.processName()
-                                    << "\" of type \"" << entry.type.name() << "\" over MPI channel instance "
-                                    << instance_;
-
-              products_[pattern_index] = std::move(entry);
-              break;
-            }
-          }
-          break;
-
-        case edm::InLumi:
-        case edm::InRun:
-        case edm::InProcess:
-          // lumi, run and process products are not supported
-          break;
-
-        default:
-          throw edm::Exception(edm::errors::LogicError)
-              << "Unexpected branch type " << product.branchType() << "\nPlease contact a Framework developer\n";
-      }
-    });
-
-    // TODO add an error if a pattern does not match any branches? how?
+      products_.emplace_back(std::move(entry));
+    }
   }
 
   void acquire(edm::Event const& event, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder holder) final {
@@ -211,6 +178,10 @@ public:
         "This module can consume arbitrary event products and copy them to an \"MPIReceiver\" module in a separate "
         "CMSSW job.");
 
+    edm::ParameterSetDescription product;
+    product.add<std::string>("type")->setComment("C++ type of the product to be sent.");
+    product.add<edm::InputTag>("name")->setComment("Input tag of the product to be sent.");
+
     edm::ParameterSetDescription desc;
     desc.add<edm::InputTag>("upstream", {"source"})
         ->setComment(
@@ -218,11 +189,10 @@ public:
             "Passing an \"MPIController\" or \"MPISource\" only identifies the pair of local and remote application "
             "that communicate. Passing an \"MPISender\" or \"MPIReceiver\" in addition imposes a scheduling "
             "dependency.");
-    desc.add<std::vector<std::string>>("products", {})
+    desc.addVPSet("products", product, {})
         ->setComment(
-            "Event products to be consumed and copied over to a separate CMSSW job. Can be a list of module labels, "
-            "branch names (similar to an OutputModule's \"keep ...\" statement), or a mix of the two. Wildcards (\"?\" "
-            "and \"*\") are allowed in a module label or in each field of a branch name.");
+            "Event products to be consumed and copied over to a separate CMSSW job."
+            "Is configured as a vector of parameter sets, each containing the C++ type and input tag of a product.");
     desc.add<int32_t>("instance", 0)
         ->setComment("A value between 1 and 255 used to identify a matching pair of \"MPISender\"/\"MPIReceiver\".");
     desc.add<edm::InputTag>("activity", edm::InputTag(""))
@@ -252,9 +222,8 @@ private:
 
   edm::EDGetTokenT<MPIToken> const upstream_;  // MPIToken used to establish the communication channel
   edm::EDPutTokenT<MPIToken> const token_;  // copy of the MPIToken that may be used to implement an ordering relation
-  std::vector<edm::ProductNamePattern> patterns_;  // branches to read from the Event and send over the MPI channel
-  std::vector<Entry> products_;                    // types and tokens corresponding to the branches
-  int32_t const instance_;                         // instance used to identify the source-destination pair
+  std::vector<Entry> products_;             // types and tokens corresponding to the branches
+  int32_t const instance_;                  // instance used to identify the source-destination pair
   std::unique_ptr<TBufferFile> buffer_;
   size_t metadata_size_;
   edm::InputTag activity_;

--- a/HeterogeneousCore/MPICore/python/configuration_splitter/editor_functions.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/editor_functions.py
@@ -65,19 +65,21 @@ def create_remote_process(local_process, modules_to_run, remote_process_name, lo
 def is_device_product(prod):
     return prod["type"].startswith("edm::DeviceProduct")
 
-def make_sender_patterns(module_name, products):
-    patterns = []
+def make_sender_psets(products):
+    psets = []
 
     for p in products:
         if is_device_product(p):
             continue
 
-        friendly_type_name = p["friendly_type_name"]
-        label = p["product_instance"]
+        psets.append(
+            cms.PSet(
+                type=cms.string(p["type"]),
+                name=cms.InputTag(p["module"])
+            )
+        )
 
-        patterns.append(f"{friendly_type_name}_{module_name}_{label}_*")
-
-    return patterns
+    return cms.VPSet(*psets)
 
 
 def make_receiver_psets(products):
@@ -126,7 +128,6 @@ def replace_module(process, name, new_module):
 
 
 def create_sender(
-    module_name,
     products,
     instance,
     sender_upstream,
@@ -135,14 +136,14 @@ def create_sender(
     """
     Add MPISender for one module.
     """
-    sender_products = make_sender_patterns(module_name, products)
+    sender_products = make_sender_psets(products)
 
     if path_state_capture is not None:
         sender = cms.EDProducer(
             "MPISender",
             upstream=cms.InputTag(sender_upstream),
             instance=cms.int32(instance),
-            products=cms.vstring(*sender_products),
+            products=cms.VPSet(*sender_products),
             activity=cms.InputTag(path_state_capture),
         )
     else:
@@ -150,7 +151,7 @@ def create_sender(
             "MPISender",
             upstream=cms.InputTag(sender_upstream),
             instance=cms.int32(instance),
-            products=cms.vstring(*sender_products),
+            products=cms.VPSet(*sender_products),
         )
 
     return sender
@@ -168,14 +169,14 @@ def create_group_sender(
     """
     sender_products = []
     for offloaded_module in group:
-        sender_products.extend(make_sender_patterns(offloaded_module, all_products[offloaded_module]))
+        sender_products.extend(make_sender_psets(all_products[offloaded_module]))
 
     if path_state_capture is not None:
         sender = cms.EDProducer(
             "MPISender",
             upstream=cms.InputTag(upstream_module),
             instance=cms.int32(instance),
-            products=cms.vstring(*sender_products),
+            products=cms.VPSet(*sender_products),
             activity=cms.InputTag(path_state_capture),
         )
     else:
@@ -183,7 +184,7 @@ def create_group_sender(
             "MPISender",
             upstream=cms.InputTag(upstream_module),
             instance=cms.int32(instance),
-            products=cms.vstring(*sender_products),
+            products=cms.VPSet(*sender_products),
         )
 
     return sender

--- a/HeterogeneousCore/MPICore/python/configuration_splitter/split_remote.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/split_remote.py
@@ -80,7 +80,6 @@ def split_remote(local_process, args, cpp_names_of_the_products):
         capture_name = f"activityCaptureBefore{local_dependency.title()}"
         insert_path_state_capture_before(local_process, first_modules_in_a_group=markers, capture_name=capture_name)
         sender = create_sender(
-                module_name=local_dependency,
                 products=cpp_names_of_the_products[local_dependency],
                 instance=instance,
                 sender_upstream=controller_name,
@@ -115,7 +114,6 @@ def split_remote(local_process, args, cpp_names_of_the_products):
                 capture_name=f"activityCaptureBefore{args.remote_process_name.title()}Group{group_idx}"
                 insert_path_state_capture_before(local_process, first_modules_in_a_group=[first_dependency_in_a_group[group_idx]], capture_name=capture_name)
                 sender = create_sender(
-                        module_name=local_dependency,
                         products=[],
                         instance=instance,
                         sender_upstream=controller_name,

--- a/HeterogeneousCore/MPICore/test/controller_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_cfg.py
@@ -40,13 +40,19 @@ process.initialcheck = cms.EDAnalyzer("edmtest::EventIDValidator",
 process.sender = MPISender(
     upstream = "mpiController",
     instance = 42,
-    products = [ "edmEventID_ids__*" ]
+    products = [ dict(
+        type = "edm::EventID",
+        name = 'ids'
+    )]
 )
 
 process.othersender = MPISender(
     upstream = "mpiController",
     instance = 19,
-    products = [ "edmEventID_ids__*" ]
+    products = [ dict(
+        type = "edm::EventID",
+        name = 'ids'
+    )]
 )
 
 process.receiver = MPIReceiver(

--- a/HeterogeneousCore/MPICore/test/controller_complex_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_complex_cfg.py
@@ -84,12 +84,24 @@ process.triggerResultsProducer = cms.EDProducer("TestWriteTriggerResults",
 process.sender = MPISender(
     upstream = "mpiController",
     instance = 42,
-    products = [
-        "FEDRawDataCollection_fedRawDataCollectionProducer__*",
-        "RawDataBuffer_rawDataBufferProducer__*",
-        "edmTriggerResults_triggerResultsProducer__*",
-        "triggerTriggerEvent_triggerEventProducer__*"
-    ]
+    products = cms.VPSet(
+        cms.PSet(
+            type = cms.string("FEDRawDataCollection"),
+            name = cms.InputTag('fedRawDataCollectionProducer')
+        ),
+        cms.PSet(
+            type = cms.string("RawDataBuffer"),
+            name = cms.InputTag('rawDataBufferProducer')
+        ),
+        cms.PSet(
+            type = cms.string("edm::TriggerResults"),
+            name = cms.InputTag('triggerResultsProducer')
+        ),
+        cms.PSet(
+            type = cms.string("trigger::TriggerEvent"),
+            name = cms.InputTag('triggerEventProducer')
+        )
+    )
 )
 
 process.path = cms.Path(

--- a/HeterogeneousCore/MPICore/test/controller_filters_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_filters_cfg.py
@@ -42,7 +42,10 @@ process.eventIDProducer = cms.EDProducer("edmtest::EventIDProducer")
 process.sender = MPISender(
     upstream = "mpiController",
     instance = 42,
-    products = [ "edmEventID_eventIDProducer__*" ]
+    products = [ dict(
+        type = "edm::EventID",
+        name = 'eventIDProducer'
+    )]
 )
 
 # Receive a PathStateToken back from the Follower. This token will be present if

--- a/HeterogeneousCore/MPICore/test/controller_multi_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_multi_cfg.py
@@ -42,13 +42,20 @@ process.mpiController1 = MPIController(
 process.sender1 = MPISender(
     upstream = "mpiController1",
     instance = 11,
-    products = [ "edmEventID_ids__*" ]
+    products = [ dict(
+        type = "edm::EventID",
+        name = 'ids'
+    )]
+    
 )
 
 process.othersender1 = MPISender(
     upstream = "mpiController1",
     instance = 12,
-    products = [ "edmEventID_ids__*" ]
+    products = [ dict(
+        type = "edm::EventID",
+        name = 'ids'
+    )]
 )
 
 process.receiver1 = MPIReceiver(
@@ -84,7 +91,10 @@ process.mpiController2 = MPIController(
 process.sender2 = MPISender(
     upstream = "mpiController2",
     instance = 21,
-    products = [ "edmEventID_ids__*" ]
+    products = [ dict(
+        type = "edm::EventID",
+        name = 'ids'
+    )]
 )
 
 process.receiver2 = MPIReceiver(

--- a/HeterogeneousCore/MPICore/test/controller_multi_rr_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_multi_rr_cfg.py
@@ -42,13 +42,19 @@ process.mpiController1 = MPIController(
 process.sender1 = MPISender(
     upstream = "mpiController1",
     instance = 11,
-    products = [ "edmEventID_ids__*" ]
+    products = [ dict(
+        type = "edm::EventID",
+        name = 'ids'
+    )]
 )
 
 process.othersender1 = MPISender(
     upstream = "mpiController1",
     instance = 12,
-    products = [ "edmEventID_ids__*" ]
+    products = [ dict(
+        type = "edm::EventID",
+        name = 'ids'
+    )]
 )
 
 process.receiver1 = MPIReceiver(
@@ -84,7 +90,10 @@ process.mpiController2 = MPIController(
 process.sender2 = MPISender(
     upstream = "mpiController2",
     instance = 21,
-    products = [ "edmEventID_ids__*" ]
+    products = [ dict(
+        type = "edm::EventID",
+        name = 'ids'
+    )]
 )
 
 process.receiver2 = MPIReceiver(

--- a/HeterogeneousCore/MPICore/test/controller_rr_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_rr_cfg.py
@@ -40,13 +40,19 @@ process.initialcheck = cms.EDAnalyzer("edmtest::EventIDValidator",
 process.sender = MPISender(
     upstream = "mpiController",
     instance = 42,
-    products = [ "edmEventID_ids__*" ]
+    products = [ dict(
+        type = "edm::EventID",
+        name = 'ids'
+    )]
 )
 
 process.othersender = MPISender(
     upstream = "mpiController",
     instance = 19,
-    products = [ "edmEventID_ids__*" ]
+    products = [ dict(
+        type = "edm::EventID",
+        name = 'ids'
+    )]
 )
 
 process.receiver = MPIReceiver(

--- a/HeterogeneousCore/MPICore/test/controller_soa_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_soa_cfg.py
@@ -47,13 +47,26 @@ process.producePortableObjects = cms.EDProducer("TestAlpakaProducer@alpaka",
 process.sender = MPISender(
     upstream = "mpiController",
     instance = 42,
-    products = [
-        "portabletestTestStructPortableHostObject_producePortableObjects__*",
-        "128falseportabletestTestSoALayoutPortableHostCollection_producePortableObjects__*",
-        "128falseportabletestSoABlocks2PortableHostCollection_producePortableObjects__*",
-        "128falseportabletestSoABlocks3PortableHostCollection_producePortableObjects__*",
-        "ushort_producePortableObjects_backend_*"
-    ]
+    products = [ dict(
+        type = "PortableHostObject<portabletest::TestStruct>",
+        name = 'producePortableObjects'
+    ),
+    dict(
+        type = "PortableHostCollection<portabletest::TestSoALayout<128,false> >",
+        name = 'producePortableObjects'
+    ),
+    dict(
+        type = "PortableHostCollection<portabletest::SoABlocks2<128,false> >",
+        name = 'producePortableObjects'
+    ),
+    dict(
+        type = "PortableHostCollection<portabletest::SoABlocks3<128,false> >",
+        name = 'producePortableObjects'
+    ),
+    dict(
+        type = "ushort",
+        name = 'producePortableObjects@backend'
+    )]
 )
 
 # Same thing, but this time disabling TrivialSerialisation so all products are
@@ -62,13 +75,26 @@ process.senderNoTrivialSerialisation = MPISender(
     upstream = "sender",
     instance = 43,
     enableTrivialSerialisation = False,
-    products = [
-        "portabletestTestStructPortableHostObject_producePortableObjects__*",
-        "128falseportabletestTestSoALayoutPortableHostCollection_producePortableObjects__*",
-        "128falseportabletestSoABlocks2PortableHostCollection_producePortableObjects__*",
-        "128falseportabletestSoABlocks3PortableHostCollection_producePortableObjects__*",
-        "ushort_producePortableObjects_backend_*"
-    ]
+    products = [ dict(
+        type = "PortableHostObject<portabletest::TestStruct>",
+        name = 'producePortableObjects'
+    ),
+    dict(
+        type = "PortableHostCollection<portabletest::TestSoALayout<128,false> >",
+        name = 'producePortableObjects'
+    ),
+    dict(
+        type = "PortableHostCollection<portabletest::SoABlocks2<128,false> >",
+        name = 'producePortableObjects'
+    ),
+    dict(
+        type = "PortableHostCollection<portabletest::SoABlocks3<128,false> >",
+        name = 'producePortableObjects'
+    ),
+    dict(
+        type = "ushort",
+        name = 'producePortableObjects@backend'
+    )]
 )
 
 process.pathSoA = cms.Path(

--- a/HeterogeneousCore/MPICore/test/controller_too_many_streams_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_too_many_streams_cfg.py
@@ -53,13 +53,19 @@ process.initialcheck = cms.EDAnalyzer("edmtest::EventIDValidator",
 process.sender = MPISender(
     upstream = "mpiController",
     instance = 42,
-    products = [ "edmEventID_ids__*" ]
+    products = [ dict(
+        type = "edm::EventID",
+        name = "ids"
+    )]
 )
 
 process.othersender = MPISender(
     upstream = "mpiController",
     instance = 19,
-    products = [ "edmEventID_ids__*" ]
+    products = [ dict(
+        type = "edm::EventID",
+        name = "ids"
+    )]
 )
 
 process.receiver = MPIReceiver(

--- a/HeterogeneousCore/MPICore/test/follower_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_cfg.py
@@ -50,7 +50,10 @@ process.otherreceiver = MPIReceiver(
 process.sender = MPISender(
     upstream = "otherreceiver", # guarantees that this module will only run after otherreceiver has run
     instance = 99,
-    products = [ "edmEventID_otherreceiver__*" ]
+    products = cms.VPSet(cms.PSet(
+        type = cms.string("edm::EventID"),
+        name = cms.InputTag('otherreceiver')
+    ))
 )
 
 process.analyzer = cms.EDAnalyzer("edmtest::EventIDValidator",

--- a/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py
@@ -50,7 +50,10 @@ process.otherreceiver = MPIReceiver(
 process.sender = MPISender(
     upstream = "otherreceiver", # guarantees that this module will only run after otherreceiver has run
     instance = 13,
-    products = [ "edmEventID_otherreceiver__*" ]
+    products = cms.VPSet(cms.PSet(
+        type = cms.string("edm::EventID"),
+        name = cms.InputTag('otherreceiver')
+    ))
 )
 
 process.analyzer = cms.EDAnalyzer("edmtest::EventIDValidator",

--- a/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py
@@ -41,7 +41,10 @@ process.receiver = MPIReceiver(
 process.sender = MPISender(
     upstream = "receiver", # guarantees that this module will only run after receiver has run
     instance = 22,
-    products = [ "edmEventID_receiver__*" ]
+    products = cms.VPSet(cms.PSet(
+        type = cms.string("edm::EventID"),
+        name = cms.InputTag('receiver')
+    ))
 )
 
 process.analyzer = cms.EDAnalyzer("edmtest::EventIDValidator",

--- a/HeterogeneousCore/MPICore/test/follower_too_many_streams_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_too_many_streams_cfg.py
@@ -50,7 +50,10 @@ process.otherreceiver = MPIReceiver(
 process.sender = MPISender(
     upstream = "otherreceiver", # guarantees that this module will only run after otherreceiver has run
     instance = 99,
-    products = [ "edmEventID_otherreceiver__*" ]
+    products = cms.VPSet(cms.PSet(
+        type = cms.string("edm::EventID"),
+        name = cms.InputTag('otherreceiver')
+    ))
 )
 
 process.analyzer = cms.EDAnalyzer("edmtest::EventIDValidator",


### PR DESCRIPTION
#### PR description:

This pull request modifies MPISender from HeterogeneousCore/MPICore to accept parameter set consisting of product type and input tag instead of string pattern. This makes configuration of MPISender and MPIReceiver more similar and easier to validate.

#### PR validation:

The integration tests have been modified to account for this change.
