### PR TITLE
[fmt 12.2] use fmt/format.h instead of heavy fmt/core.h

### DIFF
--- a/Alignment/OfflineValidation/macros/DiMuonMassProfiles.C
+++ b/Alignment/OfflineValidation/macros/DiMuonMassProfiles.C
@@ -27,7 +27,7 @@
 #include <iomanip>
 #include <iostream>
 #include <map>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 // CMSSW classes / style
 #include "Alignment/OfflineValidation/interface/FitWithRooFit.h"

--- a/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
+++ b/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
@@ -6,7 +6,7 @@
 
 #include <cuda_runtime_api.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <catch2/catch_all.hpp>
 

--- a/HeterogeneousCore/ROCmServices/test/testROCmService.cpp
+++ b/HeterogeneousCore/ROCmServices/test/testROCmService.cpp
@@ -6,7 +6,7 @@
 
 #include <hip/hip_runtime.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <catch2/catch_all.hpp>
 


### PR DESCRIPTION
Using `fmt::format` via `fmt/core.h` is deprecated since version `12.2` of the `fmt` library (https://github.com/fmtlib/fmt/blob/12.2.0/include/fmt/core.h#L10-L14) and requires defining `#define FMT_DEPRECATED_HEAVY_CORE` or including `fmt/format.h` instead. This PR suggests to use `fmt/format.h` so that we can move forward to fmt version 12 and above