### PR TITLE
Call MPI_Abort on error

### DIFF
--- a/HeterogeneousCore/MPIServices/interface/MPIService.h
+++ b/HeterogeneousCore/MPIServices/interface/MPIService.h
@@ -6,10 +6,11 @@
 #include <string>
 
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
 class MPIService {
 public:
-  MPIService(edm::ParameterSet const& config);
+  MPIService(edm::ParameterSet const& config, edm::ActivityRegistry& iRegistry);
   ~MPIService();
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
@@ -21,6 +22,8 @@ private:
   // variables related to process hash exchange
   std::once_flag init_flag_;
   std::vector<uint64_t> all_process_hashes_;
+
+  void abortOnError_(std::string const& termination_type);
 
   void exchangeProcessHashes_();
 };

--- a/HeterogeneousCore/MPIServices/plugins/MPIService.cc
+++ b/HeterogeneousCore/MPIServices/plugins/MPIService.cc
@@ -1,3 +1,3 @@
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "HeterogeneousCore/MPIServices/interface/MPIService.h"
-DEFINE_FWK_SERVICE_MAKER(MPIService, edm::serviceregistry::ParameterSetMaker<MPIService>);
+DEFINE_FWK_SERVICE_MAKER(MPIService, edm::serviceregistry::AllArgsMaker<MPIService>);

--- a/HeterogeneousCore/MPIServices/src/MPIService.cc
+++ b/HeterogeneousCore/MPIServices/src/MPIService.cc
@@ -11,12 +11,13 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "HeterogeneousCore/MPIServices/interface/MPIService.h"
 
 namespace {
-
   // list the MPI thread support levels
   const char* const mpi_thread_support_level[] = {
       "MPI_THREAD_SINGLE",      // only one thread will execute (the process is single-threaded)
@@ -27,7 +28,7 @@ namespace {
 
 }  // namespace
 
-MPIService::MPIService(edm::ParameterSet const& config) {
+MPIService::MPIService(edm::ParameterSet const& config, edm::ActivityRegistry& iRegistry) {
   /* As of Open MPI 4.1.0, `MPI_THREAD_MULTIPLE` is supported by the following transports:
    *   - the `ob1` PML, with the following BTLs:
    *       - `self`
@@ -45,6 +46,12 @@ MPIService::MPIService(edm::ParameterSet const& config) {
    *
    * See https://github.com/open-mpi/ompi/blob/v4.1.0/README .
    */
+  iRegistry.watchPreSourceEarlyTermination(
+      [this](edm::TerminationOrigin) { abortOnError_("PreSourceEarlyTermination"); });
+  iRegistry.watchPreGlobalEarlyTermination(
+      [this](edm::GlobalContext const&, edm::TerminationOrigin) { abortOnError_("PreGlobalEarlyTermination"); });
+  iRegistry.watchPreStreamEarlyTermination(
+      [this](edm::StreamContext const&, edm::TerminationOrigin) { abortOnError_("PreStreamEarlyTermination"); });
 
   // set the pmix_server_uri MCA parameter if specified in the configuration and not already set in the environment
   if (config.existsAs<std::string>("pmix_server_uri", false)) {
@@ -88,11 +95,19 @@ MPIService::MPIService(edm::ParameterSet const& config) {
 }
 
 MPIService::~MPIService() {
-  // Finalize MPI execution environment if the program finished correctly
-  // Otherwise let it proceed naturally (this way original error will be printed)
-  if (std::uncaught_exceptions() == 0) {
-    MPI_Finalize();
-  }
+  // Finalize MPI execution environment
+  MPI_Finalize();
+}
+
+void MPIService::abortOnError_(std::string const& termination_type) {
+  // Clean exit involves several blocking synchronisation calls in the destructors, which hang because the error is not yet propagated to the other processes.
+  // The hang might also occur when failing process is inside a blocking Wait() to send or receive a ususal message.
+  // Doing a flag check would solve the problem for deadlocks in the first case, but in the second case process might be already inside a Wait() call when the error occurs, therefore flag check would not help in this scenario.
+  // As we don't have any recovery mechanisms anyway, it's better to simply abort the MPI job immediately to avoid deadlocks and other issues.
+  edm::LogError("MPIService") << "MPIService: " << termination_type
+                              << " event occured, Aborting MPI to avoid possible synchronization issues..."
+                              << std::endl;
+  MPI_Abort(MPI_COMM_WORLD, edm::errors::ExternalFailure);
 }
 
 void MPIService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {


### PR DESCRIPTION
#### PR description:

This pull request implements calling MPI_Abort by MPIService when it sees early termination event. It is meant to solve any issues with MPI-related deadlocks on error.

The problem is that clean exit involves several blocking synchronization calls in the destructors. When an error is caught by the framework, modules proceed to their normal "clean" exit procedures. In case of MPI modules, clean exit involves several synchronization collective operations, which cause hangs. Until the failing process finishes, the error is not propagated to the other processes and their states diverge.
 
Apart from that, the hang might also occur when failing process is inside a blocking Wait() to send or receive an usual message.

Doing a flag check could be a solution, but it would only work for deadlocks in the first case, while in the second case process might be already inside a Wait() call when the error occurs. In this scenario flag check still does not prevent the hang.

As we don't have any recovery mechanisms anyway, this pr suggests to simply abort the MPI job immediately, avoiding deadlocks and clean finalization stage.

#### PR validation:

This pr was tested on known hang conditions like errors in configuration files, throwing errors during module construction and event processing, and with killing by ctrl+C.

So far it is not known if calling MPI_Abort can cause some other issues, as this (probably) cancels out any error handling and recovery that might happen inside the framework. Calling MPI_Abort also prevents careful cleanup (ending job/run/lumisection and calling destructors), which was usually expected when error was thrown and not handled.

I would like some further opinion on this, but for me harsh kill seems better than hang.  
