### PR TITLE
Finalize implementation of the NanoAODRNTupleOutputModule

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
@@ -411,7 +411,8 @@ void NanoAODOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descr
 
   desc.addUntracked<int>("compressionLevel", 9)->setComment("ROOT compression level of output file.");
   desc.addUntracked<std::string>("compressionAlgorithm", "ZLIB")
-      ->setComment("Algorithm used to compress data in the ROOT output file, allowed values are ZLIB and LZMA");
+      ->setComment(
+          "Algorithm used to compress data in the ROOT output file, allowed values are ZLIB, LZMA, ZSTD, and LZ4");
   desc.addUntracked<bool>("saveProvenance", true)
       ->setComment("Save process provenance information, e.g. for edmProvDump");
   desc.addUntracked<bool>("fakeNameForCrab", false)

--- a/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.cc
@@ -4,21 +4,35 @@
 void EventStringOutputFields::registerToken(const edm::EDGetToken &token) { m_tokens.push_back(token); }
 
 void EventStringOutputFields::createFields(ROOT::RNTupleModel &model) {
+  // With nothing kept there is no field at all, as in the TTree module. A token whose string is
+  // always empty still gets one -- the ordinary-MC case -- because RNTuple has to commit to the
+  // schema before seeing any event, where the TTree module can wait and then create no branch.
+  if (m_tokens.empty()) {
+    return;
+  }
   m_evstrings = RNTupleFieldPtr<std::vector<std::string>>("EventStrings", "", model);
 }
 
-void EventStringOutputFields::fill(const edm::EventForOutput &iEvent) {
-  std::vector<std::string> evstrings;
-  if (m_lastLumi != iEvent.id().luminosityBlock()) {
-    edm::Handle<std::string> handle;
-    for (const auto &t : m_tokens) {
-      iEvent.getByToken(t, handle);
-      const std::string &evstr = *handle;
-      if (!evstr.empty()) {
-        evstrings.push_back(evstr);
-      }
-    }
-    m_lastLumi = iEvent.id().luminosityBlock();
+void EventStringOutputFields::bind(ROOT::REntry &entry) const {
+  if (m_tokens.empty()) {
+    return;
   }
-  m_evstrings.fill(evstrings);
+  m_evstrings.bind(entry);
+}
+
+void EventStringOutputFields::fill(const edm::EventForOutput &iEvent) {
+  if (m_tokens.empty()) {
+    return;
+  }
+  // Read on every event rather than caching at lumi boundaries: a value has to be written for every
+  // entry anyway, and the producer makes no promise that genModel is constant within a lumi.
+  m_buffer.clear();
+  edm::Handle<std::string> handle;
+  for (const auto &token : m_tokens) {
+    iEvent.getByToken(token, handle);
+    if (!handle->empty()) {
+      m_buffer.push_back(*handle);
+    }
+  }
+  m_evstrings.fill(m_buffer);
 }

--- a/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.cc
@@ -3,7 +3,7 @@
 
 void EventStringOutputFields::registerToken(const edm::EDGetToken &token) { m_tokens.push_back(token); }
 
-void EventStringOutputFields::createFields(RNTupleModel &model) {
+void EventStringOutputFields::createFields(ROOT::RNTupleModel &model) {
   m_evstrings = RNTupleFieldPtr<std::vector<std::string>>("EventStrings", "", model);
 }
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.h
@@ -6,9 +6,12 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include <ROOT/RNTupleModel.hxx>
-using ROOT::RNTupleModel;
 
 #include "RNTupleFieldPtr.h"
+
+namespace edm {
+  class EventForOutput;
+}
 
 class EventStringOutputFields {
 private:
@@ -20,7 +23,7 @@ public:
   EventStringOutputFields() = default;
 
   void registerToken(const edm::EDGetToken &token);
-  void createFields(RNTupleModel &model);
+  void createFields(ROOT::RNTupleModel &model);
   void fill(const edm::EventForOutput &iEvent);
 };
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.h
@@ -14,17 +14,19 @@ namespace edm {
 }
 
 class EventStringOutputFields {
-private:
-  std::vector<edm::EDGetToken> m_tokens;
-  RNTupleFieldPtr<std::vector<std::string>> m_evstrings;
-  long m_lastLumi = -1;
-
 public:
   EventStringOutputFields() = default;
 
   void registerToken(const edm::EDGetToken &token);
   void createFields(ROOT::RNTupleModel &model);
+  void bind(ROOT::REntry &entry) const;
   void fill(const edm::EventForOutput &iEvent);
+
+private:
+  std::vector<edm::EDGetToken> m_tokens;
+  RNTupleFieldPtr<std::vector<std::string>> m_evstrings;
+  // Reused across events, as in the other vector-valued fields of this module.
+  std::vector<std::string> m_buffer;
 };
 
 #endif

--- a/PhysicsTools/NanoAOD/plugins/rntuple/FlatTableColumnDispatch.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/FlatTableColumnDispatch.h
@@ -1,0 +1,52 @@
+#ifndef PhysicsTools_NanoAOD_FlatTableColumnDispatch_h
+#define PhysicsTools_NanoAOD_FlatTableColumnDispatch_h
+
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <cstdint>
+#include <type_traits>
+
+// Calls func with a std::type_identity tag naming the C++ type that backs the given FlatTable
+// column type, so that code handling all ten column types can be written once:
+//
+//   dispatchColumnType(table.columnType(i), [&](auto tag) {
+//     using ColumnT = typename decltype(tag)::type;
+//     ...
+//   });
+//
+// Note that the storage type of a column is nanoaod::FlatTable::ColumnStorageType<ColumnT>, which
+// differs from ColumnT for bool: table.columnData<bool>() hands back a span of std::uint8_t.
+//
+// The switch deliberately has no default case. -Werror=switch then turns a column type added to
+// nanoaod::FlatTable into a compile error here, rather than something silently unwritten.
+template <typename F>
+decltype(auto) dispatchColumnType(nanoaod::FlatTable::ColumnType type, F&& func) {
+  using ColumnType = nanoaod::FlatTable::ColumnType;
+  switch (type) {
+    case ColumnType::UInt8:
+      return func(std::type_identity<std::uint8_t>{});
+    case ColumnType::Int16:
+      return func(std::type_identity<std::int16_t>{});
+    case ColumnType::UInt16:
+      return func(std::type_identity<std::uint16_t>{});
+    case ColumnType::Int32:
+      return func(std::type_identity<std::int32_t>{});
+    case ColumnType::UInt32:
+      return func(std::type_identity<std::uint32_t>{});
+    case ColumnType::Int64:
+      return func(std::type_identity<std::int64_t>{});
+    case ColumnType::UInt64:
+      return func(std::type_identity<std::uint64_t>{});
+    case ColumnType::Bool:
+      return func(std::type_identity<bool>{});
+    case ColumnType::Float:
+      return func(std::type_identity<float>{});
+    case ColumnType::Double:
+      return func(std::type_identity<double>{});
+  }
+  throw cms::Exception("UnsupportedType")
+      << "Unknown nanoaod::FlatTable::ColumnType " << static_cast<int>(type) << "\n";
+}
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
@@ -13,11 +13,9 @@
 #include <cstdint>
 #include <string>
 
-#include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-using ROOT::RNTupleModel;
 #include <ROOT/RNTupleWriteOptions.hxx>
-using ROOT::RNTupleWriteOptions;
+#include <ROOT/RNTupleWriter.hxx>
 
 #include "TObjString.h"
 
@@ -34,12 +32,19 @@ using ROOT::RNTupleWriteOptions;
 #include "DataFormats/NanoAOD/interface/UniqueString.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 
+#include "EventStringOutputFields.h"
 #include "NanoAODRNTuples.h"
+#include "RNTupleFieldPtr.h"
+#include "TriggerOutputFields.h"
+
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
 
 class NanoAODRNTupleOutputModule : public edm::one::OutputModule<> {
 public:
   NanoAODRNTupleOutputModule(edm::ParameterSet const& pset);
-  ~NanoAODRNTupleOutputModule() override;
+  ~NanoAODRNTupleOutputModule() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -64,6 +69,7 @@ private:
 
   std::unique_ptr<TFile> m_file;
   std::unique_ptr<RNTupleWriter> m_ntuple;
+  std::vector<edm::EDGetToken> m_eventTableTokens;
   TableCollectionSet m_tables;
   std::vector<TriggerOutputFields> m_triggers;
   EventStringOutputFields m_evstrings;
@@ -71,20 +77,20 @@ private:
   class CommonEventFields {
   public:
     void createFields(RNTupleModel& model) {
-      m_run = model.MakeField<UInt_t>("run");
-      m_luminosityBlock = model.MakeField<UInt_t>("luminosityBlock");
-      m_event = model.MakeField<std::uint64_t>("event");
+      m_run = RNTupleFieldPtr<std::uint32_t>("run", "", model);
+      m_luminosityBlock = RNTupleFieldPtr<std::uint32_t>("luminosityBlock", "", model);
+      m_event = RNTupleFieldPtr<std::uint64_t>("event", "", model);
     }
     void fill(const edm::EventID& id) {
-      *m_run = id.run();
-      *m_luminosityBlock = id.luminosityBlock();
-      *m_event = id.event();
+      m_run.fill(id.run());
+      m_luminosityBlock.fill(id.luminosityBlock());
+      m_event.fill(id.event());
     }
 
   private:
-    std::shared_ptr<UInt_t> m_run;
-    std::shared_ptr<UInt_t> m_luminosityBlock;
-    std::shared_ptr<std::uint64_t> m_event;
+    RNTupleFieldPtr<std::uint32_t> m_run;
+    RNTupleFieldPtr<std::uint32_t> m_luminosityBlock;
+    RNTupleFieldPtr<std::uint64_t> m_event;
   } m_commonFields;
 
   LumiNTuple m_lumi;
@@ -121,11 +127,8 @@ NanoAODRNTupleOutputModule::NanoAODRNTupleOutputModule(edm::ParameterSet const& 
       m_compressionAlgorithm(pset.getUntrackedParameter<std::string>("compressionAlgorithm")),
       m_compressionLevel(pset.getUntrackedParameter<int>("compressionLevel")),
       m_writeProvenance(pset.getUntrackedParameter<bool>("saveProvenance", true)),
-      m_processHistoryRegistry(),
       m_noSplitFields{pset.getUntrackedParameter<std::vector<std::string>>("noSplitFields")},
       m_writeOptions(writeOptions(pset.getUntrackedParameterSet("rntupleWriteOptions"))) {}
-
-NanoAODRNTupleOutputModule::~NanoAODRNTupleOutputModule() {}
 
 void NanoAODRNTupleOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput const& iLumi) {
   edm::Service<edm::JobReport> jr;
@@ -144,8 +147,10 @@ void NanoAODRNTupleOutputModule::writeRun(edm::RunForOutput const& iRun) {
   for (const auto& p : m_nanoMetadata) {
     iRun.getByToken(p.second, hstring);
     TObjString* tos = dynamic_cast<TObjString*>(m_file->Get(p.first.c_str()));
-    if (tos && hstring->str() != tos->GetString()) {
-      throw cms::Exception("LogicError", "Inconsistent nanoMetadata " + p.first + " (" + hstring->str() + ")");
+    if (tos) {
+      if (hstring->str() != tos->GetString()) {
+        throw cms::Exception("LogicError", "Inconsistent nanoMetadata " + p.first + " (" + hstring->str() + ")");
+      }
     } else {
       auto ostr = std::make_unique<TObjString>(hstring->str().c_str());
       m_file->WriteTObject(ostr.release(), p.first.c_str());
@@ -154,7 +159,9 @@ void NanoAODRNTupleOutputModule::writeRun(edm::RunForOutput const& iRun) {
   m_processHistoryRegistry.registerProcessHistory(iRun.processHistory());
 }
 
-bool NanoAODRNTupleOutputModule::isFileOpen() const { return nullptr != m_ntuple.get(); }
+// The Events RNTuple is only created on the first event, so the file, not the writer, tracks
+// whether output is open: otherwise a job writing no events would never be closed.
+bool NanoAODRNTupleOutputModule::isFileOpen() const { return nullptr != m_file.get(); }
 
 void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
   m_file = std::make_unique<TFile>(m_fileName.c_str(), "RECREATE", "", m_compressionLevel);
@@ -163,8 +170,6 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
   m_jrToken = jr->outputFileOpened(m_fileName,
                                    m_logicalFileName,
                                    std::string(),
-                                   // TODO check if needed
-                                   //m_fakeName ? "PoolOutputModule" : "NanoAODOutputModule",
                                    "NanoAODRNTupleOutputModule",
                                    description().moduleLabel(),
                                    edm::createGlobalIdentifier(),
@@ -178,11 +183,15 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
     m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZMA);
   } else {
     throw cms::Exception("Configuration")
-        << "NanoAODOutputModule configured with unknown compression algorithm '" << m_compressionAlgorithm << "'\n"
+        << "NanoAODRNTupleOutputModule configured with unknown compression algorithm '" << m_compressionAlgorithm
+        << "'\n"
         << "Allowed compression algorithms are ZLIB and LZMA\n";
   }
   m_writeOptions.SetCompression(m_file->GetCompressionSettings());
 
+  // Sorting the kept products by class only needs their descriptions, so it happens here rather
+  // than on the first event. What the Events model looks like does depend on the payloads, and is
+  // left to initializeNTuple().
   const auto& keeps = keptProducts();
   for (const auto& keep : keeps[edm::InRun]) {
     if (keep.first->className() == "nanoaod::MergeableCounterTable") {
@@ -195,6 +204,20 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
       throw cms::Exception(
           "Configuration",
           "NanoAODRNTupleOutputModule cannot handle class " + keep.first->className() + " in Run RNTuple");
+    }
+  }
+
+  for (const auto& keep : keeps[edm::InEvent]) {
+    if (keep.first->className() == "nanoaod::FlatTable") {
+      m_eventTableTokens.push_back(keep.second);
+    } else if (keep.first->className() == "edm::TriggerResults") {
+      m_triggers.emplace_back(keep.first->processName(), keep.second);
+    } else if (keep.first->className() == "std::basic_string<char,std::char_traits<char> >" &&
+               keep.first->productInstanceName() == "genModel") {
+      m_evstrings.registerToken(keep.second);
+    } else {
+      throw cms::Exception("Configuration",
+                           "NanoAODRNTupleOutputModule cannot handle class " + keep.first->className());
     }
   }
 }
@@ -229,25 +252,15 @@ namespace {
 }  // namespace
 
 void NanoAODRNTupleOutputModule::initializeNTuple(edm::EventForOutput const& iEvent) {
-  // set up RNTuple schema
+  // RNTuple needs the whole schema before the first Fill, and which fields a FlatTable needs is
+  // only visible from its contents, so the Events model is built on the first event.
   auto model = RNTupleModel::Create();
   m_commonFields.createFields(*model);
 
-  const auto& keeps = keptProducts();
-  for (const auto& keep : keeps[edm::InEvent]) {
-    if (keep.first->className() == "nanoaod::FlatTable") {
-      edm::Handle<nanoaod::FlatTable> handle;
-      const auto& token = keep.second;
-      iEvent.getByToken(token, handle);
-      m_tables.add(token, *handle);
-    } else if (keep.first->className() == "edm::TriggerResults") {
-      m_triggers.emplace_back(TriggerOutputFields(keep.first->processName(), keep.second));
-    } else if (keep.first->className() == "std::basic_string<char,std::char_traits<char> >" &&
-               keep.first->productInstanceName() == "genModel") {
-      m_evstrings.registerToken(keep.second);
-    } else {
-      throw cms::Exception("Configuration", "NanoAODOutputModule cannot handle class " + keep.first->className());
-    }
+  edm::Handle<nanoaod::FlatTable> handle;
+  for (const auto& token : m_eventTableTokens) {
+    iEvent.getByToken(token, handle);
+    m_tables.add(token, *handle);
   }
   m_tables.createFields(iEvent, *model);
   for (auto& trigger : m_triggers) {
@@ -303,19 +316,15 @@ void NanoAODRNTupleOutputModule::reallyCloseFile() {
   m_run.finalizeWrite();
   m_file->Write();
   m_file->Close();
+  m_file.reset();
 
   edm::Service<edm::JobReport> jr;
   jr->outputFileClosed(m_jrToken);
 }
 
 void NanoAODRNTupleOutputModule::writeProvenance() {
-  PSetNTuple pntuple;
-  pntuple.fill(edm::pset::Registry::instance(), *m_file);
-  pntuple.finalizeWrite();
-
-  MetadataNTuple mdntuple;
-  mdntuple.fill(m_processHistoryRegistry, *m_file);
-  mdntuple.finalizeWrite();
+  rntupleprovenance::writeParameterSets(*m_file);
+  rntupleprovenance::writeProcessHistory(m_processHistoryRegistry, *m_file);
 }
 
 void NanoAODRNTupleOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
@@ -13,10 +13,12 @@
 #include <cstdint>
 #include <string>
 
+#include <ROOT/REntry.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
 
+#include "Compression.h"
 #include "TObjString.h"
 
 #include "FWCore/Framework/interface/one/OutputModule.h"
@@ -30,6 +32,7 @@
 #include "FWCore/Utilities/interface/Digest.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "DataFormats/NanoAOD/interface/UniqueString.h"
+#include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 
 #include "EventStringOutputFields.h"
@@ -58,10 +61,14 @@ private:
   void writeProvenance();
 
   void initializeNTuple(edm::EventForOutput const& e);
+  // Create the entry the Events ntuple is filled through and point every field at its value. The
+  // Events model is bare, so there is no default entry to fall back on, and a schema update
+  // invalidates the entry, so this runs again after each one.
+  void bindEntry();
 
   std::string m_fileName;
   std::string m_logicalFileName;
-  std::string m_compressionAlgorithm;
+  ROOT::RCompressionSetting::EAlgorithm::EValues m_compressionAlgorithm;
   int m_compressionLevel;
   bool m_writeProvenance;
   edm::ProcessHistoryRegistry m_processHistoryRegistry;
@@ -69,6 +76,7 @@ private:
 
   std::unique_ptr<TFile> m_file;
   std::unique_ptr<RNTupleWriter> m_ntuple;
+  std::unique_ptr<ROOT::REntry> m_entry;
   std::vector<edm::EDGetToken> m_eventTableTokens;
   TableCollectionSet m_tables;
   std::vector<TriggerOutputFields> m_triggers;
@@ -80,17 +88,33 @@ private:
       m_run = RNTupleFieldPtr<std::uint32_t>("run", "", model);
       m_luminosityBlock = RNTupleFieldPtr<std::uint32_t>("luminosityBlock", "", model);
       m_event = RNTupleFieldPtr<std::uint64_t>("event", "", model);
+      m_bunchCrossing = RNTupleFieldPtr<std::uint32_t>("bunchCrossing", "", model);
+      m_orbitNumber = RNTupleFieldPtr<std::uint32_t>("orbitNumber", "", model);
     }
-    void fill(const edm::EventID& id) {
-      m_run.fill(id.run());
-      m_luminosityBlock.fill(id.luminosityBlock());
-      m_event.fill(id.event());
+    void bind(ROOT::REntry& entry) const {
+      m_run.bind(entry);
+      m_luminosityBlock.bind(entry);
+      m_event.bind(entry);
+      m_bunchCrossing.bind(entry);
+      m_orbitNumber.bind(entry);
+    }
+    void fill(const edm::EventAuxiliary& aux) {
+      m_run.fill(aux.id().run());
+      m_luminosityBlock.fill(aux.id().luminosityBlock());
+      m_event.fill(aux.id().event());
+      // EventAuxiliary reports both of these as a signed int, using -1 for "not available" (as in
+      // simulation). NanoAOD has always published them unsigned, so an unavailable value shows up
+      // as 0xffffffff; keep that rather than inventing a representation the TTree output lacks.
+      m_bunchCrossing.fill(static_cast<std::uint32_t>(aux.bunchCrossing()));
+      m_orbitNumber.fill(static_cast<std::uint32_t>(aux.orbitNumber()));
     }
 
   private:
     RNTupleFieldPtr<std::uint32_t> m_run;
     RNTupleFieldPtr<std::uint32_t> m_luminosityBlock;
     RNTupleFieldPtr<std::uint64_t> m_event;
+    RNTupleFieldPtr<std::uint32_t> m_bunchCrossing;
+    RNTupleFieldPtr<std::uint32_t> m_orbitNumber;
   } m_commonFields;
 
   LumiNTuple m_lumi;
@@ -99,10 +123,31 @@ private:
   std::vector<std::pair<std::string, edm::EDGetToken>> m_nanoMetadata;
 
   std::vector<std::string> m_noSplitFields;
+  // Whether the members of the grouped fields also get the flat TTree names; see rntupleprojection.
+  bool m_flatProjections;
   ROOT::RNTupleWriteOptions m_writeOptions;
 };
 
 namespace {
+  // The four algorithms the TTree NanoAODOutputModule accepts. RNTuple compresses its pages through
+  // the same ROOT machinery, so it supports all of them; parse here so a bad name fails at
+  // construction rather than when the first output file is opened.
+  ROOT::RCompressionSetting::EAlgorithm::EValues compressionAlgorithm(const std::string& name) {
+    using EAlgorithm = ROOT::RCompressionSetting::EAlgorithm;
+    if (name == "ZLIB") {
+      return EAlgorithm::kZLIB;
+    } else if (name == "LZMA") {
+      return EAlgorithm::kLZMA;
+    } else if (name == "ZSTD") {
+      return EAlgorithm::kZSTD;
+    } else if (name == "LZ4") {
+      return EAlgorithm::kLZ4;
+    }
+    throw cms::Exception("Configuration")
+        << "NanoAODRNTupleOutputModule configured with unknown compression algorithm '" << name << "'\n"
+        << "Allowed compression algorithms are ZLIB, LZMA, ZSTD, and LZ4\n";
+  }
+
   ROOT::RNTupleWriteOptions writeOptions(edm::ParameterSet const& iConfig) {
     ROOT::RNTupleWriteOptions options;
 
@@ -124,16 +169,20 @@ NanoAODRNTupleOutputModule::NanoAODRNTupleOutputModule(edm::ParameterSet const& 
       edm::one::OutputModule<>(pset),
       m_fileName(pset.getUntrackedParameter<std::string>("fileName")),
       m_logicalFileName(pset.getUntrackedParameter<std::string>("logicalFileName")),
-      m_compressionAlgorithm(pset.getUntrackedParameter<std::string>("compressionAlgorithm")),
+      m_compressionAlgorithm(compressionAlgorithm(pset.getUntrackedParameter<std::string>("compressionAlgorithm"))),
       m_compressionLevel(pset.getUntrackedParameter<int>("compressionLevel")),
       m_writeProvenance(pset.getUntrackedParameter<bool>("saveProvenance", true)),
       m_noSplitFields{pset.getUntrackedParameter<std::vector<std::string>>("noSplitFields")},
-      m_writeOptions(writeOptions(pset.getUntrackedParameterSet("rntupleWriteOptions"))) {}
+      m_flatProjections(pset.getUntrackedParameter<bool>("flatProjections")),
+      m_writeOptions(writeOptions(pset.getUntrackedParameterSet("rntupleWriteOptions"))) {
+  m_lumi.setFlatProjections(m_flatProjections);
+  m_run.setFlatProjections(m_flatProjections);
+}
 
 void NanoAODRNTupleOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput const& iLumi) {
   edm::Service<edm::JobReport> jr;
   jr->reportLumiSection(m_jrToken, iLumi.id().run(), iLumi.id().value());
-  m_lumi.fill(iLumi.id(), *m_file);
+  m_lumi.fill(iLumi, *m_file);
   m_processHistoryRegistry.registerProcessHistory(iLumi.processHistory());
 }
 
@@ -177,21 +226,12 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
                                    branchHash.digest().toString(),
                                    std::vector<std::string>());
 
-  if (m_compressionAlgorithm == "ZLIB") {
-    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kZLIB);
-  } else if (m_compressionAlgorithm == "LZMA") {
-    m_file->SetCompressionAlgorithm(ROOT::RCompressionSetting::EAlgorithm::kLZMA);
-  } else {
-    throw cms::Exception("Configuration")
-        << "NanoAODRNTupleOutputModule configured with unknown compression algorithm '" << m_compressionAlgorithm
-        << "'\n"
-        << "Allowed compression algorithms are ZLIB and LZMA\n";
-  }
+  m_file->SetCompressionAlgorithm(m_compressionAlgorithm);
+  // Every RNTuple in the file takes its compression from the file, so this must follow the setter.
   m_writeOptions.SetCompression(m_file->GetCompressionSettings());
 
-  // Sorting the kept products by class only needs their descriptions, so it happens here rather
-  // than on the first event. What the Events model looks like does depend on the payloads, and is
-  // left to initializeNTuple().
+  // Sorting the kept products by class only needs their descriptions, so it happens here; what the
+  // Events model looks like does depend on the payloads and is left to initializeNTuple().
   const auto& keeps = keptProducts();
   for (const auto& keep : keeps[edm::InRun]) {
     if (keep.first->className() == "nanoaod::MergeableCounterTable") {
@@ -204,6 +244,20 @@ void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
       throw cms::Exception(
           "Configuration",
           "NanoAODRNTupleOutputModule cannot handle class " + keep.first->className() + " in Run RNTuple");
+    }
+  }
+
+  // nanoaod::UniqueString is deliberately absent here: UniqueStringProducer only produces InRun, so
+  // a lumi-level one would need handling that cannot be exercised, and the throw below says so.
+  for (const auto& keep : keeps[edm::InLumi]) {
+    if (keep.first->className() == "nanoaod::MergeableCounterTable") {
+      m_lumi.registerCounterTableToken(keep.second);
+    } else if (keep.first->className() == "nanoaod::FlatTable") {
+      m_lumi.registerFlatTableToken(keep.second);
+    } else {
+      throw cms::Exception(
+          "Configuration",
+          "NanoAODRNTupleOutputModule cannot handle class " + keep.first->className() + " in LuminosityBlock RNTuple");
     }
   }
 
@@ -254,7 +308,11 @@ namespace {
 void NanoAODRNTupleOutputModule::initializeNTuple(edm::EventForOutput const& iEvent) {
   // RNTuple needs the whole schema before the first Fill, and which fields a FlatTable needs is
   // only visible from its contents, so the Events model is built on the first event.
-  auto model = RNTupleModel::Create();
+  //
+  // Bare, i.e. with no default entry of its own: ROOT refuses to add a subfield to an untyped
+  // record of a non-bare model, and that is how a trigger path first seen in a later run gets a
+  // field (TriggerRecordFields::update). Every field is therefore bound to m_entry by hand.
+  auto model = RNTupleModel::CreateBare();
   m_commonFields.createFields(*model);
 
   edm::Handle<nanoaod::FlatTable> handle;
@@ -281,11 +339,31 @@ void NanoAODRNTupleOutputModule::initializeNTuple(edm::EventForOutput const& iEv
     }
   }
 
+  // After the noSplit pass, so that a projection never lands on a source field whose column
+  // representation is about to be pinned, and so that the pass itself only ever sees real fields.
+  if (m_flatProjections) {
+    m_tables.addProjections(*model);
+    for (auto& trigger : m_triggers) {
+      trigger.addProjections(*model);
+    }
+  }
+
   // Model needs to be frozen before we bind buffers
   model->Freeze();
 
-  m_tables.bindBuffers(*model);
   m_ntuple = RNTupleWriter::Append(std::move(model), "Events", *m_file, m_writeOptions);
+  bindEntry();
+}
+
+void NanoAODRNTupleOutputModule::bindEntry() {
+  const auto& model = m_ntuple->GetModel();
+  m_entry = model.CreateBareEntry();
+  m_commonFields.bind(*m_entry);
+  m_tables.bind(*m_entry);
+  for (auto& trigger : m_triggers) {
+    trigger.bind(*m_entry, model);
+  }
+  m_evstrings.bind(*m_entry);
 }
 
 void NanoAODRNTupleOutputModule::write(edm::EventForOutput const& iEvent) {
@@ -296,13 +374,23 @@ void NanoAODRNTupleOutputModule::write(edm::EventForOutput const& iEvent) {
   edm::Service<edm::JobReport> jr;
   jr->eventWrittenToFile(m_jrToken, iEvent.id().run(), iEvent.id().event());
 
-  m_commonFields.fill(iEvent.id());
+  // A run boundary can bring a menu that the schema was not built from, and a trigger record that
+  // grows to fit it leaves every entry of the old schema invalid.
+  bool schemaChanged = false;
+  for (auto& trigger : m_triggers) {
+    schemaChanged |= trigger.updateForRun(iEvent, *m_ntuple, m_flatProjections);
+  }
+  if (schemaChanged) {
+    bindEntry();
+  }
+
+  m_commonFields.fill(iEvent.eventAuxiliary());
   m_tables.fill(iEvent);
   for (auto& trigger : m_triggers) {
     trigger.fill(iEvent);
   }
   m_evstrings.fill(iEvent);
-  m_ntuple->Fill();
+  m_ntuple->Fill(*m_entry);
   m_processHistoryRegistry.registerProcessHistory(iEvent.processHistory());
 }
 
@@ -310,7 +398,9 @@ void NanoAODRNTupleOutputModule::reallyCloseFile() {
   if (m_writeProvenance) {
     writeProvenance();
   }
-  // write ntuple to disk by calling the RNTupleWriter destructor
+  // write ntuple to disk by calling the RNTupleWriter destructor, after letting go of the entry
+  // that borrows the model the writer owns
+  m_entry.reset();
   m_ntuple.reset();
   m_lumi.finalizeWrite();
   m_run.finalizeWrite();
@@ -336,9 +426,15 @@ void NanoAODRNTupleOutputModule::fillDescriptions(edm::ConfigurationDescriptions
   desc.addUntracked<std::string>("compressionAlgorithm", "ZLIB")
       ->setComment(
           "Algorithm used to "
-          "compress data in the ROOT output file, allowed values are ZLIB and LZMA");
+          "compress data in the ROOT output file, allowed values are ZLIB, LZMA, ZSTD, and LZ4");
   desc.addUntracked<std::vector<std::string>>("noSplitFields", {})
       ->setComment("Name of fields to avoid the standard ROOT split optimization.");
+  desc.addUntracked<bool>("flatProjections", true)
+      ->setComment(
+          "Also give every member of a grouped field the flat name the TTree output uses for it: "
+          "GenJet_pt beside GenJet.pt, HLT_IsoMu24 beside HLT.IsoMu24. These are projected fields, "
+          "i.e. second names for the same columns, so they add nothing to the file but their schema "
+          "entry. Set false to write the grouped names only.");
   {
     edm::ParameterSetDescription optimizations;
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.cc
@@ -26,19 +26,53 @@ namespace {
   }
 }  // anonymous namespace
 
-void LumiNTuple::createFields(TFile& file) {
+void LumiNTuple::registerCounterTableToken(const edm::EDGetToken& token) { m_counterTableTokens.push_back(token); }
+
+void LumiNTuple::registerFlatTableToken(const edm::EDGetToken& token) { m_flatTableTokens.push_back(token); }
+
+void LumiNTuple::createFields(const edm::LuminosityBlockForOutput& iLumi, TFile& file) {
   auto model = RNTupleModel::Create();
   m_run = RNTupleFieldPtr<std::uint32_t>("run", "", *model);
   m_luminosityBlock = RNTupleFieldPtr<std::uint32_t>("luminosityBlock", "", *model);
+
+  edm::Handle<nanoaod::MergeableCounterTable> counterTableHandle;
+  for (const auto& token : m_counterTableTokens) {
+    iLumi.getByToken(token, counterTableHandle);
+    m_counterTables.emplace_back(*counterTableHandle, *model);
+  }
+
+  edm::Handle<nanoaod::FlatTable> flatTableHandle;
+  for (const auto& token : m_flatTableTokens) {
+    iLumi.getByToken(token, flatTableHandle);
+    m_flatTables.add(token, *flatTableHandle);
+  }
+  m_flatTables.createFields(iLumi, *model);
+  if (m_flatProjections) {
+    m_flatTables.addProjections(*model);
+  }
+
+  // Collection buffers can only be bound once the schema is frozen, and the writer takes ownership
+  // of the model, so this has to happen here rather than after Append().
+  model->Freeze();
+  m_flatTables.bind(model->GetDefaultEntry());
   m_ntuple = RNTupleWriter::Append(std::move(model), "LuminosityBlocks", file, writeOptions(file));
 }
 
-void LumiNTuple::fill(const edm::LuminosityBlockID& id, TFile& file) {
+void LumiNTuple::fill(const edm::LuminosityBlockForOutput& iLumi, TFile& file) {
   if (!m_ntuple) {
-    createFields(file);
+    createFields(iLumi, file);
   }
-  m_run.fill(id.run());
-  m_luminosityBlock.fill(id.value());
+  m_run.fill(iLumi.id().run());
+  m_luminosityBlock.fill(iLumi.id().value());
+
+  edm::Handle<nanoaod::MergeableCounterTable> counterTableHandle;
+  for (std::size_t i = 0; i < m_counterTableTokens.size(); i++) {
+    iLumi.getByToken(m_counterTableTokens[i], counterTableHandle);
+    m_counterTables[i].fill(*counterTableHandle);
+  }
+
+  m_flatTables.fill(iLumi);
+
   m_ntuple->Fill();
 }
 
@@ -64,7 +98,13 @@ void RunNTuple::createFields(const edm::RunForOutput& iRun, TFile& file) {
     m_flatTables.add(token, *flatTableHandle);
   }
   m_flatTables.createFields(iRun, *model);
+  if (m_flatProjections) {
+    m_flatTables.addProjections(*model);
+  }
 
+  // See LumiNTuple::createFields for why the bind sits between the freeze and the Append().
+  model->Freeze();
+  m_flatTables.bind(model->GetDefaultEntry());
   m_ntuple = RNTupleWriter::Append(std::move(model), "Runs", file, writeOptions(file));
 }
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.cc
@@ -1,28 +1,41 @@
 #include "NanoAODRNTuples.h"
 
 #include "DataFormats/NanoAOD/interface/MergeableCounterTable.h"
+#include "DataFormats/Provenance/interface/BranchType.h"
+#include "DataFormats/Provenance/interface/ParameterSetBlob.h"
+#include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "FWCore/Framework/interface/RunForOutput.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
 
 #include <ROOT/RNTupleModel.hxx>
-using ROOT::RNTupleModel;
 #include <ROOT/RNTupleWriteOptions.hxx>
-using ROOT::RNTupleWriteOptions;
 
 #include "RNTupleFieldPtr.h"
 #include "SummaryTableOutputFields.h"
 
-void LumiNTuple::createFields(const edm::LuminosityBlockID& id, TFile& file) {
+using ROOT::RNTupleModel;
+using ROOT::RNTupleWriteOptions;
+using ROOT::RNTupleWriter;
+
+namespace {
+  // Every ntuple in the file inherits the file's compression and takes the ROOT defaults otherwise.
+  RNTupleWriteOptions writeOptions(const TFile& file) {
+    RNTupleWriteOptions options;
+    options.SetCompression(file.GetCompressionSettings());
+    return options;
+  }
+}  // anonymous namespace
+
+void LumiNTuple::createFields(TFile& file) {
   auto model = RNTupleModel::Create();
-  m_run = RNTupleFieldPtr<UInt_t>("run", "", *model);
-  m_luminosityBlock = RNTupleFieldPtr<UInt_t>("luminosityBlock", "", *model);
-  RNTupleWriteOptions options;
-  options.SetCompression(file.GetCompressionSettings());
-  m_ntuple = RNTupleWriter::Append(std::move(model), "LuminosityBlocks", file, options);
+  m_run = RNTupleFieldPtr<std::uint32_t>("run", "", *model);
+  m_luminosityBlock = RNTupleFieldPtr<std::uint32_t>("luminosityBlock", "", *model);
+  m_ntuple = RNTupleWriter::Append(std::move(model), "LuminosityBlocks", file, writeOptions(file));
 }
 
 void LumiNTuple::fill(const edm::LuminosityBlockID& id, TFile& file) {
   if (!m_ntuple) {
-    createFields(id, file);
+    createFields(file);
   }
   m_run.fill(id.run());
   m_luminosityBlock.fill(id.value());
@@ -37,13 +50,12 @@ void RunNTuple::registerFlatTableToken(const edm::EDGetToken& token) { m_flatTab
 
 void RunNTuple::createFields(const edm::RunForOutput& iRun, TFile& file) {
   auto model = RNTupleModel::Create();
-  m_run = RNTupleFieldPtr<UInt_t>("run", "", *model);
+  m_run = RNTupleFieldPtr<std::uint32_t>("run", "", *model);
 
   edm::Handle<nanoaod::MergeableCounterTable> counterTableHandle;
   for (const auto& token : m_counterTableTokens) {
     iRun.getByToken(token, counterTableHandle);
-    const nanoaod::MergeableCounterTable& tab = *counterTableHandle;
-    m_counterTables.push_back(SummaryTableOutputFields(tab, *model));
+    m_counterTables.emplace_back(*counterTableHandle, *model);
   }
 
   edm::Handle<nanoaod::FlatTable> flatTableHandle;
@@ -53,9 +65,7 @@ void RunNTuple::createFields(const edm::RunForOutput& iRun, TFile& file) {
   }
   m_flatTables.createFields(iRun, *model);
 
-  RNTupleWriteOptions options;
-  options.SetCompression(file.GetCompressionSettings());
-  m_ntuple = RNTupleWriter::Append(std::move(model), "Runs", file, options);
+  m_ntuple = RNTupleWriter::Append(std::move(model), "Runs", file, writeOptions(file));
 }
 
 void RunNTuple::fill(const edm::RunForOutput& iRun, TFile& file) {
@@ -66,9 +76,8 @@ void RunNTuple::fill(const edm::RunForOutput& iRun, TFile& file) {
 
   edm::Handle<nanoaod::MergeableCounterTable> counterTableHandle;
   for (std::size_t i = 0; i < m_counterTableTokens.size(); i++) {
-    iRun.getByToken(m_counterTableTokens.at(i), counterTableHandle);
-    const nanoaod::MergeableCounterTable& tab = *counterTableHandle;
-    m_counterTables.at(i).fill(tab);
+    iRun.getByToken(m_counterTableTokens[i], counterTableHandle);
+    m_counterTables[i].fill(*counterTableHandle);
   }
 
   m_flatTables.fill(iRun);
@@ -78,49 +87,34 @@ void RunNTuple::fill(const edm::RunForOutput& iRun, TFile& file) {
 
 void RunNTuple::finalizeWrite() { m_ntuple.reset(); }
 
-void PSetNTuple::createFields(TFile& file) {
-  auto model = RNTupleModel::Create();
-  m_pset = RNTupleFieldPtr<PSetType>(edm::poolNames::idToParameterSetBlobsBranchName(), "", *model);
+namespace rntupleprovenance {
 
-  RNTupleWriteOptions options;
-  options.SetCompression(file.GetCompressionSettings());
-  m_ntuple = RNTupleWriter::Append(std::move(model), edm::poolNames::parameterSetsTreeName(), file, options);
-}
+  void writeParameterSets(TFile& file) {
+    using PSetType = std::pair<edm::ParameterSetID, edm::ParameterSetBlob>;
 
-void PSetNTuple::fill(edm::pset::Registry* pset, TFile& file) {
-  if (!pset) {
-    throw cms::Exception("LogicError", "null edm::pset::Registry::Instance pointer");
+    auto model = RNTupleModel::Create();
+    auto psets = RNTupleFieldPtr<PSetType>(edm::poolNames::idToParameterSetBlobsBranchName(), "", *model);
+    // The writer commits when it goes out of scope at the end of this function.
+    auto ntuple =
+        RNTupleWriter::Append(std::move(model), edm::poolNames::parameterSetsTreeName(), file, writeOptions(file));
+
+    for (const auto& ps : *edm::pset::Registry::instance()) {
+      std::string psString;
+      ps.second.toString(psString);
+      psets.fill(std::make_pair(ps.first, edm::ParameterSetBlob(psString)));
+      ntuple->Fill();
+    }
   }
-  if (!m_ntuple) {
-    createFields(file);
-  }
-  for (const auto& ps : *pset) {
-    std::string psString;
-    ps.second.toString(psString);
-    edm::ParameterSetBlob psBlob(psString);
-    m_pset.fill(std::make_pair(ps.first, psBlob));
-    m_ntuple->Fill();
-  }
-}
 
-void PSetNTuple::finalizeWrite() { m_ntuple.reset(); }
+  void writeProcessHistory(const edm::ProcessHistoryRegistry& procHist, TFile& file) {
+    auto model = RNTupleModel::Create();
+    auto history = RNTupleFieldPtr<edm::ProcessHistory>(edm::poolNames::processHistoryBranchName(), "", *model);
+    auto ntuple = RNTupleWriter::Append(std::move(model), edm::poolNames::metaDataTreeName(), file, writeOptions(file));
 
-void MetadataNTuple::createFields(TFile& file) {
-  auto model = RNTupleModel::Create();
-  m_procHist = RNTupleFieldPtr<edm::ProcessHistory>(edm::poolNames::processHistoryBranchName(), "", *model);
-  RNTupleWriteOptions options;
-  options.SetCompression(file.GetCompressionSettings());
-  m_ntuple = RNTupleWriter::Append(std::move(model), edm::poolNames::metaDataTreeName(), file, options);
-}
-
-void MetadataNTuple::fill(const edm::ProcessHistoryRegistry& procHist, TFile& file) {
-  if (!m_ntuple) {
-    createFields(file);
+    for (const auto& ph : procHist) {
+      history.fill(ph.second);
+      ntuple->Fill();
+    }
   }
-  for (const auto& ph : procHist) {
-    m_procHist.fill(ph.second);
-    m_ntuple->Fill();
-  }
-}
 
-void MetadataNTuple::finalizeWrite() { m_ntuple.reset(); }
+}  // namespace rntupleprovenance

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
@@ -1,25 +1,20 @@
 #ifndef PhysicsTools_NanoAOD_NanoAODRNTuples_h
 #define PhysicsTools_NanoAOD_NanoAODRNTuples_h
 
-#include "DataFormats/Provenance/interface/BranchType.h"
-#include "DataFormats/Provenance/interface/ParameterSetBlob.h"
-#include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
 #include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
 #include "FWCore/Framework/interface/RunForOutput.h"
-#include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "TFile.h"
-#include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleWriter.hxx>
-using ROOT::RNTupleWriter;
 
-#include "EventStringOutputFields.h"
 #include "RNTupleFieldPtr.h"
 #include "SummaryTableOutputFields.h"
 #include "TableOutputFields.h"
-#include "TriggerOutputFields.h"
+
+// The LuminosityBlocks and Runs ntuples are created on their first fill, because their schema is
+// only known once the first payload is in hand, and committed by finalizeWrite().
 
 class LumiNTuple {
 public:
@@ -28,10 +23,10 @@ public:
   void finalizeWrite();
 
 private:
-  void createFields(const edm::LuminosityBlockID& id, TFile& file);
-  std::unique_ptr<RNTupleWriter> m_ntuple;
-  RNTupleFieldPtr<UInt_t> m_run;
-  RNTupleFieldPtr<UInt_t> m_luminosityBlock;
+  void createFields(TFile& file);
+  std::unique_ptr<ROOT::RNTupleWriter> m_ntuple;
+  RNTupleFieldPtr<std::uint32_t> m_run;
+  RNTupleFieldPtr<std::uint32_t> m_luminosityBlock;
 };
 
 class RunNTuple {
@@ -46,35 +41,20 @@ private:
   void createFields(const edm::RunForOutput& iRun, TFile& file);
   std::vector<edm::EDGetToken> m_counterTableTokens;
   std::vector<edm::EDGetToken> m_flatTableTokens;
-  std::unique_ptr<RNTupleWriter> m_ntuple;
-  RNTupleFieldPtr<UInt_t> m_run;
+  std::unique_ptr<ROOT::RNTupleWriter> m_ntuple;
+  RNTupleFieldPtr<std::uint32_t> m_run;
   std::vector<SummaryTableOutputFields> m_counterTables;
   TableCollectionSet m_flatTables;
 };
 
-class PSetNTuple {
-public:
-  PSetNTuple() = default;
-  void fill(edm::pset::Registry* pset, TFile& file);
-  void finalizeWrite();
-
-private:
-  using PSetType = std::pair<edm::ParameterSetID, edm::ParameterSetBlob>;
-  RNTupleFieldPtr<PSetType> m_pset;
-  void createFields(TFile& file);
-  std::unique_ptr<RNTupleWriter> m_ntuple;
-};
-
-class MetadataNTuple {
-public:
-  MetadataNTuple() = default;
-  void fill(const edm::ProcessHistoryRegistry& procHist, TFile& file);
-  void finalizeWrite();
-
-private:
-  void createFields(TFile& file);
-  RNTupleFieldPtr<edm::ProcessHistory> m_procHist;
-  std::unique_ptr<RNTupleWriter> m_ntuple;
-};
+// Provenance, in contrast, is written in one pass at the end of the job. These are namespaced
+// because a plugin library exports them: the generic EDM RNTuple output in FWIO/RNTupleTemp*
+// writes the same two ntuples, and a job loading both plugins would otherwise risk an ODR clash.
+namespace rntupleprovenance {
+  // Writes the parameter set registry as the ParameterSets ntuple.
+  void writeParameterSets(TFile& file);
+  // Writes the process history as the MetaData ntuple.
+  void writeProcessHistory(const edm::ProcessHistoryRegistry& procHist, TFile& file);
+}  // namespace rntupleprovenance
 
 #endif

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
@@ -19,14 +19,24 @@
 class LumiNTuple {
 public:
   LumiNTuple() = default;
-  void fill(const edm::LuminosityBlockID& id, TFile& file);
+  void registerCounterTableToken(const edm::EDGetToken& token);
+  void registerFlatTableToken(const edm::EDGetToken& token);
+  // Whether the collections also get their members under the flat TTree names; see
+  // rntupleprojection. Has to be set before the first fill, which is what builds the schema.
+  void setFlatProjections(bool flatProjections) { m_flatProjections = flatProjections; }
+  void fill(const edm::LuminosityBlockForOutput& iLumi, TFile& file);
   void finalizeWrite();
 
 private:
-  void createFields(TFile& file);
+  void createFields(const edm::LuminosityBlockForOutput& iLumi, TFile& file);
+  bool m_flatProjections = true;
+  std::vector<edm::EDGetToken> m_counterTableTokens;
+  std::vector<edm::EDGetToken> m_flatTableTokens;
   std::unique_ptr<ROOT::RNTupleWriter> m_ntuple;
   RNTupleFieldPtr<std::uint32_t> m_run;
   RNTupleFieldPtr<std::uint32_t> m_luminosityBlock;
+  std::vector<SummaryTableOutputFields> m_counterTables;
+  TableCollectionSet m_flatTables;
 };
 
 class RunNTuple {
@@ -34,11 +44,15 @@ public:
   RunNTuple() = default;
   void registerCounterTableToken(const edm::EDGetToken& token);
   void registerFlatTableToken(const edm::EDGetToken& token);
+  // Whether the collections also get their members under the flat TTree names; see
+  // rntupleprojection. Has to be set before the first fill, which is what builds the schema.
+  void setFlatProjections(bool flatProjections) { m_flatProjections = flatProjections; }
   void fill(const edm::RunForOutput& iRun, TFile& file);
   void finalizeWrite();
 
 private:
   void createFields(const edm::RunForOutput& iRun, TFile& file);
+  bool m_flatProjections = true;
   std::vector<edm::EDGetToken> m_counterTableTokens;
   std::vector<edm::EDGetToken> m_flatTableTokens;
   std::unique_ptr<ROOT::RNTupleWriter> m_ntuple;

--- a/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleCollection.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleCollection.cc
@@ -1,5 +1,8 @@
 #include "RNTupleCollection.h"
 
+#include "FlatTableColumnDispatch.h"
+
+#include <ROOT/RField.hxx>
 #include <ROOT/RFieldBase.hxx>
 #include <ROOT/RField/RFieldRecord.hxx>
 #include <ROOT/RField/RFieldSequenceContainer.hxx>
@@ -10,71 +13,23 @@ using ROOT::RNTupleModel;
 using ROOT::RRecordField;
 using ROOT::RVectorField;
 
-std::string flatTableColumnTypeToString(nanoaod::FlatTable::ColumnType type) {
-  switch (type) {
-    case nanoaod::FlatTable::ColumnType::UInt8:
-      return "std::uint8_t";
-    case nanoaod::FlatTable::ColumnType::Int16:
-      return "std::int16_t";
-    case nanoaod::FlatTable::ColumnType::UInt16:
-      return "std::uint16_t";
-    case nanoaod::FlatTable::ColumnType::Int32:
-      return "std::int32_t";
-    case nanoaod::FlatTable::ColumnType::UInt32:
-      return "std::uint32_t";
-    case nanoaod::FlatTable::ColumnType::Int64:
-      return "std::int64_t";
-    case nanoaod::FlatTable::ColumnType::UInt64:
-      return "std::uint64_t";
-    case nanoaod::FlatTable::ColumnType::Bool:
-      return "bool";
-    case nanoaod::FlatTable::ColumnType::Float:
-      return "float";
-    case nanoaod::FlatTable::ColumnType::Double:
-      return "double";
-    default:
-      throw cms::Exception("LogicError", "Unsupported type");
+namespace {
+  // The RNTuple type name for a FlatTable column, e.g. "std::uint8_t" or "float".
+  std::string columnTypeName(nanoaod::FlatTable::ColumnType type) {
+    return dispatchColumnType(type, [](auto tag) { return ROOT::RField<typename decltype(tag)::type>::TypeName(); });
   }
-}
 
-std::tuple<const unsigned char*, unsigned int> getColStartAndTypeSize(edm::Handle<nanoaod::FlatTable>& table,
-                                                                      unsigned int colIdx) {
-  const unsigned char* col_start;
-  switch (table->columnType(colIdx)) {
-    case nanoaod::FlatTable::ColumnType::UInt8:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<uint8_t>(colIdx).data());
-      return std::make_tuple(col_start, 1);
-    case nanoaod::FlatTable::ColumnType::Int16:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<int16_t>(colIdx).data());
-      return std::make_tuple(col_start, 2);
-    case nanoaod::FlatTable::ColumnType::UInt16:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<uint16_t>(colIdx).data());
-      return std::make_tuple(col_start, 2);
-    case nanoaod::FlatTable::ColumnType::Int32:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<int32_t>(colIdx).data());
-      return std::make_tuple(col_start, 4);
-    case nanoaod::FlatTable::ColumnType::UInt32:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<uint32_t>(colIdx).data());
-      return std::make_tuple(col_start, 4);
-    case nanoaod::FlatTable::ColumnType::Int64:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<int64_t>(colIdx).data());
-      return std::make_tuple(col_start, 8);
-    case nanoaod::FlatTable::ColumnType::UInt64:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<uint64_t>(colIdx).data());
-      return std::make_tuple(col_start, 8);
-    case nanoaod::FlatTable::ColumnType::Bool:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<bool>(colIdx).data());
-      return std::make_tuple(col_start, 1);
-    case nanoaod::FlatTable::ColumnType::Float:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<float>(colIdx).data());
-      return std::make_tuple(col_start, 4);
-    case nanoaod::FlatTable::ColumnType::Double:
-      col_start = reinterpret_cast<const unsigned char*>(table->columnData<double>(colIdx).data());
-      return std::make_tuple(col_start, 8);
-    default:
-      throw cms::Exception("LogicError", "Unsupported type");
+  // Where a column's values start in the FlatTable, and how wide one value is.
+  std::tuple<const unsigned char*, unsigned int> getColStartAndTypeSize(const nanoaod::FlatTable& table,
+                                                                        unsigned int colIdx) {
+    return dispatchColumnType(table.columnType(colIdx), [&](auto tag) {
+      using ColumnT = typename decltype(tag)::type;
+      auto column = table.columnData<ColumnT>(colIdx);
+      return std::make_tuple(reinterpret_cast<const unsigned char*>(column.data()),
+                             static_cast<unsigned int>(sizeof(nanoaod::FlatTable::ColumnStorageType<ColumnT>)));
+    });
   }
-}
+}  // anonymous namespace
 
 RNTupleCollection::RNTupleCollection(const std::string& name,
                                      const std::string& desc,
@@ -84,8 +39,7 @@ RNTupleCollection::RNTupleCollection(const std::string& name,
   std::vector<std::unique_ptr<RFieldBase>> subfields;
   for (auto& table : tables) {
     for (unsigned int i = 0; i < table->nColumns(); i++) {
-      std::string type = flatTableColumnTypeToString(table->columnType(i));
-      auto field = RFieldBase::Create(table->columnName(i), type).Unwrap();
+      auto field = RFieldBase::Create(table->columnName(i), columnTypeName(table->columnType(i))).Unwrap();
       field->SetDescription(table->columnDoc(i));
       subfields.push_back(std::move(field));
     }
@@ -115,7 +69,7 @@ void RNTupleCollection::fill(std::vector<edm::Handle<nanoaod::FlatTable>>& table
                            "Mismatch in number of entries between extension and main table for " + m_name);
     }
     for (unsigned int i = 0; i < table->nColumns(); i++) {
-      auto [col_start, type_size] = getColStartAndTypeSize(table, i);
+      auto [col_start, type_size] = getColStartAndTypeSize(*table, i);
       size_t col_offset = m_record_offsets[col_idx];
 
       for (unsigned int j = 0; j < col_size; j++) {

--- a/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleCollection.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleCollection.cc
@@ -1,6 +1,7 @@
 #include "RNTupleCollection.h"
 
 #include "FlatTableColumnDispatch.h"
+#include "RNTupleProjections.h"
 
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldBase.hxx>
@@ -34,8 +35,9 @@ namespace {
 RNTupleCollection::RNTupleCollection(const std::string& name,
                                      const std::string& desc,
                                      std::vector<edm::Handle<nanoaod::FlatTable>>& tables,
-                                     RNTupleModel& model)
-    : m_name(name) {
+                                     RNTupleModel& model,
+                                     bool singleton)
+    : m_name(name), m_singleton(singleton) {
   std::vector<std::unique_ptr<RFieldBase>> subfields;
   for (auto& table : tables) {
     for (unsigned int i = 0; i < table->nColumns(); i++) {
@@ -44,24 +46,48 @@ RNTupleCollection::RNTupleCollection(const std::string& name,
       subfields.push_back(std::move(field));
     }
   }
-  auto record_field = std::make_unique<RRecordField>("_0", std::move(subfields));
+  // A singleton's record is the top-level field itself and takes the collection name; the record
+  // inside a vector is an item field, which RNTuple names "_0" by convention.
+  auto record_field = std::make_unique<RRecordField>(m_singleton ? name : "_0", std::move(subfields));
   m_record_size = record_field->GetValueSize();
   m_record_offsets = record_field->GetOffsets();
+  if (m_singleton) {
+    record_field->SetDescription(desc);
+    model.AddField(std::move(record_field));
+    return;
+  }
   auto collection_field = RVectorField::CreateUntyped(name, std::move(record_field));
   collection_field->SetDescription(desc);
   model.AddField(std::move(collection_field));
 }
 
-void RNTupleCollection::bindBuffer(RNTupleModel& model) {
-  auto& default_entry = model.GetDefaultEntry();
-  default_entry.BindRawPtr<void>(m_name, &m_buffer);
+void RNTupleCollection::addProjections(RNTupleModel& model) const { rntupleprojection::addForField(model, m_name); }
+
+void RNTupleCollection::bindBuffer(REntry& entry) {
+  if (m_singleton) {
+    // A record's value is the memory holding it, so the entry gets the buffer's contents; a vector
+    // field's value is the std::vector itself, so it gets the buffer object. Sizing the record
+    // buffer here, once, is what keeps the bound address valid: fill() must never reallocate it.
+    m_buffer.resize(m_record_size);
+    entry.BindRawPtr<void>(m_name, m_buffer.data());
+    return;
+  }
+  entry.BindRawPtr<void>(m_name, &m_buffer);
 }
 
 void RNTupleCollection::fill(std::vector<edm::Handle<nanoaod::FlatTable>>& tables) {
   unsigned int col_idx = 0;
   size_t col_size = tables.empty() ? 0 : tables[0]->size();
 
-  m_buffer.resize(m_record_size * col_size);
+  if (m_singleton) {
+    // One row, always: the field has no place to put a second and no way to say there was none.
+    if (col_size != 1) {
+      throw cms::Exception("LogicError",
+                           "Singleton table " + m_name + " has " + std::to_string(col_size) + " rows, expected 1");
+    }
+  } else {
+    m_buffer.resize(m_record_size * col_size);
+  }
 
   for (auto& table : tables) {
     if (table->size() != col_size) {

--- a/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleCollection.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleCollection.h
@@ -7,21 +7,31 @@
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/REntry.hxx>
 
+// A named FlatTable and its extensions written as one field: an untyped std::vector<record> whose
+// members are the columns, or -- for a singleton table, which carries exactly one row per entry --
+// the untyped record on its own. The TTree module makes the same distinction: singleton tables
+// become scalar branches, Generator_binvar and not nGenerator plus an array.
 class RNTupleCollection {
 public:
   RNTupleCollection() = delete;
   RNTupleCollection(const std::string& name,
                     const std::string& desc,
                     std::vector<edm::Handle<nanoaod::FlatTable>>& tables,
-                    ROOT::RNTupleModel& model);
+                    ROOT::RNTupleModel& model,
+                    bool singleton);
 
   const std::string& getFieldName() const { return m_name; }
 
-  void bindBuffer(ROOT::RNTupleModel& model);
+  // Give every column the flat name the TTree module uses for it as well: GenJet_pt beside
+  // GenJet.pt. See rntupleprojection.
+  void addProjections(ROOT::RNTupleModel& model) const;
+
+  void bindBuffer(ROOT::REntry& entry);
   void fill(std::vector<edm::Handle<nanoaod::FlatTable>>& tables);
 
 private:
   std::string m_name;
+  bool m_singleton;
   std::size_t m_record_size;
   std::vector<std::size_t> m_record_offsets;
   std::vector<unsigned char> m_buffer;

--- a/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleFieldPtr.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleFieldPtr.h
@@ -10,7 +10,17 @@ public:
   RNTupleFieldPtr() = default;
   explicit RNTupleFieldPtr(const std::string& name, const std::string& desc, ROOT::RNTupleModel& model) : m_name(name) {
     m_field = model.MakeField<T>(m_name, desc);
+    // A bare model has no default entry to allocate the value in, and MakeField hands back nothing,
+    // so the value lives here instead and reaches an entry through bind(). The Events model is bare
+    // because ROOT only lets an untyped record be extended with new subfields (the trigger backfill)
+    // in a bare model; the Runs, LuminosityBlocks and provenance models keep their default entry.
+    if (!m_field) {
+      m_field = std::make_shared<T>();
+    }
   }
+  // Point an entry at this field's value. Redundant for a model with its own default entry, and
+  // required for the bare Events model, once at the start and again after every schema update.
+  void bind(ROOT::REntry& entry) const { entry.BindValue(m_name, m_field); }
   void fill(const T& value) { *m_field = value; }
   const std::string& getFieldName() const { return m_name; }
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleProjections.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleProjections.cc
@@ -1,0 +1,151 @@
+#include "RNTupleProjections.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <ROOT/RField/RFieldRecord.hxx>
+#include <ROOT/RFieldBase.hxx>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+using ROOT::RFieldBase;
+using ROOT::RNTupleModel;
+using ROOT::RRecordField;
+
+namespace {
+
+  // The projection field and the mapping from its names onto the source names.
+  //
+  // A member of a plain record maps straight onto it: HLT_IsoMu24 is HLT.IsoMu24. A member of a
+  // record inside a vector needs both levels mapped, because the projection is a vector too: the
+  // vector itself onto the collection, and its item onto the member. RNTuple names the item field
+  // "_0" on either side, so the mapping is only ever asked about those two names.
+  std::pair<std::unique_ptr<RFieldBase>, RNTupleModel::FieldMappingFunc_t> makeProjection(
+      const std::string& name,
+      const std::string& fieldName,
+      const std::string& memberName,
+      const std::string& memberTypeName,
+      const std::string& memberDescription,
+      bool inCollection) {
+    auto field =
+        RFieldBase::Create(name, inCollection ? "std::vector<" + memberTypeName + ">" : memberTypeName).Unwrap();
+    field->SetDescription(memberDescription);
+    const std::string member = fieldName + (inCollection ? "._0." : ".") + memberName;
+    RNTupleModel::FieldMappingFunc_t mapping =
+        [name, fieldName, member, inCollection](const std::string& projected) -> std::string {
+      return (inCollection && projected == name) ? fieldName : member;
+    };
+    return {std::move(field), std::move(mapping)};
+  }
+
+  void warnDuplicate(const std::string& name, const std::string& fieldName, const std::string& memberName) {
+    edm::LogWarning("RNTupleProjections") << "Not projecting " << fieldName << "." << memberName << " to " << name
+                                          << ": a field of that name is already there.\n";
+  }
+
+  void warnRefused(const std::string& name,
+                   const std::string& fieldName,
+                   const std::string& memberName,
+                   const std::string& report) {
+    edm::LogWarning("RNTupleProjections")
+        << "Could not project " << fieldName << "." << memberName << " to " << name << ": " << report << "\n";
+  }
+
+}  // anonymous namespace
+
+std::string rntupleprojection::projectedName(const std::string& fieldName, const std::string& memberName) {
+  return fieldName + "_" + memberName;
+}
+
+bool rntupleprojection::add(RNTupleModel& model,
+                            const std::string& name,
+                            const std::string& fieldName,
+                            const std::string& memberName,
+                            const std::string& memberTypeName,
+                            const std::string& memberDescription,
+                            bool inCollection) {
+  if (model.GetFieldNames().contains(name)) {
+    warnDuplicate(name, fieldName, memberName);
+    return false;
+  }
+  auto [projection, mapping] =
+      makeProjection(name, fieldName, memberName, memberTypeName, memberDescription, inCollection);
+  auto result = model.AddProjectedField(std::move(projection), std::move(mapping));
+  if (!result) {
+    warnRefused(name, fieldName, memberName, result.GetError()->GetReport());
+    return false;
+  }
+  return true;
+}
+
+bool rntupleprojection::add(RNTupleModel::RUpdater& updater,
+                            std::unordered_set<std::string>& taken,
+                            const std::string& name,
+                            const std::string& fieldName,
+                            const std::string& memberName,
+                            const std::string& memberTypeName,
+                            const std::string& memberDescription,
+                            bool inCollection) {
+  if (!taken.insert(name).second) {
+    warnDuplicate(name, fieldName, memberName);
+    return false;
+  }
+  auto [projection, mapping] =
+      makeProjection(name, fieldName, memberName, memberTypeName, memberDescription, inCollection);
+  auto result = updater.AddProjectedField(std::move(projection), std::move(mapping));
+  if (!result) {
+    warnRefused(name, fieldName, memberName, result.GetError()->GetReport());
+    return false;
+  }
+  return true;
+}
+
+void rntupleprojection::addForField(RNTupleModel& model, const std::string& fieldName) {
+  if (!model.GetFieldNames().contains(fieldName)) {
+    return;
+  }
+  // A grouped field is the untyped record itself, or a vector whose one item field is one.
+  const auto& field = model.GetConstField(fieldName);
+  const auto* record = dynamic_cast<const RRecordField*>(&field);
+  bool inCollection = false;
+  if (nullptr == record) {
+    const auto subfields = field.GetConstSubfields();
+    if (subfields.size() != 1) {
+      return;
+    }
+    record = dynamic_cast<const RRecordField*>(subfields[0]);
+    inCollection = true;
+  }
+  if (nullptr == record) {
+    return;
+  }
+
+  // What each member needs, collected before anything is added: adding a field to the model can
+  // rehash the name set this walk reads.
+  struct Member {
+    std::string name;
+    std::string typeName;
+    std::string description;
+  };
+  const auto recordMembers = record->GetConstSubfields();
+  std::vector<Member> members;
+  members.reserve(recordMembers.size());
+  for (const auto* member : recordMembers) {
+    // Only a leaf gets a flat name; nothing this module writes nests a record inside a record.
+    if (member->GetTypeName().empty()) {
+      continue;
+    }
+    members.push_back({member->GetFieldName(), member->GetTypeName(), member->GetDescription()});
+  }
+
+  for (const auto& member : members) {
+    add(model,
+        projectedName(fieldName, member.name),
+        fieldName,
+        member.name,
+        member.typeName,
+        member.description,
+        inCollection);
+  }
+}

--- a/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleProjections.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleProjections.h
@@ -1,0 +1,52 @@
+#ifndef PhysicsTools_NanoAOD_RNTupleProjections_h
+#define PhysicsTools_NanoAOD_RNTupleProjections_h
+
+#include <ROOT/RNTupleModel.hxx>
+
+#include <string>
+#include <unordered_set>
+
+// TTree-style flat names for the members of the grouped fields.
+//
+// This module writes a named collection as one untyped std::vector<record> and a trigger group or
+// singleton table as one untyped record: GenJet.pt, HLT.IsoMu24, Generator.binvar. The TTree output
+// module writes GenJet_pt, HLT_IsoMu24 and Generator_binvar instead. A projected field gives each
+// member the TTree name too: a second name for the same columns, costing only a schema entry.
+namespace rntupleprojection {
+  // The flat name of a member: GenJet and pt give GenJet_pt. add() takes the name rather than
+  // deriving it, because not every path's flat name is this join; see splitTriggerName().
+  std::string projectedName(const std::string& fieldName, const std::string& memberName);
+
+  // Project the member `memberName` of the grouped field `fieldName` as the top-level field `name`.
+  // `inCollection` says whether the record sits inside a vector, in which case the projection is a
+  // vector of the member type rather than a scalar. Returns whether the projection was added; a
+  // name already in the model is skipped with a warning, because RNTuple throws on a duplicate
+  // rather than reporting it.
+  //
+  // For a model that is not being written yet.
+  bool add(ROOT::RNTupleModel& model,
+           const std::string& name,
+           const std::string& fieldName,
+           const std::string& memberName,
+           const std::string& memberTypeName,
+           const std::string& memberDescription,
+           bool inCollection);
+  // For an ntuple that is already being written; the updater must have an open transaction. The
+  // model cannot be asked for its names here, so `taken` carries them: seed it from
+  // GetFieldNames() before the transaction is opened, and a name used is inserted into it.
+  bool add(ROOT::RNTupleModel::RUpdater& updater,
+           std::unordered_set<std::string>& taken,
+           const std::string& name,
+           const std::string& fieldName,
+           const std::string& memberName,
+           const std::string& memberTypeName,
+           const std::string& memberDescription,
+           bool inCollection);
+
+  // Project every member of the grouped field `fieldName` under projectedName(), in the order the
+  // record holds them. Does nothing if the model has no such field, or if it is neither an untyped
+  // record nor a vector of one.
+  void addForField(ROOT::RNTupleModel& model, const std::string& fieldName);
+}  // namespace rntupleprojection
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.cc
@@ -8,14 +8,13 @@ std::vector<RNTupleFieldPtr<T>> SummaryTableOutputFields::makeFields(const std::
   std::vector<RNTupleFieldPtr<T>> fields;
   fields.reserve(tabcols.size());
   for (const auto &col : tabcols) {
-    fields.emplace_back(RNTupleFieldPtr<T>(col.name, col.doc, model));
+    fields.emplace_back(col.name, col.doc, model);
   }
   return fields;
 }
 
 template <typename T, typename Col>
-void SummaryTableOutputFields::fillScalarFields(const std::vector<Col> &tabcols,
-                                                std::vector<RNTupleFieldPtr<T>> fields) {
+void SummaryTableOutputFields::fillFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> &fields) {
   if (tabcols.size() != fields.size()) {
     throw cms::Exception("LogicError", "Mismatch in table columns");
   }
@@ -23,22 +22,12 @@ void SummaryTableOutputFields::fillScalarFields(const std::vector<Col> &tabcols,
     if (tabcols[i].name != fields[i].getFieldName()) {
       throw cms::Exception("LogicError", "Mismatch in table columns");
     }
-    fields[i].fill(tabcols[i].value);
-  }
-}
-
-// TODO: maybe we can unify with the function above since now it's the same
-template <typename T, typename Col>
-void SummaryTableOutputFields::fillVectorFields(const std::vector<Col> &tabcols,
-                                                std::vector<RNTupleFieldPtr<T>> fields) {
-  if (tabcols.size() != fields.size()) {
-    throw cms::Exception("LogicError", "Mismatch in table columns");
-  }
-  for (std::size_t i = 0; i < tabcols.size(); ++i) {
-    if (tabcols[i].name != fields[i].getFieldName()) {
-      throw cms::Exception("LogicError", "Mismatch in table columns");
+    // MergeableCounterTable spells a scalar column's payload `value` and a vector column's `values`
+    if constexpr (requires { tabcols[i].value; }) {
+      fields[i].fill(tabcols[i].value);
+    } else {
+      fields[i].fill(tabcols[i].values);
     }
-    fields[i].fill(tabcols[i].values);
   }
 }
 
@@ -52,10 +41,10 @@ SummaryTableOutputFields::SummaryTableOutputFields(const nanoaod::MergeableCount
 }
 
 void SummaryTableOutputFields::fill(const nanoaod::MergeableCounterTable &tab) {
-  fillScalarFields(tab.intCols(), m_intFields);
-  fillScalarFields(tab.floatCols(), m_floatFields);
-  fillScalarFields(tab.floatWithNormCols(), m_floatWithNormFields);
-  fillVectorFields(tab.vintCols(), m_vintFields);
-  fillVectorFields(tab.vfloatCols(), m_vfloatFields);
-  fillVectorFields(tab.vfloatWithNormCols(), m_vfloatWithNormFields);
+  fillFields(tab.intCols(), m_intFields);
+  fillFields(tab.floatCols(), m_floatFields);
+  fillFields(tab.floatWithNormCols(), m_floatWithNormFields);
+  fillFields(tab.vintCols(), m_vintFields);
+  fillFields(tab.vfloatCols(), m_vfloatFields);
+  fillFields(tab.vfloatWithNormCols(), m_vfloatWithNormFields);
 }

--- a/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.h
@@ -14,10 +14,9 @@ public:
 private:
   template <typename T, typename Col>
   std::vector<RNTupleFieldPtr<T>> makeFields(const std::vector<Col> &tabcols, ROOT::RNTupleModel &model);
+  // Fills either a scalar column (SingleColumn::value) or a vector column (VectorColumn::values).
   template <typename T, typename Col>
-  static void fillScalarFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> fields);
-  template <typename T, typename Col>
-  static void fillVectorFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> fields);
+  static void fillFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> &fields);
 
   using int_accumulator = nanoaod::MergeableCounterTable::int_accumulator;
   using float_accumulator = nanoaod::MergeableCounterTable::float_accumulator;

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.cc
@@ -40,6 +40,12 @@ void TableOutputFields::createFields(const edm::OccurrenceForOutput& event, RNTu
   }
 }
 
+void TableOutputFields::bind(ROOT::REntry& entry) const {
+  for (const auto& field : m_fields) {
+    field->bind(entry);
+  }
+}
+
 void TableOutputFields::fillEntry(const nanoaod::FlatTable& table, std::size_t i) {
   for (auto& field : m_fields) {
     field->fillRow(table, i);
@@ -69,6 +75,12 @@ void TableOutputVectorFields::createFields(const edm::OccurrenceForOutput& event
   }
 }
 
+void TableOutputVectorFields::bind(ROOT::REntry& entry) const {
+  for (const auto& field : m_fields) {
+    field->bind(entry);
+  }
+}
+
 void TableOutputVectorFields::fill(const edm::OccurrenceForOutput& event) {
   edm::Handle<nanoaod::FlatTable> handle;
   event.getByToken(m_token, handle);
@@ -90,6 +102,7 @@ void TableCollection::add(const edm::EDGetToken& table_token, const nanoaod::Fla
   if (hasMainTable()) {
     throw cms::Exception("LogicError", "Trying to save multiple main tables for " + m_collectionName + "\n");
   }
+  m_singleton = table.singleton();
   m_main = TableOutputFields(table_token);
 }
 
@@ -105,10 +118,13 @@ std::vector<edm::Handle<nanoaod::FlatTable>> TableCollection::getTables(const ed
 
 void TableCollection::createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel) {
   auto tables = getTables(event);
-  m_collection = std::make_unique<RNTupleCollection>(m_collectionName, tables.front()->doc(), tables, eventModel);
+  m_collection =
+      std::make_unique<RNTupleCollection>(m_collectionName, tables.front()->doc(), tables, eventModel, m_singleton);
 }
 
-void TableCollection::bindBuffer(RNTupleModel& eventModel) { m_collection->bindBuffer(eventModel); }
+void TableCollection::addProjections(RNTupleModel& eventModel) const { m_collection->addProjections(eventModel); }
+
+void TableCollection::bind(ROOT::REntry& entry) const { m_collection->bindBuffer(entry); }
 
 void TableCollection::fill(const edm::OccurrenceForOutput& event) {
   auto tables = getTables(event);
@@ -171,9 +187,21 @@ void TableCollectionSet::createFields(const edm::OccurrenceForOutput& event, RNT
   }
 }
 
-void TableCollectionSet::bindBuffers(RNTupleModel& eventModel) {
-  for (auto& collection : m_collections) {
-    collection.bindBuffer(eventModel);
+void TableCollectionSet::addProjections(RNTupleModel& eventModel) const {
+  for (const auto& collection : m_collections) {
+    collection.addProjections(eventModel);
+  }
+}
+
+void TableCollectionSet::bind(ROOT::REntry& entry) const {
+  for (const auto& collection : m_collections) {
+    collection.bind(entry);
+  }
+  for (const auto& fields : m_singletonFields) {
+    fields.bind(entry);
+  }
+  for (const auto& fields : m_vectorFields) {
+    fields.bind(entry);
   }
 }
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.cc
@@ -1,98 +1,54 @@
 #include "TableOutputFields.h"
 
-namespace {
-  void printTable(const nanoaod::FlatTable& table) {
-    std::cout << "FlatTable {\n";
-    std::cout << "  name: " << (table.name().empty() ? "// anon" : table.name()) << "\n";
-    std::cout << "  singleton: " << (table.singleton() ? "true" : "false") << "\n";
-    std::cout << "  size: " << table.size() << "\n";
-    std::cout << "  extension: " << (table.extension() ? "true" : "false") << "\n";
-    std::cout << "  fields: {\n";
-    for (std::size_t i = 0; i < table.nColumns(); i++) {
-      std::cout << "    " << (table.columnName(i).empty() ? "// anon" : table.columnName(i)) << ": ";
-      switch (table.columnType(i)) {
-        case nanoaod::FlatTable::ColumnType::Float:
-          std::cout << "f32,";
-          break;
-        case nanoaod::FlatTable::ColumnType::Int32:
-          std::cout << "i32,";
-          break;
-        case nanoaod::FlatTable::ColumnType::UInt8:
-          std::cout << "u8,";
-          break;
-        case nanoaod::FlatTable::ColumnType::Bool:
-          std::cout << "bool,";
-          break;
-        default:
-          std::cout << "other,";
-          break;
-          //throw cms::Exception("LogicError", "Unsupported type");
-      }
-      std::cout << "\n";
-    }
-    std::cout << "  }\n}\n";
-  }
-}  // anonymous namespace
+#include "FlatTableColumnDispatch.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-void TableOutputFields::print() const {
-  for (const auto& field : m_floatFields) {
-    std::cout << "  " << field.getFlatTableName() << ": f32,\n";
+#include <algorithm>
+
+using ROOT::RNTupleModel;
+
+namespace flattablefield {
+  std::pair<std::string, std::string> nameAndDoc(const nanoaod::FlatTable& table, std::size_t i) {
+    // case 1: the column has a name (the table may or may not have one)
+    if (!table.columnName(i).empty()) {
+      return {table.columnName(i), table.columnDoc(i)};
+    }
+    // case 2: the column is anonymous, so it takes the table's name
+    if (table.name().empty()) {
+      throw cms::Exception("LogicError", "Empty FlatTable name and field name");
+    }
+    return {table.name(), table.doc()};
   }
-  for (const auto& field : m_intFields) {
-    std::cout << "  " << field.getFlatTableName() << ": i32,\n";
+
+  unsigned int columnIndex(const nanoaod::FlatTable& table, const std::string& columnName) {
+    int index = table.columnIndex(columnName);
+    if (index == -1) {
+      throw cms::Exception("LogicError", "Missing column in input for " + table.name() + "_" + columnName);
+    }
+    return static_cast<unsigned int>(index);
   }
-  for (const auto& field : m_uint8Fields) {
-    std::cout << "  " << field.getFlatTableName() << ": u8,\n";
-  }
-  for (const auto& field : m_boolFields) {
-    std::cout << "  " << field.getFlatTableName() << ": bool,\n";
-  }
-}
+}  // namespace flattablefield
 
 void TableOutputFields::createFields(const edm::OccurrenceForOutput& event, RNTupleModel& model) {
-  edm::Handle<nanoaod::FlatTable> handle;
-  event.getByToken(m_token, handle);
-  const nanoaod::FlatTable& table = *handle;
+  const nanoaod::FlatTable& table = *getTable(event);
+  m_fields.reserve(table.nColumns());
   for (std::size_t i = 0; i < table.nColumns(); i++) {
-    switch (table.columnType(i)) {
-      case nanoaod::FlatTable::ColumnType::Float:
-        m_floatFields.emplace_back(FlatTableField<float>(table, i, model));
-        break;
-      case nanoaod::FlatTable::ColumnType::Int32:
-        m_intFields.emplace_back(FlatTableField<int>(table, i, model));
-        break;
-      case nanoaod::FlatTable::ColumnType::UInt8:
-        m_uint8Fields.emplace_back(FlatTableField<std::uint8_t>(table, i, model));
-        break;
-      case nanoaod::FlatTable::ColumnType::Bool:
-        m_boolFields.emplace_back(FlatTableField<bool>(table, i, model));
-        break;
-      default:
-        std::cout << "Unsupported type in TableOutputFields"
-                  << "\n";
-        //throw cms::Exception("LogicError", "Unsupported type");
-    }
+    dispatchColumnType(table.columnType(i), [&](auto tag) {
+      using ColumnT = typename decltype(tag)::type;
+      m_fields.push_back(std::make_unique<FlatTableField<ColumnT>>(table, i, model));
+    });
   }
 }
 
 void TableOutputFields::fillEntry(const nanoaod::FlatTable& table, std::size_t i) {
-  for (auto& field : m_floatFields) {
-    field.fill(table, i);
-  }
-  for (auto& field : m_intFields) {
-    field.fill(table, i);
-  }
-  for (auto& field : m_uint8Fields) {
-    field.fill(table, i);
-  }
-  for (auto& field : m_boolFields) {
-    field.fill(table, i);
+  for (auto& field : m_fields) {
+    field->fillRow(table, i);
   }
 }
 
 const edm::EDGetToken& TableOutputFields::getToken() const { return m_token; }
 
-const edm::Handle<nanoaod::FlatTable> TableOutputFields::getTable(const edm::OccurrenceForOutput& event) const {
+edm::Handle<nanoaod::FlatTable> TableOutputFields::getTable(const edm::OccurrenceForOutput& event) const {
   edm::Handle<nanoaod::FlatTable> handle;
   event.getByToken(m_token, handle);
   return handle;
@@ -104,42 +60,20 @@ void TableOutputVectorFields::createFields(const edm::OccurrenceForOutput& event
   edm::Handle<nanoaod::FlatTable> handle;
   event.getByToken(m_token, handle);
   const nanoaod::FlatTable& table = *handle;
+  m_fields.reserve(table.nColumns());
   for (std::size_t i = 0; i < table.nColumns(); i++) {
-    switch (table.columnType(i)) {
-      case nanoaod::FlatTable::ColumnType::Float:
-        m_vfloatFields.emplace_back(FlatTableField<std::vector<float>>(table, i, model));
-        break;
-      case nanoaod::FlatTable::ColumnType::Int32:
-        m_vintFields.emplace_back(FlatTableField<std::vector<int>>(table, i, model));
-        break;
-      case nanoaod::FlatTable::ColumnType::UInt8:
-        m_vuint8Fields.emplace_back(FlatTableField<std::vector<std::uint8_t>>(table, i, model));
-        break;
-      case nanoaod::FlatTable::ColumnType::Bool:
-        m_vboolFields.emplace_back(FlatTableField<std::vector<bool>>(table, i, model));
-        break;
-      default:
-        std::cout << "Unsupported type in TableOutputVectorFields"
-                  << "\n";
-        //throw cms::Exception("LogicError", "Unsupported type");
-    }
+    dispatchColumnType(table.columnType(i), [&](auto tag) {
+      using ColumnT = typename decltype(tag)::type;
+      m_fields.push_back(std::make_unique<FlatTableVectorField<ColumnT>>(table, i, model));
+    });
   }
 }
+
 void TableOutputVectorFields::fill(const edm::OccurrenceForOutput& event) {
   edm::Handle<nanoaod::FlatTable> handle;
   event.getByToken(m_token, handle);
-  const auto& table = *handle;
-  for (auto& field : m_vfloatFields) {
-    field.fillVectored(table);
-  }
-  for (auto& field : m_vintFields) {
-    field.fillVectored(table);
-  }
-  for (auto& field : m_vuint8Fields) {
-    field.fillVectored(table);
-  }
-  for (auto& field : m_vboolFields) {
-    field.fillVectored(table);
+  for (auto& field : m_fields) {
+    field->fillColumn(*handle);
   }
 }
 
@@ -150,7 +84,7 @@ void TableCollection::add(const edm::EDGetToken& table_token, const nanoaod::Fla
     m_collectionName = table.name();
   }
   if (table.extension()) {
-    m_extensions.emplace_back(TableOutputFields(table_token));
+    m_extensions.emplace_back(table_token);
     return;
   }
   if (hasMainTable()) {
@@ -159,49 +93,29 @@ void TableCollection::add(const edm::EDGetToken& table_token, const nanoaod::Fla
   m_main = TableOutputFields(table_token);
 }
 
-void TableCollection::createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel) {
+std::vector<edm::Handle<nanoaod::FlatTable>> TableCollection::getTables(const edm::OccurrenceForOutput& event) const {
   std::vector<edm::Handle<nanoaod::FlatTable>> tables;
-
-  auto main_table = m_main.getTable(event);
-  std::string field_desc = main_table->doc();
-
-  tables.emplace_back(main_table);
-
-  for (auto& extension : m_extensions) {
-    auto ext_table = extension.getTable(event);
-    tables.emplace_back(ext_table);
+  tables.reserve(m_extensions.size() + 1);
+  tables.emplace_back(m_main.getTable(event));
+  for (const auto& extension : m_extensions) {
+    tables.emplace_back(extension.getTable(event));
   }
-  m_collection = std::make_unique<RNTupleCollection>(m_collectionName, field_desc, tables, eventModel);
+  return tables;
+}
+
+void TableCollection::createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel) {
+  auto tables = getTables(event);
+  m_collection = std::make_unique<RNTupleCollection>(m_collectionName, tables.front()->doc(), tables, eventModel);
 }
 
 void TableCollection::bindBuffer(RNTupleModel& eventModel) { m_collection->bindBuffer(eventModel); }
 
 void TableCollection::fill(const edm::OccurrenceForOutput& event) {
-  std::vector<edm::Handle<nanoaod::FlatTable>> tables;
-
-  auto main_table = m_main.getTable(event);
-  std::string field_desc = main_table->doc();
-
-  tables.emplace_back(main_table);
-
-  for (auto& extension : m_extensions) {
-    auto ext_table = extension.getTable(event);
-    tables.emplace_back(ext_table);
-  }
-
+  auto tables = getTables(event);
   m_collection->fill(tables);
 }
 
-void TableCollection::print() const {
-  std::cout << "Collection: " << m_collectionName << " {\n";
-  m_main.print();
-  for (const auto& ext : m_extensions) {
-    ext.print();
-  }
-  std::cout << "}\n";
-}
-
-bool TableCollection::hasMainTable() { return !m_main.getToken().isUninitialized(); }
+bool TableCollection::hasMainTable() const { return !m_main.getToken().isUninitialized(); }
 
 const std::string& TableCollection::getCollectionName() const { return m_collectionName; }
 
@@ -210,8 +124,7 @@ const std::string& TableCollection::getCollectionName() const { return m_collect
 void TableCollectionSet::add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table) {
   // skip empty tables -- requirement of RNTuple to define schema before filling
   if (table.nColumns() == 0) {
-    std::cout << "Warning: skipping empty table: \n";
-    printTable(table);
+    edm::LogWarning("TableCollectionSet") << "Skipping FlatTable '" << table.name() << "': it has no columns\n";
     return;
   }
   // Can handle either anonymous table or anonymous column but not both
@@ -223,9 +136,9 @@ void TableCollectionSet::add(const edm::EDGetToken& table_token, const nanoaod::
   // case 1: create a top-level RNTuple field for each table column
   if (table.name().empty() || hasAnonymousColumn(table)) {
     if (table.singleton()) {
-      m_singletonFields.emplace_back(TableOutputFields(table_token));
+      m_singletonFields.emplace_back(table_token);
     } else {
-      m_vectorFields.emplace_back(TableOutputVectorFields(table_token));
+      m_vectorFields.emplace_back(table_token);
     }
     return;
   }
@@ -234,18 +147,11 @@ void TableCollectionSet::add(const edm::EDGetToken& table_token, const nanoaod::
     return c.getCollectionName() == table.name();
   });
   if (collection == m_collections.end()) {
-    m_collections.emplace_back(TableCollection());
+    m_collections.emplace_back();
     m_collections.back().add(table_token, table);
     return;
   }
   collection->add(table_token, table);
-}
-
-void TableCollectionSet::print() const {
-  for (const auto& collection : m_collections) {
-    collection.print();
-    std::cout << "\n";
-  }
 }
 
 void TableCollectionSet::createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel) {
@@ -276,10 +182,7 @@ void TableCollectionSet::fill(const edm::OccurrenceForOutput& event) {
     collection.fill(event);
   }
   for (auto& fields : m_singletonFields) {
-    edm::Handle<nanoaod::FlatTable> handle;
-    event.getByToken(fields.getToken(), handle);
-    const auto& table = *handle;
-    fields.fillEntry(table, 0);
+    fields.fillEntry(*fields.getTable(event), 0);
   }
   for (auto& fields : m_vectorFields) {
     fields.fill(event);
@@ -295,7 +198,7 @@ bool TableCollectionSet::hasAnonymousColumn(const nanoaod::FlatTable& table) {
   }
   if (num_anon > 1) {
     throw cms::Exception("LogicError",
-                         "FlatTable `" + table.name() + "` has " + std::to_string(num_anon) + "anonymous fields");
+                         "FlatTable `" + table.name() + "` has " + std::to_string(num_anon) + " anonymous fields");
   }
-  return num_anon;
+  return num_anon > 0;
 }

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
@@ -8,89 +8,100 @@
 #include "DataFormats/NanoAOD/interface/FlatTable.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
-#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
-#include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-using ROOT::RNTupleModel;
-using ROOT::RNTupleWriter;
+
+namespace flattablefield {
+  // The RNTuple field name and description for column i of a table: the column's own name and doc,
+  // or the table's when the column is anonymous.
+  std::pair<std::string, std::string> nameAndDoc(const nanoaod::FlatTable& table, std::size_t i);
+  // Index of the named column, throwing if this table does not carry it.
+  unsigned int columnIndex(const nanoaod::FlatTable& table, const std::string& columnName);
+}  // namespace flattablefield
+
+// One FlatTable column written as its own top-level RNTuple field. Fields are held by base class
+// pointer so that a table's columns live in a single vector whatever their types.
+class FlatTableFieldBase {
+public:
+  virtual ~FlatTableFieldBase() = default;
+  // Copy one row of this field's column into the RNTuple entry.
+  virtual void fillRow(const nanoaod::FlatTable& table, std::size_t row) = 0;
+};
 
 template <typename T>
-class FlatTableField {
+class FlatTableField : public FlatTableFieldBase {
 public:
-  FlatTableField() = default;
-  FlatTableField(const nanoaod::FlatTable& table, std::size_t i, RNTupleModel& model) {
-    m_flatTableName = table.columnName(i);
-    // case 1: field has a name (table may or may not have a name)
-    if (!table.columnName(i).empty()) {
-      m_field = RNTupleFieldPtr<T>(table.columnName(i), table.columnDoc(i), model);
-      return;
-    }
-    // case 2: field doesn't have a name: use the table name as the RNTuple field name
-    if (table.name().empty()) {
-      throw cms::Exception("LogicError", "Empty FlatTable name and field name");
-    }
-    m_field = RNTupleFieldPtr<T>(table.name(), table.doc(), model);
+  FlatTableField(const nanoaod::FlatTable& table, std::size_t i, ROOT::RNTupleModel& model)
+      : m_columnName(table.columnName(i)) {
+    auto [name, doc] = flattablefield::nameAndDoc(table, i);
+    m_field = RNTupleFieldPtr<T>(name, doc, model);
   }
-  // For collection fields and singleton fields
-  void fill(const nanoaod::FlatTable& table, std::size_t i) {
-    int col_idx = table.columnIndex(m_flatTableName);
-    if (col_idx == -1) {
-      throw cms::Exception("LogicError", "Missing column in input for " + table.name() + "_" + m_flatTableName);
-    }
-    m_field.fill(table.columnData<T>(col_idx)[i]);
+  void fillRow(const nanoaod::FlatTable& table, std::size_t row) override {
+    m_field.fill(table.columnData<T>(flattablefield::columnIndex(table, m_columnName))[row]);
   }
-  // For vector fields without a collection, we have to buffer the results
-  // internally and then fill the RNTuple field
-  void fillVectored(const nanoaod::FlatTable& table) {
-    int col_idx = table.columnIndex(m_flatTableName);
-    if (col_idx == -1) {
-      throw cms::Exception("LogicError", "Missing column in input for " + table.name() + "_" + m_flatTableName);
-    }
-    std::vector<typename T::value_type> buf(table.size());
-    for (std::size_t i = 0; i < table.size(); i++) {
-      buf[i] = table.columnData<typename T::value_type>(col_idx)[i];
-    }
-    m_field.fill(buf);
-  }
-  const std::string& getFlatTableName() const { return m_flatTableName; }
 
 private:
   RNTupleFieldPtr<T> m_field;
-  std::string m_flatTableName;
+  std::string m_columnName;
+};
+
+// The same, for a table whose columns each become one std::vector field. The column is buffered
+// because a FlatTable stores bools as bytes, so its memory is not a std::vector<T> to begin with.
+class FlatTableVectorFieldBase {
+public:
+  virtual ~FlatTableVectorFieldBase() = default;
+  // Copy this field's whole column into the RNTuple entry.
+  virtual void fillColumn(const nanoaod::FlatTable& table) = 0;
+};
+
+template <typename T>
+class FlatTableVectorField : public FlatTableVectorFieldBase {
+public:
+  FlatTableVectorField(const nanoaod::FlatTable& table, std::size_t i, ROOT::RNTupleModel& model)
+      : m_columnName(table.columnName(i)) {
+    auto [name, doc] = flattablefield::nameAndDoc(table, i);
+    m_field = RNTupleFieldPtr<std::vector<T>>(name, doc, model);
+  }
+  void fillColumn(const nanoaod::FlatTable& table) override {
+    auto column = table.columnData<T>(flattablefield::columnIndex(table, m_columnName));
+    m_buffer.assign(column.begin(), column.end());
+    m_field.fill(m_buffer);
+  }
+
+private:
+  RNTupleFieldPtr<std::vector<T>> m_field;
+  std::vector<T> m_buffer;
+  std::string m_columnName;
 };
 
 class TableOutputFields {
 public:
   TableOutputFields() = default;
   explicit TableOutputFields(const edm::EDGetToken& token) : m_token(token) {}
-  void print() const;
-  void createFields(const edm::OccurrenceForOutput& event, RNTupleModel& model);
+  void createFields(const edm::OccurrenceForOutput& event, ROOT::RNTupleModel& model);
   void fillEntry(const nanoaod::FlatTable& table, std::size_t i);
   const edm::EDGetToken& getToken() const;
-  const edm::Handle<nanoaod::FlatTable> getTable(const edm::OccurrenceForOutput& event) const;
+  edm::Handle<nanoaod::FlatTable> getTable(const edm::OccurrenceForOutput& event) const;
 
 private:
   edm::EDGetToken m_token;
-  std::vector<FlatTableField<float>> m_floatFields;
-  std::vector<FlatTableField<int>> m_intFields;
-  std::vector<FlatTableField<std::uint8_t>> m_uint8Fields;
-  std::vector<FlatTableField<bool>> m_boolFields;
+  std::vector<std::unique_ptr<FlatTableFieldBase>> m_fields;
 };
 
 class TableOutputVectorFields {
 public:
   TableOutputVectorFields() = default;
   explicit TableOutputVectorFields(const edm::EDGetToken& token) : m_token(token) {}
-  void createFields(const edm::OccurrenceForOutput& event, RNTupleModel& model);
+  void createFields(const edm::OccurrenceForOutput& event, ROOT::RNTupleModel& model);
   void fill(const edm::OccurrenceForOutput& event);
 
 private:
   edm::EDGetToken m_token;
-  std::vector<FlatTableField<std::vector<float>>> m_vfloatFields;
-  std::vector<FlatTableField<std::vector<int>>> m_vintFields;
-  std::vector<FlatTableField<std::vector<std::uint8_t>>> m_vuint8Fields;
-  std::vector<FlatTableField<std::vector<bool>>> m_vboolFields;
+  std::vector<std::unique_ptr<FlatTableVectorFieldBase>> m_fields;
 };
 
 class TableCollection {
@@ -103,14 +114,16 @@ public:
   // Invariants:
   // * m_main not null
   // * m_collectionName not empty
-  void createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel);
-  void bindBuffer(RNTupleModel& eventModel);
+  void createFields(const edm::OccurrenceForOutput& event, ROOT::RNTupleModel& eventModel);
+  void bindBuffer(ROOT::RNTupleModel& eventModel);
   void fill(const edm::OccurrenceForOutput& event);
-  void print() const;
-  bool hasMainTable();
+  bool hasMainTable() const;
   const std::string& getCollectionName() const;
 
 private:
+  // The main table followed by its extensions, the order their columns appear in.
+  std::vector<edm::Handle<nanoaod::FlatTable>> getTables(const edm::OccurrenceForOutput& event) const;
+
   std::string m_collectionName;
   std::unique_ptr<RNTupleCollection> m_collection;
   TableOutputFields m_main;
@@ -120,10 +133,9 @@ private:
 class TableCollectionSet {
 public:
   void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
-  void createFields(const edm::OccurrenceForOutput& event, RNTupleModel& eventModel);
-  void bindBuffers(RNTupleModel& eventModel);
+  void createFields(const edm::OccurrenceForOutput& event, ROOT::RNTupleModel& eventModel);
+  void bindBuffers(ROOT::RNTupleModel& eventModel);
   void fill(const edm::OccurrenceForOutput& event);
-  void print() const;
 
 private:
   // Returns true if the FlatTable has an anonymous column. Throws a cms::Exception

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
@@ -23,11 +23,12 @@ namespace flattablefield {
   unsigned int columnIndex(const nanoaod::FlatTable& table, const std::string& columnName);
 }  // namespace flattablefield
 
-// One FlatTable column written as its own top-level RNTuple field. Fields are held by base class
-// pointer so that a table's columns live in a single vector whatever their types.
+// One FlatTable column written as its own top-level RNTuple field.
 class FlatTableFieldBase {
 public:
   virtual ~FlatTableFieldBase() = default;
+  // Point the entry at this field's value; see RNTupleFieldPtr::bind.
+  virtual void bind(ROOT::REntry& entry) const = 0;
   // Copy one row of this field's column into the RNTuple entry.
   virtual void fillRow(const nanoaod::FlatTable& table, std::size_t row) = 0;
 };
@@ -40,6 +41,7 @@ public:
     auto [name, doc] = flattablefield::nameAndDoc(table, i);
     m_field = RNTupleFieldPtr<T>(name, doc, model);
   }
+  void bind(ROOT::REntry& entry) const override { m_field.bind(entry); }
   void fillRow(const nanoaod::FlatTable& table, std::size_t row) override {
     m_field.fill(table.columnData<T>(flattablefield::columnIndex(table, m_columnName))[row]);
   }
@@ -54,6 +56,8 @@ private:
 class FlatTableVectorFieldBase {
 public:
   virtual ~FlatTableVectorFieldBase() = default;
+  // Point the entry at this field's value; see RNTupleFieldPtr::bind.
+  virtual void bind(ROOT::REntry& entry) const = 0;
   // Copy this field's whole column into the RNTuple entry.
   virtual void fillColumn(const nanoaod::FlatTable& table) = 0;
 };
@@ -66,6 +70,7 @@ public:
     auto [name, doc] = flattablefield::nameAndDoc(table, i);
     m_field = RNTupleFieldPtr<std::vector<T>>(name, doc, model);
   }
+  void bind(ROOT::REntry& entry) const override { m_field.bind(entry); }
   void fillColumn(const nanoaod::FlatTable& table) override {
     auto column = table.columnData<T>(flattablefield::columnIndex(table, m_columnName));
     m_buffer.assign(column.begin(), column.end());
@@ -83,6 +88,7 @@ public:
   TableOutputFields() = default;
   explicit TableOutputFields(const edm::EDGetToken& token) : m_token(token) {}
   void createFields(const edm::OccurrenceForOutput& event, ROOT::RNTupleModel& model);
+  void bind(ROOT::REntry& entry) const;
   void fillEntry(const nanoaod::FlatTable& table, std::size_t i);
   const edm::EDGetToken& getToken() const;
   edm::Handle<nanoaod::FlatTable> getTable(const edm::OccurrenceForOutput& event) const;
@@ -97,6 +103,7 @@ public:
   TableOutputVectorFields() = default;
   explicit TableOutputVectorFields(const edm::EDGetToken& token) : m_token(token) {}
   void createFields(const edm::OccurrenceForOutput& event, ROOT::RNTupleModel& model);
+  void bind(ROOT::REntry& entry) const;
   void fill(const edm::OccurrenceForOutput& event);
 
 private:
@@ -115,7 +122,8 @@ public:
   // * m_main not null
   // * m_collectionName not empty
   void createFields(const edm::OccurrenceForOutput& event, ROOT::RNTupleModel& eventModel);
-  void bindBuffer(ROOT::RNTupleModel& eventModel);
+  void addProjections(ROOT::RNTupleModel& eventModel) const;
+  void bind(ROOT::REntry& entry) const;
   void fill(const edm::OccurrenceForOutput& event);
   bool hasMainTable() const;
   const std::string& getCollectionName() const;
@@ -125,6 +133,8 @@ private:
   std::vector<edm::Handle<nanoaod::FlatTable>> getTables(const edm::OccurrenceForOutput& event) const;
 
   std::string m_collectionName;
+  // Taken from the main table: a singleton is written as a record rather than a vector of one.
+  bool m_singleton = false;
   std::unique_ptr<RNTupleCollection> m_collection;
   TableOutputFields m_main;
   std::vector<TableOutputFields> m_extensions;
@@ -134,7 +144,10 @@ class TableCollectionSet {
 public:
   void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
   void createFields(const edm::OccurrenceForOutput& event, ROOT::RNTupleModel& eventModel);
-  void bindBuffers(ROOT::RNTupleModel& eventModel);
+  // Add the flat TTree-style aliases of every collection member: Muon_pt beside Muon.pt. The
+  // top-level fields are already flat and have nothing to project.
+  void addProjections(ROOT::RNTupleModel& eventModel) const;
+  void bind(ROOT::REntry& entry) const;
   void fill(const edm::OccurrenceForOutput& event);
 
 private:

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
@@ -1,6 +1,6 @@
 #include "TriggerOutputFields.h"
 
-#include "RNTupleFieldPtr.h"
+#include "RNTupleProjections.h"
 
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "FWCore/Common/interface/TriggerNames.h"
@@ -11,37 +11,354 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include <map>
+#include <ROOT/RField.hxx>
+#include <ROOT/RField/RFieldRecord.hxx>
+#include <ROOT/RFieldBase.hxx>
+#include <ROOT/RVersion.hxx>
 
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <memory>
+#include <optional>
+#include <unordered_set>
+#include <utility>
+
+using ROOT::REntry;
+using ROOT::RFieldBase;
 using ROOT::RNTupleModel;
+using ROOT::RNTupleWriter;
+using ROOT::RRecordField;
 
 namespace {
+
+  // The prefixes NanoAOD keeps, one record each. No prefix here may be a prefix of another.
+  const std::array<std::string, 3> kTriggerGroups = {"HLT", "Flag", "L1"};
+
+  // A version suffix is "_v" followed by the version number and nothing else. "_v" with an empty
+  // tail counts: unversioned menu entries are written that way, and the TTree module trims them too.
+  bool isVersionSuffix(const std::string& name, std::size_t vpos) {
+    for (std::size_t i = vpos + 2; i < name.size(); i++) {
+      if (std::isdigit(static_cast<unsigned char>(name[i])) == 0) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   void trimVersionSuffix(std::string& trigger_name) {
     // HLT and L1 triggers have version suffixes we trim before filling the RNTuple
     if (trigger_name.compare(0, 3, "HLT") != 0 && trigger_name.compare(0, 2, "L1") != 0) {
       return;
     }
+    // Only cut a real version. Cutting at the last "_v" whatever follows it would also eat the tail
+    // of a path that merely contains one -- an "HLT_DiJet_vbf" would land on "HLT_DiJet" and could
+    // then collide with a genuine "HLT_DiJet_v3", costing one of the two its own field.
     auto vfound = trigger_name.rfind("_v");
-    if (vfound == std::string::npos) {
+    if (vfound == std::string::npos || !isVersionSuffix(trigger_name, vfound)) {
       return;
     }
     trigger_name.replace(vfound, trigger_name.size() - vfound, "");
   }
 
-  bool isNanoaodTrigger(const std::string& name) {
-    return name.compare(0, 3, "HLT") == 0 || name.compare(0, 4, "Flag") == 0 || name.compare(0, 2, "L1") == 0;
+  // Where a path goes: its group's record, the member name inside it, and the flat name the TTree
+  // module gives the branch, which is the path name with any version suffix trimmed.
+  struct SplitTriggerName {
+    std::string group;
+    std::string member;
+    std::string flatName;
+  };
+
+  // The record and member a path belongs in, or nothing if NanoAOD does not keep it.
+  // HLT_IsoMu24_v3 is ("HLT", "IsoMu24"), so it is written as HLT.IsoMu24. A kept path that is not
+  // of the form <group>_<rest>, such as HLTriggerFinalPath, keeps its whole name as the member --
+  // the one case where the flat name is not the group and the member joined by "_" again.
+  std::optional<SplitTriggerName> splitTriggerName(std::string name) {
+    const auto group = std::find_if(kTriggerGroups.begin(), kTriggerGroups.end(), [&name](const std::string& prefix) {
+      return name.compare(0, prefix.size(), prefix) == 0;
+    });
+    if (group == kTriggerGroups.end()) {
+      return std::nullopt;
+    }
+    trimVersionSuffix(name);
+    if (name.size() > group->size() + 1 && name[group->size()] == '_') {
+      return SplitTriggerName{*group, name.substr(group->size() + 1), name};
+    }
+    return SplitTriggerName{*group, name, name};
+  }
+
+  std::string memberDescription(const std::string& processName) {
+    return "Trigger/flag bit (process: " + processName + ")";
   }
 
 }  // anonymous namespace
 
-TriggerFieldPtr::TriggerFieldPtr(
-    const std::string& name, int index, const std::string& fieldName, const std::string& fieldDesc, RNTupleModel& model)
-    : m_field(fieldName, fieldDesc, model), m_triggerName(name), m_triggerIndex(index) {}
+TriggerRecordFields::TriggerRecordFields(const std::string& groupName, const std::string& processName)
+    : m_groupName(groupName), m_fieldName(groupName), m_processName(processName) {}
 
-void TriggerFieldPtr::fill(const edm::TriggerResults& triggers) {
-  // A trigger absent from the current run's menu has no index and is filled as false
-  m_field.fill(m_triggerIndex >= 0 ? triggers.accept(m_triggerIndex) : false);
+void TriggerRecordFields::addPath(const std::string& member, const TriggerMenuEntry& path) {
+  auto found = m_positions.find(member);
+  if (found != m_positions.end()) {
+    // Two paths of one menu trimming to the same name: keep a single member and follow the last of
+    // them, which is what update() settles on too, its menu being keyed on the trimmed name.
+    edm::LogWarning("TriggerOutputFields")
+        << "More than one path in the " << m_processName << " menu maps to " << m_groupName << "." << member
+        << "; writing a single field, following the last of them.\n";
+    m_indices[found->second] = path.index;
+    return;
+  }
+  m_positions.emplace(member, m_members.size());
+  m_members.push_back(member);
+  m_flatNames.push_back(path.flatName);
+  m_indices.push_back(path.index);
+}
+
+void TriggerRecordFields::createField(RNTupleModel& model, const std::string& fieldName) {
+  m_fieldName = fieldName;
+  std::vector<std::unique_ptr<RFieldBase>> subfields;
+  subfields.reserve(m_members.size());
+  for (const auto& member : m_members) {
+    auto field = RFieldBase::Create(member, "bool").Unwrap();
+    field->SetDescription(memberDescription(m_processName));
+    subfields.push_back(std::move(field));
+  }
+  auto record = std::make_unique<RRecordField>(m_fieldName, std::move(subfields));
+  record->SetDescription("Trigger/flag bits (process: " + m_processName + ")");
+  model.AddField(std::move(record));
+}
+
+void TriggerRecordFields::addProjections(RNTupleModel& model) const {
+  // Not rntupleprojection::addForField: a path's flat name is not always the record and the member
+  // joined by "_", so each member is named here rather than derived from the record.
+  for (std::size_t i = 0; i < m_members.size(); i++) {
+    rntupleprojection::add(
+        model, m_flatNames[i], m_fieldName, m_members[i], "bool", memberDescription(m_processName), false);
+  }
+}
+
+void TriggerRecordFields::bind(REntry& entry, const RNTupleModel& model) {
+  const auto* record = dynamic_cast<const RRecordField*>(&model.GetConstField(m_fieldName));
+  if (nullptr == record) {
+    throw cms::Exception("LogicError", "Trigger field " + m_fieldName + " is not a record");
+  }
+  m_offsets = record->GetOffsets();
+  if (m_offsets.size() != m_members.size()) {
+    throw cms::Exception("LogicError",
+                         "Trigger record " + m_fieldName + " has " + std::to_string(m_offsets.size()) +
+                             " members in the model but " + std::to_string(m_members.size()) + " here");
+  }
+  m_buffer.assign(record->GetValueSize(), 0);
+  entry.BindRawPtr<void>(m_fieldName, m_buffer.data());
+  for (std::size_t i = 0; i < m_looseFlatNames.size(); i++) {
+    entry.BindValue<bool>(m_looseFlatNames[i], m_looseValues[i]);
+  }
+}
+
+bool TriggerRecordFields::update(TriggerMenu& menu, RNTupleWriter& writer, [[maybe_unused]] bool addProjections) {
+  // Point the paths already written at their index in the current menu, or at -1 if they are gone.
+  // Erasing on a match leaves only the paths this record does not have yet. A path that came back
+  // under a different flat name -- a version suffix appearing or going -- keeps the name it was
+  // written under; renaming a field mid-ntuple is not possible, and the member name is the identity.
+  for (std::size_t i = 0; i < m_members.size(); i++) {
+    auto found = menu.find(m_members[i]);
+    if (found == menu.end()) {
+      m_indices[i] = -1;
+    } else {
+      m_indices[i] = found->second.index;
+      menu.erase(found);
+    }
+  }
+  for (std::size_t i = 0; i < m_looseMembers.size(); i++) {
+    auto found = menu.find(m_looseMembers[i]);
+    if (found == menu.end()) {
+      m_looseIndices[i] = -1;
+    } else {
+      m_looseIndices[i] = found->second.index;
+      menu.erase(found);
+    }
+  }
+  if (menu.empty()) {
+    return false;
+  }
+  // Every top-level name the model holds. RNTuple throws on a duplicate rather than reporting it,
+  // so a name has to be checked before it is used; taken here, before the model starts changing.
+  std::unordered_set<std::string> taken = writer.GetModel().GetFieldNames();
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 40, 0)
+  {
+    // The updater commits when it goes out of scope. Committing explicitly as well commits twice,
+    // which leaves the model id at 0 and makes the next Fill() throw "mismatch between entry and
+    // model"; the updater must also not outlive the writer, whose model its destructor re-freezes.
+    auto updater = writer.CreateModelUpdater();
+    updater->BeginUpdate();
+    for (const auto& path : menu) {
+      auto field = RFieldBase::Create(path.first, "bool").Unwrap();
+      field->SetDescription(memberDescription(m_processName));
+      updater->AddField(std::move(field), m_fieldName);
+      m_positions.emplace(path.first, m_members.size());
+      m_members.push_back(path.first);
+      m_flatNames.push_back(path.second.flatName);
+      m_indices.push_back(path.second.index);
+      if (addProjections) {
+        // The projection resolves against the member added just above, in the same transaction.
+        rntupleprojection::add(*updater,
+                               taken,
+                               path.second.flatName,
+                               m_fieldName,
+                               path.first,
+                               "bool",
+                               memberDescription(m_processName),
+                               false);
+      }
+    }
+  }
+  for (const auto& path : menu) {
+    edm::LogInfo("TriggerOutputFields") << "Added " << m_fieldName << "." << path.first
+                                        << ", which is not in the menu the schema was built from; it reads false for "
+                                           "the entries written before now.\n";
+  }
+  menu.clear();
+  return true;
+#else
+  // Before 6.40 a record cannot grow once the ntuple is being written. The path still gets into the
+  // file, as a top-level bool field under the flat name the TTree module gives its branch, which is
+  // also the name a projection of the member would have had. It is written whether or not
+  // projections are on: the alternative is dropping the path.
+  //
+  // Settle on the names first: opening an updater invalidates the entry the caller is filling
+  // through, so it must only be opened when there is something to add.
+  std::vector<std::pair<std::string, TriggerMenuEntry>> toAdd;
+  std::vector<std::string> added;
+  for (const auto& path : menu) {
+    if (!taken.insert(path.second.flatName).second) {
+      edm::LogWarning("TriggerOutputFields")
+          << "Skipping output of " << m_fieldName << "." << path.first << ": it is not in the menu the schema was "
+          << "built from, so it would have to be written as " << path.second.flatName
+          << ", and a field of that name is already there.\n";
+      continue;
+    }
+    toAdd.push_back(path);
+    added.push_back(path.second.flatName);
+  }
+  if (!toAdd.empty()) {
+    auto updater = writer.CreateModelUpdater();
+    updater->BeginUpdate();
+    for (const auto& path : toAdd) {
+      auto field = RFieldBase::Create(path.second.flatName, "bool").Unwrap();
+      field->SetDescription(memberDescription(m_processName));
+      updater->AddField(std::move(field));
+      m_looseMembers.push_back(path.first);
+      m_looseFlatNames.push_back(path.second.flatName);
+      m_looseIndices.push_back(path.second.index);
+      m_looseValues.push_back(std::make_shared<bool>(false));
+    }
+  }
+  for (const auto& name : added) {
+    edm::LogWarning("TriggerOutputFields")
+        << "Writing " << name << " as a top-level field rather than a member of " << m_fieldName
+        << ": it is not in the menu the schema was built from, and growing the record needs ROOT 6.40. It reads false "
+           "for the entries written before now.\n";
+  }
+  menu.clear();
+  return !added.empty();
+#endif
+}
+
+void TriggerRecordFields::fill(const edm::TriggerResults& triggers) {
+  for (std::size_t i = 0; i < m_indices.size(); i++) {
+    // A path absent from the current run's menu has no index and is filled as false
+    m_buffer[m_offsets[i]] = (m_indices[i] >= 0 && triggers.accept(m_indices[i])) ? 1 : 0;
+  }
+  for (std::size_t i = 0; i < m_looseIndices.size(); i++) {
+    *m_looseValues[i] = m_looseIndices[i] >= 0 && triggers.accept(m_looseIndices[i]);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void TriggerOutputFields::createFields(const edm::EventForOutput& event, RNTupleModel& model) {
+  m_lastRun = event.id().run();
+  edm::Handle<edm::TriggerResults> handle;
+  event.getByToken(m_token, handle);
+  std::vector<std::string> triggerNames(TriggerOutputFields::getTriggerNames(*handle));
+  for (std::size_t i = 0; i < triggerNames.size(); i++) {
+    auto split = splitTriggerName(triggerNames[i]);
+    if (!split) {
+      continue;
+    }
+    auto record = std::find_if(m_records.begin(), m_records.end(), [&split](const TriggerRecordFields& candidate) {
+      return candidate.getGroupName() == split->group;
+    });
+    if (record == m_records.end()) {
+      record = m_records.emplace(m_records.end(), split->group, m_processName);
+    }
+    record->addPath(split->member, {static_cast<int>(i), split->flatName});
+  }
+  // Named only now, when the whole model is there to be checked against for a name clash.
+  for (auto& record : m_records) {
+    record.createField(model, uniqueName(model, record.getGroupName()));
+  }
+}
+
+void TriggerOutputFields::addProjections(RNTupleModel& model) const {
+  for (const auto& record : m_records) {
+    record.addProjections(model);
+  }
+}
+
+void TriggerOutputFields::bind(REntry& entry, const RNTupleModel& model) {
+  for (auto& record : m_records) {
+    record.bind(entry, model);
+  }
+}
+
+bool TriggerOutputFields::updateForRun(const edm::EventForOutput& event, RNTupleWriter& writer, bool addProjections) {
+  if (m_lastRun == static_cast<long>(event.id().run())) {
+    return false;
+  }
+  m_lastRun = event.id().run();
+  edm::Handle<edm::TriggerResults> handle;
+  event.getByToken(m_token, handle);
+  // Collect the current menu once. Each name is trimmed exactly once: trimVersionSuffix cuts at the
+  // last "_v", so trimming an already trimmed name can truncate it again.
+  std::map<std::string, TriggerMenu> menu;
+  std::vector<std::string> triggerNames(TriggerOutputFields::getTriggerNames(*handle));
+  for (std::size_t i = 0; i < triggerNames.size(); i++) {
+    auto split = splitTriggerName(triggerNames[i]);
+    if (!split) {
+      continue;
+    }
+    menu[split->group][split->member] = {static_cast<int>(i), split->flatName};
+  }
+  bool changed = false;
+  for (auto& record : m_records) {
+    auto group = menu.find(record.getGroupName());
+    if (group == menu.end()) {
+      // The whole group is gone from this run: every member of it fills as false.
+      TriggerMenu gone;
+      changed |= record.update(gone, writer, addProjections);
+      continue;
+    }
+    changed |= record.update(group->second, writer, addProjections);
+    menu.erase(group);
+  }
+  // A group with no record at all is a prefix that had no path in the menu the schema was built
+  // from. Adding one would mean a new top-level field rather than growing a record, which this
+  // module does not do.
+  for (const auto& group : menu) {
+    for (const auto& path : group.second) {
+      edm::LogWarning("TriggerOutputFields") << "Skipping output of " << group.first << "." << path.first << ": no "
+                                             << group.first << " path was in the menu the schema was built from.\n";
+    }
+  }
+  return changed;
+}
+
+void TriggerOutputFields::fill(const edm::EventForOutput& event) {
+  edm::Handle<edm::TriggerResults> handle;
+  event.getByToken(m_token, handle);
+  for (auto& record : m_records) {
+    record.fill(*handle);
+  }
 }
 
 std::vector<std::string> TriggerOutputFields::getTriggerNames(const edm::TriggerResults& triggerResults) {
@@ -66,81 +383,19 @@ std::vector<std::string> TriggerOutputFields::getTriggerNames(const edm::Trigger
   return names.triggerNames();
 }
 
-void TriggerOutputFields::createFields(const edm::EventForOutput& event, RNTupleModel& model) {
-  m_lastRun = event.id().run();
-  edm::Handle<edm::TriggerResults> handle;
-  event.getByToken(m_token, handle);
-  const edm::TriggerResults& triggerResults = *handle;
-  std::vector<std::string> triggerNames(TriggerOutputFields::getTriggerNames(triggerResults));
-  m_triggerFields.reserve(triggerNames.size());
-  for (std::size_t i = 0; i < triggerNames.size(); i++) {
-    auto& name = triggerNames[i];
-    if (!isNanoaodTrigger(name)) {
-      continue;
-    }
-    trimVersionSuffix(name);
-    std::string modelName = name;
-    makeUniqueFieldName(model, modelName);
-    std::string desc = std::string("Trigger/flag bit (process: ") + m_processName + ")";
-    m_triggerFields.emplace_back(name, i, modelName, desc, model);
+std::string TriggerOutputFields::uniqueName(const RNTupleModel& model, const std::string& name) const {
+  const auto& fieldNames = model.GetFieldNames();
+  if (!fieldNames.contains(name)) {
+    return name;
   }
-}
-
-void TriggerOutputFields::updateTriggerFields(const edm::TriggerResults& triggers) {
-  std::vector<std::string> newNames(TriggerOutputFields::getTriggerNames(triggers));
-  // Collect the current menu once. Each name is trimmed exactly once: trimVersionSuffix cuts at the
-  // last "_v", so trimming an already trimmed name can truncate it again.
-  std::map<std::string, int> menu;
-  for (std::size_t j = 0; j < newNames.size(); j++) {
-    auto& name = newNames[j];
-    if (!isNanoaodTrigger(name)) {
-      continue;
-    }
-    trimVersionSuffix(name);
-    menu[name] = static_cast<int>(j);
+  // The name is taken, usually by the same group from another process or by a table column. Append
+  // the process, and keep going if even that is taken: the model must never be handed a name it
+  // already holds, which RNTuple rejects outright, so the loop has to end on a free one.
+  std::string unique = name + "_p" + m_processName;
+  for (unsigned int i = 2; fieldNames.contains(unique); i++) {
+    unique = name + "_p" + m_processName + "_" + std::to_string(i);
   }
-  // Point the existing fields at their index in the current menu, or at -1 if they are gone.
-  // Erasing on a match leaves only the unclaimed paths behind for the warning below. It also means
-  // a menu entry is bound to at most one field: should two fields ever carry the same trimmed name
-  // (possible only if a menu holds two versions of one path), the first claims it and the rest are
-  // written as false. That is the safe reading -- the alternative, pointing several fields at the
-  // same bit, would silently duplicate one path's decision under several names.
-  for (auto& t : m_triggerFields) {
-    auto found = menu.find(t.getTriggerName());
-    if (found == menu.end()) {
-      t.setIndex(-1);
-    } else {
-      t.setIndex(found->second);
-      menu.erase(found);
-    }
-  }
-  // Whatever is left in the menu appeared after the schema was frozen and cannot be added.
-  for (const auto& entry : menu) {
-    // TODO backfill / friend ntuples
-    edm::LogWarning("TriggerOutputFields") << "Skipping output of TriggerField " << entry.first << "\n";
-  }
-}
-
-void TriggerOutputFields::makeUniqueFieldName(const RNTupleModel& model, std::string& name) {
-  bool already_exists = model.GetFieldNames().contains(name);
-
-  if (!already_exists) {
-    return;
-  }
-  edm::LogWarning("TriggerOutputFields") << "Found a field with name " << name << " already present. Will add suffix _p"
-                                         << m_processName << " to the new field.\n";
-  name += std::string("_p") + m_processName;
-}
-
-void TriggerOutputFields::fill(const edm::EventForOutput& event) {
-  edm::Handle<edm::TriggerResults> handle;
-  event.getByToken(m_token, handle);
-  const edm::TriggerResults& triggers = *handle;
-  if (m_lastRun != event.id().run()) {
-    m_lastRun = event.id().run();
-    updateTriggerFields(triggers);
-  }
-  for (auto& t : m_triggerFields) {
-    t.fill(triggers);
-  }
+  edm::LogWarning("TriggerOutputFields") << "Found a field named " << name << " already present; writing this one as "
+                                         << unique << " instead.\n";
+  return unique;
 }

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
@@ -11,7 +11,7 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include <algorithm>
+#include <map>
 
 using ROOT::RNTupleModel;
 
@@ -36,16 +36,12 @@ namespace {
 }  // anonymous namespace
 
 TriggerFieldPtr::TriggerFieldPtr(
-    std::string name, int index, std::string fieldName, std::string fieldDesc, RNTupleModel& model)
-    : m_triggerName(name), m_triggerIndex(index) {
-  m_field = RNTupleFieldPtr<bool>(fieldName, fieldDesc, model);
-}
+    const std::string& name, int index, const std::string& fieldName, const std::string& fieldDesc, RNTupleModel& model)
+    : m_field(fieldName, fieldDesc, model), m_triggerName(name), m_triggerIndex(index) {}
 
 void TriggerFieldPtr::fill(const edm::TriggerResults& triggers) {
-  if (m_triggerIndex == -1) {
-    m_field.fill(false);
-  }
-  m_field.fill(triggers.accept(m_triggerIndex));
+  // A trigger absent from the current run's menu has no index and is filled as false
+  m_field.fill(m_triggerIndex >= 0 ? triggers.accept(m_triggerIndex) : false);
 }
 
 std::vector<std::string> TriggerOutputFields::getTriggerNames(const edm::TriggerResults& triggerResults) {
@@ -86,40 +82,42 @@ void TriggerOutputFields::createFields(const edm::EventForOutput& event, RNTuple
     std::string modelName = name;
     makeUniqueFieldName(model, modelName);
     std::string desc = std::string("Trigger/flag bit (process: ") + m_processName + ")";
-    m_triggerFields.emplace_back(TriggerFieldPtr(name, i, modelName, desc, model));
+    m_triggerFields.emplace_back(name, i, modelName, desc, model);
   }
 }
 
-// Worst case O(n^2) to adjust the triggers
 void TriggerOutputFields::updateTriggerFields(const edm::TriggerResults& triggers) {
   std::vector<std::string> newNames(TriggerOutputFields::getTriggerNames(triggers));
-  // adjust existing trigger indices
-  for (auto& t : m_triggerFields) {
-    t.setIndex(-1);
-    for (std::size_t j = 0; j < newNames.size(); j++) {
-      auto& name = newNames[j];
-      if (!isNanoaodTrigger(name)) {
-        continue;
-      }
-      trimVersionSuffix(name);
-      if (name == t.getTriggerName()) {
-        t.setIndex(j);
-      }
-    }
-  }
-  // find new triggers
+  // Collect the current menu once. Each name is trimmed exactly once: trimVersionSuffix cuts at the
+  // last "_v", so trimming an already trimmed name can truncate it again.
+  std::map<std::string, int> menu;
   for (std::size_t j = 0; j < newNames.size(); j++) {
     auto& name = newNames[j];
     if (!isNanoaodTrigger(name)) {
       continue;
     }
     trimVersionSuffix(name);
-    if (std::none_of(m_triggerFields.cbegin(), m_triggerFields.cend(), [&](const TriggerFieldPtr& t) {
-          return t.getTriggerName() == name;
-        })) {
-      // TODO backfill / friend ntuples
-      edm::LogWarning("TriggerOutputFields") << "Skipping output of TriggerField " << name << "\n";
+    menu[name] = static_cast<int>(j);
+  }
+  // Point the existing fields at their index in the current menu, or at -1 if they are gone.
+  // Erasing on a match leaves only the unclaimed paths behind for the warning below. It also means
+  // a menu entry is bound to at most one field: should two fields ever carry the same trimmed name
+  // (possible only if a menu holds two versions of one path), the first claims it and the rest are
+  // written as false. That is the safe reading -- the alternative, pointing several fields at the
+  // same bit, would silently duplicate one path's decision under several names.
+  for (auto& t : m_triggerFields) {
+    auto found = menu.find(t.getTriggerName());
+    if (found == menu.end()) {
+      t.setIndex(-1);
+    } else {
+      t.setIndex(found->second);
+      menu.erase(found);
     }
+  }
+  // Whatever is left in the menu appeared after the schema was frozen and cannot be added.
+  for (const auto& entry : menu) {
+    // TODO backfill / friend ntuples
+    edm::LogWarning("TriggerOutputFields") << "Skipping output of TriggerField " << entry.first << "\n";
   }
 }
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.h
@@ -13,7 +13,11 @@ namespace edm {
 class TriggerFieldPtr {
 public:
   TriggerFieldPtr() = default;
-  TriggerFieldPtr(std::string name, int index, std::string fieldName, std::string fieldDesc, ROOT::RNTupleModel& model);
+  TriggerFieldPtr(const std::string& name,
+                  int index,
+                  const std::string& fieldName,
+                  const std::string& fieldDesc,
+                  ROOT::RNTupleModel& model);
   void fill(const edm::TriggerResults& triggers);
   const std::string& getTriggerName() const { return m_triggerName; }
   void setIndex(int newIndex) { m_triggerIndex = newIndex; }

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.h
@@ -1,32 +1,85 @@
 #ifndef PhysicsTools_NanoAOD_TriggerOutputFields_h
 #define PhysicsTools_NanoAOD_TriggerOutputFields_h
 
-#include "RNTupleFieldPtr.h"
-
 #include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include <ROOT/REntry.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleWriter.hxx>
+
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace edm {
   class EventForOutput;
   class TriggerResults;
 }  // namespace edm
 
-class TriggerFieldPtr {
+// One path of the current menu: where it sits in the TriggerResults, and the flat name the TTree
+// output module gives its branch, which is not always the record and member joined by "_"; see
+// splitTriggerName().
+struct TriggerMenuEntry {
+  int index;
+  std::string flatName;
+};
+// The paths of one group, keyed on the member name they were cut down to.
+using TriggerMenu = std::map<std::string, TriggerMenuEntry>;
+
+// One group of trigger-like paths -- HLT, Flag or L1 -- written as a single untyped record field
+// whose members are the paths: HLT_IsoMu24 becomes HLT.IsoMu24, the same relation the collection
+// fields have to the TTree module's Muon_pt branches.
+//
+// Grouping is what makes a path that only shows up in a later run recoverable: ROOT 6.40 can add a
+// subfield to an untyped record of a bare model while the ntuple is being written, and entries
+// already written read back false for it. Before 6.40 the record cannot grow, and such a path is
+// written as a top-level bool field of its own instead, under the flat name it would have been
+// projected to (HLT_IsoMu24); it is then in the file, but outside the record.
+class TriggerRecordFields {
 public:
-  TriggerFieldPtr() = default;
-  TriggerFieldPtr(const std::string& name,
-                  int index,
-                  const std::string& fieldName,
-                  const std::string& fieldDesc,
-                  ROOT::RNTupleModel& model);
+  TriggerRecordFields(const std::string& groupName, const std::string& processName);
+
+  const std::string& getGroupName() const { return m_groupName; }
+  const std::string& getFieldName() const { return m_fieldName; }
+  bool empty() const { return m_members.empty(); }
+
+  // Collect a path before the record is built. Two paths that trim to one member name share it.
+  void addPath(const std::string& member, const TriggerMenuEntry& path);
+  // Build the record from the paths collected so far. The field name may differ from the group
+  // name if something else in the model already claimed it; see TriggerOutputFields::uniqueName.
+  void createField(ROOT::RNTupleModel& model, const std::string& fieldName);
+  // Give each path the flat name the TTree module uses: HLT_IsoMu24 beside HLT.IsoMu24.
+  void addProjections(ROOT::RNTupleModel& model) const;
+  // Size the buffer from the record as the model now has it and point the entry at it. Must be
+  // redone after every schema update: the record grows and the entries are invalidated.
+  void bind(ROOT::REntry& entry, const ROOT::RNTupleModel& model);
+  // Re-point the members at their index in this run's menu, -1 if the path is gone, and add fields
+  // for paths that are new. Consumes the entries it claims. Returns true if the schema changed.
+  bool update(TriggerMenu& menu, ROOT::RNTupleWriter& writer, bool addProjections);
   void fill(const edm::TriggerResults& triggers);
-  const std::string& getTriggerName() const { return m_triggerName; }
-  void setIndex(int newIndex) { m_triggerIndex = newIndex; }
 
 private:
-  RNTupleFieldPtr<bool> m_field;
-  // The trigger results name extracted from the TriggerResults with version suffixes trimmed
-  std::string m_triggerName;
-  int m_triggerIndex = -1;
+  std::string m_groupName;
+  std::string m_fieldName;
+  std::string m_processName;
+  // Member names in record order, their flat names, their index in the current TriggerResults, and
+  // a lookup from the member name to its position in all three.
+  std::vector<std::string> m_members;
+  std::vector<std::string> m_flatNames;
+  std::vector<int> m_indices;
+  std::map<std::string, std::size_t> m_positions;
+  // The record is filled through one flat buffer, as the collection fields are.
+  std::vector<std::size_t> m_offsets;
+  std::vector<unsigned char> m_buffer;
+  // Paths the record could not take, on a ROOT too old to grow it: member name, name of the
+  // top-level field standing in for the member, index in the current TriggerResults, and the value
+  // that field is filled from.
+  std::vector<std::string> m_looseMembers;
+  std::vector<std::string> m_looseFlatNames;
+  std::vector<int> m_looseIndices;
+  std::vector<std::shared_ptr<bool>> m_looseValues;
 };
 
 class TriggerOutputFields {
@@ -35,18 +88,22 @@ public:
   explicit TriggerOutputFields(const std::string& processName, const edm::EDGetToken& token)
       : m_token(token), m_lastRun(-1), m_processName(processName) {}
   void createFields(const edm::EventForOutput& event, ROOT::RNTupleModel& model);
+  void addProjections(ROOT::RNTupleModel& model) const;
+  void bind(ROOT::REntry& entry, const ROOT::RNTupleModel& model);
+  // Called on every event before fill(): on a run boundary the menu is re-read, which can change
+  // the schema. Returns true if it did, in which case the caller has to bind a fresh entry.
+  bool updateForRun(const edm::EventForOutput& event, ROOT::RNTupleWriter& writer, bool addProjections);
   void fill(const edm::EventForOutput& event);
 
 private:
   static std::vector<std::string> getTriggerNames(const edm::TriggerResults& triggerResults);
-  // Update trigger field information on run boundaries
-  void updateTriggerFields(const edm::TriggerResults& triggerResults);
-  void makeUniqueFieldName(const ROOT::RNTupleModel& model, std::string& name);
+  // A record name not already taken in the model, warning if it had to be changed.
+  std::string uniqueName(const ROOT::RNTupleModel& model, const std::string& name) const;
 
   edm::EDGetToken m_token;
   long m_lastRun;
   std::string m_processName;
-  std::vector<TriggerFieldPtr> m_triggerFields;
+  std::vector<TriggerRecordFields> m_records;
 };
 
 #endif

--- a/PhysicsTools/NanoAOD/test/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/test/BuildFile.xml
@@ -1,6 +1,7 @@
 <bin file="test_catch2_*.cc" name="testPhysicsToolsNanoAODTP">
   <use name="FWCore/TestProcessor"/>
   <use name="DataFormats/NanoAOD"/>
+  <use name="rootntuple"/>
   <use name="catch2"/>
 </bin>
 

--- a/PhysicsTools/NanoAOD/test/test_catch2_NanoAODRNTupleFields.cc
+++ b/PhysicsTools/NanoAOD/test/test_catch2_NanoAODRNTupleFields.cc
@@ -1,0 +1,336 @@
+// Contract tests for the RNTuple behaviour NanoAODRNTupleOutputModule is built on.
+//
+// The output module (PhysicsTools/NanoAOD/plugins/rntuple/) writes its grouped fields as untyped
+// records and untyped vectors of records, gives every member a flat TTree-style name with a
+// projected field, and grows a trigger record while the ntuple is being written. None of that is
+// ordinary RNTuple usage, the API behind it has moved repeatedly across ROOT 6.3x, and the release
+// this work targets (CMSSW_20_1_0_pre2_ROOT640, ROOT 6.40) cannot be built on every developer
+// machine. These tests pin the behaviour down so a ROOT upgrade that changes it fails here rather
+// than silently in the output.
+//
+// They exercise ROOT directly, in the same shapes and the same order as the module, rather than the
+// module's own classes: those live in a plugin library, which a test binary cannot link against.
+//
+// The late-extension section is where the ROOT version matters. Adding a subfield to an untyped
+// record of a model that is already being written needs RUpdater::AddField(field, parentName),
+// which is 6.40 and newer; before that the module writes the path as a top-level field instead, and
+// this test follows the same split, so each build tests the path it actually takes.
+
+#include "catch2/catch_all.hpp"
+
+#include <ROOT/REntry.hxx>
+#include <ROOT/RField.hxx>
+#include <ROOT/RField/RFieldRecord.hxx>
+#include <ROOT/RField/RFieldSequenceContainer.hxx>
+#include <ROOT/RFieldBase.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RNTupleWriter.hxx>
+#include <ROOT/RVersion.hxx>
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+static constexpr auto s_tag = "[NanoAODRNTupleFields]";
+
+namespace {
+
+  using ROOT::RFieldBase;
+  using ROOT::RNTupleModel;
+  using ROOT::RNTupleReader;
+  using ROOT::RNTupleWriter;
+  using ROOT::RRecordField;
+  using ROOT::RVectorField;
+
+  // Every type nanoaod::FlatTable::ColumnType can hold, as RNTuple spells them. A column of any of
+  // these can end up as a member of a collection or a singleton record, so all of them must project.
+  const std::vector<std::string> kColumnTypes = {"bool",
+                                                 "std::uint8_t",
+                                                 "std::int8_t",
+                                                 "std::uint16_t",
+                                                 "std::int16_t",
+                                                 "std::uint32_t",
+                                                 "std::int32_t",
+                                                 "std::uint64_t",
+                                                 "std::int64_t",
+                                                 "float",
+                                                 "double"};
+
+  // A file that deletes itself, so a failing assertion does not leave one behind.
+  class ScopedFile {
+  public:
+    explicit ScopedFile(const std::string& name) : m_path(std::filesystem::temp_directory_path() / name) {
+      std::filesystem::remove(m_path);
+    }
+    ~ScopedFile() { std::filesystem::remove(m_path); }
+    std::string path() const { return m_path.string(); }
+
+  private:
+    std::filesystem::path m_path;
+  };
+
+  // An untyped record, as TableCollectionSet builds one for a singleton table or a trigger group.
+  std::unique_ptr<RRecordField> makeRecord(const std::string& name, const std::vector<std::string>& memberTypes) {
+    std::vector<std::unique_ptr<RFieldBase>> members;
+    members.reserve(memberTypes.size());
+    for (const auto& type : memberTypes) {
+      members.push_back(RFieldBase::Create("m_" + type, type).Unwrap());
+    }
+    return std::make_unique<RRecordField>(name, std::move(members));
+  }
+
+  // The projection of one member, as rntupleprojection::add makes it: a scalar for a member of a
+  // plain record, a vector for a member of a record inside a vector, and a mapping for each level.
+  // Returns whether ROOT accepted it -- an RResult cannot be handed to REQUIRE directly, and it
+  // throws when destroyed unchecked, so it is inspected here.
+  bool addProjection(RNTupleModel& model,
+                     const std::string& fieldName,
+                     const std::string& memberName,
+                     const std::string& memberTypeName,
+                     bool inCollection) {
+    const std::string name = fieldName + "_" + memberName;
+    auto field =
+        RFieldBase::Create(name, inCollection ? "std::vector<" + memberTypeName + ">" : memberTypeName).Unwrap();
+    const std::string member = fieldName + (inCollection ? "._0." : ".") + memberName;
+    auto result = model.AddProjectedField(std::move(field),
+                                          [name, fieldName, member, inCollection](const std::string& projected) {
+                                            return (inCollection && projected == name) ? fieldName : member;
+                                          });
+    return static_cast<bool>(result);
+  }
+
+  const RRecordField* recordOf(const RNTupleModel& model, const std::string& fieldName) {
+    return dynamic_cast<const RRecordField*>(&model.GetConstField(fieldName));
+  }
+
+}  // anonymous namespace
+
+TEST_CASE("Grouped fields carry flat projections of every column type", s_tag) {
+  ScopedFile file{"testNanoAODRNTupleProjections.root"};
+
+  // The Events model is bare: ROOT refuses to add a subfield to an untyped record of a model that
+  // has a default entry, which is what the trigger backfill needs.
+  auto model = RNTupleModel::CreateBare();
+
+  // A named collection: one untyped vector of an untyped record, one member per column type.
+  auto item = makeRecord("_0", kColumnTypes);
+  const auto collOffsets = item->GetOffsets();
+  const auto collRecordSize = item->GetValueSize();
+  model->AddField(RVectorField::CreateUntyped("Coll", std::move(item)));
+
+  // A named singleton table: the untyped record on its own, no vector around it.
+  auto singleton = makeRecord("Sing", {"float"});
+  const auto singOffsets = singleton->GetOffsets();
+  const auto singRecordSize = singleton->GetValueSize();
+  model->AddField(std::move(singleton));
+
+  SECTION("every column type projects, in a collection and on its own") {
+    for (const auto& type : kColumnTypes) {
+      REQUIRE(addProjection(*model, "Coll", "m_" + type, type, true));
+    }
+    REQUIRE(addProjection(*model, "Sing", "m_float", "float", false));
+  }
+
+  SECTION("a projection onto a name the model already holds throws") {
+    // rntupleprojection::add checks GetFieldNames() before adding for exactly this reason: the
+    // clash comes back as an exception, not in the RResult, so it cannot simply be inspected.
+    model->MakeField<float>("Sing_m_float");
+    REQUIRE_THROWS(addProjection(*model, "Sing", "m_float", "float", false));
+  }
+
+  SECTION("a projection of a member the field does not have is refused, not thrown") {
+    REQUIRE_FALSE(addProjection(*model, "Sing", "m_absent", "float", false));
+  }
+
+  SECTION("projections read back the values of the members they project") {
+    for (const auto& type : kColumnTypes) {
+      REQUIRE(addProjection(*model, "Coll", "m_" + type, type, true));
+    }
+    REQUIRE(addProjection(*model, "Sing", "m_float", "float", false));
+    model->Freeze();
+
+    auto writer = RNTupleWriter::Recreate(std::move(model), "Events", file.path());
+    auto entry = writer->GetModel().CreateBareEntry();
+
+    // Bound the way the module binds them: a vector field's value is the std::vector object, a
+    // record's value is the memory holding it, so one gets the buffer and the other its contents.
+    std::vector<unsigned char> collBuffer;
+    std::vector<unsigned char> singBuffer(singRecordSize, 0);
+    entry->BindRawPtr<void>("Coll", &collBuffer);
+    entry->BindRawPtr<void>("Sing", singBuffer.data());
+
+    constexpr std::size_t kEntries = 3;
+    constexpr std::size_t kRows = 2;
+    for (std::size_t i = 0; i < kEntries; i++) {
+      collBuffer.assign(collRecordSize * kRows, 0);
+      for (std::size_t row = 0; row < kRows; row++) {
+        // One byte per member is enough to tell the columns apart -- every type here is at least a
+        // byte wide, and on a little-endian machine that byte is the low one -- and it is the byte
+        // the projection has to come back with. The exception is bool, whose column keeps only the
+        // low bit, so it gets a value that is a valid bool to begin with.
+        for (std::size_t m = 0; m < kColumnTypes.size(); m++) {
+          const auto value = static_cast<unsigned char>(1 + i + row + m);
+          collBuffer[row * collRecordSize + collOffsets[m]] =
+              (kColumnTypes[m] == "bool") ? static_cast<unsigned char>(value & 1u) : value;
+        }
+      }
+      const float value = 0.5f * static_cast<float>(i);
+      std::memcpy(singBuffer.data() + singOffsets[0], &value, sizeof(value));
+      writer->Fill(*entry);
+    }
+    writer.reset();
+
+    auto reader = RNTupleReader::Open("Events", file.path());
+    REQUIRE(reader->GetNEntries() == kEntries);
+
+    // The members are read under their flat names, which is the point: each is its own column of
+    // the type the member has, wrapped in a vector because the record sits inside one.
+    auto bools = reader->GetView<std::vector<bool>>("Coll_m_bool");
+    auto bytes = reader->GetView<std::vector<std::uint8_t>>("Coll_m_std::uint8_t");
+    auto ints = reader->GetView<std::vector<std::int32_t>>("Coll_m_std::int32_t");
+    auto binvar = reader->GetView<float>("Sing_m_float");
+    for (std::size_t i = 0; i < kEntries; i++) {
+      REQUIRE(bools(i).size() == kRows);
+      REQUIRE(bytes(i).size() == kRows);
+      REQUIRE(ints(i).size() == kRows);
+      REQUIRE(binvar(i) == 0.5f * static_cast<float>(i));
+      for (std::size_t row = 0; row < kRows; row++) {
+        // Members 0, 1 and 6 of the record, each read back with what was written into it.
+        REQUIRE(bools(i)[row] == (((1 + i + row) & 1u) != 0));
+        REQUIRE(bytes(i)[row] == static_cast<std::uint8_t>(1 + i + row + 1));
+        REQUIRE(ints(i)[row] == static_cast<std::int32_t>(1 + i + row + 6));
+      }
+    }
+  }
+}
+
+TEST_CASE("A record grows while the ntuple is being written", s_tag) {
+  ScopedFile file{"testNanoAODRNTupleBackfill.root"};
+
+  auto model = RNTupleModel::CreateBare();
+  model->AddField(makeRecord("HLT", {"bool"}));
+  REQUIRE(addProjection(*model, "HLT", "m_bool", "bool", false));
+  model->Freeze();
+
+  auto writer = RNTupleWriter::Recreate(std::move(model), "Events", file.path());
+
+  // What the late path leaves behind differs by version, and so does what has to be bound.
+  //
+  // On 6.40 the member goes into the record and HLT_m_late is a *projection* of it: a projection is
+  // read-only, derived from the field it projects, and has no value in an entry at all -- binding
+  // one throws "invalid field name". The value reaches it through the record buffer, so there is
+  // nothing extra to bind. That is why TriggerRecordFields only ever fills m_looseFlatNames, the
+  // list bind() walks, on the pre-6.40 branch.
+  //
+  // Before 6.40 HLT_m_late is a real top-level field and does have to be bound; the projection
+  // there is HLT_m_late_alias, onto that field.
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 40, 0)
+  constexpr bool kBindsLateField = false;
+  const std::string kProjectionName = "HLT_m_late";
+#else
+  constexpr bool kBindsLateField = true;
+  const std::string kProjectionName = "HLT_m_late_alias";
+#endif
+
+  // A bare model has no default entry, and every schema change invalidates the entries made against
+  // the previous schema, so the module rebuilds and rebinds its entry after each one. Same here.
+  std::vector<unsigned char> buffer;
+  auto lateValue = std::make_shared<bool>(false);
+  auto bindEntry = [&writer, &buffer, &lateValue](bool haveLateField) {
+    const auto& model = writer->GetModel();
+    auto entry = model.CreateBareEntry();
+    const auto* record = recordOf(model, "HLT");
+    REQUIRE(record != nullptr);
+    buffer.assign(record->GetValueSize(), 0);
+    entry->BindRawPtr<void>("HLT", buffer.data());
+    if (haveLateField) {
+      entry->BindValue<bool>("HLT_m_late", lateValue);
+    }
+    return entry;
+  };
+
+  auto entry = bindEntry(false);
+  REQUIRE(recordOf(writer->GetModel(), "HLT") != nullptr);
+  const auto offsets = recordOf(writer->GetModel(), "HLT")->GetOffsets();
+  for (std::size_t i = 0; i < 2; i++) {
+    buffer[offsets[0]] = 1;
+    writer->Fill(*entry);
+  }
+
+  {
+    // The updater commits in its destructor. Committing explicitly as well commits twice, which
+    // leaves the model id at 0 and makes the next Fill() throw; the module documents this and so
+    // does not call CommitUpdate() either, which is what the Fill() below guards.
+    auto updater = writer->CreateModelUpdater();
+    updater->BeginUpdate();
+    auto field = RFieldBase::Create("m_late", "bool").Unwrap();
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 40, 0)
+    // 6.40 and newer: the member goes into the record, and its projection is added in the same
+    // transaction, resolving against the member added just above.
+    updater->AddField(std::move(field), "HLT");
+    auto projection = RFieldBase::Create("HLT_m_late", "bool").Unwrap();
+    auto added = updater->AddProjectedField(std::move(projection),
+                                            [](const std::string&) -> std::string { return "HLT.m_late"; });
+    REQUIRE(static_cast<bool>(added));
+#else
+    // Before 6.40 a record cannot grow, and the module writes the path as a top-level field under
+    // the flat name the projection would have had. A projection onto that late field still works,
+    // which is what says the two operations may share one transaction.
+    field = RFieldBase::Create("HLT_m_late", "bool").Unwrap();
+    updater->AddField(std::move(field));
+    auto projection = RFieldBase::Create("HLT_m_late_alias", "bool").Unwrap();
+    auto added = updater->AddProjectedField(std::move(projection),
+                                            [](const std::string&) -> std::string { return "HLT_m_late"; });
+    REQUIRE(static_cast<bool>(added));
+#endif
+  }
+
+  // A projection is not part of an entry on either version, whichever field it is a projection of.
+  REQUIRE_THROWS(writer->GetModel().CreateBareEntry()->BindValue<bool>(kProjectionName, lateValue));
+
+  entry = bindEntry(kBindsLateField);
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 40, 0)
+  // The record grew, so its offsets moved and the buffer was resized: re-read them, as bind() does.
+  REQUIRE(recordOf(writer->GetModel(), "HLT") != nullptr);
+  const auto grownOffsets = recordOf(writer->GetModel(), "HLT")->GetOffsets();
+  REQUIRE(grownOffsets.size() == 2);
+#endif
+  for (std::size_t i = 0; i < 2; i++) {
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 40, 0)
+    buffer[grownOffsets[0]] = 1;
+    buffer[grownOffsets[1]] = 1;
+#else
+    buffer[offsets[0]] = 1;
+    *lateValue = true;
+#endif
+    REQUIRE_NOTHROW(writer->Fill(*entry));
+  }
+  writer.reset();
+
+  auto reader = RNTupleReader::Open("Events", file.path());
+  REQUIRE(reader->GetNEntries() == 4);
+
+  auto early = reader->GetView<bool>("HLT_m_bool");
+  auto late = reader->GetView<bool>("HLT_m_late");
+  for (std::size_t i = 0; i < 4; i++) {
+    // The member written from the start is true throughout, projection and all.
+    REQUIRE(early(i));
+    // The one added later is a deferred column: the entries written before it read back false,
+    // which is what makes a trigger path first seen in a later run safe to add.
+    REQUIRE(late(i) == (i >= 2));
+  }
+
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 40, 0)
+  // Only on 6.40 is the late member inside the record; before that it is top-level and there is no
+  // HLT.m_late to read.
+  auto grouped = reader->GetView<bool>("HLT.m_late");
+  for (std::size_t i = 0; i < 4; i++) {
+    REQUIRE(grouped(i) == (i >= 2));
+  }
+#endif
+}


### PR DESCRIPTION
This is a follow-up to #51798, so that PR should be merged first.

Since now there is a special release of CMSSW with ROOT 6.40, we can start using the late-model extension of untyped records that was introduced in [root-project/root#21088](https://github.com/root-project/root/pull/21088). This allows us to group trigger-like fields into untyped records with boolean subfields and still be able to add new subfields later on if needed. I added some guards so that it still compiles and runs with older versions of ROOT.

Another important thing is that I added projections of subfields to the top level so that things look like the old TTrees to make backward compatibility easier. There is a toggle for it, so hopefully once everyone adapts to the new layout we can turn of the projections.

I've attached some more detailed description of the changes below.

:robot: _AI text below_ :robot:

**Content parity**

- `bunchCrossing` and `orbitNumber` were never written. They are now, published
  unsigned as the TTree output publishes them, so an unavailable value arrives as
  `0xffffffff` rather than in some representation the TTree side lacks.
- Lumi-level `FlatTable`s and counter tables were dropped entirely, because
  `openFile()` only looked at `keeps[edm::InRun]`. The `LuminosityBlocks` ntuple
  now carries them.
- `EventStrings` (`genModel`) is written on every event rather than only at lumi
  boundaries, so each entry stands on its own.
- `compressionAlgorithm` accepts `ZSTD` and `LZ4`, as the TTree module does, and
  an unknown name fails at construction rather than at the first file open.
- Two trigger fixes that only bite once paths are grouped: a name already taken
  in the model gets a `_p<process>` suffix instead of colliding, and only a real
  `_v<digits>` suffix is trimmed, so `HLT_DiJet_vbf` no longer lands on
  `HLT_DiJet` and collides with a genuine `HLT_DiJet_v3`.

**Layout**

- Trigger flags are grouped into `HLT`, `Flag` and `L1` records: `HLT_IsoMu24`
  becomes `HLT.IsoMu24`, the same relation the collection fields have to the
  TTree module's `Muon_pt` branches.
- Singleton `FlatTable`s are written as records rather than vectors of one:
  `Generator.binvar`, not `Generator.binvar[0]`, matching the TTree module's
  scalar branches.
- **Every grouped member also gets the flat name the TTree output uses**, as an
  RNTuple projected field: `GenJet_pt` beside `GenJet.pt`, `HLT_IsoMu24` beside
  `HLT.IsoMu24`. A projection is a second name for the same columns, so it costs
  nothing on disk beyond its schema entry. This addresses the concern that the
  grouped layout is hard to migrate to.

**ROOT 6.40**

A trigger path first seen in a later run is no longer dropped. On ROOT 6.40 the
record grows to take it — `RUpdater::AddField(field, parentName)` into an untyped
record of a bare model — and the entries already written read back false for it.
Before 6.40 a record cannot grow once the ntuple is being written, so the path is
written as a top-level field under its flat name instead, with a warning. Either
way it reaches the file. The 6.40-only call is behind
`ROOT_VERSION_CODE >= ROOT_VERSION(6, 40, 0)`, so this builds against both 6.36
and 6.40 and the feature is absent rather than broken on the older one.

**New parameter**

`flatProjections`, untracked `bool`, default `true`. Set it `false` to write the
grouped names only.

### PR validation:

- Workflow `2500.9101` (`DYToLL_M-50_13TeV_pythia8` + NANOGEN) runs to completion
  with and without `--use-rntuple`, against ROOT 6.36 in `CMSSW_20_1_0_pre2`.
- **Coverage against the TTree run:** every TTree branch name — 100 in `Events`,
  10 in `Runs`, 6 in `LuminosityBlocks` — is now a top-level RNTuple field name,
  except the 12 `n<Collection>` counters RNTuple represents implicitly.
- **The toggle backs out cleanly:** with `flatProjections = False` the output is
  identical field for field and per-column digest for digest to a run without the
  feature; the ~2 KB difference with it on is the extra schema names and nothing
  else.
- A dedicated harness drives a run transition across a changing HLT menu (one
  path version-bumped, one dropped, one new), which the workflow cannot do — it
  has a single run and no trigger products.
- **The ROOT 6.40 path was exercised on x86_64 against
  `CMSSW_20_1_0_pre2_ROOT640`**, the only place it can be: the new path lands
  inside the record, reads false for the entries written before it appeared, and
  its projection resolves onto it. Everything else here is version-independent
  and was checked on 6.36.
- `test/test_catch2_NanoAODRNTupleFields.cc` pins down the RNTuple behaviour this
  rests on — untyped records, untyped vectors of records, projections of every
  `FlatTable` column type, and growing a record mid-write — with the
  late-extension section split on `ROOT_VERSION_CODE` so each build tests the
  path it actually takes. Passes on both ROOT versions.

### Known remaining differences from the TTree output:

- The TTree module also keeps any path whose name contains `Scouting` (the
  `DST_PFScouting_*` paths); this module keeps only the `HLT`, `Flag` and `L1`
  prefixes and drops those.
- Named collections are written as *untyped* `std::vector<record>`, so RDataFrame
  cannot JIT an expression against the collection itself (`GenPart.size()`),
  though each member is exposed as its own column and the flat projections are
  ordinary top-level fields.