### PR TITLE
Update ZDC reco setting for Run3 PbPb rereco

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -316,7 +316,6 @@ modulesToRemove.append(hfreco)
 modulesToRemove.append(horeco)
 modulesToRemove.append(hcalnoise)
 modulesToRemove.append(zdcreco)
-modulesToRemove.append(zdcrecoRun3)
 modulesToRemove.append(castorreco)
 ##it's OK according to Ronny modulesToRemove.append(CSCHaloData)#needs digis
 reconstruction_fromRECO = reconstruction.copyAndExclude(modulesToRemove+noTrackingAndDependent)

--- a/RecoHI/HiCentralityAlgos/python/HiCentrality_cfi.py
+++ b/RecoHI/HiCentralityAlgos/python/HiCentrality_cfi.py
@@ -48,7 +48,7 @@ from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
 )
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(hiCentrality, srcZDChits = "zdcrecoRun3",lowGainZDC = False)
+run3_common.toModify(hiCentrality, lowGainZDC = False)
 
 from Configuration.ProcessModifiers.phase2_pp_on_AA_cff import phase2_pp_on_AA
 phase2_pp_on_AA.toModify(hiCentrality,

--- a/RecoHI/HiCentralityAlgos/python/pACentrality_cfi.py
+++ b/RecoHI/HiCentralityAlgos/python/pACentrality_cfi.py
@@ -37,5 +37,5 @@ pACentrality = cms.EDProducer("CentralityProducer",
                             )
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(pACentrality, srcZDChits = "zdcrecoRun3",lowGainZDC =False)
+run3_common.toModify(pACentrality, lowGainZDC =False)
 

--- a/RecoHI/HiEvtPlaneAlgos/python/RecoHiEvtPlane_EventContent_cff.py
+++ b/RecoHI/HiEvtPlaneAlgos/python/RecoHiEvtPlane_EventContent_cff.py
@@ -5,7 +5,6 @@ RecoHiEvtPlaneAOD = cms.PSet(
     outputCommands = cms.untracked.vstring(
 	'keep recoEvtPlanes_hiEvtPlane_*_*',
         'keep ZDCRecHitsSorted_zdcreco_*_*',
-        'keep ZDCRecHitsSorted_zdcrecoRun3_*_*',
         'keep ZDCDataFramesSorted_hcalDigis_*_*',
         'keep HFRecHitsSorted_hfreco_*_*')
 )

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -110,8 +110,6 @@ calolocalrecoCosmicsNZS = cms.Sequence(calolocalrecoTaskCosmicsNZS)
 
 #--- for Run 3 and later
 _run3_hcalLocalRecoTask = _phase1_hcalLocalRecoTask.copy()
-from RecoLocalCalo.HcalRecProducers.zdcrecoRun3_cfi import zdcrecoRun3
-_run3_hcalLocalRecoTask.remove(zdcreco)
-_run3_hcalLocalRecoTask.add(zdcrecoRun3)
+from RecoLocalCalo.HcalRecProducers.zdcrecoRun3_cfi import zdcrecoRun3 as _zdcrecoRun3
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toReplaceWith(hcalLocalRecoTask, _run3_hcalLocalRecoTask)
+run3_common.toReplaceWith(zdcreco, _zdcrecoRun3.clone())

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContentCosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContentCosmics_cff.py
@@ -24,7 +24,6 @@ RecoLocalCaloRECO = cms.PSet(
 	'keep ZDCDataFramesSorted_castorDigis_*_*',
 	'keep ZDCDataFramesSorted_simHcalUnsuppressedDigis_*_*',
 	'keep ZDCRecHitsSorted_zdcreco_*_*',
-	'keep ZDCRecHitsSorted_zdcrecoRun3_*_*',
 	'keep HcalUnpackerReport_castorDigis_*_*',
 	'keep HcalUnpackerReport_hcalDigis_*_*')
 )

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContent_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContent_cff.py
@@ -59,8 +59,7 @@ RecoLocalCaloRECO = cms.PSet(
                                            'keep ZDCDataFramesSorted_hcalDigis_*_*',
                                            'keep ZDCDataFramesSorted_castorDigis_*_*',
                                            'keep QIE10DataFrameHcalDataFrameContainer_hcalDigis_ZDC_*',
-                                           'keep ZDCRecHitsSorted_zdcreco_*_*',
-                                           'keep ZDCRecHitsSorted_zdcrecoRun3_*_*')
+                                           'keep ZDCRecHitsSorted_zdcreco_*_*')
 )
 RecoLocalCaloRECO.outputCommands.extend(RecoLocalCaloAOD.outputCommands)
 RecoLocalCaloRECO.outputCommands.extend(ecalLocalRecoRECO.outputCommands)

--- a/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
@@ -56,10 +56,6 @@ hcalOnlyLegacyLocalRecoTask.add(hbheprerecoLegacy)
 #--- for Run 3 and later
 _run3_hcalLocalRecoTask = _phase1_hcalLocalRecoTask.copy()
 _run3_hcalLocalRecoTask.remove(hbheprereco)
-
-from RecoLocalCalo.HcalRecProducers.zdcrecoRun3_cfi import zdcrecoRun3
-_run3_hcalLocalRecoTask.remove(zdcreco)
-_run3_hcalLocalRecoTask.add(zdcrecoRun3)
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toReplaceWith(hcalLocalRecoTask, _run3_hcalLocalRecoTask)
 
@@ -71,7 +67,7 @@ _run3_hcalLocalRecoPortableTask.add(hbheRecHitProducerPortableTask)
 alpaka.toReplaceWith(hcalLocalRecoTask, _run3_hcalLocalRecoPortableTask)
 
 #--- HCAL-only workflow
-hcalOnlyLocalRecoTask = hcalLocalRecoTask.copyAndExclude([zdcreco,zdcrecoRun3])
+hcalOnlyLocalRecoTask = hcalLocalRecoTask.copyAndExclude([zdcreco])
 
 #--- HCAL-only workflow for Run 2 on GPU
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
@@ -79,6 +75,6 @@ from RecoLocalCalo.HcalRecProducers.hcalRecHitSoAToLegacy_cfi import hcalRecHitS
 (alpaka & ~run3_HB).toReplaceWith(hbheprereco, hcalRecHitSoAToLegacy.clone())
 
 #--- for FastSim
-_fastSim_hcalLocalRecoTask = hcalLocalRecoTask.copyAndExclude([zdcreco,zdcrecoRun3])
+_fastSim_hcalLocalRecoTask = hcalLocalRecoTask.copyAndExclude([zdcreco])
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(hcalLocalRecoTask, _fastSim_hcalLocalRecoTask)

--- a/RecoLocalCalo/HcalRecProducers/plugins/ZdcHitReconstructor_Run3.cc
+++ b/RecoLocalCalo/HcalRecProducers/plugins/ZdcHitReconstructor_Run3.cc
@@ -179,15 +179,15 @@ void ZdcHitReconstructor_Run3::fillDescriptions(edm::ConfigurationDescriptions& 
   desc.add<bool>("dropZSmarkedPassed", true);
   desc.add<bool>("skipRPD", true);
   desc.add<int>("recoMethod", 1);
-  desc.add<int>("correctionMethodEM", 1);
-  desc.add<int>("correctionMethodHAD", 1);
+  desc.add<int>("correctionMethodEM", 0);
+  desc.add<int>("correctionMethodHAD", 0);
   desc.add<int>("correctionMethodRPD", 0);
-  desc.add<double>("ootpuRatioEM", 3.0);
-  desc.add<double>("ootpuRatioHAD", 3.0);
+  desc.add<double>("ootpuRatioEM", -1.0);
+  desc.add<double>("ootpuRatioHAD", -1.0);
   desc.add<double>("ootpuRatioRPD", -1.0);
   desc.add<double>("ootpuFracEM", 1.0);
   desc.add<double>("ootpuFracHAD", 1.0);
-  desc.add<double>("ootpuFracRPD", 0.0);
+  desc.add<double>("ootpuFracRPD", 1.0);
   desc.add<std::vector<double>>("chargeRatiosEM",
                                 {
                                     1.0,
@@ -225,7 +225,7 @@ void ZdcHitReconstructor_Run3::fillDescriptions(edm::ConfigurationDescriptions& 
                                       {
                                           1,
                                       });
-  desc.add<bool>("setSaturationFlags", true);
+  desc.add<bool>("setSaturationFlags", false);
   {
     edm::ParameterSetDescription psd0;
     psd0.add<int>("maxADCvalue", 255);

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_zdc_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_zdc_cfi.py
@@ -29,4 +29,6 @@ zdcreco = cms.EDProducer(
     saturationParameters=  cms.PSet(maxADCvalue=cms.int32(127))
     ) # zdcreco
 
-
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+from RecoLocalCalo.HcalRecProducers.zdcrecoRun3_cfi import zdcrecoRun3 as _zdcrecoRun3
+run3_common.toReplaceWith(zdcreco, _zdcrecoRun3.clone())


### PR DESCRIPTION
#### PR description:

This PR updates the ZDC reco settings meant for Run3 (as currently used offline). Moreover, it also simplifies by using era modifiers to replace the zdcreco with zdcrecoRun3 when a Run3 era is used, avoiding the need to maintain two collections at the same time.

@hjbossi @boundino @mandrenguyen 

#### PR validation:

Tested locally.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport needed