### PR TITLE
[HIN] Remove ECAL SC cut for electrons in Run3 PbPb era

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeeds_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeeds_cff.py
@@ -11,7 +11,8 @@ from RecoTracker.IterativeTracking.ElectronSeeds_cff import newCombinedSeeds
 ecalDrivenElectronSeeds.initialSeedsVector = newCombinedSeeds.seedCollections
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(ecalDrivenElectronSeeds, SCEtCut = 15.0)
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+(pp_on_AA & ~run3_common).toModify(ecalDrivenElectronSeeds, SCEtCut = 15.0)
 pp_on_AA.toModify(ecalDrivenElectronSeeds, maxHOverEBarrel = 0.5, maxHOverEEndcaps = 0.5)
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -44,8 +44,9 @@ gedGsfElectronsTmp = ecalDrivenGsfElectrons.clone(
 
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(gedGsfElectronsTmp.preselection, minSCEtBarrel = 15.0)
-pp_on_AA.toModify(gedGsfElectronsTmp.preselection, minSCEtEndcaps = 15.0)
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+(pp_on_AA & ~run3_common).toModify(gedGsfElectronsTmp.preselection, minSCEtBarrel = 15.0)
+(pp_on_AA & ~run3_common).toModify(gedGsfElectronsTmp.preselection, minSCEtEndcaps = 15.0)
 
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 egamma_lowPt_exclusive.toModify(gedGsfElectronsTmp.preselection,
@@ -55,7 +56,6 @@ egamma_lowPt_exclusive.toModify(gedGsfElectronsTmp, applyPreselection = False)
 
 
 # Activate the Egamma PFID dnn only for Run3
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(gedGsfElectronsTmp.EleDNNPFid,
     enabled = True
 )

--- a/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
@@ -25,8 +25,9 @@ ecalDrivenGsfElectrons = gsfElectronProducer.clone(
 )
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(ecalDrivenGsfElectrons.preselection, minSCEtBarrel = 15.0)
-pp_on_AA.toModify(ecalDrivenGsfElectrons.preselection, minSCEtEndcaps = 15.0)
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+(pp_on_AA & ~run3_common).toModify(ecalDrivenGsfElectrons.preselection, minSCEtBarrel = 15.0)
+(pp_on_AA & ~run3_common).toModify(ecalDrivenGsfElectrons.preselection, minSCEtEndcaps = 15.0)
 pp_on_AA.toModify(ecalDrivenGsfElectrons.preselection, maxHOverEBarrelCone = 0.5, maxHOverEEndcapsCone = 0.5)
 
 ecalDrivenGsfElectronsHGC = ecalDrivenGsfElectrons.clone(


### PR DESCRIPTION
#### PR description:

This PR removes the additional selection of ET > 15 GeV imposed on electron ECAL superclusters in the Run3 PbPb era (pp_on_PbPb). This improves the efficiency of electrons and removes biases in the ECAL SC in central PbPb collisions due to the degradation of the SC energy estimation (large regression corrections).

Checking with a sample of 10k minimum bias events from the 2025 PbPb raw data, the event size and timing per event increases by ~3% and ~2%, respectively.

@mandrenguyen 

#### PR validation:

Tested locally and with relvals 160.4,161.4,162.4,163.4

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport needed
