### PR TITLE
Add a unit test to check the handling of transient products in MPI modules

### DIFF
--- a/HeterogeneousCore/MPICore/test/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/test/BuildFile.xml
@@ -61,3 +61,8 @@
   name="testMPITooManyStreams"
   command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_too_many_streams_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_too_many_streams_cfg.py"
 />
+
+<test
+  name="testMPITransientProduct"
+  command="testMPITransientProduct.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_transient_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_transient_cfg.py"
+/>

--- a/HeterogeneousCore/MPICore/test/controller_transient_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_transient_cfg.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MPIController")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.INFO.limit = 10000000
+
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 4
+# MPIController supports a single concurrent LuminosityBlock
+process.options.numberOfConcurrentLuminosityBlocks = 1
+process.options.numberOfConcurrentRuns = 1
+process.options.wantSummary = False
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 10
+
+process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+
+process.load("Configuration.StandardSequences.Accelerators_cff")
+process.load("HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi")
+
+from HeterogeneousCore.MPICore.modules import *
+
+process.mpiController = MPIController(
+    mode = 'CommWorld',
+    followerProcessName = 'MPIFollower'
+)
+
+# MPIToken has no TrivialSerialisation plugin, so MPISenderPortable falls back
+# to ROOT serialisation. But MPIToken is declared "persistent=false" in
+# HeterogeneousCore/MPICore/src/classes_def.xml, so ROOT cannot serialise it
+# either. With no serialisation mechanism available, MPISenderPortable should
+# throw an exception when asked to operate on this product.
+process.sender = cms.EDProducer("MPISenderPortable@alpaka",
+    upstream = cms.InputTag("mpiController"),
+    instance = cms.int32(42),
+    products = cms.VPSet(
+        cms.PSet(
+            type = cms.string("MPIToken"),
+            src = cms.InputTag("mpiController"),
+        ),
+    )
+)
+
+process.pathTransient = cms.Path(
+    process.mpiController +
+    process.sender
+)

--- a/HeterogeneousCore/MPICore/test/follower_transient_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_transient_cfg.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MPIFollower")
+
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 4
+process.options.wantSummary = False
+
+process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
+
+process.load("Configuration.StandardSequences.Accelerators_cff")
+process.load("HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi")
+
+from HeterogeneousCore.MPICore.modules import *
+
+process.source = MPISource(mode = 'CommWorld',
+    controllerProcessName = 'MPIController'
+)
+
+process.maxEvents.input = -1
+
+# MPIToken has no TrivialSerialisation plugin, so MPIReceiverPortable falls back
+# to ROOT serialisation. But MPIToken is declared "persistent=false" in
+# HeterogeneousCore/MPICore/src/classes_def.xml, so ROOT cannot serialise it
+# either. With no serialisation mechanism available, MPIReceiverPortable should
+# throw an exception when asked to operate on this product.
+process.receiver = cms.EDProducer("MPIReceiverPortable@alpaka",
+    upstream = cms.InputTag("source"),
+    instance = cms.int32(42),
+    products = cms.VPSet(
+        cms.PSet(
+            type = cms.string("MPIToken"),
+            src = cms.InputTag("", ""),
+        ),
+    )
+)
+
+process.pathTransient = cms.Path(
+    process.receiver
+)

--- a/HeterogeneousCore/MPICore/test/testMPITransientProduct.sh
+++ b/HeterogeneousCore/MPICore/test/testMPITransientProduct.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+# Products without a TrivialSerialisation plugin cannot be trivially serialised.
+# If "persistent=false" is also set for these products in the corresponding
+# classes_def.xml, these products cannot be serialised through ROOT either.
+# Products that satisfy these two conditions have no serialisation mechanism,
+# and thus cannot be transferred by the MPI modules.
+#
+# This test attempts to transfer a MPIToken, which satisfies these two
+# conditions. The expected output is an exception thrown by the
+# MPISenderPortable. This script looks for the exception message in the cmsRun
+# output. If found, the test passes. Otherwise the test fails.
+
+
+# Make sure the CMSSW environment has been loaded.
+if [ -z "$CMSSW_BASE" ]; then
+  eval `scram runtime -sh`
+fi
+
+OUTPUT=$("$CMSSW_BASE"/src/HeterogeneousCore/MPICore/test/testMPICommWorld.sh "$1" "$2" 2>&1)
+STATUS=$?
+
+echo "$OUTPUT"
+
+if [ $STATUS -eq 0 ]; then
+  echo "$(basename $0): error: cmsRun did not fail when it was expected to."
+  exit 1
+fi
+
+if ! echo "$OUTPUT" | grep -q 'is transient (persistent = "false")'; then
+  echo "$(basename $0): error: cmsRun failed for an unexpected reason."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION

#### PR description:

Products without a TrivialSerialisation plugin cannot be trivially serialised. If "persistent=false" is also set for these products in the corresponding `classes_def.xml`, these products cannot be serialised through ROOT either. Products that satisfy these two conditions have no serialisation mechanism, and thus cannot be transferred by the MPI modules.

These conditions are already being checked by the `MPISenderPortable.cc` and `MPIReceiverPortable.cc` modules, but a unit test is currently missing for this check.

This PR introduces the test. The test attempts to transfer a `MPIToken`, which satisfies these two conditions and for which there is no serialisation mechanism. A `cmsRun` job is then launched, and the test looks for the expected error in the output. If the expected exception is thrown, the test passes. Otherwise it fails.

#### PR validation:

The test triggers the expected CMSSW exception and passes.
