### PR TITLE
Added dictionaries to fix unnecessary runtime autoparsing

### DIFF
--- a/DataFormats/MuonSeed/src/classes_def.xml
+++ b/DataFormats/MuonSeed/src/classes_def.xml
@@ -4,7 +4,6 @@
       </class>
       <class name="edm::reftobase::BaseHolder<io_v1::L2MuonTrajectorySeed>" />
       <class name="edm::reftobase::IndirectHolder<io_v1::L2MuonTrajectorySeed>" />
-    
       <class name="std::vector<io_v1::L2MuonTrajectorySeed>" />
       <class name="edm::Wrapper<std::vector<io_v1::L2MuonTrajectorySeed> >" splitLevel="0"/>
       <class name="edm::Ref<std::vector<io_v1::L2MuonTrajectorySeed>,io_v1::L2MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<io_v1::L2MuonTrajectorySeed>,io_v1::L2MuonTrajectorySeed> >"/>
@@ -16,6 +15,7 @@
       <class name="edm::reftobase::Holder<io_v1::L2MuonTrajectorySeed,edm::Ref<std::vector<io_v1::L2MuonTrajectorySeed>,io_v1::L2MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<io_v1::L2MuonTrajectorySeed>,io_v1::L2MuonTrajectorySeed> > >"/>
 
       <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<io_v1::L2MuonTrajectorySeed> >, edm::RefProd<std::vector<io_v1::L2MuonTrajectorySeed> > >"/>
+      <class name="edm::OneToMany<std::vector<io_v1::L2MuonTrajectorySeed>,std::vector<io_v1::L2MuonTrajectorySeed>,unsigned int >" />
       <class name="edm::AssociationMap<edm::OneToMany<std::vector<io_v1::L2MuonTrajectorySeed>,std::vector<io_v1::L2MuonTrajectorySeed>, unsigned int > >">
         <field name="transientMap_" transient="true"/>
       </class>

--- a/DataFormats/TrackingRecHitSoA/src/classes_def.xml
+++ b/DataFormats/TrackingRecHitSoA/src/classes_def.xml
@@ -6,7 +6,7 @@
   <class name="reco::TrackingHitsLayout<128, false>"/>
   <class name="reco::HitModulesLayout<128, false>"/>
   <class name="reco::TrackingBlocksLayout<128, false>"/>
-
+  <class name="reco::TrackingBlocksLayout<128,false>::View" />
   <class name="reco::TrackingRecHitHost"  rntupleStreamerMode="true"/>
   <class name="edm::Wrapper<reco::TrackingRecHitHost>" splitLevel="0"/>
 

--- a/SimDataFormats/EncodedEventId/src/classes.h
+++ b/SimDataFormats/EncodedEventId/src/classes.h
@@ -1,2 +1,3 @@
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include <vector>
+#include <utility>

--- a/SimDataFormats/EncodedEventId/src/classes_def.xml
+++ b/SimDataFormats/EncodedEventId/src/classes_def.xml
@@ -3,4 +3,5 @@
    <version ClassVersion="3" checksum="541119857"/>
   </class>
   <class name="std::vector<EncodedEventId>"/>
+  <class name="std::pair<unsigned int,EncodedEventId>"/>
 </lcgdict>

--- a/SimDataFormats/TrackingAnalysis/src/classes_def.xml
+++ b/SimDataFormats/TrackingAnalysis/src/classes_def.xml
@@ -16,6 +16,7 @@
   <class name="std::vector<io_v1::TrackingParticle>" />
   <class name="edm::Wrapper<std::vector<io_v1::TrackingParticle> >" />
   <class name="edm::RefProd<std::vector<io_v1::TrackingParticle> >" />
+  <class name="edm::refhelper::FindUsingAdvance<vector<io_v1::TrackingParticle>,io_v1::TrackingParticle >" />
   <class name="TrackingParticleRef" />
   <class name="edm::Ptr<io_v1::TrackingParticle>" />
   <class name="std::vector<edm::Ptr<io_v1::TrackingParticle>>" />

--- a/SimDataFormats/TrackingHit/src/classes_def.xml
+++ b/SimDataFormats/TrackingHit/src/classes_def.xml
@@ -7,6 +7,7 @@
   <class name="std::vector<const io_v1::PSimHit*>"/>
   <class name="edm::RefProd<std::vector<io_v1::PSimHit> >"/>
   <class name="edm::Ref<std::vector<io_v1::PSimHit>,io_v1::PSimHit,edm::refhelper::FindUsingAdvance<std::vector<io_v1::PSimHit>,io_v1::PSimHit> >"/>
+  <class name="edm::refhelper::FindUsingAdvance<vector<io_v1::PSimHit>,io_v1::PSimHit >" />
 
   <class name="edm::reftobase::BaseHolder<io_v1::PSimHit>"/>
   <class name="edm::reftobase::Holder<io_v1::PSimHit,edm::Ref<std::vector<io_v1::PSimHit>,io_v1::PSimHit,edm::refhelper::FindUsingAdvance<std::vector<io_v1::PSimHit>,io_v1::PSimHit> > >"/>

--- a/TrackingTools/PatternTools/src/classes_def.xml
+++ b/TrackingTools/PatternTools/src/classes_def.xml
@@ -10,6 +10,7 @@
   <class name="edm::Wrapper<std::vector<MomentumConstraint> >" persistent="false"/>
   <class name="edm::RefProd<std::vector<MomentumConstraint> >"/>
 
+  <class name="edm::OneToOne<std::vector<Trajectory>,std::vector<reco::io_v1::Track>,unsigned short >" />
   <class name="edm::AssociationMap<edm::OneToOne<std::vector<Trajectory>,std::vector<reco::Track>,unsigned short > >" >
     <field name="transientMap_" transient="true"/>
   </class>


### PR DESCRIPTION
This PR is a continuation of https://github.com/cms-sw/cmssw/pull/51739  
It adds ROOT dictionary instantiations identified during the investigation of ROOT autoparsing and memory usage. The changes cover several packages, including `DataFormats/MuonSeed `,  `DataFormats/TrackingRecHitSoA`, `SimDataFormats/EncodedEventId`, `SimDataFormats/TrackingAnalysis`, `SimDataFormats/TrackingHit` and `TrackingTools/PatternTools`
The goal is to provide the required dictionaries explicitly and avoid unnecessary runtime autoparsing.

Resolves https://github.com/cms-sw/framework-team/issues/2400