### PR TITLE
Make `dqm-plot` overlay option and bin labelling more flexible

### DIFF
--- a/DQMServices/Components/scripts/dqm-plot
+++ b/DQMServices/Components/scripts/dqm-plot
@@ -992,6 +992,9 @@ class DQMPlotter:
         hline=None,
         ytitle_ratio_fontsize=None,
         ratio_label=None,
+        xlabels_rotation=45,
+        xlabels_ha="right",
+        bin_labels_override=None,
         complement=False,
         rebin=None,
         clamp_yerrors=False,
@@ -1110,6 +1113,15 @@ class DQMPlotter:
                 )
                 all_ratios.extend(valid_ratios)
 
+        # Explicit user-supplied bin labels override the ones extracted from the
+        # histogram (which may be absent or numeric)
+        if bin_labels_override is not None:
+            bin_labels = [
+                lab.replace("\\n", "\n").strip()
+                for lab in bin_labels_override.split(",")
+            ]
+            has_labels = True
+
         # Styling for main plot
         # Calculate visible label length by removing LaTeX notation for sizing
         visible_ylabel = re.sub(r"\$[^$]*\$", "X", ylabel)
@@ -1122,20 +1134,13 @@ class DQMPlotter:
         ax_main.set_xlabel(xlabel, fontsize=label_size if xtitle_fontsize is None else xtitle_fontsize)
         ax_main.set_ylabel(ylabel, fontsize=label_size if ytitle_fontsize is None else ytitle_fontsize)
 
-        ha = "right"
-        # source is None in --operation mode; guard before indexing it.
-        if source and "KindOfSignalPV" in source[0][0]:
-            if rebin != None:
-                bin_labels = ['PV not Reco', 'PV Reco\nas Leading', 'PV Reco\nnot as Leading']
-                ha = "center"
-                
         if has_labels: # Set custom labels if available
             ax_main.set_xticks(
                 ref_centers,
                 bin_labels,
                 size="small" if len(bin_labels) < 10 else "xx-small",
-                rotation=45,
-                ha=ha,
+                rotation=xlabels_rotation,
+                ha=xlabels_ha,
                 va="top",
             )
             ax_main.tick_params(axis="x", which="minor", bottom=False)
@@ -1192,8 +1197,8 @@ class DQMPlotter:
                     ref_centers,
                     bin_labels,
                     size="small" if len(bin_labels) < 10 else "xx-small",
-                    rotation=0,
-                    ha="center",
+                    rotation=xlabels_rotation,
+                    ha=xlabels_ha,
                     va="top",
                 )
                 ax_ratio.tick_params(axis="x", which="minor", bottom=False)
@@ -1775,6 +1780,28 @@ if __name__ == "__main__":
         "(place them first, or after a '--' separator)."
     )
     parser.add_argument(
+        '--xlabels-rotation', type=float, required=False, default=45,
+        help="Rotation angle (degrees) of the bin labels on the x axis of "
+        "both the main and ratio plots. Set to 0 for horizontal labels. "
+        "Default: 45."
+    )
+    parser.add_argument(
+        '--xlabels-ha', type=str, required=False, default="right",
+        choices=["left", "center", "right"],
+        help="Horizontal alignment of the bin labels on the x axis of both "
+        "the main and ratio plots ('left', 'center', or 'right'). "
+        "Default: right."
+    )
+    parser.add_argument(
+        '--bin-labels', type=str, required=False, default=None,
+        help="Override the per-bin x-axis labels with a comma-separated list "
+        "(e.g. --bin-labels \"PV not Reco,PV Reco as Leading,PV Reco not as "
+        "Leading\"). Use the literal '\\n' sequence in a label to insert a "
+        "line break. The number of labels must match the number of bins. "
+        "Pass the value as a single quoted shell argument so the trailing "
+        "positional ROOT files are not swallowed by this option."
+    )
+    parser.add_argument(
         "--histograms",
         action="store_true",
         help="Plot histograms instead of points (default: points with error bars).",
@@ -1915,6 +1942,17 @@ if __name__ == "__main__":
             "ROOT files with '--' (e.g. '... --ratio-label -- file1.root file2.root')."
         )
 
+    # '--bin-labels' takes a single value; if it accidentally consumed an input
+    # ROOT file, flag it clearly instead of silently dropping that file.
+    if args.bin_labels is not None and (
+        args.bin_labels.endswith(".root") or os.path.exists(args.bin_labels)
+    ):
+        parser.error(
+            f"--bin-labels consumed '{args.bin_labels}', which looks like an input "
+            "file. Quote the comma-separated label list, or separate the ROOT "
+            "files with '--' (e.g. '... --bin-labels -- file1.root file2.root')."
+        )
+
     if args.legend is not None:
         # --legend is a single comma-separated string, e.g. -l "File 1,File 2".
         args.legend = [entry.strip() for entry in args.legend.split(",")]
@@ -2013,6 +2051,9 @@ if __name__ == "__main__":
         ylim=args.ylim,
         ylim_ratio=args.ylim_ratio,
         ytitle_ratio_fontsize=args.ytitle_ratio_fontsize,
+        xlabels_rotation=args.xlabels_rotation,
+        xlabels_ha=args.xlabels_ha,
+        bin_labels_override=args.bin_labels,
         ratio_label=args.ratio_label,
         plot_histograms=args.histograms,
         save_as_pdf=args.pdf,

--- a/DQMServices/Components/scripts/dqm-plot
+++ b/DQMServices/Components/scripts/dqm-plot
@@ -803,12 +803,15 @@ class DQMPlotter:
         Each --overlay value is one job. A job is a colon-separated list of
         specs; each spec is 'collections[@file]', where collections is a
         comma-separated list of collection patterns and the optional @file
-        selector is a 1-based file index or '*' (all files, the default).
+        selector is a 1-based file index, a comma-separated list of 1-based
+        file indices, or '*' (all files, the default).
 
         Backward compatible: '--overlay collA:collB' has no @ selectors, so
         both collections are overlaid from every file, exactly as before.
         The new form '--overlay collA,collB@1:collC@2' overlays collA and
         collB from file 1 together with collC from file 2.
+        '--overlay collA@1,2:collB@2,3' overlays collA from files 1 and 2
+        together with collB from files 2 and 3.
 
         Args:
             overlay_specs: List of --overlay strings (one per --overlay flag)
@@ -841,18 +844,19 @@ class DQMPlotter:
                     targets = range(n_files)
                 else:
                     try:
-                        idx = int(file_sel)
+                        targets = [int(x.strip()) - 1 for x in file_sel.split(",") if x.strip()]
                     except ValueError:
                         raise ValueError(
                             f"--overlay: invalid file selector '@{file_sel}' in '{spec}' "
-                            "(use a 1-based file index or '*')."
+                            "(use a 1-based file index, a comma-separated list of "
+                            "indices, or '*')."
                         )
-                    if not 1 <= idx <= n_files:
-                        raise ValueError(
-                            f"--overlay: file index {idx} in '{spec}' is out of range "
-                            f"(1..{n_files})."
-                        )
-                    targets = [idx - 1]
+                    for idx in targets:
+                        if not 0 <= idx < n_files:
+                            raise ValueError(
+                                f"--overlay: file index {idx + 1} in '{spec}' is out of "
+                                f"range (1..{n_files})."
+                            )
 
                 for collection in collection_list:
                     if collection not in patterns:

--- a/DQMServices/Components/test/test_dqm-plot.sh
+++ b/DQMServices/Components/test/test_dqm-plot.sh
@@ -49,6 +49,53 @@ print("label rendering check OK")
 PYEOF
 [ $? -eq 0 ] || die "axis-label mathtext rendering check failed" 1
 
+# Unit checks for the --overlay comma-separated file-index syntax. These run
+# without the remote DQM file.
+python3 - <<'PYEOF'
+import importlib.machinery, importlib.util, shutil, matplotlib
+matplotlib.use("Agg")
+loader = importlib.machinery.SourceFileLoader("dqmplot", shutil.which("dqm-plot"))
+m = importlib.util.module_from_spec(importlib.util.spec_from_loader("dqmplot", loader))
+loader.exec_module(m)
+p = m.DQMPlotter()
+
+# --overlay: comma-separated file indices in a single @ selector.
+# 'collA@1,2:collB@2,3' overlays collA from files 1 and 2 with collB from
+# files 2 and 3, producing series in file-major order.
+jobs = p._parse_overlay_groups(["collA@1,2:collB@2,3"], 3)
+assert len(jobs) == 1, jobs
+j = jobs[0]
+assert j["patterns"] == ["collA", "collB"], j["patterns"]
+assert j["file_patterns"][0] == ["collA"], j["file_patterns"][0]
+assert j["file_patterns"][1] == ["collA", "collB"], j["file_patterns"][1]
+assert j["file_patterns"][2] == ["collB"], j["file_patterns"][2]
+
+# Backward compatibility: no @ selector overlays every file.
+jobs = p._parse_overlay_groups(["collA:collB"], 2)
+assert jobs[0]["file_patterns"] == [["collA", "collB"], ["collA", "collB"]], jobs[0]
+
+# A single 1-based index still resolves to that one file only.
+jobs = p._parse_overlay_groups(["collA@1:collB@2"], 2)
+assert jobs[0]["file_patterns"] == [["collA"], ["collB"]], jobs[0]
+
+# Out-of-range indices must be rejected.
+try:
+    p._parse_overlay_groups(["collA@1,9:collB@2"], 2)
+    raise AssertionError("out-of-range file index not rejected")
+except ValueError as e:
+    assert "out of range" in str(e), str(e)
+
+# Non-numeric selectors must be rejected.
+try:
+    p._parse_overlay_groups(["collA@x"], 2)
+    raise AssertionError("invalid file selector not rejected")
+except ValueError as e:
+    assert "invalid file selector" in str(e), str(e)
+
+print("overlay unit checks OK")
+PYEOF
+[ $? -eq 0 ] || die "overlay unit checks failed" 1
+
 COMMMAND=`xrdfs cms-xrd-global.cern.ch locate ${REMOTE}${DQMFILE}`
 STATUS=$?
 echo "xrdfs command status = "$STATUS
@@ -77,6 +124,25 @@ if [ $STATUS -eq 0 ]; then
         -l "File 1,File 2" -o plots_overlay_perfile ./${DQMFILE} ./${DQMFILE}
     ls plots_overlay_perfile/overlay/hltMergedWrtHighPurity+hltMergedWrtHighPurityPV/*.png >/dev/null 2>&1 \
         || die 'per-file --overlay did not create overlay/<collections>/ plots' 1
+
+    # New --overlay comma-separated file-index syntax: bind one collection to
+    # a comma-separated list of 1-based file indices within a single @selector.
+    # '...@1,2' overlays that collection from both files at once, equivalent to
+    # the backward-compatible form without an @ selector here (two files).
+    run_plot "comma-index --overlay" \
+        -n 4 -s "${SRC}" \
+        --overlay "hltMergedWrtHighPurity@1,2:hltMergedWrtHighPurityPV@1,2" \
+        -l "File 1,File 2" -o plots_overlay_comma ./${DQMFILE} ./${DQMFILE}
+    ls plots_overlay_comma/overlay/hltMergedWrtHighPurity+hltMergedWrtHighPurityPV/*.png >/dev/null 2>&1 \
+        || die 'comma-index --overlay did not create overlay/<collections>/ plots' 1
+
+    # Out-of-range comma index must be rejected with a non-zero exit code.
+    dqm-plot -n 4 -s "${SRC}" \
+        --overlay "hltMergedWrtHighPurity@1,9:hltMergedWrtHighPurityPV@2" \
+        -l "File 1,File 2" -o plots_overlay_badidx ./${DQMFILE} ./${DQMFILE} \
+        > dqm-plot-badidx.log 2>&1
+    [ $? -ne 0 ] && grep -q "out of range" dqm-plot-badidx.log \
+        || die 'out-of-range comma file index was not rejected' 1
 
     # --overlay-legend / --overlay-legend-title customise the overlay legend.
     run_plot "--overlay-legend" \

--- a/DQMServices/Components/test/test_dqm-plot.sh
+++ b/DQMServices/Components/test/test_dqm-plot.sh
@@ -6,6 +6,7 @@ REMOTE="/store/group/phys_tracking/cmssw_unittests/"
 DQMFILE="DQM_V0001_R000000001__RelValTTbar_14TeV__CMSSW_12_1_0_pre5-121X_mcRun3_2021_realistic_v15-v1__DQMIO.root"
 SRC="DQMData/Run 1/HLT/Run summary/Tracking/ValidationWRTOffline/*"
 ONE="DQMData/Run 1/HLT/Run summary/Tracking/ValidationWRTOffline/hltMergedWrtHighPurity/Eff_eta"
+ONE_BINS="DQMData/Run 1/BDHadronTracks/Run summary/JetContent/nTrk_absolute_bjet"
 
 # Run dqm-plot, failing on a non-zero exit code or on any silently-failed
 # plotting task (dqm-plot keeps going and only prints "N tasks failed ...").
@@ -49,10 +50,10 @@ print("label rendering check OK")
 PYEOF
 [ $? -eq 0 ] || die "axis-label mathtext rendering check failed" 1
 
-# Unit checks for the --overlay comma-separated file-index syntax. These run
-# without the remote DQM file.
+# Unit checks for the --overlay comma-separated file-index syntax and the
+# configurable x-axis label rotation. These run without the remote DQM file.
 python3 - <<'PYEOF'
-import importlib.machinery, importlib.util, shutil, matplotlib
+import importlib.machinery, importlib.util, shutil, inspect, matplotlib
 matplotlib.use("Agg")
 loader = importlib.machinery.SourceFileLoader("dqmplot", shutil.which("dqm-plot"))
 m = importlib.util.module_from_spec(importlib.util.spec_from_loader("dqmplot", loader))
@@ -92,9 +93,19 @@ try:
 except ValueError as e:
     assert "invalid file selector" in str(e), str(e)
 
-print("overlay unit checks OK")
+# plot_comparison must accept a configurable x-axis label rotation, defaulting
+# to 45 degrees, and a configurable horizontal alignment, defaulting to center.
+sig = inspect.signature(m.DQMPlotter.plot_comparison)
+assert "xlabels_rotation" in sig.parameters, "missing xlabels_rotation parameter"
+assert sig.parameters["xlabels_rotation"].default == 45, sig.parameters["xlabels_rotation"]
+assert "xlabels_ha" in sig.parameters, "missing xlabels_ha parameter"
+assert sig.parameters["xlabels_ha"].default == "right", sig.parameters["xlabels_ha"]
+assert "bin_labels_override" in sig.parameters, "missing bin_labels_override parameter"
+assert sig.parameters["bin_labels_override"].default is None, sig.parameters["bin_labels_override"]
+
+print("overlay + rotation unit checks OK")
 PYEOF
-[ $? -eq 0 ] || die "overlay unit checks failed" 1
+[ $? -eq 0 ] || die "overlay/rotation unit checks failed" 1
 
 COMMMAND=`xrdfs cms-xrd-global.cern.ch locate ${REMOTE}${DQMFILE}`
 STATUS=$?
@@ -143,6 +154,70 @@ if [ $STATUS -eq 0 ]; then
         > dqm-plot-badidx.log 2>&1
     [ $? -ne 0 ] && grep -q "out of range" dqm-plot-badidx.log \
         || die 'out-of-range comma file index was not rejected' 1
+
+    # --xlabels-rotation configures the bin-label orientation on both the main
+    # and ratio plots (default: 45). 0 renders horizontal labels and must run
+    # cleanly alongside overlay plots that carry bin labels.
+    run_plot "--xlabels-rotation 0" \
+        -n 4 -s "${SRC}" \
+        --overlay "hltMergedWrtHighPurity:hltMergedWrtHighPurityPV" \
+        --xlabels-rotation 0 \
+        -l "File 1,File 2" -o plots_rotation0 ./${DQMFILE} ./${DQMFILE}
+    ls plots_rotation0/overlay/hltMergedWrtHighPurity+hltMergedWrtHighPurityPV/*.png >/dev/null 2>&1 \
+        || die '--xlabels-rotation 0 did not produce overlay plots' 1
+
+    # --xlabels-ha configures the horizontal alignment of the bin labels on
+    # both panels (default: right). An explicit center-aligned run must
+    # complete and produce a distinct image from the default (right-aligned)
+    # run, so the alignment is confirmed to reach the renderer.
+    run_plot "--xlabels-ha right (default)" \
+        -n 4 -s "${SRC}" \
+        --overlay "hltMergedWrtHighPurity:hltMergedWrtHighPurityPV" \
+        -l "File 1,File 2" -o plots_xlabels_right ./${DQMFILE} ./${DQMFILE}
+    run_plot "--xlabels-ha center" \
+        -n 4 -s "${SRC}" \
+        --overlay "hltMergedWrtHighPurity:hltMergedWrtHighPurityPV" \
+        --xlabels-ha center \
+        -l "File 1,File 2" -o plots_xlabels_center ./${DQMFILE} ./${DQMFILE}
+    ls plots_xlabels_center/overlay/hltMergedWrtHighPurity+hltMergedWrtHighPurityPV/*.png >/dev/null 2>&1 \
+        || die '--xlabels-ha center did not produce overlay plots' 1
+    HA_RIGHT=plots_xlabels_right/overlay/hltMergedWrtHighPurity+hltMergedWrtHighPurityPV
+    HA_CENTER=plots_xlabels_center/overlay/hltMergedWrtHighPurity+hltMergedWrtHighPurityPV
+    HA_PLOT=$(find "${HA_RIGHT}" -name "globalEfficiencies.png" | head -1)
+    HA_CENTER_PLOT=$(find "${HA_CENTER}" -name "globalEfficiencies.png" | head -1)
+    [ -n "${HA_PLOT}" ] && [ -n "${HA_CENTER_PLOT}" ] \
+        || die '--xlabels-ha: could not locate a matching overlay plot to compare' 1
+    cmp -s "${HA_PLOT}" "${HA_CENTER_PLOT}" \
+        && die '--xlabels-ha center produced the same image as the right-aligned default' 1 \
+        || true
+
+    # --bin-labels overrides the per-bin x-axis labels with a comma-separated
+    # list. The nTrk_absolute_bjet histogram has 6 bins, so a 6-label list
+    # must run cleanly, while a mismatched count must fail the plotting task.
+    run_plot "--bin-labels" \
+        -n 4 -s "${ONE_BINS}" \
+        --bin-labels "BCWeakDecay,BWeakDecay,CWeakDecay,PU,Other,Fake" \
+        -l "File 1,File 2" -o plots_bin_labels ./${DQMFILE} ./${DQMFILE}
+    ls plots_bin_labels/*.png >/dev/null 2>&1 \
+        || die '--bin-labels did not produce plots' 1
+
+    # A label count that does not match the number of bins must fail the
+    # plotting task (dqm-plot reports "tasks failed ...").
+    dqm-plot -n 4 -s "${ONE_BINS}" \
+        --bin-labels "Only,Three,Labels" \
+        -l "File 1,File 2" -o plots_bin_labels_badcount ./${DQMFILE} ./${DQMFILE} \
+        > dqm-plot-badlabels.log 2>&1
+    grep -q "tasks failed out of" dqm-plot-badlabels.log \
+        || die '--bin-labels with a mismatched label count did not fail the plotting task' 1
+
+    # --bin-labels must not swallow a trailing positional ROOT file. Passing a
+    # .root path as its value is rejected with a non-zero exit code.
+    dqm-plot -n 4 -s "${ONE_BINS}" \
+        --bin-labels ./${DQMFILE} \
+        -l "File 1,File 2" -o plots_bin_labels_swallow ./${DQMFILE} \
+        > dqm-plot-binlabels-swallow.log 2>&1
+    [ $? -ne 0 ] && grep -q "looks like an input" dqm-plot-binlabels-swallow.log \
+        || die '--bin-labels swallowed a trailing ROOT file instead of rejecting it' 1
 
     # --overlay-legend / --overlay-legend-title customise the overlay legend.
     run_plot "--overlay-legend" \


### PR DESCRIPTION
#### PR description:
This PR makes the `--overlay` option of `dqm-plot` more flexible by allowing users to specify file ranges when overlaying specific collections from specific files (e.g. `--overlay collA@1,2:collB@2,3` overlays `collA` from files 1 and 2 together with `collB` from files 2 and 3).
The PR also adds a few new customisation flags to rename histogram bins, change the name rotation, and horizontal alignment: `--bin-labels`, `--xlabels-rotation`, and `--xlabels-ha`, respectively.

#### PR validation:

New unit tests have been added to validate the new features and they all pass, together with the existing ones.