### PR TITLE
[L1T] Phase2 L1Nano: drop hpsTauTable, and the dead HARVEST step from wf .781/.782

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2327,10 +2327,24 @@ upgradeWFs['L1Complete'] = UpgradeWorkflow_L1Complete(
     offset = 0.78
 )
 
+class UpgradeWorkflow_L1CompleteNano(UpgradeWorkflow_HLT75e33Timing):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        # step2 of these workflows runs no VALIDATION/DQM sequence and writes only
+        # FEVTDEBUGHLT and/or NANOAODSIM, so step2_inDQM.root is never produced. The
+        # HARVESTING step inherited from the HLTTiming75e33 template can therefore only
+        # fail with a FileOpenError; drop it rather than schedule it.
+        if 'HARVEST' in step:
+            stepDict[stepName][k] = None
+        else:
+            super().setup_(step, stepName, stepDict, k, properties)
+
 # use HLTTiming75e33 template as it skips the steps after DIGI
-upgradeWFs['L1CompleteWithNano'] = deepcopy(upgradeWFs['HLTTiming75e33'])
-upgradeWFs['L1CompleteWithNano'].suffix = '_L1CompleteWithNano'
-upgradeWFs['L1CompleteWithNano'].offset = 0.781
+upgradeWFs['L1CompleteWithNano'] = UpgradeWorkflow_L1CompleteNano(
+    steps = deepcopy(upgradeWFs['HLTTiming75e33'].steps),
+    PU = deepcopy(upgradeWFs['HLTTiming75e33'].PU),
+    suffix = '_L1CompleteWithNano',
+    offset = 0.781,
+)
 upgradeWFs['L1CompleteWithNano'].step2 = {
     '-s': 'DIGI:pdigi_valid,L1,L1TrackTrigger,L1P2GT,DIGI2RAW,HLT:@relvalRun4,NANO:@Phase2L1DPG',
     '--datatier':'GEN-SIM-DIGI-RAW,NANOAODSIM',

--- a/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nano_cff.py
+++ b/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nano_cff.py
@@ -15,10 +15,9 @@ from DPGAnalysis.Phase2L1TNanoAOD.l1tPh2Nanotables_cff import *
 def addPh2L1Objects(process):
     process.l1tPh2NanoTask.add(p2L1TablesTask)
 
-    # This modifier excludes the hpsTauTable, which is based on the l1tHPSPFTauProducerPuppi collection, no longer available in the L1 menu.
-    # This allows to run the NANOAOD production from L1 and HLT steps, whitout requiring old inputs from the Spring24 datasets.
-    from Configuration.ProcessModifiers.nano_l1_hlt_cff import nano_l1_hlt
-    nano_l1_hlt.toReplaceWith(p2L1TablesTask, p2L1TablesTask.copyAndExclude([hpsTauTable]))
+    # NOTE: the hpsTauTable used to be excluded here under the nano_l1_hlt modifier.
+    # It is now simply not part of p2L1TablesTask, so no modifier is needed and every
+    # workflow -- not just the L1+HLT one -- can run this task.
 
     return process
 

--- a/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nanotables_cff.py
+++ b/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2Nanotables_cff.py
@@ -593,7 +593,11 @@ p2L1TablesTask = cms.Task(
     caloTauTable,
     nnCaloTauTable,
     nnPuppiTauTable,
-    hpsTauTable,
+    # hpsTauTable is intentionally not scheduled: it reads l1tHPSPFTauProducerPuppi,
+    # which is no longer part of the L1 menu (only the non-Puppi l1tHPSPFTauProducer is
+    # in the Phase-2 SimL1Emulator sequence). Keeping it here makes every workflow that
+    # runs this task abort with ProductNotFound for l1t::HPSPFTau. The producer config
+    # above is kept so the table can be re-enabled if the collection comes back.
     # GTT
     vtxTable,
     dispVtxTable,


### PR DESCRIPTION
#### PR description:

FYI @RobertJWard @BenjaminRS @quinnanm @mmusich @elenavernazza 

Workflows `29634.781`/`.782` (Phase-2 L1 NanoAOD) cannot run. Two independent causes, both reproducible on an unmodified release:

1. **`hpsTauTable` reads a collection that is no longer produced.** It reads `l1tHPSPFTauProducerPuppi`, but only the non-Puppi `l1tHPSPFTauProducer` is in the Phase-2 `SimL1Emulator` sequence, so any workflow running `p2L1TablesTask` aborts with `ProductNotFound` for `l1t::HPSPFTau`. `addPh2L1Objects` already excluded the table under the `nano_l1_hlt` modifier — with a comment noting the collection is "no longer available in the L1 menu" — but these workflows do not apply that modifier. Remove the table from `p2L1TablesTask` and drop the now-redundant modifier block; the `EDProducer` definition is kept so it can be re-enabled if the collection returns.

2. **A HARVESTING step that can never have an input.** `L1CompleteWithNano`/`L1CompleteOnlyNano` inherit `HARVESTGlobal` from the `HLTTiming75e33` template, but their `step2` runs no `VALIDATION`/`DQM` sequence and writes only `FEVTDEBUGHLT,NANOAODSIM` (`.782`: `NANOAODSIM`), so `step2_inDQM.root` is never produced and `HARVESTING:@hltValidation` fails with `FileOpenError`. Dropped via a small `UpgradeWorkflow` subclass that sets the HARVEST entry to `None`. Removing it from the `steps` list alone is not sufficient — `relval_upgrade.py` then appends the step unsuffixed. `steps`/`PU` are deep-copied so the shared `HLTTiming75e33` template is not mutated.

**Expected output changes:** the `L1hpsTau_*` branches are removed from the Phase-2 L1 NanoAOD — in current workflows they were never actually written, since the table only aborted the job, but they could still appear when running over legacy inputs containing the Puppi producer. The other four L1 tau tables (`L1caloTau`, `L1nnCaloTau`, `L1nnPuppiTau`, `L1GTnnTau`) are unaffected. `29634.781`/`.782` no longer schedule a HARVESTING step; `29634.75` and the `HLTTiming75e33` template are unchanged.

No dependencies on other PRs or externals.

#### PR validation:

`CMSSW_20_1_0_pre1`, `el9_amd64_gcc13`.

- `runTheMatrix.py --what upgrade -i all -l 29634.781` reports `1 1 tests passed, 0 0 failed`. step2 processes all 10 events with zero exceptions and writes a complete NanoAOD (10 entries, 504 branches) plus the `FEVTDEBUGHLT` output. Before this PR the same command reported `Step1-FAILED` / `Step2-NOTRUN`.
- Workflow listing confirms the HARVEST step is dropped only where intended: `29634.781`/`.782` no longer show it, while `29634.75` still shows `+HARVESTGlobal_HLT75e33Timing_Run4D110`.
- The remaining tau tables are present in the output nano: `L1caloTau`, `L1nnCaloTau`, `L1nnPuppiTau`, `L1GTnnTau`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport; targets `master`. No backport currently intended.