### PR TITLE
md5.h rename to edm_md5 to avoid collision

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/LutXml.cc
@@ -16,10 +16,10 @@
 #include <sstream>
 #include <iconv.h>
 #include <sys/time.h>
+#include <edm_md5.h>
 
 #include "CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h"
 #include "CalibCalorimetry/HcalTPGAlgos/interface/XMLProcessor.h"
-#include "md5.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CalibCalorimetry/HcalTPGAlgos/interface/HcalEmap.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
@@ -212,23 +212,23 @@ std::string &LutXml::getCurrentBrick(void) { return getString(brickElem); }
 // do MD5 checksum
 std::string LutXml::get_checksum(std::vector<unsigned int> &lut) {
   std::stringstream result;
-  md5_state_t md5er;
-  md5_byte_t digest[16];
-  md5_init(&md5er);
+  edm_md5::md5_state_t md5er;
+  edm_md5::md5_byte_t digest[16];
+  edm_md5::md5_init(&md5er);
   // linearizer LUT:
   if (lut.size() == 128) {
     unsigned char tool[2];
     for (int i = 0; i < 128; i++) {
       tool[0] = lut[i] & 0xFF;
       tool[1] = (lut[i] >> 8) & 0xFF;
-      md5_append(&md5er, tool, 2);
+      edm_md5::md5_append(&md5er, tool, 2);
     }
   } else if (lut.size() == 256) {
     unsigned char tool[2];
     for (int i = 0; i < 256; i++) {
       tool[0] = lut[i] & 0xFF;
       tool[1] = (lut[i] >> 8) & 0xFF;
-      md5_append(&md5er, tool, 2);
+      edm_md5::md5_append(&md5er, tool, 2);
     }
   }
   // compression LUT:
@@ -236,13 +236,13 @@ std::string LutXml::get_checksum(std::vector<unsigned int> &lut) {
     unsigned char tool;
     for (int i = 0; i < 1024; i++) {
       tool = lut[i] & 0xFF;
-      md5_append(&md5er, &tool, 1);
+      edm_md5::md5_append(&md5er, &tool, 1);
     }
   } else if (lut.size() == 2048) {
     unsigned char tool;
     for (int i = 0; i < 2048; i++) {
       tool = lut[i] & 0xFF;
-      md5_append(&md5er, &tool, 1);
+      edm_md5::md5_append(&md5er, &tool, 1);
     }
   }
   // HE fine grain LUT
@@ -250,14 +250,14 @@ std::string LutXml::get_checksum(std::vector<unsigned int> &lut) {
     unsigned char tool;
     for (int i = 0; i < 4096; i++) {
       tool = lut[i] & 0xFF;
-      md5_append(&md5er, &tool, 1);
+      edm_md5::md5_append(&md5er, &tool, 1);
     }
   } else {
     edm::LogError("LutXml") << "Irregular LUT size, " << lut.size()
                             << " , do not know how to compute checksum, exiting...";
     exit(-1);
   }
-  md5_finish(&md5er, digest);
+  edm_md5::md5_finish(&md5er, digest);
   for (int i = 0; i < 16; i++)
     result << std::hex << (((int)(digest[i])) & 0xFF);
 

--- a/CalibCalorimetry/HcalTPGIO/src/HcalLuttoDB.cc
+++ b/CalibCalorimetry/HcalTPGIO/src/HcalLuttoDB.cc
@@ -45,7 +45,7 @@ using namespace edm;
 using namespace std;
 #include <iostream>
 #include <fstream>
-#include "md5.h"
+#include <edm_md5.h>
 
 //
 // class decleration
@@ -174,16 +174,16 @@ void HcalLuttoDB::writeoutlut1(HcalDetId id,
 
   os << " <Parameter name='GENERALIZEDINDEX' type='int'>" << generalizedIndex << "</Parameter>" << std::endl;
   // do checksum
-  md5_state_t md5er;
-  md5_byte_t digest[16];
+  edm_md5::md5_state_t md5er;
+  edm_md5::md5_byte_t digest[16];
   unsigned char tool[2];
-  md5_init(&md5er);
+  edm_md5::md5_init(&md5er);
   for (int i = 0; i < 128; i++) {
     tool[0] = lut[i] & 0xFF;
     tool[1] = (lut[i] >> 8) & 0xFF;
-    md5_append(&md5er, tool, 2);
+    edm_md5::md5_append(&md5er, tool, 2);
   }
-  md5_finish(&md5er, digest);
+  edm_md5::md5_finish(&md5er, digest);
   os << " <Parameter name='CHECKSUM' type='string'>";
   for (int i = 0; i < 16; i++)
     os << std::hex << (((int)(digest[i])) & 0xFF);
@@ -229,11 +229,11 @@ void HcalLuttoDB::writeoutlut2(HcalTrigTowerDetId id,
   os << " <Parameter name='GENERALIZEDINDEX' type='int'>" << generalizedIndex << "</Parameter>" << std::endl;
 
   // do checksum
-  md5_state_t md5er;
-  md5_byte_t digest[16];
-  md5_init(&md5er);
-  md5_append(&md5er, &(lut[0]), 1024);
-  md5_finish(&md5er, digest);
+  edm_md5::md5_state_t md5er;
+  edm_md5::md5_byte_t digest[16];
+  edm_md5::md5_init(&md5er);
+  edm_md5::md5_append(&md5er, &(lut[0]), 1024);
+  edm_md5::md5_finish(&md5er, digest);
   os << " <Parameter name='CHECKSUM' type='string'>";
   for (int i = 0; i < 16; i++)
     os << std::hex << (((int)(digest[i])) & 0xFF);

--- a/FWCore/Utilities/interface/Digest.h
+++ b/FWCore/Utilities/interface/Digest.h
@@ -1,8 +1,7 @@
 #ifndef FWCore_Utilities_Digest_h
 #define FWCore_Utilities_Digest_h
 
-#include "md5.h"
-
+#include <edm_md5.h>
 #include <iosfwd>
 #include <string>
 #include <string_view>
@@ -59,7 +58,7 @@ namespace cms {
     MD5Result digest();
 
   private:
-    md5_state_t state_;
+    edm_md5::md5_state_t state_;
   };
 }  // namespace cms
 

--- a/FWCore/Utilities/src/Digest.cc
+++ b/FWCore/Utilities/src/Digest.cc
@@ -152,41 +152,41 @@ namespace cms {
   // Digest
   //
 
-  Digest::Digest() : state_() { md5_init(&state_); }
+  Digest::Digest() : state_() { edm_md5::md5_init(&state_); }
 
   Digest::Digest(std::string const& s) : state_() {
-    md5_init(&state_);
+    edm_md5::md5_init(&state_);
     this->append(s);
   }
 
   Digest::Digest(std::string_view v) : state_() {
-    md5_init(&state_);
+    edm_md5::md5_init(&state_);
     this->append(v);
   }
 
   Digest::Digest(const char* s) : state_() {
-    md5_init(&state_);
+    edm_md5::md5_init(&state_);
     this->append(s, strlen(s));
   }
 
   void Digest::append(std::string const& s) {
-    const md5_byte_t* data = reinterpret_cast<const md5_byte_t*>(s.data());
-    md5_append(&state_, data, s.size());
+    const edm_md5::md5_byte_t* data = reinterpret_cast<const edm_md5::md5_byte_t*>(s.data());
+    edm_md5::md5_append(&state_, data, s.size());
   }
 
   void Digest::append(std::string_view v) {
-    const md5_byte_t* data = reinterpret_cast<const md5_byte_t*>(v.data());
-    md5_append(&state_, data, v.size());
+    const edm_md5::md5_byte_t* data = reinterpret_cast<const edm_md5::md5_byte_t*>(v.data());
+    edm_md5::md5_append(&state_, data, v.size());
   }
 
   void Digest::append(const char* s, size_t size) {
-    const md5_byte_t* data = reinterpret_cast<const md5_byte_t*>(s);
-    md5_append(&state_, data, size);
+    const edm_md5::md5_byte_t* data = reinterpret_cast<const edm_md5::md5_byte_t*>(s);
+    edm_md5::md5_append(&state_, data, size);
   }
 
   MD5Result Digest::digest() {
     MD5Result aDigest;
-    md5_finish(&state_, aDigest.bytes.data());
+    edm_md5::md5_finish(&state_, aDigest.bytes.data());
     return aDigest;
   }
 }  // namespace cms


### PR DESCRIPTION
As requested in https://github.com/cms-externals/md5/issues/2 , this PR proposes to use `edm_md5.h`. This needs to go in with https://github.com/cms-sw/cmsdist/pull/10825