### PR TITLE
light modernization of `HLTriggerOffline/BTag`

### DIFF
--- a/HLTriggerOffline/Btag/interface/HLTBTagHarvestingAnalyzer.h
+++ b/HLTriggerOffline/Btag/interface/HLTBTagHarvestingAnalyzer.h
@@ -6,7 +6,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 // DQM services
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -27,7 +29,8 @@
 class HLTBTagHarvestingAnalyzer : public DQMEDHarvester {
 public:
   explicit HLTBTagHarvestingAnalyzer(const edm::ParameterSet &);
-  ~HLTBTagHarvestingAnalyzer() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  ~HLTBTagHarvestingAnalyzer() override = default;
 
   void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) override;
   TH1F calculateEfficiency1D(

--- a/HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h
+++ b/HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h
@@ -13,24 +13,25 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
 
 // Trigger
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
 // DQM services
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
 // for gen matching
 #include "DataFormats/JetMatching/interface/JetFlavourMatching.h"
-#include <Math/GenVector/VectorUtil.h>
-
 #include "FWCore/Utilities/interface/transform.h"
+#include <Math/GenVector/VectorUtil.h>
 
 /** \class HLTBTagPerformanceAnalyzer
  *
@@ -43,7 +44,8 @@
 class HLTBTagPerformanceAnalyzer : public DQMEDAnalyzer {
 public:
   explicit HLTBTagPerformanceAnalyzer(const edm::ParameterSet &);
-  ~HLTBTagPerformanceAnalyzer() override;
+  ~HLTBTagPerformanceAnalyzer() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
   void dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) override;
 
 private:

--- a/HLTriggerOffline/Btag/interface/HLTVertexPerformanceAnalyzer.h
+++ b/HLTriggerOffline/Btag/interface/HLTVertexPerformanceAnalyzer.h
@@ -5,7 +5,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 // Trigger
 #include "DataFormats/Common/interface/TriggerResults.h"
@@ -14,12 +16,12 @@
 // Vertex
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include <SimDataFormats/Vertex/interface/SimVertex.h>
+#include "SimDataFormats/Vertex/interface/SimVertex.h"
 
 // DQM services
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
 #include "FWCore/Utilities/interface/transform.h"
 
@@ -33,7 +35,8 @@
 class HLTVertexPerformanceAnalyzer : public DQMEDAnalyzer {
 public:
   explicit HLTVertexPerformanceAnalyzer(const edm::ParameterSet &);
-  ~HLTVertexPerformanceAnalyzer() override;
+  ~HLTVertexPerformanceAnalyzer() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
   void dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) override;
 
 private:

--- a/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagHarvestingAnalyzer.cc
@@ -14,8 +14,6 @@ HLTBTagHarvestingAnalyzer::HLTBTagHarvestingAnalyzer(const edm::ParameterSet &iC
   HCALSpecialsNames[HEM17] = "HEM17";
 }
 
-HLTBTagHarvestingAnalyzer::~HLTBTagHarvestingAnalyzer() {}
-
 // ------------ method called once each job just after ending the event loop
 // ------------
 void HLTBTagHarvestingAnalyzer::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
@@ -382,6 +380,47 @@ TH1F HLTBTagHarvestingAnalyzer::calculateEfficiency1D(
   me->setEfficiencyFlag();
 
   return eff;
+}
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+void HLTBTagHarvestingAnalyzer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("mainFolder", "HLT/BTV/Validation");
+  desc.add<std::vector<std::string>>("HLTPathNames",
+                                     {
+                                         "HLT_PFMET120_PFMHT120_IDTight_v",
+                                         "HLT_PFHT330PT30_QuadPFJet_75_60_45_40_v",
+                                         "HLT_PFHT400_SixPFJet32_PNet2BTagMean0p50_v",
+                                         "HLT_PFHT450_SixPFJet36_PNetBTag0p35_v",
+                                         "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_v",
+                                         "HLT_BTagMu_AK4DiJet20_Mu5_v",
+                                         "HLT_BTagMu_AK4DiJet20_Mu5_v",
+                                         "HLT_BTagMu_AK4DiJet20_Mu5_v",
+                                     });
+  desc.add<std::vector<std::string>>("histoName",
+                                     {
+                                         "hltParticleNetDiscriminatorsJetTags",
+                                         "hltParticleNetDiscriminatorsJetTags",
+                                         "hltParticleNetDiscriminatorsJetTags",
+                                         "hltParticleNetDiscriminatorsJetTags",
+                                         "hltParticleNetDiscriminatorsJetTags",
+                                         "hltBSoftMuonDiJet20L1FastJetL25Jets",
+                                         "hltDeepJetDiscriminatorsJetTags",
+                                         "hltParticleNetDiscriminatorsJetTags",
+                                     });
+  desc.add<double>("minTag", 0.2);
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::vector<unsigned int>>("light", {1, 2, 3, 21});
+    psd0.add<std::vector<unsigned int>>("c", {4});
+    psd0.add<std::vector<unsigned int>>("b", {5});
+    psd0.add<std::vector<unsigned int>>("g", {21});
+    psd0.add<std::vector<unsigned int>>("uds", {1, 2, 3});
+    desc.add<edm::ParameterSetDescription>("mcFlavours", psd0);
+  }
+  descriptions.addWithDefaultLabel(desc);
 }
 
 // define this as a plug-in

--- a/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTBTagPerformanceAnalyzer.cc
@@ -1,3 +1,6 @@
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "HLTriggerOffline/Btag/interface/HLTBTagPerformanceAnalyzer.h"
 #include <algorithm>
 #include <set>
@@ -116,11 +119,6 @@ HLTBTagPerformanceAnalyzer::HLTBTagPerformanceAnalyzer(const edm::ParameterSet &
   HCALSpecialsNames[HEP17] = "HEP17";
   HCALSpecialsNames[HEP18] = "HEP18";
   HCALSpecialsNames[HEM17] = "HEM17";
-}
-
-HLTBTagPerformanceAnalyzer::~HLTBTagPerformanceAnalyzer() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 void HLTBTagPerformanceAnalyzer::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
@@ -433,6 +431,42 @@ void HLTBTagPerformanceAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
       }
     }  /// for mc.size()
   }  /// for hltPathNames_.size()
+}
+
+void HLTBTagPerformanceAnalyzer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("TriggerResults", edm::InputTag("TriggerResults", "", "HLT"));
+  desc.add<std::string>("mainFolder", "HLT/BTV/Validation");
+  desc.add<std::vector<std::string>>("HLTPathNames",
+                                     {"HLT_PFMET120_PFMHT120_IDTight_v",
+                                      "HLT_PFHT330PT30_QuadPFJet_75_60_45_40_v",
+                                      "HLT_PFHT400_SixPFJet32_PNet2BTagMean0p50_v",
+                                      "HLT_PFHT450_SixPFJet36_PNetBTag0p35_v",
+                                      "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_v",
+                                      "HLT_BTagMu_AK4DiJet20_Mu5_v",
+                                      "HLT_BTagMu_AK4DiJet20_Mu5_v",
+                                      "HLT_BTagMu_AK4DiJet20_Mu5_v"});
+  desc.add<std::vector<edm::InputTag>>("JetTag",
+                                       {edm::InputTag("hltParticleNetDiscriminatorsJetTags", "BvsAll"),
+                                        edm::InputTag("hltParticleNetDiscriminatorsJetTags", "BvsAll"),
+                                        edm::InputTag("hltParticleNetDiscriminatorsJetTags", "BvsAll"),
+                                        edm::InputTag("hltParticleNetDiscriminatorsJetTags", "BvsAll"),
+                                        edm::InputTag("hltParticleNetDiscriminatorsJetTags", "BvsAll"),
+                                        edm::InputTag("hltBSoftMuonDiJet20L1FastJetL25Jets"),
+                                        edm::InputTag("hltDeepJetDiscriminatorsJetTags", "BvsAll"),
+                                        edm::InputTag("hltParticleNetDiscriminatorsJetTags", "BvsAll")});
+  desc.add<double>("MinJetPT", 20);
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::vector<unsigned int>>("light", {1, 2, 3, 21});
+    psd0.add<std::vector<unsigned int>>("c", {4});
+    psd0.add<std::vector<unsigned int>>("b", {5});
+    psd0.add<std::vector<unsigned int>>("g", {21});
+    psd0.add<std::vector<unsigned int>>("uds", {1, 2, 3});
+    desc.add<edm::ParameterSetDescription>("mcFlavours", psd0);
+  }
+  desc.add<edm::InputTag>("mcPartons", edm::InputTag("hltBtagJetsbyValAlgo"));
+  descriptions.addWithDefaultLabel(desc);
 }
 
 // define this as a plug-in

--- a/HLTriggerOffline/Btag/src/HLTVertexPerformanceAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTVertexPerformanceAnalyzer.cc
@@ -1,4 +1,6 @@
 #include "HLTriggerOffline/Btag/interface/HLTVertexPerformanceAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 using namespace edm;
 using namespace reco;
@@ -20,8 +22,6 @@ HLTVertexPerformanceAnalyzer::HLTVertexPerformanceAnalyzer(const edm::ParameterS
     VertexCollection_Label.push_back(label.module);
   }
 }
-
-HLTVertexPerformanceAnalyzer::~HLTVertexPerformanceAnalyzer() {}
 
 void HLTVertexPerformanceAnalyzer::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
   triggerConfChanged_ = true;
@@ -150,6 +150,24 @@ void HLTVertexPerformanceAnalyzer::bookHistograms(DQMStore::IBooker &ibooker,
       }
     }
   }
+}
+
+void HLTVertexPerformanceAnalyzer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("SimVertexCollection", edm::InputTag("g4SimHits"));
+  desc.add<edm::InputTag>("TriggerResults", edm::InputTag("TriggerResults", "", "HLT"));
+  desc.add<std::string>("mainFolder", "HLT/BTV/Validation");
+  desc.add<std::vector<std::string>>("HLTPathNames",
+                                     {"HLT_PFMET120_PFMHT120_IDTight_v",
+                                      "HLT_PFHT330PT30_QuadPFJet_75_60_45_40_v",
+                                      "HLT_PFHT400_SixPFJet32_PNet2BTagMean0p50_v",
+                                      "HLT_PFHT450_SixPFJet36_PNetBTag0p35_v",
+                                      "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_v",
+                                      "HLT_BTagMu_AK4DiJet20_Mu5_v",
+                                      "HLT_BTagMu_AK4DiJet20_Mu5_v",
+                                      "HLT_BTagMu_AK4DiJet20_Mu5_v"});
+  desc.add<std::vector<edm::InputTag>>("Vertex", {edm::InputTag("hltVerticesPF")});
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_MODULE(HLTVertexPerformanceAnalyzer);


### PR DESCRIPTION
#### PR description:

Title says it all, mostly in view of further work in https://github.com/cms-sw/cmssw/pull/51831

- provide `fillDescription` methods
- use `default` destructors
- adjust `include` statements

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A