### PR TITLE
Cleanup and fixes for NanoAODRNTupleOutputModule

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
@@ -411,7 +411,8 @@ void NanoAODOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descr
 
   desc.addUntracked<int>("compressionLevel", 9)->setComment("ROOT compression level of output file.");
   desc.addUntracked<std::string>("compressionAlgorithm", "ZLIB")
-      ->setComment("Algorithm used to compress data in the ROOT output file, allowed values are ZLIB and LZMA");
+      ->setComment(
+          "Algorithm used to compress data in the ROOT output file, allowed values are ZLIB, LZMA, ZSTD, and LZ4");
   desc.addUntracked<bool>("saveProvenance", true)
       ->setComment("Save process provenance information, e.g. for edmProvDump");
   desc.addUntracked<bool>("fakeNameForCrab", false)

--- a/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.cc
@@ -3,7 +3,7 @@
 
 void EventStringOutputFields::registerToken(const edm::EDGetToken &token) { m_tokens.push_back(token); }
 
-void EventStringOutputFields::createFields(RNTupleModel &model) {
+void EventStringOutputFields::createFields(ROOT::RNTupleModel &model) {
   m_evstrings = RNTupleFieldPtr<std::vector<std::string>>("EventStrings", "", model);
 }
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.h
@@ -6,9 +6,12 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include <ROOT/RNTupleModel.hxx>
-using ROOT::RNTupleModel;
 
 #include "RNTupleFieldPtr.h"
+
+namespace edm {
+  class EventForOutput;
+}
 
 class EventStringOutputFields {
 private:
@@ -20,7 +23,7 @@ public:
   EventStringOutputFields() = default;
 
   void registerToken(const edm::EDGetToken &token);
-  void createFields(RNTupleModel &model);
+  void createFields(ROOT::RNTupleModel &model);
   void fill(const edm::EventForOutput &iEvent);
 };
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/FlatTableColumnDispatch.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/FlatTableColumnDispatch.h
@@ -1,0 +1,52 @@
+#ifndef PhysicsTools_NanoAOD_FlatTableColumnDispatch_h
+#define PhysicsTools_NanoAOD_FlatTableColumnDispatch_h
+
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <cstdint>
+#include <type_traits>
+
+// Calls func with a std::type_identity tag naming the C++ type that backs the given FlatTable
+// column type, so that code handling all ten column types can be written once:
+//
+//   dispatchColumnType(table.columnType(i), [&](auto tag) {
+//     using ColumnT = typename decltype(tag)::type;
+//     ...
+//   });
+//
+// Note that the storage type of a column is nanoaod::FlatTable::ColumnStorageType<ColumnT>, which
+// differs from ColumnT for bool: table.columnData<bool>() hands back a span of std::uint8_t.
+//
+// The switch deliberately has no default case. -Werror=switch then turns a column type added to
+// nanoaod::FlatTable into a compile error here, rather than something silently unwritten.
+template <typename F>
+decltype(auto) dispatchColumnType(nanoaod::FlatTable::ColumnType type, F&& func) {
+  using ColumnType = nanoaod::FlatTable::ColumnType;
+  switch (type) {
+    case ColumnType::UInt8:
+      return func(std::type_identity<std::uint8_t>{});
+    case ColumnType::Int16:
+      return func(std::type_identity<std::int16_t>{});
+    case ColumnType::UInt16:
+      return func(std::type_identity<std::uint16_t>{});
+    case ColumnType::Int32:
+      return func(std::type_identity<std::int32_t>{});
+    case ColumnType::UInt32:
+      return func(std::type_identity<std::uint32_t>{});
+    case ColumnType::Int64:
+      return func(std::type_identity<std::int64_t>{});
+    case ColumnType::UInt64:
+      return func(std::type_identity<std::uint64_t>{});
+    case ColumnType::Bool:
+      return func(std::type_identity<bool>{});
+    case ColumnType::Float:
+      return func(std::type_identity<float>{});
+    case ColumnType::Double:
+      return func(std::type_identity<double>{});
+  }
+  throw cms::Exception("UnsupportedType")
+      << "Unknown nanoaod::FlatTable::ColumnType " << static_cast<int>(type) << "\n";
+}
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
@@ -13,11 +13,9 @@
 #include <cstdint>
 #include <string>
 
-#include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-using ROOT::RNTupleModel;
 #include <ROOT/RNTupleWriteOptions.hxx>
-using ROOT::RNTupleWriteOptions;
+#include <ROOT/RNTupleWriter.hxx>
 
 #include "TObjString.h"
 
@@ -34,12 +32,19 @@ using ROOT::RNTupleWriteOptions;
 #include "DataFormats/NanoAOD/interface/UniqueString.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 
+#include "EventStringOutputFields.h"
 #include "NanoAODRNTuples.h"
+#include "RNTupleFieldPtr.h"
+#include "TriggerOutputFields.h"
+
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 class NanoAODRNTupleOutputModule : public edm::one::OutputModule<> {
 public:
   NanoAODRNTupleOutputModule(edm::ParameterSet const& pset);
-  ~NanoAODRNTupleOutputModule() override;
+  ~NanoAODRNTupleOutputModule() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -64,6 +69,7 @@ private:
 
   std::unique_ptr<TFile> m_file;
   std::unique_ptr<RNTupleWriter> m_ntuple;
+  std::vector<edm::EDGetToken> m_eventTableTokens;
   TableCollectionSet m_tables;
   std::vector<TriggerOutputFields> m_triggers;
   EventStringOutputFields m_evstrings;
@@ -71,20 +77,20 @@ private:
   class CommonEventFields {
   public:
     void createFields(RNTupleModel& model) {
-      m_run = model.MakeField<UInt_t>("run");
-      m_luminosityBlock = model.MakeField<UInt_t>("luminosityBlock");
-      m_event = model.MakeField<std::uint64_t>("event");
+      m_run = RNTupleFieldPtr<std::uint32_t>("run", "", model);
+      m_luminosityBlock = RNTupleFieldPtr<std::uint32_t>("luminosityBlock", "", model);
+      m_event = RNTupleFieldPtr<std::uint64_t>("event", "", model);
     }
     void fill(const edm::EventID& id) {
-      *m_run = id.run();
-      *m_luminosityBlock = id.luminosityBlock();
-      *m_event = id.event();
+      m_run.fill(id.run());
+      m_luminosityBlock.fill(id.luminosityBlock());
+      m_event.fill(id.event());
     }
 
   private:
-    std::shared_ptr<UInt_t> m_run;
-    std::shared_ptr<UInt_t> m_luminosityBlock;
-    std::shared_ptr<std::uint64_t> m_event;
+    RNTupleFieldPtr<std::uint32_t> m_run;
+    RNTupleFieldPtr<std::uint32_t> m_luminosityBlock;
+    RNTupleFieldPtr<std::uint64_t> m_event;
   } m_commonFields;
 
   LumiNTuple m_lumi;
@@ -121,11 +127,8 @@ NanoAODRNTupleOutputModule::NanoAODRNTupleOutputModule(edm::ParameterSet const& 
       m_compressionAlgorithm(pset.getUntrackedParameter<std::string>("compressionAlgorithm")),
       m_compressionLevel(pset.getUntrackedParameter<int>("compressionLevel")),
       m_writeProvenance(pset.getUntrackedParameter<bool>("saveProvenance", true)),
-      m_processHistoryRegistry(),
       m_noSplitFields{pset.getUntrackedParameter<std::vector<std::string>>("noSplitFields")},
       m_writeOptions(writeOptions(pset.getUntrackedParameterSet("rntupleWriteOptions"))) {}
-
-NanoAODRNTupleOutputModule::~NanoAODRNTupleOutputModule() {}
 
 void NanoAODRNTupleOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput const& iLumi) {
   edm::Service<edm::JobReport> jr;
@@ -144,8 +147,10 @@ void NanoAODRNTupleOutputModule::writeRun(edm::RunForOutput const& iRun) {
   for (const auto& p : m_nanoMetadata) {
     iRun.getByToken(p.second, hstring);
     TObjString* tos = dynamic_cast<TObjString*>(m_file->Get(p.first.c_str()));
-    if (tos && hstring->str() != tos->GetString()) {
-      throw cms::Exception("LogicError", "Inconsistent nanoMetadata " + p.first + " (" + hstring->str() + ")");
+    if (tos) {
+      if (hstring->str() != tos->GetString()) {
+        throw cms::Exception("LogicError", "Inconsistent nanoMetadata " + p.first + " (" + hstring->str() + ")");
+      }
     } else {
       auto ostr = std::make_unique<TObjString>(hstring->str().c_str());
       m_file->WriteTObject(ostr.release(), p.first.c_str());
@@ -154,7 +159,9 @@ void NanoAODRNTupleOutputModule::writeRun(edm::RunForOutput const& iRun) {
   m_processHistoryRegistry.registerProcessHistory(iRun.processHistory());
 }
 
-bool NanoAODRNTupleOutputModule::isFileOpen() const { return nullptr != m_ntuple.get(); }
+// The Events RNTuple is only created on the first event, so the file, not the writer, tracks
+// whether output is open: otherwise a job writing no events would never be closed.
+bool NanoAODRNTupleOutputModule::isFileOpen() const { return nullptr != m_file.get(); }
 
 void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
   m_file = std::make_unique<TFile>(m_fileName.c_str(), "RECREATE", "", m_compressionLevel);
@@ -163,8 +170,6 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
   m_jrToken = jr->outputFileOpened(m_fileName,
                                    m_logicalFileName,
                                    std::string(),
-                                   // TODO check if needed
-                                   //m_fakeName ? "PoolOutputModule" : "NanoAODOutputModule",
                                    "NanoAODRNTupleOutputModule",
                                    description().moduleLabel(),
                                    edm::createGlobalIdentifier(),
@@ -178,11 +183,15 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
     m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZMA);
   } else {
     throw cms::Exception("Configuration")
-        << "NanoAODOutputModule configured with unknown compression algorithm '" << m_compressionAlgorithm << "'\n"
+        << "NanoAODRNTupleOutputModule configured with unknown compression algorithm '" << m_compressionAlgorithm
+        << "'\n"
         << "Allowed compression algorithms are ZLIB and LZMA\n";
   }
   m_writeOptions.SetCompression(m_file->GetCompressionSettings());
 
+  // Sorting the kept products by class only needs their descriptions, so it happens here rather
+  // than on the first event. What the Events model looks like does depend on the payloads, and is
+  // left to initializeNTuple().
   const auto& keeps = keptProducts();
   for (const auto& keep : keeps[edm::InRun]) {
     if (keep.first->className() == "nanoaod::MergeableCounterTable") {
@@ -195,6 +204,20 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
       throw cms::Exception(
           "Configuration",
           "NanoAODRNTupleOutputModule cannot handle class " + keep.first->className() + " in Run RNTuple");
+    }
+  }
+
+  for (const auto& keep : keeps[edm::InEvent]) {
+    if (keep.first->className() == "nanoaod::FlatTable") {
+      m_eventTableTokens.push_back(keep.second);
+    } else if (keep.first->className() == "edm::TriggerResults") {
+      m_triggers.emplace_back(keep.first->processName(), keep.second);
+    } else if (keep.first->className() == "std::basic_string<char,std::char_traits<char> >" &&
+               keep.first->productInstanceName() == "genModel") {
+      m_evstrings.registerToken(keep.second);
+    } else {
+      throw cms::Exception("Configuration",
+                           "NanoAODRNTupleOutputModule cannot handle class " + keep.first->className());
     }
   }
 }
@@ -229,25 +252,15 @@ namespace {
 }  // namespace
 
 void NanoAODRNTupleOutputModule::initializeNTuple(edm::EventForOutput const& iEvent) {
-  // set up RNTuple schema
+  // RNTuple needs the whole schema before the first Fill, and which fields a FlatTable needs is
+  // only visible from its contents, so the Events model is built on the first event.
   auto model = RNTupleModel::Create();
   m_commonFields.createFields(*model);
 
-  const auto& keeps = keptProducts();
-  for (const auto& keep : keeps[edm::InEvent]) {
-    if (keep.first->className() == "nanoaod::FlatTable") {
-      edm::Handle<nanoaod::FlatTable> handle;
-      const auto& token = keep.second;
-      iEvent.getByToken(token, handle);
-      m_tables.add(token, *handle);
-    } else if (keep.first->className() == "edm::TriggerResults") {
-      m_triggers.emplace_back(TriggerOutputFields(keep.first->processName(), keep.second));
-    } else if (keep.first->className() == "std::basic_string<char,std::char_traits<char> >" &&
-               keep.first->productInstanceName() == "genModel") {
-      m_evstrings.registerToken(keep.second);
-    } else {
-      throw cms::Exception("Configuration", "NanoAODOutputModule cannot handle class " + keep.first->className());
-    }
+  edm::Handle<nanoaod::FlatTable> handle;
+  for (const auto& token : m_eventTableTokens) {
+    iEvent.getByToken(token, handle);
+    m_tables.add(token, *handle);
   }
   m_tables.createFields(iEvent, *model);
   for (auto& trigger : m_triggers) {
@@ -303,19 +316,15 @@ void NanoAODRNTupleOutputModule::reallyCloseFile() {
   m_run.finalizeWrite();
   m_file->Write();
   m_file->Close();
+  m_file.reset();
 
   edm::Service<edm::JobReport> jr;
   jr->outputFileClosed(m_jrToken);
 }
 
 void NanoAODRNTupleOutputModule::writeProvenance() {
-  PSetNTuple pntuple;
-  pntuple.fill(edm::pset::Registry::instance(), *m_file);
-  pntuple.finalizeWrite();
-
-  MetadataNTuple mdntuple;
-  mdntuple.fill(m_processHistoryRegistry, *m_file);
-  mdntuple.finalizeWrite();
+  rntupleprovenance::writeParameterSets(*m_file);
+  rntupleprovenance::writeProcessHistory(m_processHistoryRegistry, *m_file);
 }
 
 void NanoAODRNTupleOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.cc
@@ -1,28 +1,41 @@
 #include "NanoAODRNTuples.h"
 
 #include "DataFormats/NanoAOD/interface/MergeableCounterTable.h"
+#include "DataFormats/Provenance/interface/BranchType.h"
+#include "DataFormats/Provenance/interface/ParameterSetBlob.h"
+#include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "FWCore/Framework/interface/RunForOutput.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
 
 #include <ROOT/RNTupleModel.hxx>
-using ROOT::RNTupleModel;
 #include <ROOT/RNTupleWriteOptions.hxx>
-using ROOT::RNTupleWriteOptions;
 
 #include "RNTupleFieldPtr.h"
 #include "SummaryTableOutputFields.h"
 
-void LumiNTuple::createFields(const edm::LuminosityBlockID& id, TFile& file) {
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
+
+namespace {
+  // Every ntuple in the file inherits the file's compression and takes the ROOT defaults otherwise.
+  RNTupleWriteOptions writeOptions(const TFile& file) {
+    RNTupleWriteOptions options;
+    options.SetCompression(file.GetCompressionSettings());
+    return options;
+  }
+}  // anonymous namespace
+
+void LumiNTuple::createFields(TFile& file) {
   auto model = RNTupleModel::Create();
-  m_run = RNTupleFieldPtr<UInt_t>("run", "", *model);
-  m_luminosityBlock = RNTupleFieldPtr<UInt_t>("luminosityBlock", "", *model);
-  RNTupleWriteOptions options;
-  options.SetCompression(file.GetCompressionSettings());
-  m_ntuple = RNTupleWriter::Append(std::move(model), "LuminosityBlocks", file, options);
+  m_run = RNTupleFieldPtr<std::uint32_t>("run", "", *model);
+  m_luminosityBlock = RNTupleFieldPtr<std::uint32_t>("luminosityBlock", "", *model);
+  m_ntuple = RNTupleWriter::Append(std::move(model), "LuminosityBlocks", file, writeOptions(file));
 }
 
 void LumiNTuple::fill(const edm::LuminosityBlockID& id, TFile& file) {
   if (!m_ntuple) {
-    createFields(id, file);
+    createFields(file);
   }
   m_run.fill(id.run());
   m_luminosityBlock.fill(id.value());
@@ -37,13 +50,12 @@ void RunNTuple::registerFlatTableToken(const edm::EDGetToken& token) { m_flatTab
 
 void RunNTuple::createFields(const edm::RunForOutput& iRun, TFile& file) {
   auto model = RNTupleModel::Create();
-  m_run = RNTupleFieldPtr<UInt_t>("run", "", *model);
+  m_run = RNTupleFieldPtr<std::uint32_t>("run", "", *model);
 
   edm::Handle<nanoaod::MergeableCounterTable> counterTableHandle;
   for (const auto& token : m_counterTableTokens) {
     iRun.getByToken(token, counterTableHandle);
-    const nanoaod::MergeableCounterTable& tab = *counterTableHandle;
-    m_counterTables.push_back(SummaryTableOutputFields(tab, *model));
+    m_counterTables.emplace_back(*counterTableHandle, *model);
   }
 
   edm::Handle<nanoaod::FlatTable> flatTableHandle;
@@ -53,9 +65,7 @@ void RunNTuple::createFields(const edm::RunForOutput& iRun, TFile& file) {
   }
   m_flatTables.createFields(iRun, *model);
 
-  RNTupleWriteOptions options;
-  options.SetCompression(file.GetCompressionSettings());
-  m_ntuple = RNTupleWriter::Append(std::move(model), "Runs", file, options);
+  m_ntuple = RNTupleWriter::Append(std::move(model), "Runs", file, writeOptions(file));
 }
 
 void RunNTuple::fill(const edm::RunForOutput& iRun, TFile& file) {
@@ -66,9 +76,8 @@ void RunNTuple::fill(const edm::RunForOutput& iRun, TFile& file) {
 
   edm::Handle<nanoaod::MergeableCounterTable> counterTableHandle;
   for (std::size_t i = 0; i < m_counterTableTokens.size(); i++) {
-    iRun.getByToken(m_counterTableTokens.at(i), counterTableHandle);
-    const nanoaod::MergeableCounterTable& tab = *counterTableHandle;
-    m_counterTables.at(i).fill(tab);
+    iRun.getByToken(m_counterTableTokens[i], counterTableHandle);
+    m_counterTables[i].fill(*counterTableHandle);
   }
 
   m_flatTables.fill(iRun);
@@ -78,49 +87,34 @@ void RunNTuple::fill(const edm::RunForOutput& iRun, TFile& file) {
 
 void RunNTuple::finalizeWrite() { m_ntuple.reset(); }
 
-void PSetNTuple::createFields(TFile& file) {
-  auto model = RNTupleModel::Create();
-  m_pset = RNTupleFieldPtr<PSetType>(edm::poolNames::idToParameterSetBlobsBranchName(), "", *model);
+namespace rntupleprovenance {
 
-  RNTupleWriteOptions options;
-  options.SetCompression(file.GetCompressionSettings());
-  m_ntuple = RNTupleWriter::Append(std::move(model), edm::poolNames::parameterSetsTreeName(), file, options);
-}
+  void writeParameterSets(TFile& file) {
+    using PSetType = std::pair<edm::ParameterSetID, edm::ParameterSetBlob>;
 
-void PSetNTuple::fill(edm::pset::Registry* pset, TFile& file) {
-  if (!pset) {
-    throw cms::Exception("LogicError", "null edm::pset::Registry::Instance pointer");
+    auto model = RNTupleModel::Create();
+    auto psets = RNTupleFieldPtr<PSetType>(edm::poolNames::idToParameterSetBlobsBranchName(), "", *model);
+    // The writer commits when it goes out of scope at the end of this function.
+    auto ntuple =
+        RNTupleWriter::Append(std::move(model), edm::poolNames::parameterSetsTreeName(), file, writeOptions(file));
+
+    for (const auto& ps : *edm::pset::Registry::instance()) {
+      std::string psString;
+      ps.second.toString(psString);
+      psets.fill(std::make_pair(ps.first, edm::ParameterSetBlob(psString)));
+      ntuple->Fill();
+    }
   }
-  if (!m_ntuple) {
-    createFields(file);
-  }
-  for (const auto& ps : *pset) {
-    std::string psString;
-    ps.second.toString(psString);
-    edm::ParameterSetBlob psBlob(psString);
-    m_pset.fill(std::make_pair(ps.first, psBlob));
-    m_ntuple->Fill();
-  }
-}
 
-void PSetNTuple::finalizeWrite() { m_ntuple.reset(); }
+  void writeProcessHistory(const edm::ProcessHistoryRegistry& procHist, TFile& file) {
+    auto model = RNTupleModel::Create();
+    auto history = RNTupleFieldPtr<edm::ProcessHistory>(edm::poolNames::processHistoryBranchName(), "", *model);
+    auto ntuple = RNTupleWriter::Append(std::move(model), edm::poolNames::metaDataTreeName(), file, writeOptions(file));
 
-void MetadataNTuple::createFields(TFile& file) {
-  auto model = RNTupleModel::Create();
-  m_procHist = RNTupleFieldPtr<edm::ProcessHistory>(edm::poolNames::processHistoryBranchName(), "", *model);
-  RNTupleWriteOptions options;
-  options.SetCompression(file.GetCompressionSettings());
-  m_ntuple = RNTupleWriter::Append(std::move(model), edm::poolNames::metaDataTreeName(), file, options);
-}
-
-void MetadataNTuple::fill(const edm::ProcessHistoryRegistry& procHist, TFile& file) {
-  if (!m_ntuple) {
-    createFields(file);
+    for (const auto& ph : procHist) {
+      history.fill(ph.second);
+      ntuple->Fill();
+    }
   }
-  for (const auto& ph : procHist) {
-    m_procHist.fill(ph.second);
-    m_ntuple->Fill();
-  }
-}
 
-void MetadataNTuple::finalizeWrite() { m_ntuple.reset(); }
+}  // namespace rntupleprovenance

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
@@ -1,25 +1,20 @@
 #ifndef PhysicsTools_NanoAOD_NanoAODRNTuples_h
 #define PhysicsTools_NanoAOD_NanoAODRNTuples_h
 
-#include "DataFormats/Provenance/interface/BranchType.h"
-#include "DataFormats/Provenance/interface/ParameterSetBlob.h"
-#include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
 #include "FWCore/Framework/interface/RunForOutput.h"
-#include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "TFile.h"
-#include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleWriter.hxx>
-using ROOT::RNTupleWriter;
 
-#include "EventStringOutputFields.h"
 #include "RNTupleFieldPtr.h"
 #include "SummaryTableOutputFields.h"
 #include "TableOutputFields.h"
-#include "TriggerOutputFields.h"
+
+// The LuminosityBlocks and Runs ntuples are created on their first fill, because their schema is
+// only known once the first payload is in hand, and committed by finalizeWrite().
 
 class LumiNTuple {
 public:
@@ -28,10 +23,10 @@ public:
   void finalizeWrite();
 
 private:
-  void createFields(const edm::LuminosityBlockID& id, TFile& file);
-  std::unique_ptr<RNTupleWriter> m_ntuple;
-  RNTupleFieldPtr<UInt_t> m_run;
-  RNTupleFieldPtr<UInt_t> m_luminosityBlock;
+  void createFields(TFile& file);
+  std::unique_ptr<ROOT::RNTupleWriter> m_ntuple;
+  RNTupleFieldPtr<std::uint32_t> m_run;
+  RNTupleFieldPtr<std::uint32_t> m_luminosityBlock;
 };
 
 class RunNTuple {
@@ -46,35 +41,20 @@ private:
   void createFields(const edm::RunForOutput& iRun, TFile& file);
   std::vector<edm::EDGetToken> m_counterTableTokens;
   std::vector<edm::EDGetToken> m_flatTableTokens;
-  std::unique_ptr<RNTupleWriter> m_ntuple;
-  RNTupleFieldPtr<UInt_t> m_run;
+  std::unique_ptr<ROOT::RNTupleWriter> m_ntuple;
+  RNTupleFieldPtr<std::uint32_t> m_run;
   std::vector<SummaryTableOutputFields> m_counterTables;
   TableCollectionSet m_flatTables;
 };
 
-class PSetNTuple {
-public:
-  PSetNTuple() = default;
-  void fill(edm::pset::Registry* pset, TFile& file);
-  void finalizeWrite();
-
-private:
-  using PSetType = std::pair<edm::ParameterSetID, edm::ParameterSetBlob>;
-  RNTupleFieldPtr<PSetType> m_pset;
-  void createFields(TFile& file);
-  std::unique_ptr<RNTupleWriter> m_ntuple;
-};
-
-class MetadataNTuple {
-public:
-  MetadataNTuple() = default;
-  void fill(const edm::ProcessHistoryRegistry& procHist, TFile& file);
-  void finalizeWrite();
-
-private:
-  void createFields(TFile& file);
-  RNTupleFieldPtr<edm::ProcessHistory> m_procHist;
-  std::unique_ptr<RNTupleWriter> m_ntuple;
-};
+// Provenance, in contrast, is written in one pass at the end of the job. These are namespaced
+// because a plugin library exports them: the generic EDM RNTuple output in FWIO/RNTupleTemp*
+// writes the same two ntuples, and a job loading both plugins would otherwise risk an ODR clash.
+namespace rntupleprovenance {
+  // Writes the parameter set registry as the ParameterSets ntuple.
+  void writeParameterSets(TFile& file);
+  // Writes the process history as the MetaData ntuple.
+  void writeProcessHistory(const edm::ProcessHistoryRegistry& procHist, TFile& file);
+}  // namespace rntupleprovenance
 
 #endif

--- a/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleCollection.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleCollection.cc
@@ -1,5 +1,8 @@
 #include "RNTupleCollection.h"
 
+#include "FlatTableColumnDispatch.h"
+
+#include <ROOT/RField.hxx>
 #include <ROOT/RFieldBase.hxx>
 #include <ROOT/RField/RFieldRecord.hxx>
 #include <ROOT/RField/RFieldSequenceContainer.hxx>
@@ -10,71 +13,23 @@ using ROOT::RNTupleModel;
 using ROOT::RRecordField;
 using ROOT::RVectorField;
 
-std::string flatTableColumnTypeToString(nanoaod::FlatTable::ColumnType type) {
-  switch (type) {
-    case nanoaod::FlatTable::ColumnType::UInt8:
-      return "std::uint8_t";
-    case nanoaod::FlatTable::ColumnType::Int16:
-      return "std::int16_t";
-    case nanoaod::FlatTable::ColumnType::UInt16:
-      return "std::uint16_t";
-    case nanoaod::FlatTable::ColumnType::Int32:
-      return "std::int32_t";
-    case nanoaod::FlatTable::ColumnType::UInt32:
-      return "std::uint32_t";
-    case nanoaod::FlatTable::ColumnType::Int64:
-      return "std::int64_t";
-    case nanoaod::FlatTable::ColumnType::UInt64:
-      return "std::uint64_t";
-    case nanoaod::FlatTable::ColumnType::Bool:
-      return "bool";
-    case nanoaod::FlatTable::ColumnType::Float:
-      return "float";
-    case nanoaod::FlatTable::ColumnType::Double:
-      return "double";
-    default:
-      throw cms::Exception("LogicError", "Unsupported type");
+namespace {
+  // The RNTuple type name for a FlatTable column, e.g. "std::uint8_t" or "float".
+  std::string columnTypeName(nanoaod::FlatTable::ColumnType type) {
+    return dispatchColumnType(type, [](auto tag) { return ROOT::RField<typename decltype(tag)::type>::TypeName(); });
   }
-}
 
-std::tuple<const unsigned char*, unsigned int> getColStartAndTypeSize(edm::Handle<nanoaod::FlatTable>& table,
-                                                                      unsigned int colIdx) {
-  const unsigned char* col_start;
-  switch (table->columnType(colIdx)) {
-    case nanoaod::FlatTable::ColumnType::UInt8:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<uint8_t>(colIdx).data());
-      return std::make_tuple(col_start, 1);
-    case nanoaod::FlatTable::ColumnType::Int16:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<int16_t>(colIdx).data());
-      return std::make_tuple(col_start, 2);
-    case nanoaod::FlatTable::ColumnType::UInt16:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<uint16_t>(colIdx).data());
-      return std::make_tuple(col_start, 2);
-    case nanoaod::FlatTable::ColumnType::Int32:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<int32_t>(colIdx).data());
-      return std::make_tuple(col_start, 4);
-    case nanoaod::FlatTable::ColumnType::UInt32:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<uint32_t>(colIdx).data());
-      return std::make_tuple(col_start, 4);
-    case nanoaod::FlatTable::ColumnType::Int64:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<int64_t>(colIdx).data());
-      return std::make_tuple(col_start, 8);
-    case nanoaod::FlatTable::ColumnType::UInt64:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<uint64_t>(colIdx).data());
-      return std::make_tuple(col_start, 8);
-    case nanoaod::FlatTable::ColumnType::Bool:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<bool>(colIdx).data());
-      return std::make_tuple(col_start, 1);
-    case nanoaod::FlatTable::ColumnType::Float:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<float>(colIdx).data());
-      return std::make_tuple(col_start, 4);
-    case nanoaod::FlatTable::ColumnType::Double:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<double>(colIdx).data());
-      return std::make_tuple(col_start, 8);
-    default:
-      throw cms::Exception("LogicError", "Unsupported type");
+  // Where a column's values start in the FlatTable, and how wide one value is.
+  std::tuple<const unsigned char*, unsigned int> getColStartAndTypeSize(const nanoaod::FlatTable& table,
+                                                                        unsigned int colIdx) {
+    return dispatchColumnType(table.columnType(colIdx), [&](auto tag) {
+      using ColumnT = typename decltype(tag)::type;
+      auto column = table.columnData<ColumnT>(colIdx);
+      return std::make_tuple(reinterpret_cast<const unsigned char*>(column.data()),
+                             static_cast<unsigned int>(sizeof(nanoaod::FlatTable::ColumnStorageType<ColumnT>)));
+    });
   }
-}
+}  // anonymous namespace
 
 RNTupleCollection::RNTupleCollection(const std::string& name,
                                      const std::string& desc,
@@ -84,8 +39,7 @@ RNTupleCollection::RNTupleCollection(const std::string& name,
   std::vector<std::unique_ptr<RFieldBase>> subfields;
   for (auto& table : tables) {
     for (unsigned int i = 0; i < table->nColumns(); i++) {
-      std::string type = flatTableColumnTypeToString(table->columnType(i));
-      auto field = RFieldBase::Create(table->columnName(i), type).Unwrap();
+      auto field = RFieldBase::Create(table->columnName(i), columnTypeName(table->columnType(i))).Unwrap();
       field->SetDescription(table->columnDoc(i));
       subfields.push_back(std::move(field));
     }
@@ -115,7 +69,7 @@ void RNTupleCollection::fill(std::vector<edm::Handle<nanoaod::FlatTable>>& table
                            "Mismatch in number of entries between extension and main table for " + m_name);
     }
     for (unsigned int i = 0; i < table->nColumns(); i++) {
-      auto [col_start, type_size] = getColStartAndTypeSize(table, i);
+      auto [col_start, type_size] = getColStartAndTypeSize(*table, i);
       size_t col_offset = m_record_offsets[col_idx];
 
       for (unsigned int j = 0; j < col_size; j++) {

--- a/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.cc
@@ -8,14 +8,13 @@ std::vector<RNTupleFieldPtr<T>> SummaryTableOutputFields::makeFields(const std::
   std::vector<RNTupleFieldPtr<T>> fields;
   fields.reserve(tabcols.size());
   for (const auto &col : tabcols) {
-    fields.emplace_back(RNTupleFieldPtr<T>(col.name, col.doc, model));
+    fields.emplace_back(col.name, col.doc, model);
   }
   return fields;
 }
 
 template <typename T, typename Col>
-void SummaryTableOutputFields::fillScalarFields(const std::vector<Col> &tabcols,
-                                                std::vector<RNTupleFieldPtr<T>> fields) {
+void SummaryTableOutputFields::fillFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> &fields) {
   if (tabcols.size() != fields.size()) {
     throw cms::Exception("LogicError", "Mismatch in table columns");
   }
@@ -23,22 +22,12 @@ void SummaryTableOutputFields::fillScalarFields(const std::vector<Col> &tabcols,
     if (tabcols[i].name != fields[i].getFieldName()) {
       throw cms::Exception("LogicError", "Mismatch in table columns");
     }
-    fields[i].fill(tabcols[i].value);
-  }
-}
-
-// TODO: maybe we can unify with the function above since now it's the same
-template <typename T, typename Col>
-void SummaryTableOutputFields::fillVectorFields(const std::vector<Col> &tabcols,
-                                                std::vector<RNTupleFieldPtr<T>> fields) {
-  if (tabcols.size() != fields.size()) {
-    throw cms::Exception("LogicError", "Mismatch in table columns");
-  }
-  for (std::size_t i = 0; i < tabcols.size(); ++i) {
-    if (tabcols[i].name != fields[i].getFieldName()) {
-      throw cms::Exception("LogicError", "Mismatch in table columns");
+    // MergeableCounterTable spells a scalar column's payload `value` and a vector column's `values`
+    if constexpr (requires { tabcols[i].value; }) {
+      fields[i].fill(tabcols[i].value);
+    } else {
+      fields[i].fill(tabcols[i].values);
     }
-    fields[i].fill(tabcols[i].values);
   }
 }
 
@@ -52,10 +41,10 @@ SummaryTableOutputFields::SummaryTableOutputFields(const nanoaod::MergeableCount
 }
 
 void SummaryTableOutputFields::fill(const nanoaod::MergeableCounterTable &tab) {
-  fillScalarFields(tab.intCols(), m_intFields);
-  fillScalarFields(tab.floatCols(), m_floatFields);
-  fillScalarFields(tab.floatWithNormCols(), m_floatWithNormFields);
-  fillVectorFields(tab.vintCols(), m_vintFields);
-  fillVectorFields(tab.vfloatCols(), m_vfloatFields);
-  fillVectorFields(tab.vfloatWithNormCols(), m_vfloatWithNormFields);
+  fillFields(tab.intCols(), m_intFields);
+  fillFields(tab.floatCols(), m_floatFields);
+  fillFields(tab.floatWithNormCols(), m_floatWithNormFields);
+  fillFields(tab.vintCols(), m_vintFields);
+  fillFields(tab.vfloatCols(), m_vfloatFields);
+  fillFields(tab.vfloatWithNormCols(), m_vfloatWithNormFields);
 }

--- a/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.h
@@ -14,10 +14,9 @@ public:
 private:
   template <typename T, typename Col>
   std::vector<RNTupleFieldPtr<T>> makeFields(const std::vector<Col> &tabcols, ROOT::RNTupleModel &model);
+  // Fills either a scalar column (SingleColumn::value) or a vector column (VectorColumn::values).
   template <typename T, typename Col>
-  static void fillScalarFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> fields);
-  template <typename T, typename Col>
-  static void fillVectorFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> fields);
+  static void fillFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> &fields);
 
   using int_accumulator = nanoaod::MergeableCounterTable::int_accumulator;
   using float_accumulator = nanoaod::MergeableCounterTable::float_accumulator;

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.cc
@@ -1,98 +1,54 @@
 #include "TableOutputFields.h"
 
-namespace {
-  void printTable(const nanoaod::FlatTable& table) {
-    std::cout << "FlatTable {\n";
-    std::cout << "  name: " << (table.name().empty() ? "// anon" : table.name()) << "\n";
-    std::cout << "  singleton: " << (table.singleton() ? "true" : "false") << "\n";
-    std::cout << "  size: " << table.size() << "\n";
-    std::cout << "  extension: " << (table.extension() ? "true" : "false") << "\n";
-    std::cout << "  fields: {\n";
-    for (std::size_t i = 0; i < table.nColumns(); i++) {
-      std::cout << "    " << (table.columnName(i).empty() ? "// anon" : table.columnName(i)) << ": ";
-      switch (table.columnType(i)) {
-        case nanoaod::FlatTable::ColumnType::Float:
-          std::cout << "f32,";
-          break;
-        case nanoaod::FlatTable::ColumnType::Int32:
-          std::cout << "i32,";
-          break;
-        case nanoaod::FlatTable::ColumnType::UInt8:
-          std::cout << "u8,";
-          break;
-        case nanoaod::FlatTable::ColumnType::Bool:
-          std::cout << "bool,";
-          break;
-        default:
-          std::cout << "other,";
-          break;
-          //throw cms::Exception("LogicError", "Unsupported type");
-      }
-      std::cout << "\n";
-    }
-    std::cout << "  }\n}\n";
-  }
-}  // anonymous namespace
+#include "FlatTableColumnDispatch.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-void TableOutputFields::print() const {
-  for (const auto& field : m_floatFields) {
-    std::cout << "  " << field.getFlatTableName() << ": f32,\n";
+#include <algorithm>
+
+using ROOT::RNTupleModel;
+
+namespace flattablefield {
+  std::pair<std::string, std::string> nameAndDoc(const nanoaod::FlatTable& table, std::size_t i) {
+    // case 1: the column has a name (the table may or may not have one)
+    if (!table.columnName(i).empty()) {
+      return {table.columnName(i), table.columnDoc(i)};
+    }
+    // case 2: the column is anonymous, so it takes the table's name
+    if (table.name().empty()) {
+      throw cms::Exception("LogicError", "Empty FlatTable name and field name");
+    }
+    return {table.name(), table.doc()};
   }
-  for (const auto& field : m_intFields) {
-    std::cout << "  " << field.getFlatTableName() << ": i32,\n";
+
+  unsigned int columnIndex(const nanoaod::FlatTable& table, const std::string& columnName) {
+    int index = table.columnIndex(columnName);
+    if (index == -1) {
+      throw cms::Exception("LogicError", "Missing column in input for " + table.name() + "_" + columnName);
+    }
+    return static_cast<unsigned int>(index);
   }
-  for (const auto& field : m_uint8Fields) {
-    std::cout << "  " << field.getFlatTableName() << ": u8,\n";
-  }
-  for (const auto& field : m_boolFields) {
-    std::cout << "  " << field.getFlatTableName() << ": bool,\n";
-  }
-}
+}  // namespace flattablefield
 
 void TableOutputFields::createFields(const edm::OccurrenceForOutput& event, RNTupleModel& model) {
-  edm::Handle<nanoaod::FlatTable> handle;
-  event.getByToken(m_token, handle);
-  const nanoaod::FlatTable& table = *handle;
+  const nanoaod::FlatTable& table = *getTable(event);
+  m_fields.reserve(table.nColumns());
   for (std::size_t i = 0; i < table.nColumns(); i++) {
-    switch (table.columnType(i)) {
-      case nanoaod::FlatTable::ColumnType::Float:
-        m_floatFields.emplace_back(FlatTableField<float>(table, i, model));
-        break;
-      case nanoaod::FlatTable::ColumnType::Int32:
-        m_intFields.emplace_back(FlatTableField<int>(table, i, model));
-        break;
-      case nanoaod::FlatTable::ColumnType::UInt8:
-        m_uint8Fields.emplace_back(FlatTableField<std::uint8_t>(table, i, model));
-        break;
-      case nanoaod::FlatTable::ColumnType::Bool:
-        m_boolFields.emplace_back(FlatTableField<bool>(table, i, model));
-        break;
-      default:
-        std::cout << "Unsupported type in TableOutputFields"
-                  << "\n";
-        //throw cms::Exception("LogicError", "Unsupported type");
-    }
+    dispatchColumnType(table.columnType(i), [&](auto tag) {
+      using ColumnT = typename decltype(tag)::type;
+      m_fields.push_back(std::make_unique<FlatTableField<ColumnT>>(table, i, model));
+    });
   }
 }
 
 void TableOutputFields::fillEntry(const nanoaod::FlatTable& table, std::size_t i) {
-  for (auto& field : m_floatFields) {
-    field.fill(table, i);
-  }
-  for (auto& field : m_intFields) {
-    field.fill(table, i);
-  }
-  for (auto& field : m_uint8Fields) {
-    field.fill(table, i);
-  }
-  for (auto& field : m_boolFields) {
-    field.fill(table, i);
+  for (auto& field : m_fields) {
+    field->fillRow(table, i);
   }
 }
 
 const edm::EDGetToken& TableOutputFields::getToken() const { return m_token; }
 
-const edm::Handle<nanoaod::FlatTable> TableOutputFields::getTable(const edm::OccurrenceForOutput& event) const {
+edm::Handle<nanoaod::FlatTable> TableOutputFields::getTable(const edm::OccurrenceForOutput& event) const {
   edm::Handle<nanoaod::FlatTable> handle;
   event.getByToken(m_token, handle);
   return handle;
@@ -104,42 +60,20 @@ void TableOutputVectorFields::createFields(const edm::OccurrenceForOutput& event
   edm::Handle<nanoaod::FlatTable> handle;
   event.getByToken(m_token, handle);
   const nanoaod::FlatTable& table = *handle;
+  m_fields.reserve(table.nColumns());
   for (std::size_t i = 0; i < table.nColumns(); i++) {
-    switch (table.columnType(i)) {
-      case nanoaod::FlatTable::ColumnType::Float:
-        m_vfloatFields.emplace_back(FlatTableField<std::vector<float>>(table, i, model));
-        break;
-      case nanoaod::FlatTable::ColumnType::Int32:
-        m_vintFields.emplace_back(FlatTableField<std::vector<int>>(table, i, model));
-        break;
-      case nanoaod::FlatTable::ColumnType::UInt8:
-        m_vuint8Fields.emplace_back(FlatTableField<std::vector<std::uint8_t>>(table, i, model));
-        break;
-      case nanoaod::FlatTable::ColumnType::Bool:
-        m_vboolFields.emplace_back(FlatTableField<std::vector<bool>>(table, i, model));
-        break;
-      default:
-        std::cout << "Unsupported type in TableOutputVectorFields"
-                  << "\n";
-        //throw cms::Exception("LogicError", "Unsupported type");
-    }
+    dispatchColumnType(table.columnType(i), [&](auto tag) {
+      using ColumnT = typename decltype(tag)::type;
+      m_fields.push_back(std::make_unique<FlatTableVectorField<ColumnT>>(table, i, model));
+    });
   }
 }
+
 void TableOutputVectorFields::fill(const edm::OccurrenceForOutput& event) {
   edm::Handle<nanoaod::FlatTable> handle;
   event.getByToken(m_token, handle);
-  const auto& table = *handle;
-  for (auto& field : m_vfloatFields) {
-    field.fillVectored(table);
-  }
-  for (auto& field : m_vintFields) {
-    field.fillVectored(table);
-  }
-  for (auto& field : m_vuint8Fields) {
-    field.fillVectored(table);
-  }
-  for (auto& field : m_vboolFields) {
-    field.fillVectored(table);
+  for (auto& field : m_fields) {
+    field->fillColumn(*handle);
   }
 }
 
@@ -150,7 +84,7 @@ void TableCollection::add(const edm::EDGetToken& table_token, const nanoaod::Fla
     m_collectionName = table.name();
   }
   if (table.extension()) {
-    m_extensions.emplace_back(TableOutputFields(table_token));
+    m_extensions.emplace_back(table_token);
     return;
   }
   if (hasMainTable()) {
@@ -159,49 +93,29 @@ void TableCollection::add(const edm::EDGetToken& table_token, const nanoaod::Fla
   m_main = TableOutputFields(table_token);
 }
 
-void TableCollection::createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel) {
+std::vector<edm::Handle<nanoaod::FlatTable>> TableCollection::getTables(const edm::OccurrenceForOutput& event) const {
   std::vector<edm::Handle<nanoaod::FlatTable>> tables;
-
-  auto main_table = m_main.getTable(event);
-  std::string field_desc = main_table->doc();
-
-  tables.emplace_back(main_table);
-
-  for (auto& extension : m_extensions) {
-    auto ext_table = extension.getTable(event);
-    tables.emplace_back(ext_table);
+  tables.reserve(m_extensions.size() + 1);
+  tables.emplace_back(m_main.getTable(event));
+  for (const auto& extension : m_extensions) {
+    tables.emplace_back(extension.getTable(event));
   }
-  m_collection = std::make_unique<RNTupleCollection>(m_collectionName, field_desc, tables, eventModel);
+  return tables;
+}
+
+void TableCollection::createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel) {
+  auto tables = getTables(event);
+  m_collection = std::make_unique<RNTupleCollection>(m_collectionName, tables.front()->doc(), tables, eventModel);
 }
 
 void TableCollection::bindBuffer(RNTupleModel& eventModel) { m_collection->bindBuffer(eventModel); }
 
 void TableCollection::fill(const edm::OccurrenceForOutput& event) {
-  std::vector<edm::Handle<nanoaod::FlatTable>> tables;
-
-  auto main_table = m_main.getTable(event);
-  std::string field_desc = main_table->doc();
-
-  tables.emplace_back(main_table);
-
-  for (auto& extension : m_extensions) {
-    auto ext_table = extension.getTable(event);
-    tables.emplace_back(ext_table);
-  }
-
+  auto tables = getTables(event);
   m_collection->fill(tables);
 }
 
-void TableCollection::print() const {
-  std::cout << "Collection: " << m_collectionName << " {\n";
-  m_main.print();
-  for (const auto& ext : m_extensions) {
-    ext.print();
-  }
-  std::cout << "}\n";
-}
-
-bool TableCollection::hasMainTable() { return !m_main.getToken().isUninitialized(); }
+bool TableCollection::hasMainTable() const { return !m_main.getToken().isUninitialized(); }
 
 const std::string& TableCollection::getCollectionName() const { return m_collectionName; }
 
@@ -210,8 +124,7 @@ const std::string& TableCollection::getCollectionName() const { return m_collect
 void TableCollectionSet::add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table) {
   // skip empty tables -- requirement of RNTuple to define schema before filling
   if (table.nColumns() == 0) {
-    std::cout << "Warning: skipping empty table: \n";
-    printTable(table);
+    edm::LogWarning("TableCollectionSet") << "Skipping FlatTable '" << table.name() << "': it has no columns\n";
     return;
   }
   // Can handle either anonymous table or anonymous column but not both
@@ -223,9 +136,9 @@ void TableCollectionSet::add(const edm::EDGetToken& table_token, const nanoaod::
   // case 1: create a top-level RNTuple field for each table column
   if (table.name().empty() || hasAnonymousColumn(table)) {
     if (table.singleton()) {
-      m_singletonFields.emplace_back(TableOutputFields(table_token));
+      m_singletonFields.emplace_back(table_token);
     } else {
-      m_vectorFields.emplace_back(TableOutputVectorFields(table_token));
+      m_vectorFields.emplace_back(table_token);
     }
     return;
   }
@@ -234,18 +147,11 @@ void TableCollectionSet::add(const edm::EDGetToken& table_token, const nanoaod::
     return c.getCollectionName() == table.name();
   });
   if (collection == m_collections.end()) {
-    m_collections.emplace_back(TableCollection());
+    m_collections.emplace_back();
     m_collections.back().add(table_token, table);
     return;
   }
   collection->add(table_token, table);
-}
-
-void TableCollectionSet::print() const {
-  for (const auto& collection : m_collections) {
-    collection.print();
-    std::cout << "\n";
-  }
 }
 
 void TableCollectionSet::createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel) {
@@ -276,10 +182,7 @@ void TableCollectionSet::fill(const edm::OccurrenceForOutput& event) {
     collection.fill(event);
   }
   for (auto& fields : m_singletonFields) {
-    edm::Handle<nanoaod::FlatTable> handle;
-    event.getByToken(fields.getToken(), handle);
-    const auto& table = *handle;
-    fields.fillEntry(table, 0);
+    fields.fillEntry(*fields.getTable(event), 0);
   }
   for (auto& fields : m_vectorFields) {
     fields.fill(event);
@@ -295,7 +198,7 @@ bool TableCollectionSet::hasAnonymousColumn(const nanoaod::FlatTable& table) {
   }
   if (num_anon > 1) {
     throw cms::Exception("LogicError",
-                         "FlatTable `" + table.name() + "` has " + std::to_string(num_anon) + "anonymous fields");
+                         "FlatTable `" + table.name() + "` has " + std::to_string(num_anon) + " anonymous fields");
   }
-  return num_anon;
+  return num_anon > 0;
 }

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
@@ -8,89 +8,100 @@
 #include "DataFormats/NanoAOD/interface/FlatTable.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
-#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
-#include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriter;
+
+namespace flattablefield {
+  // The RNTuple field name and description for column i of a table: the column's own name and doc,
+  // or the table's when the column is anonymous.
+  std::pair<std::string, std::string> nameAndDoc(const nanoaod::FlatTable& table, std::size_t i);
+  // Index of the named column, throwing if this table does not carry it.
+  unsigned int columnIndex(const nanoaod::FlatTable& table, const std::string& columnName);
+}  // namespace flattablefield
+
+// One FlatTable column written as its own top-level RNTuple field. Fields are held by base class
+// pointer so that a table's columns live in a single vector whatever their types.
+class FlatTableFieldBase {
+public:
+  virtual ~FlatTableFieldBase() = default;
+  // Copy one row of this field's column into the RNTuple entry.
+  virtual void fillRow(const nanoaod::FlatTable& table, std::size_t row) = 0;
+};
 
 template <typename T>
-class FlatTableField {
+class FlatTableField : public FlatTableFieldBase {
 public:
-  FlatTableField() = default;
-  FlatTableField(const nanoaod::FlatTable& table, std::size_t i, RNTupleModel& model) {
-    m_flatTableName = table.columnName(i);
-    // case 1: field has a name (table may or may not have a name)
-    if (!table.columnName(i).empty()) {
-      m_field = RNTupleFieldPtr<T>(table.columnName(i), table.columnDoc(i), model);
-      return;
-    }
-    // case 2: field doesn't have a name: use the table name as the RNTuple field name
-    if (table.name().empty()) {
-      throw cms::Exception("LogicError", "Empty FlatTable name and field name");
-    }
-    m_field = RNTupleFieldPtr<T>(table.name(), table.doc(), model);
+  FlatTableField(const nanoaod::FlatTable& table, std::size_t i, ROOT::RNTupleModel& model)
+      : m_columnName(table.columnName(i)) {
+    auto [name, doc] = flattablefield::nameAndDoc(table, i);
+    m_field = RNTupleFieldPtr<T>(name, doc, model);
   }
-  // For collection fields and singleton fields
-  void fill(const nanoaod::FlatTable& table, std::size_t i) {
-    int col_idx = table.columnIndex(m_flatTableName);
-    if (col_idx == -1) {
-      throw cms::Exception("LogicError", "Missing column in input for " + table.name() + "_" + m_flatTableName);
-    }
-    m_field.fill(table.columnData<T>(col_idx)[i]);
+  void fillRow(const nanoaod::FlatTable& table, std::size_t row) override {
+    m_field.fill(table.columnData<T>(flattablefield::columnIndex(table, m_columnName))[row]);
   }
-  // For vector fields without a collection, we have to buffer the results
-  // internally and then fill the RNTuple field
-  void fillVectored(const nanoaod::FlatTable& table) {
-    int col_idx = table.columnIndex(m_flatTableName);
-    if (col_idx == -1) {
-      throw cms::Exception("LogicError", "Missing column in input for " + table.name() + "_" + m_flatTableName);
-    }
-    std::vector<typename T::value_type> buf(table.size());
-    for (std::size_t i = 0; i < table.size(); i++) {
-      buf[i] = table.columnData<typename T::value_type>(col_idx)[i];
-    }
-    m_field.fill(buf);
-  }
-  const std::string& getFlatTableName() const { return m_flatTableName; }
 
 private:
   RNTupleFieldPtr<T> m_field;
-  std::string m_flatTableName;
+  std::string m_columnName;
+};
+
+// The same, for a table whose columns each become one std::vector field. The column is buffered
+// because a FlatTable stores bools as bytes, so its memory is not a std::vector<T> to begin with.
+class FlatTableVectorFieldBase {
+public:
+  virtual ~FlatTableVectorFieldBase() = default;
+  // Copy this field's whole column into the RNTuple entry.
+  virtual void fillColumn(const nanoaod::FlatTable& table) = 0;
+};
+
+template <typename T>
+class FlatTableVectorField : public FlatTableVectorFieldBase {
+public:
+  FlatTableVectorField(const nanoaod::FlatTable& table, std::size_t i, ROOT::RNTupleModel& model)
+      : m_columnName(table.columnName(i)) {
+    auto [name, doc] = flattablefield::nameAndDoc(table, i);
+    m_field = RNTupleFieldPtr<std::vector<T>>(name, doc, model);
+  }
+  void fillColumn(const nanoaod::FlatTable& table) override {
+    auto column = table.columnData<T>(flattablefield::columnIndex(table, m_columnName));
+    m_buffer.assign(column.begin(), column.end());
+    m_field.fill(m_buffer);
+  }
+
+private:
+  RNTupleFieldPtr<std::vector<T>> m_field;
+  std::vector<T> m_buffer;
+  std::string m_columnName;
 };
 
 class TableOutputFields {
 public:
   TableOutputFields() = default;
   explicit TableOutputFields(const edm::EDGetToken& token) : m_token(token) {}
-  void print() const;
-  void createFields(const edm::OccurrenceForOutput& event, RNTupleModel& model);
+  void createFields(const edm::OccurrenceForOutput& event, ROOT::RNTupleModel& model);
   void fillEntry(const nanoaod::FlatTable& table, std::size_t i);
   const edm::EDGetToken& getToken() const;
-  const edm::Handle<nanoaod::FlatTable> getTable(const edm::OccurrenceForOutput& event) const;
+  edm::Handle<nanoaod::FlatTable> getTable(const edm::OccurrenceForOutput& event) const;
 
 private:
   edm::EDGetToken m_token;
-  std::vector<FlatTableField<float>> m_floatFields;
-  std::vector<FlatTableField<int>> m_intFields;
-  std::vector<FlatTableField<std::uint8_t>> m_uint8Fields;
-  std::vector<FlatTableField<bool>> m_boolFields;
+  std::vector<std::unique_ptr<FlatTableFieldBase>> m_fields;
 };
 
 class TableOutputVectorFields {
 public:
   TableOutputVectorFields() = default;
   explicit TableOutputVectorFields(const edm::EDGetToken& token) : m_token(token) {}
-  void createFields(const edm::OccurrenceForOutput& event, RNTupleModel& model);
+  void createFields(const edm::OccurrenceForOutput& event, ROOT::RNTupleModel& model);
   void fill(const edm::OccurrenceForOutput& event);
 
 private:
   edm::EDGetToken m_token;
-  std::vector<FlatTableField<std::vector<float>>> m_vfloatFields;
-  std::vector<FlatTableField<std::vector<int>>> m_vintFields;
-  std::vector<FlatTableField<std::vector<std::uint8_t>>> m_vuint8Fields;
-  std::vector<FlatTableField<std::vector<bool>>> m_vboolFields;
+  std::vector<std::unique_ptr<FlatTableVectorFieldBase>> m_fields;
 };
 
 class TableCollection {
@@ -103,14 +114,16 @@ public:
   // Invariants:
   // * m_main not null
   // * m_collectionName not empty
-  void createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel);
-  void bindBuffer(RNTupleModel& eventModel);
+  void createFields(const edm::OccurrenceForOutput& event, ROOT::RNTupleModel& eventModel);
+  void bindBuffer(ROOT::RNTupleModel& eventModel);
   void fill(const edm::OccurrenceForOutput& event);
-  void print() const;
-  bool hasMainTable();
+  bool hasMainTable() const;
   const std::string& getCollectionName() const;
 
 private:
+  // The main table followed by its extensions, the order their columns appear in.
+  std::vector<edm::Handle<nanoaod::FlatTable>> getTables(const edm::OccurrenceForOutput& event) const;
+
   std::string m_collectionName;
   std::unique_ptr<RNTupleCollection> m_collection;
   TableOutputFields m_main;
@@ -120,10 +133,9 @@ private:
 class TableCollectionSet {
 public:
   void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
-  void createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel);
-  void bindBuffers(RNTupleModel& eventModel);
+  void createFields(const edm::OccurrenceForOutput& event, ROOT::RNTupleModel& eventModel);
+  void bindBuffers(ROOT::RNTupleModel& eventModel);
   void fill(const edm::OccurrenceForOutput& event);
-  void print() const;
 
 private:
   // Returns true if the FlatTable has an anonymous column. Throws a cms::Exception

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
@@ -11,7 +11,7 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include <algorithm>
+#include <map>
 
 using ROOT::RNTupleModel;
 
@@ -36,16 +36,12 @@ namespace {
 }  // anonymous namespace
 
 TriggerFieldPtr::TriggerFieldPtr(
-    std::string name, int index, std::string fieldName, std::string fieldDesc, RNTupleModel& model)
-    : m_triggerName(name), m_triggerIndex(index) {
-  m_field = RNTupleFieldPtr<bool>(fieldName, fieldDesc, model);
-}
+    const std::string& name, int index, const std::string& fieldName, const std::string& fieldDesc, RNTupleModel& model)
+    : m_field(fieldName, fieldDesc, model), m_triggerName(name), m_triggerIndex(index) {}
 
 void TriggerFieldPtr::fill(const edm::TriggerResults& triggers) {
-  if (m_triggerIndex == -1) {
-    m_field.fill(false);
-  }
-  m_field.fill(triggers.accept(m_triggerIndex));
+  // A trigger absent from the current run's menu has no index and is filled as false
+  m_field.fill(m_triggerIndex >= 0 ? triggers.accept(m_triggerIndex) : false);
 }
 
 std::vector<std::string> TriggerOutputFields::getTriggerNames(const edm::TriggerResults& triggerResults) {
@@ -86,40 +82,42 @@ void TriggerOutputFields::createFields(const edm::EventForOutput& event, RNTuple
     std::string modelName = name;
     makeUniqueFieldName(model, modelName);
     std::string desc = std::string("Trigger/flag bit (process: ") + m_processName + ")";
-    m_triggerFields.emplace_back(TriggerFieldPtr(name, i, modelName, desc, model));
+    m_triggerFields.emplace_back(name, i, modelName, desc, model);
   }
 }
 
-// Worst case O(n^2) to adjust the triggers
 void TriggerOutputFields::updateTriggerFields(const edm::TriggerResults& triggers) {
   std::vector<std::string> newNames(TriggerOutputFields::getTriggerNames(triggers));
-  // adjust existing trigger indices
-  for (auto& t : m_triggerFields) {
-    t.setIndex(-1);
-    for (std::size_t j = 0; j < newNames.size(); j++) {
-      auto& name = newNames[j];
-      if (!isNanoaodTrigger(name)) {
-        continue;
-      }
-      trimVersionSuffix(name);
-      if (name == t.getTriggerName()) {
-        t.setIndex(j);
-      }
-    }
-  }
-  // find new triggers
+  // Collect the current menu once. Each name is trimmed exactly once: trimVersionSuffix cuts at the
+  // last "_v", so trimming an already trimmed name can truncate it again.
+  std::map<std::string, int> menu;
   for (std::size_t j = 0; j < newNames.size(); j++) {
     auto& name = newNames[j];
     if (!isNanoaodTrigger(name)) {
       continue;
     }
     trimVersionSuffix(name);
-    if (std::none_of(m_triggerFields.cbegin(), m_triggerFields.cend(), [&](const TriggerFieldPtr& t) {
-          return t.getTriggerName() == name;
-        })) {
-      // TODO backfill / friend ntuples
-      edm::LogWarning("TriggerOutputFields") << "Skipping output of TriggerField " << name << "\n";
+    menu[name] = static_cast<int>(j);
+  }
+  // Point the existing fields at their index in the current menu, or at -1 if they are gone.
+  // Erasing on a match leaves only the unclaimed paths behind for the warning below. It also means
+  // a menu entry is bound to at most one field: should two fields ever carry the same trimmed name
+  // (possible only if a menu holds two versions of one path), the first claims it and the rest are
+  // written as false. That is the safe reading -- the alternative, pointing several fields at the
+  // same bit, would silently duplicate one path's decision under several names.
+  for (auto& t : m_triggerFields) {
+    auto found = menu.find(t.getTriggerName());
+    if (found == menu.end()) {
+      t.setIndex(-1);
+    } else {
+      t.setIndex(found->second);
+      menu.erase(found);
     }
+  }
+  // Whatever is left in the menu appeared after the schema was frozen and cannot be added.
+  for (const auto& entry : menu) {
+    // TODO backfill / friend ntuples
+    edm::LogWarning("TriggerOutputFields") << "Skipping output of TriggerField " << entry.first << "\n";
   }
 }
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.h
@@ -13,7 +13,11 @@ namespace edm {
 class TriggerFieldPtr {
 public:
   TriggerFieldPtr() = default;
-  TriggerFieldPtr(std::string name, int index, std::string fieldName, std::string fieldDesc, ROOT::RNTupleModel& model);
+  TriggerFieldPtr(const std::string& name,
+                  int index,
+                  const std::string& fieldName,
+                  const std::string& fieldDesc,
+                  ROOT::RNTupleModel& model);
   void fill(const edm::TriggerResults& triggers);
   const std::string& getTriggerName() const { return m_triggerName; }
   void setIndex(int newIndex) { m_triggerIndex = newIndex; }


### PR DESCRIPTION
This PR does some misc cleanup and fixed for the NanoAODRNTupleOutputModule that I started workin in #49551. There will be a follow-up PR with some behavior changes.

I used assistance from Claude Code for this. I've attached some more detailed description of the changes below.

:robot: _AI text below_ :robot:

**Fixes**

- A trigger index from a previous run's menu was used against the current
  `TriggerResults` with no bounds check.
- Version suffixes were trimmed once per event rather than once per menu update,
  so an already-trimmed name could be truncated a second time.
- Whether output was open was tracked by the `RNTupleWriter`, which only exists
  from the first event on, so a job that wrote no events never closed its file.
- The `nanoMetadata` strings were rewritten on every run, leaving duplicate keys
  in a multi-run job.
- `nanoaod::FlatTable` column types were dispatched in several places. The two
  that write top-level fields covered only `Float`, `Int32`, `UInt8` and `Bool`,
  reporting the rest to stdout and then dropping them. Dispatch now lives in one
  place (`FlatTableColumnDispatch.h`) and has no `default` case, so a column type
  added to `nanoaod::FlatTable` becomes a compile error here instead of silently
  missing output.

**Cleanup**

- Unsupported-type reports go through `MessageLogger` rather than stdout.
- Dead debug printing removed.
- Summary table fields are passed by reference, and their two near-identical fill
  helpers are merged into one.
- Provenance is written by plain functions in a namespace of its own, so a job
  loading both this plugin and `FWIO/RNTupleTemp*` cannot hit an ODR clash.
- Kept products are sorted by class when the output file opens rather than on the
  first event — only their descriptions are needed for that.
- Headers cut to what each file actually uses.
- Namespaces are lower case, per CMS naming rule 7.
- Corrects the comment in the TTree `NanoAODOutputModule` listing the compression
  algorithms it accepts.

The only change here that alters what lands in the file is the column-type
dispatch fix, which writes columns that were previously dropped. Everything else
is behaviour-preserving.

### PR validation:

Builds clean against ROOT 6.36 in `CMSSW_20_1_0_pre2` (`el9_aarch64_gcc13`) with
no errors or warnings, `scram b runtests` passes, and the code is
clang-format-clean.