### PR TITLE
Modify CLUE3D in the barrel for EGM linking

### DIFF
--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCLUE3D.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCLUE3D.cc
@@ -698,8 +698,12 @@ int PatternRecognitionbyCLUE3D<TILES>::findAndAssignTracksters(
   std::vector<std::pair<int, int>> localStack;
   const auto &critical_transverse_distance =
       useAbsoluteProjectiveScale_ ? criticalXYDistance_ : criticalEtaPhiDistance_;
+
   // find cluster seeds and outlier
   unsigned int maxLayer = (isBarrel_) ? this->rhtools_->lastLayerBarrel() + 1 : 2 * this->rhtools_->lastLayer();
+
+  std::vector<std::pair<unsigned int, unsigned int>> seed_clusterIdx_map;
+
   for (unsigned int layer = 0; layer < maxLayer; layer++) {
     auto &clustersOnLayer = clusters_[layer];
     unsigned int numberOfClusters = clustersOnLayer.x.size();
@@ -727,6 +731,7 @@ int PatternRecognitionbyCLUE3D<TILES>::findAndAssignTracksters(
         }
         clustersOnLayer.clusterIndex[i] = nTracksters++;
         tracksterSeedAlgoId_.push_back(algoId);
+        seed_clusterIdx_map.emplace_back(layer, i);
         clustersOnLayer.isSeed[i] = true;
         localStack.emplace_back(layer, i);
       } else if (!isOutlier) {
@@ -748,16 +753,88 @@ int PatternRecognitionbyCLUE3D<TILES>::findAndAssignTracksters(
     }
   }
 
+  //vector keeping the soaIdx of the ECAL cluster inside a trackster (not the seed)
+  std::vector<int> ecal_LC_content_idx(nTracksters, -1);
+
   // Propagate cluster index
   while (!localStack.empty()) {
     auto [lyrIdx, soaIdx] = localStack.back();
     auto &thisSeed = clusters_[lyrIdx].followers[soaIdx];
+
+    // This is the algo ID
+    auto current_algoId = clusters_[lyrIdx].algoId[soaIdx];
+    auto current_tracksterid = clusters_[lyrIdx].clusterIndex[soaIdx];
+
+    if (isBarrel_) {
+      if ((current_algoId == 0) && (!clusters_[lyrIdx].isSeed[soaIdx]) &&
+          ((current_algoId == tracksterSeedAlgoId_[current_tracksterid]))) {
+        //skip this connection --> create a new trackster
+        clusters_[lyrIdx].clusterIndex[soaIdx] = nTracksters++;
+        tracksterSeedAlgoId_.push_back(current_algoId);
+        ecal_LC_content_idx.emplace_back(-1);  // Only the ECAL LC not seeds are saved
+        clusters_[lyrIdx].isSeed[soaIdx] = true;
+        // Do not pop from the stack, it will be reanalyze
+        continue;
+      }
+
+      if ((current_algoId == 0) && (!clusters_[lyrIdx].isSeed[soaIdx]) &&
+          (tracksterSeedAlgoId_[current_tracksterid] != 0)) {
+        if (ecal_LC_content_idx[current_tracksterid] != -1) {
+          // We need to compare ECAL LCs
+          // We need to get the cluster index of the seed cluster from the trackster seed idx
+          auto [seed_lyrIdx, seed_soaIdx] = seed_clusterIdx_map[current_tracksterid];
+          auto otherEcal_soaIdx = ecal_LC_content_idx[current_tracksterid];
+          constexpr unsigned int otherEcal_lyrIdx = 0;
+
+          auto dist_first = reco::deltaR2(clusters_[lyrIdx].eta[soaIdx],
+                                          clusters_[lyrIdx].phi[soaIdx],
+                                          clusters_[seed_lyrIdx].eta[seed_soaIdx],
+                                          clusters_[seed_lyrIdx].phi[seed_soaIdx]);
+
+          auto dist_second = reco::deltaR2(clusters_[otherEcal_lyrIdx].eta[otherEcal_soaIdx],
+                                           clusters_[otherEcal_lyrIdx].phi[otherEcal_soaIdx],
+                                           clusters_[seed_lyrIdx].eta[seed_soaIdx],
+                                           clusters_[seed_lyrIdx].phi[seed_soaIdx]);
+
+          if (dist_first < dist_second) {
+            // swap
+            ecal_LC_content_idx[current_tracksterid] = soaIdx;  // I become the ECAL LC of that trackster
+            // Now remove the other , create a new trackster
+            clusters_[otherEcal_lyrIdx].clusterIndex[otherEcal_soaIdx] = nTracksters++;
+            tracksterSeedAlgoId_.push_back(current_algoId);
+            ecal_LC_content_idx.emplace_back(-1);
+            clusters_[otherEcal_lyrIdx].isSeed[otherEcal_soaIdx] = true;
+            localStack.emplace_back(otherEcal_lyrIdx, otherEcal_soaIdx);
+          } else {
+            //skip this connection --> create a new trackster
+            //Pruning
+            clusters_[lyrIdx].clusterIndex[soaIdx] = nTracksters++;
+            tracksterSeedAlgoId_.push_back(current_algoId);
+            ecal_LC_content_idx.emplace_back(-1);
+            clusters_[lyrIdx].isSeed[soaIdx] = true;
+            // Do not pop from the stack, it will be reanalyzed
+            continue;
+          }
+
+        } else {
+          // I'm ECAL, there is nobody else, I take this trackster
+          ecal_LC_content_idx[current_tracksterid] = soaIdx;  // Now I'm the ECAL LC of that trackster
+        }
+      }  // end of check for other ECAL LC
+    }
+    // We arrive here if
+    // - the cluster is the seed
+    // - the cluster is not ECAL
+    // - the cluster is ECAL, gets assigned to the trackster as the best ECAL
     localStack.pop_back();
 
     // loop over followers
     for (auto [follower_lyrIdx, follower_soaIdx] : thisSeed) {
       // pass id to a follower
-      clusters_[follower_lyrIdx].clusterIndex[follower_soaIdx] = clusters_[lyrIdx].clusterIndex[soaIdx];
+      if (clusters_[follower_lyrIdx].isSeed[follower_soaIdx]) {
+        continue;
+      }
+      clusters_[follower_lyrIdx].clusterIndex[follower_soaIdx] = current_tracksterid;
       // push this follower to localStack
       localStack.emplace_back(follower_lyrIdx, follower_soaIdx);
     }


### PR DESCRIPTION
#### PR description:

This PR modifies the logic used in CLUE3D to create tracksters in the barrel. The goal is to avoid having multiple ECAL clusters in the same 3D trackster, as linking them is the job of the superclustering step that will happen later.
The code is entirely in the `isBarrel_` check, so it should not affect the endcap, and it splits tracksters whenever an ECAL cluster is going to be attached to a trackster that already contains one. If one of the two is the seed, the other is removed and creates a new trackster on its own. If neither of them is the seed, only the closest one to the seed is kept.

#### PR validation:

Tested on wf 31953.209, checking that with this PR there are no CLUE3D tracksters with more than one ECAL cluster in the barrel.
More info in [this presentation](https://indico.cern.ch/event/1639386/sessions/645076/attachments/3311320/5926200/27_07_09%20TICL%20-%20ECAL_graph_building.pdf).

FYI @valsdav 