### PR TITLE
Add Sherpa3Interface

### DIFF
--- a/GeneratorInterface/Sherpa3Interface/BuildFile.xml
+++ b/GeneratorInterface/Sherpa3Interface/BuildFile.xml
@@ -1,0 +1,8 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="GeneratorInterface/Core"/>
+<use name="GeneratorInterface/ExternalDecays"/>
+<use name="Utilities/OpenSSL"/>
+<use name="clhep"/>
+<use name="sherpa3"/>
+<flags EDM_PLUGIN="1"/>

--- a/GeneratorInterface/Sherpa3Interface/data/WZ_polarisation_nLO.yml
+++ b/GeneratorInterface/Sherpa3Interface/data/WZ_polarisation_nLO.yml
@@ -1,0 +1,52 @@
+### test example of WZ polarisation from Sherpa v3.0.5 manual:
+### https://sherpa-team.gitlab.io/sherpa/v3.0.5/manual/examples.html#polarized-mathrm-w-z-boson-pair-production-pair-production-at-nlo-ps
+
+# collider setup
+BEAMS: 2212
+BEAM_ENERGIES: 6500
+
+# settings matrix-element generation
+ME_GENERATORS:
+  - Comix
+  - Amegic
+  - OpenLoops
+COMIX_DEFAULT_GAUGE: 0
+
+# scale setting
+SCALES: METS{0.25*sqr(80.352+91.153)}
+
+# width 0 for the stable vector bosons in the hard matrix element
+PARTICLE_DATA:
+  24: 
+    Width: 0
+  23:
+    Width: 0
+WIDTH_SCHEME: Fixed
+
+# speed and neg weight fraction improvements
+MC@NLO:
+  PSMODE: 2
+
+# vector boson production part pp -> WZ
+PROCESSES:
+# leading order
+- 93 93 -> 24 23:
+    Order: {QCD: 0, EW: 2}
+# NLO QCD corrections
+    NLO_Mode: MC@NLO
+    NLO_Order: {QCD: 1, EW: 0}
+    ME_Generator: Amegic
+    RS_ME_Generator: Comix
+    Loop_Generator: OpenLoops
+
+# vector boson decays
+HARD_DECAYS:
+  Enabled: true
+  Channels:
+    24,12,-11: {Status: 2}
+    23,13,-13: {Status: 2}
+# settings for polarized cross sections 
+  Pol_Cross_Section:
+    Enabled: true
+    Reference_System: [Lab, COM]
+

--- a/GeneratorInterface/Sherpa3Interface/data/mkSherpa3Gridpack.sh
+++ b/GeneratorInterface/Sherpa3Interface/data/mkSherpa3Gridpack.sh
@@ -1,0 +1,487 @@
+#!/bin/bash
+#
+#  file:        mkSherpa3Gridpack.sh
+#  description: BASH script to produce a Sherpa3 gridpack (process libraries +
+#               cross sections) from a Sherpa 3 runcard in YAML format.
+#               Must be run inside a CMSSW environment (cmsenv) with the
+#               sherpa3 tool set up, so that SHERPA3_* / SCRAM_ARCH /
+#               CMSSW_VERSION are defined.
+#
+#  usage:       mkSherpa3Gridpack.sh -yml <runcard.yaml> [options]
+#
+#  options: -exe, --sh_exe   path   Sherpa3 executable
+#                                   (default: the CMSSW sherpa3 from the sherpa3 tool)
+#           -yml, --sh_yml   path   runcard in YAML format; it is copied to
+#                                   "Sherpa.yaml" inside the running directory
+#           -o,   --outpath  path   running directory; all output goes there
+#                                   (default: TEMP_SHERPA; deleted & recreated
+#                                   if it exists)
+#           -n,   --nthreads N      number of MPI ranks for the cross section
+#                                   integration run (default: 1 -> no mpiexec)
+#           -ol,  --openloops path  OpenLoops prefix used for OL_PREFIX in
+#                                   Sherpa.yaml (default: the openloops CMSSW
+#                                   points to, CMS_OPENLOOPS_PREFIX; only set
+#                                   when the runcard mentions OpenLoops)
+#           -so,  --sh_opt "opts"   additional Sherpa options (string), passed
+#                                   to Sherpa for the cross section
+#                                   integration run
+#           -ht,  --hyperthread     allow using hyperthreads: NTHREADS may go
+#                                   beyond the physical cores up to the total
+#                                   number of threads (mpiexec is run with
+#                                   --use-hwthread-cpus)
+#           -nw,  --no-weights      skip the weight-name probe (see notes); the
+#                                   cff is then written without a
+#                                   SherpaWeightsBlock and the event weights end
+#                                   up in the GEN output unnamed
+#           -v,   --verbose         also print the Sherpa/makelibs running
+#                                   output to stdout (default: log file only)
+#           -h,   --help            display this help and exit
+#
+#  notes:       AMEGIC usage is detected automatically: if the runcard mentions
+#               Amegic (e.g. in ME_GENERATORS), or if the library-writing step
+#               produced ./makelibs, the process libraries are compiled with
+#               ./makelibs. If the runcard contains "AMEGIC_LIBRARY_MODE: 0",
+#               ./makelibs is run with "-m" (one library per process).
+#
+#               Weight names: after the gridpack is packed, one event is
+#               generated with Sherpa's HepMC3 output enabled and the weight
+#               names are read back from it. They are written into the cff as a
+#               SherpaWeightsBlock, so the GEN job can label its weights. This
+#               is the only way to get the names right: they depend on the
+#               runcard (scale/PDF variations, associated contributions) and
+#               Sherpa only materialises them when it fills an event. Nothing
+#               downstream carries them otherwise - HepMC3Product stores no
+#               GenRunInfo and GenEventInfoProduct3 stores values only, so
+#               GenLumiInfoHeader (fed from this block) is the only channel.
+#               The block also documents SherpaRenamedWeights /
+#               SherpaRenamedVariationWeights: the EDM-facing names the
+#               hadronizer stores ('+' -> 'p', '-' -> 'm'), one per entry of
+#               the matching Sherpa list, in the same order.
+#
+#               OL_PREFIX is baked into the cff for the CMSSW release used to
+#               build the gridpack. At event-generation time the hadronizer
+#               overrides it with the OpenLoops of the running release
+#               (CMS_OPENLOOPS_PREFIX), unless the fragment opts out with
+#               FIXED_OL_PREFIX = cms.bool(True) in Sherpa3Parameters.
+#
+#  output:      Sherpa3_<runcard_name>_<SCRAM_ARCH>_<CMSSW_VERSION>_tarball.tar.xz
+#               in the directory where the script is invoked, plus the CMSSW
+#               python fragment Sherpa3_<runcard_name>_cff.py for it and the
+#               plain list of weight names Sherpa3_<runcard_name>_weights.txt.
+#               A log file with all stdout/stderr is stored inside the gridpack.
+
+set -uo pipefail
+
+# +-----------------------------------------------------------------------------------------------+
+# defaults & argument parsing
+# +-----------------------------------------------------------------------------------------------+
+
+SH_EXE=""
+SH_YML=""
+FLAG_AMEGIC=0
+OUTPATH="SHERPA3TEMP"
+NTHREADS=1
+OL_PREFIX=""
+OL_EXPLICIT=0
+SH_OPT=""
+USE_HT=0
+EVTGEN_DIR="./SHERPA3GEN" # Sherpa3 event generation directory in cff
+GET_WEIGHTS=1
+VERBOSE=0
+
+# remember the original command line (for the log)
+ORIG_CMD="$0 $*"
+
+# print the header comment block (everything after the shebang up to the first
+# non-comment line), so the help never goes stale when the header grows
+print_help() { awk 'NR>1 && /^#/ {print; next} NR>1 {exit}' "$0"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -exe|--sh_exe)     SH_EXE="$2";      shift 2 ;;
+    -yml|--sh_yml)     SH_YML="$2";      shift 2 ;;
+    -o|--outpath)      OUTPATH="$2";     shift 2 ;;
+    -n|--nthreads)     NTHREADS="$2";    shift 2 ;;
+    -ol|--openloops)   OL_PREFIX="$2"; OL_EXPLICIT=1; shift 2 ;;
+    -so|--sh_opt)      SH_OPT="$2";      shift 2 ;;
+    -ht|--hyperthread) USE_HT=1;         shift   ;;
+    -nw|--no-weights)  GET_WEIGHTS=0;    shift   ;;
+    -eg|--evtgendir)   EVTGEN_DIR="$2";  shift 2 ;;
+    -v|--verbose)      VERBOSE=1;        shift   ;;
+    -h|--help)         print_help;       exit 0  ;;
+    *) echo "mkSherpa3Gridpack: unknown option '$1' (use -h for help)"; exit 1 ;;
+  esac
+done
+
+# +-----------------------------------------------------------------------------------------------+
+# sanity checks
+# +-----------------------------------------------------------------------------------------------+
+
+if [ -z "${SH_YML}" ]; then
+  echo "mkSherpa3Gridpack: no runcard given, use -yml/--sh_yml (use -h for help)"
+  exit 1
+fi
+if [ ! -f "${SH_YML}" ]; then
+  echo "mkSherpa3Gridpack: runcard '${SH_YML}' not found"
+  exit 1
+fi
+# make the runcard path absolute (the script changes into OUTPATH later)
+SH_YML="$(cd "$(dirname "${SH_YML}")" && pwd)/$(basename "${SH_YML}")"
+
+if [ -z "${SHERPA3_SHARE_PATH:-}" ]; then
+  echo "mkSherpa3Gridpack: SHERPA3_SHARE_PATH is not set."
+  echo "                   Run this script in a CMSSW environment (cmsenv) with the sherpa3 tool set up."
+  exit 1
+fi
+
+# default Sherpa3 executable: the CMSSW sherpa3 (derived from the sherpa3 tool paths)
+if [ -z "${SH_EXE}" ]; then
+  SH_EXE="$(cd "${SHERPA3_SHARE_PATH}/../.." && pwd)/bin/Sherpa3"
+fi
+if [ ! -x "${SH_EXE}" ]; then
+  echo "mkSherpa3Gridpack: Sherpa3 executable '${SH_EXE}' not found or not executable"
+  exit 1
+fi
+
+if [ -z "${SCRAM_ARCH:-}" ] || [ -z "${CMSSW_VERSION:-}" ]; then
+  echo "mkSherpa3Gridpack: SCRAM_ARCH and/or CMSSW_VERSION not set; run inside cmsenv."
+  exit 1
+fi
+
+# OpenLoops prefix for OL_PREFIX in Sherpa.yaml.
+# Only needed when the runcard uses OpenLoops; -ol forces it.
+if grep -qi "openloops" "${SH_YML}"; then
+  FLAG_OPENLOOPS=1
+else
+  FLAG_OPENLOOPS=0
+fi
+if [ "${OL_EXPLICIT}" -eq 1 ] && [ "${FLAG_OPENLOOPS}" -eq 0 ]; then
+  echo "mkSherpa3Gridpack: WARNING: -ol given but runcard '${SH_YML}' does not mention OpenLoops"
+fi
+if [ "${FLAG_OPENLOOPS}" -eq 0 ] && [ "${OL_EXPLICIT}" -eq 0 ]; then
+  OL_PREFIX=""
+elif [ -z "${OL_PREFIX}" ]; then
+  OL_PREFIX="${CMS_OPENLOOPS_PREFIX:-}"
+fi
+if [ -n "${OL_PREFIX}" ] && [ ! -d "${OL_PREFIX}" ]; then
+  echo "mkSherpa3Gridpack: OpenLoops prefix '${OL_PREFIX}' is not a directory"
+  exit 1
+fi
+
+# +-----------------------------------------------------------------------------------------------+
+# automatic AMEGIC detection (from the runcard)
+# +-----------------------------------------------------------------------------------------------+
+
+if grep -qi "amegic" "${SH_YML}"; then
+  FLAG_AMEGIC=1
+fi
+MKLIBS_OPTS=""
+if grep -Eq "^[[:space:]]*AMEGIC_LIBRARY_MODE:[[:space:]]*0([[:space:]]|$)" "${SH_YML}"; then
+  MKLIBS_OPTS="-m"
+fi
+
+ORIGIN_NAME=$(basename "${SH_YML}")
+ORIGIN_NAME="${ORIGIN_NAME%.*}"
+GRIDPACK="$(pwd)/Sherpa3_${ORIGIN_NAME}_${SCRAM_ARCH}_${CMSSW_VERSION}_tarball.tar.xz"
+CFFFILE="$(pwd)/Sherpa3_${ORIGIN_NAME}_cff.py"
+WEIGHTS_FILE="$(pwd)/Sherpa3_${ORIGIN_NAME}_weights.txt"
+LOG="$(pwd)/${ORIGIN_NAME}.log"
+rm -f "${WEIGHTS_FILE}"
+: > "${LOG}"
+
+# +-----------------------------------------------------------------------------------------------+
+# logging helpers
+# +-----------------------------------------------------------------------------------------------+
+
+logecho() {
+  # print to stdout and append to the log file
+  echo "$@" | tee -a "${LOG}"
+}
+
+run_step() {
+  # log a command and run it; append all stdout/stderr to the log file
+  # (and print it live when running verbose)
+  echo "" >> "${LOG}"
+  logecho "+ $*"
+  if [ "${VERBOSE}" = "1" ]; then
+    "$@" 2>&1 | tee -a "${LOG}"
+    return "${PIPESTATUS[0]}"
+  else
+    "$@" >> "${LOG}" 2>&1
+    return $?
+  fi
+}
+
+get_weight_names() {
+    # Generate a single event with Sherpa's HepMC3 output enabled and read the
+    # weight names back from the "W" record of the HepMC3 ASCII file. Must be
+    # called from inside OUTPATH, after the integration run. Writes the names,
+    # one per line, to ${WEIGHTS_FILE}; leaves it absent on failure.
+    logecho "##############################"
+    logecho ">>> PROBING WEIGHT NAMES"
+    logecho "##############################"
+
+    local probe_card="weights_probe.yaml"
+    local probe_out="weights_probe"
+
+    cp Sherpa.yaml "${probe_card}" || { logecho " could not create ${probe_card}"; return 1; }
+    echo "EVENT_OUTPUT: HepMC3[${probe_out}]" >> "${probe_card}"
+
+    # one event only; Sherpa loads libSherpaHepMC3Output on demand
+    if ! run_step "${SH_EXE}" "EVENT_OUTPUT: HepMC3[${probe_out}]" ${SH_OPT} -e 1 "${probe_card}"; then
+      logecho " WARNING: the weight-name probe run failed, see the log."
+      logecho "          The cff will be written without a SherpaWeightsBlock."
+      return 1
+    fi
+
+    # Sherpa writes <name>.gz (or an uncompressed variant, depending on build)
+    local probe_file
+    probe_file=$(ls -1 "${probe_out}".gz "${probe_out}".hepmc3 "${probe_out}" 2>/dev/null | head -1)
+    if [ -z "${probe_file}" ]; then
+      logecho " WARNING: no HepMC3 output found from the weight-name probe."
+      logecho "          The cff will be written without a SherpaWeightsBlock."
+      return 1
+    fi
+
+    # the W record lists the names separated by '\|'
+    local reader="cat"
+    case "${probe_file}" in *.gz) reader="zcat" ;; esac
+    ${reader} "${probe_file}" 2>/dev/null | grep -m1 '^W ' | sed -e 's/^W //' \
+      | tr '\\' '\n' | sed -e 's/^|//' | grep -v '^$' > "${WEIGHTS_FILE}"
+
+    if [ ! -s "${WEIGHTS_FILE}" ]; then
+      logecho " WARNING: could not read any weight name from ${probe_file}."
+      logecho "          (HEPMC_USE_NAMED_WEIGHTS disabled in the runcard?)"
+      logecho "          The cff will be written without a SherpaWeightsBlock."
+      rm -f "${WEIGHTS_FILE}"
+      return 1
+    fi
+
+    logecho " found $(wc -l < "${WEIGHTS_FILE}") weight names -> ${WEIGHTS_FILE} -> weights_list.txt"
+    rm -f "${probe_card}" "${probe_out}".gz "${probe_out}".hepmc3 "${probe_out}"
+    return 0
+}
+
+write_weights_block() {
+    # Turn ${WEIGHTS_FILE} into a SherpaWeightsBlock PSet on stdout.
+    # The nominal weight and the bookkeeping entries (EXTRA__*, IRREG__*) go
+    # into SherpaWeights, everything else is a variation and goes into
+    # SherpaVariationWeights, which the hadronizer divides by the weight
+    # normalisation for unweighted events. "Weight" must stay first: the
+    # hadronizer normalises index 0 of the rearranged list.
+    # Next to each list a SherpaRenamed* list documents the EDM-facing names
+    # the hadronizer stores ('+' -> 'p', '-' -> 'm'; downstream CMSSW consumers
+    # such as RivetAnalyzer mangle characters outside [A-Za-z0-9._=], which
+    # would make Sherpa's polarisation weights collide). Same order as the
+    # original list.
+    local base var
+    base=$( (grep -x 'Weight' "${WEIGHTS_FILE}"; grep -E '^(EXTRA__|IRREG__)' "${WEIGHTS_FILE}") )
+    var=$(grep -vx 'Weight' "${WEIGHTS_FILE}" | grep -vE '^(EXTRA__|IRREG__)')
+
+    echo "  SherpaWeightsBlock = cms.PSet("
+    echo "    SherpaWeights = cms.vstring("
+    echo "${base}" | sed -e "s/^/      '/;s/$/',/" -e '$s/,$//'
+    echo "    ),"
+    echo "    # EDM-facing names, one per SherpaWeights entry in the same order"
+    echo "    SherpaRenamedWeights = cms.vstring("
+    echo "${base}" | sed -e 's/+/p/g; s/-/m/g' | sed -e "s/^/      '/;s/$/',/" -e '$s/,$//'
+    echo "    ),"
+    echo "    SherpaVariationWeights = cms.vstring("
+    if [ -n "${var}" ]; then
+      echo "${var}" | sed -e "s/^/      '/;s/$/',/" -e '$s/,$//'
+    fi
+    echo "    ),"
+    echo "    # EDM-facing names, one per SherpaVariationWeights entry in the same order"
+    echo "    SherpaRenamedVariationWeights = cms.vstring("
+    if [ -n "${var}" ]; then
+      echo "${var}" | sed -e 's/+/p/g; s/-/m/g' | sed -e "s/^/      '/;s/$/',/" -e '$s/,$//'
+    fi
+    echo "    )"
+    echo "  ),"
+}
+
+create_cff() {
+    logecho "##############################"
+    logecho ">>> CREATING CFF"
+    logecho "##############################"
+
+    TMPDIR_CFF=$(mktemp -d)
+    trap 'rm -rf "${TMPDIR_CFF}"' EXIT
+
+    tar -xOJf "${GRIDPACK}" ./Sherpa.yaml > "${TMPDIR_CFF}/Sherpa.yaml" 2>/dev/null \
+      || { logecho " could not extract ./Sherpa.yaml from ${GRIDPACK}"; exit 1; }
+
+    CHECKSUM=$(md5sum "${GRIDPACK}" | awk '{print $1}')
+
+    # embed the YAML lines verbatim (indentation is significant in YAML!),
+    # only escaping '\' and '"' and quoting each line (no trailing comma on the last one)
+    sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' "${TMPDIR_CFF}/Sherpa.yaml" \
+      | sed -e 's/^/                                "/;s/$/\",/' \
+      | sed -e '$s/\",$/"/' > "${TMPDIR_CFF}/card.tmp"
+
+    if [ -e "${CFFFILE}" ]; then rm "${CFFFILE}"; fi
+    touch "${CFFFILE}"
+
+    echo "import FWCore.ParameterSet.Config as cms"                          >> ${CFFFILE}
+    echo "import os"                                                         >> ${CFFFILE}
+    echo ""                                                                  >> ${CFFFILE}
+    echo "source = cms.Source(\"EmptySource\")"                              >> ${CFFFILE}
+    echo ""                                                                  >> ${CFFFILE}
+    echo "generator = cms.EDFilter(\"Sherpa3GeneratorFilter\","              >> ${CFFFILE}
+    echo "  maxEventsToPrint = cms.int32(0),"                                >> ${CFFFILE}
+    echo "  filterEfficiency = cms.untracked.double(1.0),"                   >> ${CFFFILE}
+    echo "  crossSection = cms.untracked.double(-1),"                        >> ${CFFFILE}
+    echo "  Sherpa3Process = cms.string('"${ORIGIN_NAME}"'),"                >> ${CFFFILE}
+    echo "  GridpackLocation = cms.string('"${GRIDPACK}"'),"                 >> ${CFFFILE}
+    echo "  GridpackChecksum = cms.string('"${CHECKSUM}"'),"                 >> ${CFFFILE}
+    echo "  EvtGenDirectory = cms.string('"${EVTGEN_DIR}"'),"                >> ${CFFFILE}
+    if [ -s "${WEIGHTS_FILE}" ]; then
+      write_weights_block                                                    >> ${CFFFILE}
+    fi
+    echo "  Sherpa3Parameters = cms.PSet(parameterSets = cms.vstring("       >> ${CFFFILE}
+    echo "                             \"Run\"),"                            >> ${CFFFILE}
+    echo "                              Run = cms.vstring("                  >> ${CFFFILE}
+    cat "${TMPDIR_CFF}/card.tmp"                                             >> ${CFFFILE}
+    echo "                              )"                                   >> ${CFFFILE}
+    echo "                             )"                                    >> ${CFFFILE}
+    echo ")"                                                                 >> ${CFFFILE}
+    echo ""                                                                  >> ${CFFFILE}
+    echo "ProductionFilterSequence = cms.Sequence(generator)"                >> ${CFFFILE}
+    echo ""                                                                  >> ${CFFFILE}
+}
+
+# +-----------------------------------------------------------------------------------------------+
+# workflow
+# +-----------------------------------------------------------------------------------------------+
+
+# cap the number of MPI ranks / compile jobs: by default at the number of
+# physical CPU cores (OpenMPI counts physical cores as slots); with
+# -ht/--hyperthread at the total number of threads (hyperthreads included)
+PHYS_CORES=$(lscpu -p=CORE 2>/dev/null | grep -v '^#' | sort -u | wc -l)
+if [ -z "${PHYS_CORES}" ] || [ "${PHYS_CORES}" -lt 1 ] 2>/dev/null; then
+  PHYS_CORES=$(nproc 2>/dev/null || echo 1)
+fi
+TOTAL_THREADS=$(nproc 2>/dev/null || echo "${PHYS_CORES}")
+MPI_HT_OPT=""
+if [ "${USE_HT}" = "1" ]; then
+  MAX_RANKS=${TOTAL_THREADS}
+  MPI_HT_OPT="--use-hwthread-cpus"
+else
+  MAX_RANKS=${PHYS_CORES}
+fi
+if [ "${NTHREADS}" -gt "${MAX_RANKS}" ]; then
+  logecho " requested nthreads=${NTHREADS} exceeds the maximum ranks (${MAX_RANKS}); using ${MAX_RANKS}"
+  NTHREADS=${MAX_RANKS}
+fi
+
+logecho "##############################"
+logecho ">>> START INFO"
+logecho "##############################"
+logecho " command        = ${ORIG_CMD}"
+logecho " date           = $(date)"
+logecho " runcard        = ${SH_YML}"
+logecho " Sherpa3 exe    = ${SH_EXE}"
+logecho " FLAG_AMEGIC    = ${FLAG_AMEGIC} (auto-detected)"
+logecho " makelibs opts  = '${MKLIBS_OPTS}'"
+logecho " OL_PREFIX      = ${OL_PREFIX}"
+logecho " Sherpa options = '${SH_OPT}'"
+logecho " outpath        = ${OUTPATH}"
+logecho " nthreads       = ${NTHREADS} (max ${MAX_RANKS}, hyperthreads=${USE_HT})"
+logecho " gridpack       = ${GRIDPACK}"
+logecho " evtgendir      = ${EVTGEN_DIR}"
+
+# (1) create outpath (delete & recreate if it exists)
+if [ -e "${OUTPATH}" ]; then
+  logecho " removing existing '${OUTPATH}'"
+  rm -rf "${OUTPATH}" || exit 1
+fi
+mkdir -p "${OUTPATH}" || exit 1
+
+logecho "##############################"
+logecho ">>> RUNNING"
+logecho "##############################"
+
+cd "${OUTPATH}" || exit 1
+
+# (2) copy runcard to Sherpa.yaml
+cp "${SH_YML}" Sherpa.yaml || { logecho " failed to copy runcard"; exit 1; }
+
+# (2b) set up OL_PREFIX in Sherpa.yaml (replace an existing setting, else append)
+if [ -n "${OL_PREFIX}" ]; then
+  if grep -Eq "^[[:space:]]*OL_PREFIX:" Sherpa.yaml; then
+    sed -i "s|^[[:space:]]*OL_PREFIX:.*|OL_PREFIX: ${OL_PREFIX}|" Sherpa.yaml \
+      || { logecho " failed to set OL_PREFIX in Sherpa.yaml"; exit 1; }
+  else
+    echo "OL_PREFIX: ${OL_PREFIX}" >> Sherpa.yaml \
+      || { logecho " failed to set OL_PREFIX in Sherpa.yaml"; exit 1; }
+  fi
+  logecho " OL_PREFIX set to ${OL_PREFIX} in Sherpa.yaml"
+fi
+
+# (3) initiate: write process source code
+run_step "${SH_EXE}" ${SH_OPT} -I Sherpa.yaml || { logecho " library-writing step failed, see ${LOG}"; exit 1; }
+
+# if the library-writing step produced ./makelibs, process libraries must be
+# compiled regardless of the runcard-based detection
+if [ -x ./makelibs ] && [ "${FLAG_AMEGIC}" != "1" ]; then
+  logecho " ./makelibs was produced, enabling AMEGIC library compilation"
+  FLAG_AMEGIC=1
+fi
+
+# (4) compile process libraries (only if AMEGIC is used)
+if [ "${FLAG_AMEGIC}" = "1" ]; then
+  if [ -x ./makelibs ]; then
+    run_step ./makelibs ${MKLIBS_OPTS} -j ${NTHREADS} || { logecho " makelibs failed, see ${LOG}"; exit 1; }
+  else
+    logecho " WARNING: AMEGIC detected in runcard but no ./makelibs was produced;"
+    logecho "          no process libraries to compile, continuing."
+  fi
+fi
+
+# (5) cross section integration run
+# (MPI_HT_OPT and additional Sherpa options from -so/--sh_opt are word-split on purpose)
+if [ "${NTHREADS}" -gt 1 ]; then
+  run_step mpiexec ${MPI_HT_OPT} -np "${NTHREADS}" "${SH_EXE}" ${SH_OPT} -e 0 Sherpa.yaml \
+    || { logecho " integration run failed, see ${LOG}"; exit 1; }
+else
+  run_step "${SH_EXE}" ${SH_OPT} -e 0 Sherpa.yaml \
+    || { logecho " integration run failed, see ${LOG}"; exit 1; }
+fi
+
+# (6) probe the weight names (after packing, so the probe leaves no trace in
+# the gridpack; a failure here is not fatal, the cff is just written without
+# a SherpaWeightsBlock)
+if [ "${GET_WEIGHTS}" = "1" ]; then
+  get_weight_names || true
+else
+  logecho " weight-name probe skipped (-nw/--no-weights)"
+fi
+cp "${WEIGHTS_FILE}" "weights_list.txt"
+
+# (7) compress to gridpack (log file included)
+run_step echo "mkSherpa3Gridpack finished at $(date)"
+ORIGIN_LOG="${LOG}"
+mv "${ORIGIN_LOG}" gridpack_generation.log
+# from here on, append to the moved log inside OUTPATH
+LOG="gridpack_generation.log"
+logecho "##############################"
+logecho ">>> PACKING"
+logecho "##############################"
+logecho " packing '${GRIDPACK}' ..."
+cp "${LOG}" "${ORIGIN_LOG}"
+tar -cJf "${GRIDPACK}" . || { logecho " failed to create gridpack"; exit 1; }
+
+cd ..
+# back in the invocation directory: append further log lines to the copied log
+LOG="${ORIGIN_LOG}"
+logecho "[ mkSherpa3Gridpack ] gridpack created: ${GRIDPACK}"
+
+# (8) generate the CMSSW python fragment (cff) for the gridpack
+create_cff
+logecho "[ mkSherpa3Gridpack ] cff created: ${CFFFILE}"
+if [ -s "${WEIGHTS_FILE}" ]; then
+  logecho "[ mkSherpa3Gridpack ] weight names: ${WEIGHTS_FILE} ($(wc -l < "${WEIGHTS_FILE}") entries, embedded in the cff)"
+else
+  logecho "[ mkSherpa3Gridpack ] WARNING: no weight names available; the GEN output will store the"
+  logecho "                      event weights unnamed. Re-run without -nw/--no-weights to fix."
+fi

--- a/GeneratorInterface/Sherpa3Interface/data/mkSherpa3cff.sh
+++ b/GeneratorInterface/Sherpa3Interface/data/mkSherpa3cff.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+#
+#  file:        mkSherpa3cff.sh
+#  description: Generate the CMSSW python fragment (cff) for an existing
+#               Sherpa3 gridpack produced by mkSherpa3Gridpack.sh.
+#               The runcard (Sherpa.yaml) is taken from inside the gridpack,
+#               and the gridpack md5 checksum is included.
+#
+#  usage:       mkSherpa3cff.sh -gp <gridpack.tar.xz> [options]
+#
+#  options: -gp,  --gridpack path  the Sherpa3 gridpack tarball
+#           -yml, --sh_yml   path  runcard in YAML format (default: Sherpa.yaml
+#                                  extracted from the gridpack)
+#           -w,   --weights  path  file with the Sherpa weight names, one per
+#                                  line, as written by mkSherpa3Gridpack.sh
+#                                  (Sherpa3_<origin_name>_weights.txt). Without
+#                                  it the cff gets no SherpaWeightsBlock and the
+#                                  event weights end up in the GEN output
+#                                  unnamed. This script does not run Sherpa, so
+#                                  the names cannot be determined here.
+#                                  The SherpaWeightsBlock also contains
+#                                  SherpaRenamedWeights /
+#                                  SherpaRenamedVariationWeights: the
+#                                  EDM-facing names ('+' -> 'p', '-' -> 'm')
+#                                  the hadronizer stores, one per entry of the
+#                                  matching Sherpa list, in the same order.
+#           -o,   --output   path  output cff file name
+#                                  (default: Sherpa3_<origin_name>_cff.py)
+#           -h,   --help            display this help and exit
+#
+#  output:      Sherpa3_<origin_name>_cff.py with a Sherpa3GeneratorFilter
+#               (Sherpa 3 always produces HepMC3).
+
+set -uo pipefail
+
+# +-----------------------------------------------------------------------------------------------+
+# defaults & argument parsing
+# +-----------------------------------------------------------------------------------------------+
+
+GRIDPACK=""
+SH_YML=""
+CFFFILE=""
+WEIGHTS_FILE=""
+
+# print the header comment block (everything after the shebang up to the first
+# non-comment line), so the help never goes stale when the header grows
+print_help() { awk 'NR>1 && /^#/ {print; next} NR>1 {exit}' "$0"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -gp|--gridpack) GRIDPACK="$2";  shift 2 ;;
+    -yml|--sh_yml)  SH_YML="$2";    shift 2 ;;
+    -w|--weights)   WEIGHTS_FILE="$2"; shift 2 ;;
+    -o|--output)    CFFFILE="$2";   shift 2 ;;
+    -h|--help)      print_help; exit 0 ;;
+    *) echo "mkSherpa3cff: unknown option '$1' (use -h for help)"; exit 1 ;;
+  esac
+done
+
+# +-----------------------------------------------------------------------------------------------+
+# sanity checks
+# +-----------------------------------------------------------------------------------------------+
+
+if [ -z "${GRIDPACK}" ]; then
+  echo "mkSherpa3cff: no gridpack given, use -gp/--gridpack (use -h for help)"
+  exit 1
+fi
+if [ ! -f "${GRIDPACK}" ]; then
+  echo "mkSherpa3cff: gridpack '${GRIDPACK}' not found"
+  exit 1
+fi
+GRIDPACK="$(cd "$(dirname "${GRIDPACK}")" && pwd)/$(basename "${GRIDPACK}")"
+
+# process/origin name from the gridpack file name:
+# Sherpa3_<origin>_<SCRAM_ARCH>_<CMSSW_VERSION>_tarball.tar.xz
+ORIGIN_NAME=$(basename "${GRIDPACK}")
+ORIGIN_NAME="${ORIGIN_NAME%_tarball.tar.xz}"   # strip _tarball.tar.xz
+ORIGIN_NAME="${ORIGIN_NAME#Sherpa3_}"          # strip Sherpa3_ prefix
+ORIGIN_NAME=$(echo "${ORIGIN_NAME}" | sed -e 's/_[a-z0-9]*_amd64_gcc[0-9]*_.*$//')  # strip _<arch>_<release>
+
+if [ -z "${CFFFILE}" ]; then
+  CFFFILE="Sherpa3_${ORIGIN_NAME}_cff.py"
+fi
+
+CHECKSUM=$(md5sum "${GRIDPACK}" | awk '{print $1}')
+
+# +-----------------------------------------------------------------------------------------------+
+# get the runcard (from inside the gridpack, unless given explicitly)
+# +-----------------------------------------------------------------------------------------------+
+
+TMPDIR_CFF=$(mktemp -d)
+trap 'rm -rf "${TMPDIR_CFF}"' EXIT
+
+if [ -z "${SH_YML}" ]; then
+  tar -xOJf "${GRIDPACK}" ./Sherpa.yaml > "${TMPDIR_CFF}/Sherpa.yaml" 2>/dev/null \
+    || { echo "mkSherpa3cff: could not extract ./Sherpa.yaml from ${GRIDPACK}"; exit 1; }
+  SH_YML="${TMPDIR_CFF}/Sherpa.yaml"
+fi
+if [ ! -f "${SH_YML}" ]; then
+  echo "mkSherpa3cff: runcard '${SH_YML}' not found"
+  exit 1
+fi
+
+if [ -n "${WEIGHTS_FILE}" ] && [ ! -s "${WEIGHTS_FILE}" ]; then
+  echo "mkSherpa3cff: weight name file '${WEIGHTS_FILE}' not found or empty"
+  exit 1
+fi
+
+echo "mkSherpa3cff: gridpack  = ${GRIDPACK}"
+echo "mkSherpa3cff: process   = ${ORIGIN_NAME}"
+echo "mkSherpa3cff: md5       = ${CHECKSUM}"
+echo "mkSherpa3cff: runcard   = ${SH_YML}"
+echo "mkSherpa3cff: cff       = ${CFFFILE}"
+if [ -n "${WEIGHTS_FILE}" ]; then
+  echo "mkSherpa3cff: weights   = ${WEIGHTS_FILE} ($(wc -l < "${WEIGHTS_FILE}") names)"
+else
+  echo "mkSherpa3cff: weights   = none given (-w/--weights); weights will be unnamed in GEN output"
+fi
+
+# +-----------------------------------------------------------------------------------------------+
+# build the cff
+# +-----------------------------------------------------------------------------------------------+
+
+# embed the YAML lines verbatim (indentation is significant in YAML!),
+# only escaping '\' and '"' and quoting each line (no trailing comma on the last one)
+sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' "${SH_YML}" \
+  | sed -e 's/^/                                "/;s/$/\",/' \
+  | sed -e '$s/\",$/"/' > "${TMPDIR_CFF}/card.tmp"
+
+if [ -e "${CFFFILE}" ]; then rm "${CFFFILE}"; fi
+touch "${CFFFILE}"
+
+echo "import FWCore.ParameterSet.Config as cms"                          >> ${CFFFILE}
+echo "import os"                                                         >> ${CFFFILE}
+echo ""                                                                  >> ${CFFFILE}
+echo "source = cms.Source(\"EmptySource\")"                              >> ${CFFFILE}
+echo ""                                                                  >> ${CFFFILE}
+echo "generator = cms.EDFilter(\"Sherpa3GeneratorFilter\","              >> ${CFFFILE}
+echo "  maxEventsToPrint = cms.int32(0),"                                >> ${CFFFILE}
+echo "  filterEfficiency = cms.untracked.double(1.0),"                   >> ${CFFFILE}
+echo "  crossSection = cms.untracked.double(-1),"                        >> ${CFFFILE}
+echo "  Sherpa3Process = cms.string('"${ORIGIN_NAME}"'),"                >> ${CFFFILE}
+echo "  GridpackLocation = cms.string('"${GRIDPACK}"'),"                 >> ${CFFFILE}
+echo "  GridpackChecksum = cms.string('"${CHECKSUM}"'),"                 >> ${CFFFILE}
+if [ -n "${WEIGHTS_FILE}" ]; then
+  # nominal + bookkeeping entries first (the hadronizer normalises index 0),
+  # everything else is a variation and gets divided by the weight normalisation.
+  # Next to each list a SherpaRenamed* list documents the EDM-facing names the
+  # hadronizer stores ('+' -> 'p', '-' -> 'm'; downstream CMSSW consumers such
+  # as RivetAnalyzer mangle characters outside [A-Za-z0-9._=], which would make
+  # Sherpa's polarisation weights collide). Same order as the original list.
+  {
+    echo "  SherpaWeightsBlock = cms.PSet("
+    echo "    SherpaWeights = cms.vstring("
+    (grep -x 'Weight' "${WEIGHTS_FILE}"; grep -E '^(EXTRA__|IRREG__)' "${WEIGHTS_FILE}") \
+      | sed -e "s/^/      '/;s/$/',/" -e '$s/,$//'
+    echo "    ),"
+    echo "    # EDM-facing names, one per SherpaWeights entry in the same order"
+    echo "    SherpaRenamedWeights = cms.vstring("
+    (grep -x 'Weight' "${WEIGHTS_FILE}"; grep -E '^(EXTRA__|IRREG__)' "${WEIGHTS_FILE}") \
+      | sed -e 's/+/p/g; s/-/m/g' | sed -e "s/^/      '/;s/$/',/" -e '$s/,$//'
+    echo "    ),"
+    echo "    SherpaVariationWeights = cms.vstring("
+    grep -vx 'Weight' "${WEIGHTS_FILE}" | grep -vE '^(EXTRA__|IRREG__)' \
+      | sed -e "s/^/      '/;s/$/',/" -e '$s/,$//'
+    echo "    ),"
+    echo "    # EDM-facing names, one per SherpaVariationWeights entry in the same order"
+    echo "    SherpaRenamedVariationWeights = cms.vstring("
+    grep -vx 'Weight' "${WEIGHTS_FILE}" | grep -vE '^(EXTRA__|IRREG__)' \
+      | sed -e 's/+/p/g; s/-/m/g' | sed -e "s/^/      '/;s/$/',/" -e '$s/,$//'
+    echo "    )"
+    echo "  ),"
+  }                                                                      >> ${CFFFILE}
+fi
+echo "  Sherpa3Parameters = cms.PSet(parameterSets = cms.vstring("       >> ${CFFFILE}
+echo "                             \"Run\"),"                            >> ${CFFFILE}
+echo "                              Run = cms.vstring("                  >> ${CFFFILE}
+cat "${TMPDIR_CFF}/card.tmp"                                             >> ${CFFFILE}
+echo "                              )"                                   >> ${CFFFILE}
+echo "                             )"                                    >> ${CFFFILE}
+echo ")"                                                                 >> ${CFFFILE}
+echo ""                                                                  >> ${CFFFILE}
+echo "ProductionFilterSequence = cms.Sequence(generator)"                >> ${CFFFILE}
+echo ""                                                                  >> ${CFFFILE}
+
+echo "mkSherpa3cff: cff created: ${CFFFILE}"

--- a/GeneratorInterface/Sherpa3Interface/doc/html/index.html
+++ b/GeneratorInterface/Sherpa3Interface/doc/html/index.html
@@ -1,0 +1,11 @@
+<! Template File - Modify as required.>
+<! Use as an index to other html documents>
+<! References to local pages should be relative to this directory>
+<! This makes it easy for both users of the web project space and>
+<! any others who might simply look at html files directly in the source code.>
+<! e.g. href=page1.html or  href=mysubdir/page2.html > 
+<html>
+<body>
+This Text Inserted from File doc/html/index.html
+</body>
+</html>

--- a/GeneratorInterface/Sherpa3Interface/doc/html/overview.html
+++ b/GeneratorInterface/Sherpa3Interface/doc/html/overview.html
@@ -1,0 +1,12 @@
+<! Template File - Modify as required.>
+<! Use as a brief project description that appears on your main page>
+<! Links are not encouraged from this section - use index.html for this>
+This Text Inserted from File doc/html/overview.html
+<table border=0 width=100%>
+<tr>
+<td align=center><b>Status :</b></td>
+<td align=center>
+Unknown
+</td>
+</tr>
+</table>

--- a/GeneratorInterface/Sherpa3Interface/interface/Sherpa3Utils.h
+++ b/GeneratorInterface/Sherpa3Interface/interface/Sherpa3Utils.h
@@ -1,0 +1,40 @@
+#ifndef GeneratorInterface_Sherpa3Interface_Sherpa3Utils_h
+#define GeneratorInterface_Sherpa3Interface_Sherpa3Utils_h
+
+#include <iostream>
+#include <string>
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
+#include <fcntl.h>
+#include <openssl/evp.h>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "Utilities/OpenSSL/interface/openssl_init.h"
+
+namespace sh3utils {
+
+  class Sherpa3Utils {
+  public:
+    Sherpa3Utils(edm::ParameterSet const &);
+    ~Sherpa3Utils();
+    int Fetch();
+    const char *classname() const { return "Sherpa3Utils"; }
+
+  private:
+    int CopyFile(const std::string &pathstring);
+    // function for calculating the MD5 checksum of a file
+    void MD5File(std::string, char*);
+    std::string Sherpa3Process;
+    std::string GridpackLocation;
+    std::string GridpackChecksum;
+    std::string EvtGenDirectory;
+  };
+
+}  // namespace sh3utils
+
+#endif

--- a/GeneratorInterface/Sherpa3Interface/src/Sherpa3Hadronizer.cc
+++ b/GeneratorInterface/Sherpa3Interface/src/Sherpa3Hadronizer.cc
@@ -1,0 +1,718 @@
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <memory>
+#include <cstdint>
+#include <map>
+#include <regex>
+#include <set>
+#include <vector>
+
+#include <dlfcn.h>
+#include <glob.h>
+
+#include "SHERPA/Main/Sherpa.H"
+#include "ATOOLS/Math/Random.H"
+
+#include "ATOOLS/Org/Exception.H"
+#include "ATOOLS/Org/Run_Parameter.H"
+#include "ATOOLS/Org/MyStrStream.H"
+#include "ATOOLS/Org/CXXFLAGS.H"
+#include "ATOOLS/Org/CXXFLAGS_PACKAGES.H"
+#include "ATOOLS/Org/My_MPI.H"
+
+#include "GeneratorInterface/Core/interface/ParameterCollector.h"
+#include "GeneratorInterface/Core/interface/BaseHadronizer.h"
+#include "GeneratorInterface/Core/interface/GeneratorFilter.h"
+#include "GeneratorInterface/Core/interface/HadronizerFilter.h"
+#include "GeneratorInterface/Sherpa3Interface/interface/Sherpa3Utils.h"
+
+#include "CLHEP/Random/RandomEngine.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <HepMC3/GenEvent.h>
+#include "HepMC3/Print.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMC3Product.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct3.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+
+//This unnamed namespace is used (instead of static variables) to pass the
+//randomEngine passed to doSetRandomEngine to the External Random
+//Number Generator CMS_SHERPA_HepMC3_RNG of sherpa
+//The advantage of the unnamed namespace over static variables is
+//that it is only accessible in this file
+
+namespace {
+  CLHEP::HepRandomEngine *ExternalEngine = nullptr;
+  CLHEP::HepRandomEngine *GetExternalEngine() { return ExternalEngine; }
+  void SetExternalEngine(CLHEP::HepRandomEngine *v) { ExternalEngine = v; }
+
+  // ATOOLS::Exception does not derive from std::exception, so a Sherpa error that
+  // escapes into the framework is reported as "an exception of unknown type was
+  // thrown" without any message. Every call into Sherpa goes through this wrapper,
+  // which turns it into a cms::Exception carrying the Sherpa diagnostics.
+  template <typename F>
+  auto callSherpa(const char *context, F &&f) -> decltype(f()) {
+    try {
+      return f();
+    } catch (const ATOOLS::normal_exit &e) {
+      std::ostringstream sherpaMessage;
+      sherpaMessage << e;
+      throw cms::Exception("Sherpa3Interface")
+          << "Sherpa requested a normal exit while " << context << ":\n"
+          << sherpaMessage.str();
+    } catch (const ATOOLS::Exception &e) {
+      std::ostringstream sherpaMessage;
+      sherpaMessage << e;
+      throw cms::Exception("Sherpa3Interface") << "Sherpa raised an exception while " << context << ":\n"
+                                               << sherpaMessage.str();
+    }
+  }
+
+  // Sherpa loads its optional plugin libraries itself, on demand: the model via
+  // Library_Loader::LoadLibrary("Sherpa" + MODEL), the matrix element generators via
+  // LoadLibrary("Sherpa" + generator), analyses and event outputs likewise - always
+  // with RTLD_GLOBAL, and from SHERPA_LIBRARY_PATH, which the CMS build of Sherpa 3
+  // takes from SHERPA3_LIBRARY_PATH. Preloading those libraries here instead would
+  // register their getters in every job, whether the runcard asks for them or not:
+  // the model libraries then re-register identical Lorentz calculators (the
+  // 'Doubled identifier "DHVV*"' warnings), and libSherpaHiggs.so registers a
+  // Tree_ME2 getter that reads HIGGS_INTERFERENCE_ONLY before the Higgs interface
+  // has declared its defaults, which aborts the run. So preload everything except
+  // the libSherpa*.so plugins, keeping only the core Sherpa libraries listed here.
+  const std::array<std::string, 6> kCoreSherpaLibraries{{"libSherpaMain.so",
+                                                         "libSherpaInitialization.so",
+                                                         "libSherpaSingleEvents.so",
+                                                         "libSherpaSoftPhysics.so",
+                                                         "libSherpaPerturbativePhysics.so",
+                                                         "libSherpaTools.so"}};
+
+  bool isOnDemandSherpaPlugin(const std::string &libPath) {
+    const std::string libName = libPath.substr(libPath.find_last_of('/') + 1);
+    if (libName.compare(0, 9, "libSherpa") != 0)
+      return false;
+    return std::find(kCoreSherpaLibraries.begin(), kCoreSherpaLibraries.end(), libName) == kCoreSherpaLibraries.end();
+  }
+
+  // EDM-facing name for a Sherpa weight. Downstream CMSSW consumers mangle
+  // characters outside [A-Za-z0-9._=]: RivetAnalyzer replaces each of them with
+  // '_' before calling HepMC3::GenRunInfo::set_weight_names, which rejects
+  // duplicate names. Sherpa's polarised cross-section weights use '+' and '-'
+  // (e.g. "PolWeight_COM.W+.+_W+.-") and collide after that cleaning
+  // ("W_._W_._" for all four +/- combinations), so they are renamed here:
+  // '+' -> 'p', '-' -> 'm'. The original Sherpa name remains the lookup key
+  // into the event weights; only the stored name changes.
+  std::string edmWeightName(const std::string &sherpaName) {
+    std::string name = sherpaName;
+    std::replace(name.begin(), name.end(), '+', 'p');
+    std::replace(name.begin(), name.end(), '-', 'm');
+    return name;
+  }
+}  // namespace
+
+class Sherpa3Hadronizer : public gen::BaseHadronizer {
+public:
+  Sherpa3Hadronizer(const edm::ParameterSet &params);
+  ~Sherpa3Hadronizer() override;
+
+  bool readSettings(int) { return true; }
+  bool initializeForInternalPartons();
+  bool declareStableParticles(const std::vector<int> &pdgIds);
+  bool declareSpecialSettings(const std::vector<std::string> &) { return true; }
+  void statistics();
+  bool generatePartonsAndHadronize();
+  bool decay();
+  bool residualDecay();
+  void finalizeEvent();
+  std::unique_ptr<GenLumiInfoHeader> getGenLumiInfoHeader() const override;
+  const char *classname() const { return "Sherpa3Hadronizer"; }
+
+private:
+  void doSetRandomEngine(CLHEP::HepRandomEngine *v) override;
+  void preloadSherpaLibraries() const;
+
+  std::string SherpaProcess;
+  std::string EvtGenDirectory;
+  std::string SherpaResultDir;
+  edm::ParameterSet SherpaParameterSet;
+  unsigned int maxEventsToPrint;
+  std::vector<std::string> arguments;
+  // Sherpa 3 has no default constructor; the generator is created in
+  // initializeForInternalPartons() once the command-line arguments are known
+  std::unique_ptr<SHERPA::Sherpa> Generator;
+  bool isInitialized;
+  bool isRNGinitialized;
+  bool rearrangeWeights;
+  bool warnedAboutUnnamedWeights;
+  std::vector<std::string> weightlist;
+  std::vector<std::string> variationweightlist;
+  // EDM-facing names, one per weightlist/variationweightlist entry, in the same
+  // order: either the optional SherpaRenamedWeights/SherpaRenamedVariationWeights
+  // from the SherpaWeightsBlock, or derived from the Sherpa names with
+  // edmWeightName. Used for the lumi header and the HepMC3 run info.
+  std::vector<std::string> storedWeightNames;
+  std::vector<std::string> storedVariationWeightNames;
+};
+
+class CMS_SHERPA_HepMC3_RNG : public ATOOLS::External_RNG {
+public:
+  CMS_SHERPA_HepMC3_RNG() : randomEngine(nullptr) {
+    edm::LogVerbatim("Sherpa3Hadronizer") << "Use stored reference for the external RNG";
+    setRandomEngine(GetExternalEngine());
+  }
+  void setRandomEngine(CLHEP::HepRandomEngine *v) { randomEngine = v; }
+
+private:
+  double Get() override;
+  CLHEP::HepRandomEngine *randomEngine;
+};
+
+void Sherpa3Hadronizer::doSetRandomEngine(CLHEP::HepRandomEngine *v) {
+  // In Sherpa 3 the global ATOOLS::ran is only created by the SHERPA::Sherpa
+  // constructor, which runs later (in initializeForInternalPartons); it is
+  // still null when the framework calls this method for the first time
+  CMS_SHERPA_HepMC3_RNG *cmsSherpaRng =
+      ATOOLS::ran ? dynamic_cast<CMS_SHERPA_HepMC3_RNG *>(ATOOLS::ran->GetExternalRng()) : nullptr;
+  if (cmsSherpaRng == nullptr) {
+    //First time call to this function makes the interface store the reference in the unnamed namespace
+    if (!isRNGinitialized) {
+      isRNGinitialized = true;
+      edm::LogVerbatim("Sherpa3Hadronizer") << "Store assigned reference of the randomEngine";
+      SetExternalEngine(v);
+      // Throw exception if there is no reference to an external RNG and it is not the first call!
+    } else {
+      if (isInitialized and v != nullptr) {
+        throw edm::Exception(edm::errors::LogicError)
+            << "The Sherpa interface got a randomEngine reference but there is "
+               "no reference to the external RNG to hand it over to\n";
+      }
+    }
+  } else {
+    cmsSherpaRng->setRandomEngine(v);
+  }
+}
+
+Sherpa3Hadronizer::Sherpa3Hadronizer(const edm::ParameterSet &params)
+    : BaseHadronizer(params),
+      SherpaParameterSet(params.getParameter<edm::ParameterSet>("Sherpa3Parameters")),
+      isInitialized(false),
+      isRNGinitialized(false),
+      rearrangeWeights(false),
+      warnedAboutUnnamedWeights(false) {
+  // Set the HepMC version to 3 for the Sherpa 3 interface. BaseHadronizer defaults
+  // this to 2, and GeneratorFilter reads it once at initialization to decide whether
+  // to produce HepMCProduct/GenEventInfoProduct or HepMC3Product/GenEventInfoProduct3.
+  // Without this the filter looks for a HepMC2 event, never finds one, and rejects
+  // every event.
+  ivhepmc = 3;
+  if (!params.exists("Sherpa3Process"))
+    SherpaProcess = "";
+  else
+    SherpaProcess = params.getParameter<std::string>("Sherpa3Process");
+  // directory where Sherpa.yaml is written and from which Sherpa reads it
+  // (the gridpack is unpacked into the current working directory)
+  if (!params.exists("EvtGenDirectory"))
+    EvtGenDirectory = "./SHERPA3GEN";
+  else
+    EvtGenDirectory = params.getParameter<std::string>("EvtGenDirectory");
+  // directory of the Sherpa results DB (<RESULT_DIRECTORY>.zip); the
+  // Sherpa3 gridpacks store it with the Sherpa default "Results"
+  // (Results.zip), so do not change this unless the gridpacks are
+  // produced with a matching setting
+  if (!params.exists("SherpaResultDir"))
+    SherpaResultDir = "Results";
+  else
+    SherpaResultDir = params.getParameter<std::string>("SherpaResultDir");
+  if (!params.exists("maxEventsToPrint")) {
+    maxEventsToPrint = 0;
+  } else {
+    const int nEventsToPrint = params.getParameter<int>("maxEventsToPrint");
+    if (nEventsToPrint < 0)
+      throw cms::Exception("Sherpa3Interface")
+          << "maxEventsToPrint must not be negative, got " << nEventsToPrint << std::endl;
+    maxEventsToPrint = nEventsToPrint;
+  }
+  // if hepmcextendedweights is used the event weights have to be reordered ( unordered list can be accessed via event->weights().write() )
+  // two lists have to be provided:
+  // 1) SherpaWeights
+  // - containing nominal event weight, combined matrix element and phase space weight, event normalization, and possibly other sherpa weights
+  // 2) SherpaVariationsWeights
+  // - containing weights from scale and PDF variations ( have to be defined in the runcard )
+  // - in case of unweighted events these weights are also divided by the event normalization (see list 1 )
+  // Sherpa Documentation: http://sherpa.hepforge.org/doc/SHERPA-MC-2.2.0.html#Scale-and-PDF-variations
+  if (!params.exists("SherpaWeightsBlock")) {
+    rearrangeWeights = false;
+  } else {
+    rearrangeWeights = true;
+    edm::ParameterSet WeightsBlock = params.getParameter<edm::ParameterSet>("SherpaWeightsBlock");
+    if (WeightsBlock.exists("SherpaWeights"))
+      weightlist = WeightsBlock.getParameter<std::vector<std::string> >("SherpaWeights");
+    else
+      throw cms::Exception("Sherpa3Interface") << "SherpaWeights does not exists in SherpaWeightsBlock" << std::endl;
+    if (WeightsBlock.exists("SherpaVariationWeights"))
+      variationweightlist = WeightsBlock.getParameter<std::vector<std::string> >("SherpaVariationWeights");
+    else
+      throw cms::Exception("Sherpa3Interface")
+          << "SherpaVariationWeights does not exists in SherpaWeightsBlock" << std::endl;
+    // EDM-facing names for the weights, optional SherpaRenamedWeights /
+    // SherpaRenamedVariationWeights with one entry per SherpaWeights /
+    // SherpaVariationWeights entry in the same order; if absent, the names are
+    // derived from the Sherpa names with edmWeightName ('+' -> 'p', '-' -> 'm')
+    if (WeightsBlock.exists("SherpaRenamedWeights")) {
+      storedWeightNames = WeightsBlock.getParameter<std::vector<std::string> >("SherpaRenamedWeights");
+      if (storedWeightNames.size() != weightlist.size())
+        throw cms::Exception("Sherpa3Interface")
+            << "SherpaRenamedWeights has " << storedWeightNames.size() << " entries but SherpaWeights has "
+            << weightlist.size() << std::endl;
+    } else {
+      storedWeightNames.reserve(weightlist.size());
+      for (const auto &i : weightlist)
+        storedWeightNames.push_back(edmWeightName(i));
+    }
+    if (WeightsBlock.exists("SherpaRenamedVariationWeights")) {
+      storedVariationWeightNames =
+          WeightsBlock.getParameter<std::vector<std::string> >("SherpaRenamedVariationWeights");
+      if (storedVariationWeightNames.size() != variationweightlist.size())
+        throw cms::Exception("Sherpa3Interface")
+            << "SherpaRenamedVariationWeights has " << storedVariationWeightNames.size()
+            << " entries but SherpaVariationWeights has " << variationweightlist.size() << std::endl;
+    } else {
+      storedVariationWeightNames.reserve(variationweightlist.size());
+      for (const auto &i : variationweightlist)
+        storedVariationWeightNames.push_back(edmWeightName(i));
+    }
+    // the stored names go into the lumi header and the HepMC3 run info, where
+    // duplicates are rejected (HepMC3::GenRunInfo::set_weight_names throws)
+    std::set<std::string> storedNames;
+    for (const auto &i : storedWeightNames)
+      if (!storedNames.insert(i).second)
+        throw cms::Exception("Sherpa3Interface")
+            << "Duplicate stored weight name '" << i << "' in SherpaWeights" << std::endl;
+    for (const auto &i : storedVariationWeightNames)
+      if (!storedNames.insert(i).second)
+        throw cms::Exception("Sherpa3Interface")
+            << "Duplicate stored weight name '" << i << "' in SherpaVariationWeights" << std::endl;
+    edm::LogVerbatim("Sherpa3Hadronizer")
+        << "Sherpa3Hadronizer will try rearrange the event weights according to "
+           "SherpaWeights and SherpaVariationWeights";
+  }
+
+  sh3utils::Sherpa3Utils Fetcher(params);
+  int retval = Fetcher.Fetch();
+  if (retval != 0) {
+    throw cms::Exception("Sherpa3Interface") << "Sherpa3Hadronizer: Preparation of Gridpack failed ... ";
+  }
+  // Sherpa 3 reads a single YAML runcard (Sherpa.yaml in the PATH directory)
+  // instead of the per-section *.dat files used by Sherpa 2.
+  // The ids (names) of parameter sets to be read are given as a vstring;
+  // the contents of all sets are concatenated, in the given order, into Sherpa.yaml.
+  std::vector<std::string> setNames = SherpaParameterSet.getParameter<std::vector<std::string> >("parameterSets");
+  std::string datfile = EvtGenDirectory + "/Sherpa.yaml";
+  std::ofstream os(datfile.c_str());
+  if (!os.is_open())
+    throw cms::Exception("Sherpa3Interface") << "Could not open the Sherpa runcard " << datfile << " for writing"
+                                             << std::endl;
+  edm::LogVerbatim("Sherpa3Hadronizer") << "Write Sherpa parameter sets to " << datfile;
+  // OpenLoops ships with the CMSSW release, so an OL_PREFIX baked into the
+  // fragment points at the wrong installation once the job runs with a
+  // different release. Unless the fragment opts out with
+  // FIXED_OL_PREFIX = cms.bool(True) in Sherpa3Parameters, replace it with the
+  // prefix of the running release (CMS_OPENLOOPS_PREFIX is set by the
+  // openloops scram tool).
+  const char *openloopsPrefix = std::getenv("CMS_OPENLOOPS_PREFIX");
+  const bool fixedOLPrefix =
+      SherpaParameterSet.exists("FIXED_OL_PREFIX") && SherpaParameterSet.getParameter<bool>("FIXED_OL_PREFIX");
+  const std::regex olPrefixSetting("^\\s*OL_PREFIX\\s*:.*");
+  //Loop all set names...
+  for (unsigned i = 0; i < setNames.size(); ++i) {
+    // ...and read the parameters for each set given in vstrings
+    std::vector<std::string> pars = SherpaParameterSet.getParameter<std::vector<std::string> >(setNames[i]);
+    // Loop over all strings and write them to the runcard
+    for (std::vector<std::string>::const_iterator itPar = pars.begin(); itPar != pars.end(); ++itPar) {
+      std::string line = *itPar;
+      if (std::regex_match(line, olPrefixSetting)) {
+        if (fixedOLPrefix) {
+          edm::LogVerbatim("Sherpa3Hadronizer")
+              << "FIXED_OL_PREFIX is set in Sherpa3Parameters, keeping '" << line << "' from the fragment"
+              << std::endl;
+        } else if (openloopsPrefix != nullptr) {
+          edm::LogVerbatim("Sherpa3Hadronizer")
+              << "Overriding '" << line
+              << "' from the fragment with the OpenLoops installation of the running release" << std::endl;
+          line = std::string("OL_PREFIX: ") + openloopsPrefix;
+        } else {
+          edm::LogWarning("Sherpa3Hadronizer")
+              << "The fragment sets '" << line
+              << "' but CMS_OPENLOOPS_PREFIX is not set (openloops scram tool not in the environment);"
+                 " keeping the fragment value" << std::endl;
+        }
+      }
+      os << line << std::endl;
+    }
+  }
+  os.close();
+  if (os.fail())
+    throw cms::Exception("Sherpa3Interface") << "Failed to write the Sherpa runcard " << datfile << std::endl;
+
+  //To be conform to the default Sherpa usage create a command line:
+  //name of executable  (only for demonstration, could also be empty)
+  std::string shRun = "Sherpa3";
+  //Path where Sherpa.yaml is read from (Sherpa 3 setting PATH)
+  std::string shPath = "PATH=" + EvtGenDirectory;
+  //Path where results are stored
+  std::string shRes = "RESULT_DIRECTORY=" + SherpaResultDir;
+  //Name of the external random number class
+  std::string shRng = "EXTERNAL_RNG=CMS_SHERPA_HepMC3_RNG";
+
+  //create the command line
+  arguments.push_back(shRun);
+  arguments.push_back(shPath);
+  arguments.push_back(shRes);
+  arguments.push_back(shRng);
+  //initialization of Sherpa moved to initializeForInternalPartons
+#ifdef USING__MPI
+  // FIXME this should be replaced with a call to the MPIService
+  int argc = 0;
+  char **argv = nullptr;
+  MPI_Init(&argc, &argv);
+#endif
+}
+
+Sherpa3Hadronizer::~Sherpa3Hadronizer() {
+  // ~Sherpa tears down the ATOOLS globals (and, with MPI, calls MPI_Barrier), so it
+  // has to run before MPI_Finalize below
+  Generator.reset();
+#ifdef USING__MPI
+  MPI_Finalize();
+#endif
+}
+
+void Sherpa3Hadronizer::preloadSherpaLibraries() const {
+  // Sherpa 3 libraries do not record inter-library dependencies (libYFSMain.so, for
+  // instance, does not list libYFSTools.so, which defines the symbols it calls), and
+  // CMSSW loads this plugin in a local symbol scope, so cross-library calls would
+  // fail when first used. Preload the Sherpa libraries into the global symbol scope
+  // before initializing Sherpa. Data relocations are resolved eagerly at dlopen time,
+  // so a library whose dependencies have not been loaded yet fails; iterate until no
+  // more progress is made.
+  const char *sherpaLibPath = std::getenv("SHERPA3_LIBRARY_PATH");
+  // No fallback to SHERPA_LIBRARY_PATH: with the sherpa (Sherpa 2) tool in the
+  // runtime environment that variable points at the Sherpa 2 libraries, and pulling
+  // those into the global scope would be worse than not preloading at all.
+  if (sherpaLibPath == nullptr)
+    throw cms::Exception("Sherpa3Interface")
+        << "SHERPA3_LIBRARY_PATH is not set. The sherpa3 scram tool environment is required to run\n"
+        << "Sherpa 3; run cmsenv in the CMSSW area before cmsRun. Without the library preload the\n"
+        << "Sherpa 3 libraries cannot resolve each other's symbols and the job dies with a symbol\n"
+        << "lookup error." << std::endl;
+
+  const std::string pattern = std::string(sherpaLibPath) + "/lib*.so";
+  std::vector<std::string> libraries;
+  glob_t globResult;
+  if (glob(pattern.c_str(), 0, nullptr, &globResult) == 0) {
+    for (size_t i = 0; i < globResult.gl_pathc; ++i)
+      libraries.emplace_back(globResult.gl_pathv[i]);
+    globfree(&globResult);
+  }
+  if (libraries.empty())
+    throw cms::Exception("Sherpa3Interface")
+        << "No Sherpa libraries found in " << sherpaLibPath << " (looking for " << pattern << ")" << std::endl;
+
+  std::vector<std::string> librariesToPreload;
+  std::copy_if(libraries.begin(),
+               libraries.end(),
+               std::back_inserter(librariesToPreload),
+               [](const std::string &lib) { return !isOnDemandSherpaPlugin(lib); });
+
+  size_t loaded = 0;
+  size_t previouslyLoaded = 0;
+  std::string lastError;
+  do {
+    previouslyLoaded = loaded;
+    loaded = 0;
+    lastError.clear();
+    for (const auto &lib : librariesToPreload) {
+      if (dlopen(lib.c_str(), RTLD_LAZY | RTLD_GLOBAL) != nullptr) {
+        ++loaded;
+      } else {
+        // dlerror() has to be read right after the failing call, and may be null
+        const char *error = dlerror();
+        lastError = (error != nullptr) ? error : "unknown dlopen error";
+      }
+    }
+  } while (loaded > previouslyLoaded && loaded < librariesToPreload.size());
+
+  edm::LogVerbatim("Sherpa3Hadronizer") << "Preloaded " << loaded << " of " << librariesToPreload.size()
+                                        << " Sherpa libraries from " << sherpaLibPath << " ("
+                                        << (libraries.size() - librariesToPreload.size())
+                                        << " on-demand plugin libraries skipped, Sherpa loads those itself)";
+  if (loaded < librariesToPreload.size())
+    edm::LogWarning("Sherpa3Hadronizer") << "Only " << loaded << " of " << librariesToPreload.size()
+                                         << " Sherpa libraries in " << sherpaLibPath
+                                         << " could be preloaded; last dlopen error: " << lastError;
+}
+
+bool Sherpa3Hadronizer::initializeForInternalPartons() {
+  //initialize Sherpa but only once
+  if (!isInitialized) {
+    preloadSherpaLibraries();
+
+    std::vector<char *> argv;
+    argv.reserve(arguments.size());
+    for (auto &argument : arguments)
+      argv.push_back(const_cast<char *>(argument.c_str()));
+    // Sherpa 3 takes the command-line arguments in the constructor
+    Generator = callSherpa("constructing the Sherpa generator", [&argv]() {
+      return std::make_unique<SHERPA::Sherpa>(static_cast<int>(argv.size()), argv.data());
+    });
+    if (!callSherpa("initializing the Sherpa run", [this]() { return Generator->InitializeTheRun(); }))
+      throw cms::Exception("Sherpa3Interface") << "Sherpa::InitializeTheRun() failed" << std::endl;
+    if (!callSherpa("initializing the Sherpa event handler",
+                    [this]() { return Generator->InitializeTheEventHandler(); }))
+      throw cms::Exception("Sherpa3Interface") << "Sherpa::InitializeTheEventHandler() failed" << std::endl;
+    isInitialized = true;
+  }
+  return true;
+}
+
+bool Sherpa3Hadronizer::declareStableParticles(const std::vector<int> &pdgIds) { return false; }
+
+void Sherpa3Hadronizer::statistics() {
+  // statistics() is called at the end of the job whether or not the generator was
+  // ever initialized
+  if (!Generator) {
+    edm::LogWarning("Sherpa3Hadronizer") << "No Sherpa generator, skipping the run summary";
+    return;
+  }
+
+  //calculate statistics
+  callSherpa("summarizing the Sherpa run", [this]() { return Generator->SummarizeRun(); });
+
+  //get the xsec & err
+  double xsec_val = Generator->TotalXS();
+  double xsec_err = Generator->TotalErr();
+
+  //set the internal cross section in pb in GenRunInfoProduct
+  runInfo().setInternalXSec(GenRunInfoProduct::XSec(xsec_val, xsec_err));
+}
+
+bool Sherpa3Hadronizer::generatePartonsAndHadronize() {
+  //get the next event and check if it produced
+  bool rc = false;
+  std::string lastError;
+  for (int itry = 1; itry <= 3; ++itry) {
+    try {
+      rc = Generator->GenerateOneEvent();
+      lastError.clear();
+      break;
+    } catch (const ATOOLS::Exception &e) {
+      std::ostringstream sherpaMessage;
+      sherpaMessage << e;
+      lastError = sherpaMessage.str();
+    } catch (...) {
+      lastError = "exception of unknown type";
+    }
+    edm::LogWarning("Sherpa3Hadronizer") << "Exception from Generator->GenerateOneEvent(), call # " << itry
+                                         << " for this event:\n"
+                                         << lastError;
+  }
+  if (!lastError.empty())
+    throw cms::Exception("Sherpa3Interface") << "Sherpa failed to generate an event in 3 attempts, last error:\n"
+                                             << lastError << std::endl;
+  if (rc) {
+    //convert it to HepMC3. Sherpa attaches its own GenRunInfo to the event
+    //(HepMC3_Interface::Sherpa2HepMC calls set_run_info), so do not create one here.
+    auto evt = std::make_unique<HepMC3::GenEvent>();
+    callSherpa("filling the HepMC3 event", [this, &evt]() { Generator->FillHepMCEvent(*evt); });
+
+    // in case of unweighted events sherpa puts the max weight as event weight.
+    // this is not optimal, we want 1 for unweighted events, so we check
+    // whether we are producing unweighted events ("EVENT_GENERATION_MODE" == "1")
+    // In Sherpa 3 the HepMC3 output uses named weights by default
+    // (HEPMC_USE_NAMED_WEIGHTS: true):
+    //   "Weight"                     event weight
+    //   <variation names>            on-the-fly scale/PDF variation weights
+    //   "EXTRA__MEWeight"            combined matrix element and phase space weight
+    //                                (missing only PDF information, thus directly
+    //                                suitable for PDF reweighting)
+    //   "EXTRA__WeightNormalisation" event weight normalisation (in case of
+    //                                unweighted events event weights of ~ +/-1 can
+    //                                be obtained by (event weight)/(normalisation))
+    //   "EXTRA__NTrials"             number of trials
+    // With unnamed weights the legacy index layout [0..3] applies instead.
+    if (!evt->run_info())
+      throw cms::Exception("Sherpa3Interface") << "Sherpa did not attach a GenRunInfo to the HepMC3 event"
+                                               << std::endl;
+
+    // Build name->index map
+    const std::vector<std::string> &weight_list = evt->run_info()->weight_names();
+    std::map<std::string, std::size_t> nameToIndex;
+    for (std::size_t i = 0; i < weight_list.size(); ++i) {
+      nameToIndex[weight_list[i]] = i;
+    }
+    // Helper lambda: get weight by name; fall back to the legacy index layout
+    // only when no named weights are available at all
+    auto getWeightByName = [&](const std::string &name, std::size_t fallbackIdx) -> double {
+      if (!nameToIndex.empty()) {
+        auto it = nameToIndex.find(name);
+        if (it != nameToIndex.end() && it->second < evt->weights().size())
+          return evt->weights()[it->second];
+        throw cms::Exception("Sherpa3Interface")
+            << "Weight '" << name << "' not found in the named HepMC weights, please check the runcard!" << std::endl;
+      }
+      if (fallbackIdx < evt->weights().size())
+        return evt->weights()[fallbackIdx];
+      throw cms::Exception("Sherpa3Interface") << "Missing weight at index " << fallbackIdx << std::endl;
+    };
+
+    bool unweighted = false;
+    double weight_normalization = -1;
+    int EVENT_GENERATION_MODE = ATOOLS::ToType<int>(ATOOLS::rpa->gen.Variable("EVENT_GENERATION_MODE"));
+    if ((EVENT_GENERATION_MODE == 1) || (EVENT_GENERATION_MODE == 2)) {
+      // EVENT_GENERATION_MODE: 1->Unweighted; 2->PartiallyUnweighted;
+      if (evt->weights().size() > 2) {
+        unweighted = true;
+        weight_normalization = getWeightByName("EXTRA__WeightNormalisation", 2);
+        if (weight_normalization == 0.)
+          throw cms::Exception("Sherpa3Interface")
+              << "Requested unweighted production but the event weight normalization is zero." << std::endl;
+      } else {
+        throw cms::Exception("Sherpa3Interface")
+            << "Requested unweighted production. Missing normalization weight." << std::endl;
+      }
+    }
+    // vector to fill new weights in correct order
+    std::vector<double> newWeights;
+    if (rearrangeWeights) {
+      // the Sherpa names are the lookup keys; the EDM-facing names
+      // (storedWeightNames/storedVariationWeightNames) go into the run info
+      std::vector<std::string> newWeightNames;
+      for (std::size_t iw = 0; iw < weightlist.size(); ++iw) {
+        auto it = nameToIndex.find(weightlist[iw]);
+        if (it != nameToIndex.end()) {
+          newWeights.push_back(evt->weights()[it->second]);
+          newWeightNames.push_back(storedWeightNames[iw]);
+        } else {
+          throw cms::Exception("Sherpa3Interface")
+              << "Missing weights! Key " << weightlist[iw]
+              << " not found, please check the weight definition!" << std::endl;
+        }
+      }
+      for (std::size_t iw = 0; iw < variationweightlist.size(); ++iw) {
+        auto it = nameToIndex.find(variationweightlist[iw]);
+        if (it != nameToIndex.end()) {
+          double w = evt->weights()[it->second];
+          newWeights.push_back(unweighted ? w / weight_normalization : w);
+          newWeightNames.push_back(storedVariationWeightNames[iw]);
+        } else {
+          throw cms::Exception("Sherpa3Interface")
+              << "Missing weights! Key " << variationweightlist[iw]
+              << " not found, please check the weight definition!" << std::endl;
+        }
+      }
+
+      //Change original weights for reordered ones, and keep the names in the run
+      //info in step with them (Sherpa rewrites the names for every event, so this
+      //has to be redone here for every event as well)
+      evt->weights() = newWeights;
+      evt->run_info()->set_weight_names(newWeightNames);
+    } else if (!warnedAboutUnnamedWeights && evt->weights().size() > 1) {
+      // Nothing downstream carries the Sherpa weight names: HepMC3Product stores
+      // no GenRunInfo and GenEventInfoProduct3 stores values only, so without a
+      // SherpaWeightsBlock the weights are written unlabelled and cannot be
+      // interpreted later. Say so once, with the names actually on offer.
+      warnedAboutUnnamedWeights = true;
+      edm::LogWarning("Sherpa3Hadronizer")
+          << evt->weights().size() << " event weights are being stored without names, because no "
+          << "SherpaWeightsBlock is configured.\nThe names are known only to Sherpa (they depend on "
+          << "the runcard) and are lost in the output.\nRegenerate the fragment with "
+          << "mkSherpa3Gridpack.sh (or mkSherpa3cff.sh -w) to embed them. Sherpa offers:\n"
+          << [&weight_list]() {
+               std::ostringstream names;
+               for (const auto &name : weight_list)
+                 names << "  " << name << "\n";
+               return names.str();
+             }();
+    }
+    if (unweighted) {
+      if (evt->weights().empty())
+        throw cms::Exception("Sherpa3Interface")
+            << "Requested unweighted production but the event has no weights left to normalize." << std::endl;
+      evt->weights()[0] /= weight_normalization;
+    }
+    resetEvent3(std::move(evt));
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool Sherpa3Hadronizer::decay() { return true; }
+
+bool Sherpa3Hadronizer::residualDecay() { return true; }
+
+void Sherpa3Hadronizer::finalizeEvent() {
+  eventInfo3() = std::make_unique<GenEventInfoProduct3>(event3().get());
+  //******** Verbosity *******
+  if (maxEventsToPrint > 0) {
+    maxEventsToPrint--;
+    HepMC3::Print::listing(*(event3().get()));
+  }
+}
+
+//GETTER for the external random numbers
+DECLARE_GETTER(CMS_SHERPA_HepMC3_RNG, "CMS_SHERPA_HepMC3_RNG", ATOOLS::External_RNG, ATOOLS::RNG_Key);
+
+ATOOLS::External_RNG *ATOOLS::Getter<ATOOLS::External_RNG, ATOOLS::RNG_Key, CMS_SHERPA_HepMC3_RNG>::operator()(
+    const ATOOLS::RNG_Key &) const {
+  return new CMS_SHERPA_HepMC3_RNG();
+}
+
+void ATOOLS::Getter<ATOOLS::External_RNG, ATOOLS::RNG_Key, CMS_SHERPA_HepMC3_RNG>::PrintInfo(std::ostream &str,
+                                                                                             const size_t) const {
+  str << "CMS_SHERPA_HepMC3_RNG interface";
+}
+
+double CMS_SHERPA_HepMC3_RNG::Get() {
+  if (randomEngine == nullptr) {
+    throw edm::Exception(edm::errors::LogicError) << "The Sherpa code attempted to a generate random number while\n"
+                                                  << "the engine pointer was null. This might mean that the code\n"
+                                                  << "was modified to generate a random number outside the event and\n"
+                                                  << "beginLuminosityBlock methods, which is not allowed.\n";
+  }
+  return randomEngine->flat();
+}
+std::unique_ptr<GenLumiInfoHeader> Sherpa3Hadronizer::getGenLumiInfoHeader() const {
+  auto genLumiInfoHeader = BaseHadronizer::getGenLumiInfoHeader();
+
+  if (rearrangeWeights) {
+    edm::LogPrint("Sherpa3Hadronizer") << "The order of event weights was changed!";
+    // store the EDM-facing names; log the Sherpa name alongside when it differs
+    auto pushNames = [&genLumiInfoHeader](const std::vector<std::string> &sherpaNames,
+                                          const std::vector<std::string> &storedNames) {
+      for (std::size_t i = 0; i < sherpaNames.size(); ++i) {
+        genLumiInfoHeader->weightNames().push_back(storedNames[i]);
+        if (storedNames[i] == sherpaNames[i])
+          edm::LogVerbatim("Sherpa3Hadronizer") << storedNames[i];
+        else
+          edm::LogVerbatim("Sherpa3Hadronizer") << storedNames[i] << "  (Sherpa name: " << sherpaNames[i] << ")";
+      }
+    };
+    pushNames(weightlist, storedWeightNames);
+    pushNames(variationweightlist, storedVariationWeightNames);
+  }
+
+  return genLumiInfoHeader;
+}
+
+#include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
+
+typedef edm::GeneratorFilter<Sherpa3Hadronizer, gen::ExternalDecayDriver> Sherpa3GeneratorFilter;
+DEFINE_FWK_MODULE(Sherpa3GeneratorFilter);

--- a/GeneratorInterface/Sherpa3Interface/src/Sherpa3Utils.cc
+++ b/GeneratorInterface/Sherpa3Interface/src/Sherpa3Utils.cc
@@ -1,0 +1,170 @@
+#include "GeneratorInterface/Sherpa3Interface/interface/Sherpa3Utils.h"
+
+#include <cstdlib>
+#include <fstream>
+
+namespace sh3utils {
+
+  Sherpa3Utils::Sherpa3Utils(edm::ParameterSet const &pset) {
+    if (!pset.exists("Sherpa3Process"))
+      Sherpa3Process = "";
+    else
+      Sherpa3Process = pset.getParameter<std::string>("Sherpa3Process");
+    if (!pset.exists("GridpackLocation"))
+      GridpackLocation = "";
+    else
+      GridpackLocation = pset.getParameter<std::string>("GridpackLocation");
+    if (!pset.exists("GridpackChecksum"))
+      GridpackChecksum = "";
+    else
+      GridpackChecksum = pset.getParameter<std::string>("GridpackChecksum");
+    if (!pset.exists("EvtGenDirectory"))
+      EvtGenDirectory = "./SHERPA3GEN";
+    else
+      EvtGenDirectory = pset.getParameter<std::string>("EvtGenDirectory");
+  }
+
+  int Sherpa3Utils::Fetch() {
+    // GridpackLocation is the full path to a
+    // Sherpa3_<process>_<SCRAM_ARCH>_<CMSSW_VERSION>_tarball.tar.xz file
+    std::string gridpackPath = GridpackLocation;
+    size_t lastSlash = gridpackPath.find_last_of("/\\");
+    std::string gridpack = (lastSlash == std::string::npos) ? gridpackPath : gridpackPath.substr(lastSlash + 1);
+
+    std::cout << "Sherpa3Utils: Trying to fetch the Gridpack from " << gridpackPath << std::endl;
+    int res = CopyFile(gridpackPath);
+    if (res != 1) {
+    throw cms::Exception("Sherpa3Interface")
+        << "Sherpa3Utils: Fetching of Gridpack did not succeed, terminating" << std::endl;
+    return -1;
+    }
+    std::cout << "Sherpa3Utils: Fetching successful" << std::endl;
+
+    std::ifstream my_file(gridpack.c_str());
+    if (!my_file.good()) {
+      throw cms::Exception("Sherpa3Interface") << "Sherpa3Utils: No Gridpack found at " << gridpack
+                                               << std::endl;
+      return -2;
+    }
+    my_file.close();
+    std::cout << "Sherpa3Utils: Gridpack found" << std::endl;
+
+    if (!GridpackChecksum.empty()) {
+      char md5checksum[33];
+      MD5File(gridpack, md5checksum);
+      for (int k = 0; k < 33; k++) {
+        if (md5checksum[k] != GridpackChecksum[k]) {
+          throw cms::Exception("Sherpa3Interface")
+              << "Sherpa3Utils: failure, calculated and specified checksums differ!" << std::endl;
+          return -3;
+        }
+      }
+      std::cout << "Sherpa3Utils: Calculated checksum of the Gridpack is " << md5checksum << " and matches"
+                << std::endl;
+    } else {
+      std::cout << "Sherpa3Utils: Ignoring Checksum" << std::endl;
+    }
+
+    const char *envCMSSWVersion = std::getenv("CMSSW_VERSION");
+    const char *envSCRAMArch = std::getenv("SCRAM_ARCH");
+    std::string cmsswVersion = envCMSSWVersion ? envCMSSWVersion : "";
+    std::string scramArch = envSCRAMArch ? envSCRAMArch : "";
+    if (!cmsswVersion.empty() && !scramArch.empty()) {
+      bool versionMatch = (gridpack.find(cmsswVersion) != std::string::npos);
+      bool archMatch = (gridpack.find(scramArch) != std::string::npos);
+      if (versionMatch && archMatch) {
+        std::cout << "Sherpa3Utils: CMSSW_VERSION (" << cmsswVersion << ") and SCRAM_ARCH (" << scramArch
+                  << ") match the Gridpack" << std::endl;
+      } else {
+        if (!versionMatch)
+          std::cout << "Sherpa3Utils: WARNING - CMSSW_VERSION mismatch: environment has " << cmsswVersion
+                    << " but not found in Gridpack " << gridpack << std::endl;
+        if (!archMatch)
+          std::cout << "Sherpa3Utils: WARNING - SCRAM_ARCha CH mismatch: environment has " << scramArch
+                    << " but not found in Gridpack " << gridpack << std::endl;
+      }
+    } else {
+      std::cout << "Sherpa3Utils: CMSSW_VERSION or SCRAM_ARCH not set in environment, skipping compatibility "
+                   "check"
+                << std::endl;
+    }
+
+    // (re)create the event generation directory: delete it if it exists,
+    // then create it fresh
+    std::cout << "Sherpa3Utils: Preparing event generation directory " << EvtGenDirectory << std::endl;
+    std::string rmCmd = "rm -rf " + EvtGenDirectory;
+    if (system(rmCmd.c_str()) != 0) {
+      throw cms::Exception("Sherpa3Interface")
+          << "Sherpa3Utils: Could not remove existing directory " << EvtGenDirectory << std::endl;
+      return -4;
+    }
+    std::string mkdirCmd = "mkdir -p " + EvtGenDirectory;
+    if (system(mkdirCmd.c_str()) != 0) {
+      throw cms::Exception("Sherpa3Interface")
+          << "Sherpa3Utils: Could not create directory " << EvtGenDirectory << std::endl;
+      return -4;
+    }
+
+    std::cout << "Sherpa3Utils: Trying to decompress the Gridpack (tar.xz): " << gridpack << std::endl;
+    std::string tarCmd = "tar -xJf " + gridpack + " -C " + EvtGenDirectory;
+    res = system(tarCmd.c_str());
+    if (res != 0) {
+      throw cms::Exception("Sherpa3Interface") << "Sherpa3Utils: Decompressing failed " << std::endl;
+      return -4;
+    }
+    std::cout << "Sherpa3Utils: Decompressing successful " << std::endl;
+    return 0;
+  }
+
+  int Sherpa3Utils::CopyFile(const std::string &pathstring) {
+    // if the file is already present in the current directory, no need to copy
+    size_t lastSlash = pathstring.find_last_of("/\\");
+    std::string filename = (lastSlash == std::string::npos) ? pathstring : pathstring.substr(lastSlash + 1);
+    std::ifstream existing(filename.c_str());
+    if (existing.good()) {
+      existing.close();
+      std::cout << "\t File " << filename << " already present, no need to copy" << std::endl;
+      return 1;
+    }
+    existing.close();
+    std::cout << "\t Trying to copy file " << pathstring << std::endl;
+    std::string command = "cp " + pathstring + " .";
+    FILE *pipe = popen(command.c_str(), "r");
+    if (!pipe)
+      throw cms::Exception("Sherpa3Interface") << "failed to copy Gridpack ";
+    pclose(pipe);
+    return 1;
+  }
+
+  // function for calculating the MD5 checksum of a file
+  void Sherpa3Utils::MD5File(std::string filename, char *result) {
+    char buffer[4096];
+    cms::openssl_init();
+    EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+    const EVP_MD *md = EVP_get_digestbyname("MD5");
+    EVP_DigestInit_ex(mdctx, md, nullptr);
+
+    //Open File
+    int fd = open(filename.c_str(), O_RDONLY);
+    int nb_read;
+    while ((nb_read = read(fd, buffer, 4096 - 1))) {
+      EVP_DigestUpdate(mdctx, buffer, nb_read);
+      memset(buffer, 0, 4096);
+    }
+    close(fd);
+
+    unsigned int md_len = 0;
+    unsigned char tmp[EVP_MAX_MD_SIZE];
+    EVP_DigestFinal_ex(mdctx, tmp, &md_len);
+    EVP_MD_CTX_free(mdctx);
+
+    assert(result);
+    //Convert the result
+    for (unsigned int k = 0; k < md_len; ++k) {
+      sprintf(result + k * 2, "%02x", tmp[k]);
+    }
+  }
+
+  Sherpa3Utils::~Sherpa3Utils() {}
+
+}  // namespace sh3utils


### PR DESCRIPTION
#### PR description:

Depends on cmsdist PR [#10818](https://github.com/cms-sw/cmsdist/pull/10818), which adds Sherpa3.

This PR adds the Sherpa3Interface. The upgrade from Sherpa version 2 to 3 is substantial, so the interface functions needed to be refurbished accordingly. This PR includes:

- `mkSherpa3Gridpack.sh` to generate a `gridpack` (formerly known as `sherpack`) and a python fragment `<Process>_cff.py` for `cmsDriver.py`.
- `Sherpa3Utils.cc` and `Sherpa3Hadronizer` to unpack the `gridpack` and generate events with `HepMC3`.

#### PR validation:

Local validation has been done.

##### Step1: generate gridpack, e.g.,

```bash
cmsrel CMSSW_20_1_X # choose CMSSW release with Sherpa3
cd CMSSW_20_1_X/src && cmsenv
git cms-addpkg GeneratorInterface/SherpaInterface
mkdir -p MY/PROJECT/test MY/PROJECT/python
cp GeneratorInterface/SherpaInterface/data/mkSherpa3Gridpack.sh GeneratorInterface/SherpaInterface/data/*.yml MY/PROJECT/test
cd MY/PROJECT/test
./mkSherpa3Gridpack.sh -yml WZ_polarisation_nLO.yml -n 66 -v
```

After running, the gridpack `Sherpa3_WZ_polarisation_nLO_el9_amd64_gcc13_CMSSW_20_1_0_pre2_tarball.tar.xz` and python fragment `Sherpa3_WZ_polarisation_nLO_cff.py` will be generated.

##### Step2: generate events

```bash
cp Sherpa3_WZ_polarisation_nLO_cff.py ../python
cd ../.. && scram b -j4 && cd -
cmsDriver.py MY/PROJECT/python/Sherpa3_WZ_polarisation_nLO_cff.py -s GEN -n 100 --no_exec --conditions auto:mc --eventcontent RAWSIM --beamspot DBrealistic
cmsRun Sherpa3_WZ_polarisation_nLO_cff_py_GEN.py
```

The generated events can then be found in `Sherpa3_WZ_polarisation_nLO_cff_py_GEN.root`.