### PR TITLE
Fix `hltGetConfiguration --dbproxy`

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -100,10 +100,6 @@ class OfflineConverter:
 
         if self.proxy:
             self.proxy_connect_args = ('--dbproxy', '--dbproxyport', self.proxyPort, '--dbproxyhost', self.proxyHost)
-            temp_connect = []
-            for entry in self.connect:
-                temp_connect.append(entry.replace(key,item))
-            self.connect  = tuple(temp_connect)
         else:
             self.proxy_connect_args = ()
 


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/49150

#### PR description:

Trivial fix for https://github.com/cms-sw/cmssw/issues/49150, as a leftover from https://github.com/cms-sw/cmssw/pull/47704.
Removal of part of the script causing runtime failures.

#### PR validation:

First prepared the area with the following script [1] `get-hlt-configuration.sh` on a machine outside of the CERN network.
Then run:

```bash
./get-hlt-configuration.sh
cd cmssw
export PYTHONPATH="$(pwd)/pylib:$PYTHONPATH"
ssh -f -N -D 8080 lxtunnel.cern.ch
cd HLTrigger/Configuration/scripts/
./hltGetConfiguration /dev/CMSSW_15_0_0/GRun/V114 \
		      --full \
		      --data \
		      --type GRun \
		      --unprescale \
		      --process HLTGRun \
		      --globaltag auto:run3_hlt_GRun \
		      --path MC_AK4CaloJets_v21 \
		      --input root://eoscms.cern.ch//store/data/Run2025E/EphemeralHLTPhysics4/RAW/v1/000/396/102/00000/6fa8a698-f11e-4eeb-86f3-645874f1d4e6.root \
		      --dbproxy > hlt.py
```

and verified that `hltGetConfiguration --dbproxy` works fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will be backported down to `CMSSW_15_1_X` in which  https://github.com/cms-sw/cmssw/pull/47704 was first merged.

[1]
<details>

<summary> Click me. </summary>

Save as `get-hlt-configuration.sh`

```bash
#!/usr/bin/env bash

# Sparse checkout of cms-sw/cmssw limited to:
#   - HLTrigger/Configuration
#   - Configuration/AlCa
#   - Configuration/StandardSequences
# plus the structure of symlink 'pylib/' allowing CMSSW-style imports
# (eg. "import HLTrigger.Configuration.Tools.confdb") without installing scram/CMSSW .
#
# Usage:
#   ./get-hlt-configuration.sh                        # only checkout, read-only
#   ./get-hlt-configuration.sh <tuo-utente-github>    # also sets the fork as 'origin'
set -euo pipefail

REPO_DIR="cmssw"
BRANCH="master"
GITHUB_USER="${1:-}"

# list of packages to download (Package/Subsystem)
PACKAGES=(
    "HLTrigger/Configuration"
    "Configuration/AlCa"
    "Configuration/StandardSequences"
)

if [ -d "$REPO_DIR" ]; then
    echo "Error: '$REPO_DIR' already exists in $(pwd). Remove or execute the script elsewhere." >&2
    exit 1
fi

echo "==> Clone cms-sw/cmssw (shallow, without blob)"
git clone --no-checkout --filter=blob:none --depth 1 https://github.com/cms-sw/cmssw.git "$REPO_DIR"
cd "$REPO_DIR"

echo "==> allow sparse-checkout in cone modality"
git sparse-checkout init --cone

echo "==> set the packages: ${PACKAGES[*]}"
git sparse-checkout set "${PACKAGES[@]}"

echo "==> Checkout $BRANCH (here will dowload files)"
git checkout "$BRANCH"

echo "==> Create the structure pylib/ with symlinks in CMSSW style (scram b python)"
REPO_ROOT="$(pwd)"
mkdir -p pylib
for pkg in "${PACKAGES[@]}"; do
    # pkg is of type "HLTrigger/Configuration" -> Package=HLTrigger, Subsystem=Configuration
    package="${pkg%%/*}"
    subsystem="${pkg#*/}"
    src="$REPO_ROOT/$pkg/python"
    dst="pylib/$package/$subsystem"

    if [ ! -d "$src" ]; then
        echo "    WARNING: $src doesn't exist, skipping $pkg" >&2
        continue
    fi

    mkdir -p "pylib/$package"
    if [ -L "$dst" ] || [ -e "$dst" ]; then
        rm -rf "$dst"
    fi
    ln -s "$src" "$dst"
    echo "    linked: $dst -> $src"
done

echo
echo "==> Done. Content of $REPO_DIR:"
ls -la

echo
echo "To use import CMSSW-style imports, export PYTHONPATH:"
echo "  export PYTHONPATH=\"$REPO_ROOT/pylib:\$PYTHONPATH\""
echo
echo "Then, e.g.:"
echo "  python3 -c \"from HLTrigger.Configuration.extend_argparse import *; import HLTrigger.Configuration.Tools.confdb as confdb; import HLTrigger.Configuration.Tools.options as options\""

if [ -n "$GITHUB_USER" ]; then
    echo
    echo "==> Configure the tuo fork (github.com/$GITHUB_USER/cmssw) as 'origin'"
    git remote rename origin upstream
    git remote add origin "https://github.com/$GITHUB_USER/cmssw.git"
    git remote -v
    echo
    echo "Note: cms-sw/cmssw fork must exist in $GITHUB_USER/cmssw,"
    echo "otherwise push will yield an error."
    echo
    echo "Next steps:"
    echo "  git checkout -b fix-confdb-proxy-nameerror"
    echo "  # modify HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py"
    echo "  git add HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py"
    echo "  git commit -m 'Fix NameError in OfflineConverter when using --dbproxy'"
    echo "  git push -u origin fix-confdb-proxy-nameerror"
else
    echo
    echo "No GitHub user, 'origin' remains on cms-sw/cmssw (clone read-only)."
    echo "Launch as: $0 <your-github-user> to reset the fork remote."
fi

```

</details>

