### PR TITLE
Remove dependency of L1Trigger on HLTrigger Psets

### DIFF
--- a/L1Trigger/L1THGCal/python/hgcalTriggerRecoConstants_cfi.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerRecoConstants_cfi.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase2_hgcalV19_cff import phase2_hgcalV19
+
+# Number of silicon thickness/type categories:
+# <V19: HD120, LD200, LD300
+# >=V19: HD120, LD200, LD300, HD200
+HGCAL_reco_constants = cms.PSet(
+    numberOfThicknesses = cms.uint32(3),
+    maxNumberOfThickIndices = cms.uint32(6),
+)
+
+phase2_hgcalV19.toModify(HGCAL_reco_constants,
+                         numberOfThicknesses = 4,
+                         maxNumberOfThickIndices = 8,
+                         )

--- a/L1Trigger/L1THGCal/python/l1tHGCalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalConcentratorProducer_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
-from HLTrigger.Configuration.HLT_75e33.psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
+from . import hgcalTriggerRecoConstants_cfi as recoconstparam
 
 # Digitization parameters
 adcSaturationBH_MIP = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcSaturation_fC
@@ -12,7 +12,7 @@ adcNbitsBH = digiparam.hgchebackDigitizer.digiCfg.feCfg.adcNbits
 # <V19: 3 different silicon thicknesses/types (HD120, LD200, LD300) + scintillator portion
 # >=V19: 4 different silicon thicknesses/types (HD120, LD200, LD300, HD200) + scintillator portion
 MAX_LAYERS = 52
-N_THICKNESSES = HGCAL_reco_constants.numberOfThicknesses.value()
+N_THICKNESSES = recoconstparam.HGCAL_reco_constants.numberOfThicknesses.value()
 CTC_2_SIZES = cms.vuint32( [2]*(MAX_LAYERS+1)*(N_THICKNESSES+1) )
 STC_4_AND_16_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [16]*(MAX_LAYERS+1)*N_THICKNESSES )
 STC_4_AND_8_SIZES = cms.vuint32( [4]*(MAX_LAYERS+1)+ [8]*(MAX_LAYERS+1)*N_THICKNESSES )

--- a/L1Trigger/L1THGCal/python/l1tHGCalVFEProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalVFEProducer_cfi.py
@@ -4,7 +4,7 @@ import SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi as digiparam
 import RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi as recoparam
 import RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi as recocalibparam 
 from . import hgcalLayersCalibrationCoefficients_cfi as layercalibparam
-from HLTrigger.Configuration.HLT_75e33.psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
+from . import hgcalTriggerRecoConstants_cfi as recoconstparam
 
 feCfg_si = digiparam.hgceeDigitizer.digiCfg.feCfg
 feCfg_sc = digiparam.hgchebackDigitizer.digiCfg.feCfg
@@ -71,7 +71,7 @@ thicknessCorrectionSi = recocalibparam.HGCalRecHit.thicknessCorrection
 thicknessCorrectionSc = recocalibparam.HGCalRecHit.sciThicknessCorrection
 thicknessCorrectionNose = recocalibparam.HGCalRecHit.thicknessNoseCorrection
 
-NTHICKNESS = HGCAL_reco_constants.numberOfThicknesses.value() 
+NTHICKNESS = recoconstparam.HGCAL_reco_constants.numberOfThicknesses.value() 
 # Silicon thickness correction in HGCalRecHit_cfi.py is in the form:
 # [CE_E_120um, CE_E_200um, CE_E_300um, CE_H_120um, CE_H_200um, CE_H_300um]
 # While here there are two different sets for CE-E and CE-H


### PR DESCRIPTION
This PR separates L1Trigger and HLT PSets to avoid creating circular dependencies between L1T and HLT. 
Previously, L1Trigger/L1THGCal/python/l1tHGCalConcentratorProducer_cfi.py was loading the PSets from HLT configurations

Technical change, no physics changes expected

