### PR TITLE
Joint customizer for disabling L1 CSF and updating payloads

### DIFF
--- a/RecoTracker/Configuration/python/customizeBPixShapeCSFRegions.py
+++ b/RecoTracker/Configuration/python/customizeBPixShapeCSFRegions.py
@@ -26,3 +26,20 @@ def customizeNoBPixShapeCutL1(process):
     for prod in esproducers_by_type(process, 'ClusterShapeHitFilterESProducer'):
         prod.noBPixShapeCutRegions = regions.copy()
     return process
+
+# Cluster shape payloads retuned for the 2026 Run 3 pixel detector.
+# The L1 file is only relevant when the shape cut is applied on BPix L1,
+# i.e. it is loaded but unused on top of customizeNoBPixShapeCutL1.
+_run3_2026_PixelShapeFile = 'RecoTracker/PixelLowPtUtilities/data/data/run3_2026_L2_L3_L4.par'
+_run3_2026_PixelShapeFileL1 = 'RecoTracker/PixelLowPtUtilities/data/data/run3_2026_L1.par'
+
+def customizeRun3_2026PixelShapePayloads(process):
+    for prod in esproducers_by_type(process, 'ClusterShapeHitFilterESProducer'):
+        prod.PixelShapeFile = _run3_2026_PixelShapeFile
+        prod.PixelShapeFileL1 = _run3_2026_PixelShapeFileL1
+    return process
+
+def customizeNoBPixShapeCutL1Run3_2026(process):
+    process = customizeNoBPixShapeCutL1(process)
+    process = customizeRun3_2026PixelShapePayloads(process)
+    return process


### PR DESCRIPTION
#### PR description:

This PR introduces a customizer that updates the cluster shape filter payloads to Run3_2026 tune, and one that additionally disables the filter in L1. The purpose of the customizer is to simplify tracker studies and enable submission of RelVals without a long list of customizations (e.g., https://gitlab.cern.ch/cms-ppd/monitoring-operation/special-relvals-requests/-/work_items/301)

#### PR validation:

Reco config with and without `--customise RecoTracker/Configuration/customizeBPixShapeCSFRegions.customizeNoBPixShapeCutL1Run3_2026` shows the expected differences in payloads and `noBPixShapeCutRegions` parameter sets. Example, for one of the ESProducer instances
```
<     PixelShapeFile = cms.string('RecoTracker/PixelLowPtUtilities/data/pixelShapePhase1_noL1.par'),
<     PixelShapeFileL1 = cms.string('RecoTracker/PixelLowPtUtilities/data/pixelShapePhase1_loose.par'),
---
>     PixelShapeFile = cms.string('RecoTracker/PixelLowPtUtilities/data/data/run3_2026_L2_L3_L4.par'),
>     PixelShapeFileL1 = cms.string('RecoTracker/PixelLowPtUtilities/data/data/run3_2026_L1.par'),
...
<     noBPixShapeCutRegions = cms.VPSet(template = cms.PSetTemplate(
<         ladders = cms.vuint32(),
<         layers = cms.required.vuint32,
<         modules = cms.vuint32()
---
>     noBPixShapeCutRegions = cms.VPSet(cms.PSet(
>         layers = cms.vuint32(1)
```

When running RECO job on the config with the customizer, LogInfo reports the expected: "[ClusterShapeHitFilter] pixel shape cut disabled for 96 BPix modules" (entire L1)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backports are planned.
