### PR TITLE
[L1DTTrackFinder] Remove unnecessary lib in BuildFile

### DIFF
--- a/DataFormats/L1DTTrackFinder/BuildFile.xml
+++ b/DataFormats/L1DTTrackFinder/BuildFile.xml
@@ -3,5 +3,4 @@
 <use name="DataFormats/L1GlobalMuonTrigger"/>
 <export>
   <lib name="1"/>
-  <lib name="DataFormatsL1DTTrackFinder"/>
 </export>


### PR DESCRIPTION
`<lib name="DataFormatsL1DTTrackFinder"/>` is not needed as `<lib name="1"/>` does the same. This PR remove the unnecessary lib which should avoid the SCRAM warning
```
***WARNING: Multiple usage of "DataFormatsL1DTTrackFinder". Please cleanup "lib" in "export" section of "src/DataFormats/L1DTTrackFinder/BuildFile.xml"
```