### PR TITLE
Fix null mother deref in GenPartIsoProducer

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenPartIsoProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenPartIsoProducer.cc
@@ -78,12 +78,12 @@ void GenPartIsoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
         double this_dR_lgamma = reco::deltaR(
             genPart->eta(), genPart->phi(), (*packedGenParticles)[k].eta(), (*packedGenParticles)[k].phi());
         bool idmatch = false;
-        if ((*packedGenParticles)[k].mother(0)->pdgId() == genPart->pdgId())
-          idmatch = true;
-        const reco::Candidate* mother = (*packedGenParticles)[k].mother(0);
-        for (size_t m = 0; m < mother->numberOfMothers(); m++) {
-          if ((*packedGenParticles)[k].mother(m)->pdgId() == genPart->pdgId())
+        for (size_t m = 0; m < (*packedGenParticles)[k].numberOfMothers(); m++) {
+          const reco::Candidate* mother = (*packedGenParticles)[k].mother(m);
+          if (mother != nullptr && mother->pdgId() == genPart->pdgId()) {
             idmatch = true;
+            break;
+          }
         }
         if (!idmatch)
           continue;


### PR DESCRIPTION
#### PR description:

`GenPartIsoProducer` dereferences `packedGenParticles[k].mother(0)` without a null
check, and bounds the mother loop by `mother->numberOfMothers()` (the mother's count)
while indexing `packedGenParticles[k].mother(m)` (the particle's mothers), which reads
out of range whenever the two differ.

No change to the output: packed gen particles have one mother whose own mother count is
also one, so old and new code both test exactly `mother(0)`.

Depends on nothing.

#### PR validation:

Ran `-s NANO` over a Run 3 DY MiniAOD sample; `GenPart_iso` is unchanged. The crash was
found with a `packedGenParticles` collection containing motherless status-1 particles,
which segfaults before this PR and runs after it.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.
