### PR TITLE
remove MC truth consuming modules from `vertexrecoTask`

### DIFF
--- a/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
@@ -14,8 +14,7 @@ from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
 
 _phase2_tktiming_RecoVertexEventContent = [ 'keep *_offlinePrimaryVertices4D__*',
-                                            'keep *_offlinePrimaryVertices4DWithBS__*',
-                                            'keep *_trackTimeValueMapProducer_*_*' ]
+                                            'keep *_offlinePrimaryVertices4DWithBS__*' ]
 
 _phase2_tktiming_layer_RecoVertexEventContent = [ 'keep *_tofPID_*_*']
 phase2_timing.toModify( RecoVertexAOD,

--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -42,31 +42,25 @@ vertexrecoTask = cms.Task(unsortedOfflinePrimaryVertices,
 vertexreco = cms.Sequence(vertexrecoTask)
 
 #modifications for timing
-from RecoVertex.Configuration.RecoVertex_phase2_timing_cff import (tpClusterProducer ,
-                                                                  quickTrackAssociatorByHits ,
-                                                                  trackTimeValueMapProducer ,
-                                                                  unsortedOfflinePrimaryVertices4DwithPID ,
-                                                                  offlinePrimaryVertices4DwithPID ,
-                                                                  offlinePrimaryVertices4DwithPIDWithBS,
-                                                                  tofPID,
-                                                                  tofPID3D,
-                                                                  tofPID4DnoPID,
-                                                                  unsortedOfflinePrimaryVertices4D,
-                                                                  trackWithVertexRefSelectorBeforeSorting4D,
-                                                                  trackRefsForJetsBeforeSorting4D,
-                                                                  offlinePrimaryVertices4D,
-                                                                  offlinePrimaryVertices4DWithBS)
+from RecoVertex.Configuration.RecoVertex_phase2_timing_cff import (unsortedOfflinePrimaryVertices4DwithPID ,
+                                                                   offlinePrimaryVertices4DwithPID ,
+                                                                   offlinePrimaryVertices4DwithPIDWithBS,
+                                                                   tofPID,
+                                                                   tofPID3D,
+                                                                   tofPID4DnoPID,
+                                                                   unsortedOfflinePrimaryVertices4D,
+                                                                   trackWithVertexRefSelectorBeforeSorting4D,
+                                                                   trackRefsForJetsBeforeSorting4D,
+                                                                   offlinePrimaryVertices4D,
+                                                                   offlinePrimaryVertices4DWithBS)
 
 _phase2_tktiming_vertexrecoTask = cms.Task( vertexrecoTask.copy() ,
-                                            tpClusterProducer ,
-                                            quickTrackAssociatorByHits ,
-                                            trackTimeValueMapProducer ,
                                             unsortedOfflinePrimaryVertices4D,
                                             trackWithVertexRefSelectorBeforeSorting4D ,
                                             trackRefsForJetsBeforeSorting4D,
                                             offlinePrimaryVertices4D,
                                             offlinePrimaryVertices4DWithBS,
-                                            )
+                                           )
 
 _phase2_tktiming_layer_vertexrecoTask = cms.Task( _phase2_tktiming_vertexrecoTask.copy() ,
                                             tofPID3D,


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/51814

#### PR description:

Title says it all.

#### PR validation:

```
runTheMatrix.py -l phase2 -i all --ibeos
```

runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A