### PR TITLE
Fix some tests in HeterogeneousCore/MPICore

### DIFF
--- a/HeterogeneousCore/MPICore/python/configuration_splitter/editor_functions.py
+++ b/HeterogeneousCore/MPICore/python/configuration_splitter/editor_functions.py
@@ -7,9 +7,9 @@ from HeterogeneousCore.MPICore.modules import *
 
 
 def add_controller_to_local(process, remote_name):
+    process.load("Configuration.StandardSequences.Accelerators_cff")
     process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
     process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
-    process.MPIService.pmix_server_uri = "file:server.uri"
     controller_name = f"mpiController{remote_name.title()}"
     controller = cms.EDProducer("MPIController",
                                followerProcessName = cms.string(remote_name))
@@ -46,7 +46,6 @@ def create_remote_process(local_process, modules_to_run, remote_process_name, lo
 
     remote_process.load("HeterogeneousCore.MPIServices.MPIService_cfi")
     remote_process.load("HeterogeneousCore.MPIServices.MPIConsistencyChecker_cfi")
-    remote_process.MPIService.pmix_server_uri = "file:server.uri"
 
     # where do i get this firstRun parameter from?
     remote_process.source = MPISource(

--- a/HeterogeneousCore/MPICore/test/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/test/BuildFile.xml
@@ -40,7 +40,10 @@
 <test
   name="testMPISoADeviceTransfer"
   command="testMPICommWorld.sh ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/controller_soa_device_cfg.py ${CMSSW_BASE}/src/HeterogeneousCore/MPICore/test/follower_soa_device_cfg.py"
-/>
+>
+  <use name="alpaka"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</test>
 
 <test
   name="testMPIComplexTransfer"

--- a/HeterogeneousCore/MPIServices/BuildFile.xml
+++ b/HeterogeneousCore/MPIServices/BuildFile.xml
@@ -2,6 +2,8 @@
 <use name="rootrio"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
+<use name="HeterogeneousCore/CUDAServices"/>
+<use name="HeterogeneousCore/ROCmServices"/>
 <export>
   <lib name="1"/>
 </export>

--- a/HeterogeneousCore/MPIServices/src/MPIService.cc
+++ b/HeterogeneousCore/MPIServices/src/MPIService.cc
@@ -13,7 +13,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAInterface.h"
 #include "HeterogeneousCore/MPIServices/interface/MPIService.h"
+#include "HeterogeneousCore/ROCmServices/interface/ROCmInterface.h"
 
 namespace {
 
@@ -45,6 +47,23 @@ MPIService::MPIService(edm::ParameterSet const& config) {
    *
    * See https://github.com/open-mpi/ompi/blob/v4.1.0/README .
    */
+
+  // If a CUDAService or a ROCmService is configured for this job, construct it
+  // now, before the MPIService is constructed. This is to make sure the
+  // MPIService is destructed (and MPI_Finalize() is called) *before* the
+  // CUDAService/ROCmService destructors are called (specifically, before
+  // cudaDeviceReset()/hipDeviceReset() are called). Otherwise MPI_Finalize()
+  // would segfault on nodes with AMD GPUs.
+  //
+  // Triggering the construction of the cuda and rocm services is the purpose of
+  // the isAvailable() call below.
+  //
+  // Note that the MPIService does not require a ROCmService nor a CUDAService
+  // to run.
+  edm::Service<CUDAInterface> cuda;
+  cuda.isAvailable();
+  edm::Service<ROCmInterface> rocm;
+  rocm.isAvailable();
 
   // set the pmix_server_uri MCA parameter if specified in the configuration and not already set in the environment
   if (config.existsAs<std::string>("pmix_server_uri", false)) {


### PR DESCRIPTION
### PR description:

-  Make `testMPISoADeviceTransfer` run on all alpaka backends.

- Make `testMPIAutosplitter` not hang, by making the MPI configuration splitter unconditionally include 
```python
process.load("Configuration.StandardSequences.Accelerators_cff")
```
in both local and remote configurations. This prevents OpenMPI from hanging at the beginning of the job when accelerators are loaded in only one side.

- Make `testMPISoATransfer` and `testMPISoADeviceTransfer` not crash on `MPI_Finalize()` on nodes with AMD GPUs. The crash happened if a ROCmService was configured for the job. In this case, the ROCmService would be destructed (and `hipDeviceReset()` called) before the `MPI_Finalize()` in the MPIService's destructor. Then the `MPI_Finalize()` would crash.

To prevent the crash, triggered the construction of the ROCmService before the construction of the MPIService, so that the MPIService is destructed _before_ the ROCmService is destructed.

This crash has been observed in a node with a W7900, but it has not been observed in a with Nvidia L40s. Other backends have not been tested.


This PR includes another two smaller changes:
- Explicitly select `ucx` to be used as the OpenMPI PML in `testMPICommWorld.sh`. This is to prevent OpenMPI from hanging in the very specific case when local and remote processes run on the same machine, and `CUDA_VISIBLE_DEVICES` is unset in the _local_ process but not in the _remote_ one. In this case OpenMPI selects (unless forced otherwise) the `ob1` pml and the `smcuda` BLT, and hangs at initialization time.
- Do not write the unused `remote_process.MPIService.pmix_server_uri = "file:server.uri" ` into the local and remote generated configs.


### PR validation:

All `MPICore` tests pass on nodes with an L40s or with a W7900.
