### PR TITLE
Drop clamped pixels, bounds-check cluster ids in SiPixelClusterizer

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoAAlpaka.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoAAlpaka.cc
@@ -80,6 +80,7 @@ void SiPixelDigisClustersFromSoAAlpaka<TrackerTraits>::produce(edm::StreamID,
 
   const auto& ttopo = iSetup.getData(topoToken_);
   constexpr auto maxModules = TrackerTraits::numberOfModules;
+  constexpr int32_t maxNumClustersPerModules = TrackerTraits::maxNumClustersPerModules;
 
   std::unique_ptr<edm::DetSetVector<PixelDigi>> outputDigis;
   if (produceDigis_)
@@ -111,6 +112,13 @@ void SiPixelDigisClustersFromSoAAlpaka<TrackerTraits>::produce(edm::StreamID,
     if (digisView[i].clus() < 0) {
       edm::LogError("SiPixelDigisClustersFromSoAAlpaka")
           << "Skipping pixel digi with unexpected invalid cluster id " << digisView[i].clus();
+      continue;
+    }
+    // unexpected out-of-range value: it would index outside of the `aclusters` buffer below
+    if (digisView[i].clus() >= maxNumClustersPerModules) {
+      edm::LogError("SiPixelDigisClustersFromSoAAlpaka")
+          << "Skipping pixel digi with out-of-range cluster id " << digisView[i].clus()
+          << " (>= " << maxNumClustersPerModules << ") in module " << digisView[i].rawIdArr();
       continue;
     }
 
@@ -190,6 +198,13 @@ void SiPixelDigisClustersFromSoAAlpaka<TrackerTraits>::produce(edm::StreamID,
     if (digisView[i].clus() < 0) {
       edm::LogError("SiPixelDigisClustersFromSoAAlpaka")
           << "Skipping pixel digi with unexpected invalid cluster id " << digisView[i].clus();
+      continue;
+    }
+    // unexpected out-of-range value: it would index outside of the `aclusters` buffer below
+    if (digisView[i].clus() >= maxNumClustersPerModules) {
+      edm::LogError("SiPixelDigisClustersFromSoAAlpaka")
+          << "Skipping pixel digi with out-of-range cluster id " << digisView[i].clus()
+          << " (>= " << maxNumClustersPerModules << ") in module " << digisView[i].rawIdArr();
       continue;
     }
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
@@ -77,7 +77,7 @@ namespace pixelClustering {
 
         uint32_t nclus = clus_view[thisModuleId].clusInModule();
         if (nclus == 0)
-          return;
+          continue;  // nothing to do for this module, but other modules may still be assigned to this block
 
         if (cms::alpakatools::once_per_block(acc) && nclus > maxNumClustersPerModules)
           printf("Warning: too many clusters in module %u in block %u: %u > %d\n",
@@ -95,7 +95,7 @@ namespace pixelClustering {
               break;  // end of module
             if (digi_view[i].clus() >= maxNumClustersPerModules) {
               digi_view[i].moduleId() = invalidModuleId;
-              digi_view[i].clus() = invalidModuleId;
+              digi_view[i].clus() = invalidClusterId;
             }
           }
           nclus = maxNumClustersPerModules;
@@ -174,9 +174,10 @@ namespace pixelClustering {
             continue;  // not valid
           if (digi_view[i].moduleId() != thisModuleId)
             break;  // end of module
-          if (0 == ok[digi_view[i].clus()])
-            digi_view[i].moduleId() = digi_view[i].clus() = invalidModuleId;
-          else
+          if (0 == ok[digi_view[i].clus()]) {
+            digi_view[i].moduleId() = invalidModuleId;
+            digi_view[i].clus() = invalidClusterId;
+          } else
             digi_view[i].clus() = newclusId[digi_view[i].clus()];
         }
 


### PR DESCRIPTION
#### PR description:

Resolves #51605 ("segfaults in the HSCP/MCP Summer24 DRPremix step").

Root cause: when `FindClus` clamps a module to `TrackerTraits::maxPixInModule`, the pixels past
the clamp point keep a valid `moduleId` and `clus() == their digi index`. That value is then used
as an index into per-module buffers of `maxNumClustersPerModules` (Phase1: 1024) entries, so both
`ClusterChargeCut` (`charge[]`, shared memory) and `SiPixelDigisClustersFromSoAAlpaka`
(`aclusters[]`, a 1.5 MB stack array) write out of bounds. `master` already drops those pixels in
`FindClus`, so it does not have the primary trigger; this PR hardens the two consumers so a
violated invariant costs a log message instead of silent memory corruption:

- `SiPixelDigisClustersFromSoAAlpaka`: reject `clus() >= maxNumClustersPerModules` with an
  `edm::LogError` instead of indexing `aclusters` out of bounds.
- `ClusterChargeCut`: `return` -> `continue` when `nclus == 0`, so a module with no clusters no
  longer abandons the other modules assigned to the block; and mark killed digis with
  `invalidClusterId` rather than `invalidModuleId`, which is a *positive* value (65534) that would
  itself be out of range if a consumer looked at `clus()` before `moduleId()`.

No change in output for any valid input: the new guards only fire on digis that are already
inconsistent. No dependencies on other PRs or externals.

#### PR validation:

`scram b` clean for the serial, CUDA and ROCm backends. Workflow 12834.402
(`TTbar_14TeV+2024_Patatrack_PixelOnlyAlpaka`) passes all four steps with unchanged output.

The mechanism was reproduced in `CMSSW_14_0_24` using the McM setups of
`EXO-RunIII2024Summer24HSCPwmLHEGS-00832` and `EXO-RunIII2024Summer24DRPremix-06134`, with the
clamp threshold lowered so that ordinary events reach it. Same input and configuration, only the
clusterizer differs: unmodified code dies after 4 events with

```
too many pixels in module 77: 381 > 200
A fatal system signal has occurred: segmentation violation
Module: SiPixelDigisClustersFromSoAAlpakaPhase1:hltSiPixelClustersSerialSync (crashed)
#19 SiPixelDigisClustersFromSoAAlpaka[pixelTopology::Phase1](vscode-webview://00mbuicm3er78k6sl69p95cb5udprutkf1sk6g7od1pfl5mdudnn/index.html?id=7f9b12b3-f259-4ab9-8a14-5644474ea8a2&parentId=53&origin=29f4a601-9872-4b55-a9b8-abb722e2b12a&swVersion=5&extensionId=Anthropic.claude-code&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app&remoteAuthority=ssh-remote%2Blxplus.cern.ch&purpose=webviewView&session=4a1369e6-a00c-40c8-bfa3-adf04fcda6dd)::produce(...)::{lambda(unsigned int)#1}
```

(identical to the stack trace in #51605), while the fixed code hits the same clamp 66 times over
all 29 events and exits 0.

#### If this PR is a backport ...

Not a backport. Backports are intended for `14_0_X`, `14_1_X` and `15_0_X`, which are the branches
that still have the actual crash: there the backport additionally has to port the invalidation of
the clamped pixels in `FindClus` that `master` already carries. `14_0_X` is the one that unblocks
the affected Summer24 HSCP production (`CMSSW_14_0_24`).