### PR TITLE
Temporarily drop `ticl::TICLAssociationMap` for backward-compatibility

### DIFF
--- a/Alignment/CommonAlignmentMonitor/test/testAlignmentStats_cfg.py
+++ b/Alignment/CommonAlignmentMonitor/test/testAlignmentStats_cfg.py
@@ -54,7 +54,14 @@ process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
 from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_TTbarPhase2RECO
 process.source = cms.Source("PoolSource",
                             fileNames = filesDefaultMC_TTbarPhase2RECO,
-                            duplicateCheckMode = cms.untracked.string('checkAllFilesOpened')
+                            duplicateCheckMode = cms.untracked.string('checkAllFilesOpened'),
+                            # Workaround after renaming SimDataFormats' ticl::AssociationMap
+                            # TODO: revert after new relvals
+                            inputCommands = cms.untracked.vstring([
+                                "keep *",
+                                "drop ticlFractionTypeticlAssociationElementsSimClustersCaloParticlesticlAssociationMap_*_*_*",
+                                "drop ticlSharedEnergyTypefloatstdpairticlAssociationElementssticlTrackstersticlTrackstersticlAssociationMap_*_*_*",
+                            ])
                             )
 
 runboundary = 1

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/DMR_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/DMR_cfg.py
@@ -48,6 +48,14 @@ else:
                                 skipEvents = cms.untracked.uint32(0)
                             )
 
+# Workaround after renaming SimDataFormats' ticl::AssociationMap
+# TODO: revert after new relvals
+process.source.inputCommands = cms.untracked.vstring([
+    "keep *",
+    "drop ticlFractionTypeticlAssociationElementsSimClustersCaloParticlesticlAssociationMap_*_*_*",
+    "drop ticlSharedEnergyTypefloatstdpairticlAssociationElementssticlTrackstersticlTrackstersticlAssociationMap_*_*_*",
+])
+
 ##Get good lumi section
 if "goodlumi" in config["validation"]:
     if os.path.isfile(config["validation"]["goodlumi"]):

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/DiMuonV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/DiMuonV_cfg.py
@@ -54,6 +54,14 @@ else:
                                 fileNames = cms.untracked.vstring(filesDefaultMC_DoubleMuon_string),
                                 skipEvents = cms.untracked.uint32(0))
 
+# Workaround after renaming SimDataFormats' ticl::AssociationMap
+# TODO: revert after new relvals
+process.source.inputCommands = cms.untracked.vstring([
+    "keep *",
+    "drop ticlFractionTypeticlAssociationElementsSimClustersCaloParticlesticlAssociationMap_*_*_*",
+    "drop ticlSharedEnergyTypefloatstdpairticlAssociationElementssticlTrackstersticlTrackstersticlAssociationMap_*_*_*",
+    ])
+
 ###################################################################
 # Get good lumi section and load data or handle MC
 ###################################################################

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/GenericV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/GenericV_cfg.py
@@ -50,6 +50,14 @@ else:
                                 skipEvents = cms.untracked.uint32(0)
                                 ) 
 
+# Workaround after renaming SimDataFormats' ticl::AssociationMap
+# TODO: revert after new relvals
+process.source.inputCommands = cms.untracked.vstring([
+    "keep *",
+    "drop ticlFractionTypeticlAssociationElementsSimClustersCaloParticlesticlAssociationMap_*_*_*",
+    "drop ticlSharedEnergyTypefloatstdpairticlAssociationElementssticlTrackstersticlTrackstersticlAssociationMap_*_*_*",
+    ])
+
 ###################################################################
 # Get good lumi section and load data or handle MC
 ###################################################################

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/PV_cfg.py
@@ -52,6 +52,14 @@ else:
                                 skipEvents = cms.untracked.uint32(0)
                             )
 
+# Workaround after renaming SimDataFormats' ticl::AssociationMap
+# TODO: revert after new relvals
+process.source.inputCommands = cms.untracked.vstring([
+    "keep *",
+    "drop ticlFractionTypeticlAssociationElementsSimClustersCaloParticlesticlAssociationMap_*_*_*",
+    "drop ticlSharedEnergyTypefloatstdpairticlAssociationElementssticlTrackstersticlTrackstersticlAssociationMap_*_*_*",
+    ])
+
 ##Get good lumi section and load data or handle MC
 if "goodlumi" in config["validation"]:
     if os.path.isfile(config["validation"]["goodlumi"]):

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
@@ -51,6 +51,14 @@ else:
                                 skipEvents = cms.untracked.uint32(0)
                                ) 
 
+# Workaround after renaming SimDataFormats' ticl::AssociationMap
+# TODO: revert after new relvals
+process.source.inputCommands = cms.untracked.vstring([
+    "keep *",
+    "drop ticlFractionTypeticlAssociationElementsSimClustersCaloParticlesticlAssociationMap_*_*_*",
+    "drop ticlSharedEnergyTypefloatstdpairticlAssociationElementssticlTrackstersticlTrackstersticlAssociationMap_*_*_*",
+    ])
+
 ###################################################################
 # Get good lumi section and load data or handle MC
 ###################################################################

--- a/Alignment/OfflineValidation/test/DiElectronVertexValidation_cfg.py
+++ b/Alignment/OfflineValidation/test/DiElectronVertexValidation_cfg.py
@@ -199,7 +199,15 @@ else:
     readFiles = cms.untracked.vstring([options.myfile])
 
 process.source = cms.Source("PoolSource",
-                            fileNames = readFiles)
+                            fileNames = readFiles,
+                            # Workaround after renaming SimDataFormats' ticl::AssociationMap
+                            # TODO: revert after new relvals
+                            inputCommands = cms.untracked.vstring([
+                                "keep *",
+                                "drop ticlFractionTypeticlAssociationElementsSimClustersCaloParticlesticlAssociationMap_*_*_*",
+                                "drop ticlSharedEnergyTypefloatstdpairticlAssociationElementssticlTrackstersticlTrackstersticlAssociationMap_*_*_*",
+                            ])
+                            )
 
 ###################################################################
 # TransientTrack from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideTransientTracks

--- a/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
+++ b/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
@@ -215,6 +215,13 @@ else:
 
 process.source = cms.Source("PoolSource",
                             fileNames = readFiles,
+                            # Workaround after renaming SimDataFormats' ticl::AssociationMap
+                            # TODO: revert after new relvals
+                            inputCommands = cms.untracked.vstring([
+                                "keep *",
+                                "drop ticlFractionTypeticlAssociationElementsSimClustersCaloParticlesticlAssociationMap_*_*_*",
+                                "drop ticlSharedEnergyTypefloatstdpairticlAssociationElementssticlTrackstersticlTrackstersticlAssociationMap_*_*_*",
+                            ])
                             #skipEvents = cms.untracked.uint32(45000)
 )
 

--- a/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py
+++ b/Alignment/OfflineValidation/test/SagittaBiasNtuplizer_cfg.py
@@ -131,7 +131,15 @@ else:
     readFiles = cms.untracked.vstring([options.myfile])
 
 process.source = cms.Source("PoolSource",
-                            fileNames = readFiles)
+                            fileNames = readFiles,
+                            # Workaround after renaming SimDataFormats' ticl::AssociationMap
+                            # TODO: revert after new relvals
+                            inputCommands = cms.untracked.vstring([
+                                "keep *",
+                                "drop ticlFractionTypeticlAssociationElementsSimClustersCaloParticlesticlAssociationMap_*_*_*",
+                                "drop ticlSharedEnergyTypefloatstdpairticlAssociationElementssticlTrackstersticlTrackstersticlAssociationMap_*_*_*",
+                            ])
+                            )
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(options.maxEvents))
 

--- a/Alignment/OfflineValidation/test/eopElecTreeWriter_cfg.py
+++ b/Alignment/OfflineValidation/test/eopElecTreeWriter_cfg.py
@@ -62,7 +62,15 @@ process.source = cms.Source("PoolSource",
                                 '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/0abaf7aa-c2ec-4bcb-96f1-d22d5c7bd937.root',
                                 '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/053a2340-040a-4be4-b335-7f546f24bab6.root',
                                 '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/cf187c8c-96e7-4949-9a75-67d4b7696cf8.root',
-                                '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/0c2bfdc1-278c-4e60-8fa1-2ef58cc3a35b.root'))
+                                '/store/relval/CMSSW_20_0_0_pre1/RelValZEE_14/GEN-SIM-RECO/150X_mcRun4_realistic_v1_STD_RegeneratedGS_D121_noPU-v1/2590000/0c2bfdc1-278c-4e60-8fa1-2ef58cc3a35b.root'),
+                            # Workaround after renaming SimDataFormats' ticl::AssociationMap
+                            # TODO: revert after new relvals
+                            inputCommands = cms.untracked.vstring([
+                                "keep *",
+                                "drop ticlFractionTypeticlAssociationElementsSimClustersCaloParticlesticlAssociationMap_*_*_*",
+                                "drop ticlSharedEnergyTypefloatstdpairticlAssociationElementssticlTrackstersticlTrackstersticlAssociationMap_*_*_*",
+                            ])
+                            )
                         
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(options.maxEvents)

--- a/Alignment/OfflineValidation/test/testG4Refitter_cfg.py
+++ b/Alignment/OfflineValidation/test/testG4Refitter_cfg.py
@@ -22,7 +22,14 @@ options.parseArguments()
 ###################################################################
 process.source = cms.Source("PoolSource",
                             fileNames = filesDefaultMC_TTbarPhase2RECO,
-                            duplicateCheckMode = cms.untracked.string('checkAllFilesOpened')
+                            duplicateCheckMode = cms.untracked.string('checkAllFilesOpened'),
+                            # Workaround after renaming SimDataFormats' ticl::AssociationMap
+                            # TODO: revert after new relvals
+                            inputCommands = cms.untracked.vstring([
+                                "keep *",
+                                "drop ticlFractionTypeticlAssociationElementsSimClustersCaloParticlesticlAssociationMap_*_*_*",
+                                "drop ticlSharedEnergyTypefloatstdpairticlAssociationElementssticlTrackstersticlTrackstersticlAssociationMap_*_*_*",
+                            ])
                             )
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )

--- a/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
+++ b/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
@@ -59,7 +59,15 @@ process.options.numberOfThreads = 8
 ###################################################################
 process.source = cms.Source("PoolSource",
                             fileNames = (filesDefaultMC_TTbarPhase2RECO if (options.isPhase2) else filesDefaultMC_TTBarPU),
-                            duplicateCheckMode = cms.untracked.string('checkAllFilesOpened'))
+                            duplicateCheckMode = cms.untracked.string('checkAllFilesOpened'),
+                            # Workaround after renaming SimDataFormats' ticl::AssociationMap
+                            # TODO: revert after new relvals
+                            inputCommands = cms.untracked.vstring([
+                                "keep *",
+                                "drop ticlFractionTypeticlAssociationElementsSimClustersCaloParticlesticlAssociationMap_*_*_*",
+                                "drop ticlSharedEnergyTypefloatstdpairticlAssociationElementssticlTrackstersticlTrackstersticlAssociationMap_*_*_*",
+                            ])
+                            )
 
 runboundary = 1
 process.source.firstRun = cms.untracked.uint32(int(runboundary))

--- a/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
@@ -29,7 +29,14 @@ process.options.numberOfThreads = 8
 ###################################################################
 process.source = cms.Source("PoolSource",
                             fileNames = filesDefaultMC_TTbarPhase2RECO,
-                            duplicateCheckMode = cms.untracked.string('checkAllFilesOpened')
+                            duplicateCheckMode = cms.untracked.string('checkAllFilesOpened'),
+                            # Workaround after renaming SimDataFormats' ticl::AssociationMap 
+                            # TODO: revert after new relvals
+                            inputCommands = cms.untracked.vstring([
+                                "keep *",
+                                "drop ticlFractionTypeticlAssociationElementsSimClustersCaloParticlesticlAssociationMap_*_*_*",
+                                "drop ticlSharedEnergyTypefloatstdpairticlAssociationElementssticlTrackstersticlTrackstersticlAssociationMap_*_*_*",
+                            ])
                             )
 
 runboundary = 1


### PR DESCRIPTION
#### PR description:

This PR drops the collections using the `ticl::TICLAssociationMap` to prevent test failures in with the current relvals, as discussed in PR #51649 and issue #51756.
The problem comes from the renaming of the data structure in PR #51649 and causes the corresponding dictionaries to be not found.

FYI: @Electricks94 @mmusich 