### PR TITLE
[HIN] Add Harmonics2 dEdx to PbPb MiniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -174,7 +174,7 @@ _upc_extraCommands = [
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 run3_upc.toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _upc_extraCommands)
 
-_dedx_extraCommands = ["keep recoDeDxDataedmValueMap_dedxEstimator_dedxAllLikelihood_*"]
+_dedx_extraCommands = ["keep recoDeDxDataedmValueMap_dedxEstimator_*_*"]
 from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 dedx_lfit.toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _dedx_extraCommands)
 

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -124,11 +124,12 @@ _photonDRN.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), patPhotonsD
 from Configuration.Eras.Modifier_dedx_lfit_cff import dedx_lfit
 from PhysicsTools.PatAlgos.modules import DeDxEstimatorRekeyer
 dedxEstimator = DeDxEstimatorRekeyer()
-dedx_lfit.toModify(dedxEstimator, dedxEstimators = ["dedxHarmonic2", "dedxPixelHarmonic2", "dedxPixelLikelihood", "dedxStripLikelihood", "dedxAllLikelihood"])
+dedx_lfit.toModify(dedxEstimator, dedxEstimators = ["dedxHarmonic2", "dedxAllLikelihood"])
 dedx_lfit.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), dedxEstimator))
 
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 run3_upc.toModify(dedxEstimator, dedxHits  = "dedxHitInfo", dedxMomentum = "dedxHitInfo:momentumAtHit")
+run3_upc.toModify(dedxEstimator, dedxEstimators = ["dedxHarmonic2", "dedxPixelHarmonic2", "dedxPixelLikelihood", "dedxStripLikelihood", "dedxAllLikelihood"])
 run3_upc.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), hiPixelTracks, packedPFCandidateTrackChi2, lostTrackChi2))
 
 from Configuration.Eras.Modifier_run3_oxygen_cff import run3_oxygen


### PR DESCRIPTION
#### PR description:

This PR adds add the Harmonics2 dEdx estimator to MiniAOD produced using the PbPb era, meant to complement the likelihood fit estimator already included.

Checks done on 10k minimum bias events of 2025 PbPb data, show an increase of ~4% in memory and a decrease of ~3% in timing (since now only two estimators are processed instead of five that was done before).

@CesarBernardes @mandrenguyen @flodamas 

#### PR validation:

Tested locally using 2025 PbPb data and with relvals 141.202,142.202,143.202,144.202

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport needed
