### PR TITLE
implementation of MPI consistency check service

### DIFF
--- a/HeterogeneousCore/MPICore/interface/MPIChannel.h
+++ b/HeterogeneousCore/MPICore/interface/MPIChannel.h
@@ -209,6 +209,9 @@ public:
     }
   }
 
+  // send/receive information about the MPI modules in the current process
+  void sendModulesInfo(std::vector<char> const& buffer);
+
 private:
   // serialize an EDM object to a simplified representation that can be transmitted as an MPI message
   void edmToBuffer_(EDM_MPI_RunAuxiliary_t& buffer, edm::RunAuxiliary const& aux);

--- a/HeterogeneousCore/MPICore/interface/MutableOnceFlag.h
+++ b/HeterogeneousCore/MPICore/interface/MutableOnceFlag.h
@@ -1,0 +1,10 @@
+#ifndef HeterogeneousCore_MPICore_interface_MutableOnceFlag_h
+#define HeterogeneousCore_MPICore_interface_MutableOnceFlag_h
+#include <mutex>
+
+struct MutableOnceFlag {
+  //Using mutable since we want to update the value.
+  mutable std::once_flag information_recorded_flag;
+};
+
+#endif  // HeterogeneousCore_MPICore_interface_MutableOnceFlag_h

--- a/HeterogeneousCore/MPICore/interface/messages.h
+++ b/HeterogeneousCore/MPICore/interface/messages.h
@@ -24,6 +24,7 @@ enum EDM_MPI_MessageTag {
   EDM_MPI_EndLuminosityBlock,
   EDM_MPI_ProcessEvent,
   EDM_MPI_SendMetadata,
+  EDM_MPI_SendModulesInfo,
   EDM_MPI_SendSerializedProduct,
   EDM_MPI_SendTrivialProduct,
   EDM_MPI_SendTrivialCopyProduct,

--- a/HeterogeneousCore/MPICore/plugins/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/plugins/BuildFile.xml
@@ -30,6 +30,7 @@
   <use name="HeterogeneousCore/AlpakaCore"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <use name="HeterogeneousCore/MPICore"/>
+  <use name="HeterogeneousCore/MPIServices"/>
   <use name="HeterogeneousCore/TrivialSerialisation"/>
   <flags ALPAKA_BACKENDS="1"/>
   <flags EDM_PLUGIN="1"/>

--- a/HeterogeneousCore/MPICore/plugins/MPIController.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIController.cc
@@ -33,6 +33,7 @@
 #include "HeterogeneousCore/MPICore/interface/MPIToken.h"
 #include "HeterogeneousCore/MPICore/interface/messages.h"
 #include "HeterogeneousCore/MPIServices/interface/MPIService.h"
+#include "HeterogeneousCore/MPIServices/interface/MPIConsistencyChecker.h"
 
 /* MPIController class
  *
@@ -76,6 +77,7 @@ private:
   std::vector<std::vector<std::unique_ptr<MPIChannel>>> channels_;
   edm::EDPutTokenT<MPIToken> token_;
   Mode mode_;
+  std::string module_label_;
   // Set once beginJob() has sent the initial Connect message to all followers.
   // Used to prevent the MPIController from hanging in it's destructor's
   // MPI_Comm_disconnect() in the case some other module in the local process
@@ -85,7 +87,8 @@ private:
 
 MPIController::MPIController(edm::ParameterSet const& config)
     : token_(produces<MPIToken>()),
-      mode_(parseMode(config.getUntrackedParameter<std::string>("mode")))  //
+      mode_(parseMode(config.getUntrackedParameter<std::string>("mode"))),
+      module_label_(config.getParameter<std::string>("@module_label"))  //
 {
   // Make sure that MPI is initialised.
   MPIService::required();
@@ -153,6 +156,7 @@ MPIController::MPIController(edm::ParameterSet const& config)
       followers_.emplace_back(comm, follower);
       channels_.emplace_back();
     }
+
   } else if (mode_ == kIntercommunicator) {
     // Use an intercommunicator to let two groups of processes communicate with each other.
     // The current implementation supports only two processes: one controller and one source.
@@ -187,6 +191,10 @@ MPIController::MPIController(edm::ParameterSet const& config)
     throw edm::Exception(edm::errors::Configuration)
         << "Invalid mode \"" << config.getUntrackedParameter<std::string>("mode") << "\"";
   }
+
+  // Record the controller name to reconstruct paths for MPI configuration consistency validation
+  edm::Service<MPIConsistencyChecker> module_info_service;
+  module_info_service->registerMPIPathOrigin(module_label_);
 }
 
 MPIController::~MPIController() {
@@ -228,6 +236,15 @@ void MPIController::beginJob() {
     edm::LogInfo("MPI") << keyval.first << ": " << keyval.second;
   }
   */
+
+  edm::Service<MPIConsistencyChecker> module_info_service;
+  module_info_service->reconstructMPIPaths();
+  std::vector<char> buffer;
+  module_info_service->getSerializedMPIModuleInfo(buffer, module_label_);
+  for (auto& follower : followers_) {
+    // transmit the information about the MPI senders and receivers in the current path
+    follower.sendModulesInfo(buffer);
+  }
 }
 
 void MPIController::endJob() {

--- a/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPIReceiver.cc
@@ -1,6 +1,7 @@
 // C++ include files
 #include <cassert>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <utility>
 
@@ -26,13 +27,15 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "HeterogeneousCore/MPICore/interface/MPIChannel.h"
 #include "HeterogeneousCore/MPICore/interface/MPIToken.h"
+#include "HeterogeneousCore/MPICore/interface/MutableOnceFlag.h"
+#include "HeterogeneousCore/MPIServices/interface/MPIConsistencyChecker.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/AnyBuffer.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/SerialiserBase.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/SerialiserFactory.h"
 
-class MPIReceiver : public edm::stream::EDProducer<edm::ExternalWork> {
+class MPIReceiver : public edm::stream::EDProducer<edm::ExternalWork, edm::GlobalCache<MutableOnceFlag>> {
 public:
-  MPIReceiver(edm::ParameterSet const& config)
+  MPIReceiver(edm::ParameterSet const& config, MutableOnceFlag const* cache)
       : upstream_(consumes<MPIToken>(config.getParameter<edm::InputTag>("upstream"))),
         token_(produces<MPIToken>()),
         instance_(config.getParameter<int32_t>("instance")),
@@ -66,7 +69,29 @@ public:
     }
 
     received_wrappers_.resize(products_.size());
+
+    // record information about this receiver for configuration consistency check
+    edm::Service<MPIConsistencyChecker> module_info_service;
+    std::vector<std::string> product_types;
+    product_types.reserve(products_.size());
+    for (auto const& entry : products_) {
+      product_types.push_back(entry.type.name());
+    }
+    std::string module_label = config.getParameter<std::string>("@module_label");
+    std::string upstream_label = config.getParameter<edm::InputTag>("upstream").label();
+    if (cache == nullptr) {
+      throw cms::Exception("MPIReceiver") << "MPIReceiver's global cache is null";
+    }
+    std::call_once(cache->information_recorded_flag, [&]() {
+      module_info_service->recordMPIModuleInfo(false, module_label, upstream_label, this->instance_, product_types);
+    });
   }
+
+  static std::unique_ptr<MutableOnceFlag> initializeGlobalCache(edm::ParameterSet const&) {
+    return std::make_unique<MutableOnceFlag>();
+  }
+
+  static void globalEndJob(MutableOnceFlag const*) {}
 
   void acquire(edm::Event const& event, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder holder) final {
     const MPIToken& token = event.get(upstream_);

--- a/HeterogeneousCore/MPICore/plugins/MPISender.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISender.cc
@@ -1,5 +1,6 @@
 // C++ include files
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <iomanip>
 #include <iostream>
@@ -33,13 +34,15 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "HeterogeneousCore/MPICore/interface/MPIChannel.h"
 #include "HeterogeneousCore/MPICore/interface/MPIToken.h"
+#include "HeterogeneousCore/MPICore/interface/MutableOnceFlag.h"
+#include "HeterogeneousCore/MPIServices/interface/MPIConsistencyChecker.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/AnyBuffer.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/SerialiserBase.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/SerialiserFactory.h"
 
-class MPISender : public edm::stream::EDProducer<edm::ExternalWork> {
+class MPISender : public edm::stream::EDProducer<edm::ExternalWork, edm::GlobalCache<MutableOnceFlag>> {
 public:
-  MPISender(edm::ParameterSet const& config)
+  MPISender(edm::ParameterSet const& config, MutableOnceFlag const* cache)
       : upstream_(consumes<MPIToken>(config.getParameter<edm::InputTag>("upstream"))),
         token_(produces<MPIToken>()),
         instance_(config.getParameter<int32_t>("instance")),
@@ -73,7 +76,29 @@ public:
 
       products_.emplace_back(std::move(entry));
     }
+
+    // record information about this sender for configuration consistency check
+    edm::Service<MPIConsistencyChecker> module_info_service;
+    std::vector<std::string> product_types;
+    product_types.reserve(products_.size());
+    for (auto const& entry : products_) {
+      product_types.push_back(entry.type.name());
+    }
+    std::string module_label = config.getParameter<std::string>("@module_label");
+    std::string upstream_label = config.getParameter<edm::InputTag>("upstream").label();
+    if (cache == nullptr) {
+      throw cms::Exception("MPISender") << "MPISender's global cache is null";
+    }
+    std::call_once(cache->information_recorded_flag, [&]() {
+      module_info_service->recordMPIModuleInfo(true, module_label, upstream_label, this->instance_, product_types);
+    });
   }
+
+  static std::unique_ptr<MutableOnceFlag> initializeGlobalCache(edm::ParameterSet const&) {
+    return std::make_unique<MutableOnceFlag>();
+  }
+
+  static void globalEndJob(MutableOnceFlag const*) {}
 
   void acquire(edm::Event const& event, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder holder) final {
     const MPIToken& token = event.get(upstream_);

--- a/HeterogeneousCore/MPICore/plugins/MPISource.cc
+++ b/HeterogeneousCore/MPICore/plugins/MPISource.cc
@@ -39,6 +39,7 @@
 #include "HeterogeneousCore/MPICore/interface/conversion.h"
 #include "HeterogeneousCore/MPICore/interface/messages.h"
 #include "HeterogeneousCore/MPIServices/interface/MPIService.h"
+#include "HeterogeneousCore/MPIServices/interface/MPIConsistencyChecker.h"
 
 class MPISource : public edm::ProducerSourceBase {
 public:
@@ -70,7 +71,6 @@ private:
   std::vector<std::unique_ptr<MPIChannel>> channels_;
   edm::EDPutTokenT<MPIToken> token_;
   Mode mode_;
-
   edm::ProcessHistory history_;
 
   // temporary value used to pass information from setRunAndEventInfo() to produce()
@@ -148,6 +148,7 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
     // The remote process always has rank 0 in the new communicator.
     remote = 0;
     controller_ = MPIChannel(comm_, remote);
+
   } else if (mode_ == kIntercommunicator) {
     // Use an intercommunicator to let two groups of processes communicate with each other.
     // The current implementation supports only two processes: one controller and one source.
@@ -183,6 +184,10 @@ MPISource::MPISource(edm::ParameterSet const& config, edm::InputSourceDescriptio
     throw edm::Exception(edm::errors::Configuration)
         << "Invalid mode \"" << config.getUntrackedParameter<std::string>("mode") << "\"";
   }
+
+  // Record the source name to reconstruct paths for MPI configuration consistency validation
+  edm::Service<MPIConsistencyChecker> module_info_service;
+  module_info_service->registerMPIPathOrigin("source");
 
   // Wait for a client to connect.
   MPI_Status status;
@@ -316,6 +321,25 @@ bool MPISource::setRunAndEventInfo(edm::EventID& event,
         // receive the LuminosityBlockAuxiliary
         EDM_MPI_LuminosityBlockAuxiliary_t buffer;
         MPI_Mrecv(&buffer, 1, EDM_MPI_LuminosityBlockAuxiliary, &message, &status);
+
+        // receive the next message
+        break;
+      }
+
+      case EDM_MPI_SendModulesInfo: {
+        // receive the serialized modules info
+        int size;
+        MPI_Get_count(&status, MPI_BYTE, &size);
+        std::vector<char> buffer;
+        buffer.resize(size);
+        MPI_Mrecv(buffer.data(), size, MPI_BYTE, &message, &status);
+
+        // deserialize the modules info and compare with local modules
+        std::vector<MPIModuleInfo> remote_modules;
+        edm::Service<MPIConsistencyChecker> module_info_service;
+        module_info_service->deserializeMPIModuleInfo(buffer, remote_modules);
+        module_info_service->reconstructMPIPaths();
+        module_info_service->compareMPIModules(remote_modules, "source", "local", "remote");
 
         // receive the next message
         break;

--- a/HeterogeneousCore/MPICore/plugins/alpaka/MPIReceiverPortable.cc
+++ b/HeterogeneousCore/MPICore/plugins/alpaka/MPIReceiverPortable.cc
@@ -33,6 +33,8 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/MPICore/interface/MPIChannel.h"
 #include "HeterogeneousCore/MPICore/interface/MPIToken.h"
+#include "HeterogeneousCore/MPICore/interface/MutableOnceFlag.h"
+#include "HeterogeneousCore/MPIServices/interface/MPIConsistencyChecker.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/AnyBuffer.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/SerialiserBase.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/SerialiserFactory.h"
@@ -45,10 +47,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   // Inherit from ProducerBase. This is so we have access to the EDMetadata,
   // which we need for synchronization
-  class MPIReceiverPortable : public ProducerBase<edm::stream::EDProducer, edm::ExternalWork> {
+  class MPIReceiverPortable
+      : public ProducerBase<edm::stream::EDProducer, edm::ExternalWork, edm::GlobalCache<MutableOnceFlag>> {
   public:
-    MPIReceiverPortable(edm::ParameterSet const& config)
-        : ProducerBase<edm::stream::EDProducer, edm::ExternalWork>(config),
+    MPIReceiverPortable(edm::ParameterSet const& config, MutableOnceFlag const* cache)
+        : ProducerBase<edm::stream::EDProducer, edm::ExternalWork, edm::GlobalCache<MutableOnceFlag>>(config),
           upstream_(consumes<MPIToken>(config.getParameter<edm::InputTag>("upstream"))),
           token_(this->producesCollector().template produces<MPIToken>()),
           instance_(config.getParameter<int32_t>("instance")) {
@@ -238,7 +241,29 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         products_.emplace_back(std::move(entry));
       }
+
+      // record information about this receiver for configuration consistency check
+      edm::Service<MPIConsistencyChecker> module_info_service;
+      std::vector<std::string> product_types;
+      product_types.reserve(products_.size());
+      for (auto const& entry : products_) {
+        product_types.push_back(entry.typeName);
+      }
+      std::string module_label = config.getParameter<std::string>("@module_label");
+      std::string upstream_label = config.getParameter<edm::InputTag>("upstream").label();
+      if (cache == nullptr) {
+        throw cms::Exception("MPIReceiverPortable") << "MPIReceiverPortable's global cache is null";
+      }
+      std::call_once(cache->information_recorded_flag, [&]() {
+        module_info_service->recordMPIModuleInfo(false, module_label, upstream_label, this->instance_, product_types);
+      });
     }
+
+    static std::unique_ptr<MutableOnceFlag> initializeGlobalCache(edm::ParameterSet const&) {
+      return std::make_unique<MutableOnceFlag>();
+    }
+
+    static void globalEndJob(MutableOnceFlag const*) {}
 
     void acquire(edm::Event const& event, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder holder) final {
       // reset the metadata that could have been left behind by a previous event

--- a/HeterogeneousCore/MPICore/plugins/alpaka/MPISenderPortable.cc
+++ b/HeterogeneousCore/MPICore/plugins/alpaka/MPISenderPortable.cc
@@ -36,6 +36,8 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/MPICore/interface/MPIChannel.h"
 #include "HeterogeneousCore/MPICore/interface/MPIToken.h"
+#include "HeterogeneousCore/MPICore/interface/MutableOnceFlag.h"
+#include "HeterogeneousCore/MPIServices/interface/MPIConsistencyChecker.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/AnyBuffer.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/ReaderBase.h"
 #include "HeterogeneousCore/TrivialSerialisation/interface/SerialiserBase.h"
@@ -48,10 +50,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   // Inherit from ProducerBase. This is so we have access to the EDMetadata,
   // which we need for synchronization
-  class MPISenderPortable : public ProducerBase<edm::stream::EDProducer, edm::ExternalWork> {
+  class MPISenderPortable
+      : public ProducerBase<edm::stream::EDProducer, edm::ExternalWork, edm::GlobalCache<MutableOnceFlag>> {
   public:
-    MPISenderPortable(edm::ParameterSet const& config)
-        : ProducerBase<edm::stream::EDProducer, edm::ExternalWork>(config),
+    MPISenderPortable(edm::ParameterSet const& config, MutableOnceFlag const* cache)
+        : ProducerBase<edm::stream::EDProducer, edm::ExternalWork, edm::GlobalCache<MutableOnceFlag>>(config),
           upstream_(consumes<MPIToken>(config.getParameter<edm::InputTag>("upstream"))),
           token_(this->producesCollector().template produces<MPIToken>()),
           instance_(config.getParameter<int32_t>("instance")) {
@@ -208,7 +211,29 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       LogDebug("MPISenderPortable") << "configured to send " << products_.size()
                                     << " products over MPI channel instance " << instance_;
+
+      // record information about this sender for configuration consistency check
+      edm::Service<MPIConsistencyChecker> module_info_service;
+      std::vector<std::string> product_types;
+      product_types.reserve(products_.size());
+      for (auto const& entry : products_) {
+        product_types.push_back(entry.typeName);
+      }
+      std::string module_label = config.getParameter<std::string>("@module_label");
+      std::string upstream_label = config.getParameter<edm::InputTag>("upstream").label();
+      if (cache == nullptr) {
+        throw cms::Exception("MPISenderPortable") << "MPISenderPortable's global cache is null";
+      }
+      std::call_once(cache->information_recorded_flag, [&]() {
+        module_info_service->recordMPIModuleInfo(true, module_label, upstream_label, this->instance_, product_types);
+      });
     }
+
+    static std::unique_ptr<MutableOnceFlag> initializeGlobalCache(edm::ParameterSet const&) {
+      return std::make_unique<MutableOnceFlag>();
+    }
+
+    static void globalEndJob(MutableOnceFlag const*) {}
 
     void acquire(edm::Event const& event, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder holder) final {
       MPIToken const& token = event.get(upstream_);

--- a/HeterogeneousCore/MPICore/python/configuration_splitter/editor_functions.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/editor_functions.py
@@ -8,6 +8,7 @@ from HeterogeneousCore.MPICore.modules import *
 
 def add_controller_to_local(process, remote_name):
     process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+    process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
     process.MPIService.pmix_server_uri = "file:server.uri"
     controller_name = f"mpiController{remote_name.title()}"
     controller = cms.EDProducer("MPIController",
@@ -44,6 +45,7 @@ def create_remote_process(local_process, modules_to_run, remote_process_name, lo
         remote_process.MessageLogger = local_process.MessageLogger.clone()
 
     remote_process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+    remote_process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
     remote_process.MPIService.pmix_server_uri = "file:server.uri"
 
     # where do i get this firstRun parameter from?
@@ -75,7 +77,7 @@ def make_sender_psets(products):
         psets.append(
             cms.PSet(
                 type=cms.string(p["type"]),
-                name=cms.InputTag(p["module"])
+                name=cms.InputTag(p["module"], p['product_instance'])
             )
         )
 

--- a/HeterogeneousCore/MPICore/src/MPIChannel.cc
+++ b/HeterogeneousCore/MPICore/src/MPIChannel.cc
@@ -388,3 +388,8 @@ void MPIChannel::receiveInitializedTrivialCopyAsync(int instance,
     MPI_Irecv(regions[i].data(), regions[i].size_bytes(), MPI_BYTE, dest_, tag, comm_, &requests[base + i]);
   }
 }
+
+void MPIChannel::sendModulesInfo(std::vector<char> const& buffer) {
+  int tag = EDM_MPI_SendModulesInfo;
+  MPI_Send(buffer.data(), buffer.size(), MPI_BYTE, dest_, tag, comm_);
+}

--- a/HeterogeneousCore/MPICore/test/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/test/BuildFile.xml
@@ -18,6 +18,11 @@
 />
 
 <test
+  name="testMPINestedEventId"
+  command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/nested_config_a_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/nested_config_b_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/nested_config_c_cfg.py"
+/>
+
+<test
   name="testMPIRoundRobinEventId"
   command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_rr_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_cfg.py"
 />

--- a/HeterogeneousCore/MPICore/test/controller_complex_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_complex_cfg.py
@@ -22,6 +22,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 from HeterogeneousCore.MPICore.modules import *
 

--- a/HeterogeneousCore/MPICore/test/controller_filters_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_filters_cfg.py
@@ -19,6 +19,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 from eventlist_cff import eventlist
 process.source = cms.Source("EmptySourceFromEventIDs",

--- a/HeterogeneousCore/MPICore/test/controller_multi_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_multi_cfg.py
@@ -16,6 +16,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 from eventlist_cff import eventlist
 process.source = cms.Source("EmptySourceFromEventIDs",

--- a/HeterogeneousCore/MPICore/test/controller_multi_rr_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_multi_rr_cfg.py
@@ -16,6 +16,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 from eventlist_cff import eventlist
 process.source = cms.Source("EmptySourceFromEventIDs",

--- a/HeterogeneousCore/MPICore/test/controller_rr_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_rr_cfg.py
@@ -16,6 +16,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 from eventlist_cff import eventlist
 process.source = cms.Source("EmptySourceFromEventIDs",

--- a/HeterogeneousCore/MPICore/test/controller_soa_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_soa_cfg.py
@@ -22,6 +22,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 # produce and send a portable object, a portable collection, and some portable multicollections
 process.load("Configuration.StandardSequences.Accelerators_cff")
@@ -65,7 +66,7 @@ process.sender = MPISender(
     ),
     dict(
         type = "ushort",
-        name = 'producePortableObjects@backend'
+        name = 'producePortableObjects:backend'
     )]
 )
 
@@ -93,7 +94,7 @@ process.senderNoTrivialSerialisation = MPISender(
     ),
     dict(
         type = "ushort",
-        name = 'producePortableObjects@backend'
+        name = 'producePortableObjects:backend'
     )]
 )
 

--- a/HeterogeneousCore/MPICore/test/controller_soa_device_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_soa_device_cfg.py
@@ -16,6 +16,7 @@ process.source = cms.Source("EmptySource")
 process.maxEvents.input = 10
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 # produce and send device collections
 process.load("Configuration.StandardSequences.Accelerators_cff")

--- a/HeterogeneousCore/MPICore/test/controller_too_many_streams_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_too_many_streams_cfg.py
@@ -29,6 +29,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 from eventlist_cff import eventlist
 process.source = cms.Source("EmptySourceFromEventIDs",

--- a/HeterogeneousCore/MPICore/test/follower_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_cfg.py
@@ -15,6 +15,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 from HeterogeneousCore.MPICore.modules import *
 

--- a/HeterogeneousCore/MPICore/test/follower_complex_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_complex_cfg.py
@@ -13,6 +13,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 from HeterogeneousCore.MPICore.modules import *
 

--- a/HeterogeneousCore/MPICore/test/follower_filters_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_filters_cfg.py
@@ -15,6 +15,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 from HeterogeneousCore.MPICore.modules import MPISource, MPIReceiver, MPISender
 

--- a/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_multi1_cfg.py
@@ -15,6 +15,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 from HeterogeneousCore.MPICore.modules import *
 

--- a/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_multi2_cfg.py
@@ -15,6 +15,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 from HeterogeneousCore.MPICore.modules import *
 

--- a/HeterogeneousCore/MPICore/test/follower_soa_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_soa_cfg.py
@@ -13,6 +13,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 from HeterogeneousCore.MPICore.modules import *
 

--- a/HeterogeneousCore/MPICore/test/follower_soa_device_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_soa_device_cfg.py
@@ -7,6 +7,7 @@ process.options.numberOfStreams = 4
 process.options.wantSummary = False
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 # needed for MPIReceiverPortable and the automatic device-to-host conversion
 process.load("Configuration.StandardSequences.Accelerators_cff")

--- a/HeterogeneousCore/MPICore/test/follower_too_many_streams_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_too_many_streams_cfg.py
@@ -15,6 +15,7 @@ process.MessageLogger.cerr.MPI = cms.untracked.PSet(
 )
 
 process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
 
 from HeterogeneousCore.MPICore.modules import *
 

--- a/HeterogeneousCore/MPICore/test/nested_config_a_cfg.py
+++ b/HeterogeneousCore/MPICore/test/nested_config_a_cfg.py
@@ -1,10 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("MPIController")
+process = cms.Process("ConfigA")
 
 process.options.numberOfThreads = 4
 process.options.numberOfStreams = 4
-# MPIController supports a single concurrent LuminosityBlock
 process.options.numberOfConcurrentLuminosityBlocks = 1
 process.options.numberOfConcurrentRuns = 1
 process.options.wantSummary = False
@@ -29,7 +28,7 @@ from HeterogeneousCore.MPICore.modules import *
 
 process.mpiController = MPIController(
     mode = 'CommWorld',
-    followerProcessName = 'Follower'
+    followerProcessName = 'ConfigB'
 )
 
 process.ids = cms.EDProducer("edmtest::EventIDProducer")
@@ -47,26 +46,4 @@ process.sender = MPISender(
     )]
 )
 
-process.othersender = MPISender(
-    upstream = "mpiController",
-    instance = 19,
-    products = [ dict(
-        type = "edm::EventID",
-        name = 'ids'
-    )]
-)
-
-process.receiver = MPIReceiver(
-    upstream = "othersender",   # guarantees that this module will only run after "othersender" has run
-    instance = 99,
-    products = [ dict(
-        type = "edm::EventID",
-        label = ""
-    )]
-)
-
-process.finalcheck = cms.EDAnalyzer("edmtest::EventIDValidator",
-    source = cms.untracked.InputTag('receiver')
-)
-
-process.path = cms.Path(process.mpiController + process.ids + process.initialcheck + process.sender + process.othersender + process.receiver + process.finalcheck)
+process.path = cms.Path(process.mpiController + process.ids + process.initialcheck + process.sender)

--- a/HeterogeneousCore/MPICore/test/nested_config_b_cfg.py
+++ b/HeterogeneousCore/MPICore/test/nested_config_b_cfg.py
@@ -1,0 +1,59 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ConfigB")
+
+process.options.numberOfThreads = 8
+process.options.numberOfStreams = 8
+process.options.numberOfConcurrentLuminosityBlocks = 1
+process.options.numberOfConcurrentRuns = 1
+process.options.wantSummary = False
+
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
+process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
+
+from HeterogeneousCore.MPICore.modules import *
+
+process.source = MPISource(
+    mode = 'CommWorld',
+    controllerProcessName = 'ConfigA'
+)
+
+process.maxEvents.input = -1
+
+# Receive data from ConfigA
+process.receiver = MPIReceiver(
+    upstream = "source",
+    instance = 42,
+    products = [ dict(
+        type = "edm::EventID",
+        label = ""
+    )]
+)
+
+process.checkA = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag("receiver")
+)
+
+# Act as controller for ConfigC
+process.mpiController = MPIController(
+    mode = 'CommWorld',
+    followerProcessName = 'ConfigC'
+)
+
+# Send (potentially modified) data to ConfigC
+process.sender = MPISender(
+    upstream = "mpiController",
+    instance = 99,
+    products = [ dict(
+        type = "edm::EventID",
+        name = 'receiver'
+    )]
+)
+
+process.path = cms.Path(process.receiver + process.checkA + process.mpiController + process.sender)

--- a/HeterogeneousCore/MPICore/test/nested_config_c_cfg.py
+++ b/HeterogeneousCore/MPICore/test/nested_config_c_cfg.py
@@ -1,0 +1,43 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ConfigC")
+
+process.options.numberOfThreads = 6
+process.options.numberOfStreams = 6
+process.options.numberOfConcurrentLuminosityBlocks = 1
+process.options.numberOfConcurrentRuns = 1
+process.options.wantSummary = False
+
+process.load("FWCore.ParameterSet.MessageLogger")
+process.MessageLogger.cerr.MPI = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32( 1 ),
+    limit = cms.untracked.int32( 10000000 )
+)
+
+process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
+
+from HeterogeneousCore.MPICore.modules import *
+
+process.source = MPISource(
+    mode = 'CommWorld',
+    controllerProcessName = 'ConfigB'
+)
+
+process.maxEvents.input = -1
+
+# Receive data from ConfigB
+process.receiver = MPIReceiver(
+    upstream = "source",
+    instance = 99,
+    products = [ dict(
+        type = "edm::EventID",
+        label = ""
+    )]
+)
+
+process.finalcheck = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag("receiver")
+)
+
+process.path = cms.Path(process.receiver + process.finalcheck)

--- a/HeterogeneousCore/MPIServices/BuildFile.xml
+++ b/HeterogeneousCore/MPIServices/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="mpi"/>
+<use name="rootrio"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
 <export>

--- a/HeterogeneousCore/MPIServices/README.md
+++ b/HeterogeneousCore/MPIServices/README.md
@@ -1,0 +1,21 @@
+This package contains the services related to remote offloading via MPI.
+
+## MPI services
+
+- `MPIService` initializes MPI for a CMSSW job and provides job-wide api for processes
+to exchange their names in order to find correspondence between MPI ranks of discovered
+processes and their pre-configured names
+
+- `MPIConsistencyChecker` checks
+that for all senders/receivers in a configuration there is a correct pair on the other side, 
+helping to detect mismatches, that could otherwise cause a distributed job to hang.
+
+### Usage
+
+Both services have to be added in a CMSSW configuration in order to use MPI modules:
+
+```python
+process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
+```
+

--- a/HeterogeneousCore/MPIServices/interface/MPIConsistencyChecker.h
+++ b/HeterogeneousCore/MPIServices/interface/MPIConsistencyChecker.h
@@ -1,0 +1,53 @@
+#ifndef HeterogeneousCore_MPIServices_interface_MPIConsistencyChecker_h
+#define HeterogeneousCore_MPIServices_interface_MPIConsistencyChecker_h
+
+#include <mutex>
+#include <string>
+#include <cstring>
+#include <unordered_map>
+#include <vector>
+
+// ROOT headers
+#include <TBufferFile.h>
+#include <TClass.h>
+#include <Rtypes.h>
+
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
+struct MPIModuleInfo {
+  bool is_sender;
+  int instance;
+  std::string module_label;
+  std::vector<std::string> product_types;
+};
+
+class MPIConsistencyChecker {
+public:
+  MPIConsistencyChecker(edm::ParameterSet const& config);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void required();
+
+  void recordMPIModuleInfo(bool is_sender,
+                           std::string const& module_label,
+                           std::string const& upstream_label,
+                           int instance,
+                           std::vector<std::string> const& product_types);
+  void registerMPIPathOrigin(std::string const& controller_or_source_name);
+  void reconstructMPIPaths();
+  void getSerializedMPIModuleInfo(std::vector<char>& buffer, std::string const& origin_name);
+  void deserializeMPIModuleInfo(std::vector<char> const& buffer, std::vector<MPIModuleInfo>& info);
+  void compareMPIModules(std::vector<MPIModuleInfo> const& other,
+                         std::string const& origin_name,
+                         std::string const& other_process_name,
+                         std::string const& this_process_name);
+
+private:
+  std::once_flag paths_reconstructed_flag_;
+  std::vector<MPIModuleInfo> modules_info_;
+  std::vector<std::string> module_upstream_labels_;
+  std::mutex modules_info_mutex_;
+  std::unordered_map<std::string, std::vector<MPIModuleInfo>> mpi_paths_mappings_;
+};
+
+#endif  // HeterogeneousCore_MPIServices_interface_MPIConsistencyChecker_h

--- a/HeterogeneousCore/MPIServices/interface/MPIService.h
+++ b/HeterogeneousCore/MPIServices/interface/MPIService.h
@@ -14,9 +14,11 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   static void required();
+
   std::vector<int> getRanksByProcessName(std::string const& processName);
 
 private:
+  // variables related to process hash exchange
   std::once_flag init_flag_;
   std::vector<uint64_t> all_process_hashes_;
 

--- a/HeterogeneousCore/MPIServices/plugins/MPIConsistencyChecker.cc
+++ b/HeterogeneousCore/MPIServices/plugins/MPIConsistencyChecker.cc
@@ -1,0 +1,3 @@
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "HeterogeneousCore/MPIServices/interface/MPIConsistencyChecker.h"
+DEFINE_FWK_SERVICE_MAKER(MPIConsistencyChecker, edm::serviceregistry::ParameterSetMaker<MPIConsistencyChecker>);

--- a/HeterogeneousCore/MPIServices/src/MPIConsistencyChecker.cc
+++ b/HeterogeneousCore/MPIServices/src/MPIConsistencyChecker.cc
@@ -1,0 +1,195 @@
+// -*- C++ -*-
+#include <algorithm>
+#include <mutex>
+#include <sstream>
+#include <unordered_map>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "HeterogeneousCore/MPIServices/interface/MPIConsistencyChecker.h"
+
+MPIConsistencyChecker::MPIConsistencyChecker(edm::ParameterSet const&) {}
+
+void MPIConsistencyChecker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.add("MPIConsistencyChecker", desc);
+  descriptions.setComment("This service records and validates MPI sender and receiver module information.");
+}
+
+void MPIConsistencyChecker::required() {
+  edm::Service<MPIConsistencyChecker> service;
+  if (not service.isAvailable()) {
+    throw cms::Exception("Configuration") << R"(The MPIConsistencyChecker is required by this module.
+Please add it to the configuration, for example via
+
+process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
+)";
+  }
+}
+
+void MPIConsistencyChecker::recordMPIModuleInfo(bool is_sender,
+                                                std::string const& module_label,
+                                                std::string const& upstream_label,
+                                                int instance,
+                                                std::vector<std::string> const& product_types) {
+  std::lock_guard<std::mutex> lock(modules_info_mutex_);
+  modules_info_.push_back(MPIModuleInfo{is_sender, instance, module_label, product_types});
+  module_upstream_labels_.push_back(upstream_label);
+}
+
+void MPIConsistencyChecker::getSerializedMPIModuleInfo(std::vector<char>& buffer, std::string const& origin_name) {
+  std::lock_guard<std::mutex> lock(modules_info_mutex_);
+  auto const& modules = mpi_paths_mappings_[origin_name];
+  TBufferFile buf(TBuffer::kWrite);
+
+  TClass* cls = TClass::GetClass<std::vector<MPIModuleInfo>>();
+
+  if (!cls) {
+    throw cms::Exception("MPIConsistencyChecker") << "Failed to get TClass for std::vector<MPIModuleInfo>";
+  }
+
+  // We use const_cast here because TBufferFile::Streamer requires a non-const pointer, even though it does not modify the vector.
+  cls->Streamer(const_cast<std::vector<MPIModuleInfo>*>(&modules), buf);
+
+  buffer.resize(buf.Length());
+  std::memcpy(buffer.data(), buf.Buffer(), buf.Length());
+}
+
+void MPIConsistencyChecker::deserializeMPIModuleInfo(std::vector<char> const& buffer,
+                                                     std::vector<MPIModuleInfo>& info) {
+  // We use const_cast here because TBufferFile::Streamer requires a non-const pointer, even though it does not modify the buffer.
+  TBufferFile buf(TBuffer::kRead, buffer.size(), const_cast<char*>(buffer.data()), false);
+  TClass* cls = TClass::GetClass<std::vector<MPIModuleInfo>>();
+
+  if (!cls) {
+    throw cms::Exception("MPIConsistencyChecker") << "Failed to get TClass for std::vector<MPIModuleInfo>";
+  }
+
+  cls->Streamer(&info, buf);
+}
+
+void MPIConsistencyChecker::registerMPIPathOrigin(std::string const& origin_name) {
+  std::lock_guard<std::mutex> lock(modules_info_mutex_);
+  mpi_paths_mappings_.try_emplace(origin_name);
+}
+
+void MPIConsistencyChecker::reconstructMPIPaths() {
+  std::call_once(paths_reconstructed_flag_, [&]() {
+    std::lock_guard<std::mutex> lock(modules_info_mutex_);
+    std::unordered_map<std::string, size_t> module_by_label;
+    for (size_t i = 0; i < modules_info_.size(); ++i) {
+      module_by_label.emplace(modules_info_[i].module_label, i);
+    }
+
+    std::vector<std::pair<std::string, size_t>> module_paths(modules_info_.size());
+    for (size_t i = 0; i < modules_info_.size(); ++i) {
+      std::string origin = module_upstream_labels_[i];
+      size_t distance = 0;
+      std::vector<bool> visited(modules_info_.size(), false);
+
+      while (not mpi_paths_mappings_.count(origin)) {
+        auto module = module_by_label.find(origin);
+        if (module == module_by_label.end() || visited[module->second]) {
+          throw cms::Exception("MPIConsistencyChecker")
+              << "Could not assign MPI module " << modules_info_[i].module_label << " to any MPI path";
+        }
+        visited[module->second] = true;
+        origin = module_upstream_labels_[module->second];
+        ++distance;
+      }
+      module_paths[i] = {origin, distance};
+    }
+
+    for (auto& path : mpi_paths_mappings_) {
+      std::vector<size_t> indices;
+      for (size_t i = 0; i < module_paths.size(); ++i) {
+        if (module_paths[i].first == path.first) {
+          indices.push_back(i);
+        }
+      }
+      std::stable_sort(indices.begin(), indices.end(), [&](size_t left, size_t right) {
+        return module_paths[left].second < module_paths[right].second;
+      });
+      for (auto index : indices) {
+        path.second.push_back(modules_info_[index]);
+      }
+    }
+  });
+}
+
+void MPIConsistencyChecker::compareMPIModules(std::vector<MPIModuleInfo> const& other,
+                                              std::string const& origin_name,
+                                              std::string const& other_process_name,
+                                              std::string const& this_process_name) {
+  std::lock_guard<std::mutex> lock(modules_info_mutex_);
+  auto const& local_modules = mpi_paths_mappings_[origin_name];
+
+  // print the local and remote modules info for debugging
+  LogDebug("MPIConsistencyChecker") << "Local MPI modules info: ";
+  for (auto const& module : local_modules) {
+    LogDebug("MPIConsistencyChecker") << "  is_sender: " << module.is_sender << ", instance: " << module.instance
+                                      << ", product_types: ";
+    for (auto const& type : module.product_types) {
+      LogDebug("MPIConsistencyChecker") << "    " << type;
+    }
+  }
+  LogDebug("MPIConsistencyChecker") << "Remote MPI modules info: ";
+  for (auto const& module : other) {
+    LogDebug("MPIConsistencyChecker") << "  is_sender: " << module.is_sender << ", instance: " << module.instance
+                                      << ", product_types: ";
+    for (auto const& type : module.product_types) {
+      LogDebug("MPIConsistencyChecker") << "    " << type;
+    }
+  }
+
+  std::vector<std::string> errors;
+  if (local_modules.size() != other.size()) {
+    std::ostringstream error;
+    error << "Mismatch in number of MPI modules between process " << this_process_name << " and process "
+          << other_process_name << ": " << local_modules.size() << " vs " << other.size();
+    errors.push_back(error.str());
+  }
+  for (auto const& local_module : local_modules) {
+    auto it = std::find_if(other.begin(), other.end(), [&](MPIModuleInfo const& remote_module) {
+      return remote_module.is_sender != local_module.is_sender && remote_module.instance == local_module.instance;
+    });
+    if (it == other.end()) {
+      std::ostringstream error;
+      error << "No matching sender/receiver found in process " << other_process_name << " for MPI module instance "
+            << local_module.instance << " label " << local_module.module_label << " in process " << this_process_name;
+      errors.push_back(error.str());
+      continue;
+    }
+    if (local_module.product_types.size() != it->product_types.size()) {
+      std::ostringstream error;
+      error << "Mismatch in number of product types between sender module " << local_module.instance << " label "
+            << local_module.module_label << " in process " << this_process_name << " and receiver module "
+            << it->instance << " in process " << other_process_name << ": " << local_module.product_types.size()
+            << " vs " << it->product_types.size();
+      errors.push_back(error.str());
+      continue;
+    }
+    for (size_t i = 0; i < local_module.product_types.size(); ++i) {
+      if (local_module.product_types[i] != it->product_types[i]) {
+        std::ostringstream error;
+        error << "Mismatch in product type at index " << i << " between sender module " << local_module.instance
+              << " label " << local_module.module_label << " in process " << this_process_name << " ("
+              << local_module.product_types[i] << ") and receiver module " << it->instance << " label "
+              << it->module_label << " in process " << other_process_name << " (" << it->product_types[i] << ")";
+        errors.push_back(error.str());
+      }
+    }
+  }
+  if (not errors.empty()) {
+    cms::Exception exception("MPIConsistencyChecker");
+    exception << "Found " << errors.size() << " MPI consistency error(s):";
+    for (auto const& error : errors) {
+      exception << "\n  - " << error;
+    }
+    throw exception;
+  }
+}

--- a/HeterogeneousCore/MPIServices/src/classes.h
+++ b/HeterogeneousCore/MPIServices/src/classes.h
@@ -1,0 +1,1 @@
+#include "HeterogeneousCore/MPIServices/interface/MPIConsistencyChecker.h"

--- a/HeterogeneousCore/MPIServices/src/classes_def.xml
+++ b/HeterogeneousCore/MPIServices/src/classes_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="MPIModuleInfo" splitLevel="0"/>
+  <class name="std::vector<MPIModuleInfo>" splitLevel="0"/>
+</lcgdict>


### PR DESCRIPTION
#### PR description:

This pull request adds runtime verification whether in case of using remote offloading functionality the senders-receivers pairs on local and remote are consistent (eg. matching instances and matching types). It adds MPIConsistencyChecker service to store information about MPI modules in the current process + helper functions for serialization and comparison. 

#### PR validation:

The existing tests pass
