### PR TITLE
fix memory leak (missing Geant4 track deletion)

### DIFF
--- a/SimG4Core/Application/src/Phase2SteppingAction.cc
+++ b/SimG4Core/Application/src/Phase2SteppingAction.cc
@@ -115,6 +115,7 @@ void Phase2SteppingAction::UserSteppingAction(const G4Step* aStep) {
         if (status == fKill) {
           step->AddTotalEnergyDeposit(track->GetKineticEnergy());
           secit = sec->erase(secit);
+          delete track;
         } else {
           ++secit;
         }


### PR DESCRIPTION
#### PR description:

#51312 accidentally introduced another memory leak while fixing other issues. This PR attempts to solve it by restoring an omitted line deleting tracks in Geant4.

#### PR validation:

Private testing shows RSS memory no longer increasing during event processing. This PR is submitted simultaneously in case the automated memory checks can also pick up the change.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will be backported to 20_0 and 17_0 once it is confirmed that this fixes the problem.