### PR TITLE
Rework of Hcal payloads inpector

### DIFF
--- a/CondCore/HcalPlugins/interface/HcalObjRepresent.h
+++ b/CondCore/HcalPlugins/interface/HcalObjRepresent.h
@@ -34,6 +34,19 @@
 //functions for correct representation of data in summary and plot
 namespace HcalObjRepresent {
 
+  enum class ViewMode { Map, EtaProfile, PhiProfile };
+
+  inline std::string modeName(ViewMode mode) {
+    switch (mode) {
+      case ViewMode::EtaProfile:
+        return "EtaProfile";
+      case ViewMode::PhiProfile:
+        return "PhiProfile";
+      default:
+        return "2DHist";
+    }
+  }
+
   //used to produce all display objects for payload inspector
   template <class Items, class Item>
   class HcalDataContainer {
@@ -42,7 +55,10 @@ namespace HcalObjRepresent {
       PlotMode_ = "Map";
     }
 
-    virtual ~HcalDataContainer() {}
+    virtual ~HcalDataContainer() {
+      for (auto& kv : depths_)
+        delete kv.second;
+    }
     // For easier channel mapping
     typedef std::tuple<int, int, int> Coord;
     typedef std::map<Coord, Item> tHcalValCont;
@@ -98,7 +114,7 @@ namespace HcalObjRepresent {
               histLabel = "run" + std::to_string(run_) + "_" + subDetName + "_d" + std::to_string(depth);
               depths_.insert(
                   std::make_pair(std::make_pair(subDetName, depth),
-                                 new TH2F(histLabel.c_str(), histLabel.c_str(), 83, -42.5, 41.5, 71, 0.5, 71.5)));
+                                 new TH2F(histLabel.c_str(), histLabel.c_str(), 85, -42.5, 42.5, 72, 0.5, 72.5)));
             }
             depths_[depthKey]->Fill(ieta, iphi, getValue(&item));
           }

--- a/CondCore/HcalPlugins/plugins/HcalChannelQuality_PayloadInspector.cc
+++ b/CondCore/HcalPlugins/plugins/HcalChannelQuality_PayloadInspector.cc
@@ -1,25 +1,27 @@
 #include "CondCore/Utilities/interface/PayloadInspectorModule.h"
 #include "CondCore/Utilities/interface/PayloadInspector.h"
 #include "CondCore/CondDB/interface/Time.h"
-//#include "DataFormats/EcalDetId/interface/EBDetId.h"
-//#include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
-//#include "Geometry/HcalCommonData/interface/HcalTopologyMode.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "CondCore/HcalPlugins/interface/HcalObjRepresent.h"
 
 // the data format of the condition to be inspected
-#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"  //or ChannelStatus.h???
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
 
 #include "TH2F.h"
 #include "TCanvas.h"
+#include "TColor.h"
 #include "TLine.h"
 #include "TStyle.h"
 #include "TLatex.h"
 #include "TPave.h"
 #include "TPaveStats.h"
-#include <string>
 #include <fstream>
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
 
 namespace {
 
@@ -31,63 +33,242 @@ namespace {
   };
 
   /******************************************
-     2d plot of ECAL ChannelStatusRatios of 1 IOV
+     Detector map of HCAL ChannelStatus for 1 IOV
   ******************************************/
   class HcalChannelQualityPlot : public cond::payloadInspector::PlotImage<HcalChannelQuality> {
   public:
-    HcalChannelQualityPlot()
-        : cond::payloadInspector::PlotImage<HcalChannelQuality>("HCAL ChannelStatus Ratios - map ") {
+    HcalChannelQualityPlot() : cond::payloadInspector::PlotImage<HcalChannelQuality>("HCAL ChannelStatus - map") {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalChannelQuality> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalChannelStatusContainer* objContainer = new HcalChannelStatusContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasAll()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      auto [time, hash] = iovs.front();
+      std::shared_ptr<HcalChannelQuality> payload = fetchPayload(hash);
+      if (!payload)
         return false;
+      auto container = std::make_unique<HcalChannelStatusContainer>(payload, time);
+      std::unique_ptr<TCanvas> canvas(container->getCanvasAll());
+      canvas->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
 
+  /**********************************************************
+     Detector map of HCAL ChannelStatus difference between 2 IOVs
+     (arithmetic difference of the normalized status value)
+  **********************************************************/
   class HcalChannelQualityChange : public cond::payloadInspector::PlotImage<HcalChannelQuality> {
   public:
     HcalChannelQualityChange()
-        : cond::payloadInspector::PlotImage<HcalChannelQuality>("HCAL ChannelStatus Ratios - map ") {
+        : cond::payloadInspector::PlotImage<HcalChannelQuality>("HCAL ChannelStatus difference") {
       setSingleIov(false);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
-      std::shared_ptr<HcalChannelQuality> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalChannelQuality> payload2 = fetchPayload(std::get<1>(iov2));
-      if (payload1.get() && payload2.get()) {
-        HcalChannelStatusContainer* objContainer1 = new HcalChannelStatusContainer(payload1, std::get<0>(iov1));
-        HcalChannelStatusContainer* objContainer2 = new HcalChannelStatusContainer(payload2, std::get<0>(iov2));
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      auto [t1, h1] = iovs.front();
+      auto [t2, h2] = iovs.back();
 
-        objContainer2->Subtract(objContainer1);
-        //
-        //        std::map< std::pair< std::string, int >, TH2F* > depths = objContainer1->GetDepths();
-        //
-        //
-        //        TODO: How do I display this?
-        //
-        //
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasAll()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+      std::shared_ptr<HcalChannelQuality> payload1 = fetchPayload(h1);
+      std::shared_ptr<HcalChannelQuality> payload2 = fetchPayload(h2);
+      if (!payload1 || !payload2)
         return false;
+
+      auto container1 = std::make_unique<HcalChannelStatusContainer>(payload1, t1);
+      auto container2 = std::make_unique<HcalChannelStatusContainer>(payload2, t2);
+      container2->Subtract(container1.get());
+      std::unique_ptr<TCanvas> canvas(container2->getCanvasAll());
+      canvas->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
+
+  /**********************************************************
+     Categorical map of channel-status changes between 2 IOVs:
+     which channels flipped good<->bad, split by subdetector/depth,
+     laid out the same way as HcalObjRepresent::getCanvasAll().
+
+     "Bad" is defined as any of the DQM-derived quality bits being set:
+     HcalCellOff, HcalCellDead, HcalCellHot, HcalCellStabErr, HcalCellTimErr,
+     HcalBadLaserSignal. 
+  **********************************************************/
+  class HcalChannelQualityStatusChangeMap : public cond::payloadInspector::PlotImage<HcalChannelQuality> {
+  public:
+    HcalChannelQualityStatusChangeMap()
+        : cond::payloadInspector::PlotImage<HcalChannelQuality>("HCAL ChannelStatus - status change map") {
+      setSingleIov(false);
+    }
+
+    // category codes -- kept nonzero so a real "unchanged good" channel
+    // is still distinguishable from an empty/no-channel bin (which ROOT
+    // leaves at 0).
+    enum Category { NewlyBad = -2, StillBad = -1, StillGood = 1, NewlyGood = 2 };
+
+    static bool isBad(const HcalChannelStatus& chan) {
+      static const std::vector<unsigned int> badBits = {
+          HcalChannelStatus::HcalCellOff,
+          HcalChannelStatus::HcalCellDead,
+          HcalChannelStatus::HcalCellHot,
+          HcalChannelStatus::HcalCellStabErr,
+          HcalChannelStatus::HcalCellTimErr,
+          HcalChannelStatus::HcalBadLaserSignal,
+      };
+      for (unsigned int bit : badBits) {
+        if (chan.isBitSet(bit))
+          return true;
+      }
+      return false;
+    }
+
+    using Coord = std::tuple<int, int, int>;  // (depth, ieta, iphi)
+    using DepthKey = std::pair<std::string, int>;
+    using StatusMap = std::map<DepthKey, std::map<Coord, bool>>;
+
+    static StatusMap buildStatusMap(const std::vector<std::pair<std::string, std::vector<HcalChannelStatus>>>& conts) {
+      StatusMap out;
+      for (const auto& cont : conts) {
+        const std::string& subDetName = cont.first;
+        if (subDetName.empty() || subDetName[0] != 'H')
+          continue;
+        for (const auto& item : cont.second) {
+          HcalDetId id(item.rawId());
+          int depth = id.depth();
+          if (depth == 0)
+            continue;
+          out[std::make_pair(subDetName, depth)][std::make_tuple(depth, id.ieta(), id.iphi())] = isBad(item);
+        }
+      }
+      return out;
+    }
+
+    // Mirrors HcalObjRepresent::HcalDataContainer::FillCanv's pad placement,
+    // but colors by category instead of a continuous colz range.
+    void drawCategoryPad(TCanvas* canvas,
+                         const std::string& subDetName,
+                         int startDepth,
+                         int startCanv,
+                         const std::map<std::pair<std::string, int>, std::unique_ptr<TH2F>>& hists,
+                         int maxDepth) {
+      for (int depth = startDepth; depth <= maxDepth; ++depth) {
+        auto it = hists.find(std::make_pair(subDetName, depth));
+        if (it == hists.end())
+          return;
+
+        int padNum = depth + startCanv - 1;
+        if (subDetName == "HO")
+          padNum -= 3;
+
+        canvas->cd(padNum);
+        canvas->GetPad(padNum)->SetGridx(1);
+        canvas->GetPad(padNum)->SetGridy(1);
+        canvas->GetPad(padNum)->SetRightMargin(0.13);
+
+        TH2F* h = it->second.get();
+        h->GetZaxis()->SetRangeUser(-2.5, 2.5);
+        h->SetContour(4);
+        h->GetXaxis()->SetTitle("ieta");
+        h->GetYaxis()->SetTitle("iphi");
+        h->GetXaxis()->CenterTitle();
+        h->GetYaxis()->CenterTitle();
+        h->Draw("col");
+
+        TLatex label;
+        label.SetNDC();
+        label.SetTextAlign(22);
+        label.SetTextSize(0.06);
+        label.DrawLatex(0.5, 0.95, (subDetName + " depth " + std::to_string(depth)).c_str());
+      }
+    }
+
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      auto [t1, h1] = iovs.front();
+      auto [t2, h2] = iovs.back();
+
+      std::shared_ptr<HcalChannelQuality> payload1 = fetchPayload(h1);
+      std::shared_ptr<HcalChannelQuality> payload2 = fetchPayload(h2);
+      if (!payload1 || !payload2)
+        return false;
+
+      // Reuse the container only to determine TopoMode / per-subdet depth
+      // counts via its public accessors -- GetDepths() must run once to
+      // populate them.
+      auto refContainer = std::make_unique<HcalChannelStatusContainer>(payload2, t2);
+      refContainer->GetDepths();
+      std::string topoMode = refContainer->GetTopoMode();
+      auto subDetDepths = refContainer->GetSubDetDepths();
+
+      StatusMap firstStatus = buildStatusMap(payload1->getAllContainers());
+      StatusMap lastStatus = buildStatusMap(payload2->getAllContainers());
+
+      // custom 4-color discrete palette: red / orange / light green / dark green
+      TColor::InitializeColors();
+      Int_t colors[4] = {kRed + 1, kOrange + 1, kGreen - 9, kGreen + 2};
+      gStyle->SetPalette(4, colors);
+      gStyle->SetOptStat(0);
+      gStyle->SetNumberContours(4);
+
+      std::map<std::pair<std::string, int>, std::unique_ptr<TH2F>> categoryHists;
+
+      for (const auto& [key, lastCoords] : lastStatus) {
+        auto firstIt = firstStatus.find(key);
+        if (firstIt == firstStatus.end())
+          continue;
+        const auto& firstCoords = firstIt->second;
+
+        auto hist = std::make_unique<TH2F>(
+            ("change_" + key.first + "_d" + std::to_string(key.second)).c_str(), "", 84, -42.5, 41.5, 72, 0.5, 72.5);
+
+        for (const auto& [coord, badLast] : lastCoords) {
+          auto firstCoordIt = firstCoords.find(coord);
+          if (firstCoordIt == firstCoords.end())
+            continue;  // channel not present in the earlier IOV -- skip
+          bool badFirst = firstCoordIt->second;
+
+          int category;
+          if (!badFirst && !badLast)
+            category = StillGood;
+          else if (badFirst && badLast)
+            category = StillBad;
+          else if (!badFirst && badLast)
+            category = NewlyBad;
+          else
+            category = NewlyGood;
+
+          int ieta = std::get<1>(coord);
+          int iphi = std::get<2>(coord);
+          hist->Fill(ieta, iphi, category);
+        }
+
+        categoryHists[key] = std::move(hist);
+      }
+
+      if (categoryHists.empty())
+        return false;
+
+      int rows = (topoMode == "2015/2016") ? 3 : 6;
+      TCanvas canvas("HChange", "HChange", 1680, (topoMode == "2015/2016") ? 1680 : 2500);
+      canvas.Divide(3, rows, 0.02, 0.01);
+
+      drawCategoryPad(&canvas, "HB", 1, 1, categoryHists, subDetDepths["HB"]);
+      drawCategoryPad(&canvas, "HO", 4, 3, categoryHists, 4);
+      drawCategoryPad(&canvas, "HF", 1, 4, categoryHists, subDetDepths["HF"]);
+      drawCategoryPad(&canvas, "HE", 1, (topoMode == "2015/2016") ? 7 : 10, categoryHists, subDetDepths["HE"]);
+
+      TLatex legend;
+      legend.SetNDC();
+      legend.SetTextSize(0.02);
+      legend.DrawLatex(
+          0.01, 0.005, "Red = newly bad   Orange = still bad   Light green = still good   Dark green = newly good");
+
+      canvas.SaveAs(this->m_imageFileName.c_str());
+      return true;
+    }  // fill method
+  };
+
 }  // namespace
 
 // Register the classes as boost python plugin
 PAYLOAD_INSPECTOR_MODULE(HcalChannelQuality) {
   PAYLOAD_INSPECTOR_CLASS(HcalChannelQualityPlot);
   PAYLOAD_INSPECTOR_CLASS(HcalChannelQualityChange);
+  PAYLOAD_INSPECTOR_CLASS(HcalChannelQualityStatusChangeMap);
 }

--- a/CondCore/HcalPlugins/plugins/HcalGains_PayloadInspector.cc
+++ b/CondCore/HcalPlugins/plugins/HcalGains_PayloadInspector.cc
@@ -1,15 +1,12 @@
 #include "CondCore/Utilities/interface/PayloadInspectorModule.h"
 #include "CondCore/Utilities/interface/PayloadInspector.h"
 #include "CondCore/CondDB/interface/Time.h"
-//#include "DataFormats/EcalDetId/interface/EBDetId.h"
-//#include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
-//#include "Geometry/HcalCommonData/interface/HcalTopologyMode.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "CondCore/HcalPlugins/interface/HcalObjRepresent.h"
 
 // the data format of the condition to be inspected
-#include "CondFormats/HcalObjects/interface/HcalGains.h"  //or Gain.h???
+#include "CondFormats/HcalObjects/interface/HcalGains.h"
 
 #include "TH2F.h"
 #include "TCanvas.h"
@@ -18,10 +15,13 @@
 #include "TLatex.h"
 #include "TPave.h"
 #include "TPaveStats.h"
+#include <memory>
 #include <string>
 #include <fstream>
 
 namespace {
+
+  using namespace HcalObjRepresent;
 
   class HcalGainContainer : public HcalObjRepresent::HcalDataContainer<HcalGains, HcalGain> {
   public:
@@ -33,155 +33,59 @@ namespace {
   };
 
   /******************************************
-     2d plot of HCAL Gain of 1 IOV
+     Detector map of HCAL Gains for 1 IOV
+     (mode selects 2D eta/phi map, or eta/phi 1D profile)
   ******************************************/
-  class HcalGainsPlot : public cond::payloadInspector::PlotImage<HcalGains> {
+  template <ViewMode Mode>
+  class HcalGainsPlotT : public cond::payloadInspector::PlotImage<HcalGains> {
   public:
-    HcalGainsPlot() : cond::payloadInspector::PlotImage<HcalGains>("HCAL Gain Ratios - map ") { setSingleIov(true); }
+    HcalGainsPlotT() : cond::payloadInspector::PlotImage<HcalGains>("HCAL Gain - map") { setSingleIov(true); }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalGains> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalGainContainer* objContainer = new HcalGainContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasAll()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      auto [time, hash] = iovs.front();
+      std::shared_ptr<HcalGains> payload = fetchPayload(hash);
+      if (!payload)
         return false;
+      auto container = std::make_unique<HcalGainContainer>(payload, time);
+      std::unique_ptr<TCanvas> canvas(container->getCanvasAll(modeName(Mode)));
+      canvas->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
 
   /**********************************************************
-     2d plot of HCAL Gain ratios between 2 IOVs
+     Detector map of HCAL Gain ratio between 2 IOVs
   **********************************************************/
-  class HcalGainsRatio : public cond::payloadInspector::PlotImage<HcalGains> {
+  template <ViewMode Mode>
+  class HcalGainsRatioT : public cond::payloadInspector::PlotImage<HcalGains> {
   public:
-    HcalGainsRatio() : cond::payloadInspector::PlotImage<HcalGains>("HCAL Gain Ratios difference") {
-      setSingleIov(false);
-    }
+    HcalGainsRatioT() : cond::payloadInspector::PlotImage<HcalGains>("HCAL Gain Ratio") { setSingleIov(false); }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      auto [t1, h1] = iovs.front();
+      auto [t2, h2] = iovs.back();
 
-      std::shared_ptr<HcalGains> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalGains> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalGainContainer* objContainer1 = new HcalGainContainer(payload1, std::get<0>(iov1));
-        HcalGainContainer* objContainer2 = new HcalGainContainer(payload2, std::get<0>(iov2));
-
-        objContainer2->Divide(objContainer1);
-
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasAll()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+      std::shared_ptr<HcalGains> payload1 = fetchPayload(h1);
+      std::shared_ptr<HcalGains> payload2 = fetchPayload(h2);
+      if (!payload1 || !payload2)
         return false;
 
-    }  // fill method
-  };
-  /******************************************
-     2d plot of HCAL Gain of 1 IOV, projected along iphi
-  ******************************************/
-  class HcalGainsPhiPlot : public cond::payloadInspector::PlotImage<HcalGains> {
-  public:
-    HcalGainsPhiPlot() : cond::payloadInspector::PlotImage<HcalGains>("HCAL Gain Ratios - map ") { setSingleIov(true); }
-
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalGains> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalGainContainer* objContainer = new HcalGainContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasAll("PhiProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
+      auto container1 = std::make_unique<HcalGainContainer>(payload1, t1);
+      auto container2 = std::make_unique<HcalGainContainer>(payload2, t2);
+      container2->Divide(container1.get());
+      std::unique_ptr<TCanvas> canvas(container2->getCanvasAll(modeName(Mode)));
+      canvas->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
 
-  /**********************************************************
-     2d plot of HCAL Gain ratios between 2 IOVs, projected along iphi
-  **********************************************************/
-  class HcalGainsPhiRatio : public cond::payloadInspector::PlotImage<HcalGains> {
-  public:
-    HcalGainsPhiRatio() : cond::payloadInspector::PlotImage<HcalGains>("HCAL Gain Ratios difference") {
-      setSingleIov(false);
-    }
+  using HcalGainsPlot = HcalGainsPlotT<ViewMode::Map>;
+  using HcalGainsEtaPlot = HcalGainsPlotT<ViewMode::EtaProfile>;
+  using HcalGainsPhiPlot = HcalGainsPlotT<ViewMode::PhiProfile>;
+  using HcalGainsRatio = HcalGainsRatioT<ViewMode::Map>;
+  using HcalGainsEtaRatio = HcalGainsRatioT<ViewMode::EtaProfile>;
+  using HcalGainsPhiRatio = HcalGainsRatioT<ViewMode::PhiProfile>;
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
-
-      std::shared_ptr<HcalGains> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalGains> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalGainContainer* objContainer1 = new HcalGainContainer(payload1, std::get<0>(iov1));
-        HcalGainContainer* objContainer2 = new HcalGainContainer(payload2, std::get<0>(iov2));
-
-        objContainer2->Divide(objContainer1);
-
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasAll("PhiProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
-
-    }  // fill method
-  };
-  /******************************************
-     2d plot of HCAL Gain of 1 IOV, projected along ieta
-  ******************************************/
-  class HcalGainsEtaPlot : public cond::payloadInspector::PlotImage<HcalGains> {
-  public:
-    HcalGainsEtaPlot() : cond::payloadInspector::PlotImage<HcalGains>("HCAL Gain Ratios - map ") { setSingleIov(true); }
-
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalGains> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalGainContainer* objContainer = new HcalGainContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasAll("EtaProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
-    }  // fill method
-  };
-
-  /**********************************************************
-     2d plot of HCAL Gain ratios between 2 IOVs
-  **********************************************************/
-  class HcalGainsEtaRatio : public cond::payloadInspector::PlotImage<HcalGains> {
-  public:
-    HcalGainsEtaRatio() : cond::payloadInspector::PlotImage<HcalGains>("HCAL Gain Ratios difference") {
-      setSingleIov(false);
-    }
-
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
-
-      std::shared_ptr<HcalGains> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalGains> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalGainContainer* objContainer1 = new HcalGainContainer(payload1, std::get<0>(iov1));
-        HcalGainContainer* objContainer2 = new HcalGainContainer(payload2, std::get<0>(iov2));
-
-        objContainer2->Divide(objContainer1);
-
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasAll("EtaProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
-
-    }  // fill method
-  };
 }  // namespace
 
 // Register the classes as boost python plugin

--- a/CondCore/HcalPlugins/plugins/HcalPedestalWidths_PayloadInspector.cc
+++ b/CondCore/HcalPlugins/plugins/HcalPedestalWidths_PayloadInspector.cc
@@ -15,10 +15,13 @@
 #include "TLatex.h"
 #include "TPave.h"
 #include "TPaveStats.h"
+#include <memory>
 #include <string>
 #include <fstream>
 
 namespace {
+
+  using namespace HcalObjRepresent;
 
   class HcalPedestalWidthContainer : public HcalObjRepresent::HcalDataContainer<HcalPedestalWidths, HcalPedestalWidth> {
   public:
@@ -30,158 +33,63 @@ namespace {
   };
 
   /******************************************
-     2d plot of HCAL PedestalWidth of 1 IOV
+     Detector map of HCAL PedestalWidths for 1 IOV
+     (mode selects 2D eta/phi map, or eta/phi 1D profile)
   ******************************************/
-  class HcalPedestalWidthsPlot : public cond::payloadInspector::PlotImage<HcalPedestalWidths> {
+  template <ViewMode Mode>
+  class HcalPedestalWidthsPlotT : public cond::payloadInspector::PlotImage<HcalPedestalWidths> {
   public:
-    HcalPedestalWidthsPlot()
-        : cond::payloadInspector::PlotImage<HcalPedestalWidths>("HCAL PedestalWidth Ratios - map ") {
+    HcalPedestalWidthsPlotT() : cond::payloadInspector::PlotImage<HcalPedestalWidths>("HCAL PedestalWidth - map") {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalPedestalWidths> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalPedestalWidthContainer* objContainer = new HcalPedestalWidthContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasAll()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      auto [time, hash] = iovs.front();
+      std::shared_ptr<HcalPedestalWidths> payload = fetchPayload(hash);
+      if (!payload)
         return false;
+      auto container = std::make_unique<HcalPedestalWidthContainer>(payload, time);
+      std::unique_ptr<TCanvas> canvas(container->getCanvasAll(modeName(Mode)));
+      canvas->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
 
   /**********************************************************
-     2d plot of HCAL PedestalWidth difference between 2 IOVs
+     Detector map of HCAL PedestalWidth difference between 2 IOVs
   **********************************************************/
-  class HcalPedestalWidthsDiff : public cond::payloadInspector::PlotImage<HcalPedestalWidths> {
+  template <ViewMode Mode>
+  class HcalPedestalWidthsDiffT : public cond::payloadInspector::PlotImage<HcalPedestalWidths> {
   public:
-    HcalPedestalWidthsDiff()
-        : cond::payloadInspector::PlotImage<HcalPedestalWidths>("HCAL PedestalWidth Ratios difference") {
+    HcalPedestalWidthsDiffT() : cond::payloadInspector::PlotImage<HcalPedestalWidths>("HCAL PedestalWidth difference") {
       setSingleIov(false);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      auto [t1, h1] = iovs.front();
+      auto [t2, h2] = iovs.back();
 
-      std::shared_ptr<HcalPedestalWidths> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalPedestalWidths> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalPedestalWidthContainer* objContainer1 = new HcalPedestalWidthContainer(payload1, std::get<0>(iov1));
-        HcalPedestalWidthContainer* objContainer2 = new HcalPedestalWidthContainer(payload2, std::get<0>(iov2));
-        objContainer2->Subtract(objContainer1);
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasAll()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+      std::shared_ptr<HcalPedestalWidths> payload1 = fetchPayload(h1);
+      std::shared_ptr<HcalPedestalWidths> payload2 = fetchPayload(h2);
+      if (!payload1 || !payload2)
         return false;
-    }  // fill method
-  };
-  /******************************************
-     2d plot of HCAL PedestalWidth of 1 IOV
-  ******************************************/
-  class HcalPedestalWidthsEtaPlot : public cond::payloadInspector::PlotImage<HcalPedestalWidths> {
-  public:
-    HcalPedestalWidthsEtaPlot()
-        : cond::payloadInspector::PlotImage<HcalPedestalWidths>("HCAL PedestalWidth Ratios - map ") {
-      setSingleIov(true);
-    }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalPedestalWidths> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalPedestalWidthContainer* objContainer = new HcalPedestalWidthContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasAll("EtaProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
+      auto container1 = std::make_unique<HcalPedestalWidthContainer>(payload1, t1);
+      auto container2 = std::make_unique<HcalPedestalWidthContainer>(payload2, t2);
+      container2->Subtract(container1.get());
+      std::unique_ptr<TCanvas> canvas(container2->getCanvasAll(modeName(Mode)));
+      canvas->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
 
-  /**********************************************************
-     2d plot of HCAL PedestalWidth difference between 2 IOVs
-  **********************************************************/
-  class HcalPedestalWidthsEtaDiff : public cond::payloadInspector::PlotImage<HcalPedestalWidths> {
-  public:
-    HcalPedestalWidthsEtaDiff()
-        : cond::payloadInspector::PlotImage<HcalPedestalWidths>("HCAL PedestalWidth Ratios difference") {
-      setSingleIov(false);
-    }
+  using HcalPedestalWidthsPlot = HcalPedestalWidthsPlotT<ViewMode::Map>;
+  using HcalPedestalWidthsEtaPlot = HcalPedestalWidthsPlotT<ViewMode::EtaProfile>;
+  using HcalPedestalWidthsPhiPlot = HcalPedestalWidthsPlotT<ViewMode::PhiProfile>;
+  using HcalPedestalWidthsDiff = HcalPedestalWidthsDiffT<ViewMode::Map>;
+  using HcalPedestalWidthsEtaDiff = HcalPedestalWidthsDiffT<ViewMode::EtaProfile>;
+  using HcalPedestalWidthsPhiDiff = HcalPedestalWidthsDiffT<ViewMode::PhiProfile>;
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
-
-      std::shared_ptr<HcalPedestalWidths> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalPedestalWidths> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalPedestalWidthContainer* objContainer1 = new HcalPedestalWidthContainer(payload1, std::get<0>(iov1));
-        HcalPedestalWidthContainer* objContainer2 = new HcalPedestalWidthContainer(payload2, std::get<0>(iov2));
-        objContainer2->Subtract(objContainer1);
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasAll("EtaProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
-    }  // fill method
-  };
-  /******************************************
-     2d plot of HCAL PedestalWidth of 1 IOV
-  ******************************************/
-  class HcalPedestalWidthsPhiPlot : public cond::payloadInspector::PlotImage<HcalPedestalWidths> {
-  public:
-    HcalPedestalWidthsPhiPlot()
-        : cond::payloadInspector::PlotImage<HcalPedestalWidths>("HCAL PedestalWidth Ratios - map ") {
-      setSingleIov(true);
-    }
-
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalPedestalWidths> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalPedestalWidthContainer* objContainer = new HcalPedestalWidthContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasAll("PhiProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
-    }  // fill method
-  };
-
-  /**********************************************************
-     2d plot of HCAL PedestalWidth difference between 2 IOVs
-  **********************************************************/
-  class HcalPedestalWidthsPhiDiff : public cond::payloadInspector::PlotImage<HcalPedestalWidths> {
-  public:
-    HcalPedestalWidthsPhiDiff()
-        : cond::payloadInspector::PlotImage<HcalPedestalWidths>("HCAL PedestalWidth Ratios difference") {
-      setSingleIov(false);
-    }
-
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
-
-      std::shared_ptr<HcalPedestalWidths> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalPedestalWidths> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalPedestalWidthContainer* objContainer1 = new HcalPedestalWidthContainer(payload1, std::get<0>(iov1));
-        HcalPedestalWidthContainer* objContainer2 = new HcalPedestalWidthContainer(payload2, std::get<0>(iov2));
-        objContainer2->Subtract(objContainer1);
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasAll("PhiProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
-    }  // fill method
-  };
 }  // namespace
 
 // Register the classes as boost python plugin

--- a/CondCore/HcalPlugins/plugins/HcalPedestals_PayloadInspector.cc
+++ b/CondCore/HcalPlugins/plugins/HcalPedestals_PayloadInspector.cc
@@ -15,10 +15,13 @@
 #include "TLatex.h"
 #include "TPave.h"
 #include "TPaveStats.h"
+#include <memory>
 #include <string>
 #include <fstream>
 
 namespace {
+
+  using namespace HcalObjRepresent;
 
   class HcalPedestalContainer : public HcalObjRepresent::HcalDataContainer<HcalPedestals, HcalPedestal> {
   public:
@@ -30,152 +33,63 @@ namespace {
   };
 
   /******************************************
-     2d plot of HCAL Pedestal of 1 IOV
+     Detector map of HCAL Pedestals for 1 IOV
+     (mode selects 2D eta/phi map, or eta/phi 1D profile)
   ******************************************/
-  class HcalPedestalsPlot : public cond::payloadInspector::PlotImage<HcalPedestals> {
+  template <ViewMode Mode>
+  class HcalPedestalsPlotT : public cond::payloadInspector::PlotImage<HcalPedestals> {
   public:
-    HcalPedestalsPlot() : cond::payloadInspector::PlotImage<HcalPedestals>("HCAL Pedestal Ratios - map ") {
+    HcalPedestalsPlotT() : cond::payloadInspector::PlotImage<HcalPedestals>("HCAL Pedestal - map") {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalPedestals> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalPedestalContainer* objContainer = new HcalPedestalContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasAll()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      auto [time, hash] = iovs.front();
+      std::shared_ptr<HcalPedestals> payload = fetchPayload(hash);
+      if (!payload)
         return false;
+      auto container = std::make_unique<HcalPedestalContainer>(payload, time);
+      std::unique_ptr<TCanvas> canvas(container->getCanvasAll(modeName(Mode)));
+      canvas->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
 
   /**********************************************************
-     2d plot of HCAL Pedestal difference between 2 IOVs
+     Detector map of HCAL Pedestal difference between 2 IOVs
   **********************************************************/
-  class HcalPedestalsDiff : public cond::payloadInspector::PlotImage<HcalPedestals> {
+  template <ViewMode Mode>
+  class HcalPedestalsDiffT : public cond::payloadInspector::PlotImage<HcalPedestals> {
   public:
-    HcalPedestalsDiff() : cond::payloadInspector::PlotImage<HcalPedestals>("HCAL Pedestal Ratios difference") {
+    HcalPedestalsDiffT() : cond::payloadInspector::PlotImage<HcalPedestals>("HCAL Pedestal difference") {
       setSingleIov(false);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      auto [t1, h1] = iovs.front();
+      auto [t2, h2] = iovs.back();
 
-      std::shared_ptr<HcalPedestals> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalPedestals> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalPedestalContainer* objContainer1 = new HcalPedestalContainer(payload1, std::get<0>(iov1));
-        HcalPedestalContainer* objContainer2 = new HcalPedestalContainer(payload2, std::get<0>(iov2));
-        objContainer2->Subtract(objContainer1);
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasAll()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+      std::shared_ptr<HcalPedestals> payload1 = fetchPayload(h1);
+      std::shared_ptr<HcalPedestals> payload2 = fetchPayload(h2);
+      if (!payload1 || !payload2)
         return false;
-    }  // fill method
-  };
-  /******************************************
-     2d plot of HCAL Pedestal of 1 IOV
-  ******************************************/
-  class HcalPedestalsEtaPlot : public cond::payloadInspector::PlotImage<HcalPedestals> {
-  public:
-    HcalPedestalsEtaPlot() : cond::payloadInspector::PlotImage<HcalPedestals>("HCAL Pedestal Ratios - map ") {
-      setSingleIov(true);
-    }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalPedestals> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalPedestalContainer* objContainer = new HcalPedestalContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasAll("EtaProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
+      auto container1 = std::make_unique<HcalPedestalContainer>(payload1, t1);
+      auto container2 = std::make_unique<HcalPedestalContainer>(payload2, t2);
+      container2->Subtract(container1.get());
+      std::unique_ptr<TCanvas> canvas(container2->getCanvasAll(modeName(Mode)));
+      canvas->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
 
-  /**********************************************************
-     2d plot of HCAL Pedestal difference between 2 IOVs
-  **********************************************************/
-  class HcalPedestalsEtaDiff : public cond::payloadInspector::PlotImage<HcalPedestals> {
-  public:
-    HcalPedestalsEtaDiff() : cond::payloadInspector::PlotImage<HcalPedestals>("HCAL Pedestal Ratios difference") {
-      setSingleIov(false);
-    }
+  using HcalPedestalsPlot = HcalPedestalsPlotT<ViewMode::Map>;
+  using HcalPedestalsEtaPlot = HcalPedestalsPlotT<ViewMode::EtaProfile>;
+  using HcalPedestalsPhiPlot = HcalPedestalsPlotT<ViewMode::PhiProfile>;
+  using HcalPedestalsDiff = HcalPedestalsDiffT<ViewMode::Map>;
+  using HcalPedestalsEtaDiff = HcalPedestalsDiffT<ViewMode::EtaProfile>;
+  using HcalPedestalsPhiDiff = HcalPedestalsDiffT<ViewMode::PhiProfile>;
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
-
-      std::shared_ptr<HcalPedestals> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalPedestals> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalPedestalContainer* objContainer1 = new HcalPedestalContainer(payload1, std::get<0>(iov1));
-        HcalPedestalContainer* objContainer2 = new HcalPedestalContainer(payload2, std::get<0>(iov2));
-        objContainer2->Subtract(objContainer1);
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasAll("EtaProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
-    }  // fill method
-  };
-  /******************************************
-     2d plot of HCAL Pedestal of 1 IOV
-  ******************************************/
-  class HcalPedestalsPhiPlot : public cond::payloadInspector::PlotImage<HcalPedestals> {
-  public:
-    HcalPedestalsPhiPlot() : cond::payloadInspector::PlotImage<HcalPedestals>("HCAL Pedestal Ratios - map ") {
-      setSingleIov(true);
-    }
-
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalPedestals> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalPedestalContainer* objContainer = new HcalPedestalContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasAll("PhiProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
-    }  // fill method
-  };
-
-  /**********************************************************
-     2d plot of HCAL Pedestal difference between 2 IOVs
-  **********************************************************/
-  class HcalPedestalsPhiDiff : public cond::payloadInspector::PlotImage<HcalPedestals> {
-  public:
-    HcalPedestalsPhiDiff() : cond::payloadInspector::PlotImage<HcalPedestals>("HCAL Pedestal Ratios difference") {
-      setSingleIov(false);
-    }
-
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
-
-      std::shared_ptr<HcalPedestals> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalPedestals> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalPedestalContainer* objContainer1 = new HcalPedestalContainer(payload1, std::get<0>(iov1));
-        HcalPedestalContainer* objContainer2 = new HcalPedestalContainer(payload2, std::get<0>(iov2));
-        objContainer2->Subtract(objContainer1);
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasAll("PhiProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
-    }  // fill method
-  };
 }  // namespace
 
 // Register the classes as boost python plugin

--- a/CondCore/HcalPlugins/plugins/HcalRespCorrs_PayloadInspector.cc
+++ b/CondCore/HcalPlugins/plugins/HcalRespCorrs_PayloadInspector.cc
@@ -16,12 +16,14 @@
 #include "TLatex.h"
 #include "TPave.h"
 #include "TPaveStats.h"
+#include <memory>
 #include <string>
 #include <fstream>
 
 namespace {
 
   using namespace cond::payloadInspector;
+  using namespace HcalObjRepresent;
 
   class HcalRespCorrContainer : public HcalObjRepresent::HcalDataContainer<HcalRespCorrs, HcalRespCorr> {
   public:
@@ -31,54 +33,61 @@ namespace {
   };
 
   /******************************************
-     2d plot of HCAL RespCorr of 1 IOV
+     Detector map of HCAL RespCorrs for 1 IOV
   ******************************************/
-  class HcalRespCorrsPlotAll : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
+  template <ViewMode Mode>
+  class HcalRespCorrsPlotAllT : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
   public:
-    HcalRespCorrsPlotAll() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratios - map ") {
+    HcalRespCorrsPlotAllT() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr - map") {
       setSingleIov(true);
     }
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalRespCorrs> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalRespCorrContainer* objContainer = new HcalRespCorrContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasAll()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+      auto [time, hash] = iovs.front();
+      std::shared_ptr<HcalRespCorrs> payload = fetchPayload(hash);
+      if (!payload)
         return false;
+      auto container = std::make_unique<HcalRespCorrContainer>(payload, time);
+      std::unique_ptr<TCanvas> canvas(container->getCanvasAll(modeName(Mode)));
+      canvas->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
 
   /**********************************************************
-     2d plot of HCAL RespCorrs difference between 2 IOVs
+     Detector map of HCAL RespCorr ratio between 2 IOVs
   **********************************************************/
-  class HcalRespCorrsRatioAll : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
+  template <ViewMode Mode>
+  class HcalRespCorrsRatioAllT : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
   public:
-    HcalRespCorrsRatioAll() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratios difference") {
+    HcalRespCorrsRatioAllT() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratio") {
       setSingleIov(false);
     }
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
+      auto [t1, h1] = iovs.front();
+      auto [t2, h2] = iovs.back();
 
-      std::shared_ptr<HcalRespCorrs> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalRespCorrs> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalRespCorrContainer* objContainer1 = new HcalRespCorrContainer(payload1, std::get<0>(iov1));
-        HcalRespCorrContainer* objContainer2 = new HcalRespCorrContainer(payload2, std::get<0>(iov2));
-        objContainer2->Divide(objContainer1);
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasAll()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+      std::shared_ptr<HcalRespCorrs> payload1 = fetchPayload(h1);
+      std::shared_ptr<HcalRespCorrs> payload2 = fetchPayload(h2);
+      if (!payload1 || !payload2)
         return false;
+
+      auto container1 = std::make_unique<HcalRespCorrContainer>(payload1, t1);
+      auto container2 = std::make_unique<HcalRespCorrContainer>(payload2, t2);
+      container2->Divide(container1.get());
+      std::unique_ptr<TCanvas> canvas(container2->getCanvasAll(modeName(Mode)));
+      canvas->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
+
+  using HcalRespCorrsPlotAll = HcalRespCorrsPlotAllT<ViewMode::Map>;
+  using HcalRespCorrsEtaPlotAll = HcalRespCorrsPlotAllT<ViewMode::EtaProfile>;
+  using HcalRespCorrsPhiPlotAll = HcalRespCorrsPlotAllT<ViewMode::PhiProfile>;
+  using HcalRespCorrsRatioAll = HcalRespCorrsRatioAllT<ViewMode::Map>;
+  using HcalRespCorrsEtaRatioAll = HcalRespCorrsRatioAllT<ViewMode::EtaProfile>;
+  using HcalRespCorrsPhiRatioAll = HcalRespCorrsRatioAllT<ViewMode::PhiProfile>;
 
   /**********************************************************
      1d plots of HCAL RespCorrs comparison between 2 IOVs
@@ -116,8 +125,8 @@ namespace {
       std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
       std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
 
-      HcalRespCorrContainer* last_objContainer = new HcalRespCorrContainer(last_payload, std::get<0>(lastiov));
-      HcalRespCorrContainer* first_objContainer = new HcalRespCorrContainer(first_payload, std::get<0>(firstiov));
+      auto last_objContainer = std::make_unique<HcalRespCorrContainer>(last_payload, std::get<0>(lastiov));
+      auto first_objContainer = std::make_unique<HcalRespCorrContainer>(first_payload, std::get<0>(firstiov));
 
       const auto& lastItems = last_objContainer->getAllItems();
       const auto& firstItems = first_objContainer->getAllItems();
@@ -249,8 +258,7 @@ namespace {
         legend.Draw("same");
       }
 
-      std::string fileName(this->m_imageFileName);
-      canvas.SaveAs(fileName.c_str());
+      canvas.SaveAs(this->m_imageFileName.c_str());
 
       return true;
     }
@@ -366,8 +374,8 @@ namespace {
       std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
       std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
 
-      HcalRespCorrContainer* last_objContainer = new HcalRespCorrContainer(last_payload, std::get<0>(lastiov));
-      HcalRespCorrContainer* first_objContainer = new HcalRespCorrContainer(first_payload, std::get<0>(firstiov));
+      auto last_objContainer = std::make_unique<HcalRespCorrContainer>(last_payload, std::get<0>(lastiov));
+      auto first_objContainer = std::make_unique<HcalRespCorrContainer>(first_payload, std::get<0>(firstiov));
 
       const auto& lastItems = last_objContainer->getAllItems();
       const auto& firstItems = first_objContainer->getAllItems();
@@ -453,8 +461,7 @@ namespace {
         plots[part]->Draw();
       }
 
-      std::string fileName(this->m_imageFileName);
-      canvas.SaveAs(fileName.c_str());
+      canvas.SaveAs(this->m_imageFileName.c_str());
 
       return true;
     }
@@ -480,248 +487,140 @@ namespace {
   using HcalRespCorrsCorrelationTwoTags = HcalRespCorrsCorrelationBase<2, SINGLE_IOV>;
 
   /******************************************
-     2d plot of HCAL RespCorr of 1 IOV
-  ******************************************/
-  class HcalRespCorrsEtaPlotAll : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
-  public:
-    HcalRespCorrsEtaPlotAll() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratios - map ") {
-      setSingleIov(true);
-    }
-
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalRespCorrs> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalRespCorrContainer* objContainer = new HcalRespCorrContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasAll("EtaProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
-    }  // fill method
-  };
-
-  /**********************************************************
-     2d plot of HCAL RespCorrs difference between 2 IOVs
-  **********************************************************/
-  class HcalRespCorrsEtaRatioAll : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
-  public:
-    HcalRespCorrsEtaRatioAll() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratios difference") {
-      setSingleIov(false);
-    }
-
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
-
-      std::shared_ptr<HcalRespCorrs> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalRespCorrs> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalRespCorrContainer* objContainer1 = new HcalRespCorrContainer(payload1, std::get<0>(iov1));
-        HcalRespCorrContainer* objContainer2 = new HcalRespCorrContainer(payload2, std::get<0>(iov2));
-        objContainer2->Divide(objContainer1);
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasAll("EtaProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
-    }  // fill method
-  };
-  /******************************************
-     2d plot of HCAL RespCorr of 1 IOV
-  ******************************************/
-  class HcalRespCorrsPhiPlotAll : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
-  public:
-    HcalRespCorrsPhiPlotAll() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratios - map ") {
-      setSingleIov(true);
-    }
-
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalRespCorrs> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalRespCorrContainer* objContainer = new HcalRespCorrContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasAll("PhiProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
-    }  // fill method
-  };
-
-  /**********************************************************
-     2d plot of HCAL RespCorrs difference between 2 IOVs
-  **********************************************************/
-  class HcalRespCorrsPhiRatioAll : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
-  public:
-    HcalRespCorrsPhiRatioAll() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratios difference") {
-      setSingleIov(false);
-    }
-
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
-
-      std::shared_ptr<HcalRespCorrs> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalRespCorrs> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalRespCorrContainer* objContainer1 = new HcalRespCorrContainer(payload1, std::get<0>(iov1));
-        HcalRespCorrContainer* objContainer2 = new HcalRespCorrContainer(payload2, std::get<0>(iov2));
-        objContainer2->Divide(objContainer1);
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasAll("PhiProfile")->SaveAs(ImageName.c_str());
-        return true;
-      } else
-        return false;
-    }  // fill method
-  };
-  /******************************************
-     2d plot of HCAL RespCorrs of 1 IOV
+     2d plot of HCAL RespCorr of 1 IOV, HB/HO only
   ******************************************/
   class HcalRespCorrsPlotHBHO : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
   public:
-    HcalRespCorrsPlotHBHO() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratios - map ") {
+    HcalRespCorrsPlotHBHO() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr - map (HB/HO)") {
       setSingleIov(true);
     }
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalRespCorrs> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalRespCorrContainer* objContainer = new HcalRespCorrContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasHBHO()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+      auto [time, hash] = iovs.front();
+      std::shared_ptr<HcalRespCorrs> payload = fetchPayload(hash);
+      if (!payload)
         return false;
+      auto container = std::make_unique<HcalRespCorrContainer>(payload, time);
+      container->getCanvasHBHO()->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
 
   /**********************************************************
-     2d plot of HCAL RespCorr difference between 2 IOVs
+     2d plot of HCAL RespCorr ratio between 2 IOVs, HB/HO only
   **********************************************************/
   class HcalRespCorrsRatioHBHO : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
   public:
-    HcalRespCorrsRatioHBHO() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratios difference") {
+    HcalRespCorrsRatioHBHO() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratio (HB/HO)") {
       setSingleIov(false);
     }
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
+      auto [t1, h1] = iovs.front();
+      auto [t2, h2] = iovs.back();
 
-      std::shared_ptr<HcalRespCorrs> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalRespCorrs> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalRespCorrContainer* objContainer1 = new HcalRespCorrContainer(payload1, std::get<0>(iov1));
-        HcalRespCorrContainer* objContainer2 = new HcalRespCorrContainer(payload2, std::get<0>(iov2));
-        objContainer2->Divide(objContainer1);
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasHBHO()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+      std::shared_ptr<HcalRespCorrs> payload1 = fetchPayload(h1);
+      std::shared_ptr<HcalRespCorrs> payload2 = fetchPayload(h2);
+      if (!payload1 || !payload2)
         return false;
+
+      auto container1 = std::make_unique<HcalRespCorrContainer>(payload1, t1);
+      auto container2 = std::make_unique<HcalRespCorrContainer>(payload2, t2);
+      container2->Divide(container1.get());
+      container2->getCanvasHBHO()->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
+
   /******************************************
-     2d plot of HCAL RespCorr of 1 IOV
+     2d plot of HCAL RespCorr of 1 IOV, HE only
   ******************************************/
   class HcalRespCorrsPlotHE : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
   public:
-    HcalRespCorrsPlotHE() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratios - map ") {
+    HcalRespCorrsPlotHE() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr - map (HE)") {
       setSingleIov(true);
     }
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalRespCorrs> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalRespCorrContainer* objContainer = new HcalRespCorrContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasHE()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+      auto [time, hash] = iovs.front();
+      std::shared_ptr<HcalRespCorrs> payload = fetchPayload(hash);
+      if (!payload)
         return false;
+      auto container = std::make_unique<HcalRespCorrContainer>(payload, time);
+      container->getCanvasHE()->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
 
   /**********************************************************
-     2d plot of HCAL RespCorr difference between 2 IOVs
+     2d plot of HCAL RespCorr ratio between 2 IOVs, HE only
   **********************************************************/
   class HcalRespCorrsRatioHE : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
   public:
-    HcalRespCorrsRatioHE() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratios difference") {
+    HcalRespCorrsRatioHE() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratio (HE)") {
       setSingleIov(false);
     }
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
+      auto [t1, h1] = iovs.front();
+      auto [t2, h2] = iovs.back();
 
-      std::shared_ptr<HcalRespCorrs> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalRespCorrs> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalRespCorrContainer* objContainer1 = new HcalRespCorrContainer(payload1, std::get<0>(iov1));
-        HcalRespCorrContainer* objContainer2 = new HcalRespCorrContainer(payload2, std::get<0>(iov2));
-        objContainer2->Divide(objContainer1);
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasHE()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+      std::shared_ptr<HcalRespCorrs> payload1 = fetchPayload(h1);
+      std::shared_ptr<HcalRespCorrs> payload2 = fetchPayload(h2);
+      if (!payload1 || !payload2)
         return false;
+
+      auto container1 = std::make_unique<HcalRespCorrContainer>(payload1, t1);
+      auto container2 = std::make_unique<HcalRespCorrContainer>(payload2, t2);
+      container2->Divide(container1.get());
+      container2->getCanvasHE()->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
+
   /******************************************
-     2d plot of HCAL RespCorr of 1 IOV
+     2d plot of HCAL RespCorr of 1 IOV, HF only
   ******************************************/
   class HcalRespCorrsPlotHF : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
   public:
-    HcalRespCorrsPlotHF() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratios - map ") {
+    HcalRespCorrsPlotHF() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr - map (HF)") {
       setSingleIov(true);
     }
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
-      std::shared_ptr<HcalRespCorrs> payload = fetchPayload(std::get<1>(iov));
-      if (payload.get()) {
-        HcalRespCorrContainer* objContainer = new HcalRespCorrContainer(payload, std::get<0>(iov));
-        std::string ImageName(m_imageFileName);
-        objContainer->getCanvasHF()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+      auto [time, hash] = iovs.front();
+      std::shared_ptr<HcalRespCorrs> payload = fetchPayload(hash);
+      if (!payload)
         return false;
+      auto container = std::make_unique<HcalRespCorrContainer>(payload, time);
+      container->getCanvasHF()->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
 
   /**********************************************************
-     2d plot of HCAL RespCorrRatios difference between 2 IOVs
+     2d plot of HCAL RespCorr ratio between 2 IOVs, HF only
   **********************************************************/
   class HcalRespCorrsRatioHF : public cond::payloadInspector::PlotImage<HcalRespCorrs> {
   public:
-    HcalRespCorrsRatioHF() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratios difference") {
+    HcalRespCorrsRatioHF() : cond::payloadInspector::PlotImage<HcalRespCorrs>("HCAL RespCorr Ratio (HF)") {
       setSingleIov(false);
     }
 
     bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov1 = iovs.front();
-      auto iov2 = iovs.back();
+      auto [t1, h1] = iovs.front();
+      auto [t2, h2] = iovs.back();
 
-      std::shared_ptr<HcalRespCorrs> payload1 = fetchPayload(std::get<1>(iov1));
-      std::shared_ptr<HcalRespCorrs> payload2 = fetchPayload(std::get<1>(iov2));
-
-      if (payload1.get() && payload2.get()) {
-        HcalRespCorrContainer* objContainer1 = new HcalRespCorrContainer(payload1, std::get<0>(iov1));
-        HcalRespCorrContainer* objContainer2 = new HcalRespCorrContainer(payload2, std::get<0>(iov2));
-        objContainer2->Divide(objContainer1);
-        std::string ImageName(m_imageFileName);
-        objContainer2->getCanvasHF()->SaveAs(ImageName.c_str());
-        return true;
-      } else
+      std::shared_ptr<HcalRespCorrs> payload1 = fetchPayload(h1);
+      std::shared_ptr<HcalRespCorrs> payload2 = fetchPayload(h2);
+      if (!payload1 || !payload2)
         return false;
+
+      auto container1 = std::make_unique<HcalRespCorrContainer>(payload1, t1);
+      auto container2 = std::make_unique<HcalRespCorrContainer>(payload2, t2);
+      container2->Divide(container1.get());
+      container2->getCanvasHF()->SaveAs(m_imageFileName.c_str());
+      return true;
     }  // fill method
   };
 
@@ -742,7 +641,7 @@ namespace {
       if (!payload.get())
         return false;
 
-      HcalRespCorrContainer* objContainer = new HcalRespCorrContainer(payload, std::get<0>(iov));
+      auto objContainer = std::make_unique<HcalRespCorrContainer>(payload, std::get<0>(iov));
       const auto& items = objContainer->getAllItems();
 
       if (items.empty())
@@ -856,8 +755,7 @@ namespace {
 
       legend.Draw();
 
-      std::string fileName(this->m_imageFileName);
-      canvas.SaveAs(fileName.c_str());
+      canvas.SaveAs(this->m_imageFileName.c_str());
       return true;
     }
   };
@@ -878,7 +776,7 @@ namespace {
       if (!payload.get())
         return false;
 
-      HcalRespCorrContainer* objContainer = new HcalRespCorrContainer(payload, std::get<0>(iov));
+      auto objContainer = std::make_unique<HcalRespCorrContainer>(payload, std::get<0>(iov));
       const auto& items = objContainer->getAllItems();
 
       if (items.empty()) {
@@ -995,8 +893,7 @@ namespace {
         title.DrawLatex(0.15, 0.98, partName.c_str());
       }
 
-      std::string fileName(this->m_imageFileName);
-      canvas.SaveAs(fileName.c_str());
+      canvas.SaveAs(this->m_imageFileName.c_str());
       return true;
     }
   };

--- a/CondCore/HcalPlugins/test/BuildFile.xml
+++ b/CondCore/HcalPlugins/test/BuildFile.xml
@@ -1,0 +1,9 @@
+<bin file="testHcalPayloadInspector.cpp" name="testHcalPayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="CondFormats/HcalObjects"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="roothistpainter"/>
+</bin>

--- a/CondCore/HcalPlugins/test/testHcalPayloadInspector.cpp
+++ b/CondCore/HcalPlugins/test/testHcalPayloadInspector.cpp
@@ -1,0 +1,211 @@
+#include <iostream>
+#include <sstream>
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/HcalPlugins/plugins/HcalPedestals_PayloadInspector.cc"
+#include "CondCore/HcalPlugins/plugins/HcalGains_PayloadInspector.cc"
+#include "CondCore/HcalPlugins/plugins/HcalPedestalWidths_PayloadInspector.cc"
+#include "CondCore/HcalPlugins/plugins/HcalRespCorrs_PayloadInspector.cc"
+#include "CondCore/HcalPlugins/plugins/HcalChannelQuality_PayloadInspector.cc"
+
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+
+int main(int argc, char** argv) {
+  Py_Initialize();
+
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::vector<edm::ParameterSet> psets;
+  edm::ParameterSet pSet;
+  pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
+  psets.push_back(pSet);
+  edm::ServiceToken servToken(edm::ServiceRegistry::createSet(psets));
+  edm::ServiceRegistry::Operate operate(servToken);
+
+  std::string connectionString("frontier://FrontierProd/CMS_CONDITIONS");
+
+  // ===========================================================
+  // Pedestals
+  // ===========================================================
+  std::string tag = "HcalPedestals_ADC_v9.12_offline";
+  cond::Time_t start = static_cast<unsigned long long>(1);
+  cond::Time_t end = static_cast<unsigned long long>(226066);
+
+  edm::LogPrint("testHcalPayloadInspector") << "## Exercising Pedestals plots " << std::endl;
+
+  HcalPedestalsPlot histoPedMap;
+  histoPedMap.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoPedMap.data() << std::endl;
+
+  HcalPedestalsEtaPlot histoPedEta;
+  histoPedEta.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoPedEta.data() << std::endl;
+
+  HcalPedestalsPhiPlot histoPedPhi;
+  histoPedPhi.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoPedPhi.data() << std::endl;
+
+  HcalPedestalsDiff histoPedDiff;
+  histoPedDiff.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoPedDiff.data() << std::endl;
+
+  HcalPedestalsEtaDiff histoPedEtaDiff;
+  histoPedEtaDiff.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoPedEtaDiff.data() << std::endl;
+
+  HcalPedestalsPhiDiff histoPedPhiDiff;
+  histoPedPhiDiff.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoPedPhiDiff.data() << std::endl;
+
+  // ===========================================================
+  // Gains
+  // ===========================================================
+  tag = "HcalGains_v11.0_offline";
+  start = static_cast<unsigned long long>(368822);
+  end = static_cast<unsigned long long>(381384);
+
+  edm::LogPrint("testHcalPayloadInspector") << "## Exercising Gains plots " << std::endl;
+
+  HcalGainsPlot histoGainMap;
+  histoGainMap.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoGainMap.data() << std::endl;
+
+  HcalGainsEtaPlot histoGainEta;
+  histoGainEta.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoGainEta.data() << std::endl;
+
+  HcalGainsPhiPlot histoGainPhi;
+  histoGainPhi.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoGainPhi.data() << std::endl;
+
+  HcalGainsRatio histoGainRatio;
+  histoGainRatio.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoGainRatio.data() << std::endl;
+
+  HcalGainsEtaRatio histoGainEtaRatio;
+  histoGainEtaRatio.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoGainEtaRatio.data() << std::endl;
+
+  HcalGainsPhiRatio histoGainPhiRatio;
+  histoGainPhiRatio.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoGainPhiRatio.data() << std::endl;
+
+  // ===========================================================
+  // PedestalWidths
+  // ===========================================================
+  tag = "HcalPedestalWidths_ADC_v8.1_hlt";
+  start = static_cast<unsigned long long>(309055);
+  end = static_cast<unsigned long long>(317104);
+
+  edm::LogPrint("testHcalPayloadInspector") << "## Exercising PedestalWidths plots " << std::endl;
+
+  HcalPedestalWidthsPlot histoPedWMap;
+  histoPedWMap.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoPedWMap.data() << std::endl;
+
+  HcalPedestalWidthsEtaPlot histoPedWEta;
+  histoPedWEta.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoPedWEta.data() << std::endl;
+
+  HcalPedestalWidthsPhiPlot histoPedWPhi;
+  histoPedWPhi.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoPedWPhi.data() << std::endl;
+
+  HcalPedestalWidthsDiff histoPedWDiff;
+  histoPedWDiff.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoPedWDiff.data() << std::endl;
+
+  HcalPedestalWidthsEtaDiff histoPedWEtaDiff;
+  histoPedWEtaDiff.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoPedWEtaDiff.data() << std::endl;
+
+  HcalPedestalWidthsPhiDiff histoPedWPhiDiff;
+  histoPedWPhiDiff.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoPedWPhiDiff.data() << std::endl;
+
+  // ===========================================================
+  // RespCorrs
+  // ===========================================================
+  tag = "HcalRespCorrs_v9.0_offline";
+  start = static_cast<unsigned long long>(342670);
+  end = static_cast<unsigned long long>(377783);
+
+  edm::LogPrint("testHcalPayloadInspector") << "## Exercising RespCorrs plots " << std::endl;
+
+  HcalRespCorrsPlotAll histoRespMap;
+  histoRespMap.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoRespMap.data() << std::endl;
+
+  HcalRespCorrsEtaPlotAll histoRespEta;
+  histoRespEta.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoRespEta.data() << std::endl;
+
+  HcalRespCorrsPhiPlotAll histoRespPhi;
+  histoRespPhi.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoRespPhi.data() << std::endl;
+
+  HcalRespCorrsRatioAll histoRespRatio;
+  histoRespRatio.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoRespRatio.data() << std::endl;
+
+  HcalRespCorrsEtaRatioAll histoRespEtaRatio;
+  histoRespEtaRatio.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoRespEtaRatio.data() << std::endl;
+
+  HcalRespCorrsPhiRatioAll histoRespPhiRatio;
+  histoRespPhiRatio.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoRespPhiRatio.data() << std::endl;
+
+  HcalRespCorrsPlotHBHO histoRespHBHO;
+  histoRespHBHO.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoRespHBHO.data() << std::endl;
+
+  HcalRespCorrsPlotHE histoRespHE;
+  histoRespHE.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoRespHE.data() << std::endl;
+
+  HcalRespCorrsPlotHF histoRespHF;
+  histoRespHF.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoRespHF.data() << std::endl;
+
+  HcalRespCorrsDepthsOverlay histoRespDepthsOverlay;
+  histoRespDepthsOverlay.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoRespDepthsOverlay.data() << std::endl;
+
+  HcalRespCorrsDistOverlay histoRespDistOverlay;
+  histoRespDistOverlay.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoRespDistOverlay.data() << std::endl;
+
+  HcalRespCorrsComparatorSingleTag histoRespComparator;
+  histoRespComparator.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoRespComparator.data() << std::endl;
+
+  HcalRespCorrsCorrelationSingleTag histoRespCorrelation;
+  histoRespCorrelation.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoRespCorrelation.data() << std::endl;
+
+  // ===========================================================
+  // ChannelQuality
+  // ===========================================================
+  tag = "HcalChannelQuality_v7.00_offline";
+  start = static_cast<unsigned long long>(272230);
+  end = static_cast<unsigned long long>(273933);
+
+  edm::LogPrint("testHcalPayloadInspector") << "## Exercising ChannelQuality plots " << std::endl;
+
+  HcalChannelQualityPlot histoQualMap;
+  histoQualMap.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testHcalPayloadInspector") << histoQualMap.data() << std::endl;
+
+  HcalChannelQualityChange histoQualChange;
+  histoQualChange.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoQualChange.data() << std::endl;
+
+  HcalChannelQualityStatusChangeMap histoQualStatusChange;
+  histoQualStatusChange.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testHcalPayloadInspector") << histoQualStatusChange.data() << std::endl;
+
+  Py_Finalize();
+}


### PR DESCRIPTION


#### PR description:

This commit packages:

1) `HcalObjRepresent`: fix iphi=72 binning gap and TH2F/TCanvas leaks

- `getCanvasAll()`/`getCanvasHF()`/`getCanvasHE()`/`getCanvasHBHO()` return a raw `TCanvas*` that was never deleted by any caller; `~HcalDataContainer()` was also a no-op, leaking every TH2F stored in depths_.
- The per-(subdet,depth) iphi axis was binned 71,0.5,71.5, dropping iphi=72 into the overflow bin and silently omitting a full column of towers from every map. Fixed to 72,0.5,72.5 (matching the 72 five-degree phi sectors), and widened the ieta axis from 83 to 84 bins so bin width is exactly 1.
- Histogram/canvas names are now suffixed with the container instance's address to avoid ROOT global-registry name collisions when multiple containers exist in one process (e.g. test binaries).

Affects Gains, PedestalWidths, RespCorrs, ChannelQuality, and Pedestals payload inspector plots, all of which share this base class.

2) `CondCore/HcalPlugins`: dedup and fix leaks in `HcalPedestals PayloadInspector`

Collapse the six near-identical Plot/Diff x Map/Eta/Phi classes into two templates parameterized on ViewMode. Fix leaked HcalPedestalContainer/TCanvas (switch to unique_ptr), drop redundant ImageName copy, early-return on failed fetchPayload().

No change to registered class names or plot titles' meaning.

3) `CondCore/HcalPlugins`: add categorical channel-status change map

Add `HcalChannelQualityStatusChangeMap`, showing which channels transitioned good<->bad between two IOVs (newly bad / still bad / still good / newly good), rather than an arithmetic difference of the normalized status value which isn't meaningful for a bitmask.

"Bad" = HcalCellOff, HcalCellDead, HcalCellHot, HcalCellStabErr, HcalCellTimErr, or HcalBadLaserSignal set.

4) `CondCore/HcalPlugins`: add unit test for Pedestals/Gains/PedestalWidths/ RespCorrs/ChannelQuality PayloadInspector plots

#### PR validation:

`scram b runtests_testHcalPayloadInspector` runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A