### PR TITLE
[Mini2Mini] Fix consistency for jet taggers, PUPPI weights, MET vetoes, and isolated-track references

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackRekeyer.cc
@@ -24,13 +24,13 @@ private:
 
   edm::EDGetTokenT<IsoTracksC> input_tracks_token_;
   edm::EDGetTokenT<PackedCandsC> packed_cands_token_;
-  edm::EDGetTokenT<PackedCandsC> lost_cands_token_;
+  edm::EDGetTokenT<PackedCandsC> ori_packed_cands_token_;
 
 public:
   PATIsolatedTrackRekeyer(edm::ParameterSet const& params)
       : input_tracks_token_{consumes<IsoTracksC>(params.getParameter<edm::InputTag>("src"))},
         packed_cands_token_{consumes<PackedCandsC>(params.getParameter<edm::InputTag>("packedCands"))},
-        lost_cands_token_{consumes<PackedCandsC>(params.getParameter<edm::InputTag>("lostTrackCands"))} {
+        ori_packed_cands_token_{consumes<PackedCandsC>(params.getParameter<edm::InputTag>("packedCandsOri"))} {
     produces<IsoTracksC>();
   }
 
@@ -45,19 +45,21 @@ public:
     edm::Handle<pat::PackedCandidateCollection> packed_cands;
     iEvent.getByToken(packed_cands_token_, packed_cands);
 
-    edm::Handle<pat::PackedCandidateCollection> lost_cands;
-    iEvent.getByToken(lost_cands_token_, lost_cands);
+    edm::Handle<pat::PackedCandidateCollection> ori_packed_cands;
+    iEvent.getByToken(ori_packed_cands_token_, ori_packed_cands);
+
+    auto rekey = [&](pat::PackedCandidateRef const& ref) {
+      return (ref.isNonnull() && ref.id() == ori_packed_cands.id())
+                 ? pat::PackedCandidateRef(packed_cands, ref.key())
+                 : ref;
+    };
 
     for (const auto& track : *input_tracks) {
       // copy original pat object and append to vector
 
-      auto const cand_ref = edm::Ref(packed_cands, track.packedCandRef().key());
-      auto const near_ref = track.nearestPFPackedCandRef().isNonnull()
-                                ? edm::Ref(packed_cands, track.packedCandRef().key())
-                                : track.nearestPFPackedCandRef();
-      auto const lost_ref = track.nearestLostTrackPackedCandRef().isNonnull()
-                                ? edm::Ref(lost_cands, track.packedCandRef().key())
-                                : track.nearestLostTrackPackedCandRef();
+      auto const cand_ref = rekey(track.packedCandRef());
+      auto const near_ref = rekey(track.nearestPFPackedCandRef());
+      auto const lost_ref = rekey(track.nearestLostTrackPackedCandRef());
 
       out_tracks->emplace_back((pat::IsolatedTrack(track.pfIsolationDR03(),
                                                    track.miniPFIsolation(),

--- a/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackRekeyer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackRekeyer.cc
@@ -49,9 +49,8 @@ public:
     iEvent.getByToken(ori_packed_cands_token_, ori_packed_cands);
 
     auto rekey = [&](pat::PackedCandidateRef const& ref) {
-      return (ref.isNonnull() && ref.id() == ori_packed_cands.id())
-                 ? pat::PackedCandidateRef(packed_cands, ref.key())
-                 : ref;
+      return (ref.isNonnull() && ref.id() == ori_packed_cands.id()) ? pat::PackedCandidateRef(packed_cands, ref.key())
+                                                                    : ref;
     };
 
     for (const auto& track : *input_tracks) {

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateUpdater.cc
@@ -18,6 +18,7 @@ namespace pat {
     edm::EDGetTokenT<std::vector<pat::PackedCandidate>> candsToken_;
 
     bool updatePuppiWeights_;
+    bool updatePuppiWeightNoLep_;
     edm::EDGetTokenT<edm::ValueMap<float>> puppiWeightToken_;
     edm::EDGetTokenT<edm::ValueMap<float>> puppiWeightNoLepToken_;
   };
@@ -28,6 +29,7 @@ using namespace pat;
 PATPackedCandidateUpdater::PATPackedCandidateUpdater(const edm::ParameterSet& iConfig)
     : candsToken_(consumes<std::vector<pat::PackedCandidate>>(iConfig.getParameter<edm::InputTag>("src"))),
       updatePuppiWeights_(iConfig.getParameter<bool>("updatePuppiWeights")),
+      updatePuppiWeightNoLep_(iConfig.getParameter<bool>("updatePuppiWeightNoLep")),
       puppiWeightToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiWeight"))),
       puppiWeightNoLepToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("puppiWeightNoLep"))) {
   produces<std::vector<pat::PackedCandidate>>();
@@ -41,7 +43,8 @@ void PATPackedCandidateUpdater::produce(edm::Event& iEvent, const edm::EventSetu
   edm::Handle<edm::ValueMap<float>> puppiWeightNoLep;
   if (updatePuppiWeights_) {
     iEvent.getByToken(puppiWeightToken_, puppiWeight);
-    iEvent.getByToken(puppiWeightNoLepToken_, puppiWeightNoLep);
+    if (updatePuppiWeightNoLep_)
+      iEvent.getByToken(puppiWeightNoLepToken_, puppiWeightNoLep);
   }
 
   auto outPtrP = std::make_unique<std::vector<pat::PackedCandidate>>();
@@ -56,7 +59,8 @@ void PATPackedCandidateUpdater::produce(edm::Event& iEvent, const edm::EventSetu
 
     if (updatePuppiWeights_) {
       float puppiWeightVal = (*puppiWeight)[pkref];
-      float puppiWeightNoLepVal = (*puppiWeightNoLep)[pkref];
+      float puppiWeightNoLepVal =
+          updatePuppiWeightNoLep_ ? (*puppiWeightNoLep)[pkref] : (*cands)[ic].puppiWeightNoLep();
       outPtrP->back().setPuppiWeight(puppiWeightVal, puppiWeightNoLepVal);
     }
   }

--- a/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAODFromMiniAOD_tools.py
@@ -14,9 +14,11 @@ def miniAODFromMiniAOD_customizeCommon(process):
     ###########################################################################
     # Update packedPFCandidates with the recomputed puppi weights
     ###########################################################################
+    # puppiWeightNoLep is kept as in the input: NanoAOD muon PNet reads it off the candidate
     addToProcessAndTask("packedPFCandidates", cms.EDProducer("PATPackedCandidateUpdater",
         src = cms.InputTag("packedPFCandidates", processName=cms.InputTag.skipCurrentProcess()),
         updatePuppiWeights = cms.bool(True),
+        updatePuppiWeightNoLep = cms.bool(False),
         puppiWeight = cms.InputTag("packedpuppi"),
         puppiWeightNoLep = cms.InputTag("packedpuppiNoLep"),
       ),
@@ -159,13 +161,18 @@ def miniAODFromMiniAOD_customizeCommon(process):
 
         return process
 
-    # FIXME: this probably needs to be era dependent, but all enabled for now
+    # Preserve input MiniAOD DeepJet and CHS ParticleNet values consumed by NanoAOD unless they are recomputed.
+    # Keep other taggers enabled so updateJetCollection refreshes CHS JECs used by PATTauHybridProducer.
+    from Configuration.ProcessModifiers.run2_miniAOD_miniAODUL_cff import run2_miniAOD_miniAODUL as _run2_miniAOD_miniAODUL
     m2m_addDeepInfoAK4CHS_switch = cms.PSet(
         m2m_addDeepBTag_switch = cms.untracked.bool(True),
-        m2m_addDeepFlavourTag_switch = cms.untracked.bool(True),
-        m2m_addParticleNet_switch = cms.untracked.bool(True),
+        m2m_addDeepFlavourTag_switch = cms.untracked.bool(False),
+        m2m_addParticleNet_switch = cms.untracked.bool(False),
         m2m_addRobustParTAK4Tag_switch = cms.untracked.bool(True),
         m2m_addUnifiedParTAK4Tag_switch = cms.untracked.bool(True)
+    )
+    _run2_miniAOD_miniAODUL.toModify(
+        m2m_addDeepInfoAK4CHS_switch, m2m_addParticleNet_switch = True
     )
     _m2m_addDeepInfoAK4CHS(process,
                            addDeepBTag = m2m_addDeepInfoAK4CHS_switch.m2m_addDeepBTag_switch,
@@ -468,15 +475,39 @@ def miniAODFromMiniAOD_customizeCommon(process):
     )
 
 
+    # packedCandsOri is what tells a packedPFCandidates reference from a lostTracks
+    # one: only the former is replaced by this process, and only it may be rekeyed.
     addToProcessAndTask("isolatedTracks", cms.EDProducer("PATIsolatedTrackRekeyer",
         src = cms.InputTag("isolatedTracks", processName=cms.InputTag.skipCurrentProcess()),
         packedCands = cms.InputTag("packedPFCandidates",processName=cms.InputTag.currentProcess()),
-        lostTrackCands = cms.InputTag("lostTracks",processName=cms.InputTag.skipCurrentProcess()),
-
+        packedCandsOri = cms.InputTag("packedPFCandidates",processName=cms.InputTag.skipCurrentProcess()),
       ),
       process, task
     )
 
+    # CandPtrProjector vetoes by Ptr identity, so a veto pointing at a rekeyed
+    # collection never matches candidates from the original packedPFCandidates
+    # and the vetoed objects survive.
+    _rekeyed = set(m for m in process.producers.keys()
+                   if getattr(process, m).type_().endswith('Rekeyer'))
+
+    def _projectsOriginalCands(tag, depth=0):
+        label = tag.getModuleLabel()
+        if depth > 20 or not hasattr(process, label) \
+           or getattr(process, label).type_() != 'CandPtrProjector':
+            return tag.getProcessName() == cms.InputTag.skipCurrentProcess()
+        return _projectsOriginalCands(getattr(process, label).src, depth + 1)
+
+    for mod in process.producers.keys():
+        module = getattr(process, mod)
+        if module.type_() != 'CandPtrProjector' or not hasattr(module, 'veto'):
+            continue
+        if not _projectsOriginalCands(module.src):
+            continue
+        if module.veto.getModuleLabel() in _rekeyed and module.veto.getProcessName() == '':
+            module.veto = cms.InputTag(module.veto.getModuleLabel(),
+                                       module.veto.getProductInstanceLabel(),
+                                       cms.InputTag.skipCurrentProcess())
 
     _modified_run2_task = task.copyAndExclude([getattr(process,thisone) for thisone in ['slimmedDisplacedMuons']])
     from PhysicsTools.PatAlgos.patRefitVertexProducer_cfi import patRefitVertexProducer


### PR DESCRIPTION
#### PR description:

## Summary

Fixes the last wave Mini2Mini inconsistencies found by comparing direct MiniAOD-to-NanoAODv15 (on-the-fly) processing with Mini2Mini-to-NanoAODv15 processing.

## Changes

- Preserve input CHS DeepJet discriminants instead of recomputing them.
- Recompute CHS ParticleNet only for Run 2, matching NanoAOD behavior.
- Preserve `puppiWeightNoLep` when updating packed candidates.
- Correct `CandPtrProjector` veto references used by PuppiMET unclustered variations.
- Rekey isolated-track references only when they point to the replaced `packedPFCandidates` collection.

#### PR validation:

Validated on 1,000-event Data and MC samples from 2018 and 2023. 

| Sample | Changed branches | Tau PNet events | PuppiMET events | Max PuppiMET pT difference | Max Muon PNet difference |
|---|---:|---:|---:|---:|---:|
| MC2023 | 44 to 32 | 231 to 0 | 715 to 10 | 9.06 to 0.125 GeV | 0.206 to 0.00125 |
| Data2023 | 41 to 30 | 160 to 0 | 811 to 15 | 8.0 to 0.125 GeV | 0.152 to 0.00412 |
| MC2018 | 68 to 62 | 0 to 0 | 719 to 8 | 5.13 to 0.109 GeV | 0.423 to 0.0142 |
| Data2018 | 80 to 59 | 0 to 0 | 748 to 12 | 3.32 to 0.125 GeV | 0.188 to 0.0239 |

Run-2 DeepJet-dependent lepton variables previously differed in 482 to 926 events per branch and are now identical. Mini2mini also previously marked no isolated tracks as originating from `lostTracks`, while the reference contained 167 to 462 per sample; the flags and collection sizes now agree.

Remaining differences are understood persistence-precision effects or expected Run-2 NanoAOD era asymmetries.

Validation plots: https://ftorresd.web.cern.ch/ftorresd/xpog/mini2mini_2025_08_28/

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backports planned.
