### PR TITLE
Simplify ROOT dictionaries of SoALayouts

### DIFF
--- a/DataFormats/EcalDigi/src/classes_def.xml
+++ b/DataFormats/EcalDigi/src/classes_def.xml
@@ -142,7 +142,6 @@
    <!-- ::Layout alias must be listed before the aliased-to type -->
    <class name="EcalDigiHostCollection::Layout"/>
    <class name="EcalDigiSoA"/>
-   <class name="EcalDigiSoA::View"/>
    <class name="EcalDigiHostCollection" rntupleStreamerMode="true"/>
    <class name="edm::Wrapper<EcalDigiHostCollection>" splitLevel="0"/>
 
@@ -150,7 +149,6 @@
    <!-- ::Layout alias must be listed before the aliased-to type -->
    <class name="EcalDigiPhase2HostCollection::Layout"/>
    <class name="EcalDigiPhase2SoA"/>
-   <class name="EcalDigiPhase2SoA::View"/>
    <class name="EcalDigiPhase2HostCollection" rntupleStreamerMode="true"/>
    <class name="edm::Wrapper<EcalDigiPhase2HostCollection>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/EcalRecHit/src/classes_def.xml
+++ b/DataFormats/EcalRecHit/src/classes_def.xml
@@ -43,14 +43,12 @@
   <class name="EcalUncalibratedRecHitHostCollection::Layout"/>
   <class name="EcalOotAmpArray"/>
   <class name="EcalUncalibratedRecHitSoA"/>
-  <class name="EcalUncalibratedRecHitSoA::View"/>
   <class name="edm::Wrapper<EcalUncalibratedRecHitHostCollection>" splitLevel="0"/>
 
   <class name="EcalRecHitHostCollection" rntupleStreamerMode="true"/>
   <!-- EcalRecHitHostCollection::Layout must be listed before the aliased-to type -->
   <class name="EcalRecHitHostCollection::Layout"/>
   <class name="EcalRecHitSoA"/>
-  <class name="EcalRecHitSoA::View"/>
   <class name="edm::Wrapper<EcalRecHitHostCollection>" splitLevel="0"/>
 
 </lcgdict>

--- a/DataFormats/HGCalDigi/src/classes_def.xml
+++ b/DataFormats/HGCalDigi/src/classes_def.xml
@@ -51,7 +51,6 @@
   <!-- ::Layout alias must be listed before the aliased-to type -->
   <class name="hgcaldigi::HGCalDigiHost::Layout"/>
   <class name="hgcaldigi::HGCalDigiSoA"/>
-  <class name="hgcaldigi::HGCalDigiSoA::View"/>
 
   <class name="hgcaldigi::HGCalDigiSoALayout<128,false>"/>
   <class name="edm::Wrapper<PortableHostCollection<hgcaldigi::HGCalDigiSoALayout<128,false> > >" splitLevel="0"/>
@@ -60,21 +59,18 @@
   <!-- ::Layout alias must be listed before the aliased-to type -->
   <class name="hgcaldigi::HGCalECONDPacketInfoHost::Layout"/>
   <class name="hgcaldigi::HGCalECONDPacketInfoSoA"/>
-  <class name="hgcaldigi::HGCalECONDPacketInfoSoA::View"/>
   <class name="edm::Wrapper<hgcaldigi::HGCalECONDPacketInfoHost>" splitLevel="0"/>
 
   <class name="hgcaldigi::HGCalFEDPacketInfoHost" rntupleStreamerMode="true"/>
   <!-- ::Layout alias must be listed before the aliased-to type -->
   <class name="hgcaldigi::HGCalFEDPacketInfoHost::Layout"/>
   <class name="hgcaldigi::HGCalFEDPacketInfoSoA"/>
-  <class name="hgcaldigi::HGCalFEDPacketInfoSoA::View"/>
   <class name="edm::Wrapper<hgcaldigi::HGCalFEDPacketInfoHost>" splitLevel="0"/>
 
   <class name="hgcaldigi::HGCalDigiTriggerHost" rntupleStreamerMode="true"/>
   <!-- ::Layout alias must be listed before the aliased-to type -->
   <class name="hgcaldigi::HGCalDigiTriggerHost::Layout"/>
   <class name="hgcaldigi::HGCalDigiTriggerSoA"/>
-  <class name="hgcaldigi::HGCalDigiTriggerSoA::View"/>
   <class name="hgcaldigi::HGCalDigiTriggerSoALayout<128,false>"/>
   <class name="edm::Wrapper<PortableHostCollection<hgcaldigi::HGCalDigiTriggerSoALayout<128,false> > >" splitLevel="0"/>
   

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -71,7 +71,6 @@
   <!-- MtdHostCollection::Layout must be listed before the aliased-to type -->
   <class name="MtdHostCollection::Layout"/>
   <class name="MtdSoA"/>
-  <class name="MtdSoA::View"/>
   <class name="edm::Wrapper<MtdHostCollection>" splitLevel="0"/>
 
   <class name="HGCalSoARecHitsHostCollection" rntupleStreamerMode="true"/>

--- a/DataFormats/HcalDigi/src/classes_def.xml
+++ b/DataFormats/HcalDigi/src/classes_def.xml
@@ -115,14 +115,12 @@
   <!-- hcal::Phase1DigiHostCollection::Layout must be listed before the aliased-to type -->
   <class name="hcal::Phase1DigiHostCollection::Layout"/>
   <class name="hcal::HcalPhase1DigiSoA"/>
-  <class name="hcal::HcalPhase1DigiSoA::View"/>
   <class name="edm::Wrapper<hcal::Phase1DigiHostCollection>" splitLevel="0"/>
 
   <class name="hcal::Phase0DigiHostCollection" rntupleStreamerMode="true"/> 
   <!-- hcal::Phase0DigiHostCollection::Layout must be listed before the aliased-to type -->
   <class name="hcal::Phase0DigiHostCollection::Layout"/>
   <class name="hcal::HcalPhase0DigiSoA"/>
-  <class name="hcal::HcalPhase0DigiSoA::View"/>
   <class name="edm::Wrapper<hcal::Phase0DigiHostCollection>" splitLevel="0"/>
 
 </lcgdict>

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -105,6 +105,5 @@
   <!-- hcal::RecHitHostCollection::Layout must be listed before the aliased-to type -->
   <class name="hcal::RecHitHostCollection::Layout" />
   <class name="hcal::HcalRecHitSoA"/>
-  <class name="hcal::HcalRecHitSoA::View"/>
   <class name="edm::Wrapper<hcal::RecHitHostCollection>" splitLevel="0"/>
   </lcgdict>

--- a/DataFormats/ParticleFlowReco/src/classes_serial_def.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_serial_def.xml
@@ -3,27 +3,23 @@
   <!-- reco::CaloRecHitHostCollection::Layout must be listed before the aliased-to type -->
   <class name="reco::CaloRecHitHostCollection::Layout"/>
   <class name="reco::CaloRecHitSoA"/>
-  <class name="reco::CaloRecHitSoA::View"/>
   <class name="edm::Wrapper<reco::CaloRecHitHostCollection>" splitLevel="0"/>
 
   <class name="reco::PFRecHitHostCollection" rntupleStreamerMode="true"/>
   <!-- reco::PFRecHitHostCollection::Layout must be listed before the aliased-to type -->
   <class name="reco::PFRecHitHostCollection::Layout"/>
   <class name="reco::PFRecHitSoA"/>
-  <class name="reco::PFRecHitSoA::View"/>
   <class name="edm::Wrapper<reco::PFRecHitHostCollection>" splitLevel="0"/>
 
   <class name="reco::PFClusterHostCollection" rntupleStreamerMode="true"/>
   <!-- reco::PFClusterHostCollection::Layout must be listed before the aliased-to type -->
   <class name="reco::PFClusterHostCollection::Layout"/>
   <class name="reco::PFClusterSoA"/>
-  <class name="reco::PFClusterSoA::View"/>
   <class name="edm::Wrapper<reco::PFClusterHostCollection>" splitLevel="0"/>
 
   <class name="reco::PFRecHitFractionHostCollection" rntupleStreamerMode="true"/>
   <!-- reco::PFRecHitFractionHostCollection::Layout must be listed before the aliased-to type -->
   <class name="reco::PFRecHitFractionHostCollection::Layout"/>
   <class name="reco::PFRecHitFractionSoA"/>
-  <class name="reco::PFRecHitFractionSoA::View"/>
   <class name="edm::Wrapper<reco::PFRecHitFractionHostCollection>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/Portable/interface/PortableHostCollectionReadRules.h
+++ b/DataFormats/Portable/interface/PortableHostCollectionReadRules.h
@@ -50,7 +50,7 @@ namespace ROOT {
     // build the read rules
     std::vector<ROOT::Internal::TSchemaHelper> readrules(1);
     ROOT::Internal::TSchemaHelper &rule = readrules[0];
-    rule.fTarget = "buffer_,layout_,view_";
+    rule.fTarget = "layout_";
     rule.fSourceClass = type;
     rule.fSource = type + "::Layout layout_;";
     rule.fCode = type + "::ROOTReadStreamer(newObj, onfile.layout_)";

--- a/DataFormats/Portable/interface/PortableHostObjectReadRules.h
+++ b/DataFormats/Portable/interface/PortableHostObjectReadRules.h
@@ -55,7 +55,7 @@ namespace ROOT {
     // build the read rules
     std::vector<ROOT::Internal::TSchemaHelper> readrules(1);
     ROOT::Internal::TSchemaHelper &rule = readrules[0];
-    rule.fTarget = "buffer_,product_";
+    rule.fTarget = "product_";
     rule.fSourceClass = type;
     rule.fSource = type + "::Product* product_;";
     rule.fCode = type + "::ROOTReadStreamer(newObj, *onfile.product_)";

--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -39,47 +39,35 @@
   <!-- portabletest::ParticleHostCollection::Layout must be listed before the aliased-to type -->
   <class name="portabletest::ParticleHostCollection::Layout"/>
   <class name="portabletest::ParticleSoA"/>
-  <class name="portabletest::ParticleSoA::View"/>
-  <class name="portabletest::ParticleSoA::ConstView"/>
   <class name="edm::Wrapper<portabletest::ParticleHostCollection>" splitLevel="0"/>
 
   <class name="portabletest::SimpleNetHostCollection" rntupleStreamerMode="true"/>
   <!-- portabletest::SimpleNetHostCollection::Layout must be listed before the aliased-to type -->
   <class name="portabletest::SimpleNetHostCollection::Layout"/>
   <class name="portabletest::SimpleNetSoA"/>
-  <class name="portabletest::SimpleNetSoA::View"/>
-  <class name="portabletest::SimpleNetSoA::ConstView"/>
   <class name="edm::Wrapper<portabletest::SimpleNetHostCollection>" splitLevel="0"/>
 
   <class name="portabletest::MultiHeadNetHostCollection" rntupleStreamerMode="true"/>
   <!-- portabletest::MultiHeadNetHostCollection::Layout must be listed before the aliased-to type -->
   <class name="portabletest::MultiHeadNetHostCollection::Layout"/>
   <class name="portabletest::MultiHeadNetSoA"/>
-  <class name="portabletest::MultiHeadNetSoA::View"/>
-  <class name="portabletest::MultiHeadNetSoA::ConstView"/>
   <class name="edm::Wrapper<portabletest::MultiHeadNetHostCollection>" splitLevel="0"/>
 
   <class name="portabletest::ImageHostCollection" rntupleStreamerMode="true"/>
   <!-- portabletest::ImageHostCollection::Layout must be listed before the aliased-to type -->
   <class name="portabletest::ImageHostCollection::Layout"/>
   <class name="portabletest::ImageSoA"/>
-  <class name="portabletest::ImageSoA::View"/>
-  <class name="portabletest::ImageSoA::ConstView"/>
   <class name="edm::Wrapper<portabletest::ImageHostCollection>" splitLevel="0"/>
 
   <class name="portabletest::LogitsHostCollection" rntupleStreamerMode="true"/>
   <!-- portabletest::LogitsHostCollection::Layout must be listed before the aliased-to type -->
   <class name="portabletest::LogitsHostCollection::Layout"/>
   <class name="portabletest::LogitsSoA"/>
-  <class name="portabletest::LogitsSoA::View"/>
-  <class name="portabletest::LogitsSoA::ConstView"/>
   <class name="edm::Wrapper<portabletest::LogitsHostCollection>" splitLevel="0"/>
 
   <class name="portabletest::MaskHostCollection" rntupleStreamerMode="true"/>
   <!-- portabletest::MaskHostCollection::Layout must be listed before the aliased-to type -->
   <class name="portabletest::MaskHostCollection::Layout"/>
   <class name="portabletest::MaskSoA"/>
-  <class name="portabletest::MaskSoA::View"/>
-  <class name="portabletest::MaskSoA::ConstView"/>
   <class name="edm::Wrapper<portabletest::MaskHostCollection>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/SiPixelClusterSoA/src/classes_def.xml
+++ b/DataFormats/SiPixelClusterSoA/src/classes_def.xml
@@ -3,7 +3,6 @@
   <!-- PortableHostCollection<SiPixelClustersSoA>::Layout must be listed before the aliased-to type -->
   <class name="PortableHostCollection<SiPixelClustersSoA>::Layout"/>
   <class name="SiPixelClustersSoA"/>
-  <class name="SiPixelClustersSoA::View"/>
 
   <class name="SiPixelClustersHost"/>
   <class name="edm::Wrapper<SiPixelClustersHost>" splitLevel="0"/>

--- a/DataFormats/SiPixelDigiSoA/src/classes_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/classes_def.xml
@@ -3,7 +3,6 @@
   <!-- PortableHostCollection<SiPixelDigisSoA>::Layout must be listed before the aliased-to type -->
   <class name="PortableHostCollection<SiPixelDigisSoA>::Layout"/>
   <class name="SiPixelDigisSoA"/>
-  <class name="SiPixelDigisSoA::View"/>
   <class name="SiPixelDigisHost"/>
   <class name="edm::Wrapper<SiPixelDigisHost>" splitLevel="0"/>
 
@@ -11,7 +10,6 @@
   <!-- PortableHostCollection<SiPixelDigiErrorsSoA>::Layout must be listed before the aliased-to type -->
   <class name="PortableHostCollection<SiPixelDigiErrorsSoA>::Layout"/>
   <class name="SiPixelDigiErrorsSoA"/>
-  <class name="SiPixelDigiErrorsSoA::View"/>
   <class name="SiPixelDigiErrorsHost"/>
   <class name="edm::Wrapper<SiPixelDigiErrorsHost>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/TrackSoA/src/classes_def.xml
+++ b/DataFormats/TrackSoA/src/classes_def.xml
@@ -3,7 +3,6 @@
   <!-- reco::TracksHost::Layout must be listed before the aliased-to type see #48824 -->
   <class name="reco::TracksHost::Layout"/>
   <class name="reco::TrackBlocks"/>
-  <class name="reco::TrackBlocks::View"/>
   
   <class name="reco::TrackLayout<128, false>"/>
   <class name="reco::TrackHitsLayout<128, false>"/>

--- a/DataFormats/VertexSoA/src/classes_def.xml
+++ b/DataFormats/VertexSoA/src/classes_def.xml
@@ -3,7 +3,6 @@
   <!-- reco::ZVertexHost::Layout must be listed before the aliased-to type see #48824 -->
   <class name="reco::ZVertexHost::Layout"/>
   <class name="reco::ZVertexBlocks"/>
-  <class name="reco::ZVertexBlocks::View"/>
 
   <class name="reco::ZVertexLayout<128, false>"/>
   <class name="reco::ZVertexTracksLayout<128, false>"/>


### PR DESCRIPTION
#### PR description:

Specifying the transient data members (buffer_ and view_) in the target list (fTarget) of the [PortableHostCollection custom read rule](https://github.com/cms-sw/cmssw/blob/master/DataFormats/Portable/interface/PortableHostCollectionReadRules.h) forces ROOT to create TStreamerArtificial metadata elements during streamer initialization. As a result, ROOT attempts to inspect and resolve the template type of View, requiring every SoA layout's View class to be declared in the ROOT dictionary despite never being written to disk.

This PR removes `buffer_` and `view_` from `fTarget` in `set_PortableHostCollection_read_rules`, restricting the target list to `layout_`, which is the only non-transient data member.

**Dictionary Cleanup**: Removed unnecessary ROOT dictionary declarations for View classes

#### PR validation:

unit tests ran locally

FYI @felicepantaleo 
