### PR TITLE
LST: speedups in slow events group T3s by MD/LS for T5/T4 reco and T5s by MD for hit extension

### DIFF
--- a/RecoTracker/LSTCore/interface/Common.h
+++ b/RecoTracker/LSTCore/interface/Common.h
@@ -46,6 +46,7 @@ namespace lst {
 
   constexpr uint16_t kTCEmptyLowerModule = 0xFFFF;     // Sentinel for empty lowerModule index
   constexpr unsigned int kTCEmptyHitIdx = 0xFFFFFFFF;  // Sentinel for empty hit slots
+  constexpr unsigned int kInvalidU32Idx = 0xFFFFFFFF;  // Sentinel for invalid uint32 idx
 
   constexpr float kB = lstgeometry::kB;
   constexpr float kC = lstgeometry::kC;

--- a/RecoTracker/LSTCore/interface/MiniDoubletsSoA.h
+++ b/RecoTracker/LSTCore/interface/MiniDoubletsSoA.h
@@ -43,7 +43,8 @@ namespace lst {
                       SOA_COLUMN(float, noShiftedDphis),
                       SOA_COLUMN(float, noShiftedDphiChanges),
 #endif
-                      SOA_COLUMN(unsigned int, connectedMax))
+                      SOA_COLUMN(unsigned int, connectedMax),
+                      SOA_COLUMN(unsigned int, connectedT3sMax))
 
   GENERATE_SOA_LAYOUT(MiniDoubletsOccupancySoALayout,
                       SOA_COLUMN(unsigned int, nMDs),

--- a/RecoTracker/LSTCore/interface/MiniDoubletsSoA.h
+++ b/RecoTracker/LSTCore/interface/MiniDoubletsSoA.h
@@ -44,15 +44,25 @@ namespace lst {
                       SOA_COLUMN(float, noShiftedDphiChanges),
 #endif
                       SOA_COLUMN(unsigned int, connectedMax),
-                      SOA_COLUMN(unsigned int, connectedT3sMax))
+                      SOA_COLUMN(unsigned int, connectedT3sMax),
+                      SOA_COLUMN(unsigned int, connectedT5s0Max),
+                      SOA_COLUMN(unsigned int, connectedT5s1Max))
 
   GENERATE_SOA_LAYOUT(MiniDoubletsOccupancySoALayout,
                       SOA_COLUMN(unsigned int, nMDs),
                       SOA_COLUMN(unsigned int, totOccupancyMDs))
 
+  GENERATE_SOA_LAYOUT(QuintupletsRangesSoALayout, SOA_COLUMN(uint32_t, offset), SOA_COLUMN(uint32_t, n));
+
+  using QuintupletsRangesSoA = QuintupletsRangesSoALayout<>;
+  using QuintupletsRanges = QuintupletsRangesSoA::View;
+  using QuintupletsRangesConst = QuintupletsRangesSoA::ConstView;
+
   GENERATE_SOA_BLOCKS(MiniDoubletsSoABlocksLayout,
                       SOA_BLOCK(miniDoublets, MiniDoubletsSoALayout),
-                      SOA_BLOCK(miniDoubletsOccupancy, MiniDoubletsOccupancySoALayout))
+                      SOA_BLOCK(miniDoubletsOccupancy, MiniDoubletsOccupancySoALayout),
+                      SOA_BLOCK(quintupletsRangesByMD0, QuintupletsRangesSoALayout),
+                      SOA_BLOCK(quintupletsRangesByMD1, QuintupletsRangesSoALayout))
 
   using MiniDoubletsSoA = MiniDoubletsSoALayout<>;
   using MiniDoubletsOccupancySoA = MiniDoubletsOccupancySoALayout<>;

--- a/RecoTracker/LSTCore/interface/ObjectRangesSoA.h
+++ b/RecoTracker/LSTCore/interface/ObjectRangesSoA.h
@@ -31,6 +31,8 @@ namespace lst {
                       SOA_SCALAR(unsigned int, nTotalTrips),
                       SOA_SCALAR(unsigned int, nTotalQuads),
                       SOA_SCALAR(unsigned int, nTotalQuints),
+                      SOA_SCALAR(unsigned int, nTotalQuintsByMD0),
+                      SOA_SCALAR(unsigned int, nTotalQuintsByMD1),
                       SOA_SCALAR(uint16_t, nEligibleT4Modules),
                       SOA_SCALAR(uint16_t, nEligibleT5Modules))
 

--- a/RecoTracker/LSTCore/interface/QuintupletsSoA.h
+++ b/RecoTracker/LSTCore/interface/QuintupletsSoA.h
@@ -54,9 +54,29 @@ namespace lst {
   using QuintupletsOccupancy = QuintupletsOccupancySoA::View;
   using QuintupletsOccupancyConst = QuintupletsOccupancySoA::ConstView;
 
+  // index and fast cached data if any
+  GENERATE_SOA_LAYOUT(QuintupletsBySegmentSoALayout, SOA_COLUMN(unsigned int, quintupletIndex));
+
+  using QuintupletsBySegmentSoA = QuintupletsBySegmentSoALayout<>;
+  using QuintupletsBySegment = QuintupletsBySegmentSoA::View;
+  using QuintupletsBySegmentConst = QuintupletsBySegmentSoA::ConstView;
+
+  // index and fast cached data if any
+  GENERATE_SOA_LAYOUT(QuintupletsByMDSoALayout,
+                      SOA_COLUMN(unsigned int, quintupletIndex),
+                      SOA_COLUMN(uint32_t, mdBarCode));
+  constexpr uint32_t kT5ByMDBarCodeMask = 0xFF;
+  constexpr short kT5ByMDBarOffset = 8;
+
+  using QuintupletsByMDSoA = QuintupletsByMDSoALayout<>;
+  using QuintupletsByMD = QuintupletsByMDSoA::View;
+  using QuintupletsByMDConst = QuintupletsByMDSoA::ConstView;
+
   GENERATE_SOA_BLOCKS(QuintupletsSoABlocksLayout,
                       SOA_BLOCK(quintuplets, QuintupletsSoALayout),
-                      SOA_BLOCK(quintupletsOccupancy, QuintupletsOccupancySoALayout))
+                      SOA_BLOCK(quintupletsOccupancy, QuintupletsOccupancySoALayout),
+                      SOA_BLOCK(quintupletsByMD0, QuintupletsByMDSoALayout),
+                      SOA_BLOCK(quintupletsByMD1, QuintupletsByMDSoALayout))
 
   using QuintupletsSoABlocks = QuintupletsSoABlocksLayout<>;
   using QuintupletsSoABlocksView = QuintupletsSoABlocks::View;

--- a/RecoTracker/LSTCore/interface/TripletsSoA.h
+++ b/RecoTracker/LSTCore/interface/TripletsSoA.h
@@ -45,9 +45,33 @@ namespace lst {
   using TripletsOccupancy = TripletsOccupancySoA::View;
   using TripletsOccupancyConst = TripletsOccupancySoA::ConstView;
 
+  GENERATE_SOA_LAYOUT(TripletsRangesSoALayout, SOA_COLUMN(int, offset), SOA_COLUMN(uint32_t, n));
+
+  using TripletsRangesSoA = TripletsRangesSoALayout<>;
+  using TripletsRanges = TripletsRangesSoA::View;
+  using TripletsRangesConst = TripletsRangesSoA::ConstView;
+
+  // index and fast cached data if any
+  GENERATE_SOA_LAYOUT(TripletsBySegmentSoALayout, SOA_COLUMN(unsigned int, tripletIndex));
+
+  using TripletsBySegmentSoA = TripletsBySegmentSoALayout<>;
+  using TripletsBySegment = TripletsBySegmentSoA::View;
+  using TripletsBySegmentConst = TripletsBySegmentSoA::ConstView;
+
+  // index and fast cached data if any
+  GENERATE_SOA_LAYOUT(TripletsByMDSoALayout, SOA_COLUMN(unsigned int, tripletIndex));
+
+  using TripletsByMDSoA = TripletsByMDSoALayout<>;
+  using TripletsByMD = TripletsByMDSoA::View;
+  using TripletsByMDConst = TripletsByMDSoA::ConstView;
+
   GENERATE_SOA_BLOCKS(TripletsSoABlocksLayout,
                       SOA_BLOCK(triplets, TripletsSoALayout),
-                      SOA_BLOCK(tripletsOccupancy, TripletsOccupancySoALayout))
+                      SOA_BLOCK(tripletsOccupancy, TripletsOccupancySoALayout),
+                      SOA_BLOCK(tripletsRangesBySegment, TripletsRangesSoALayout),
+                      SOA_BLOCK(tripletsBySegment, TripletsBySegmentSoALayout),
+                      SOA_BLOCK(tripletsRangesByMD, TripletsRangesSoALayout),
+                      SOA_BLOCK(tripletsByMD, TripletsByMDSoALayout))
 
   using TripletsSoABlocks = TripletsSoABlocksLayout<>;
   using TripletsSoABlocksView = TripletsSoABlocks::View;

--- a/RecoTracker/LSTCore/src/alpaka/Kernels.h
+++ b/RecoTracker/LSTCore/src/alpaka/Kernels.h
@@ -277,26 +277,27 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     quintuplets.hitIndices()[winnerIdx][2 * newSlot + 1] = quintuplets.hitIndices()[loserIdx][2 * loserSlot + 1];
   }
 
-  struct ExtendT5FromDupT5 {
+  //kT5DuplicateMinSharedHits = 8 variant of what was previously ExtendT5FromDupT5
+  //the initial variant preserves its logic re T5s both starting in B1 (not checked)
+  struct ExtendT5FromDupT5ByMD {
     // Packed [score:32 | T5 index:28 | layer slot:4] for atomic best-per-OT-layer tracking.
     static constexpr int kPackedScoreShift = 32;
     static constexpr int kPackedIndexShift = 4;
     static constexpr unsigned int kPackedIndexMask = 0xFFFFFFF;
     static constexpr unsigned int kPackedSlotMask = 0xF;
-    static constexpr int kT5DuplicateMinSharedHits = 8;
-    static constexpr unsigned int kMaxCompatModules = 40;
+    static constexpr int kT5DuplicateMinSharedHits = 8;  //can not change
 
     ALPAKA_FN_ACC void operator()(Acc1D const& acc,
-                                  ModulesConst modules,
-                                  ObjectRangesConst ranges,
                                   Quintuplets quintuplets,
-                                  QuintupletsOccupancyConst quintupletsOccupancy) const {
+                                  QuintupletsOccupancyConst quintupletsOccupancy,
+                                  QuintupletsRangesConst quintupletsRangesByMD0,
+                                  QuintupletsByMDConst quintupletsByMD0,
+                                  QuintupletsRangesConst quintupletsRangesByMD1,
+                                  QuintupletsByMDConst quintupletsByMD1,
+                                  TripletsConst triplets,
+                                  SegmentsConst segments) const {
       // Best candidate per OT logical layer (1..11), packed score|index|slot.
       uint64_t* sharedBestPacked = alpaka::declareSharedVar<uint64_t[lst::kLogicalOTLayers], __COUNTER__>(acc);
-      unsigned int* testModuleStart = alpaka::declareSharedVar<unsigned int[kMaxCompatModules], __COUNTER__>(acc);
-      unsigned int* testModuleLength = alpaka::declareSharedVar<unsigned int[kMaxCompatModules], __COUNTER__>(acc);
-      unsigned int& testModules = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
-      uint8_t* testModuleLogicalLayer = alpaka::declareSharedVar<uint8_t[kMaxCompatModules], __COUNTER__>(acc);
 
       // One block per T5 in 1D; block index = ref T5 index.
       const unsigned int refT5Index = alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u];
@@ -310,11 +311,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
         for (int logicalLayerBin = 0; logicalLayerBin < lst::kLogicalOTLayers; ++logicalLayerBin) {
           sharedBestPacked[logicalLayerBin] = 0;
         }
-        for (unsigned int iM = 0; iM < kMaxCompatModules; ++iM) {
-          testModuleStart[iM] = 0;
-          testModuleLength[iM] = 0;
-        }
-        testModules = 0;
       }
       alpaka::syncBlockThreads(acc);
 
@@ -333,155 +329,157 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       CMS_UNROLL_LOOP
       for (unsigned int h = 0; h < kRefHits; ++h)
         refHits[h] = quintuplets.hitIndices()[refT5Index][h];
-      auto refModuleIndex1 = quintuplets.lowerModuleIndices()[refT5Index][1];
 
-      const auto threadIndexFlat = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u];
-      const auto blockDimFlat = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
+      const auto threadIndexFlat = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc).x();
+      const auto blockDimFlat = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc).x();
 
-      // Ref-starts-at-layer-1 special case: only ref's slot-1 module can host a valid candidate.
-      const bool restrictToRefSlot1 = (refStartLogicalLayer == 1);
-      const uint16_t nEligibleT5Modules = ranges.nEligibleT5Modules();
-      const unsigned int loopCount = restrictToRefSlot1 ? 1 : nEligibleT5Modules;
+      const bool lookForwardOnly = (refStartLogicalLayer == 1);
+      const auto refLS0Index = triplets.segmentIndices()[quintuplets.tripletIndices()[refT5Index][0]][0];
+      const auto& mdIndices = segments.mdIndices();
+      const auto refMD0Index = mdIndices[refLS0Index][0];
+      const auto refMD1Index = mdIndices[refLS0Index][1];
+      const auto refModuleIndex1 = quintuplets.lowerModuleIndices()[refT5Index][1];
+      const bool refMD1HasT5s = quintupletsOccupancy.nQuintuplets()[refModuleIndex1];
 
-      for (auto idx = threadIndexFlat; idx < loopCount; idx += blockDimFlat) {
-        const uint16_t testModuleIndex =
-            restrictToRefSlot1 ? refModuleIndex1 : ranges.indicesOfEligibleT5Modules()[idx];
+      const auto refLS1Index = triplets.segmentIndices()[quintuplets.tripletIndices()[refT5Index][0]][1];
+      const auto refLS3Index = triplets.segmentIndices()[quintuplets.tripletIndices()[refT5Index][1]][1];
+      //MDs 1, 2, 3, 4; MD to LS: 0:0_0, 1:0_1/1_0, 2:1_1/2_0, 3:2_1/3_0, 4:3_1
+      const uint32_t refMD1234Bar = (mdIndices[refLS1Index][0] & kT5ByMDBarCodeMask) |
+                                    ((mdIndices[refLS1Index][1] & kT5ByMDBarCodeMask) << kT5ByMDBarOffset) |
+                                    ((mdIndices[refLS3Index][0] & kT5ByMDBarCodeMask) << (kT5ByMDBarOffset * 2)) |
+                                    ((mdIndices[refLS3Index][1] & kT5ByMDBarCodeMask) << (kT5ByMDBarOffset * 3));
 
-        const short modSubdet = modules.subdets()[testModuleIndex];
-        const uint8_t testStartLogicalLayer =
-            static_cast<uint8_t>(modules.layers()[testModuleIndex]) + (modSubdet == Endcap ? 6 : 0);
-        if (!restrictToRefSlot1) {
-          // Skip same-starting-layer modules (logical = physical + 6 for endcap, see Triplet.h).
-          if (testStartLogicalLayer == refStartLogicalLayer)
-            continue;
-          if constexpr (kT5DuplicateMinSharedHits == 8) {
-            if (testStartLogicalLayer > refStartLogicalLayer && testModuleIndex != refModuleIndex1)
-              continue;
+      auto testT5 = [&](unsigned int testT5Index) {
+        // Per-T5 eta/phi window.
+        const float candidateEta = __H2F(quintuplets.eta()[testT5Index]);
+        if (alpaka::math::abs(acc, baseEta - candidateEta) > 0.1f)
+          return;
+
+        const float candidatePhi = __H2F(quintuplets.phi()[testT5Index]);
+        if (alpaka::math::abs(acc, cms::alpakatools::deltaPhi(acc, basePhi, candidatePhi)) > 0.1f)
+          return;
+
+        // Embedding distance against hoisted refEmbed.
+        float embedDistance2 = 0.f;
+        CMS_UNROLL_LOOP
+        for (unsigned int embedIndex = 0; embedIndex < Params_T5::kEmbed; ++embedIndex) {
+          const float diff = refEmbed[embedIndex] - quintuplets.t5Embed()[testT5Index][embedIndex];
+          embedDistance2 += diff * diff;
+        }
+        if (embedDistance2 > 1.0f)
+          return;
+
+        int unmatchedLayerSlot = -1;
+        // Hit matching against hoisted ref hits; record the candidate slot with no shared hit.
+        int sharedHitCount = 0;
+        CMS_UNROLL_LOOP
+        for (unsigned int layerIndex = 0; layerIndex < Params_T5::kBaseLayers; ++layerIndex) {
+          const unsigned int candidateHit0 = quintuplets.hitIndices()[testT5Index][2 * layerIndex + 0];
+          const unsigned int candidateHit1 = quintuplets.hitIndices()[testT5Index][2 * layerIndex + 1];
+
+          bool hit0InBase = false;
+          bool hit1InBase = false;
+          CMS_UNROLL_LOOP
+          for (unsigned int baseHitIndex = 0; baseHitIndex < kRefHits; ++baseHitIndex) {
+            const unsigned int baseHit = refHits[baseHitIndex];
+            hit0InBase = hit0InBase || (candidateHit0 == baseHit);
+            hit1InBase = hit1InBase || (candidateHit1 == baseHit);
           }
-          // Module-level eta/phi pre-cut; margin covers per-T5 window plus T5-vs-module spread.
-          if (alpaka::math::abs(acc, baseEta - modules.eta()[testModuleIndex]) > 0.3f)
-            continue;
-          if (alpaka::math::abs(acc, cms::alpakatools::deltaPhi(acc, basePhi, modules.phi()[testModuleIndex])) > 0.5f)
-            continue;
+
+          sharedHitCount += int(hit0InBase) + int(hit1InBase);
+          if (!hit0InBase && !hit1InBase)
+            unmatchedLayerSlot = layerIndex;
         }
 
-        const int firstQuintupletInModule = ranges.quintupletModuleIndices()[testModuleIndex];
-        if (firstQuintupletInModule == -1)
-          continue;
+        if (sharedHitCount < kT5DuplicateMinSharedHits)
+          return;
+        if (unmatchedLayerSlot < 0)
+          return;
 
-        const unsigned int nQuintupletsInModule = quintupletsOccupancy.nQuintuplets()[testModuleIndex];
-        unsigned int iTestModule = alpaka::atomicAdd(acc, &testModules, 1u, alpaka::hierarchy::Threads{});
-        if (iTestModule >= kMaxCompatModules) {
-#ifdef WARNINGS
-          printf("ERROR! Compatible module excess in ExtendT5FromDupT5: now at %d\n", iTestModule);
-#endif
-        } else {
-          testModuleStart[iTestModule] = firstQuintupletInModule;
-          testModuleLength[iTestModule] = nQuintupletsInModule;
-          testModuleLogicalLayer[iTestModule] = testStartLogicalLayer;
+        // Score = DNN output; layer bin = candidate's unmatched OT layer (1..11) - 1.
+        const float candidateScore = quintuplets.dnnScore()[testT5Index];
+        const uint8_t newLogicalLayer = quintuplets.logicalLayers()[testT5Index][unmatchedLayerSlot];
+        const int logicalLayerBin = static_cast<int>(newLogicalLayer) - 1;
+
+        uint64_t scoreBits = std::bit_cast<uint32_t>(candidateScore);
+        uint64_t newPacked = (scoreBits << kPackedScoreShift) |
+                             (static_cast<uint64_t>(testT5Index & kPackedIndexMask) << kPackedIndexShift) |
+                             (unmatchedLayerSlot & kPackedSlotMask);
+
+        // Atomic CAS into shared best-per-layer slot, retry until we win or are beaten.
+        uint64_t oldPacked = sharedBestPacked[logicalLayerBin];
+        while (true) {
+          const float oldScore = std::bit_cast<float>(static_cast<uint32_t>(oldPacked >> kPackedScoreShift));
+          if (candidateScore <= oldScore)
+            break;
+
+          uint64_t assumedOld = alpaka::atomicCas(
+              acc, &sharedBestPacked[logicalLayerBin], oldPacked, newPacked, alpaka::hierarchy::Threads{});
+
+          if (assumedOld == oldPacked) {
+            break;
+          } else {
+            oldPacked = assumedOld;
+          }
         }
-      }
-      alpaka::syncBlockThreads(acc);
-      auto const tModuleMax = testModules < kMaxCompatModules ? testModules : kMaxCompatModules;
-      for (unsigned int tModule = 0; tModule < tModuleMax; ++tModule) {
-        auto const testT5Min = testModuleStart[tModule] + threadIndexFlat;
-        auto const testT5Max = testModuleStart[tModule] + testModuleLength[tModule];
-        auto const testModuleLayer = testModuleLogicalLayer[tModule];
-        for (auto testT5Index = testT5Min; testT5Index < testT5Max; testT5Index += blockDimFlat) {
+      };  // testT5()
+
+      constexpr uint32_t k3Mask = 0xFFFFFF;
+      constexpr uint32_t k2Mask = 0xFFFF;
+      if (refMD1HasT5s) {
+        const auto testT5ByMDOffset = quintupletsRangesByMD0.offset()[refMD1Index];
+        const auto testT5ByMDMax = quintupletsRangesByMD0.n()[refMD1Index];
+        for (auto idx = threadIndexFlat; idx < testT5ByMDMax; idx += blockDimFlat) {
+          const auto testT5ByMDIndex = testT5ByMDOffset + idx;
+          const auto testT5Index = quintupletsByMD0.quintupletIndex()[testT5ByMDIndex];
           if (testT5Index == refT5Index)
             continue;
 
-          if constexpr (kT5DuplicateMinSharedHits == 8) {
-            // most frequent (leave the rare case for the full check)
-            if (refHits[kRefHits - 1] != quintuplets.hitIndices()[testT5Index][kRefHits - 1]) {
-              bool hitMiss = false;
-              int refOffset = 2;
-              int testOffset = 0;
-              if (testModuleLayer < refStartLogicalLayer) {
-                refOffset = 0;
-                testOffset = 2;
-              }
-              for (unsigned int h = 0; h < kRefHits - 2; ++h) {
-                if (refHits[h + refOffset] != quintuplets.hitIndices()[testT5Index][h + testOffset]) {
-                  hitMiss = true;
-                  break;
-                }
-              }
-              if (hitMiss)
-                continue;
-            }
+          const uint32_t refBar234 = refMD1234Bar >> kT5ByMDBarOffset;
+          const uint32_t testBarFull = quintupletsByMD0.mdBarCode()[testT5ByMDIndex];
+          //check ref234 with test 123x, x234, 1x34, and 13x4
+          if ((testBarFull & k3Mask) == refBar234 || (testBarFull >> kT5ByMDBarOffset) == refBar234 ||
+              ((testBarFull & kT5ByMDBarCodeMask) | ((testBarFull >> kT5ByMDBarOffset) & ~kT5ByMDBarCodeMask)) ==
+                  refBar234 ||
+              ((testBarFull & k2Mask) | ((testBarFull >> kT5ByMDBarOffset) & ~k2Mask)) == refBar234)
+            testT5(testT5Index);
+        }
+      }
+      if (not lookForwardOnly) {
+        {
+          const auto testT5ByMDOffset = quintupletsRangesByMD1.offset()[refMD0Index];
+          const auto testT5ByMDMax = quintupletsRangesByMD1.n()[refMD0Index];
+          for (auto idx = threadIndexFlat; idx < testT5ByMDMax; idx += blockDimFlat) {
+            const auto testT5ByMDIndex = testT5ByMDOffset + idx;
+            const auto testT5Index = quintupletsByMD1.quintupletIndex()[testT5ByMDIndex];
+            if (testT5Index == refT5Index)
+              continue;
+
+            const uint32_t testBar234 = quintupletsByMD1.mdBarCode()[testT5ByMDIndex] >> kT5ByMDBarOffset;
+            //check test234 with ref 123 and 234 (covers a gap in first logical layers)
+            if (testBar234 == (refMD1234Bar & k3Mask) || (testBar234 == (refMD1234Bar >> kT5ByMDBarOffset)) ||
+                testBar234 == ((refMD1234Bar & kT5ByMDBarCodeMask) |
+                               ((refMD1234Bar >> kT5ByMDBarOffset) & ~kT5ByMDBarCodeMask)) ||
+                testBar234 == ((refMD1234Bar & k2Mask) | ((refMD1234Bar >> kT5ByMDBarOffset) & ~k2Mask)))
+              testT5(testT5Index);
           }
-          // Per-T5 eta/phi window.
-          const float candidateEta = __H2F(quintuplets.eta()[testT5Index]);
-          if (alpaka::math::abs(acc, baseEta - candidateEta) > 0.1f)
-            continue;
+        }
+        {  //should be with lookForwardOnly as well (but not covered in ExtendT5FromDupT5)
+          const auto testT5ByMDOffset = quintupletsRangesByMD1.offset()[refMD1Index];
+          const auto testT5ByMDMax = quintupletsRangesByMD1.n()[refMD1Index];
+          for (auto idx = threadIndexFlat; idx < testT5ByMDMax; idx += blockDimFlat) {
+            const auto testT5ByMDIndex = testT5ByMDOffset + idx;
+            const auto testT5Index = quintupletsByMD1.quintupletIndex()[testT5ByMDIndex];
+            if (testT5Index == refT5Index)
+              continue;
+            const auto testBar1234 = quintupletsByMD1.mdBarCode()[testT5ByMDIndex];
+            if ((testBar1234 & kT5ByMDBarCodeMask) == refStartLogicalLayer)
+              continue;
 
-          const float candidatePhi = __H2F(quintuplets.phi()[testT5Index]);
-          if (alpaka::math::abs(acc, cms::alpakatools::deltaPhi(acc, basePhi, candidatePhi)) > 0.1f)
-            continue;
-
-          // Embedding distance against hoisted refEmbed.
-          float embedDistance2 = 0.f;
-          CMS_UNROLL_LOOP
-          for (unsigned int embedIndex = 0; embedIndex < Params_T5::kEmbed; ++embedIndex) {
-            const float diff = refEmbed[embedIndex] - quintuplets.t5Embed()[testT5Index][embedIndex];
-            embedDistance2 += diff * diff;
-          }
-          if (embedDistance2 > 1.0f)
-            continue;
-
-          // Hit matching against hoisted ref hits; record the candidate slot with no shared hit.
-          int sharedHitCount = 0;
-          int unmatchedLayerSlot = -1;
-          CMS_UNROLL_LOOP
-          for (unsigned int layerIndex = 0; layerIndex < Params_T5::kBaseLayers; ++layerIndex) {
-            const unsigned int candidateHit0 = quintuplets.hitIndices()[testT5Index][2 * layerIndex + 0];
-            const unsigned int candidateHit1 = quintuplets.hitIndices()[testT5Index][2 * layerIndex + 1];
-
-            bool hit0InBase = false;
-            bool hit1InBase = false;
-            CMS_UNROLL_LOOP
-            for (unsigned int baseHitIndex = 0; baseHitIndex < kRefHits; ++baseHitIndex) {
-              const unsigned int baseHit = refHits[baseHitIndex];
-              hit0InBase = hit0InBase || (candidateHit0 == baseHit);
-              hit1InBase = hit1InBase || (candidateHit1 == baseHit);
-            }
-
-            sharedHitCount += int(hit0InBase) + int(hit1InBase);
-            if (!hit0InBase && !hit1InBase)
-              unmatchedLayerSlot = layerIndex;
-          }
-
-          if (sharedHitCount < kT5DuplicateMinSharedHits)
-            continue;
-          if (unmatchedLayerSlot < 0)
-            continue;
-
-          // Score = DNN output; layer bin = candidate's unmatched OT layer (1..11) - 1.
-          const float candidateScore = quintuplets.dnnScore()[testT5Index];
-          const uint8_t newLogicalLayer = quintuplets.logicalLayers()[testT5Index][unmatchedLayerSlot];
-          const int logicalLayerBin = static_cast<int>(newLogicalLayer) - 1;
-
-          uint64_t scoreBits = std::bit_cast<uint32_t>(candidateScore);
-          uint64_t newPacked = (scoreBits << kPackedScoreShift) |
-                               (static_cast<uint64_t>(testT5Index & kPackedIndexMask) << kPackedIndexShift) |
-                               (unmatchedLayerSlot & kPackedSlotMask);
-
-          // Atomic CAS into shared best-per-layer slot, retry until we win or are beaten.
-          uint64_t oldPacked = sharedBestPacked[logicalLayerBin];
-          while (true) {
-            const float oldScore = std::bit_cast<float>(static_cast<uint32_t>(oldPacked >> kPackedScoreShift));
-            if (candidateScore <= oldScore)
-              break;
-
-            uint64_t assumedOld = alpaka::atomicCas(
-                acc, &sharedBestPacked[logicalLayerBin], oldPacked, newPacked, alpaka::hierarchy::Threads{});
-
-            if (assumedOld == oldPacked) {
-              break;
-            } else {
-              oldPacked = assumedOld;
-            }
+            const uint32_t testBar234 = testBar1234 >> kT5ByMDBarOffset;
+            //check test234 with ref234 (the only option here)
+            if (testBar234 == (refMD1234Bar >> kT5ByMDBarOffset))
+              testT5(testT5Index);
           }
         }
       }

--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
@@ -235,7 +235,7 @@ void LSTEvent::createMiniDoublets() {
     *nTotalMDs_buf_h.data() += 2 * pixelSize_;
     unsigned int nTotalMDs = *nTotalMDs_buf_h.data();
 
-    miniDoubletsDC_.emplace(queue_, nTotalMDs, nLowerModules_ + 1);
+    miniDoubletsDC_.emplace(queue_, nTotalMDs, nLowerModules_ + 1, nTotalMDsOT_, nTotalMDsOT_);
     if (objectsStatistics_) {
       double mb = alpaka::getExtentProduct(miniDoubletsDC_->buffer()) / 1e6;
       memoryAllocatedMB_ += mb;
@@ -254,6 +254,10 @@ void LSTEvent::createMiniDoublets() {
   alpaka::memset(queue_, connView, 0u);
   auto connT3View = cms::alpakatools::make_device_view(queue_, mdView.connectedT3sMax());
   alpaka::memset(queue_, connT3View, 0u);
+  auto connT50View = cms::alpakatools::make_device_view(queue_, mdView.connectedT5s0Max());
+  alpaka::memset(queue_, connT50View, 0u);
+  auto connT51View = cms::alpakatools::make_device_view(queue_, mdView.connectedT5s1Max());
+  alpaka::memset(queue_, connT51View, 0u);
 
   unsigned int mdSize = pixelSize_ * 2;
   auto src_view_mdSize = cms::alpakatools::make_host_view(mdSize);
@@ -933,7 +937,7 @@ void LSTEvent::createQuintuplets() {
                         countConn_workDiv,
                         kernel,
                         modules_.const_view().modules(),
-                        miniDoubletsDC_->const_view().miniDoublets(),
+                        miniDoubletsDC_->view().miniDoublets(),
                         segmentsDC_->const_view().segments(),
                         tripletsDC_->view().triplets(),
                         tripletsDC_->const_view().tripletsOccupancy(),
@@ -955,22 +959,35 @@ void LSTEvent::createQuintuplets() {
                       modules_.const_view().modules(),
                       tripletsDC_->const_view().tripletsOccupancy(),
                       rangesDC_->view(),
-                      tripletsDC_->view().triplets());
+                      tripletsDC_->const_view().triplets(),
+                      miniDoubletsDC_->const_view().miniDoublets(),
+                      miniDoubletsDC_->const_view().miniDoubletsOccupancy(),
+                      miniDoubletsDC_->view().quintupletsRangesByMD0(),
+                      miniDoubletsDC_->view().quintupletsRangesByMD1());
 
   auto nEligibleT5Modules_buf = cms::alpakatools::make_host_buffer<uint16_t>(queue_);
   auto nTotalQuintuplets_buf = cms::alpakatools::make_host_buffer<unsigned int>(queue_);
-  auto rangesOccupancy = rangesDC_->view();
+  auto nTotalQuintuplets0_buf = cms::alpakatools::make_host_buffer<unsigned int>(queue_);
+  auto nTotalQuintuplets1_buf = cms::alpakatools::make_host_buffer<unsigned int>(queue_);
+  auto rangesOccupancy = rangesDC_->const_view();
   auto nEligibleT5Modules_view_d = cms::alpakatools::make_device_view(queue_, rangesOccupancy.nEligibleT5Modules());
   auto nTotalQuintuplets_view_d = cms::alpakatools::make_device_view(queue_, rangesOccupancy.nTotalQuints());
+  auto nTotalQuintuplets0_view_d = cms::alpakatools::make_device_view(queue_, rangesOccupancy.nTotalQuintsByMD0());
+  auto nTotalQuintuplets1_view_d = cms::alpakatools::make_device_view(queue_, rangesOccupancy.nTotalQuintsByMD1());
   alpaka::memcpy(queue_, nEligibleT5Modules_buf, nEligibleT5Modules_view_d);
   alpaka::memcpy(queue_, nTotalQuintuplets_buf, nTotalQuintuplets_view_d);
+  alpaka::memcpy(queue_, nTotalQuintuplets0_buf, nTotalQuintuplets0_view_d);
+  alpaka::memcpy(queue_, nTotalQuintuplets1_buf, nTotalQuintuplets1_view_d);
   alpaka::wait(queue_);  // wait for the values before using them
 
   auto nEligibleT5Modules = *nEligibleT5Modules_buf.data();
   auto nTotalQuintuplets = *nTotalQuintuplets_buf.data();
+  auto nTotalQuintuplets0 = *nTotalQuintuplets0_buf.data();
+  auto nTotalQuintuplets1 = *nTotalQuintuplets1_buf.data();
 
   if (!quintupletsDC_) {
-    quintupletsDC_.emplace(queue_, nTotalQuintuplets, nLowerModules_);
+    // last two set quintupletsByMD{0,1} sizes, which can differ from nTotalQuintuplets due to truncation
+    quintupletsDC_.emplace(queue_, nTotalQuintuplets, nLowerModules_, nTotalQuintuplets0, nTotalQuintuplets1);
     if (objectsStatistics_) {
       double mb = alpaka::getExtentProduct(quintupletsDC_->buffer()) / 1e6;
       memoryAllocatedMB_ += mb;
@@ -1002,6 +1019,7 @@ void LSTEvent::createQuintuplets() {
                         kernel,
                         modules_.const_view().modules(),
                         miniDoubletsDC_->const_view().miniDoublets(),
+                        miniDoubletsDC_->const_view().miniDoubletsOccupancy(),
                         segmentsDC_->const_view().segments(),
                         tripletsDC_->view().triplets(),
                         tripletsDC_->const_view().tripletsOccupancy(),
@@ -1009,6 +1027,10 @@ void LSTEvent::createQuintuplets() {
                         tripletsDC_->const_view().tripletsRangesByMD(),
                         quintupletsDC_->view().quintuplets(),
                         quintupletsDC_->view().quintupletsOccupancy(),
+                        miniDoubletsDC_->view().quintupletsRangesByMD0(),
+                        quintupletsDC_->view().quintupletsByMD0(),
+                        miniDoubletsDC_->view().quintupletsRangesByMD1(),
+                        quintupletsDC_->view().quintupletsByMD1(),
                         rangesDC_->const_view(),
                         nEligibleT5Modules,
                         ptCut_);
@@ -1019,15 +1041,19 @@ void LSTEvent::createQuintuplets() {
     execCreateQuintuplets(CreateQuintuplets{});
 
   if (nTotalQuintuplets > 0) {
-    auto const extendT5_workDiv = cms::alpakatools::make_workdiv<Acc1D>(nTotalQuintuplets, 128);
+    auto const extendT5_workDiv = cms::alpakatools::make_workdiv<Acc1D>(nTotalQuintuplets, 32);
 
     alpaka::exec<Acc1D>(queue_,
                         extendT5_workDiv,
-                        ExtendT5FromDupT5{},
-                        modules_.const_view().modules(),
-                        rangesDC_->const_view(),
+                        ExtendT5FromDupT5ByMD{},
                         quintupletsDC_->view().quintuplets(),
-                        quintupletsDC_->const_view().quintupletsOccupancy());
+                        quintupletsDC_->const_view().quintupletsOccupancy(),
+                        miniDoubletsDC_->const_view().quintupletsRangesByMD0(),
+                        quintupletsDC_->const_view().quintupletsByMD0(),
+                        miniDoubletsDC_->const_view().quintupletsRangesByMD1(),
+                        quintupletsDC_->const_view().quintupletsByMD1(),
+                        tripletsDC_->const_view().triplets(),
+                        segmentsDC_->const_view().segments());
   }
 
   auto const removeDupQuintupletsAfterBuild_workDiv =

--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
@@ -231,6 +231,7 @@ void LSTEvent::createMiniDoublets() {
     alpaka::memcpy(queue_, nTotalMDs_buf_h, nTotalMDs_buf_d);
     alpaka::wait(queue_);  // wait to get the data before manipulation
 
+    nTotalMDsOT_ = *nTotalMDs_buf_h.data();
     *nTotalMDs_buf_h.data() += 2 * pixelSize_;
     unsigned int nTotalMDs = *nTotalMDs_buf_h.data();
 
@@ -251,6 +252,8 @@ void LSTEvent::createMiniDoublets() {
   auto mdView = miniDoubletsDC_->view().miniDoublets();
   auto connView = cms::alpakatools::make_device_view(queue_, mdView.connectedMax());
   alpaka::memset(queue_, connView, 0u);
+  auto connT3View = cms::alpakatools::make_device_view(queue_, mdView.connectedT3sMax());
+  alpaka::memset(queue_, connT3View, 0u);
 
   unsigned int mdSize = pixelSize_ * 2;
   auto src_view_mdSize = cms::alpakatools::make_host_view(mdSize);
@@ -332,6 +335,7 @@ void LSTEvent::createSegmentsWithModuleMap() {
     alpaka::memcpy(queue_, nTotalSegments_view_h, nTotalSegments_view_d);
     alpaka::wait(queue_);  // wait to get the value before manipulation
 
+    nTotalSegmentsOT_ = nTotalSegments_;
     nTotalSegments_ += pixelSize_;
 
     segmentsDC_.emplace(queue_, nTotalSegments_, nLowerModules_ + 1);
@@ -399,7 +403,7 @@ void LSTEvent::createTriplets() {
                           countSegConn_wd,
                           kernel,
                           modules_.const_view().modules(),
-                          miniDoubletsDC_->const_view().miniDoublets(),
+                          miniDoubletsDC_->view().miniDoublets(),
                           segmentsDC_->view().segments(),
                           segmentsDC_->const_view().segmentsOccupancy(),
                           rangesDC_->const_view(),
@@ -428,7 +432,8 @@ void LSTEvent::createTriplets() {
     alpaka::wait(queue_);  // wait to get the value before using it
 
     unsigned int nTotalTriplets = *maxTriplets_buf_h.data();
-    tripletsDC_.emplace(queue_, nTotalTriplets, nLowerModules_);
+    tripletsDC_.emplace(
+        queue_, nTotalTriplets, nLowerModules_, nTotalSegmentsOT_, nTotalTriplets, nTotalMDsOT_, nTotalTriplets);
     if (objectsStatistics_) {
       double mb = alpaka::getExtentProduct(tripletsDC_->buffer()) / 1e6;
       memoryAllocatedMB_ += mb;
@@ -505,10 +510,15 @@ void LSTEvent::createTriplets() {
                         kernel,
                         modules_.const_view().modules(),
                         miniDoubletsDC_->const_view().miniDoublets(),
+                        miniDoubletsDC_->const_view().miniDoubletsOccupancy(),
                         segmentsDC_->const_view().segments(),
                         segmentsDC_->const_view().segmentsOccupancy(),
                         tripletsDC_->view().triplets(),
                         tripletsDC_->view().tripletsOccupancy(),
+                        tripletsDC_->view().tripletsBySegment(),
+                        tripletsDC_->view().tripletsRangesBySegment(),
+                        tripletsDC_->view().tripletsByMD(),
+                        tripletsDC_->view().tripletsRangesByMD(),
                         rangesDC_->const_view(),
                         index_gpu_buf.data(),
                         nonZeroModules,
@@ -927,6 +937,8 @@ void LSTEvent::createQuintuplets() {
                         segmentsDC_->const_view().segments(),
                         tripletsDC_->view().triplets(),
                         tripletsDC_->const_view().tripletsOccupancy(),
+                        tripletsDC_->const_view().tripletsByMD(),
+                        tripletsDC_->const_view().tripletsRangesByMD(),
                         rangesDC_->const_view(),
                         ptCut_);
   };
@@ -993,6 +1005,8 @@ void LSTEvent::createQuintuplets() {
                         segmentsDC_->const_view().segments(),
                         tripletsDC_->view().triplets(),
                         tripletsDC_->const_view().tripletsOccupancy(),
+                        tripletsDC_->const_view().tripletsByMD(),
+                        tripletsDC_->const_view().tripletsRangesByMD(),
                         quintupletsDC_->view().quintuplets(),
                         quintupletsDC_->view().quintupletsOccupancy(),
                         rangesDC_->const_view(),
@@ -1201,6 +1215,8 @@ void LSTEvent::createQuadruplets() {
                         segmentsDC_->const_view().segments(),
                         tripletsDC_->view().triplets(),
                         tripletsDC_->const_view().tripletsOccupancy(),
+                        tripletsDC_->const_view().tripletsBySegment(),
+                        tripletsDC_->const_view().tripletsRangesBySegment(),
                         rangesDC_->const_view(),
                         ptCut_);
   };
@@ -1260,8 +1276,10 @@ void LSTEvent::createQuadruplets() {
                         modules_.const_view().modules(),
                         miniDoubletsDC_->const_view().miniDoublets(),
                         segmentsDC_->const_view().segments(),
-                        tripletsDC_->view().triplets(),
+                        tripletsDC_->const_view().triplets(),
                         tripletsDC_->const_view().tripletsOccupancy(),
+                        tripletsDC_->const_view().tripletsBySegment(),
+                        tripletsDC_->const_view().tripletsRangesBySegment(),
                         quadrupletsDC_->view().quadruplets(),
                         quadrupletsDC_->view().quadrupletsOccupancy(),
                         rangesDC_->const_view(),

--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.h
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.h
@@ -55,7 +55,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     std::array<unsigned int, 5> n_quintuplets_by_layer_endcap_{};
     std::array<unsigned int, 6> n_quadruplets_by_layer_barrel_{};
     std::array<unsigned int, 5> n_quadruplets_by_layer_endcap_{};
+    unsigned int nTotalMDsOT_;
     unsigned int nTotalSegments_;
+    unsigned int nTotalSegmentsOT_;
     unsigned int pixelSize_;
     uint16_t pixelModuleIndex_;
 

--- a/RecoTracker/LSTCore/src/alpaka/Quadruplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quadruplet.h
@@ -519,8 +519,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   ModulesConst modules,
                                   MiniDoubletsConst mds,
                                   SegmentsConst segments,
-                                  Triplets triplets,
+                                  TripletsConst triplets,
                                   TripletsOccupancyConst tripletsOccupancy,
+                                  TripletsBySegmentConst tripletsBySegment,
+                                  TripletsRangesConst tripletsRangesBySegment,
                                   Quadruplets quadruplets,
                                   QuadrupletsOccupancy quadrupletsOccupancy,
                                   ObjectRangesConst ranges,
@@ -596,19 +598,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
           const uint16_t lowerModule2 = lmIdx[innerTripletIndex][1];
           const unsigned int nOuterTriplets = tripletsOccupancy.nTriplets()[lowerModule2];
-          if (nOuterTriplets == 0)
+          const unsigned int nOuterTripletsByLS = tripletsRangesBySegment.n()[innerT3LS2Index];
+          if (nOuterTripletsByLS == 0)
             continue;
 
           const float innerRadius = triplets.radius()[innerTripletIndex];
           const uint16_t lowerModule3 = lmIdx[innerTripletIndex][2];
 
-          const auto outerTripletOffset = tripIdx[lowerModule2];
-          for (unsigned int outerTripletArrayIndex : cms::alpakatools::uniform_elements_x(acc, nOuterTriplets)) {
-            unsigned int outerTripletIndex = outerTripletOffset + outerTripletArrayIndex;
-            //check if the 2 T3s have a common LS
-            const auto outerT3LS1Index = segIdx[outerTripletIndex][0];
-            if (innerT3LS2Index != outerT3LS1Index)
-              continue;
+          const auto outerOffset = tripletsRangesBySegment.offset()[innerT3LS2Index];
+          for (unsigned int outerIndex : cms::alpakatools::uniform_elements_x(acc, nOuterTripletsByLS)) {
+            unsigned int outerTripletIndex = tripletsBySegment.tripletIndex()[outerOffset + outerIndex];
 
             if (triplets.partOfPT5()[outerTripletIndex])
               continue;  //don't create T4s for T3s accounted in pT5s
@@ -841,6 +840,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   SegmentsConst segments,
                                   Triplets triplets,
                                   TripletsOccupancyConst tripletsOcc,
+                                  TripletsBySegmentConst tripletsBySegment,
+                                  TripletsRangesConst tripletsRangesBySegment,
                                   ObjectRangesConst ranges,
                                   const float ptCut) const {
       // The atomicAdd below with hierarchy::Threads{} requires one block in x, y dimensions.
@@ -875,16 +876,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           const unsigned int nOuterTriplets = tripletsOcc.nTriplets()[lowerModule2];
           if (nOuterTriplets == 0)
             continue;
-
           const unsigned int secondSegIdx = segIdx[innerTripletIndex][1];
+          const unsigned int nOuterTripletsByLS = tripletsRangesBySegment.n()[secondSegIdx];
+          if (nOuterTripletsByLS == 0)
+            continue;
 
-          const auto outerTripletOffset = tripIdx[lowerModule2];
-          for (unsigned int outerTripletArrayIndex : cms::alpakatools::uniform_elements_x(acc, nOuterTriplets)) {
-            const unsigned int outerTripletIndex = outerTripletOffset + outerTripletArrayIndex;
-            const unsigned int thirdSegIdx = segIdx[outerTripletIndex][0];
-            //check if the 2 T3s have a common LS
-            if (secondSegIdx != thirdSegIdx)
-              continue;
+          const auto outerOffset = tripletsRangesBySegment.offset()[secondSegIdx];
+          for (unsigned int outerIndex : cms::alpakatools::uniform_elements_x(acc, nOuterTripletsByLS)) {
+            const unsigned int outerTripletIndex = tripletsBySegment.tripletIndex()[outerOffset + outerIndex];
 
             if (partOfPT5[outerTripletIndex])
               continue;  //don't create T4s for T3s accounted in pT5s

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -2040,12 +2040,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       // The atomicAdd below with hierarchy::Threads{} requires one block in x, y dimensions.
       ALPAKA_ASSERT_ACC((alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[1] == 1) &&
                         (alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[2] == 1));
+      unsigned int& denseMatchCount = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
+
       const auto& mdIndices = segments.mdIndices();
       const auto& segIdx = triplets.segmentIndices();
       const auto& lmIdx = triplets.lowerModuleIndices();
       const auto& tripIdx = ranges.tripletModuleIndices();
 
       for (uint16_t lowerModule1 : cms::alpakatools::uniform_groups_z(acc, modules.nLowerModules())) {
+        if (cms::alpakatools::once_per_block(acc)) {
+          denseMatchCount = 0;
+        }
+        alpaka::syncBlockThreads(acc);
+
         if (!isValidQuintRegion(modules, lowerModule1))
           continue;
 
@@ -2075,6 +2082,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             if (!ReduceMem && nInnerTriplets < kNTripletThreshold && nOuterTriplets < kNTripletThreshold) {
               alpaka::atomicAdd(acc, &triplets.connectedMax()[innerTripletIndex], 1u, alpaka::hierarchy::Threads{});
             } else {
+              //asynchronous stop; exact truncation here is not important
+              if (denseMatchCount > kNQuintupletThreshold)
+                break;
+
               const uint16_t lowerModule2 = lmIdx[innerTripletIndex][1];
               const uint16_t lowerModule4 = lmIdx[outerTripletIndex][1];
               const uint16_t lowerModule5 = lmIdx[outerTripletIndex][2];
@@ -2114,6 +2125,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                        ptCut);
               if (ok) {
                 alpaka::atomicAdd(acc, &triplets.connectedMax()[innerTripletIndex], 1u, alpaka::hierarchy::Threads{});
+                alpaka::atomicAdd(acc, &denseMatchCount, 1u, alpaka::hierarchy::Threads{});
               }
             }
           }

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -1698,6 +1698,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   SegmentsConst segments,
                                   Triplets triplets,
                                   TripletsOccupancyConst tripletsOccupancy,
+                                  TripletsByMDConst tripletsByMD,
+                                  TripletsRangesConst tripletsRangesByMD,
                                   Quintuplets quintuplets,
                                   QuintupletsOccupancy quintupletsOccupancy,
                                   ObjectRangesConst ranges,
@@ -1768,18 +1770,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           if (nOuterTriplets == 0)
             continue;
 
-          const auto outerTripletOffset = tripIdx[lowerModule3];
-          const auto secondSegmentIndex = segIdx[innerTripletIndex][1];
-          const auto miniDoublet3Index = mdIndices[secondSegmentIndex][1];  //outermost MD
-          for (unsigned int outerTripletArrayIndex : cms::alpakatools::uniform_elements_x(acc, nOuterTriplets)) {
-            unsigned int outerTripletIndex = outerTripletOffset + outerTripletArrayIndex;
+          const unsigned int secondSegIdx = segIdx[innerTripletIndex][1];
+          const unsigned int secondMDOuter = mdIndices[secondSegIdx][1];
+          const unsigned int nOuterTripletsByMD = tripletsRangesByMD.n()[secondMDOuter];
+          if (nOuterTripletsByMD == 0)
+            continue;
 
-            const auto thirdSegmentIndex = segIdx[outerTripletIndex][0];
-            const auto outerInnerInnerMiniDoubletIndex = mdIndices[thirdSegmentIndex][0];  //outer triplet innermost MD
-
-            //matching MDs
-            if (miniDoublet3Index != outerInnerInnerMiniDoubletIndex)
-              continue;
+          const auto outerOffset = tripletsRangesByMD.offset()[secondMDOuter];
+          for (unsigned int outerIndex : cms::alpakatools::uniform_elements_x(acc, nOuterTripletsByMD)) {
+            unsigned int outerTripletIndex = tripletsByMD.tripletIndex()[outerOffset + outerIndex];
 
             // If densely connected, do not attempt parallel processing to avoid truncation
             if (ReduceMem || nInnerTriplets >= kNTripletThreshold || nOuterTriplets >= kNTripletThreshold) {
@@ -2034,6 +2033,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   SegmentsConst segments,
                                   Triplets triplets,
                                   TripletsOccupancyConst tripletsOcc,
+                                  TripletsByMDConst tripletsByMD,
+                                  TripletsRangesConst tripletsRangesByMD,
                                   ObjectRangesConst ranges,
                                   const float ptCut) const {
       // The atomicAdd below with hierarchy::Threads{} requires one block in x, y dimensions.
@@ -2062,57 +2063,57 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
           const unsigned int secondSegIdx = segIdx[innerTripletIndex][1];
           const unsigned int secondMDOuter = mdIndices[secondSegIdx][1];
+          const unsigned int nOuterTripletsByMD = tripletsRangesByMD.n()[secondMDOuter];
+          if (nOuterTripletsByMD == 0)
+            continue;
 
-          for (unsigned int outerTripletArrayIndex : cms::alpakatools::uniform_elements_x(acc, nOuterTriplets)) {
-            const unsigned int outerTripletIndex = tripIdx[lowerModule3] + outerTripletArrayIndex;
-            const unsigned int thirdSegIdx = segIdx[outerTripletIndex][0];
-            const unsigned int thirdMDInner = mdIndices[thirdSegIdx][0];
+          const auto outerOffset = tripletsRangesByMD.offset()[secondMDOuter];
+          for (unsigned int outerIndex : cms::alpakatools::uniform_elements_x(acc, nOuterTripletsByMD)) {
+            const unsigned int outerTripletIndex = tripletsByMD.tripletIndex()[outerOffset + outerIndex];
 
-            if (secondMDOuter == thirdMDInner) {
-              // Will only perform runQuintupletDefaultAlgorithm() checks if densely connected
-              if (!ReduceMem && nInnerTriplets < kNTripletThreshold && nOuterTriplets < kNTripletThreshold) {
+            // Will only perform runQuintupletDefaultAlgorithm() checks if densely connected
+            if (!ReduceMem && nInnerTriplets < kNTripletThreshold && nOuterTriplets < kNTripletThreshold) {
+              alpaka::atomicAdd(acc, &triplets.connectedMax()[innerTripletIndex], 1u, alpaka::hierarchy::Threads{});
+            } else {
+              const uint16_t lowerModule2 = lmIdx[innerTripletIndex][1];
+              const uint16_t lowerModule4 = lmIdx[outerTripletIndex][1];
+              const uint16_t lowerModule5 = lmIdx[outerTripletIndex][2];
+
+              float innerRadius, outerRadius, bridgeRadius;
+              float regCx, regCy, regR;
+              float rzChi2, chi2, nonAnchorChi2, dBeta1, dBeta2, dnnScore;
+              float t5Embed[Params_T5::kEmbed] = {0.f};
+              bool tightFlag = false;
+
+              const bool ok = runQuintupletDefaultAlgo(acc,
+                                                       modules,
+                                                       mds,
+                                                       segments,
+                                                       triplets,
+                                                       lowerModule1,
+                                                       lowerModule2,
+                                                       lowerModule3,
+                                                       lowerModule4,
+                                                       lowerModule5,
+                                                       innerTripletIndex,
+                                                       outerTripletIndex,
+                                                       innerRadius,
+                                                       outerRadius,
+                                                       bridgeRadius,
+                                                       regCx,
+                                                       regCy,
+                                                       regR,
+                                                       rzChi2,
+                                                       chi2,
+                                                       nonAnchorChi2,
+                                                       dBeta1,
+                                                       dBeta2,
+                                                       dnnScore,
+                                                       tightFlag,
+                                                       t5Embed,
+                                                       ptCut);
+              if (ok) {
                 alpaka::atomicAdd(acc, &triplets.connectedMax()[innerTripletIndex], 1u, alpaka::hierarchy::Threads{});
-              } else {
-                const uint16_t lowerModule2 = lmIdx[innerTripletIndex][1];
-                const uint16_t lowerModule4 = lmIdx[outerTripletIndex][1];
-                const uint16_t lowerModule5 = lmIdx[outerTripletIndex][2];
-
-                float innerRadius, outerRadius, bridgeRadius;
-                float regCx, regCy, regR;
-                float rzChi2, chi2, nonAnchorChi2, dBeta1, dBeta2, dnnScore;
-                float t5Embed[Params_T5::kEmbed] = {0.f};
-                bool tightFlag = false;
-
-                const bool ok = runQuintupletDefaultAlgo(acc,
-                                                         modules,
-                                                         mds,
-                                                         segments,
-                                                         triplets,
-                                                         lowerModule1,
-                                                         lowerModule2,
-                                                         lowerModule3,
-                                                         lowerModule4,
-                                                         lowerModule5,
-                                                         innerTripletIndex,
-                                                         outerTripletIndex,
-                                                         innerRadius,
-                                                         outerRadius,
-                                                         bridgeRadius,
-                                                         regCx,
-                                                         regCy,
-                                                         regR,
-                                                         rzChi2,
-                                                         chi2,
-                                                         nonAnchorChi2,
-                                                         dBeta1,
-                                                         dBeta2,
-                                                         dnnScore,
-                                                         tightFlag,
-                                                         t5Embed,
-                                                         ptCut);
-                if (ok) {
-                  alpaka::atomicAdd(acc, &triplets.connectedMax()[innerTripletIndex], 1u, alpaka::hierarchy::Threads{});
-                }
               }
             }
           }

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -20,7 +20,10 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void addQuintupletToMemory(TripletsConst triplets,
+                                                            SegmentsConst segments,
                                                             Quintuplets quintuplets,
+                                                            QuintupletsByMD quintupletsByMD0,
+                                                            QuintupletsByMD quintupletsByMD1,
                                                             unsigned int innerTripletIndex,
                                                             unsigned int outerTripletIndex,
                                                             uint16_t lowerModule1,
@@ -45,6 +48,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                             float scores,
                                                             uint8_t layer,
                                                             unsigned int quintupletIndex,
+                                                            unsigned int quintupletByMD0Index,
+                                                            unsigned int quintupletByMD1Index,
                                                             const float (&t5Embed)[Params_T5::kEmbed],
                                                             bool tightCutFlag,
                                                             float dnnScore) {
@@ -105,6 +110,25 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       quintuplets.lowerModuleIndices()[quintupletIndex][i] = lst::kTCEmptyLowerModule;
       quintuplets.hitIndices()[quintupletIndex][2 * i] = lst::kTCEmptyHitIdx;
       quintuplets.hitIndices()[quintupletIndex][2 * i + 1] = lst::kTCEmptyHitIdx;
+    }
+
+    auto const& lsIdx = triplets.segmentIndices();
+    auto const& mdIdx = segments.mdIndices();
+    const uint32_t md1Bar = mdIdx[lsIdx[innerTripletIndex][1]][0] & kT5ByMDBarCodeMask;
+    const uint32_t md2Bar = mdIdx[lsIdx[innerTripletIndex][1]][1] & kT5ByMDBarCodeMask;
+    const uint32_t md3Bar = mdIdx[lsIdx[outerTripletIndex][1]][0] & kT5ByMDBarCodeMask;
+    const uint32_t md4Bar = mdIdx[lsIdx[outerTripletIndex][1]][1] & kT5ByMDBarCodeMask;
+    const uint32_t md1234Bar =
+        md1Bar | (md2Bar << kT5ByMDBarOffset) | (md3Bar << (kT5ByMDBarOffset * 2)) | (md4Bar << (kT5ByMDBarOffset * 3));
+    if (quintupletByMD0Index != kInvalidU32Idx) {
+      quintupletsByMD0.quintupletIndex()[quintupletByMD0Index] = quintupletIndex;
+      quintupletsByMD0.mdBarCode()[quintupletByMD0Index] = md1234Bar;
+    }
+    if (quintupletByMD1Index != kInvalidU32Idx) {
+      quintupletsByMD1.quintupletIndex()[quintupletByMD1Index] = quintupletIndex;
+      //save the starting logical layer index instead of md1Bar
+      quintupletsByMD1.mdBarCode()[quintupletByMD1Index] =
+          (quintuplets.logicalLayers()[quintupletIndex][0] & kT5ByMDBarCodeMask) | (md1234Bar & ~kT5ByMDBarCodeMask);
     }
   }
 
@@ -1690,11 +1714,150 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     return true;
   }
 
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE void tryAddQuintuplet(Acc3D const& acc,
+                                                       ModulesConst modules,
+                                                       MiniDoubletsConst mds,
+                                                       SegmentsConst segments,
+                                                       Triplets triplets,
+                                                       Quintuplets quintuplets,
+                                                       QuintupletsOccupancy quintupletsOccupancy,
+                                                       QuintupletsRanges quintupletsRangesByMD0,
+                                                       QuintupletsByMD quintupletsByMD0,
+                                                       QuintupletsRanges quintupletsRangesByMD1,
+                                                       QuintupletsByMD quintupletsByMD1,
+                                                       ObjectRangesConst ranges,
+                                                       unsigned int innerTripletIndex,
+                                                       unsigned int outerTripletIndex,
+                                                       uint16_t lowerModule1,
+                                                       const float ptCut) {
+    const auto& mdIndices = segments.mdIndices();
+    const auto& segIdx = triplets.segmentIndices();
+    const auto& lmIdx = triplets.lowerModuleIndices();
+    uint16_t lowerModule2 = lmIdx[innerTripletIndex][1];
+    uint16_t lowerModule3 = lmIdx[innerTripletIndex][2];
+    uint16_t lowerModule4 = lmIdx[outerTripletIndex][1];
+    uint16_t lowerModule5 = lmIdx[outerTripletIndex][2];
+
+    float innerRadius, outerRadius, bridgeRadius, regressionCenterX, regressionCenterY, regressionRadius, rzChiSquared,
+        chiSquared, nonAnchorChiSquared, dBeta1, dBeta2,
+        dnnScore;  //required for making distributions
+
+    float t5Embed[Params_T5::kEmbed] = {0.f};
+
+    bool tightCutFlag = false;
+
+    bool success = runQuintupletDefaultAlgo(acc,
+                                            modules,
+                                            mds,
+                                            segments,
+                                            triplets,
+                                            lowerModule1,
+                                            lowerModule2,
+                                            lowerModule3,
+                                            lowerModule4,
+                                            lowerModule5,
+                                            innerTripletIndex,
+                                            outerTripletIndex,
+                                            innerRadius,
+                                            outerRadius,
+                                            bridgeRadius,
+                                            regressionCenterX,
+                                            regressionCenterY,
+                                            regressionRadius,
+                                            rzChiSquared,
+                                            chiSquared,
+                                            nonAnchorChiSquared,
+                                            dBeta1,
+                                            dBeta2,
+                                            dnnScore,
+                                            tightCutFlag,
+                                            t5Embed,
+                                            ptCut);
+    if (success) {
+      int totOccupancyQuintuplets = alpaka::atomicAdd(
+          acc, &quintupletsOccupancy.totOccupancyQuintuplets()[lowerModule1], 1u, alpaka::hierarchy::Threads{});
+      if (totOccupancyQuintuplets >= ranges.quintupletModuleOccupancy()[lowerModule1]) {
+#ifdef WARNINGS
+        printf("Quintuplet excess alert! Module index = %d, Occupancy = %d\n", lowerModule1, totOccupancyQuintuplets);
+#endif
+      } else {
+        int quintupletModuleIndex = alpaka::atomicAdd(
+            acc, &quintupletsOccupancy.nQuintuplets()[lowerModule1], 1u, alpaka::hierarchy::Threads{});
+        unsigned int quintupletIndex = ranges.quintupletModuleIndices()[lowerModule1] + quintupletModuleIndex;
+        auto const ls0Index = segIdx[innerTripletIndex][0];
+        auto const md0Index = mdIndices[ls0Index][0];
+        auto const quintupletByMD0Local =
+            alpaka::atomicAdd(acc, &quintupletsRangesByMD0.n()[md0Index], 1u, alpaka::hierarchy::Threads{});
+        auto quintupletByMD0Index = quintupletByMD0Local + quintupletsRangesByMD0.offset()[md0Index];
+        if (quintupletByMD0Local >= mds.connectedT5s0Max()[md0Index]) {
+          alpaka::atomicSub(acc, &quintupletsRangesByMD0.n()[md0Index], 1u, alpaka::hierarchy::Threads{});
+          quintupletByMD0Index = kInvalidU32Idx;
+        }
+        auto const md1Index = mdIndices[ls0Index][1];
+        auto const quintupletByMD1Local =
+            alpaka::atomicAdd(acc, &quintupletsRangesByMD1.n()[md1Index], 1u, alpaka::hierarchy::Blocks{});
+        auto quintupletByMD1Index = quintupletByMD1Local + quintupletsRangesByMD1.offset()[md1Index];
+        if (quintupletByMD1Local >= mds.connectedT5s1Max()[md1Index]) {
+          alpaka::atomicSub(acc, &quintupletsRangesByMD1.n()[md1Index], 1u, alpaka::hierarchy::Blocks{});
+          quintupletByMD1Index = kInvalidU32Idx;
+        }
+
+        auto const layer = modules.layers()[lowerModule1];
+        //get upper segment to be in second layer
+        //assumes only 1 and 2 are possible here (isValidQuintRegion)
+        const short layer2_adjustment = layer == 1 ? 1 : 0;
+
+        float phi = mds.anchorPhi()[mdIndices[ls0Index][layer2_adjustment]];
+        float eta = mds.anchorEta()[mdIndices[ls0Index][layer2_adjustment]];
+        float pt = (innerRadius + outerRadius) * k2Rinv1GeVf;
+        float scores = chiSquared + nonAnchorChiSquared;
+        addQuintupletToMemory(triplets,
+                              segments,
+                              quintuplets,
+                              quintupletsByMD0,
+                              quintupletsByMD1,
+                              innerTripletIndex,
+                              outerTripletIndex,
+                              lowerModule1,
+                              lowerModule2,
+                              lowerModule3,
+                              lowerModule4,
+                              lowerModule5,
+                              innerRadius,
+                              bridgeRadius,
+                              outerRadius,
+                              regressionCenterX,
+                              regressionCenterY,
+                              regressionRadius,
+                              rzChiSquared,
+                              chiSquared,
+                              nonAnchorChiSquared,
+                              dBeta1,
+                              dBeta2,
+                              pt,
+                              eta,
+                              phi,
+                              scores,
+                              layer,
+                              quintupletIndex,
+                              quintupletByMD0Index,
+                              quintupletByMD1Index,
+                              t5Embed,
+                              tightCutFlag,
+                              dnnScore);
+
+        triplets.partOfT5()[quintuplets.tripletIndices()[quintupletIndex][0]] = true;
+        triplets.partOfT5()[quintuplets.tripletIndices()[quintupletIndex][1]] = true;
+      }
+    }
+  };  //tryAddQuintuplet
+
   template <bool ReduceMem>
   struct CreateQuintupletsT {
     ALPAKA_FN_ACC void operator()(Acc3D const& acc,
                                   ModulesConst modules,
                                   MiniDoubletsConst mds,
+                                  MiniDoubletsOccupancyConst mdOccupancy,
                                   SegmentsConst segments,
                                   Triplets triplets,
                                   TripletsOccupancyConst tripletsOccupancy,
@@ -1702,6 +1865,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   TripletsRangesConst tripletsRangesByMD,
                                   Quintuplets quintuplets,
                                   QuintupletsOccupancy quintupletsOccupancy,
+                                  QuintupletsRanges quintupletsRangesByMD0,
+                                  QuintupletsByMD quintupletsByMD0,
+                                  QuintupletsRanges quintupletsRangesByMD1,
+                                  QuintupletsByMD quintupletsByMD1,
                                   ObjectRangesConst ranges,
                                   uint16_t nEligibleT5Modules,
                                   const float ptCut) const {
@@ -1739,27 +1906,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
         if (cms::alpakatools::once_per_block(acc)) {
           matchCount = 0;
         }
+        alpaka::syncBlockThreads(acc);
 
-        short layer2_adjustment;
         int layer = modules.layers()[lowerModule1];
-        if (layer == 1) {
-          layer2_adjustment = 1;
-        }  // get upper segment to be in second layer
-        else if (layer == 2) {
-          layer2_adjustment = 0;
-        }  // get lower segment to be in second layer
-        else {
+        //redundant wrt isValidQuintRegion in CreateEligibleModulesListForQuintuplets
+        if (layer > 2)
           continue;
-        }
 
         unsigned int nInnerTriplets = tripletsOccupancy.nTriplets()[lowerModule1];
         if (nInnerTriplets == 0)
           continue;
-
-        alpaka::syncBlockThreads(acc);
+        const auto innerTripletOffset = tripIdx[lowerModule1];
 
         // Step 1: Make inner and outer triplet pairs
-        const auto innerTripletOffset = tripIdx[lowerModule1];
         for (unsigned int innerTripletArrayIndex : cms::alpakatools::uniform_elements_y(acc, nInnerTriplets)) {
           unsigned int innerTripletIndex = innerTripletOffset + innerTripletArrayIndex;
           if (triplets.connectedMax()[innerTripletIndex] == 0)
@@ -1782,99 +1941,22 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
             // If densely connected, do not attempt parallel processing to avoid truncation
             if (ReduceMem || nInnerTriplets >= kNTripletThreshold || nOuterTriplets >= kNTripletThreshold) {
-              uint16_t lowerModule2 = lmIdx[innerTripletIndex][1];
-              uint16_t lowerModule4 = lmIdx[outerTripletIndex][1];
-              uint16_t lowerModule5 = lmIdx[outerTripletIndex][2];
-
-              float innerRadius, outerRadius, bridgeRadius, regressionCenterX, regressionCenterY, regressionRadius,
-                  rzChiSquared, chiSquared, nonAnchorChiSquared, dBeta1, dBeta2,
-                  dnnScore;  //required for making distributions
-
-              float t5Embed[Params_T5::kEmbed] = {0.f};
-
-              bool tightCutFlag = false;
-
-              bool success = runQuintupletDefaultAlgo(acc,
-                                                      modules,
-                                                      mds,
-                                                      segments,
-                                                      triplets,
-                                                      lowerModule1,
-                                                      lowerModule2,
-                                                      lowerModule3,
-                                                      lowerModule4,
-                                                      lowerModule5,
-                                                      innerTripletIndex,
-                                                      outerTripletIndex,
-                                                      innerRadius,
-                                                      outerRadius,
-                                                      bridgeRadius,
-                                                      regressionCenterX,
-                                                      regressionCenterY,
-                                                      regressionRadius,
-                                                      rzChiSquared,
-                                                      chiSquared,
-                                                      nonAnchorChiSquared,
-                                                      dBeta1,
-                                                      dBeta2,
-                                                      dnnScore,
-                                                      tightCutFlag,
-                                                      t5Embed,
-                                                      ptCut);
-              if (success) {
-                int totOccupancyQuintuplets =
-                    alpaka::atomicAdd(acc,
-                                      &quintupletsOccupancy.totOccupancyQuintuplets()[lowerModule1],
-                                      1u,
-                                      alpaka::hierarchy::Threads{});
-                if (totOccupancyQuintuplets >= ranges.quintupletModuleOccupancy()[lowerModule1]) {
-#ifdef WARNINGS
-                  printf("Quintuplet excess alert! Module index = %d, Occupancy = %d\n",
-                         lowerModule1,
-                         totOccupancyQuintuplets);
-#endif
-                } else {
-                  int quintupletModuleIndex = alpaka::atomicAdd(
-                      acc, &quintupletsOccupancy.nQuintuplets()[lowerModule1], 1u, alpaka::hierarchy::Threads{});
-                  unsigned int quintupletIndex = ranges.quintupletModuleIndices()[lowerModule1] + quintupletModuleIndex;
-                  float phi = mds.anchorPhi()[mdIndices[segIdx[innerTripletIndex][0]][layer2_adjustment]];
-                  float eta = mds.anchorEta()[mdIndices[segIdx[innerTripletIndex][0]][layer2_adjustment]];
-                  float pt = (innerRadius + outerRadius) * k2Rinv1GeVf;
-                  float scores = chiSquared + nonAnchorChiSquared;
-                  addQuintupletToMemory(triplets,
-                                        quintuplets,
-                                        innerTripletIndex,
-                                        outerTripletIndex,
-                                        lowerModule1,
-                                        lowerModule2,
-                                        lowerModule3,
-                                        lowerModule4,
-                                        lowerModule5,
-                                        innerRadius,
-                                        bridgeRadius,
-                                        outerRadius,
-                                        regressionCenterX,
-                                        regressionCenterY,
-                                        regressionRadius,
-                                        rzChiSquared,
-                                        chiSquared,
-                                        nonAnchorChiSquared,
-                                        dBeta1,
-                                        dBeta2,
-                                        pt,
-                                        eta,
-                                        phi,
-                                        scores,
-                                        layer,
-                                        quintupletIndex,
-                                        t5Embed,
-                                        tightCutFlag,
-                                        dnnScore);
-
-                  triplets.partOfT5()[quintuplets.tripletIndices()[quintupletIndex][0]] = true;
-                  triplets.partOfT5()[quintuplets.tripletIndices()[quintupletIndex][1]] = true;
-                }
-              }
+              tryAddQuintuplet(acc,
+                               modules,
+                               mds,
+                               segments,
+                               triplets,
+                               quintuplets,
+                               quintupletsOccupancy,
+                               quintupletsRangesByMD0,
+                               quintupletsByMD0,
+                               quintupletsRangesByMD1,
+                               quintupletsByMD1,
+                               ranges,
+                               innerTripletIndex,
+                               outerTripletIndex,
+                               lowerModule1,
+                               ptCut);
               continue;
             }
 
@@ -1919,97 +2001,22 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           int innerTripletIndex = quintuplets.preAllocatedTripletIndices()[quintupletIndex][0];
           int outerTripletIndex = quintuplets.preAllocatedTripletIndices()[quintupletIndex][1];
 
-          uint16_t lowerModule2 = lmIdx[innerTripletIndex][1];
-          uint16_t lowerModule3 = lmIdx[innerTripletIndex][2];
-          uint16_t lowerModule4 = lmIdx[outerTripletIndex][1];
-          uint16_t lowerModule5 = lmIdx[outerTripletIndex][2];
-
-          float innerRadius, outerRadius, bridgeRadius, regressionCenterX, regressionCenterY, regressionRadius,
-              rzChiSquared, chiSquared, nonAnchorChiSquared, dBeta1, dBeta2,
-              dnnScore;  //required for making distributions
-
-          float t5Embed[Params_T5::kEmbed] = {0.f};
-
-          bool tightCutFlag = false;
-
-          bool success = runQuintupletDefaultAlgo(acc,
-                                                  modules,
-                                                  mds,
-                                                  segments,
-                                                  triplets,
-                                                  lowerModule1,
-                                                  lowerModule2,
-                                                  lowerModule3,
-                                                  lowerModule4,
-                                                  lowerModule5,
-                                                  innerTripletIndex,
-                                                  outerTripletIndex,
-                                                  innerRadius,
-                                                  outerRadius,
-                                                  bridgeRadius,
-                                                  regressionCenterX,
-                                                  regressionCenterY,
-                                                  regressionRadius,
-                                                  rzChiSquared,
-                                                  chiSquared,
-                                                  nonAnchorChiSquared,
-                                                  dBeta1,
-                                                  dBeta2,
-                                                  dnnScore,
-                                                  tightCutFlag,
-                                                  t5Embed,
-                                                  ptCut);
-          if (success) {
-            int totOccupancyQuintuplets = alpaka::atomicAdd(
-                acc, &quintupletsOccupancy.totOccupancyQuintuplets()[lowerModule1], 1u, alpaka::hierarchy::Threads{});
-            if (totOccupancyQuintuplets >= ranges.quintupletModuleOccupancy()[lowerModule1]) {
-#ifdef WARNINGS
-              printf("Quintuplet excess alert! Module index = %d, Occupancy = %d\n",
-                     lowerModule1,
-                     totOccupancyQuintuplets);
-#endif
-            } else {
-              int quintupletModuleIndex = alpaka::atomicAdd(
-                  acc, &quintupletsOccupancy.nQuintuplets()[lowerModule1], 1u, alpaka::hierarchy::Threads{});
-              unsigned int quintupletIndex = ranges.quintupletModuleIndices()[lowerModule1] + quintupletModuleIndex;
-              float phi = mds.anchorPhi()[mdIndices[segIdx[innerTripletIndex][0]][layer2_adjustment]];
-              float eta = mds.anchorEta()[mdIndices[segIdx[innerTripletIndex][0]][layer2_adjustment]];
-              float pt = (innerRadius + outerRadius) * k2Rinv1GeVf;
-              float scores = chiSquared + nonAnchorChiSquared;
-              addQuintupletToMemory(triplets,
-                                    quintuplets,
-                                    innerTripletIndex,
-                                    outerTripletIndex,
-                                    lowerModule1,
-                                    lowerModule2,
-                                    lowerModule3,
-                                    lowerModule4,
-                                    lowerModule5,
-                                    innerRadius,
-                                    bridgeRadius,
-                                    outerRadius,
-                                    regressionCenterX,
-                                    regressionCenterY,
-                                    regressionRadius,
-                                    rzChiSquared,
-                                    chiSquared,
-                                    nonAnchorChiSquared,
-                                    dBeta1,
-                                    dBeta2,
-                                    pt,
-                                    eta,
-                                    phi,
-                                    scores,
-                                    layer,
-                                    quintupletIndex,
-                                    t5Embed,
-                                    tightCutFlag,
-                                    dnnScore);
-
-              triplets.partOfT5()[quintuplets.tripletIndices()[quintupletIndex][0]] = true;
-              triplets.partOfT5()[quintuplets.tripletIndices()[quintupletIndex][1]] = true;
-            }
-          }
+          tryAddQuintuplet(acc,
+                           modules,
+                           mds,
+                           segments,
+                           triplets,
+                           quintuplets,
+                           quintupletsOccupancy,
+                           quintupletsRangesByMD0,
+                           quintupletsByMD0,
+                           quintupletsRangesByMD1,
+                           quintupletsByMD1,
+                           ranges,
+                           innerTripletIndex,
+                           outerTripletIndex,
+                           lowerModule1,
+                           ptCut);
         }
       }
     }
@@ -2029,7 +2036,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   struct CountTripletConnectionsT {
     ALPAKA_FN_ACC void operator()(Acc3D const& acc,
                                   ModulesConst modules,
-                                  MiniDoubletsConst mds,
+                                  MiniDoublets mds,
                                   SegmentsConst segments,
                                   Triplets triplets,
                                   TripletsOccupancyConst tripletsOcc,
@@ -2081,6 +2088,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             // Will only perform runQuintupletDefaultAlgorithm() checks if densely connected
             if (!ReduceMem && nInnerTriplets < kNTripletThreshold && nOuterTriplets < kNTripletThreshold) {
               alpaka::atomicAdd(acc, &triplets.connectedMax()[innerTripletIndex], 1u, alpaka::hierarchy::Threads{});
+              auto const ls0Index = segIdx[innerTripletIndex][0];
+              auto const md0Index = mdIndices[ls0Index][0];
+              alpaka::atomicAdd(acc, &mds.connectedT5s0Max()[md0Index], 1u, alpaka::hierarchy::Threads{});
+              auto const md1Index = mdIndices[ls0Index][1];
+              alpaka::atomicAdd(acc, &mds.connectedT5s1Max()[md1Index], 1u, alpaka::hierarchy::Blocks{});
             } else {
               //asynchronous stop; exact truncation here is not important
               if (denseMatchCount > kNQuintupletThreshold)
@@ -2125,6 +2137,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                        ptCut);
               if (ok) {
                 alpaka::atomicAdd(acc, &triplets.connectedMax()[innerTripletIndex], 1u, alpaka::hierarchy::Threads{});
+                auto const ls0Index = segIdx[innerTripletIndex][0];
+                auto const md0Index = mdIndices[ls0Index][0];
+                alpaka::atomicAdd(acc, &mds.connectedT5s0Max()[md0Index], 1u, alpaka::hierarchy::Threads{});
+                auto const md1Index = mdIndices[ls0Index][1];
+                alpaka::atomicAdd(acc, &mds.connectedT5s1Max()[md1Index], 1u, alpaka::hierarchy::Blocks{});
                 alpaka::atomicAdd(acc, &denseMatchCount, 1u, alpaka::hierarchy::Threads{});
               }
             }
@@ -2142,15 +2159,23 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   ModulesConst modules,
                                   TripletsOccupancyConst tripletsOcc,
                                   ObjectRanges ranges,
-                                  TripletsConst triplets) const {
+                                  TripletsConst triplets,
+                                  MiniDoubletsConst mds,
+                                  MiniDoubletsOccupancyConst mdsOcc,
+                                  QuintupletsRanges quintupletsRangesByMD0,
+                                  QuintupletsRanges quintupletsRangesByMD1) const {
       // Single-block kernel
       ALPAKA_ASSERT_ACC((alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0] == 1));
 
       int& nEligibleT5Modulesx = alpaka::declareSharedVar<int, __COUNTER__>(acc);
       int& nTotalQuintupletsx = alpaka::declareSharedVar<int, __COUNTER__>(acc);
+      int& nTotalQuintuplets0x = alpaka::declareSharedVar<int, __COUNTER__>(acc);
+      int& nTotalQuintuplets1x = alpaka::declareSharedVar<int, __COUNTER__>(acc);
       if (cms::alpakatools::once_per_block(acc)) {
-        nTotalQuintupletsx = 0;
         nEligibleT5Modulesx = 0;
+        nTotalQuintupletsx = 0;
+        nTotalQuintuplets0x = 0;
+        nTotalQuintuplets1x = 0;
       }
       alpaka::syncBlockThreads(acc);
 
@@ -2183,11 +2208,46 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
         ranges.quintupletModuleOccupancy()[lowerModule] = dynamic_count;
       }
 
+      auto setMDranges = [&](uint16_t const lowerModule,
+                             unsigned int const nMDs,
+                             unsigned int const* __restrict__ connectedMax,
+                             QuintupletsRanges qRanges,
+                             int& nTotal) {
+        // Sum the real connectivity for MDs in this module
+        // There should be no truncation (unlike in nTotalQuintupletsx),
+        // else need to keep track which T3's MD can be used in T5 reco
+        int connectedInModule = 0;
+        const unsigned int firstIdx = ranges.miniDoubletModuleIndices()[lowerModule];
+        for (unsigned int idx = 0; idx < nMDs; ++idx) {
+          unsigned int mdIndex = firstIdx + idx;
+          connectedInModule += connectedMax[mdIndex];
+        }
+
+        int nStart = alpaka::atomicAdd(acc, &nTotal, connectedInModule, alpaka::hierarchy::Threads{});
+
+        for (unsigned int idx = 0; idx < nMDs; ++idx) {
+          unsigned int mdIndex = firstIdx + idx;
+          qRanges.offset()[mdIndex] = nStart;
+          qRanges.n()[mdIndex] = 0;
+          nStart += connectedMax[mdIndex];
+        }
+      };
+      for (uint16_t lowerModule : cms::alpakatools::uniform_elements(acc, modules.nLowerModules())) {
+        unsigned int nMDs = mdsOcc.nMDs()[lowerModule];
+        if (nMDs == 0)
+          continue;
+
+        setMDranges(lowerModule, nMDs, mds.connectedT5s0Max().data(), quintupletsRangesByMD0, nTotalQuintuplets0x);
+        setMDranges(lowerModule, nMDs, mds.connectedT5s1Max().data(), quintupletsRangesByMD1, nTotalQuintuplets1x);
+      }
+
       // Wait for all threads to finish before reporting final values
       alpaka::syncBlockThreads(acc);
       if (cms::alpakatools::once_per_block(acc)) {
         ranges.nEligibleT5Modules() = static_cast<uint16_t>(nEligibleT5Modulesx);
         ranges.nTotalQuints() = static_cast<unsigned int>(nTotalQuintupletsx);
+        ranges.nTotalQuintsByMD0() = static_cast<unsigned int>(nTotalQuintuplets0x);
+        ranges.nTotalQuintsByMD1() = static_cast<unsigned int>(nTotalQuintuplets1x);
       }
     }
   };

--- a/RecoTracker/LSTCore/src/alpaka/Triplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Triplet.h
@@ -79,7 +79,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void addTripletToMemory(ModulesConst modules,
                                                          MiniDoubletsConst mds,
                                                          SegmentsConst segments,
-                                                         Triplets& triplets,
+                                                         Triplets triplets,
+                                                         TripletsBySegment tripletsBySegment,
+                                                         TripletsByMD tripletsByMD,
                                                          unsigned int innerSegmentIndex,
                                                          unsigned int outerSegmentIndex,
                                                          uint16_t innerInnerLowerModuleIndex,
@@ -91,6 +93,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                                          float circleCenterX,
                                                          float circleCenterY,
                                                          unsigned int tripletIndex,
+                                                         unsigned int tripletBySegmentIndex,
+                                                         unsigned int tripletByMDIndex,
                                                          float (&t3Scores)[dnn::t3dnn::kOutputFeatures],
                                                          short charge) {
     triplets.segmentIndices()[tripletIndex][0] = innerSegmentIndex;
@@ -129,6 +133,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     triplets.fakeScore()[tripletIndex] = t3Scores[0];
     triplets.promptScore()[tripletIndex] = t3Scores[1];
     triplets.displacedScore()[tripletIndex] = t3Scores[2];
+
+    //ordered cached data
+    tripletsBySegment.tripletIndex()[tripletBySegmentIndex] = tripletIndex;
+    tripletsByMD.tripletIndex()[tripletByMDIndex] = tripletIndex;
   }
 
   template <alpaka::concepts::Acc TAcc>
@@ -520,10 +528,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     ALPAKA_FN_ACC void operator()(Acc3D const& acc,
                                   ModulesConst modules,
                                   MiniDoubletsConst mds,
+                                  MiniDoubletsOccupancyConst mdOccupancy,
                                   SegmentsConst segments,
                                   SegmentsOccupancyConst segmentsOccupancy,
                                   Triplets triplets,
                                   TripletsOccupancy tripletsOccupancy,
+                                  TripletsBySegment tripletsBySegment,
+                                  TripletsRanges tripletsRangesBySegment,
+                                  TripletsByMD tripletsByMD,
+                                  TripletsRanges tripletsRangesByMD,
                                   ObjectRangesConst ranges,
                                   uint16_t* index_gpu,
                                   uint16_t nonZeroModules,
@@ -585,13 +598,23 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 #endif
           return;
         }
-        unsigned int tripletModuleIndex = alpaka::atomicAdd(
+        const unsigned int tripletModuleIndex = alpaka::atomicAdd(
             acc, &tripletsOccupancy.nTriplets()[innerInnerLowerModuleIndex], 1u, alpaka::hierarchy::Threads{});
-        unsigned int tripletIndex = ranges.tripletModuleIndices()[innerInnerLowerModuleIndex] + tripletModuleIndex;
+        const unsigned int tripletIndex =
+            ranges.tripletModuleIndices()[innerInnerLowerModuleIndex] + tripletModuleIndex;
+        const unsigned int tripletBySegmentIndex =
+            alpaka::atomicAdd(acc, &tripletsRangesBySegment.n()[innerSegmentIndex], 1u, alpaka::hierarchy::Threads{}) +
+            tripletsRangesBySegment.offset()[innerSegmentIndex];
+        auto const innerMDIndex = segments.mdIndices()[innerSegmentIndex][0];
+        const unsigned int tripletByMDIndex =
+            alpaka::atomicAdd(acc, &tripletsRangesByMD.n()[innerMDIndex], 1u, alpaka::hierarchy::Threads{}) +
+            tripletsRangesByMD.offset()[innerMDIndex];
         addTripletToMemory(modules,
                            mds,
                            segments,
                            triplets,
+                           tripletsBySegment,
+                           tripletsByMD,
                            innerSegmentIndex,
                            outerSegmentIndex,
                            innerInnerLowerModuleIndex,
@@ -603,6 +626,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                            circleCenterX,
                            circleCenterY,
                            tripletIndex,
+                           tripletBySegmentIndex,
+                           tripletByMDIndex,
                            t3Scores,
                            charge);
       };
@@ -623,11 +648,35 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
         unsigned int nInnerSegments = segmentsOccupancy.nSegments()[innerInnerLowerModuleIndex];
         if (nInnerSegments == 0)
           continue;
+        const auto innerSegmentOffset = ranges.segmentRanges()[innerInnerLowerModuleIndex][0];
+
+        if (cms::alpakatools::once_per_block(acc)) {
+          //the loops are probably too simple to parallelize with a needed atomicAdd for tripletOffset
+          {
+            auto tripletOffset = ranges.tripletModuleIndices()[innerInnerLowerModuleIndex];
+            for (unsigned int idx = 0; idx < nInnerSegments; ++idx) {
+              unsigned int innerSegmentIndex = innerSegmentOffset + idx;
+              tripletsRangesBySegment.offset()[innerSegmentIndex] = tripletOffset;
+              tripletsRangesBySegment.n()[innerSegmentIndex] = 0;
+              tripletOffset += segments.connectedMax()[innerSegmentIndex];
+            }
+          }
+          {
+            auto tripletOffset = ranges.tripletModuleIndices()[innerInnerLowerModuleIndex];
+            const auto innerMDOffset = ranges.mdRanges()[innerInnerLowerModuleIndex][0];
+            const auto nInnerMDs = mdOccupancy.nMDs()[innerInnerLowerModuleIndex];
+            for (unsigned int idx = 0; idx < nInnerMDs; ++idx) {
+              unsigned int innerMDIndex = innerMDOffset + idx;
+              tripletsRangesByMD.offset()[innerMDIndex] = tripletOffset;
+              tripletsRangesByMD.n()[innerMDIndex] = 0;
+              tripletOffset += mds.connectedT3sMax()[innerMDIndex];
+            }
+          }
+        }
 
         alpaka::syncBlockThreads(acc);
 
         // Step 1: Make inner and outer SG pairs
-        const auto innerSegmentOffset = ranges.segmentRanges()[innerInnerLowerModuleIndex][0];
         for (unsigned int innerSegmentArrayIndex : cms::alpakatools::uniform_elements_y(acc, nInnerSegments)) {
           unsigned int innerSegmentIndex = innerSegmentOffset + innerSegmentArrayIndex;
           if (segments.connectedMax()[innerSegmentIndex] == 0)
@@ -722,7 +771,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   struct CountSegmentConnectionsT {
     ALPAKA_FN_ACC void operator()(Acc3D const& acc,
                                   ModulesConst modules,
-                                  MiniDoubletsConst mds,
+                                  MiniDoublets mds,
                                   Segments segments,
                                   SegmentsOccupancyConst segOcc,
                                   ObjectRangesConst ranges,
@@ -791,6 +840,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             }
             if (counts) {
               alpaka::atomicAdd(acc, &segments.connectedMax()[innerSegmentIndex], 1u, alpaka::hierarchy::Threads{});
+              auto const innerMDIndex = mdIndices[innerSegmentIndex][0];
+              alpaka::atomicAdd(acc, &mds.connectedT3sMax()[innerMDIndex], 1u, alpaka::hierarchy::Threads{});
             }
           }
         }


### PR DESCRIPTION
This is an incremental contribution towards #51245

Changes are essentially technical, adding up to about a factor of 4 speedup on the slow QCD 2 TeV events

- 617888b1d5cee2c8cda74d58cd85011e157a005d: T3s by MD/LS for T5/T4 reco: in high occupancy modules/bundles most of the time spent in `Count` and `Create` T4 and T5 kernels is taken by looping in a middle module to find a T3 matching by MD/LS. This commit adds direct indexing from MD/LS to a T3 and uses this in the corresponding T5/T4 kernels.
- 67c0a3d11b9f82291b7dbfa59bfd737862d0cfbe: T5 reco with occupancy truncation were still computing all cuts for all combinations beyond truncation; this commit stops the computation shortly above the threshold (cross-thread randomness is moved to the `Count` kernel)
- cc53146c65acf4e95939a3c083b4c9469ca753a0: earlier updates in `ExtendT5FromDupT5` kernel (in #51596 ) looked quite well (x10 speedup) in a single-core CPU setup, but less impressive on GPU (x2.5 faster) and "full load" CPU (x1.5), limited by increased relative cache memory pressure. This commit gets rid of the loops over modules to loop over T5s by adding indexing by MD and now directly for every T5 loops over compatible T5s by MD. Additionally, a quick prematch is added using MD index "barcode", which can be used in coalesced reads before navigating to (quite uncoalesced T5 details).

Timing in a standalone LST setup: comparing in 1700pre2 with #51686   as a reference
| Sample | Module | CPU Time (Before → After*) | GPU (L4) Time (Before → After*) |
| :--- | :--- | :--- | :--- |
| **2 TeV "very slow"**<br>*(10 evts, 1 stream)* | `all` | 102.0 → 26.6 s/ev | 49.7 → 11.8 s/ev |
| | `CountTripletLSConnectionsT` | 23 -> 0.35 s/ev | 13.6 → 0.07 s/ev |
| | `CreateQuadrupletsT` | 3.2 → 0.08 s/ev | 2.77 → 0.03 s/ev |
| | `CountTripletConnectionsT` | 35 -> 6.6 s/ev | 14.6 → 0.17 s/ev |
| | `CreateQuintupletsT` | 17.3 → 1.84 s/ev | 6.8 → 0.09 s/ev |
| | `ExtendT5FromDupT5` | 6.9 → 0.33 s/ev | 0.23 → 0.003 s/ev |
| | `createTriplets` | ~unchanged | ~unchanged |
| | `createSegments` | ~unchanged | ~unchanged |
| **2 TeV "very slow"**<br>*(10 evts, 16 1-stream jobs on a tile#)* | `all` |  303 → 67 s/ev |  - |
| | `CountTripletLSConnectionsT` |  51 -> 0.53 s/ev | - |
| | `CreateQuadrupletsT` |  8.5 → 0.14 s/ev | - |
| | `CountTripletConnectionsT` |  65 -> 12 s/ev | - |
| | `CreateQuintupletsT` |  30 → 2.9 s/ev |  - |
| | `ExtendT5FromDupT5` | 105 → 0.73 s/ev | - |
| | `createTriplets` | ~unchanged | - |
| | `createSegments` | ~unchanged | - |
| **ttbar PU200**<br>*(100 evts, 1 stream)* | `all` | 907 → 916 ms/ev | 6.5 → 6.3 ms/ev |
| | `CountTripletLSConnectionsT` |  1.5 → 1.0 ms/ev | 0.32 → 0.30 ms/ev |
| | `CreateQuadrupletsT` | 3.3 → 3.1 ms/ev | 0.16 → 0.14 ms/ev |
| | `CountTripletConnectionsT` | 3.0 → 2.3 ms/ev | 0.34 → 0.16 ms/ev |
| | `CreateQuintupletsT` | 25 → 29 ms/ev | 0.50 → 0.48 ms/ev |
| | `ExtendT5FromDupT5` | 7.3 → 1.2 ms/ev | 0.13 → 0.05 ms/ev |
| | `createTriplets` | ~unchanged | ~unchanged |
| | `createSegments` | ~unchanged | ~unchanged |

Notes:
- (*) the "After" was measured on an earlier version of the last commit with relatively small [logical differences](https://github.com/SegmentLinking/cmssw/compare/82e0e65a302adf03de9341c52b721592a11183f2..cc53146c65acf4e95939a3c083b4c9469ca753a0) (the initialization code earlier in `CreateQuintupletsT` was moved to `CreateEligibleModulesListForQuintuplets`)
- (#) a "tile" setup restricts the parallel jobs to run on the same AMD CPU tile (CPU logical cores 1-7, 128-135 for the background jobs while keeping the test job for profiling on CPU 0)

