### PR TITLE
update the tracker alignment payloads for geometries T36,T37 and T38

### DIFF
--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -63,9 +63,9 @@ allTags["Template"] = {
 
 allTags["TkAlignment"] = {
     'T35' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T33_design_v1' ,TkAlRecord, connectionString, "", "2024-09-12 15:37:00"] ), ),
-    'T36' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T36_design_v1' ,TkAlRecord, connectionString, "", "2024-09-12 15:37:00"] ), ),
-    'T37' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T37_design_v1' ,TkAlRecord, connectionString, "", "2024-09-12 15:37:00"] ), ),
-    'T38' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T38_design_v1' ,TkAlRecord, connectionString, "", "2024-09-12 15:37:00"] ), ),
+    'T36' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T36_design_v2_Post48118' ,TkAlRecord, connectionString, "", "2026-09-10 09:13:00"] ), ),
+    'T37' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T37_design_v2_Post48118' ,TkAlRecord, connectionString, "", "2026-09-10 08:32:00"] ), ),
+    'T38' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T38_design_v2_Post48118' ,TkAlRecord, connectionString, "", "2026-09-10 09:13:00"] ), ),
 }
 
 allTags["TkAPE"] = {


### PR DESCRIPTION
#### PR description:

PR https://github.com/cms-sw/cmssw/pull/48118 introduced changes in the position of the sensitive volumes in the Tracker geometries T36, T37 and T38.
As these geometries are aligned, any change of the sensitive volumes must be reflected in the corresponding alignment payload.
These were produced in `CMSSW_17_0_0_pre5` (for technical reasons it's not possible to upload to the conditions database paylaods produced in recent CMSSW_20_1_X pre-releases, due to the not yet supported boost version v1.92, see [log](https://cms-conddb.cern.ch/cmsDbBrowser/logs/show_cond_uploader_log/Prod/033afb04bed2f73cc6d5772e58235e2d8fa85a85)) by running the following recipe:

```bash
cmsrel CMSSW_17_0_0_pre5
cd CMSSW_17_0_0_pre5/src
git cms-addpkg Alignment/TrackerAlignment
scram b -j 20
cmsenv
cmsRun createTrackerAlignmentRcds_Phase2_cfg.py Scenario=Run4D111 # for T36
cmsRun createTrackerAlignmentRcds_Phase2_cfg.py Scenario=Run4D112 # for T37
cmsRun createTrackerAlignmentRcds_Phase2_cfg.py Scenario=Run4D113 # for T38
```

#### PR validation:

Verified that technically the following workflows run:

```
runTheMatrix.py --what upgrade -l 30000.0, 30400.0, 30800.0 -t 4 -j 8
```

Also compared the new payloads again the one currently used in the symbolic `autoCondPhase2` Global Tags.
In all cases a shift of 1.5mm is observed in the z coordinates of the Forward Inner Tracker disks modules. 

## T36
<img width="1996" height="1172" alt="image" src="https://github.com/user-attachments/assets/bd0d561e-334b-459f-9f26-cfb31bfd4b2a" />

## T37
<img width="1996" height="1172" alt="image" src="https://github.com/user-attachments/assets/5981581a-9e20-4627-bfdd-55f185e38624" />

## T38
<img width="1996" height="1172" alt="image" src="https://github.com/user-attachments/assets/39b83083-4cfc-4029-b262-ac56901a57d0" />

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it might be backported (in case there is interest)

FYI: @cms-sw/geometry-l2 @cms-sw/trk-dpg-l2 