### PR TITLE
HGCAL: Fixes to dense index for SiPM-on-tile + additional FED unpacking flags

### DIFF
--- a/DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h
+++ b/DataFormats/HGCalDigi/interface/HGCalFEDPacketInfoSoA.h
@@ -10,11 +10,12 @@
 
 namespace hgcaldigi {
 
-  namespace FEDUnpackingFlags {
+  namespace FEDUnpackingFlags {  // NOTE: the FED flag is uint16_t, so all bits are defined
     constexpr uint8_t NormalUnpacking = 0, GenericUnpackError = 1, ErrorSLinkHeader = 2, ErrorPayload = 3,
                       ErrorCaptureBlockHeader = 4, ActiveCaptureBlockFlags = 5, ErrorECONDHeader = 6,
                       ECONDPayloadLengthOverflow = 7, ECONDPayloadLengthMismatch = 8, ErrorSLinkTrailer = 9,
-                      EarlySLinkEnd = 10, GenericUnpackWarning = 11;
+                      EarlySLinkEnd = 10, GenericUnpackWarning = 11, InvalidMetaData = 12, EventMismatch = 13,
+                      OrbitMismatch = 14, BunchMismatch = 15;
   }  // namespace FEDUnpackingFlags
 
   inline constexpr bool isNotNormalFED(uint16_t fedUnpackingFlag) {
@@ -49,6 +50,18 @@ namespace hgcaldigi {
   }
   inline constexpr bool hasEarlySLinkEnd(uint16_t fedUnpackingFlag) {
     return ((fedUnpackingFlag >> FEDUnpackingFlags::EarlySLinkEnd) & 0x1);
+  }
+  inline constexpr bool hasInvalidMetadata(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::InvalidMetaData) & 0x1);
+  }
+  inline constexpr bool hasEventMismatch(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::EventMismatch) & 0x1);
+  }
+  inline constexpr bool hasOrbitMismatch(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::OrbitMismatch) & 0x1);
+  }
+  inline constexpr bool hasBunchMismatch(uint16_t fedUnpackingFlag) {
+    return ((fedUnpackingFlag >> FEDUnpackingFlags::BunchMismatch) & 0x1);
   }
 
   GENERATE_SOA_LAYOUT(HGCalFEDPacketInfoSoALayout,

--- a/EventFilter/HGCalRawToDigi/plugins/BuildFile.xml
+++ b/EventFilter/HGCalRawToDigi/plugins/BuildFile.xml
@@ -2,5 +2,6 @@
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/HGCDigi"/>
 <use name="EventFilter/HGCalRawToDigi"/>
+<use name="FWCore/MessageLogger"/>
 <use name="clhep"/>
 <flags EDM_PLUGIN="1"/>

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalDenseIndexInfoESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalDenseIndexInfoESProducer.cc
@@ -86,11 +86,18 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             uint32_t detid = module_row.detid();
 
             //get the appropriate geometry
-            DetId::Detector det = DetId(detid).det();
+            DetId::Detector det = isSiPM ? DetId::Detector::HGCalHSc : DetId(detid).det();
             int subdet = ForwardSubdetector::ForwardEmpty;
             const HGCalGeometry* hgcal_geom =
                 static_cast<const HGCalGeometry*>(geo.getSubdetectorGeometry(det, subdet));
+            if (hgcal_geom == nullptr) {
+              throw cms::Exception("HGCalDenseIndexInfoESProducer") << "Unable to find geometry for detid=0x" << std::hex << detid;
+            }
 
+            //CE-H has a layer offset in the DetId include it to get the layer number correctly
+            auto layerOffset = hgcal_geom->topology().dddConstants().getLayerOffset();
+            if(layerOffset>0) layerOffset-=1;
+            
             //get the offset to start reading the cell info from sequential
             uint32_t cellInfoOffset = cellIndexer.offsets_[typeidx];
 
@@ -123,26 +130,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                                     module_row.celltype(),
                                                                     cell_row.i1(),
                                                                     cell_row.i2());
-                  row.layer() = HGCScintillatorDetId(row.detid()).layer();
+                  row.layer() = HGCScintillatorDetId(row.detid()).layer() + layerOffset;
                 } else {
                   row.detid() = module_row.detid() + cell_row.detid();
-                  row.layer() = HGCSiliconDetId(row.detid()).layer();
+                  row.layer() = HGCSiliconDetId(row.detid()).layer() + layerOffset;
                 }
 
                 //assign position from geometry
-                row.x() = 0;
-                row.y() = 0;
-                row.z() = 0;
-                row.eta() = 0;
-                row.phi() = 0;
-                if (hgcal_geom != nullptr) {
-                  GlobalPoint position = hgcal_geom->getPosition(row.detid());
-                  row.x() = position.x();
-                  row.y() = position.y();
-                  row.z() = position.z();
-                  row.eta() = position.eta();
-                  row.phi() = position.phi();
-                }
+                GlobalPoint position = hgcal_geom->getPosition(row.detid());
+                row.x() = position.x();
+                row.y() = position.y();
+                row.z() = position.z();
+                row.eta() = position.eta();
+                row.phi() = position.phi();               
               }
             }  // end cell loop
 

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalDenseIndexInfoESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalDenseIndexInfoESProducer.cc
@@ -91,13 +91,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             const HGCalGeometry* hgcal_geom =
                 static_cast<const HGCalGeometry*>(geo.getSubdetectorGeometry(det, subdet));
             if (hgcal_geom == nullptr) {
-              throw cms::Exception("HGCalDenseIndexInfoESProducer") << "Unable to find geometry for detid=0x" << std::hex << detid;
+              throw cms::Exception("HGCalDenseIndexInfoESProducer")
+                  << "Unable to find geometry for detid=0x" << std::hex << detid;
             }
 
             //CE-H has a layer offset in the DetId include it to get the layer number correctly
             auto layerOffset = hgcal_geom->topology().dddConstants().getLayerOffset();
-            if(layerOffset>0) layerOffset-=1;
-            
+            if (layerOffset > 0)
+              layerOffset -= 1;
+
             //get the offset to start reading the cell info from sequential
             uint32_t cellInfoOffset = cellIndexer.offsets_[typeidx];
 
@@ -142,7 +144,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                 row.y() = position.y();
                 row.z() = position.z();
                 row.eta() = position.eta();
-                row.phi() = position.phi();               
+                row.phi() = position.phi();
               }
             }  // end cell loop
 

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
@@ -135,7 +135,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   HGCalSoARecHitsDeviceCollection::View recHits,
                                   HGCalDigiDevice::ConstView digis,
                                   HGCalCalibParamDevice::ConstView calibs,
-                                  HGCalMappingCellParamDevice::ConstView maps,
+                                  HGCalMappingCellParamDevice::ConstView cell_maps,
                                   HGCalDenseIndexInfoDevice::ConstView index) const {
       auto time_average = [&](float time_surr, float time_calib, float energy_surr, float energy_calib) {
         bool is_time_surr(time_surr > 0);
@@ -149,6 +149,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       };
 
       for (auto idx : uniform_elements(acc, digis.metadata().size())) {
+
+        auto cellIndex = index[idx].cellInfoIdx();
+
+        //only applies to Si
+        bool isSiPM(cell_maps[cellIndex].isSiPM());
+        if(isSiPM) continue;
+        
         auto calib = calibs[idx];
         bool calibvalid = calib.valid();
         auto digi = digis[idx];
@@ -158,9 +165,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         bool isToAavailable((digiflags != ::hgcal::DIGI_FLAG::ZS_ToA) &&
                             (digiflags != ::hgcal::DIGI_FLAG::ZS_ToA_ADCm1));
 
-        auto cellIndex = index[idx].cellInfoIdx();
-        bool isCalibCell(maps[cellIndex].iscalib());
-        int offset = maps[cellIndex].caliboffset();  // calibration-to-surrounding cell offset
+        bool isCalibCell(cell_maps[cellIndex].iscalib());
+        int offset = cell_maps[cellIndex].caliboffset();  // calibration-to-surrounding cell offset
         bool is_surr_cell((offset != 0) && isAvailable && isCalibCell);
 
         // effectively operate only on the cell that surrounds the calibration cells
@@ -243,10 +249,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   int32_t* __restrict__ nsel,
                                   int32_t* __restrict__ sidx,
                                   HGCalSoARecHitsDeviceCollection::ConstView recHits,
+                                  HGCalMappingCellParamDevice::ConstView cell_maps,
+                                  HGCalDenseIndexInfoDevice::ConstView index,
                                   double k_noise = 0.) const {
       for (auto idx : uniform_elements(acc, recHits.metadata().size())) {
-        if (!recHits[idx].flags() && recHits[idx].energy() > k_noise * recHits[idx].sigmaNoise() &&
-            recHits[idx].layer() != 0)
+        //quality + ZS cuts + connected (non-calib) channel
+        auto cellIndex = index[idx].cellInfoIdx();
+        if(!recHits[idx].flags() && recHits[idx].energy() > k_noise * recHits[idx].sigmaNoise() && cell_maps[cellIndex].t()>0)
           sidx[alpaka::atomicAdd(acc, nsel, 1)] = idx;
       }
     }
@@ -271,7 +280,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       HGCalDigiHost const& host_digis,
       HGCalCalibParamDevice const& device_calib,
       HGCalMappingModuleParamDevice const& device_mapmod,
-      HGCalMappingCellParamDevice const& device_mapping,
+      HGCalMappingCellParamDevice const& device_cell_mapping,
       HGCalDenseIndexInfoDevice const& device_index,
       double k_noise) const {
     LogDebug("HGCalRecHitCalibrationAlgorithms") << "\n\nINFO -- Start of calibrate\n\n" << std::endl;
@@ -319,7 +328,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         device_recHits.view(),
                         device_digis.const_view(),
                         device_calib.const_view(),
-                        device_mapping.const_view(),
+                        device_cell_mapping.const_view(),
                         device_index.const_view());
     alpaka::exec<Acc1D>(queue,
                         grid,
@@ -329,8 +338,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         device_index.const_view());
 
     // select rec hits
-    alpaka::exec<Acc1D>(
-        queue, grid, HGCalRecHitCalibrationKernel_countRecHits{}, nsel, sidx, device_recHits.const_view(), k_noise);
+    alpaka::exec<Acc1D>(queue,
+                        grid,
+                        HGCalRecHitCalibrationKernel_countRecHits{},
+                        nsel,
+                        sidx,
+                        device_recHits.const_view(),
+                        device_cell_mapping.const_view(),
+                        device_index.const_view(),
+                        k_noise);
 
     return device_recHits;
   }

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
@@ -149,13 +149,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       };
 
       for (auto idx : uniform_elements(acc, digis.metadata().size())) {
-
         auto cellIndex = index[idx].cellInfoIdx();
 
         //only applies to Si
         bool isSiPM(cell_maps[cellIndex].isSiPM());
-        if(isSiPM) continue;
-        
+        if (isSiPM)
+          continue;
+
         auto calib = calibs[idx];
         bool calibvalid = calib.valid();
         auto digi = digis[idx];
@@ -255,7 +255,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       for (auto idx : uniform_elements(acc, recHits.metadata().size())) {
         //quality + ZS cuts + connected (non-calib) channel
         auto cellIndex = index[idx].cellInfoIdx();
-        if(!recHits[idx].flags() && recHits[idx].energy() > k_noise * recHits[idx].sigmaNoise() && cell_maps[cellIndex].t()>0)
+        if (!recHits[idx].flags() && recHits[idx].energy() > k_noise * recHits[idx].sigmaNoise() &&
+            cell_maps[cellIndex].t() > 0)
           sidx[alpaka::atomicAdd(acc, nsel, 1)] = idx;
       }
     }


### PR DESCRIPTION
#### PR description:

This PR  adds:
- some fixes to the local reconstruction kernels and dense indexing of HGCAL specific to SiPM-on-tile related to geometry
-  additional FED unpacking flags to signal mismatches of E/B/O and the validity of MetaData

The fixes and flags were added and tested during the June/July test beams. No backporting needed.


#### PR validation:

This was mostly tested with TestBeam and Cassette data.