### PR TITLE
Add Phase-2 HLT b-tag validation

### DIFF
--- a/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
@@ -302,6 +302,8 @@ HLTDebugRAW = cms.PSet(
 HLTDebugFEVT = cms.PSet(
     outputCommands = cms.vstring( *(
         'drop *_hlt*_*_*',
+        'keep *_hltPfDeepFlavourJetTagsModEta2p4_*_*',
+        'keep *_hltDeepCombinedSecondaryVertexBJetTagsPFPuppiModEta2p4_*_*',
         'keep *RecHit*_hltSiPixelRecHitsSoASerialSync_*_*',
         'keep *RecHit*_hltSiPixelRecHitsSoA_*_*',
         'keep *_hltAK4CaloJetsCorrectedIDPassed_*_*',

--- a/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
+++ b/HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py
@@ -304,6 +304,8 @@ HLTDebugFEVT = cms.PSet(
         'drop *_hlt*_*_*',
         'keep *_hltPfDeepFlavourJetTagsModEta2p4_*_*',
         'keep *_hltDeepCombinedSecondaryVertexBJetTagsPFPuppiModEta2p4_*_*',
+        'keep *_hltPfDeepFlavourJetTags_*_*',
+        'keep *_hltDeepCombinedSecondaryVertexBJetTagsPFPuppi_*_*',
         'keep *RecHit*_hltSiPixelRecHitsSoASerialSync_*_*',
         'keep *RecHit*_hltSiPixelRecHitsSoA_*_*',
         'keep *_hltAK4CaloJetsCorrectedIDPassed_*_*',

--- a/HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h
+++ b/HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h
@@ -76,6 +76,11 @@ private:
   //                shallowTagInfosCalo;
   edm::Handle<std::vector<reco::ShallowTagInfo>> shallowTagInfosPf;
 
+  // phase2-only configuration
+  bool isPhase2_;
+  std::vector<std::vector<std::string>> l1Seeds_;
+  std::vector<std::vector<std::string>> pathFilters_;
+
   /// other class variable
   std::vector<bool> _isfoundHLTs;
   std::vector<int> hltPathIndexs_;
@@ -102,6 +107,9 @@ private:
   std::vector<std::map<std::string, MonitorElement *>> H2EtaPhi_;
   std::vector<std::map<std::string, MonitorElement *>> H2EtaPhi_threshold_;
   std::vector<std::map<std::string, MonitorElement *>> H2Phi_;
+
+  // phase2-only histograms
+  std::vector<std::map<std::string, MonitorElement *>> H1Iso_;
 
   // Other variables
   edm::EDConsumerBase::Labels label;

--- a/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
+++ b/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
@@ -99,3 +99,76 @@ fastSim.toModify(HltVertexValidationVertices, SimVertexCollection = "fastSimProd
     #    cms.InputTag("hltVerticesPF"), 
     #)
 
+#Including phase2 conditions
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+
+triggerConditions_phase2 = cms.vstring(
+    "HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_2p4* OR HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepFlavour_2p4* OR HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepFlavour_2p4* OR HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4*")
+
+phase2_common.toModify(hltBtagTriggerSelection,
+                       triggerConditions = triggerConditions_phase2)
+
+HLTPathNames_phase2 = cms.vstring(
+    'HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_2p4',
+    'HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepFlavour_2p4',
+    'HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepFlavour_2p4',
+    'HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4'
+)
+
+phase2_common.toModify(hltbTagValidation,
+                       HLTPathNames = HLTPathNames_phase2)
+
+phase2_common.toModify(HltVertexValidationVertices,
+                       HLTPathNames = HLTPathNames_phase2)
+
+phase2_common.toModify(
+    HltVertexValidationVertices,
+    Vertex = cms.VInputTag(
+            cms.InputTag("hltOfflinePrimaryVertices","","HLT"),
+    )
+)
+
+phase2_common.toModify(
+    hltbTagValidation,
+    isPhase2 = cms.bool(True),
+    L1Seeds = cms.VPSet(
+        cms.PSet(seeds = cms.vstring("pDoublePuppiJet112_112")),
+        cms.PSet(seeds = cms.vstring("pPuppiHT400", "pQuadJet70_55_40_40")),
+        cms.PSet(seeds = cms.vstring("pPuppiHT400", "pQuadJet70_55_40_40")),
+        cms.PSet(seeds = cms.vstring("pDoublePuppiJet112_112"))
+    ),
+    JetTag = cms.VInputTag(
+        cms.InputTag("hltDeepCombinedSecondaryVertexBJetTagsPFPuppiModEta2p4","probb"),
+        cms.InputTag("hltPfDeepFlavourJetTagsModEta2p4","probb"),
+        cms.InputTag("hltPfDeepFlavourJetTagsModEta2p4","probb"),
+        cms.InputTag("hltPfDeepFlavourJetTagsModEta2p4","probb")
+    ),
+    PathFilters = cms.VPSet(
+        cms.PSet(filters = cms.vstring(
+            "hltDoublePFPuppiJets128MaxEta2p4",
+            "hltDoublePFPuppiJets128Eta2p4MaxDeta1p6",
+            "hltBTagPFPuppiDeepCSV0p865DoubleEta2p4"
+        )),
+        cms.PSet(filters = cms.vstring(
+            "hltPFPuppiCentralJetQuad30MaxEta2p4",
+            "hlt1PFPuppiCentralJet75MaxEta2p4",
+            "hlt2PFPuppiCentralJet60MaxEta2p4",
+            "hlt3PFPuppiCentralJet45MaxEta2p4",
+            "hlt4PFPuppiCentralJet40MaxEta2p4",
+            "hltPFPuppiCentralJetsQuad30HT330MaxEta2p4",
+            "hltBTagPFPuppiDeepFlavour0p275Eta2p4TripleEta2p4"
+        )),
+        cms.PSet(filters = cms.vstring(
+            "hltPFPuppiCentralJetQuad30MaxEta2p4",
+            "hlt1PFPuppiCentralJet70MaxEta2p4",
+            "hlt2PFPuppiCentralJet40MaxEta2p4",
+            "hltPFPuppiCentralJetsQuad30HT200MaxEta2p4",
+            "hltBTagPFPuppiDeepFlavour0p375Eta2p4TripleEta2p4"
+        )),
+        cms.PSet(filters = cms.vstring(
+            "hltDoublePFPuppiJets128MaxEta2p4",
+            "hltDoublePFPuppiJets128Eta2p4MaxDeta1p6",
+            "hltBTagPFPuppiDeepFlavour0p935DoubleEta2p4"
+        ))
+    )
+)

--- a/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
+++ b/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
@@ -68,7 +68,10 @@ hltbTagValidation = DQMEDAnalyzer('HLTBTagPerformanceAnalyzer',
 		g = cms.vuint32(21),
 		uds = cms.vuint32(1, 2, 3)
 	),
-	mcPartons = cms.InputTag("hltBtagJetsbyValAlgo")
+	mcPartons = cms.InputTag("hltBtagJetsbyValAlgo"),
+	isPhase2 = cms.bool(False),
+	L1Seeds = cms.VPSet(),
+	PathFilters = cms.VPSet()
 )
 
 #put all in a path
@@ -102,48 +105,45 @@ fastSim.toModify(HltVertexValidationVertices, SimVertexCollection = "fastSimProd
 #Including phase2 conditions
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 
-triggerConditions_phase2 = cms.vstring(
-    "HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_2p4* OR HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepFlavour_2p4* OR HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepFlavour_2p4* OR HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4*")
-
-phase2_common.toModify(hltBtagTriggerSelection,
-                       triggerConditions = triggerConditions_phase2)
-
-HLTPathNames_phase2 = cms.vstring(
+HLTPathNames_phase2 = [
     'HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_2p4',
     'HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepFlavour_2p4',
     'HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepFlavour_2p4',
-    'HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4'
-)
+    'HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4',
+    'DST_PFScouting',
+    'DST_PFScouting'
+]
+
+phase2_common.toModify(hltBtagTriggerSelection,
+                       triggerConditions = [" OR ".join(p + "*" for p in dict.fromkeys(HLTPathNames_phase2))])
 
 phase2_common.toModify(hltbTagValidation,
                        HLTPathNames = HLTPathNames_phase2)
 
 phase2_common.toModify(HltVertexValidationVertices,
-                       HLTPathNames = HLTPathNames_phase2)
-
-phase2_common.toModify(
-    HltVertexValidationVertices,
-    Vertex = cms.VInputTag(
-            cms.InputTag("hltOfflinePrimaryVertices","","HLT"),
-    )
-)
+                       HLTPathNames = list(dict.fromkeys(HLTPathNames_phase2)),
+                       Vertex = ["hltOfflinePrimaryVertices::HLT"])
 
 phase2_common.toModify(
     hltbTagValidation,
-    isPhase2 = cms.bool(True),
-    L1Seeds = cms.VPSet(
+    isPhase2 = True,
+    L1Seeds = [
         cms.PSet(seeds = cms.vstring("pDoublePuppiJet112_112")),
         cms.PSet(seeds = cms.vstring("pPuppiHT400", "pQuadJet70_55_40_40")),
         cms.PSet(seeds = cms.vstring("pPuppiHT400", "pQuadJet70_55_40_40")),
-        cms.PSet(seeds = cms.vstring("pDoublePuppiJet112_112"))
-    ),
-    JetTag = cms.VInputTag(
-        cms.InputTag("hltDeepCombinedSecondaryVertexBJetTagsPFPuppiModEta2p4","probb"),
-        cms.InputTag("hltPfDeepFlavourJetTagsModEta2p4","probb"),
-        cms.InputTag("hltPfDeepFlavourJetTagsModEta2p4","probb"),
-        cms.InputTag("hltPfDeepFlavourJetTagsModEta2p4","probb")
-    ),
-    PathFilters = cms.VPSet(
+        cms.PSet(seeds = cms.vstring("pDoublePuppiJet112_112")),
+        cms.PSet(seeds = cms.vstring()),
+        cms.PSet(seeds = cms.vstring())
+    ],
+    JetTag = [
+        "hltDeepCombinedSecondaryVertexBJetTagsPFPuppiModEta2p4:probb",
+        "hltPfDeepFlavourJetTagsModEta2p4:probb",
+        "hltPfDeepFlavourJetTagsModEta2p4:probb",
+        "hltPfDeepFlavourJetTagsModEta2p4:probb",
+        "hltDeepCombinedSecondaryVertexBJetTagsPFPuppi:probb",
+        "hltPfDeepFlavourJetTags:probb"
+    ],
+    PathFilters = [
         cms.PSet(filters = cms.vstring(
             "hltDoublePFPuppiJets128MaxEta2p4",
             "hltDoublePFPuppiJets128Eta2p4MaxDeta1p6",
@@ -169,6 +169,8 @@ phase2_common.toModify(
             "hltDoublePFPuppiJets128MaxEta2p4",
             "hltDoublePFPuppiJets128Eta2p4MaxDeta1p6",
             "hltBTagPFPuppiDeepFlavour0p935DoubleEta2p4"
-        ))
-    )
+        )),
+        cms.PSet(filters = cms.vstring()),
+        cms.PSet(filters = cms.vstring())
+    ]
 )

--- a/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
@@ -97,19 +97,15 @@ HLTBTagPerformanceAnalyzer::HLTBTagPerformanceAnalyzer(const edm::ParameterSet &
       consumes<std::vector<reco::ShallowTagInfo>>(edm::InputTag("hltDeepCombinedSecondaryVertexBJetTagsInfos"));
 
   // phase2-only config
-  isPhase2_ = iConfig.existsAs<bool>("isPhase2") ? iConfig.getParameter<bool>("isPhase2") : false;
+  isPhase2_ = iConfig.getParameter<bool>("isPhase2");
   if (isPhase2_) {
-    if (iConfig.existsAs<std::vector<edm::ParameterSet>>("L1Seeds")) {
-      auto l1SeedsCfg = iConfig.getParameter<std::vector<edm::ParameterSet>>("L1Seeds");
-      for (auto const &ps : l1SeedsCfg)
-        l1Seeds_.push_back(ps.getParameter<std::vector<std::string>>("seeds"));
-    }
+    auto const &l1SeedsCfg = iConfig.getParameter<std::vector<edm::ParameterSet>>("L1Seeds");
+    for (auto const &ps : l1SeedsCfg)
+      l1Seeds_.push_back(ps.getParameter<std::vector<std::string>>("seeds"));
 
-    if (iConfig.existsAs<std::vector<edm::ParameterSet>>("PathFilters")) {
-      auto pathFiltersCfg = iConfig.getParameter<std::vector<edm::ParameterSet>>("PathFilters");
-      for (auto const &ps : pathFiltersCfg)
-        pathFilters_.push_back(ps.getParameter<std::vector<std::string>>("filters"));
-    }
+    auto const &pathFiltersCfg = iConfig.getParameter<std::vector<edm::ParameterSet>>("PathFilters");
+    for (auto const &ps : pathFiltersCfg)
+      pathFilters_.push_back(ps.getParameter<std::vector<std::string>>("filters"));
   }
 
   m_mcPartons = consumes<JetFlavourMatchingCollection>(iConfig.getParameter<InputTag>("mcPartons"));
@@ -513,7 +509,7 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     }
 
     // phase2-only isolated histograms
-    if (isPhase2_) {
+    if (isPhase2_ && ind < pathFilters_.size() && !pathFilters_[ind].empty()) {
       ibooker.setCurrentFolder(dqmFolder + "/filters");
       H1Iso_.back()["L1"] = ibooker.book1D("L1", "L1", btagBins, btagL, btagU);
       H1Iso_.back()["L1"]->setAxisTitle("disc", 1);
@@ -663,6 +659,18 @@ void HLTBTagPerformanceAnalyzer::fillDescriptions(edm::ConfigurationDescriptions
     desc.add<edm::ParameterSetDescription>("mcFlavours", psd0);
   }
   desc.add<edm::InputTag>("mcPartons", edm::InputTag("hltBtagJetsbyValAlgo"));
+  // phase2-only parameters, unused in the Run 3 configuration
+  desc.add<bool>("isPhase2", false);
+  {
+    edm::ParameterSetDescription psd1;
+    psd1.add<std::vector<std::string>>("seeds", {});
+    desc.addVPSet("L1Seeds", psd1, {});
+  }
+  {
+    edm::ParameterSetDescription psd2;
+    psd2.add<std::vector<std::string>>("filters", {});
+    desc.addVPSet("PathFilters", psd2, {});
+  }
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
@@ -4,6 +4,7 @@
 #include "HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h"
 #include <algorithm>
 #include <set>
+#include "FWCore/Common/interface/TriggerNames.h"
 
 using namespace edm;
 using namespace reco;
@@ -94,6 +95,23 @@ HLTBTagPerformanceAnalyzer::HLTBTagPerformanceAnalyzer(const edm::ParameterSet &
   //        (edm::InputTag("hltDeepCombinedSecondaryVertexBJetTagsInfosCalo"));
   shallowTagInfosTokenPf_ =
       consumes<std::vector<reco::ShallowTagInfo>>(edm::InputTag("hltDeepCombinedSecondaryVertexBJetTagsInfos"));
+
+  // phase2-only config
+  isPhase2_ = iConfig.existsAs<bool>("isPhase2") ? iConfig.getParameter<bool>("isPhase2") : false;
+  if (isPhase2_) {
+    if (iConfig.existsAs<std::vector<edm::ParameterSet>>("L1Seeds")) {
+      auto l1SeedsCfg = iConfig.getParameter<std::vector<edm::ParameterSet>>("L1Seeds");
+      for (auto const &ps : l1SeedsCfg)
+        l1Seeds_.push_back(ps.getParameter<std::vector<std::string>>("seeds"));
+    }
+
+    if (iConfig.existsAs<std::vector<edm::ParameterSet>>("PathFilters")) {
+      auto pathFiltersCfg = iConfig.getParameter<std::vector<edm::ParameterSet>>("PathFilters");
+      for (auto const &ps : pathFiltersCfg)
+        pathFilters_.push_back(ps.getParameter<std::vector<std::string>>("filters"));
+    }
+  }
+
   m_mcPartons = consumes<JetFlavourMatchingCollection>(iConfig.getParameter<InputTag>("mcPartons"));
   hltPathNames_ = iConfig.getParameter<std::vector<std::string>>("HLTPathNames");
   edm::ParameterSet mc = iConfig.getParameter<edm::ParameterSet>("mcFlavours");
@@ -129,6 +147,10 @@ void HLTBTagPerformanceAnalyzer::dqmBeginRun(const edm::Run &iRun, const edm::Ev
   const std::vector<std::string> &allHltPathNames = hltConfigProvider_.triggerNames();
 
   // fill hltPathIndexs_ with the trigger number of each hltPathNames_
+  if (isPhase2_) {  // phase-2 only: allow dqmBeginRun to be re-entered
+    hltPathIndexs_.clear();
+    _isfoundHLTs.clear();
+  }
   for (size_t trgs = 0; trgs < hltPathNames_.size(); trgs++) {
     unsigned int found = 1;
     int it_mem = -1;
@@ -186,7 +208,7 @@ void HLTBTagPerformanceAnalyzer::analyze(const edm::Event &iEvent, const edm::Ev
     JetTagMap JetTag;
     if (!_isfoundHLTs[ind])
       continue;  // if the hltPath is not in the event, skip the event
-    if (!triggerResults.accept(hltPathIndexs_[ind]))
+    if (!isPhase2_ && !triggerResults.accept(hltPathIndexs_[ind]))
       continue;  // if the hltPath was not accepted skip the event
 
     // get JetTagCollection
@@ -206,27 +228,77 @@ void HLTBTagPerformanceAnalyzer::analyze(const edm::Event &iEvent, const edm::Ev
       }
     else {
       edm::LogInfo("NoCollection") << "Collection " << JetTagCollection_Label[ind] << " ==> not found";
-      return;
+      if (isPhase2_)
+        continue;  // phase-2 only: drop this path, keep analysing the others
+      return;      // original behaviour
     }
+
+    bool passFullPath = triggerResults.accept(hltPathIndexs_[ind]);
+
     // fill Inputs for All
-    if (shallowTagInfosPf.isValid()) {
-      for (auto &info : *(shallowTagInfosPf)) {
-        TaggingVariableList vars = info.taggingVariables();
-        for (auto entry = vars.begin(); entry != vars.end(); ++entry) {
-          if (keepSet.find(TaggingVariableTokens[entry->first]) !=
-              keepSet.end()) {  // if Input name in defined list to keep
-            try {
-              H1_.at(ind)[TaggingVariableTokens[entry->first]]->Fill(std::fmax(0.0, entry->second));
-            } catch (const std::exception &e) {
+    if (!isPhase2_) {  // inputs are not booked for phase-2
+      if (shallowTagInfosPf.isValid()) {
+        for (auto &info : *(shallowTagInfosPf)) {
+          TaggingVariableList vars = info.taggingVariables();
+          for (auto entry = vars.begin(); entry != vars.end(); ++entry) {
+            if (keepSet.find(TaggingVariableTokens[entry->first]) !=
+                keepSet.end()) {  // if Input name in defined list to keep
+              try {
+                H1_.at(ind)[TaggingVariableTokens[entry->first]]->Fill(std::fmax(0.0, entry->second));
+              } catch (const std::exception &e) {
+                continue;
+              }
+            } else
               continue;
-            }
-          } else
-            continue;
+          }
+        }
+      } else {
+        edm::LogInfo("NoCollection") << "No shallowTagInfosPf collection";
+      }
+    }
+
+    // phase2-only filter monitoring
+    bool passL1Seed = false;
+    std::vector<bool> passFilters;
+    std::vector<bool> validFilters;
+    bool passAllFilters = false;
+
+    if (isPhase2_) {
+      const edm::TriggerNames &trigNames = iEvent.triggerNames(triggerResults);
+      passL1Seed = true;
+      if (ind < l1Seeds_.size() && !l1Seeds_[ind].empty()) {
+        for (const auto &l1name : l1Seeds_[ind]) {
+          unsigned int idx = trigNames.triggerIndex(l1name);
+          bool thisPass = (idx < triggerResults.size() && triggerResults.accept(idx));
+          passL1Seed = passL1Seed && thisPass;
+        }
+      } else {
+        passL1Seed = false;
+      }
+
+      if (ind < pathFilters_.size()) {
+        passFilters.assign(pathFilters_[ind].size(), false);
+        validFilters.assign(pathFilters_[ind].size(), false);
+
+        // a filter passed iff it ran before the module that stopped the path,
+        // or the path was accepted (in which case every filter on it passed)
+        const unsigned int lastRun = triggerResults.index(hltPathIndexs_[ind]);
+        const unsigned int nMod = hltConfigProvider_.size(hltPathIndexs_[ind]);
+        for (size_t ifilt = 0; ifilt < pathFilters_[ind].size(); ++ifilt) {
+          const unsigned int mIdx = hltConfigProvider_.moduleIndex(hltPathIndexs_[ind], pathFilters_[ind][ifilt]);
+          if (mIdx < nMod) {
+            validFilters[ifilt] = true;
+            passFilters[ifilt] = passFullPath || (mIdx < lastRun);
+          }
+        }
+
+        passAllFilters = !passFilters.empty();
+        for (size_t ifilt = 0; ifilt < passFilters.size(); ++ifilt) {
+          passAllFilters = passAllFilters && validFilters[ifilt] && passFilters[ifilt];
         }
       }
-    } else {
-      edm::LogInfo("NoCollection") << "No shallowTagInfosPf collection";
     }
+
     // fill tagging
     for (auto &BtagJT : JetTag) {
       std::map<HCALSpecials, bool> inmodule;
@@ -234,60 +306,134 @@ void HLTBTagPerformanceAnalyzer::analyze(const edm::Event &iEvent, const edm::Ev
       inmodule[HEP18] = (BtagJT.first->phi() >= -0.52) && (BtagJT.first->phi() < -0.17) && (BtagJT.first->eta() > 1.3);
       inmodule[HEM17] = (BtagJT.first->phi() >= -0.87) && (BtagJT.first->phi() < -0.52) && (BtagJT.first->eta() < -1.3);
 
-      // fill 1D btag plot for 'all'
-      H1_.at(ind)[JetTagCollection_Label[ind]]->Fill(std::fmax(0.0, BtagJT.second));
-      for (const auto &i : HCALSpecialsNames) {
-        if (inmodule[i.first])
-          H1mod_.at(ind)[JetTagCollection_Label[ind]][i.first]->Fill(std::fmax(0.0, BtagJT.second));
+      // original final full-path plots
+      if (passFullPath) {
+        // fill 1D btag plot for 'all'
+        H1_.at(ind)[JetTagCollection_Label[ind]]->Fill(std::fmax(0.0, BtagJT.second));
+        if (!isPhase2_) {
+          for (const auto &i : HCALSpecialsNames) {
+            if (inmodule[i.first])
+              H1mod_.at(ind)[JetTagCollection_Label[ind]][i.first]->Fill(std::fmax(0.0, BtagJT.second));
+          }
+        }
+
+        if (MCOK) {
+          int m = closestJet(BtagJT.first, *h_mcPartons, m_mcRadius);
+          unsigned int flavour = (m != -1) ? abs((*h_mcPartons)[m].second.getFlavour()) : 0;
+          for (unsigned int i = 0; i < m_mcLabels.size(); ++i) {
+            std::string flavour_str = m_mcLabels[i];
+            flavours_t flav_collection = m_mcFlavours[i];
+            auto it = std::find(flav_collection.begin(), flav_collection.end(), flavour);
+            if (it == flav_collection.end())
+              continue;
+            std::string label = JetTagCollection_Label[ind] + "__";
+            label += flavour_str;
+            H1_.at(ind)[label]->Fill(std::fmax(0.0, BtagJT.second));  // fill 1D btag plot for 'b,c,uds'
+            if (!isPhase2_) {
+              for (const auto &j : HCALSpecialsNames) {
+                if (inmodule[j.first])
+                  H1mod_.at(ind)[label][j.first]->Fill(
+                      std::fmax(0.0, BtagJT.second));  // fill 1D btag plot for 'b,c,uds' in
+                                                       // modules (HEP17 etc.)
+              }
+            }
+            label = JetTagCollection_Label[ind] + "___";
+            label += flavour_str;
+            std::string labelEta = label;
+            std::string labelPhi = label;
+            std::string labelEtaPhi = label;
+            std::string labelEtaPhi_threshold = label;
+            label += "_disc_pT";
+            H2_.at(ind)[label]->Fill(std::fmax(0.0, BtagJT.second),
+                                     BtagJT.first->pt());  // fill 2D btag, jetPt plot for 'b,c,uds'
+            if (!isPhase2_) {
+              for (const auto &j : HCALSpecialsNames) {
+                if (inmodule[j.first])
+                  H2mod_.at(ind)[label][j.first]->Fill(std::fmax(0.0, BtagJT.second), BtagJT.first->pt());
+              }
+            }
+            labelEta += "_disc_eta";
+            H2Eta_.at(ind)[labelEta]->Fill(std::fmax(0.0, BtagJT.second),
+                                           BtagJT.first->eta());  // fill 2D btag, jetEta plot for 'b,c,uds'
+            labelPhi += "_disc_phi";
+            H2Phi_.at(ind)[labelPhi]->Fill(std::fmax(0.0, BtagJT.second),
+                                           BtagJT.first->phi());  // fill 2D btag, jetPhi plot for 'b,c,uds'
+            labelEtaPhi += "_eta_phi";
+            H2EtaPhi_.at(ind)[labelEtaPhi]->Fill(BtagJT.first->eta(),
+                                                 BtagJT.first->phi());  // fill 2D btag, jetPhi plot for 'b,c,uds'
+            labelEtaPhi_threshold += "_eta_phi_disc05";
+            if (BtagJT.second > 0.5) {
+              H2EtaPhi_threshold_.at(ind)[labelEtaPhi_threshold]->Fill(
+                  BtagJT.first->eta(),
+                  BtagJT.first->phi());  // fill 2D btag, jetPhi plot for 'b,c,uds'
+            }
+          }  /// for flavour
+        }  /// if MCOK
+      }  /// if passFullPath
+
+      // phase2-only isolated histograms
+      if (isPhase2_ && passL1Seed) {
+        H1Iso_.at(ind)["L1"]->Fill(std::fmax(0.0, BtagJT.second));
+
+        if (MCOK) {
+          int m = closestJet(BtagJT.first, *h_mcPartons, m_mcRadius);
+          unsigned int flavour = (m != -1) ? abs((*h_mcPartons)[m].second.getFlavour()) : 0;
+
+          for (unsigned int i = 0; i < m_mcLabels.size(); ++i) {
+            const std::string flavour_str = m_mcLabels[i];
+            const flavours_t flav_collection = m_mcFlavours[i];
+            auto it = std::find(flav_collection.begin(), flav_collection.end(), flavour);
+            if (it == flav_collection.end())
+              continue;
+
+            const std::string key = "L1__" + flavour_str;
+            H1Iso_.at(ind)[key]->Fill(std::fmax(0.0, BtagJT.second));
+          }
+        }
+
+        for (size_t ifilt = 0; ifilt < passFilters.size(); ++ifilt) {
+          if (passFilters[ifilt]) {
+            const std::string key = "L1__" + pathFilters_[ind][ifilt];
+            H1Iso_.at(ind)[key]->Fill(std::fmax(0.0, BtagJT.second));
+
+            if (MCOK) {
+              int m = closestJet(BtagJT.first, *h_mcPartons, m_mcRadius);
+              unsigned int flavour = (m != -1) ? abs((*h_mcPartons)[m].second.getFlavour()) : 0;
+
+              for (unsigned int i = 0; i < m_mcLabels.size(); ++i) {
+                const std::string flavour_str = m_mcLabels[i];
+                const flavours_t flav_collection = m_mcFlavours[i];
+                auto it = std::find(flav_collection.begin(), flav_collection.end(), flavour);
+                if (it == flav_collection.end())
+                  continue;
+
+                const std::string flavKey = "L1__" + pathFilters_[ind][ifilt] + "__" + flavour_str;
+                H1Iso_.at(ind)[flavKey]->Fill(std::fmax(0.0, BtagJT.second));
+              }
+            }
+          }
+        }
+
+        if (passAllFilters) {
+          H1Iso_.at(ind)["L1__ALL"]->Fill(std::fmax(0.0, BtagJT.second));
+
+          if (MCOK) {
+            int m = closestJet(BtagJT.first, *h_mcPartons, m_mcRadius);
+            unsigned int flavour = (m != -1) ? abs((*h_mcPartons)[m].second.getFlavour()) : 0;
+
+            for (unsigned int i = 0; i < m_mcLabels.size(); ++i) {
+              const std::string flavour_str = m_mcLabels[i];
+              const flavours_t flav_collection = m_mcFlavours[i];
+              auto it = std::find(flav_collection.begin(), flav_collection.end(), flavour);
+              if (it == flav_collection.end())
+                continue;
+
+              const std::string key = "L1__ALL__" + flavour_str;
+              H1Iso_.at(ind)[key]->Fill(std::fmax(0.0, BtagJT.second));
+            }
+          }
+        }
       }
-      if (MCOK) {
-        int m = closestJet(BtagJT.first, *h_mcPartons, m_mcRadius);
-        unsigned int flavour = (m != -1) ? abs((*h_mcPartons)[m].second.getFlavour()) : 0;
-        for (unsigned int i = 0; i < m_mcLabels.size(); ++i) {
-          std::string flavour_str = m_mcLabels[i];
-          flavours_t flav_collection = m_mcFlavours[i];
-          auto it = std::find(flav_collection.begin(), flav_collection.end(), flavour);
-          if (it == flav_collection.end())
-            continue;
-          std::string label = JetTagCollection_Label[ind] + "__";
-          label += flavour_str;
-          H1_.at(ind)[label]->Fill(std::fmax(0.0, BtagJT.second));  // fill 1D btag plot for 'b,c,uds'
-          for (const auto &j : HCALSpecialsNames) {
-            if (inmodule[j.first])
-              H1mod_.at(ind)[label][j.first]->Fill(
-                  std::fmax(0.0, BtagJT.second));  // fill 1D btag plot for 'b,c,uds' in
-                                                   // modules (HEP17 etc.)
-          }
-          label = JetTagCollection_Label[ind] + "___";
-          label += flavour_str;
-          std::string labelEta = label;
-          std::string labelPhi = label;
-          std::string labelEtaPhi = label;
-          std::string labelEtaPhi_threshold = label;
-          label += "_disc_pT";
-          H2_.at(ind)[label]->Fill(std::fmax(0.0, BtagJT.second),
-                                   BtagJT.first->pt());  // fill 2D btag, jetPt plot for 'b,c,uds'
-          for (const auto &j : HCALSpecialsNames) {
-            if (inmodule[j.first])
-              H2mod_.at(ind)[label][j.first]->Fill(std::fmax(0.0, BtagJT.second), BtagJT.first->pt());
-          }
-          labelEta += "_disc_eta";
-          H2Eta_.at(ind)[labelEta]->Fill(std::fmax(0.0, BtagJT.second),
-                                         BtagJT.first->eta());  // fill 2D btag, jetEta plot for 'b,c,uds'
-          labelPhi += "_disc_phi";
-          H2Phi_.at(ind)[labelPhi]->Fill(std::fmax(0.0, BtagJT.second),
-                                         BtagJT.first->phi());  // fill 2D btag, jetPhi plot for 'b,c,uds'
-          labelEtaPhi += "_eta_phi";
-          H2EtaPhi_.at(ind)[labelEtaPhi]->Fill(BtagJT.first->eta(),
-                                               BtagJT.first->phi());  // fill 2D btag, jetPhi plot for 'b,c,uds'
-          labelEtaPhi_threshold += "_eta_phi_disc05";
-          if (BtagJT.second > 0.5) {
-            H2EtaPhi_threshold_.at(ind)[labelEtaPhi_threshold]->Fill(
-                BtagJT.first->eta(),
-                BtagJT.first->phi());  // fill 2D btag, jetPhi plot for 'b,c,uds'
-          }
-        }  /// for flavour
-      }  /// if MCOK
     }  /// for BtagJT
   }  // for triggers
 }
@@ -314,6 +460,8 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
     H2Phi_.push_back(std::map<std::string, MonitorElement *>());
     H2EtaPhi_.push_back(std::map<std::string, MonitorElement *>());
     H2EtaPhi_threshold_.push_back(std::map<std::string, MonitorElement *>());
+    if (isPhase2_)
+      H1Iso_.push_back(std::map<std::string, MonitorElement *>());
     ibooker.setCurrentFolder(dqmFolder);
 
     // book 1D btag plot for 'all'
@@ -321,45 +469,90 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
       H1_.back()[JetTagCollection_Label[ind]] = ibooker.book1D(
           JetTagCollection_Label[ind] + "_all", JetTagCollection_Label[ind] + "_all", btagBins, btagL, btagU);
       H1_.back()[JetTagCollection_Label[ind]]->setAxisTitle(JetTagCollection_Label[ind] + "discriminant", 1);
+
       // Input storing
-      ibooker.setCurrentFolder(dqmFolder + "/inputs");
-      ibooker.setCurrentFolder(dqmFolder + "/inputs/Jet");
-      for (int i = 0; i < 100; i++) {
-        if (keepSetJet.find(TaggingVariableTokens[i]) != keepSetJet.end()) {  // if input name in defined set
-          std::string inpt = TaggingVariableTokens[i];
-          H1_.back()[inpt] = ibooker.book1D(inpt, inpt, 105, -5, 100.);
-          H1_.back()[inpt]->setAxisTitle(inpt, 1);
-        } else
-          continue;
+      if (!isPhase2_) {
+        ibooker.setCurrentFolder(dqmFolder + "/inputs");
+        ibooker.setCurrentFolder(dqmFolder + "/inputs/Jet");
+        for (int i = 0; i < 100; i++) {
+          if (keepSetJet.find(TaggingVariableTokens[i]) != keepSetJet.end()) {  // if input name in defined set
+            std::string inpt = TaggingVariableTokens[i];
+            H1_.back()[inpt] = ibooker.book1D(inpt, inpt, 105, -5, 100.);
+            H1_.back()[inpt]->setAxisTitle(inpt, 1);
+          } else
+            continue;
+        }
+        ibooker.setCurrentFolder(dqmFolder + "/inputs/Track");
+        for (int i = 0; i < 100; i++) {
+          if (keepSetTrack.find(TaggingVariableTokens[i]) != keepSetTrack.end()) {  // if input name in defined set
+            std::string inpt = TaggingVariableTokens[i];
+            H1_.back()[inpt] = ibooker.book1D(inpt, inpt, 105, -5, 100.);
+            H1_.back()[inpt]->setAxisTitle(inpt, 1);
+          } else
+            continue;
+        }
+        ibooker.setCurrentFolder(dqmFolder + "/inputs/Vertex");
+        for (int i = 0; i < 100; i++) {
+          if (keepSetVtx.find(TaggingVariableTokens[i]) != keepSetVtx.end()) {  // if input name in defined set
+            std::string inpt = TaggingVariableTokens[i];
+            H1_.back()[inpt] = ibooker.book1D(inpt, inpt, 105, -5, 100.);
+            H1_.back()[inpt]->setAxisTitle(inpt, 1);
+          } else
+            continue;
+        }
+
+        for (const auto &i : HCALSpecialsNames) {
+          ibooker.setCurrentFolder(dqmFolder + "/" + i.second);
+          H1mod_.back()[JetTagCollection_Label[ind]][i.first] = ibooker.book1D(
+              JetTagCollection_Label[ind] + "_all", JetTagCollection_Label[ind] + "_all", btagBins, btagL, btagU);
+          H1mod_.back()[JetTagCollection_Label[ind]][i.first]->setAxisTitle(
+              JetTagCollection_Label[ind] + "discriminant", 1);
+        }
+        ibooker.setCurrentFolder(dqmFolder);
       }
-      ibooker.setCurrentFolder(dqmFolder + "/inputs/Track");
-      for (int i = 0; i < 100; i++) {
-        if (keepSetTrack.find(TaggingVariableTokens[i]) != keepSetTrack.end()) {  // if input name in defined set
-          std::string inpt = TaggingVariableTokens[i];
-          H1_.back()[inpt] = ibooker.book1D(inpt, inpt, 105, -5, 100.);
-          H1_.back()[inpt]->setAxisTitle(inpt, 1);
-        } else
-          continue;
-      }
-      ibooker.setCurrentFolder(dqmFolder + "/inputs/Vertex");
-      for (int i = 0; i < 100; i++) {
-        if (keepSetVtx.find(TaggingVariableTokens[i]) != keepSetVtx.end()) {  // if input name in defined set
-          std::string inpt = TaggingVariableTokens[i];
-          H1_.back()[inpt] = ibooker.book1D(inpt, inpt, 105, -5, 100.);
-          H1_.back()[inpt]->setAxisTitle(inpt, 1);
-        } else
-          continue;
+    }
+
+    // phase2-only isolated histograms
+    if (isPhase2_) {
+      ibooker.setCurrentFolder(dqmFolder + "/filters");
+      H1Iso_.back()["L1"] = ibooker.book1D("L1", "L1", btagBins, btagL, btagU);
+      H1Iso_.back()["L1"]->setAxisTitle("disc", 1);
+
+      for (unsigned int i = 0; i < m_mcLabels.size(); ++i) {
+        const std::string flavour = m_mcLabels[i];
+        const std::string key = "L1__" + flavour;
+        H1Iso_.back()[key] = ibooker.book1D(key, key, btagBins, btagL, btagU);
+        H1Iso_.back()[key]->setAxisTitle("disc", 1);
       }
 
-      for (const auto &i : HCALSpecialsNames) {
-        ibooker.setCurrentFolder(dqmFolder + "/" + i.second);
-        H1mod_.back()[JetTagCollection_Label[ind]][i.first] = ibooker.book1D(
-            JetTagCollection_Label[ind] + "_all", JetTagCollection_Label[ind] + "_all", btagBins, btagL, btagU);
-        H1mod_.back()[JetTagCollection_Label[ind]][i.first]->setAxisTitle(JetTagCollection_Label[ind] + "discriminant",
-                                                                          1);
+      if (ind < pathFilters_.size()) {
+        for (const auto &filterLabel : pathFilters_[ind]) {
+          const std::string key = "L1__" + filterLabel;
+          H1Iso_.back()[key] = ibooker.book1D(key, key, btagBins, btagL, btagU);
+          H1Iso_.back()[key]->setAxisTitle("disc", 1);
+
+          for (unsigned int i = 0; i < m_mcLabels.size(); ++i) {
+            const std::string flavour = m_mcLabels[i];
+            const std::string flavKey = "L1__" + filterLabel + "__" + flavour;
+            H1Iso_.back()[flavKey] = ibooker.book1D(flavKey, flavKey, btagBins, btagL, btagU);
+            H1Iso_.back()[flavKey]->setAxisTitle("disc", 1);
+          }
+        }
       }
+
+      H1Iso_.back()["L1__ALL"] = ibooker.book1D("L1__ALL", "L1__ALL", btagBins, btagL, btagU);
+      H1Iso_.back()["L1__ALL"]->setAxisTitle("disc", 1);
+
+      for (unsigned int i = 0; i < m_mcLabels.size(); ++i) {
+        const std::string flavour = m_mcLabels[i];
+        const std::string key = "L1__ALL__" + flavour;
+        H1Iso_.back()[key] = ibooker.book1D(key, key, btagBins, btagL, btagU);
+        H1Iso_.back()[key]->setAxisTitle("disc", 1);
+      }
+
       ibooker.setCurrentFolder(dqmFolder);
     }
+
     int nBinsPt = 60;
     double pTmin = 30;
     double pTMax = 330;
@@ -385,11 +578,13 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
         H1_.back()[label] = ibooker.book1D(
             label, Form("%s %s", JetTagCollection_Label[ind].c_str(), flavour.c_str()), btagBins, btagL, btagU);
         H1_.back()[label]->setAxisTitle("disc", 1);
-        for (const auto &j : HCALSpecialsNames) {
-          ibooker.setCurrentFolder(dqmFolder + "/" + j.second);
-          H1mod_.back()[label][j.first] = ibooker.book1D(
-              label, Form("%s %s", JetTagCollection_Label[ind].c_str(), flavour.c_str()), btagBins, btagL, btagU);
-          H1mod_.back()[label][j.first]->setAxisTitle("disc", 1);
+        if (!isPhase2_) {
+          for (const auto &j : HCALSpecialsNames) {
+            ibooker.setCurrentFolder(dqmFolder + "/" + j.second);
+            H1mod_.back()[label][j.first] = ibooker.book1D(
+                label, Form("%s %s", JetTagCollection_Label[ind].c_str(), flavour.c_str()), btagBins, btagL, btagU);
+            H1mod_.back()[label][j.first]->setAxisTitle("disc", 1);
+          }
         }
         ibooker.setCurrentFolder(dqmFolder);
         label = JetTagCollection_Label[ind] + "___";
@@ -407,11 +602,13 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
         H2_.back()[label] = ibooker.book2D(label, label, btagBins, btagL, btagU, nBinsPt, pTmin, pTMax);
         H2_.back()[label]->setAxisTitle("pT", 2);
         H2_.back()[label]->setAxisTitle("disc", 1);
-        for (const auto &j : HCALSpecialsNames) {
-          ibooker.setCurrentFolder(dqmFolder + "/" + j.second);
-          H2mod_.back()[label][j.first] = ibooker.book2D(label, label, btagBins, btagL, btagU, nBinsPt, pTmin, pTMax);
-          H2mod_.back()[label][j.first]->setAxisTitle("pT", 2);
-          H2mod_.back()[label][j.first]->setAxisTitle("disc", 1);
+        if (!isPhase2_) {
+          for (const auto &j : HCALSpecialsNames) {
+            ibooker.setCurrentFolder(dqmFolder + "/" + j.second);
+            H2mod_.back()[label][j.first] = ibooker.book2D(label, label, btagBins, btagL, btagU, nBinsPt, pTmin, pTMax);
+            H2mod_.back()[label][j.first]->setAxisTitle("pT", 2);
+            H2mod_.back()[label][j.first]->setAxisTitle("disc", 1);
+          }
         }
         ibooker.setCurrentFolder(dqmFolder);
         H2Eta_.back()[labelEta] = ibooker.book2D(labelEta, labelEta, btagBins, btagL, btagU, nBinsEta, etamin, etaMax);

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -118,7 +118,6 @@ _hltvalidationWithMC_Phase2 = hltvalidationWithMC.copyAndExclude([#HLTMuonVal,
   ExoticaValidationSequence,
   b2gHLTriggerValidation,
   SMPValidationSequence,
-  hltbtagValidationSequence,
   hltHCALdigisAnalyzer,
   hltHCALRecoAnalyzer,
   hltHCALNoiseRates])


### PR DESCRIPTION
#### PR description:

Enables the HLT b-tag validation for Phase-2 and extends HLTBTagPerformanceAnalyzer with per-filter and per-L1-seed monitoring.

Changes 5 files:

- HLTriggerOffline/Common/python/HLTValidation_cff.py: removes hltbtagValidationSequence from the Phase-2 exclusion list.
- HLTriggerOffline/Btag/python/HltBtagValidation_cff.py: adds the needed paths and their corresponding jettags and filters to be consumed by the analyzer.
- HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc + interface/HLTBTagPerformanceAnalyzer.h: new isPhase2_ flag, l1Seeds_, pathFilters_. All new histograms behind isPhase2_ flag.
- HLTrigger/Configuration/python/HLTrigger_EventContent_cff.py: keeping the required jettags

New DQM phase2-related output under HLT/BTV/Validation/, which includes the histograms containing the full path acceptance, with the per-filter plots under the /filter folder. All plots are also split by jet-flavor.

#### PR validation:

`CMSSW_20_1_0_pre3`  `el9_amd64_gcc14`

Phase-2: workflows 34434.0 (Run4D121) and 38434.0 (Run4D128) run end to end. Now the folder with btv plots can be seem in HLT/BTV/Validation (which was absent in phase2 conditions)

runTheMatrix.py -l limited -i all --ibeos also shows workflows 37634.0/37834.0 (D127, noPU and PU200) also passing the tests.


Not a backport.
