### PR TITLE
[L1T] Extend P2GT members accessors

### DIFF
--- a/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2GTtables_cff.py
+++ b/DPGAnalysis/Phase2L1TNanoAOD/python/l1tPh2GTtables_cff.py
@@ -72,9 +72,8 @@ gtTkPhoTable =cms.EDProducer(
         hwQual = Var("hwQualityFlags_toInt()",int),
         hwIso = Var("hwIsolationPT_toInt()",int),
         ## more physical values
-        ## using the GT scales for HW to physicsal vonversion, see scales in https://github.com/cms-sw/cmssw/blob/master/L1Trigger/Phase2L1GT/python/l1tGTScales.py
-        iso = Var(f"hwIsolationPT_toInt()*{scale_parameter.isolationPT_lsb.value()}",float, doc = "absolute isolation"),
-        relIso = Var(f"hwIsolationPT_toInt()*{scale_parameter.isolationPT_lsb.value()} / pt",float, doc = "relative isolation")
+        iso = Var("isolationPT()",float, doc = "absolute isolation"),
+        relIso = Var("isolationPT()/pt",float, doc = "relative isolation")
     )
 )
 
@@ -198,7 +197,7 @@ gtHtSumTable = cms.EDProducer(
         # l1GTObjVars,
         mht = Var("pt", float, doc="MHT pt"),
         mhtPhi = Var("phi", float, doc="MHT phi"),
-        ht = Var(f"hwScalarSumPT_toInt()*{scale_parameter.scalarSumPT_lsb.value()}", float, doc="HT"), ## HACK via hw value!
+        ht = Var("scalarSumPT()", float, doc="HT"),
     )
 )
 

--- a/DataFormats/L1Trigger/interface/P2GTCandidate.h
+++ b/DataFormats/L1Trigger/interface/P2GTCandidate.h
@@ -99,7 +99,6 @@ namespace l1t {
       void setHwEta(hwEta_t hwEta) { hwEta_ = hwEta.to_int(); }
       void setHwZ0(hwZ0_t hwZ0) { hwZ0_ = hwZ0.to_int(); }
       void setHwIsolationPT(hwIsolationPT_t hwIso) { hwIsolationPT_ = hwIso.to_int(); }
-      void setIsolationPT(double isolationPT) { isolationPT_ = isolationPT; }
       void setHwQualityFlags(hwQualityFlags_t hwQualityFlags) { hwQualityFlags_ = hwQualityFlags.to_int(); }
       void setHwQualityScore(hwQualityScore_t hwQualityScore) { hwQualityScore_ = hwQualityScore.to_int(); }
       void setHwCharge(hwCharge_t hwCharge) { hwCharge_ = hwCharge.to_int(); }
@@ -110,7 +109,6 @@ namespace l1t {
       void setHwSeed_pT(hwSeed_pT_t hwSeed_pT) { hwSeed_pT_ = hwSeed_pT.to_int(); }
       void setHwSeed_z0(hwSeed_z0_t hwSeed_z0) { hwSeed_z0_ = hwSeed_z0.to_int(); }
       void setHwScalarSumPT(hwScalarSumPT_t hwScalarSumPT) { hwScalarSumPT_ = hwScalarSumPT.to_int(); }
-      void setScalarSumPT(double scalarSumPT) { scalarSumPT_ = scalarSumPT; }
       void setHwNumber_of_tracks(hwNumber_of_tracks_t hwNumber_of_tracks) {
         hwNumber_of_tracks_ = hwNumber_of_tracks.to_int();
       }

--- a/DataFormats/L1Trigger/interface/P2GTCandidate.h
+++ b/DataFormats/L1Trigger/interface/P2GTCandidate.h
@@ -99,6 +99,7 @@ namespace l1t {
       void setHwEta(hwEta_t hwEta) { hwEta_ = hwEta.to_int(); }
       void setHwZ0(hwZ0_t hwZ0) { hwZ0_ = hwZ0.to_int(); }
       void setHwIsolationPT(hwIsolationPT_t hwIso) { hwIsolationPT_ = hwIso.to_int(); }
+      void setIsolationPT(double isolationPT) { isolationPT_ = isolationPT; }
       void setHwQualityFlags(hwQualityFlags_t hwQualityFlags) { hwQualityFlags_ = hwQualityFlags.to_int(); }
       void setHwQualityScore(hwQualityScore_t hwQualityScore) { hwQualityScore_ = hwQualityScore.to_int(); }
       void setHwCharge(hwCharge_t hwCharge) { hwCharge_ = hwCharge.to_int(); }
@@ -109,6 +110,7 @@ namespace l1t {
       void setHwSeed_pT(hwSeed_pT_t hwSeed_pT) { hwSeed_pT_ = hwSeed_pT.to_int(); }
       void setHwSeed_z0(hwSeed_z0_t hwSeed_z0) { hwSeed_z0_ = hwSeed_z0.to_int(); }
       void setHwScalarSumPT(hwScalarSumPT_t hwScalarSumPT) { hwScalarSumPT_ = hwScalarSumPT.to_int(); }
+      void setScalarSumPT(double scalarSumPT) { scalarSumPT_ = scalarSumPT; }
       void setHwNumber_of_tracks(hwNumber_of_tracks_t hwNumber_of_tracks) {
         hwNumber_of_tracks_ = hwNumber_of_tracks.to_int();
       }
@@ -159,6 +161,13 @@ namespace l1t {
           throw std::invalid_argument("Object doesn't have isolationPT");
         }
         return static_cast<int>(hwIsolationPT_);
+      }
+
+      double isolationPT() const {
+        if (!isolationPT_) {
+          throw std::invalid_argument("Object doesn't have isolationPT");
+        }
+        return isolationPT_;
       }
 
       hwQualityFlags_t hwQualityFlags() const {
@@ -229,6 +238,13 @@ namespace l1t {
           throw std::invalid_argument("Object doesn't have scalarSumPT");
         }
         return static_cast<int>(hwScalarSumPT_);
+      }
+
+      double scalarSumPT() const {
+        if (!scalarSumPT_) {
+          throw std::invalid_argument("Object doesn't have scalarSumPT");
+        }
+        return scalarSumPT_;
       }
 
       hwNumber_of_tracks_t hwNumber_of_tracks() const {
@@ -320,12 +336,20 @@ namespace l1t {
                objectType_ == CL2JetsSC4 || objectType_ == CL2JetsSC8;
       }
 
+      bool isEtSum() const { return objectType_ == GCTEtSum || objectType_ == GTTEtSum || objectType_ == CL2EtSum; }
+
+      bool isHtSum() const {
+        return objectType_ == GCTHtSum || objectType_ == GTTPromptHtSum || objectType_ == GTTDisplacedHtSum ||
+               objectType_ == CL2HtSum;
+      }
+
     private:
       Optional<int> hwPT_;
       Optional<int> hwPhi_;
       Optional<int> hwEta_;
       Optional<int> hwZ0_;
       Optional<int> hwIsolationPT_;
+      Optional<double> isolationPT_;
       Optional<int> hwQualityFlags_;
       Optional<int> hwQualityScore_;
       Optional<int> hwCharge_;
@@ -336,6 +360,7 @@ namespace l1t {
       Optional<int> hwSeed_pT_;
       Optional<int> hwSeed_z0_;
       Optional<int> hwScalarSumPT_;
+      Optional<double> scalarSumPT_;
       Optional<int> hwNumber_of_tracks_;
       Optional<int> hwNumber_of_displaced_tracks_;
 

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -16,9 +16,7 @@
   <class name="l1t::io_v1::P2GTCandidate::Optional<int>"/>
   <class name="l1t::io_v1::P2GTCandidate::Optional<double>"/>
   <class name="l1t::io_v1::P2GTCandidate" ClassVersion="4">
-    <!-- TODO: checksum below is a placeholder; recompute with scripts/edmCheckClassVersion
-         (or let CI report the correct value) once this can be built. -->
-    <version ClassVersion="4" checksum="0"/>
+    <version ClassVersion="4" checksum="3737213310"/>
     <version ClassVersion="3" checksum="1444610149"/>
   </class>
   <class name="l1t::P2GTCandidateCollection"/>

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -14,7 +14,11 @@
 
 
   <class name="l1t::io_v1::P2GTCandidate::Optional<int>"/>
-  <class name="l1t::io_v1::P2GTCandidate" ClassVersion="3">
+  <class name="l1t::io_v1::P2GTCandidate::Optional<double>"/>
+  <class name="l1t::io_v1::P2GTCandidate" ClassVersion="4">
+    <!-- TODO: checksum below is a placeholder; recompute with scripts/edmCheckClassVersion
+         (or let CI report the correct value) once this can be built. -->
+    <version ClassVersion="4" checksum="0"/>
     <version ClassVersion="3" checksum="1444610149"/>
   </class>
   <class name="l1t::P2GTCandidateCollection"/>

--- a/L1Trigger/Phase2L1GT/plugins/L1GTProducer.cc
+++ b/L1Trigger/Phase2L1GT/plugins/L1GTProducer.cc
@@ -240,6 +240,7 @@ namespace l1t {
       gtObj.hwPT_ = htMiss.Et.V.to_int();
       gtObj.hwPhi_ = obj.hwPhi();
       gtObj.hwScalarSumPT_ = obj.hwPt();
+      gtObj.scalarSumPT_ = scales_.to_scalarSumPT(obj.hwPt());
       gtObj.objectType_ = P2GTCandidate::GTTPromptHtSum;
 
       outputCollection->push_back(gtObj);
@@ -262,6 +263,7 @@ namespace l1t {
       gtObj.hwPT_ = htMiss.Et.V.to_int();
       gtObj.hwPhi_ = obj.hwPhi();
       gtObj.hwScalarSumPT_ = obj.hwPt();
+      gtObj.scalarSumPT_ = scales_.to_scalarSumPT(obj.hwPt());
       gtObj.objectType_ = P2GTCandidate::GTTDisplacedHtSum;
 
       outputCollection->push_back(gtObj);
@@ -357,6 +359,7 @@ namespace l1t {
       gtObj.hwZ0_ = hwZ0;
       gtObj.hwQualityFlags_ = obj.apQualFlags().to_int();
       gtObj.hwIsolationPT_ = obj.apIso().to_int();
+      gtObj.isolationPT_ = scales_.to_isolationPT(obj.apIso().to_int());
       gtObj.hwCharge_ = obj.apCharge().to_int();
       gtObj.hwD0_ = obj.apD0().to_int();
       gtObj.hwBeta_ = obj.apBeta().to_int();
@@ -427,6 +430,7 @@ namespace l1t {
       gtObj.hwPhi_ = gtPhoton.v3.phi.V.to_int();
       gtObj.hwEta_ = gtPhoton.v3.eta.V.to_int();
       gtObj.hwIsolationPT_ = gtPhoton.isolationPT.V.to_int();
+      gtObj.isolationPT_ = scales_.to_isolationPT(gtPhoton.isolationPT.V.to_int());
       gtObj.hwQualityFlags_ = gtPhoton.qualityFlags.V.to_int();
       gtObj.objectType_ = P2GTCandidate::CL2Photons;
 
@@ -452,6 +456,7 @@ namespace l1t {
       gtObj.hwEta_ = gtElectron.v3.eta.V.to_int();
       gtObj.hwZ0_ = hwZ0;
       gtObj.hwIsolationPT_ = gtElectron.isolationPT.V.to_int();
+      gtObj.isolationPT_ = scales_.to_isolationPT(gtElectron.isolationPT.V.to_int());
       gtObj.hwQualityFlags_ = gtElectron.qualityFlags.V.to_int();
       gtObj.hwQualityScore_ = gtElectron.idScore.V.to_int();
       gtObj.hwCharge_ = gtElectron.charge.V.to_int();
@@ -500,6 +505,7 @@ namespace l1t {
     gtObj.hwPT_ = sum.vector_pt.V.to_int();
     gtObj.hwPhi_ = sum.vector_phi.V.to_int();
     gtObj.hwScalarSumPT_ = sum.scalar_pt.V.to_int();
+    gtObj.scalarSumPT_ = scales_.to_scalarSumPT(sum.scalar_pt.V.to_int());
     gtObj.objectType_ = P2GTCandidate::CL2EtSum;
 
     outputCollection->push_back(gtObj);
@@ -517,6 +523,7 @@ namespace l1t {
     gtObj.hwPT_ = mht.hwPt();
     gtObj.hwPhi_ = mht.hwPhi();
     gtObj.hwScalarSumPT_ = ht.hwPt();
+    gtObj.scalarSumPT_ = scales_.to_scalarSumPT(ht.hwPt());
     gtObj.objectType_ = P2GTCandidate::CL2HtSum;
 
     outputCollection->push_back(gtObj);


### PR DESCRIPTION
#### PR description:

Addresses #51794. FYI @mmusich @BenjaminRS @quinnanm @RobertJWard 

`l1t::P2GTCandidate` exposes only raw hardware ints, so consumers reading the objects straight from the event (e.g. the HLT prototype analyzer, which has no access to the producer's `L1GTScales`) cannot tell an Et-sum from an Ht-sum, and cannot get isolation or HT in GeV. `DPGAnalysis/Phase2L1TNanoAOD` worked around this by multiplying the hw value by an LSB hardcoded from the python scales config — the HT line was commented `## HACK via hw value!`.

- `P2GTCandidate.h`: add `isEtSum()`/`isHtSum()` predicates and `isolationPT()`/`scalarSumPT()` accessors, backed by two new `Optional<double>` members, throwing `std::invalid_argument` when unset like every other getter in the class.
- `L1GTProducer.cc`: fill them from the producer's live `L1GTScales`, so the LSB stays defined only in `l1tGTScales.py`. All 7 sites that set `hwIsolationPT_` (3) or `hwScalarSumPT_` (4) are covered.
- `classes_def.xml`: register `Optional<double>`, bump `ClassVersion` 3 → 4 (`checksum="3737213310"`), keep the v3 record.
- `l1tPh2GTtables_cff.py`: use the accessors for `iso`, `relIso` and `ht`.

**Expected output changes:** schema change (v3 files stay readable, new members come back unset); the `l1tGTProducer` product grows ~9% (~210 B/event); **no change to any NanoAOD value**, since the producer is configured from the same `scale_parameter` PSet the hardcoded LSBs were copied from.

**This is an ABI change.** Eight packages `#include` the header and must be rebuilt: `DataFormats/L1Trigger`, `DataFormats/HLTReco`, `L1Trigger/Phase2L1GT`, `DPGAnalysis/Phase2L1TNanoAOD`, `HLTrigger/HLTcore`, `HLTrigger/HLTfilters`, `RecoEgamma/EgammaHLTProducers`, `RecoHGCal/TICL`. NB! a partial local checkout instead yields spurious Object doesn't have qualityFlags from `hltTiclSeedingL1 / hltL1TEGammaFilteredCollectionProducer`.

No dependencies on other PRs or externals. (The relval used below only runs with cms-sw/cmssw#51803, which fixes a pre-existing, unrelated breakage of the Phase-2 L1 nano workflows.)

#### PR validation:

`CMSSW_20_1_0_pre1`, `el9_amd64_gcc13`.

- Clean build; `edmCheckClassVersion` passes standalone — the recorded checksum is the value the tool itself reports.
- **NanoAOD A/B vs the unmodified release**, same `step1.root`, single-threaded: `L1GTtkPhoton_iso`/`relIso` (n=99), `L1GTtkElectron_iso`/`relIso` (n=69) and `L1GTscJetSum_ht` (n=10) all give `max|PR-BASE| = 0` on non-trivial values, as do untouched control branches (`hwIso`, `pt`, `mht`, `mhtPhi`). **NB!** The comparison must be single-threaded — the multithreaded Phase-2 L1 chain is not reproducible run-to-run, in the unmodified release as much as here.
- **EDM round-trip**, FWLite over the persisted `FEVTDEBUGHLT` output (443 objects, 13 `l1tGTProducer` collections), which exercises the v4 dictionary: `isEtSum()`/`isHtSum()` true exactly for the Et-/Ht-sum types and false elsewhere; `isolationPT() == hwIsolationPT_toInt()*0.25` for `CL2Photons`/`CL2Electrons`/`GMTTkMuons`; `scalarSumPT() == hwScalarSumPT_toInt()*0.03125` for `CL2EtSum`/`CL2HtSum`/`GTTPromptHtSum`/`GTTDisplacedHtSum`; both throw where unset. `GTTEtSum` sets no scalar sum in the producer, so it throws there — unchanged from the existing `hwScalarSumPT()` behaviour.
- **Backward compatibility:** a file written by the unmodified release (StreamerInfo `ClassVersion=3`) reads under the v4 dictionary — 198 objects, hardware accessors and `objectType_` predicates fine, new members unset, no crash.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport; targets `master`. No backport currently intended.