### PR TITLE
Enable the MPI modules to serialise host types for which only a portable serialiser exists

### DIFF
--- a/HeterogeneousCore/MPICore/plugins/alpaka/MPIReceiverPortable.cc
+++ b/HeterogeneousCore/MPICore/plugins/alpaka/MPIReceiverPortable.cc
@@ -140,7 +140,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
         if (deviceSerialiser) {
           edm::TypeID typeID{deviceSerialiser->productTypeID()};
-          hasDeviceProducts_ = true;
+          hasPortableProducts_ = true;
 
           LogDebug("MPIReceiverPortable") << "found device serialiser for type \"" << type << "\"";
 
@@ -157,7 +157,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             LogDebug("MPIReceiverPortable") << "No D to H transform found for type \"" << type << "\"";
             entry.token = this->producesCollector().template produces<edm::Transition::Event>(typeID, produceInstance);
           }
-          entry.deviceSerialiser = std::move(deviceSerialiser);
+          entry.portableSerialiser = std::move(deviceSerialiser);
 
           LogDebug("MPIReceiverPortable") << "receive device type \"" << typeID << "\" (" << type << ") for instance \""
                                           << produceInstance << "\" over MPI channel instance " << instance_;
@@ -166,18 +166,39 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           continue;
         }
 
-        // Check 2: "type" could be a host type alias "T" for which a host
-        // serialiser (and perhaps a portable serialiser for the H->D transform)
-        // exists.
+        // Check 2: type is a host type. Lookup a host serialiser and a portable
+        // serialiser for this host type. If both found, prefer the portable
+        // serialiser.
         edm::TypeWithDict twd = edm::TypeWithDict::byName(bareType);
         std::unique_ptr<ngt::SerialiserBase> portableSerialiser;
         std::unique_ptr<::ngt::SerialiserBase> hostSerialiser;
-        LogDebug("MPIReceiverPortable") << "looking for host serialiser for type \"" << type << "\"";
+        LogDebug("MPIReceiverPortable") << "looking for serialiser for host type \"" << type << "\"";
         if (bool(twd)) {
           portableSerialiser = ngt::SerialiserFactoryDevice::get()->tryToCreate(twd.typeInfo().name());
           hostSerialiser = ::ngt::SerialiserFactory::get()->tryToCreate(twd.typeInfo().name());
         }
 
+        // The equality "edm::TypeID{portableSerialiser->productTypeID()} ==
+        // edm::TypeID{twd.typeInfo()}" holds only on the serial CPU backend, where
+        // DeviceProductType<TYPE_DEVICE> == TYPE_DEVICE == TYPE_HOST
+        if (portableSerialiser and bool(twd) and
+            edm::TypeID{portableSerialiser->productTypeID()} == edm::TypeID{twd.typeInfo()}) {
+          edm::TypeID typeID{twd.typeInfo()};
+          LogDebug("MPIReceiverPortable") << "using portable serialiser as host serialiser for type \"" << type << "\"";
+
+          hasPortableProducts_ = true;
+          entry.token = this->producesCollector().template produces<edm::Transition::Event>(typeID, produceInstance);
+          entry.portableSerialiser = std::move(portableSerialiser);
+
+          LogDebug("MPIReceiverPortable") << "receive host type \"" << typeID << "\" (" << type << ") for instance \""
+                                          << produceInstance << "\" over MPI channel instance " << instance_;
+
+          products_.emplace_back(std::move(entry));
+          continue;
+        }
+
+        // Fall back to the host serialiser, using the portable one (if any) for
+        // the H->D transform.
         if (hostSerialiser && bool(twd)) {
           edm::TypeID typeID{twd.typeInfo()};
           LogDebug("MPIReceiverPortable") << "found host serialiser for type \"" << type << "\"";
@@ -243,7 +264,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     void acquire(edm::Event const& event, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder holder) final {
       // reset the metadata that could have been left behind by a previous event
       metadata_.reset();
-      if (hasDeviceProducts_) {
+      if (hasPortableProducts_) {
         metadata_ = std::make_shared<EDMetadata>(detail::chooseDevice(event.streamID()));
       }
 
@@ -272,7 +293,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                   token.channel()->receiveSerializedBuffer(instance_, receivedProductMetadata_->serializedBufferSize());
             }
 
-            struct PendingDeviceWriter {
+            struct PendingPortableWriter {
               size_t index;
               std::unique_ptr<ngt::WriterBase> writer;
             };
@@ -282,7 +303,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             };
 
             std::vector<MPI_Request> requests;
-            std::vector<PendingDeviceWriter> pendingDeviceWriters;
+            std::vector<PendingPortableWriter> pendingPortableWriters;
             std::vector<PendingHostWriter> pendingHostWriters;
 
             for (size_t i = 0; i < products_.size(); ++i) {
@@ -325,21 +346,21 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
               // ProductMetadata::Kind::TrivialCopy, and thus a serialiser (host
               // or device) should exist for them.
 
-              if (entry.deviceSerialiser) {
-                auto writer = entry.deviceSerialiser->writer();
+              if (entry.portableSerialiser) {
+                auto writer = entry.portableSerialiser->writer();
                 ::ngt::AnyBuffer buffer = writer->uninitialized_parameters();
                 if (buffer.size_bytes() != product_meta.sizeMeta) {
                   throw cms::Exception("MPIReceiverPortable")
-                      << "Buffer size mismatch for device product '" << entry.typeName << "': deviceSerialiser expects "
-                      << buffer.size_bytes() << " bytes of metadata, but sender sent " << product_meta.sizeMeta
-                      << " bytes.";
+                      << "Buffer size mismatch for portable product '" << entry.typeName
+                      << "': portableSerialiser expects " << buffer.size_bytes()
+                      << " bytes of metadata, but sender sent " << product_meta.sizeMeta << " bytes.";
                 }
                 std::memcpy(buffer.data(), product_meta.trivialCopyOffset, product_meta.sizeMeta);
 
                 writer->initialize(metadata_->queue(), buffer);
                 asyncWorkLaunched_ = true;
                 token.channel()->receiveInitializedTrivialCopyAsync(instance_, *writer, requests);
-                pendingDeviceWriters.push_back({i, std::move(writer)});
+                pendingPortableWriters.push_back({i, std::move(writer)});
               } else {
                 // Host path: allocate host buffer, then post a non-blocking receive.
                 auto writer = entry.hostSerialiser->writer();
@@ -361,7 +382,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             // Wait for all non-blocking receives to complete.
             MPIChannel::waitAll(requests);
 
-            for (auto& pending : pendingDeviceWriters) {
+            for (auto& pending : pendingPortableWriters) {
               pending.writer->finalize();
               receivedWrappers_[pending.index] = pending.writer->get(metadata_);
             }
@@ -448,7 +469,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     struct Entry {
       std::string typeName;  // type name from config (for PathStateToken check and logging)
       edm::EDPutToken token;
-      std::unique_ptr<ngt::SerialiserBase> deviceSerialiser;
+      std::unique_ptr<ngt::SerialiserBase> portableSerialiser;
       std::unique_ptr<::ngt::SerialiserBase> hostSerialiser;
       edm::TypeWithDict wrappedType;
     };
@@ -457,7 +478,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     edm::EDPutTokenT<MPIToken> const token_;
     std::vector<Entry> products_;
     int32_t const instance_;
-    bool hasDeviceProducts_ = false;
+    bool hasPortableProducts_ = false;
 
     std::shared_ptr<ProductMetadataBuilder> receivedProductMetadata_;
     std::vector<std::unique_ptr<edm::WrapperBase>> receivedWrappers_;

--- a/HeterogeneousCore/MPICore/plugins/alpaka/MPISenderPortable.cc
+++ b/HeterogeneousCore/MPICore/plugins/alpaka/MPISenderPortable.cc
@@ -133,10 +133,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           // from the event. This typeID is the product type wrapped in
           // edm::DeviceProduct, and includes the alpaka device.
           edm::TypeID typeID{deviceSerialiser->productTypeID()};
-          hasDeviceProducts_ = true;
+          hasPortableProducts_ = true;
           entry.typeID = typeID;
           entry.token = this->consumes(edm::TypeToGet{typeID, edm::PRODUCT_TYPE}, src);
-          entry.deviceSerialiser = std::move(deviceSerialiser);
+          entry.portableSerialiser = std::move(deviceSerialiser);
 
           LogDebug("MPISenderPortable") << "send device type \"" << typeID << "\" (" << type << "), label \""
                                         << src.label() << "\" instance \"" << src.instance()
@@ -146,20 +146,37 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           continue;
         }
 
-        // Check 2: Lookup a host serialiser registered in the host
-        // SerialiserFactory.
+        // Check 2: type is a host type. Lookup a host serialiser and a portable
+        // serialiser for this host type. If both found, prefer the portable
+        // serialiser.
         edm::TypeWithDict twd = edm::TypeWithDict::byName(bareType);
+        std::unique_ptr<ngt::SerialiserBase> portableSerialiser;
         std::unique_ptr<::ngt::SerialiserBase> hostSerialiser;
 
-        LogDebug("MPISenderPortable") << "looking for host serialiser for type \"" << type << "\"";
+        LogDebug("MPISenderPortable") << "looking for a serialiser for the host type \"" << type << "\"";
         if (bool(twd)) {
+          portableSerialiser = ngt::SerialiserFactoryDevice::get()->tryToCreate(twd.typeInfo().name());
           hostSerialiser = ::ngt::SerialiserFactory::get()->tryToCreate(twd.typeInfo().name());
         }
-        if (hostSerialiser) {
-          LogDebug("MPISenderPortable") << "found host serialiser for type \"" << type << "\"";
+
+        // The equality "edm::TypeID{portableSerialiser->productTypeID()} ==
+        // edm::TypeID{twd.typeInfo()}" holds only on the serial CPU backend, where
+        // DeviceProductType<TYPE_DEVICE> == TYPE_DEVICE == TYPE_HOST
+        bool const portableSerialiserForAHostType =
+            portableSerialiser and bool(twd) and
+            edm::TypeID{portableSerialiser->productTypeID()} == edm::TypeID{twd.typeInfo()};
+
+        if (portableSerialiserForAHostType or hostSerialiser) {
+          LogDebug("MPISenderPortable")
+              << "found a serialiser (host serialiser or portable serialiser) for host type \"" << type << "\"";
           entry.typeID = edm::TypeID{twd.typeInfo()};
           entry.token = this->consumes(edm::TypeToGet{entry.typeID, edm::PRODUCT_TYPE}, src);
-          entry.hostSerialiser = std::move(hostSerialiser);
+          if (portableSerialiserForAHostType) {
+            hasPortableProducts_ = true;
+            entry.portableSerialiser = std::move(portableSerialiser);
+          } else {
+            entry.hostSerialiser = std::move(hostSerialiser);
+          }
 
           LogDebug("MPISenderPortable") << "send host type \"" << entry.typeID << "\" (" << type << "), label \""
                                         << src.label() << "\" instance \"" << src.instance()
@@ -232,11 +249,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto toBeSent = std::make_shared<DataToBeSent>();
       toBeSent->pendingRegions.reserve(productCount);
 
-      // The EDMetadata the device serialisers need to access a device product T
-      // from its wrapped form.
-      std::shared_ptr<EDMetadata> deviceMetadata;
-      if (hasDeviceProducts_) {
-        deviceMetadata = std::make_shared<EDMetadata>(detail::chooseDevice(event.streamID()));
+      // The EDMetadata the portable serialisers need to access a device product
+      // T from its wrapped form.
+      std::shared_ptr<EDMetadata> portableMetadata;
+      if (hasPortableProducts_) {
+        portableMetadata = std::make_shared<EDMetadata>(detail::chooseDevice(event.streamID()));
       }
 
       for (auto const& entry : products_) {
@@ -254,9 +271,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         if (handle.isValid()) {
           edm::WrapperBase const* wrapper = handle.product();
           // extract memory regions
-          if (entry.deviceSerialiser) {
-            // If the product is on device
-            auto reader = entry.deviceSerialiser->reader(*wrapper, *deviceMetadata);
+          if (entry.portableSerialiser) {
+            auto reader = entry.portableSerialiser->reader(*wrapper, *portableMetadata);
             ::ngt::AnyBuffer buffer = reader->parameters();
             productMetadata->addTrivialCopy(buffer.data(), buffer.size_bytes());
             toBeSent->pendingRegions.push_back(reader->regions());
@@ -290,22 +306,27 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       // Lambda that waits for device work and the metadata send, then sends
       // all data products, to be passed to runAsync.
-      auto sendData =
-          [token, instance = instance_, productMetadata, productMetadataRequest, toBeSent, isActive, deviceMetadata]() {
-            if (deviceMetadata) {
-              alpaka::wait(deviceMetadata->queue());
-            }
-            MPIChannel::waitMetadata(*productMetadataRequest);
-            if (isActive) {
-              if (toBeSent->rootBuffer)
-                token.channel()->sendBuffer(toBeSent->rootBuffer->Buffer(),
-                                            toBeSent->rootBuffer->Length(),
-                                            instance,
-                                            EDM_MPI_SendSerializedProduct);
-              for (auto const& regions : toBeSent->pendingRegions)
-                token.channel()->sendTrivialCopyProduct(instance, regions);
-            }
-          };
+      auto sendData = [token,
+                       instance = instance_,
+                       productMetadata,
+                       productMetadataRequest,
+                       toBeSent,
+                       isActive,
+                       portableMetadata]() {
+        if (portableMetadata) {
+          alpaka::wait(portableMetadata->queue());
+        }
+        MPIChannel::waitMetadata(*productMetadataRequest);
+        if (isActive) {
+          if (toBeSent->rootBuffer)
+            token.channel()->sendBuffer(toBeSent->rootBuffer->Buffer(),
+                                        toBeSent->rootBuffer->Length(),
+                                        instance,
+                                        EDM_MPI_SendSerializedProduct);
+          for (auto const& regions : toBeSent->pendingRegions)
+            token.channel()->sendTrivialCopyProduct(instance, regions);
+        }
+      };
 
       edm::Service<edm::Async> asyncService;
       asyncService->runAsync(
@@ -363,7 +384,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       edm::EDGetToken token;
 
       std::unique_ptr<::ngt::SerialiserBase> hostSerialiser;
-      std::unique_ptr<ngt::SerialiserBase> deviceSerialiser;
+      std::unique_ptr<ngt::SerialiserBase> portableSerialiser;
       edm::TypeWithDict wrappedType;
     };
 
@@ -371,7 +392,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     edm::EDPutTokenT<MPIToken> const token_;
     std::vector<Entry> products_;
     int32_t const instance_;
-    bool hasDeviceProducts_ = false;
+    bool hasPortableProducts_ = false;
   };
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/MPICore/test/controller_soa_device_cfg.py
+++ b/HeterogeneousCore/MPICore/test/controller_soa_device_cfg.py
@@ -38,10 +38,14 @@ process.producePortableObjects = cms.EDProducer("TestAlpakaProducer@alpaka",
     )
 )
 
+# a host product with no device counterpart, serialised through ROOT
+process.ids = cms.EDProducer("edmtest::EventIDProducer")
+
 process.sender = cms.EDProducer("MPISenderPortable@alpaka",
     upstream = cms.InputTag("mpiController"),
     instance = cms.int32(42),
     products = cms.VPSet(
+        # various device products
         cms.PSet(
             type = cms.string("ALPAKA_ACCELERATOR_NAMESPACE::portabletest::TestDeviceObject"),
             src = cms.InputTag("producePortableObjects", ""),
@@ -58,11 +62,27 @@ process.sender = cms.EDProducer("MPISenderPortable@alpaka",
             type = cms.string("ALPAKA_ACCELERATOR_NAMESPACE::portabletest::TestDeviceCollection3"),
             src = cms.InputTag("producePortableObjects", ""),
         ),
+        # a host product with a portable trivial serialiser
+        cms.PSet(
+            type = cms.string("portabletest::TestHostCollection"),
+            src = cms.InputTag("producePortableObjects", ""),
+        ),
+        # a host product with a non-portable trivial serialiser
+        cms.PSet(
+            type = cms.string("ushort"),
+            src = cms.InputTag("producePortableObjects", "backend"),
+        ),
+        # a host product with no trivial serialiser
+        cms.PSet(
+            type = cms.string("edm::EventID"),
+            src = cms.InputTag("ids", ""),
+        ),
     )
 )
 
 process.pathSoA = cms.Path(
     process.mpiController +
     process.producePortableObjects +
+    process.ids +
     process.sender
 )

--- a/HeterogeneousCore/MPICore/test/follower_soa_device_cfg.py
+++ b/HeterogeneousCore/MPICore/test/follower_soa_device_cfg.py
@@ -42,6 +42,21 @@ process.receiver = cms.EDProducer("MPIReceiverPortable@alpaka",
             type = cms.string("ALPAKA_ACCELERATOR_NAMESPACE::portabletest::TestDeviceCollection3"),
             src = cms.InputTag("", ""),
         ),
+        # a host product with a portable trivial serialiser
+        cms.PSet(
+            type = cms.string("portabletest::TestHostCollection"),
+            src = cms.InputTag("hostPortable", ""),
+        ),
+        # a host product with a non-portable trivial serialiser
+        cms.PSet(
+            type = cms.string("ushort"),
+            src = cms.InputTag("hostTrivial", ""),
+        ),
+        # a host product with no trivial serialiser, falling back to ROOT
+        cms.PSet(
+            type = cms.string("edm::EventID"),
+            src = cms.InputTag("hostRoot", ""),
+        ),
     )
 )
 
@@ -53,8 +68,18 @@ process.validatePortableObject = cms.EDAnalyzer("TestAlpakaObjectAnalyzer",
     source = cms.InputTag("receiver")
 )
 
+process.validateReceived = cms.EDAnalyzer("GenericConsumer",
+    eventProducts = cms.untracked.vstring("receiver")
+)
+
+process.validateEventId = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag("receiver", "hostRoot")
+)
+
 process.pathSoA = cms.Path(
     process.receiver +
     process.validatePortableCollections +
-    process.validatePortableObject
+    process.validatePortableObject +
+    process.validateReceived +
+    process.validateEventId
 )

--- a/HeterogeneousCore/TrivialSerialisation/plugins/alpaka/GenericClonerPortable.cc
+++ b/HeterogeneousCore/TrivialSerialisation/plugins/alpaka/GenericClonerPortable.cc
@@ -1,11 +1,13 @@
 /*
- * This Alpaka EDProducer clones host or device event products declared in
- * its configuration, using the plugin-based NGT trivial serialisation.
+ * This Alpaka EDProducer clones host or device event products declared in its
+ * configuration, using the plugin-based NGT trivial serialisation.
  *
  * - Host type aliases (e.g. "portabletest::TestHostCollection") are cloned
- *   using the host TrivialSerialisation mechanism with std::memcpy. If a
- *   matching device serialiser is registered, the H->D transformation is
- *   also registered at construction time.
+ *   using the host TrivialSerialisation mechanism with std::memcpy if no
+ *   portable serialiser exists for them. If a portable serialiser exists for
+ *   these types and the backend is the serial CPU, it is preferred over the
+ *   host serialiser, and the copy goes through alpaka::memcpy. The H->D
+ *   transformation is also registered at construction time in this case.
  *
  * - Device type aliases (e.g. "sistrip::SiStripClusterDevice") are cloned on
  *   device using alpaka::memcpy. The D->H transformation is registered if
@@ -69,13 +71,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
       edm::TypeID typeID;
       edm::EDGetToken getToken;
       edm::EDPutToken putToken;
-      std::unique_ptr<ngt::SerialiserBase> deviceSerialiser;
+      std::unique_ptr<ngt::SerialiserBase> portableSerialiser;
       std::unique_ptr<::ngt::SerialiserBase> hostSerialiser;
       edm::TypeWithDict wrappedType;
     };
 
     std::vector<Entry> eventProducts_;
-    bool hasDeviceProducts_ = false;
+    bool hasPortableProducts_ = false;
     bool verbose_;
   };
 
@@ -141,7 +143,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
       if (deviceSerialiser) {
         entry.typeID = edm::TypeID{deviceSerialiser->productTypeID()};
         entry.getToken = this->consumes(edm::TypeToGet{entry.typeID, edm::PRODUCT_TYPE}, src);
-        hasDeviceProducts_ = true;
+        hasPortableProducts_ = true;
 
         if (deviceSerialiser->hasCopyToHost()) {
           entry.putToken = this->produces(src.instance())
@@ -155,7 +157,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
               this->producesCollector().template produces<edm::Transition::Event>(entry.typeID, src.instance());
         }
 
-        entry.deviceSerialiser = std::move(deviceSerialiser);
+        entry.portableSerialiser = std::move(deviceSerialiser);
 
         if (verbose_) {
           edm::LogInfo("GenericClonerPortable") << "will clone device product of type '" << type << "', " << src;
@@ -166,8 +168,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
       }
 
       // Check 2: "type" could be a host type alias "T" for which a host
-      // serialiser (and perhaps a portable serialiser for the H->D transform)
-      // exists.
+      // serialiser and/or a portable serialiser exist. See check 2a for the
+      // priority between the two.
       edm::TypeWithDict twd = edm::TypeWithDict::byName(bareType);
       std::unique_ptr<ngt::SerialiserBase> portableSerialiser;
       std::unique_ptr<::ngt::SerialiserBase> hostSerialiser;
@@ -176,6 +178,37 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
         hostSerialiser = ::ngt::SerialiserFactory::get()->tryToCreate(twd.typeInfo().name());
       }
 
+      // Check 2a: prefer a portable serialiser that can act as a host
+      // serialiser directly, i.e. its product type is the host type itself
+      // and not edm::DeviceProduct<T> (e.g. on the serial backend): it
+      // allocates pinned host memory, enabling faster/async H<->D copies,
+      // unlike a plain host serialiser.
+      //
+      // The equality "edm::TypeID{portableSerialiser->productTypeID()} ==
+      // edm::TypeID{twd.typeInfo()}" holds only on the serial CPU backend, where
+      // DeviceProductType<TYPE_DEVICE> == TYPE_DEVICE == TYPE_HOST
+      if (portableSerialiser and bool(twd) and
+          edm::TypeID{portableSerialiser->productTypeID()} == edm::TypeID{twd.typeInfo()}) {
+        entry.typeID = edm::TypeID{twd.typeInfo()};
+        entry.getToken = this->consumes(edm::TypeToGet{entry.typeID, edm::PRODUCT_TYPE}, src);
+        entry.putToken =
+            this->producesCollector().template produces<edm::Transition::Event>(entry.typeID, src.instance());
+
+        hasPortableProducts_ = true;
+        entry.portableSerialiser = std::move(portableSerialiser);
+
+        if (verbose_) {
+          edm::LogInfo("GenericClonerPortable")
+              << "will clone host product of type '" << type << "' using a portable serialiser, label '" << src.label()
+              << "', instance '" << src.instance() << "'";
+        }
+
+        eventProducts_.emplace_back(std::move(entry));
+        continue;
+      }
+
+      // Check 2b: fall back to the host serialiser, using the portable one
+      // (if any) for the H->D transform.
       if (hostSerialiser && bool(twd)) {
         entry.typeID = edm::TypeID{twd.typeInfo()};
         entry.getToken = this->consumes(edm::TypeToGet{entry.typeID, edm::PRODUCT_TYPE}, src);
@@ -244,7 +277,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
 
   void GenericClonerPortable::produce(edm::Event& event, edm::EventSetup const& /*unused*/) {
     std::unique_ptr<::ALPAKA_ACCELERATOR_NAMESPACE::detail::EDMetadataSentry> sentry;
-    if (hasDeviceProducts_) {
+    if (hasPortableProducts_) {
       sentry = std::make_unique<::ALPAKA_ACCELERATOR_NAMESPACE::detail::EDMetadataSentry>(event.streamID(),
                                                                                           this->synchronize());
     }
@@ -277,9 +310,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ngt {
 
         writer->finalize();
         event.put(entry.putToken, writer->get());
-      } else if (entry.deviceSerialiser) {
-        auto reader = entry.deviceSerialiser->reader(*wrapper, *sentry->metadata());
-        auto writer = entry.deviceSerialiser->writer();
+      } else if (entry.portableSerialiser) {
+        auto reader = entry.portableSerialiser->reader(*wrapper, *sentry->metadata());
+        auto writer = entry.portableSerialiser->writer();
 
         writer->initialize(sentry->metadata()->queue(), reader->parameters());
 

--- a/HeterogeneousCore/TrivialSerialisation/test/testGenericClonerPortable_cfg.py
+++ b/HeterogeneousCore/TrivialSerialisation/test/testGenericClonerPortable_cfg.py
@@ -25,6 +25,21 @@ process.producePortableObjects = cms.EDProducer("TestAlpakaProducer@alpaka",
     )
 )
 
+# a host product with no device counterpart, serialised through ROOT
+process.ids = cms.EDProducer("edmtest::EventIDProducer")
+
+# Alias "backend", to "backend2". This is to avoid "Duplicate Product
+# Identifier" errors, because "backend" is already produced by
+# clonePortableObjectsHtoH by default. "backend2" here has no meaning; is just
+# something we use as an example of a host product with a non-portable trivial
+# serialiser.
+process.backendAlias = cms.EDAlias(
+    producePortableObjects = cms.VPSet(
+        cms.PSet(type = cms.string("*"), fromProductInstance =
+                 cms.string("backend"), toProductInstance = cms.string("backend2"))
+    )
+)
+
 # Clone from host to host, registering the H->D transformation
 process.clonePortableObjectsHtoH = cms.EDProducer("ngt::GenericClonerPortable@alpaka",
     products = cms.VPSet(
@@ -43,6 +58,16 @@ process.clonePortableObjectsHtoH = cms.EDProducer("ngt::GenericClonerPortable@al
         cms.PSet(
             src = cms.InputTag("producePortableObjects"),
             type = cms.string("portabletest::TestHostCollection3")
+        ),
+        # a host product with a non-portable trivial serialiser
+        cms.PSet(
+            src = cms.InputTag("backendAlias", "backend2"),
+            type = cms.string("ushort")
+        ),
+        # a host product with no trivial serialiser, falling back to ROOT
+        cms.PSet(
+            src = cms.InputTag("ids"),
+            type = cms.string("edm::EventID")
         ),
     ),
     verbose = cms.untracked.bool(True),
@@ -86,10 +111,21 @@ process.validatePortableObject = cms.EDAnalyzer("TestAlpakaObjectAnalyzer",
     source = cms.InputTag("clonePortableObjectsDtoD")
 )
 
+process.validateReceived = cms.EDAnalyzer("GenericConsumer",
+    eventProducts = cms.untracked.vstring("clonePortableObjectsHtoH")
+)
+
+process.validateEventId = cms.EDAnalyzer("edmtest::EventIDValidator",
+    source = cms.untracked.InputTag("clonePortableObjectsHtoH", "")
+)
+
 process.pathSoA = cms.Path(
     process.producePortableObjects +
+    process.ids +
     process.clonePortableObjectsHtoH +
     process.clonePortableObjectsDtoD +
     process.validatePortableCollections +
-    process.validatePortableObject
+    process.validatePortableObject +
+    process.validateReceived +
+    process.validateEventId
 )


### PR DESCRIPTION
#### PR description:

- Add support for host types which have a portable serialiser, but not a host serialiser, to the portable MPI modules.
- When both portable and host serialisers exist for a host type, prefer using the portable serialiser.


#### PR validation:

Extended the `controller_soa_device_cfg.py` and `testGenericClonerPortable_cfg.py` tests with more types, in order to cover all possible scenarios handles by the portable MPI modules and by the `GenericClonerPortable.cc` test module.
