### PR TITLE
Add a per-module summary output to `edmModuleAllocMonitorAnalyze.py` and make it the default

### DIFF
--- a/PerfTools/AllocMonitor/scripts/edmModuleAllocMonitorAnalyze.py
+++ b/PerfTools/AllocMonitor/scripts/edmModuleAllocMonitorAnalyze.py
@@ -818,7 +818,7 @@ class PostEDModuleAcquireParser(EDModuleTransitionParser):
     def jsonVisInfo(self,  data):
         if self._moduleCentric:
             #inject an external work at end of the same slot to guarantee module run is in that slot
-            return self._postJsonVis( data, jsonModuleTransition(type=self.transition, id=self.index, modID=self.moduleID, callID=self.callID, activity=Activity.externalWork, start=self.time))
+            return self._postJsonVis(data, self.allocInfo, injectAfter=jsonModuleTransition(type=self.transition, id=self.index, modID=self.moduleID, callID=self.callID, activity=Activity.externalWork, start=self.time))
         return self._postJsonVis(data, self.allocInfo)
     def jsonInfo(self, syncs, temp, data):
         #some cases acquire and produce are in the log in the wrong order
@@ -1456,6 +1456,8 @@ class TestModuleCommand(unittest.TestCase):
              f'F {Phase.Event} 1 1 1 2 {incr(t)}',
              f'N {Phase.Event} 0 1 1 0 {incr(t)}',
              f'n {Phase.Event} 0 1 1 0 {incr(t)} 6 5 30 0 100 80',
+             f'A {Phase.Event} 0 1 0 {incr(t)}',
+             f'a {Phase.Event} 0 1 0 {incr(t)} 2 1 10 0 20 15',
              f'M {Phase.Event} 0 1 0 {incr(t)}',
              f'M {Phase.Event} 1 1 0 {incr(t)}',
              f'm {Phase.Event} 1 1 0 {incr(t)} 3 2 20 0 50 25',
@@ -1499,12 +1501,12 @@ class TestModuleCommand(unittest.TestCase):
         j = jsonInfo(parser, False)
         self.assertEqual(len(j.data()),3) 
         self.assertEqual(len(j.data()["source"]), 10)
-        self.assertEqual(len(j.data()["Module"]), 8)
+        self.assertEqual(len(j.data()["Module"]), 9)
         self.assertEqual(len(j.data()["ESModule"]), 1)
     def testJsonTemporal(self):
         parser = ModuleAllocCompactFileParser(self.tracerFile, True)
         j = jsonInfo(parser, True)
-        self.assertEqual(len(j.data()),19)
+        self.assertEqual(len(j.data()),20)
     def testSortBy(self):
         parser = ModuleAllocCompactFileParser(self.tracerFile, True)
         d = sortByAttribute(parser, 'maxTemp')
@@ -1526,7 +1528,7 @@ class TestModuleCommand(unittest.TestCase):
         self.assertEqual(len(j["transitions"][0]["slots"][1]), 4)
         self.assertEqual(len(j["transitions"][1]["slots"]), 2)
         self.assertEqual(len(j["transitions"][1]["slots"][0]), 5)
-        self.assertEqual(len(j["transitions"][1]["slots"][1]), 3)
+        self.assertEqual(len(j["transitions"][1]["slots"][1]), 4)
         self.assertEqual(len(j["transitions"][2]["slots"]), 2)
         self.assertEqual(len(j["transitions"][2]["slots"][0]), 5)
         self.assertEqual(len(j["transitions"][2]["slots"][1]), 2)
@@ -1549,7 +1551,7 @@ class TestModuleCommand(unittest.TestCase):
         self.assertEqual(len(j["transitions"][2]["slots"]), 1)
         self.assertEqual(len(j["transitions"][2]["slots"][0]), 5)
         self.assertEqual(len(j["transitions"][4]["slots"]), 2)
-        self.assertEqual(len(j["transitions"][4]["slots"][0]), 7)
+        self.assertEqual(len(j["transitions"][4]["slots"][0]), 9)
         self.assertEqual(len(j["transitions"][4]["slots"][1]), 1)
         self.assertTrue(j["transitions"][4]["slots"][1][-1]['finish'] != 0.0)
         self.assertEqual(len(j["transitions"][5]["slots"]), 1)

--- a/PerfTools/AllocMonitor/scripts/edmModuleAllocMonitorAnalyze.py
+++ b/PerfTools/AllocMonitor/scripts/edmModuleAllocMonitorAnalyze.py
@@ -203,31 +203,31 @@ class AllocInfo(object):
     """Container for memory allocation information from CMSSW module transitions.
     
     Attributes:
-        nAllocs: Number of memory allocations
-        nDeallocs: Number of memory deallocations  
+        nAlloc: Number of memory allocations
+        nDealloc: Number of memory deallocations
         added: Net memory added (in bytes)
         minTemp: Minimum temporary memory usage
         maxTemp: Maximum temporary memory usage
         max1Alloc: Largest single allocation
     """
     def __init__(self,payload):
-        self.nAllocs = int(payload[0])
-        self.nDeallocs = int(payload[1])
+        self.nAlloc = int(payload[0])
+        self.nDealloc = int(payload[1])
         self.added = int(payload[2])
         self.minTemp = int(payload[3])
         self.maxTemp = int(payload[4])
         self.max1Alloc = int(payload[5])
     def inject(self, transition):
-        transition["nAllocs"]=self.nAllocs
-        transition["nDeallocs"]=self.nDeallocs
+        transition["nAlloc"]=self.nAlloc
+        transition["nDealloc"]=self.nDealloc
         transition["added"]=self.added
         transition["minTemp"]=self.minTemp
         transition["maxTemp"]=self.maxTemp
         transition["max1Alloc"]=self.max1Alloc
     def __repr__(self):
-        return "{{'nAlloc': {}, 'nDealloc': {}, 'added': {}, 'minTemp': {}, 'maxTemp': {}, 'max1Alloc': {} }}".format(self.nAllocs, self.nDeallocs, self.added, self.minTemp, self.maxTemp, self.max1Alloc)
+        return "{{'nAlloc': {}, 'nDealloc': {}, 'added': {}, 'minTemp': {}, 'maxTemp': {}, 'max1Alloc': {} }}".format(self.nAlloc, self.nDealloc, self.added, self.minTemp, self.maxTemp, self.max1Alloc)
     def toSimpleDict(self):
-        return {'nAlloc' : self.nAllocs, 'nDealloc' :self.nDeallocs, 'added' : self.added, 'minTemp' : self.minTemp, 'maxTemp' : self.maxTemp, 'max1Alloc' : self.max1Alloc }
+        return {'nAlloc' : self.nAlloc, 'nDealloc' :self.nDealloc, 'added' : self.added, 'minTemp' : self.minTemp, 'maxTemp' : self.maxTemp, 'max1Alloc' : self.max1Alloc }
         
 class SyncValues(object):
     def __init__(self):
@@ -1078,6 +1078,8 @@ def textOutput( parser ):
     for p in parser.processingSteps():
         print(p.text(context))
 
+kSummaryFields = ("nAlloc", "nDealloc", "added", "minTemp", "maxTemp", "max1Alloc")
+
 def summaryData( parser ):
     """Return an ordered summary of averaged alloc info.
     Structure:
@@ -1161,16 +1163,12 @@ def summaryData( parser ):
                 infos = groups[(transition, activity, record)]
                 n = len(infos)
                 avg = {}
-                for field, attr in (("nAlloc","nAllocs"), ("nDealloc","nDeallocs"),
-                                    ("added","added"), ("minTemp","minTemp"),
-                                    ("maxTemp","maxTemp"), ("max1Alloc","max1Alloc")):
-                    avg[field] = int(round(sum(getattr(i, attr) for i in infos) / n))
+                for field in kSummaryFields:
+                    avg[field] = int(round(sum(getattr(i, field) for i in infos) / n))
                 activities.append((activityName(activity), record, n, avg))
             transitions.append((transitionName(transition), activities))
         result.append((label, transitions))
     return result
-
-kSummaryFields = ("nAlloc", "nDealloc", "added", "minTemp", "maxTemp", "max1Alloc")
 
 def summaryOutput( parser, field=None ):
     """Print the per-module/per-transition/per-activity averaged summary.
@@ -1780,7 +1778,7 @@ if __name__=="__main__":
     parser.add_argument('-s', '--sortBy',
                         default = '',
                         type = str,
-                        help="sort modules by attribute. Allowed values 'nAllocs', 'nDeallocs', 'added', 'minTemp', 'maxTemp', and 'max1Alloc'")
+                        help="sort modules by attribute. Allowed values 'nAlloc', 'nDealloc', 'added', 'minTemp', 'maxTemp', and 'max1Alloc'")
 #    parser.add_argument('-w', '--web',
 #                        action='store_true',
 #                        help='''Writes data.js file that can be used with the web based inspector. To use, copy directory ${CMSSW_RELEASE_BASE}/src/FWCore/Services/template/web to a web accessible area and move data.js into that directory.''')

--- a/PerfTools/AllocMonitor/scripts/edmModuleAllocMonitorAnalyze.py
+++ b/PerfTools/AllocMonitor/scripts/edmModuleAllocMonitorAnalyze.py
@@ -50,6 +50,7 @@ kSourceFindEvent = "sourceFindEvent"
 kSourceDelayedRead ="sourceDelayedRead"
 #this value is defined in the framework itself
 kLargestLumiNumber = 4294967295
+kSummaryIndent = "  "
 
 #these values must match the enum class Phase in tracer_setupFile.cc
 class Phase (object):
@@ -1077,6 +1078,126 @@ def textOutput( parser ):
     for p in parser.processingSteps():
         print(p.text(context))
 
+def summaryData( parser ):
+    """Return an ordered summary of averaged alloc info.
+    Structure:
+      [ (label, [ (transitionName, [ (activityName, record, count, {field: avgInt}) ]) ]) ]
+    where record is None, (recordName, callID) for EventSetup modules, or
+    (None, callID) for ED modules with a nonzero callID (used by Transform /
+    TransformAsync / ExternalWork-style callbacks). The grouping key is
+    (transition, activity, record) so that EventSetup entries with different
+    records/callIDs, and ED-module entries with different nonzero callIDs,
+    are reported separately.
+
+    Ordering: labels and transitions keep first-seen / insertion order.
+    Within a transition, entries are grouped by record name (None counts as
+    its own "no record" group, used by ED modules and by EventSetup entries
+    with no distinguishing record). The "no record" group, if present, comes
+    first; any actual EventSetup record names are then sorted alphabetically
+    ascending. Within each record-name group, activities are sorted by
+    ascending callID and, for a given callID, by activity (acquire before
+    process) - regardless of the order they first appeared in the trace.
+    """
+    data = jsonInfo(parser, False)   # ModuleCentricModuleData, module-centric
+    result = []
+    for label, entries in data.data().items():
+        if not entries:
+            continue
+        # group by (transition, activity, record), preserving first-seen order
+        groups = {}          # (transition, activity, record) -> list[AllocInfo]
+        transOrder = []      # first-seen transition ints
+        actOrder = {}        # transition -> first-seen list of (activity, record)
+        for e in entries:
+            # e.record is (recordName, callID). EventSetup entries carry a
+            # record name and always keep (name, callID). ED module entries
+            # have no record name, but a nonzero callID (used by Transform /
+            # TransformAsync / ExternalWork-style callbacks) must still be
+            # kept distinct so different callbacks are not averaged
+            # together. callID == 0 (or missing) means "no distinguishing
+            # information".
+            recordName, callID = e.record
+            if recordName is not None:
+                record = (recordName, callID)
+            elif callID:
+                record = (None, callID)
+            else:
+                record = None
+            key = (e.transition, e.activity, record)
+            if key not in groups:
+                groups[key] = []
+                if e.transition not in actOrder:
+                    actOrder[e.transition] = []
+                    transOrder.append(e.transition)
+                actOrder[e.transition].append((e.activity, record))
+            groups[key].append(e.allocInfo)
+        # activity is sorted first (acquire before process) so that, for a
+        # given callID, acquire is always listed before process.
+        activityRank = {Activity.acquire: 0, Activity.process: 1}
+        def recordNameOf(record):
+            return None if record is None else record[0]
+        def callIDOf(record):
+            return 0 if record is None else (record[1] or 0)
+        transitions = []
+        for transition in transOrder:
+            # Group by record name (None is its own group: "no record",
+            # used by ED modules and by EventSetup entries with no
+            # distinguishing record). The "no record" group comes first,
+            # then EventSetup record names are sorted alphabetically
+            # ascending. Within each record-name group, sort by (callID,
+            # activity) so callIDs are ascending and, for a given callID,
+            # acquire comes before process.
+            byRecordName = defaultdict(list)
+            for activity, record in actOrder[transition]:
+                rn = recordNameOf(record)
+                byRecordName[rn].append( (activity, record) )
+            recordNameOrder = sorted(byRecordName.keys(), key=lambda rn: (rn is not None, rn))
+            sortedActRecords = []
+            for rn in recordNameOrder:
+                group = byRecordName[rn]
+                group.sort(key=lambda ar: (callIDOf(ar[1]), activityRank.get(ar[0], 2)))
+                sortedActRecords.extend(group)
+            activities = []
+            for activity, record in sortedActRecords:
+                infos = groups[(transition, activity, record)]
+                n = len(infos)
+                avg = {}
+                for field, attr in (("nAlloc","nAllocs"), ("nDealloc","nDeallocs"),
+                                    ("added","added"), ("minTemp","minTemp"),
+                                    ("maxTemp","maxTemp"), ("max1Alloc","max1Alloc")):
+                    avg[field] = int(round(sum(getattr(i, attr) for i in infos) / n))
+                activities.append((activityName(activity), record, n, avg))
+            transitions.append((transitionName(transition), activities))
+        result.append((label, transitions))
+    return result
+
+kSummaryFields = ("nAlloc", "nDealloc", "added", "minTemp", "maxTemp", "max1Alloc")
+
+def summaryOutput( parser, field=None ):
+    """Print the per-module/per-transition/per-activity averaged summary.
+    If field is None (default), all six alloc quantities (kSummaryFields)
+    are printed on one row. If field is one of kSummaryFields, only that
+    quantity is printed.
+    """
+    fields = (field,) if field else kSummaryFields
+    for label, transitions in summaryData(parser):
+        if label == "clearEvent":
+            print(f"{label} transition:")
+        else:
+            print(f"Module label {label}, transitions:")
+        for transitionName_, activities in transitions:
+            print(f"{kSummaryIndent}{transitionName_}")
+            for activityName_, record, n, avg in activities:
+                if record is not None:
+                    recordName, callID = record
+                    if recordName is not None:
+                        print(f"{kSummaryIndent*2}{activityName_} record {recordName} callID {callID} ({n} calls)")
+                    else:
+                        print(f"{kSummaryIndent*2}{activityName_} callID {callID} ({n} calls)")
+                else:
+                    print(f"{kSummaryIndent*2}{activityName_} ({n} calls)")
+                print(kSummaryIndent*3 + " ".join(f"{f} {avg[f]}" for f in fields))
+        print()
+
 def showSourceTypes( parser ):
     print("Source Module Types:")
     print("===================")
@@ -1400,6 +1521,7 @@ class TestModuleCommand(unittest.TestCase):
         
         self.tracerFile.extend([
             '#R 1 Record',
+            '#R 2 Alpha',
             '#M 1 Module ModuleType',
             '#N 1 ESModule ESModuleType',
             '#S 1 Source SourceType',
@@ -1456,12 +1578,33 @@ class TestModuleCommand(unittest.TestCase):
              f'F {Phase.Event} 1 1 1 2 {incr(t)}',
              f'N {Phase.Event} 0 1 1 0 {incr(t)}',
              f'n {Phase.Event} 0 1 1 0 {incr(t)} 6 5 30 0 100 80',
+             # Second EventSetup record ("Alpha") with multiple callIDs,
+             # deliberately traced out of both alphabetical (Alpha is
+             # traced after Record) and numeric (callIDs 2, 0, 1) order, so
+             # testSummary can verify summaryData() sorts EventSetup record
+             # names alphabetically and callIDs numerically ascending
+             # rather than relying on first-seen trace order.
+             f'N {Phase.Event} 0 1 2 2 {incr(t)}',
+             f'n {Phase.Event} 0 1 2 2 {incr(t)} 4 3 12 0 40 20',
+             f'N {Phase.Event} 0 1 2 0 {incr(t)}',
+             f'n {Phase.Event} 0 1 2 0 {incr(t)} 1 1 2 0 10 5',
+             f'N {Phase.Event} 0 1 2 1 {incr(t)}',
+             f'n {Phase.Event} 0 1 2 1 {incr(t)} 2 2 4 0 20 10',
              f'A {Phase.Event} 0 1 0 {incr(t)}',
              f'a {Phase.Event} 0 1 0 {incr(t)} 2 1 10 0 20 15',
              f'M {Phase.Event} 0 1 0 {incr(t)}',
              f'M {Phase.Event} 1 1 0 {incr(t)}',
              f'm {Phase.Event} 1 1 0 {incr(t)} 3 2 20 0 50 25',
              f'm {Phase.Event} 0 1 0 {incr(t)} 3 2 20 0 50 25',
+             # callID 2 appears in the trace before callID 1 so testSummary
+             # can verify summaryData() sorts by callID ascending rather than
+             # by first-seen trace order.
+             f'M {Phase.Event} 0 1 2 {incr(t)}',
+             f'm {Phase.Event} 0 1 2 {incr(t)} 7 6 70 0 90 45',
+             f'A {Phase.Event} 0 1 1 {incr(t)}',
+             f'a {Phase.Event} 0 1 1 {incr(t)} 2 1 10 0 20 15',
+             f'M {Phase.Event} 0 1 1 {incr(t)}',
+             f'm {Phase.Event} 0 1 1 {incr(t)} 5 4 40 0 60 30',
              f'f {Phase.Event} 0 1 1 1 {incr(t)}',
              f'f {Phase.Event} 1 1 1 2 {incr(t)}'])
 
@@ -1501,12 +1644,69 @@ class TestModuleCommand(unittest.TestCase):
         j = jsonInfo(parser, False)
         self.assertEqual(len(j.data()),3) 
         self.assertEqual(len(j.data()["source"]), 10)
-        self.assertEqual(len(j.data()["Module"]), 9)
-        self.assertEqual(len(j.data()["ESModule"]), 1)
+        self.assertEqual(len(j.data()["Module"]), 12)
+        self.assertEqual(len(j.data()["ESModule"]), 4)
+    def testSummary(self):
+        parser = ModuleAllocCompactFileParser(self.tracerFile, False)
+        s = summaryData(parser)
+        labels = [label for label, _ in s]
+        self.assertEqual(labels, ['source', 'Module', 'ESModule'])
+        summ = dict(s)
+        # helper: transition -> {(activity, record): (count, avgdict)}
+        def byName(transitions):
+            return {tn: {(an, rec): (n, avg) for an, rec, n, avg in acts} for tn, acts in transitions}
+        src = byName(summ['source'])
+        self.assertEqual(src['get next transition'][('process', None)][0], 5)
+        self.assertEqual(src['event'][('process', None)][0], 2)
+        mod = byName(summ['Module'])
+        self.assertEqual(mod['stream begin run'][('process', None)][0], 2)
+        self.assertEqual(mod['event'][('process', None)][1]['nAlloc'], 3)
+        self.assertEqual(mod['event'][('process', None)][1]['nDealloc'], 2)
+        self.assertEqual(mod['event'][('process', None)][1]['added'], 20)
+        self.assertEqual(mod['event'][('process', None)][1]['max1Alloc'], 25)
+        # ED-module nonzero callID (Transform/ExternalWork-style callback) must
+        # stay distinct from the callID 0 group instead of being averaged in.
+        self.assertEqual(mod['event'][('process', (None, 1))][0], 1)
+        self.assertEqual(mod['event'][('process', (None, 1))][1]['nAlloc'], 5)
+        self.assertEqual(mod['event'][('acquire', (None, 1))][0], 1)
+        self.assertEqual(mod['event'][('acquire', (None, 1))][1]['nAlloc'], 2)
+        # Even though callID 2 appears in the trace before callID 1 (see
+        # fixture), the "event" activities must be sorted by ascending
+        # callID, and acquire must precede process for the same callID.
+        modTransitions = dict(summ['Module'])
+        eventActs = [(an, rec) for an, rec, n, avg in modTransitions['event']]
+        self.assertEqual(eventActs, [
+            ('acquire', None),
+            ('process', None),
+            ('acquire', (None, 1)),
+            ('process', (None, 1)),
+            ('process', (None, 2)),
+        ])
+        es = byName(summ['ESModule'])
+        # EventSetup entry carries a record (name, callID) in the grouping key
+        self.assertEqual(es['event'][('process', ('Record', 0))][0], 1)
+        self.assertEqual(es['event'][('process', ('Record', 0))][1]['nAlloc'], 6)
+        self.assertEqual(es['event'][('process', ('Record', 0))][1]['nDealloc'], 5)
+        self.assertEqual(es['event'][('process', ('Record', 0))][1]['added'], 30)
+        self.assertEqual(es['event'][('process', ('Alpha', 0))][1]['nAlloc'], 1)
+        self.assertEqual(es['event'][('process', ('Alpha', 1))][1]['nAlloc'], 2)
+        self.assertEqual(es['event'][('process', ('Alpha', 2))][1]['nAlloc'], 4)
+        # "Alpha" is traced after "Record" and with callIDs out of numeric
+        # order (2, 0, 1); the summary must still list EventSetup records
+        # sorted alphabetically ascending by record name, and within a
+        # record, callIDs sorted numerically ascending.
+        esModTransitions = dict(summ['ESModule'])
+        esEventActs = [(an, rec) for an, rec, n, avg in esModTransitions['event']]
+        self.assertEqual(esEventActs, [
+            ('process', ('Alpha', 0)),
+            ('process', ('Alpha', 1)),
+            ('process', ('Alpha', 2)),
+            ('process', ('Record', 0)),
+        ])
     def testJsonTemporal(self):
         parser = ModuleAllocCompactFileParser(self.tracerFile, True)
         j = jsonInfo(parser, True)
-        self.assertEqual(len(j.data()),20)
+        self.assertEqual(len(j.data()),26)
     def testSortBy(self):
         parser = ModuleAllocCompactFileParser(self.tracerFile, True)
         d = sortByAttribute(parser, 'maxTemp')
@@ -1528,7 +1728,7 @@ class TestModuleCommand(unittest.TestCase):
         self.assertEqual(len(j["transitions"][0]["slots"][1]), 4)
         self.assertEqual(len(j["transitions"][1]["slots"]), 2)
         self.assertEqual(len(j["transitions"][1]["slots"][0]), 5)
-        self.assertEqual(len(j["transitions"][1]["slots"][1]), 4)
+        self.assertEqual(len(j["transitions"][1]["slots"][1]), 10)
         self.assertEqual(len(j["transitions"][2]["slots"]), 2)
         self.assertEqual(len(j["transitions"][2]["slots"][0]), 5)
         self.assertEqual(len(j["transitions"][2]["slots"][1]), 2)
@@ -1551,11 +1751,11 @@ class TestModuleCommand(unittest.TestCase):
         self.assertEqual(len(j["transitions"][2]["slots"]), 1)
         self.assertEqual(len(j["transitions"][2]["slots"][0]), 5)
         self.assertEqual(len(j["transitions"][4]["slots"]), 2)
-        self.assertEqual(len(j["transitions"][4]["slots"][0]), 9)
+        self.assertEqual(len(j["transitions"][4]["slots"][0]), 13)
         self.assertEqual(len(j["transitions"][4]["slots"][1]), 1)
         self.assertTrue(j["transitions"][4]["slots"][1][-1]['finish'] != 0.0)
         self.assertEqual(len(j["transitions"][5]["slots"]), 1)
-        self.assertEqual(len(j["transitions"][5]["slots"][0]), 1)
+        self.assertEqual(len(j["transitions"][5]["slots"][0]), 4)
 
 def runTests():
     return unittest.main(argv=sys.argv[:1])
@@ -1593,6 +1793,13 @@ if __name__=="__main__":
     parser.add_argument('--showSourceTypes',
                         action='store_true', 
                         help='''Display source module types.''')
+    parser.add_argument('--trace',
+                        action='store_true',
+                        help='''Print the detailed per-transition trace (previous default output).''')
+    parser.add_argument('--summaryField',
+                        default = None,
+                        choices = kSummaryFields,
+                        help='''For the default summary output, print only this quantity instead of all six. Allowed values 'nAlloc', 'nDealloc', 'added', 'minTemp', 'maxTemp', and 'max1Alloc'.''')
 
     args = parser.parse_args()
 
@@ -1615,5 +1822,7 @@ if __name__=="__main__":
             print(json.dumps(sortByAttribute(parser, args.sortBy), indent=2))
         elif args.showSourceTypes:
             showSourceTypes(parser)
-        else:
+        elif args.trace:
             textOutput(parser)
+        else:
+            summaryOutput(parser, args.summaryField)

--- a/PerfTools/AllocMonitor/test/BuildFile.xml
+++ b/PerfTools/AllocMonitor/test/BuildFile.xml
@@ -12,6 +12,8 @@
   <use name="catch2"/>
 </bin>
 
+<test name="TestPerfToolsModuleAllocMonitorAnalyze" command="edmModuleAllocMonitorAnalyze.py -T"/>
+
 <ifrelease name="!ASAN">
   <bin file="test_proxies.cc" name="testAllocMonitorPreload">
     <use name="PerfTools/AllocMonitor"/>

--- a/PerfTools/AllocMonitor/test/runModuleAlloc.sh
+++ b/PerfTools/AllocMonitor/test/runModuleAlloc.sh
@@ -25,6 +25,42 @@ diff allEDModules.log ${LOCAL_TEST_DIR}/unittest_output/allEDModules.log || die 
 grep '^[nN]' moduleAlloc.log.orig | awk '{print $1,$2,$3,$4,$5,$6}' > allESModules.log
 diff allESModules.log ${LOCAL_TEST_DIR}/unittest_output/allESModules.log || die 'differences in allESModules' $?
 
+# per-transition trace output
+edmModuleAllocMonitorAnalyze.py --trace moduleAlloc.log.orig > moduleAlloc.trace.txt || die 'Failure using --trace' $?
+grep -q 'starting action: .* during construction : id=' moduleAlloc.trace.txt || die 'trace missing construction action' $?
+grep -q 'starting: begin job : id=' moduleAlloc.trace.txt || die 'trace missing begin job' $?
+grep -q 'during event : id=' moduleAlloc.trace.txt || die 'trace missing event' $?
+
+# per-module/per-transition/per-activity averaged summary
+edmModuleAllocMonitorAnalyze.py moduleAlloc.log.orig > moduleAlloc.summary.txt || die 'Failure using default summary' $?
+grep -q '^Module label source,'            moduleAlloc.summary.txt || die 'summary missing source' $?
+grep -q '^Module label thingProducer,'     moduleAlloc.summary.txt || die 'summary missing thingProducer' $?
+grep -q '^Module label Thing,'             moduleAlloc.summary.txt || die 'summary missing Thing' $?
+grep -q '^Module label WhatsItESProducer,' moduleAlloc.summary.txt || die 'summary missing ES module' $?
+grep -Eq '^ +event$'             moduleAlloc.summary.txt || die 'summary missing event transition' $?
+grep -Eq '^ +process \(.*calls\)$' moduleAlloc.summary.txt || die 'summary missing calls note' $?
+grep -Eq '^ +nAlloc '            moduleAlloc.summary.txt || die 'summary missing nAlloc avg' $?
+grep -Eq '^ +nAlloc .* max1Alloc [0-9-]+$' moduleAlloc.summary.txt || die 'summary fields not on one row' $?
+# EventSetup modules are split per record/callID
+grep -Eq '^ +process record GadgetRcd callID 0 (.*)$' moduleAlloc.summary.txt || die 'summary missing ES record callID 0' $?
+grep -Eq '^ +process record GadgetRcd callID 4 (.*)$' moduleAlloc.summary.txt || die 'summary missing ES record callID 4' $?
+
+# --summaryField restricts the summary to a single quantity
+edmModuleAllocMonitorAnalyze.py --summaryField max1Alloc moduleAlloc.log.orig > moduleAlloc.summary.max1Alloc.txt || die 'Failure using --summaryField max1Alloc' $?
+grep -Eq '^ +max1Alloc [0-9-]+$' moduleAlloc.summary.max1Alloc.txt || die '--summaryField max1Alloc missing max1Alloc line' $?
+grep -Eq '^ +nAlloc '           moduleAlloc.summary.max1Alloc.txt && die '--summaryField max1Alloc unexpectedly printed nAlloc' 1
+grep -Eq '^ +nDealloc '         moduleAlloc.summary.max1Alloc.txt && die '--summaryField max1Alloc unexpectedly printed nDealloc' 1
+grep -Eq '^ +added '            moduleAlloc.summary.max1Alloc.txt && die '--summaryField max1Alloc unexpectedly printed added' 1
+grep -Eq '^ +minTemp '          moduleAlloc.summary.max1Alloc.txt && die '--summaryField max1Alloc unexpectedly printed minTemp' 1
+grep -Eq '^ +maxTemp '          moduleAlloc.summary.max1Alloc.txt && die '--summaryField max1Alloc unexpectedly printed maxTemp' 1
+
+# an unknown --summaryField value must be rejected by argparse
+if edmModuleAllocMonitorAnalyze.py --summaryField bogus moduleAlloc.log.orig > /dev/null 2>summaryField_bad.log; then
+  die '--summaryField bogus unexpectedly succeeded' 1
+fi
+grep -q 'invalid choice' summaryField_bad.log || die '--summaryField bogus did not report invalid choice' $?
+
+
 ############### only 1 ED module kept
 LD_PRELOAD="libPerfToolsAllocMonitorPreload.so" cmsRun ${LOCAL_TEST_DIR}/moduleAlloc_cfg.py --edmodule || die 'Failure using moduleAlloc_cfg.py --edmodule' $?
 mv moduleAlloc.log moduleAlloc.log.edmodule
@@ -77,3 +113,21 @@ edmModuleAllocJsonToCircles.py acquireTransform.json > acquireTransform.circles.
 grep '"\(record\|type\|label\)": ".*",' acquireTransform.circles.json > acquireTransform.circles.txt
 # to be enabled later when the circles output is stable
 #diff acquireTransform.circles.txt ${LOCAL_TEST_DIR}/unittest_output/acquireTransform.circles.txt || die 'differences in edmModuleAllocJsonToCircles.py output' $?
+
+# summary must expose non-process (acquire) activities on the event transition
+edmModuleAllocMonitorAnalyze.py moduleAllocAcquireTransform.log > acquireTransform.summary.txt || die 'Failure using default summary for acquire+transform' $?
+grep -q '^Module label externalWorkAllocProducer,'   acquireTransform.summary.txt || die 'summary missing externalWork module' $?
+grep -q '^Module label transformAsyncAllocProducer,' acquireTransform.summary.txt || die 'summary missing transformAsync module' $?
+grep -Eq '^ +event$'        acquireTransform.summary.txt || die 'summary missing event transition' $?
+grep -Eq '^ +acquire (.*)$' acquireTransform.summary.txt || die 'summary missing acquire activity' $?
+grep -Eq '^ +process (.*)$' acquireTransform.summary.txt || die 'summary missing process activity' $?
+# ED module (Transform/TransformAsync/ExternalWork) callID must be split, not averaged together
+grep -Eq '^ +process callID 1 (.*)$' acquireTransform.summary.txt || die 'summary missing ED module process callID 1' $?
+grep -Eq '^ +process callID 2 (.*)$' acquireTransform.summary.txt || die 'summary missing ED module process callID 2' $?
+grep -Eq '^ +acquire callID 2 (.*)$' acquireTransform.summary.txt || die 'summary missing ED module acquire callID 2' $?
+# transformAllocProducer has 3 callID-only process lines (1, 2, 3); the
+# 'process' activities for the event transition must be listed with
+# ascending callID even though the underlying trace order is 1, 3, 2.
+awk '/^Module label transformAllocProducer/{p=1} p&&/^[a-zA-Z]/&&!/^Module label transformAllocProducer/{p=0} p&&/^ +process callID [0-9]+ /{print $3}' acquireTransform.summary.txt > transformAllocProducer_callIDs.txt
+printf '1\n2\n3\n' > transformAllocProducer_callIDs_expected.txt
+diff transformAllocProducer_callIDs.txt transformAllocProducer_callIDs_expected.txt || die 'transformAllocProducer process callIDs not sorted ascending' $?


### PR DESCRIPTION
#### PR description:

This PR makes the default output of `edmModuleAllocMonitorAnalyze.py` to be a per-module per-transition summary. The previous default output was moved under `--trace` option. A `--summaryField` option is added to show only one of the measured quantities in the summary. Example of the summary output
```
Module label thingProducer, transitions:
  construction
    process (1 calls)
      nAlloc 270 nDealloc 240 added 5744 minTemp 0 maxTemp 7024 max1Alloc 872
  begin job
    process (1 calls)
      nAlloc 2 nDealloc 2 added 0 minTemp 0 maxTemp 672 max1Alloc 513
  begin stream
    process (1 calls)
      nAlloc 2 nDealloc 2 added 0 minTemp 0 maxTemp 672 max1Alloc 513
  global begin run
    process (1 calls)
      nAlloc 6 nDealloc 3 added 304 minTemp 0 maxTemp 672 max1Alloc 513
  global begin lumi
    process (1 calls)
      nAlloc 6 nDealloc 3 added 304 minTemp 0 maxTemp 672 max1Alloc 513
  event
    process (3 calls)
      nAlloc 7 nDealloc 4 added 304 minTemp 0 maxTemp 672 max1Alloc 513
``` 

Made with AI assistance.

Resolves https://github.com/cms-sw/framework-team/issues/2360

#### PR validation:

Unit tests pass