### PR TITLE
Add STXS 1.3 binning

### DIFF
--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -30,15 +30,34 @@ namespace Rivet {
     /// @{
 
     /// follow a "propagating" particle and return its last instance
-    Particle getLastInstance(Particle ptcl) {
-      if (ptcl.genParticle()->end_vertex()) {
-        if (!hasChild(ptcl.genParticle(), ptcl.pid()))
-          return ptcl;
-        else
-          return getLastInstance(ptcl.children()[0]);
+    Particle getLastInstance(const Particle& ptcl) {
+      Particle current = ptcl;
+      // Until no later copy of the particle is found, keep following the decay chain
+      while (current.genParticle()->end_vertex()) {
+        bool found = false;
+
+        for (const auto& c : current.children()) {
+          if (c.pid() == current.pid()) {
+            current = c;
+            found = true;
+            break;
+          }
+        }
+
+        if (!found) break;
       }
-      return ptcl;
+      return current;
     }
+    // TODO: delete below
+    // Particle getLastInstance(Particle ptcl) {
+    //   if (ptcl.genParticle()->end_vertex()) {
+    //     if (!hasChild(ptcl.genParticle(), ptcl.pid()))
+    //       return ptcl;
+    //     else
+    //       return getLastInstance(ptcl.children()[0]);
+    //   }
+    //   return ptcl;
+    // }
 
     /// @brief Whether particle p originate from any of the ptcls
     bool originateFrom(const Particle &p, const Particles &ptcls) {
@@ -51,7 +70,7 @@ namespace Rivet {
           if (ancestor == part.genParticle())
             return true;
       }
-      // if we get here, no ancetor matched any input particle
+      // if we get here, no ancestor matched any input particle
       return false;
     }
 
@@ -138,6 +157,10 @@ namespace Rivet {
       cat.stage1_2_cat_pTjet30GeV = HTXS::Stage1_2::UNKNOWN;
       cat.stage1_2_fine_cat_pTjet25GeV = HTXS::Stage1_2_Fine::UNKNOWN;
       cat.stage1_2_fine_cat_pTjet30GeV = HTXS::Stage1_2_Fine::UNKNOWN;
+      cat.stage1_3_cat_pTjet25GeV = HTXS::Stage1_3::UNKNOWN;
+      cat.stage1_3_cat_pTjet30GeV = HTXS::Stage1_3::UNKNOWN;
+      cat.stage1_3_fine_cat_pTjet25GeV = HTXS::Stage1_3_Fine::UNKNOWN;
+      cat.stage1_3_fine_cat_pTjet30GeV = HTXS::Stage1_3_Fine::UNKNOWN;
 
       if (prodMode == HTXS::UNKNOWN)
         return error(cat,
@@ -190,15 +213,20 @@ namespace Rivet {
       FourMomentum uncatV_p4(0, 0, 0, 0);
       FourVector uncatV_v4(0, 0, 0, 0);
       int nWs = 0, nZs = 0;
+      int nLep = 0;
+
       if (isVH(prodMode)) {
         for (const auto &ptcl : HepMCUtils::particles(HSvtx, Relatives::CHILDREN)) {
           if (PID::isW(ptcl->pdg_id())) {
             ++nWs;
             cat.V = Particle(ptcl);
           }
-          if (PID::isZ(ptcl->pdg_id())) {
+          else if (PID::isZ(ptcl->pdg_id())) {
             ++nZs;
             cat.V = Particle(ptcl);
+          }
+          else if (fabs(ptcl->pdg_id()) == 11 || fabs(ptcl->pdg_id()) == 12 || fabs(ptcl->pdg_id()) == 13 || fabs(ptcl->pdg_id()) == 14 || fabs(ptcl->pdg_id()) == 15 || fabs(ptcl->pdg_id()) == 16) {
+            ++nLep;
           }
         }
         if (nWs + nZs > 0)
@@ -208,12 +236,21 @@ namespace Rivet {
             if (!PID::isHiggs(ptcl->pdg_id())) {
               uncatV_decays += Particle(ptcl);
               uncatV_p4 += Particle(ptcl).momentum();
-              // uncatV_v4 += Particle(ptcl).origin();
+              //uncatV_v4 += Particle(ptcl).origin();
             }
           }
-          // is_uncatdV = true; cat.V = Particle(24,uncatV_p4,uncatV_v4);
-          is_uncatdV = true;
+          // cat.V = Particle(24, uncatV_p4, uncatV_v4);
           cat.V = Particle(24, uncatV_p4);
+
+          // consider event as categorised if exactly 2 leptons produced with Higgs;
+          // pretend they come from a V-decay (practical reason only, do not consider EFT contact interaction separately)
+          if (nLep == 2 && uncatV_decays.size() == 2) {
+            if( prodMode == HTXS::WH)
+              nWs++;
+            else if( prodMode == HTXS::QQ2ZH || prodMode == HTXS::GG2ZH)
+              nZs++;
+          } else
+            is_uncatdV = true;
         }
       }
 
@@ -250,6 +287,17 @@ namespace Rivet {
       // Make sure result make sense
       if ((prodMode == HTXS::TTH && Ws.size() < 2) || (prodMode == HTXS::TH && Ws.empty()))
         return error(cat, HTXS::TOP_W_IDENTIFICATION, "Failed to identify W-boson(s) from t-decay!");
+
+      // Differentiate tHq from tHW by presence of W in HSvtx children
+      cat.isTHW = false;
+      if (prodMode == HTXS::TH) {
+        for (const auto &ptcl : HepMCUtils::particles(HSvtx, Relatives::CHILDREN)) {
+          if (PID::isW(ptcl->pdg_id())) {
+            cat.isTHW = true;
+            break;
+          }
+        }
+      }
 
       /*****
        * Step 3.
@@ -302,27 +350,31 @@ namespace Rivet {
       cat.jets25 = jets.jetsByPt(Cuts::pT > 25.0);
       cat.jets30 = jets.jetsByPt(Cuts::pT > 30.0);
 
-      // Temporary fix: add variables to perform STXS 1.3 classification with nanoAOD on-the-fly
+      // HTXS classification variables (STXS 1.3)
       // Vector-boson pt for VH production modes
       if (isVH(prodMode)) {
-        cat.V_pt = cat.V.pt();
+        cat.pt_V = cat.V.pt();
       } else {
-        cat.V_pt = -999;
+        cat.pt_V = -999;
+      }
+      // Single jet variable
+      if (cat.jets30.size() >= 1) {
+        cat.pt_Hj_over_pt_H = (cat.jets30[0].mom() + cat.higgs.momentum()).pt() / cat.higgs.pt();
+      } else {
+        cat.pt_Hj_over_pt_H = -999;
       }
       // Dijet variables using jets30 collection
       if (cat.jets30.size() >= 2) {
-        cat.Mjj = (cat.jets30[0].mom() + cat.jets30[1].mom()).mass();
-        cat.ptHjj = (cat.jets30[0].mom() + cat.jets30[1].mom() + cat.higgs.momentum()).pt();
-        cat.dPhijj = cat.jets30[0].mom().phi() - cat.jets30[1].mom().phi();
-        // Return phi angle in the interval [-PI,PI)
-        if (cat.dPhijj >= Rivet::pi)
-          cat.dPhijj -= 2 * Rivet::pi;
-        else if (cat.dPhijj < -1 * Rivet::pi)
-          cat.dPhijj += 2 * Rivet::pi;
+        cat.M_jj = (cat.jets30[0].mom() + cat.jets30[1].mom()).mass();
+        cat.pt_Hjj = (cat.jets30[0].mom() + cat.jets30[1].mom() + cat.higgs.momentum()).pt();
+        cat.deltaphi_jj =
+          cat.jets30[0].eta() > cat.jets30[1].eta()
+          ? deltaPhi(cat.jets30[0], cat.jets30[1])
+          : -1*deltaPhi(cat.jets30[0], cat.jets30[1]);
       } else {
-        cat.Mjj = -999;
-        cat.ptHjj = -999;
-        cat.dPhijj = -999;
+        cat.M_jj = -999;
+        cat.pt_Hjj = -999;
+        cat.deltaphi_jj = -999;
       }
 
       // check that four mometum sum of all stable particles satisfies momentum consevation
@@ -356,6 +408,10 @@ namespace Rivet {
       cat.stage1_2_cat_pTjet30GeV = getStage1_2_Category(prodMode, cat.higgs, cat.jets30, cat.V);
       cat.stage1_2_fine_cat_pTjet25GeV = getStage1_2_Fine_Category(prodMode, cat.higgs, cat.jets25, cat.V);
       cat.stage1_2_fine_cat_pTjet30GeV = getStage1_2_Fine_Category(prodMode, cat.higgs, cat.jets30, cat.V);
+      cat.stage1_3_cat_pTjet25GeV = getStage1_3_Category(prodMode, cat.higgs, cat.jets25, cat.V);
+      cat.stage1_3_cat_pTjet30GeV = getStage1_3_Category(prodMode, cat.higgs, cat.jets30, cat.V);
+      cat.stage1_3_fine_cat_pTjet25GeV = getStage1_3_Fine_Category(prodMode, cat.higgs, cat.jets25, cat.V, cat.isTHW);
+      cat.stage1_3_fine_cat_pTjet30GeV = getStage1_3_Fine_Category(prodMode, cat.higgs, cat.jets30, cat.V, cat.isTHW);
 
       cat.errorCode = HTXS::SUCCESS;
       ++m_errorCount[HTXS::SUCCESS];
@@ -378,10 +434,10 @@ namespace Rivet {
       return bins.size() - 1;
     }
 
-    /// @brief VBF topolog selection
+    /// @brief VBF topology selection for Stage 1.0
     /// 0 = fail loose selction: m_jj > 400 GeV and Dy_jj > 2.8
     /// 1 pass loose, but fail additional cut pT(Hjj)<25. 2 pass tight selection
-    int vbfTopology(const Jets &jets, const Particle &higgs) {
+    int vbfTopology_Stage1(const Jets &jets, const Particle &higgs) {
       if (jets.size() < 2)
         return 0;
       const FourMomentum &j1 = jets[0].momentum(), &j2 = jets[1].momentum();
@@ -389,7 +445,7 @@ namespace Rivet {
       return VBFtopo ? (j1 + j2 + higgs.momentum()).pt() < 25 ? 2 : 1 : 0;
     }
 
-    /// @brief VBF topology selection Stage1.1 and Stage1.2
+    /// @brief VBF topology selection for Stage1.1, 1.2 and Stage1.3
     /// 0 = fail loose selection: m_jj > 350 GeV
     /// 1 pass loose, but fail additional cut pT(Hjj)<25. 2 pass pT(Hjj)>25 selection
     /// 3 pass tight (m_jj>700 GeV), but fail additional cut pT(Hjj)<25. 4 pass pT(Hjj)>25 selection
@@ -429,6 +485,37 @@ namespace Rivet {
         return 0;
     }
 
+    /// @brief VBF topology selection for Stage1.3 Fine
+    /// Extends upon vbfTopology_Stage1_X_Fine with additional deltaphi_jj binning
+    int vbfTopology_Stage1_3_Fine(const Jets &jets, const Particle &higgs) {
+      if (jets.size() < 2) 
+        return 0;
+      const FourMomentum &j1 = jets[0].momentum(), &j2 = jets[1].momentum();
+      double mjj = (j1 + j2).mass();
+      double pthjj = (j1 + j2 + higgs.momentum()).pt();
+      double deltaphijj = 
+        j1.eta() > j2.eta()
+        ? deltaPhi(j1, j2)
+        : -1*deltaPhi(j1, j2);
+      // mjj-pthjj binning
+      int mjj_pthjj_bin = 0;
+      if (mjj > 350 && mjj <= 700)
+        mjj_pthjj_bin = pthjj < 25 ? 1 : 2;
+      else if (mjj > 700 && mjj <= 1000)
+        mjj_pthjj_bin = pthjj < 25 ? 3 : 4;
+      else if (mjj > 1000 && mjj <= 1500)
+        mjj_pthjj_bin = pthjj < 25 ? 5 : 6;
+      else if (mjj > 1500)
+        mjj_pthjj_bin = pthjj < 25 ? 7 : 8;
+      else
+        mjj_pthjj_bin = 0;
+      // deltaphijj binning
+      constexpr double pi = 3.14159265358979323846;
+      int deltaphijj_bin = mjj > 350 ? 8*getBin(deltaphijj, {-1*pi, -0.5*pi, 0, 0.5*pi, pi}) : 0;
+      // total vbfTopo binning
+      return deltaphijj_bin + mjj_pthjj_bin;
+    }
+
     /// @brief Whether the Higgs is produced in association with a vector boson (VH)
     bool isVH(HTXS::HiggsProdMode p) { return p == HTXS::WH || p == HTXS::QQ2ZH || p == HTXS::GG2ZH; }
 
@@ -440,7 +527,7 @@ namespace Rivet {
       int ctrlHiggs = std::abs(higgs.rapidity()) < 2.5;
       // Special cases first, qq→Hqq
       if ((prodMode == HTXS::WH || prodMode == HTXS::QQ2ZH) && quarkDecay(V)) {
-        return ctrlHiggs ? VH2HQQ : VH2HQQ_FWDH;
+        return ctrlHiggs ? VH2HQQ_FID : VH2HQQ_FWDH;
       } else if (prodMode == HTXS::GG2ZH && quarkDecay(V)) {
         return Category(HTXS::GGF * 10 + ctrlHiggs);
       }
@@ -456,7 +543,7 @@ namespace Rivet {
       using namespace HTXS::Stage1;
       int Njets = jets.size(), ctrlHiggs = std::abs(higgs.rapidity()) < 2.5, fwdHiggs = !ctrlHiggs;
       double pTj1 = !jets.empty() ? jets[0].momentum().pt() : 0;
-      int vbfTopo = vbfTopology(jets, higgs);
+      int vbfTopo = vbfTopology_Stage1(jets, higgs);
 
       // 1. GGF Stage 1 categories
       //    Following YR4 write-up: XXXXX
@@ -960,6 +1047,246 @@ namespace Rivet {
       return UNKNOWN;
     }
 
+    /// @brief Stage-1.3 categorization
+    HTXS::Stage1_3::Category getStage1_3_Category(const HTXS::HiggsProdMode prodMode, 
+                                                  const Particle &higgs,
+                                                  const Jets &jets, 
+                                                  const Particle &V) {
+      using namespace HTXS::Stage1_3;
+      int Njets = jets.size(), ctrlHiggs = std::abs(higgs.rapidity()) < 2.5, fwdHiggs = !ctrlHiggs;
+      int vbfTopo = vbfTopology_Stage1_X(jets, higgs);
+
+      // 1. GGF Stage 1.3 categories
+      if (prodMode == HTXS::GGF || (prodMode == HTXS::GG2ZH && quarkDecay(V))) {
+        if (fwdHiggs) 
+          return GG2H_FWDH;
+        if (higgs.pt() > 200) 
+          return Category(GG2H_PTH_200_300 + getBin(higgs.pt(), {200, 300, 450, 650, 1000}));
+        if (Njets == 0) 
+          return Category(GG2H_0J_PTH_0_5 + getBin(higgs.pt(), {0, 5, 10, 15, 20, 25, 30, 200}));
+        if (Njets == 1) 
+          return Category(GG2H_1J_PTH_0_30 + getBin(higgs.pt(), {0, 30, 60, 120, 200}));
+        if (Njets > 1) {
+          // VBF topology
+          if (vbfTopo) 
+            return Category(GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25 + vbfTopo - 1);
+          // Njets >= 2jets without VBF topology (mjj<350)
+          return Category(GG2H_GE2J_MJJ_0_350_PTH_0_30 + getBin(higgs.pt(), {0, 30, 60, 120, 200}));
+        }
+      }
+      // 2. Electroweak qq->Hqq Stage 1.3 categories
+      else if (prodMode == HTXS::VBF || (isVH(prodMode) && quarkDecay(V))) {
+        if (std::abs(higgs.rapidity()) > 2.5) 
+          return QQ2HQQ_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0)
+          return QQ2HQQ_0J;
+        else if (Njets == 1)
+          return QQ2HQQ_1J;
+        else if (Njets >= 2) {
+          double mjj = (jets[0].mom() + jets[1].mom()).mass();
+          if (mjj < 60)
+            return higgs.pt() < 200 ? QQ2HQQ_GE2J_MJJ_0_60_PTH_0_200 : QQ2HQQ_GE2J_MJJ_0_60_PTH_GT200;
+          else if (60 < mjj && mjj < 120)
+            return higgs.pt() < 200 ? QQ2HQQ_GE2J_MJJ_60_120_PTH_0_200 : QQ2HQQ_GE2J_MJJ_60_120_PTH_GT200;
+          else if (120 < mjj && mjj < 350)
+            return higgs.pt() < 200 ? QQ2HQQ_GE2J_MJJ_120_350_PTH_0_200 : QQ2HQQ_GE2J_MJJ_120_350_PTH_GT200;
+          else if (mjj > 350) {
+            if (higgs.pt() > 200)
+              return higgs.pt() < 450 ? QQ2HQQ_GE2J_MJJ_GT350_PTH_200_450 : QQ2HQQ_GE2J_MJJ_GT350_PTH_GT450;
+            if (vbfTopo) 
+              return Category(QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25 + vbfTopo - 1);
+          }
+        }
+      }
+      // 3. WH->Hlv Stage 1.3 categories
+      else if (prodMode == HTXS::WH) {
+        if (fwdHiggs)
+          return QQ2HLNU_FWDH;
+        else if (V.pt() < 75)
+          return QQ2HLNU_PTV_0_75;
+        else if (V.pt() < 150)
+          return QQ2HLNU_PTV_75_150;
+        else if (V.pt() < 250)
+          return jets.size() == 0 ? QQ2HLNU_PTV_150_250_0J : QQ2HLNU_PTV_150_250_GE1J;
+        else if (V.pt() < 400)
+          return jets.size() == 0 ? QQ2HLNU_PTV_250_400_0J : QQ2HLNU_PTV_250_400_GE1J;
+        else if (V.pt() < 600)
+          return QQ2HLNU_PTV_400_600;
+        return QQ2HLNU_PTV_GT600;
+      }
+      // 4. qq->ZH->llH Stage 1.3 categories
+      else if (prodMode == HTXS::QQ2ZH) {
+        if (fwdHiggs)
+          return QQ2HLL_FWDH;
+        else if (V.pt() < 75)
+          return QQ2HLL_PTV_0_75;
+        else if (V.pt() < 150)
+          return QQ2HLL_PTV_75_150;
+        else if (V.pt() < 250)
+          return jets.size() == 0 ? QQ2HLL_PTV_150_250_0J : QQ2HLL_PTV_150_250_GE1J;
+        else if (V.pt() < 400)
+          return jets.size() == 0 ? QQ2HLL_PTV_250_400_0J : QQ2HLL_PTV_250_400_GE1J;
+        else if (V.pt() < 600)
+          return QQ2HLL_PTV_400_600;
+        return QQ2HLL_PTV_GT600;
+      }
+      // 5. gg->ZH->llH Stage 1.3 categories
+      else if (prodMode == HTXS::GG2ZH) {
+        if (fwdHiggs)
+          return GG2HLL_FWDH;
+        else if (V.pt() < 75)
+          return GG2HLL_PTV_0_75;
+        else if (V.pt() < 150)
+          return GG2HLL_PTV_75_150;
+        else if (V.pt() < 250)
+          return jets.size() == 0 ? GG2HLL_PTV_150_250_0J : GG2HLL_PTV_150_250_GE1J;
+        else if (V.pt() < 400)
+          return jets.size() == 0 ? GG2HLL_PTV_250_400_0J : GG2HLL_PTV_250_400_GE1J;
+        else if (V.pt() < 600)
+          return GG2HLL_PTV_400_600;
+        return GG2HLL_PTV_GT600;
+      }
+      // 6.ttH,bbH,tH Stage 1.3 categories
+      else if (prodMode == HTXS::TTH) {
+        if (fwdHiggs)
+          return TTH_FWDH;
+        else
+          return Category(TTH_PTH_0_60 + getBin(higgs.pt(), {0, 60, 120, 200, 300, 450, 650}));
+      } else if (prodMode == HTXS::BBH)
+        return Category(BBH_FWDH + ctrlHiggs);
+      else if (prodMode == HTXS::TH)
+        return Category(TH_FWDH + ctrlHiggs);
+      return UNKNOWN;
+    }
+
+    /// @brief Stage-1.3 Fine categorization
+    HTXS::Stage1_3_Fine::Category getStage1_3_Fine_Category(const HTXS::HiggsProdMode prodMode, 
+                                                            const Particle &higgs,
+                                                            const Jets &jets, 
+                                                            const Particle &V, 
+                                                            const bool isTHW) {
+      using namespace HTXS::Stage1_3_Fine;
+      int Njets = jets.size(), ctrlHiggs = std::abs(higgs.rapidity()) < 2.5, fwdHiggs = !ctrlHiggs;
+      int vbfTopo = vbfTopology_Stage1_3_Fine(jets, higgs);
+
+      // 1. GGF Stage 1.3 categories (fine)
+      if (prodMode == HTXS::GGF || (prodMode == HTXS::GG2ZH && quarkDecay(V))) {
+        if (fwdHiggs) 
+          return GG2H_FWDH;
+        if (higgs.pt() > 200) {
+          if (Njets > 0) {
+            double pthj = (jets[0].momentum() + higgs.momentum()).pt();
+            if (pthj / higgs.pt() > 0.15)
+              return Category(GG2H_PTH_200_300_PTHJoverPTH_GT15 + getBin(higgs.pt(), {200, 300, 450, 650, 1000}));
+            else
+              return Category(GG2H_PTH_200_300_PTHJoverPTH_0_15 + getBin(higgs.pt(), {200, 300, 450, 650, 1000}));
+          } else
+            return Category(GG2H_PTH_200_300_PTHJoverPTH_0_15 + getBin(higgs.pt(), {200, 300, 450, 650, 1000}));
+        }
+        if (Njets == 0) 
+          return Category(GG2H_0J_PTH_0_5 + getBin(higgs.pt(), {0, 5, 10, 15, 20, 25, 30, 200}));
+        if (Njets == 1) 
+          return Category(GG2H_1J_PTH_0_30 + getBin(higgs.pt(), {0, 30, 60, 120, 200}));
+        if (Njets > 1) {
+          double mjj = (jets[0].mom()+jets[1].mom()).mass();
+          double pthjj = (jets[0].momentum() + jets[1].momentum() + higgs.momentum()).pt();
+          // VBF topology
+          if (mjj < 350){
+              if (pthjj < 25)
+                return Category(GG2H_GE2J_MJJ_0_350_PTH_0_30_PTHJJ_0_25 + getBin(higgs.pt(), {0, 30, 60, 120, 200}));
+              else
+                return Category(GG2H_GE2J_MJJ_0_350_PTH_0_30_PTHJJ_GT25 + getBin(higgs.pt(), {0, 30, 60, 120, 200}));
+          } else
+              return Category(GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 + vbfTopo - 1);
+        }
+      }
+
+      // 2. Electroweak qq->Hqq Stage 1.3 categories (fine)
+      else if (prodMode == HTXS::VBF || (isVH(prodMode) && quarkDecay(V))) {
+        if (std::abs(higgs.rapidity()) > 2.5) 
+          return QQ2HQQ_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0)
+          return QQ2HQQ_0J;
+        else if (Njets == 1)
+          return Category(QQ2HQQ_1J_PTH_0_200 + getBin(higgs.pt(), {0, 200, 450, 650}));
+        else if (Njets >= 2) {
+          double mjj = (jets[0].mom() + jets[1].mom()).mass();
+          double pthjj = (jets[0].momentum() + jets[1].momentum() + higgs.momentum()).pt();
+          if (mjj < 350) {
+            if (higgs.pt() < 200){
+              if (pthjj < 25)
+                return Category(QQ2HQQ_GE2J_MJJ_0_60_PTH_0_200_PTHJJ_0_25 + getBin(mjj, {0, 60, 120, 350}));
+              else
+                return Category(QQ2HQQ_GE2J_MJJ_0_60_PTH_0_200_PTHJJ_GT25 + getBin(mjj, {0, 60, 120, 350}));              
+            } else {
+              if (pthjj < 25)
+                return Category(QQ2HQQ_GE2J_MJJ_0_60_PTH_GT200_PTHJJ_0_25 + getBin(mjj, {0, 60, 120, 350}));
+              else
+                return Category(QQ2HQQ_GE2J_MJJ_0_60_PTH_GT200_PTHJJ_GT25 + getBin(mjj, {0, 60, 120, 350}));
+            }
+          } else {  // mjj>350 GeV
+            if (higgs.pt() < 200)
+              return Category(QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 + vbfTopo - 1);
+            else if (higgs.pt() < 450)
+              return Category(QQ2HQQ_GE2J_MJJ_350_700_PTH_200_450_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 + vbfTopo - 1);
+            else
+              return Category(QQ2HQQ_GE2J_MJJ_350_700_PTH_GT450 + getBin(mjj, {350, 700, 1000, 1500}));
+          }
+        }
+      }
+
+      // 3. WH->Hlv Stage 1.3 categories (fine)
+      else if (prodMode == HTXS::WH) {
+        if (fwdHiggs) 
+          return QQ2HLNU_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0) 
+          return Category(QQ2HLNU_PTV_0_75_0J + getBin(V.pt(), {0, 75, 150, 250, 400, 600}));
+        if (Njets == 1) 
+          return Category(QQ2HLNU_PTV_0_75_1J + getBin(V.pt(), {0, 75, 150, 250, 400, 600}));
+        return Category(QQ2HLNU_PTV_0_75_GE2J + getBin(V.pt(), {0, 75, 150, 250, 400, 600}));
+      }
+
+      // 4. qq->ZH->llH Stage 1.3 categories (fine)
+      else if (prodMode == HTXS::QQ2ZH) {
+        if (fwdHiggs) 
+          return QQ2HLL_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0) 
+          return Category(QQ2HLL_PTV_0_75_0J + getBin(V.pt(), {0, 75, 150, 250, 400, 600}));
+        if (Njets == 1) 
+          return Category(QQ2HLL_PTV_0_75_1J + getBin(V.pt(), {0, 75, 150, 250, 400, 600}));
+        return Category(QQ2HLL_PTV_0_75_GE2J + getBin(V.pt(), {0, 75, 150, 250, 400, 600}));
+        }
+
+      // 5. gg->ZH->llH Stage 1.3 categories (fine)
+      else if (prodMode == HTXS::GG2ZH) {
+        if (fwdHiggs) 
+          return GG2HLL_FWDH;
+        int Njets = jets.size();
+        if (Njets == 0) 
+          return Category(GG2HLL_PTV_0_75_0J + getBin(V.pt(), {0, 75, 150, 250, 400, 600}));
+        if (Njets == 1) 
+          return Category(GG2HLL_PTV_0_75_1J + getBin(V.pt(), {0, 75, 150, 250, 400, 600}));
+        return Category(GG2HLL_PTV_0_75_GE2J + getBin(V.pt(), {0, 75, 150, 250, 400, 600}));
+      }
+
+      // 6.ttH,bbH,tH Stage 1.3 categories (fine)
+      else if (prodMode == HTXS::TTH) {
+        if (fwdHiggs)
+          return TTH_FWDH;
+        else
+          return Category(TTH_PTH_0_60 + getBin(higgs.pt(), {0, 60, 120, 200, 300, 450, 650}));
+      } else if (prodMode == HTXS::BBH)
+        return Category(BBH_FWDH + ctrlHiggs);
+      else if (prodMode == HTXS::TH)
+        return Category(THQ_FWDH + 2*isTHW + ctrlHiggs);
+      return UNKNOWN;
+    }
+
+
     /// @}
 
     /// @name Default Rivet analysis methods and steering methods
@@ -1027,13 +1354,10 @@ namespace Rivet {
       m_sumw += weight;
 
       int F = cat.stage0_cat % 10, P = cat.stage1_cat_pTjet30GeV / 100;
-      hist_stage0->fill(cat.stage0_cat / 10 * 2 + F, weight);
 
       // Stage 1 enum offsets for each production mode: GGF=12, VBF=6, WH= 5, QQ2ZH=5, GG2ZH=4, TTH=2, BBH=2, TH=2
-      vector<int> offset({0, 1, 13, 19, 24, 29, 33, 35, 37, 39});
-      int off = offset[P];
-      hist_stage1_pTjet25->fill(cat.stage1_cat_pTjet25GeV % 100 + off, weight);
-      hist_stage1_pTjet30->fill(cat.stage1_cat_pTjet30GeV % 100 + off, weight);
+      vector<int> offset1({0, 1, 13, 19, 24, 29, 33, 35, 37, 39});
+      int off1 = offset1[P];
 
       // Stage 1_2 enum offsets for each production mode: GGF=17, VBF=11, WH= 6, QQ2ZH=6, GG2ZH=6, TTH=6, BBH=2, TH=2
       static vector<int> offset1_2({0, 1, 18, 29, 35, 41, 47, 53, 55, 57});
@@ -1041,20 +1365,32 @@ namespace Rivet {
       // Stage 1_2 Fine enum offsets for each production mode: GGF=28, VBF=25, WH= 16, QQ2ZH=16, GG2ZH=16, TTH=7, BBH=2, TH=2
       static vector<int> offset1_2f({0, 1, 29, 54, 70, 86, 102, 109, 111, 113});
       int off1_2f = offset1_2f[P];
+
+      // Stage 1_3 enum offsets for each production mode: GGF=25, VBF=15, WH= 9, QQ2ZH=9, GG2ZH=9, TTH=8, BBH=2, TH=2
+      static vector<int> offset1_3({0, 1, 26, 41, 50, 59, 68, 76, 78, 80});
+      int off1_3 = offset1_3[P];
+      // Stage 1_3 Fine enum offsets for each production mode: GGF=62, VBF=86, WH= 19, QQ2ZH=19, GG2ZH=19, TTH=8, BBH=2, TH=4
+      static vector<int> offset1_3f({0, 1, 63, 149, 168, 187, 206, 214, 216, 220});
+      int off1_3f = offset1_3f[P];
+
+      hist_stage0->fill(cat.stage0_cat / 10 * 2 + F, weight);
+      hist_stage1_pTjet25->fill(cat.stage1_cat_pTjet25GeV % 100 + off1, weight);
+      hist_stage1_pTjet30->fill(cat.stage1_cat_pTjet30GeV % 100 + off1, weight);
       hist_stage1_2_pTjet25->fill(cat.stage1_2_cat_pTjet25GeV % 100 + off1_2, weight);
       hist_stage1_2_pTjet30->fill(cat.stage1_2_cat_pTjet30GeV % 100 + off1_2, weight);
       hist_stage1_2_fine_pTjet25->fill(cat.stage1_2_fine_cat_pTjet25GeV % 100 + off1_2f, weight);
       hist_stage1_2_fine_pTjet30->fill(cat.stage1_2_fine_cat_pTjet30GeV % 100 + off1_2f, weight);
+      hist_stage1_3_pTjet25->fill(cat.stage1_3_cat_pTjet25GeV % 100 + off1_3, weight);
+      hist_stage1_3_pTjet30->fill(cat.stage1_3_cat_pTjet30GeV % 100 + off1_3, weight);
+      hist_stage1_3_fine_pTjet25->fill(cat.stage1_3_fine_cat_pTjet25GeV % 100 + off1_3f, weight);
+      hist_stage1_3_fine_pTjet30->fill(cat.stage1_3_fine_cat_pTjet30GeV % 100 + off1_3f, weight);
 
       // Fill histograms: variables used in the categorization
       hist_pT_Higgs->fill(cat.higgs.pT(), weight);
       hist_y_Higgs->fill(cat.higgs.rapidity(), weight);
       hist_pT_V->fill(cat.V.pT(), weight);
-
       hist_Njets25->fill(cat.jets25.size(), weight);
       hist_Njets30->fill(cat.jets30.size(), weight);
-
-      hist_isZ2vv->fill(cat.isZ2vvDecay, weight);
 
       // Jet variables. Use jet collection with pT threshold at 30 GeV
       if (!cat.jets30.empty())
@@ -1064,7 +1400,16 @@ namespace Rivet {
         hist_deltay_jj->fill(std::abs(j1.rapidity() - j2.rapidity()), weight);
         hist_dijet_mass->fill((j1 + j2).mass(), weight);
         hist_pT_Hjj->fill((j1 + j2 + cat.higgs.momentum()).pt(), weight);
+        double delta_phi_jj = 
+          cat.jets30[0].eta() > cat.jets30[1].eta()
+          ? deltaPhi(cat.jets30[0], cat.jets30[1])
+          : -1*deltaPhi(cat.jets30[0], cat.jets30[1]);
+        hist_deltaphi_jj->fill(delta_phi_jj, weight);
       }
+
+      // Variable for Z decay
+      hist_isZ2vv->fill(cat.isZ2vvDecay, weight);
+
     }
 
     void printClassificationSummary() {
@@ -1102,6 +1447,10 @@ namespace Rivet {
              hist_stage1_2_pTjet30,
              hist_stage1_2_fine_pTjet25,
              hist_stage1_2_fine_pTjet30,
+             hist_stage1_3_pTjet25,
+             hist_stage1_3_pTjet30,
+             hist_stage1_3_fine_pTjet25,
+             hist_stage1_3_fine_pTjet30,
              hist_Njets25,
              hist_Njets30,
              hist_pT_Higgs,
@@ -1110,7 +1459,9 @@ namespace Rivet {
              hist_pT_jet1,
              hist_deltay_jj,
              hist_dijet_mass,
-             hist_pT_Hjj},
+             hist_pT_Hjj,
+             hist_deltaphi_jj,
+             hist_isZ2vv},
             sf);
     }
 
@@ -1126,6 +1477,10 @@ namespace Rivet {
       book(hist_stage1_2_pTjet30, "HTXS_stage1_2_pTjet30", 57, 0, 57);
       book(hist_stage1_2_fine_pTjet25, "HTXS_stage1_2_fine_pTjet25", 113, 0, 113);
       book(hist_stage1_2_fine_pTjet30, "HTXS_stage1_2_fine_pTjet30", 113, 0, 113);
+      book(hist_stage1_3_pTjet25, "HTXS_stage1_3_pTjet25", 80, 0, 80);
+      book(hist_stage1_3_pTjet30, "HTXS_stage1_3_pTjet30", 80, 0, 80);
+      book(hist_stage1_3_fine_pTjet25, "HTXS_stage1_3_fine_pTjet25", 220, 0, 220);
+      book(hist_stage1_3_fine_pTjet30, "HTXS_stage1_3_fine_pTjet30", 220, 0, 220);
       book(hist_pT_Higgs, "pT_Higgs", 80, 0, 400);
       book(hist_y_Higgs, "y_Higgs", 80, -4, 4);
       book(hist_pT_V, "pT_V", 80, 0, 400);
@@ -1133,6 +1488,7 @@ namespace Rivet {
       book(hist_deltay_jj, "deltay_jj", 50, 0, 10);
       book(hist_dijet_mass, "m_jj", 50, 0, 2000);
       book(hist_pT_Hjj, "pT_Hjj", 50, 0, 250);
+      book(hist_deltaphi_jj, "deltaphi_jj", 50, -4, 4);
       book(hist_Njets25, "Njets25", 10, 0, 10);
       book(hist_Njets30, "Njets30", 10, 0, 10);
       book(hist_isZ2vv, "isZ2vv", 2, 0, 2);
@@ -1152,9 +1508,11 @@ namespace Rivet {
     Histo1DPtr hist_stage1_pTjet25, hist_stage1_pTjet30;
     Histo1DPtr hist_stage1_2_pTjet25, hist_stage1_2_pTjet30;
     Histo1DPtr hist_stage1_2_fine_pTjet25, hist_stage1_2_fine_pTjet30;
+    Histo1DPtr hist_stage1_3_pTjet25, hist_stage1_3_pTjet30;
+    Histo1DPtr hist_stage1_3_fine_pTjet25, hist_stage1_3_fine_pTjet30;
     Histo1DPtr hist_pT_Higgs, hist_y_Higgs;
     Histo1DPtr hist_pT_V, hist_pT_jet1;
-    Histo1DPtr hist_deltay_jj, hist_dijet_mass, hist_pT_Hjj;
+    Histo1DPtr hist_deltay_jj, hist_dijet_mass, hist_pT_Hjj, hist_deltaphi_jj;
     Histo1DPtr hist_Njets25, hist_Njets30;
     Histo1DPtr hist_isZ2vv;
   };

--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -48,16 +48,6 @@ namespace Rivet {
       }
       return current;
     }
-    // TODO: delete below
-    // Particle getLastInstance(Particle ptcl) {
-    //   if (ptcl.genParticle()->end_vertex()) {
-    //     if (!hasChild(ptcl.genParticle(), ptcl.pid()))
-    //       return ptcl;
-    //     else
-    //       return getLastInstance(ptcl.children()[0]);
-    //   }
-    //   return ptcl;
-    // }
 
     /// @brief Whether particle p originate from any of the ptcls
     bool originateFrom(const Particle &p, const Particles &ptcls) {

--- a/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
+++ b/GeneratorInterface/RivetInterface/src/HiggsTemplateCrossSections.cc
@@ -343,28 +343,28 @@ namespace Rivet {
       // HTXS classification variables (STXS 1.3)
       // Vector-boson pt for VH production modes
       if (isVH(prodMode)) {
-        cat.pt_V = cat.V.pt();
+        cat.V_pt = cat.V.pt();
       } else {
-        cat.pt_V = -999;
+        cat.V_pt = -999;
       }
       // Single jet variable
       if (cat.jets30.size() >= 1) {
-        cat.pt_Hj_over_pt_H = (cat.jets30[0].mom() + cat.higgs.momentum()).pt() / cat.higgs.pt();
+        cat.ptHj_over_ptH = (cat.jets30[0].mom() + cat.higgs.momentum()).pt() / cat.higgs.pt();
       } else {
-        cat.pt_Hj_over_pt_H = -999;
+        cat.ptHj_over_ptH = -999;
       }
       // Dijet variables using jets30 collection
       if (cat.jets30.size() >= 2) {
-        cat.M_jj = (cat.jets30[0].mom() + cat.jets30[1].mom()).mass();
-        cat.pt_Hjj = (cat.jets30[0].mom() + cat.jets30[1].mom() + cat.higgs.momentum()).pt();
-        cat.deltaphi_jj =
+        cat.Mjj = (cat.jets30[0].mom() + cat.jets30[1].mom()).mass();
+        cat.ptHjj = (cat.jets30[0].mom() + cat.jets30[1].mom() + cat.higgs.momentum()).pt();
+        cat.dPhijj =
           cat.jets30[0].eta() > cat.jets30[1].eta()
           ? deltaPhi(cat.jets30[0], cat.jets30[1])
           : -1*deltaPhi(cat.jets30[0], cat.jets30[1]);
       } else {
-        cat.M_jj = -999;
-        cat.pt_Hjj = -999;
-        cat.deltaphi_jj = -999;
+        cat.Mjj = -999;
+        cat.ptHjj = -999;
+        cat.dPhijj = -999;
       }
 
       // check that four mometum sum of all stable particles satisfies momentum consevation

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -121,11 +121,11 @@ HTXSCategoryTable = simpleHTXSFlatTableProducer.clone(
         njets30 = Var("jets30.size()","uint8", doc="number of jets with pt>30 GeV as identified in HTXS"),
         njets25 = Var("jets25.size()","uint8", doc="number of jets with pt>25 GeV as identified in HTXS"),
         # HTXS classification variables (STXS 1.3)
-        M_jj = Var("Mjj",float, doc="invariant mass of the dijet (pt>30) system as identified in HTXS", precision=14),
-        pt_Hjj = Var("ptHjj",float, doc="pt of the dijet(pt>30)-plus-higgs system as identified in HTXS", precision=14),
-        deltaphi_jj = Var("dPhijj",float, doc="DeltaPhi between jets (pt>30) in dijet system as identified in HTXS. Sign is determined by eta-ordering of jets", precision=12),
-        pt_Hj_over_pt_H = Var("ptHj_over_ptH",float, doc="pt of the leading jet (pt>30)-plus0Higgs system divided by pt of Higgs as identified in HTXS", precision=14),
-        pt_V = Var("V_pt",float, doc="pt of the vector boson as identified in HTXS", precision=14),
+        Mjj = Var("M_jj",float, doc="invariant mass of the dijet (pt>30) system as identified in HTXS", precision=14),
+        ptHjj = Var("pt_Hjj",float, doc="pt of the dijet(pt>30)-plus-higgs system as identified in HTXS", precision=14),
+        dPhijj = Var("deltaphi_jj",float, doc="DeltaPhi between jets (pt>30) in dijet system as identified in HTXS. Sign is determined by eta-ordering of jets", precision=12),
+        ptHj_over_ptH = Var("pt_Hj_over_pt_H",float, doc="pt of the leading jet (pt>30)-plus0Higgs system divided by pt of Higgs as identified in HTXS", precision=14),
+        V_pt = Var("pt_V",float, doc="pt of the vector boson as identified in HTXS", precision=14),
    )
 )
 

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -121,11 +121,11 @@ HTXSCategoryTable = simpleHTXSFlatTableProducer.clone(
         njets30 = Var("jets30.size()","uint8", doc="number of jets with pt>30 GeV as identified in HTXS"),
         njets25 = Var("jets25.size()","uint8", doc="number of jets with pt>25 GeV as identified in HTXS"),
         # HTXS classification variables (STXS 1.3)
-        M_jj = Var("M_jj",float, doc="invariant mass of the dijet (pt>30) system as identified in HTXS", precision=14),
-        pt_Hjj = Var("pt_Hjj",float, doc="pt of the dijet(pt>30)-plus-higgs system as identified in HTXS", precision=14),
-        deltaphi_jj = Var("deltaphi_jj",float, doc="DeltaPhi between jets (pt>30) in dijet system as identified in HTXS. Sign is determined by eta-ordering of jets", precision=12),
-        pt_Hj_over_pt_H = Var("pt_Hj_over_pt_H",float, doc="pt of the leading jet (pt>30)-plus0Higgs system divided by pt of Higgs as identified in HTXS", precision=14),
-        pt_V = Var("pt_V",float, doc="pt of the vector boson as identified in HTXS", precision=14),
+        M_jj = Var("Mjj",float, doc="invariant mass of the dijet (pt>30) system as identified in HTXS", precision=14),
+        pt_Hjj = Var("ptHjj",float, doc="pt of the dijet(pt>30)-plus-higgs system as identified in HTXS", precision=14),
+        deltaphi_jj = Var("dPhijj",float, doc="DeltaPhi between jets (pt>30) in dijet system as identified in HTXS. Sign is determined by eta-ordering of jets", precision=12),
+        pt_Hj_over_pt_H = Var("ptHj_over_ptH",float, doc="pt of the leading jet (pt>30)-plus0Higgs system divided by pt of Higgs as identified in HTXS", precision=14),
+        pt_V = Var("V_pt",float, doc="pt of the vector boson as identified in HTXS", precision=14),
    )
 )
 

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -121,11 +121,11 @@ HTXSCategoryTable = simpleHTXSFlatTableProducer.clone(
         njets30 = Var("jets30.size()","uint8", doc="number of jets with pt>30 GeV as identified in HTXS"),
         njets25 = Var("jets25.size()","uint8", doc="number of jets with pt>25 GeV as identified in HTXS"),
         # HTXS classification variables (STXS 1.3)
-        Mjj = Var("M_jj",float, doc="invariant mass of the dijet (pt>30) system as identified in HTXS", precision=14),
-        ptHjj = Var("pt_Hjj",float, doc="pt of the dijet(pt>30)-plus-higgs system as identified in HTXS", precision=14),
-        dPhijj = Var("deltaphi_jj",float, doc="DeltaPhi between jets (pt>30) in dijet system as identified in HTXS. Sign is determined by eta-ordering of jets", precision=12),
-        ptHj_over_ptH = Var("pt_Hj_over_pt_H",float, doc="pt of the leading jet (pt>30)-plus0Higgs system divided by pt of Higgs as identified in HTXS", precision=14),
-        V_pt = Var("pt_V",float, doc="pt of the vector boson as identified in HTXS", precision=14),
+        V_pt = Var("V_pt",float, doc="pt of the vector boson as identified in HTXS", precision=14),
+        Mjj = Var("Mjj",float, doc="invariant mass of the dijet (pt>30) system as identified in HTXS", precision=14),
+        ptHjj = Var("ptHjj",float, doc="pt of the dijet(pt>30)-plus-higgs system as identified in HTXS", precision=14),
+        dPhijj = Var("dPhijj",float, doc="DeltaPhi between jets (pt>30) in dijet system as identified in HTXS. Sign is determined by eta-ordering of jets", precision=12),
+        ptHj_over_ptH = Var("ptHj_over_ptH",float, doc="pt of the leading jet (pt>30)-plus0Higgs system divided by pt of Higgs as identified in HTXS", precision=14),
    )
 )
 

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -112,15 +112,20 @@ HTXSCategoryTable = simpleHTXSFlatTableProducer.clone(
         stage1_2_cat_pTjet25GeV = Var("stage1_2_cat_pTjet25GeV",int,doc="HTXS stage-1.2 category(jet pt>25 GeV)"),
         stage1_2_fine_cat_pTjet30GeV = Var("stage1_2_fine_cat_pTjet30GeV",int,doc="HTXS stage-1.2-fine category(jet pt>30 GeV)"),
         stage1_2_fine_cat_pTjet25GeV = Var("stage1_2_fine_cat_pTjet25GeV",int,doc="HTXS stage-1.2-fine category(jet pt>25 GeV)"),
+        stage1_3_cat_pTjet30GeV = Var("stage1_3_cat_pTjet30GeV",int,doc="HTXS stage-1.3 category(jet pt>30 GeV)"),
+        stage1_3_cat_pTjet25GeV = Var("stage1_3_cat_pTjet25GeV",int,doc="HTXS stage-1.3 category(jet pt>25 GeV)"),
+        stage1_3_fine_cat_pTjet30GeV = Var("stage1_3_fine_cat_pTjet30GeV",int,doc="HTXS stage-1.3-fine category(jet pt>30 GeV)"),
+        stage1_3_fine_cat_pTjet25GeV = Var("stage1_3_fine_cat_pTjet25GeV",int,doc="HTXS stage-1.3-fine category(jet pt>25 GeV)"),
         Higgs_pt = Var("higgs.Pt()",float, doc="pt of the Higgs boson as identified in HTXS", precision=14),
         Higgs_y = Var("higgs.Rapidity()",float, doc="rapidity of the Higgs boson as identified in HTXS", precision=12),
         njets30 = Var("jets30.size()","uint8", doc="number of jets with pt>30 GeV as identified in HTXS"),
         njets25 = Var("jets25.size()","uint8", doc="number of jets with pt>25 GeV as identified in HTXS"),
-        # Temporary fix: add variables to perform STXS 1.3 classification with nanoAOD on-the-fly
-        V_pt = Var("V_pt",float, doc="pt of the vector boson as identified in HTXS", precision=14),
-        Mjj = Var("Mjj",float, doc="invariant mass of the dijet (pt>30) system as identified in HTXS", precision=14),
-        ptHjj = Var("ptHjj",float, doc="pt of the dijet(pt>30)-plus-higgs system as identified in HTXS", precision=14),
-        dPhijj = Var("dPhijj",float, doc="DeltaPhi between jets (pt>30) in dijet system as identified in HTXS", precision=12),
+        # HTXS classification variables (STXS 1.3)
+        M_jj = Var("M_jj",float, doc="invariant mass of the dijet (pt>30) system as identified in HTXS", precision=14),
+        pt_Hjj = Var("pt_Hjj",float, doc="pt of the dijet(pt>30)-plus-higgs system as identified in HTXS", precision=14),
+        deltaphi_jj = Var("deltaphi_jj",float, doc="DeltaPhi between jets (pt>30) in dijet system as identified in HTXS. Sign is determined by eta-ordering of jets", precision=12),
+        pt_Hj_over_pt_H = Var("pt_Hj_over_pt_H",float, doc="pt of the leading jet (pt>30)-plus0Higgs system divided by pt of Higgs as identified in HTXS", precision=14),
+        pt_V = Var("pt_V",float, doc="pt of the vector boson as identified in HTXS", precision=14),
    )
 )
 

--- a/SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h
+++ b/SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h
@@ -878,11 +878,11 @@ namespace HTXS {
     // Flag to distinguish tHW from tHq
     bool isTHW = false;
     // HTXS classification variables (STXS 1.3)
-    double M_jj;
-    double pt_Hjj;
-    double deltaphi_jj;
-    double pt_Hj_over_pt_H;
-    double pt_V;
+    double V_pt;
+    double Mjj;
+    double ptHjj;
+    double dPhijj;
+    double ptHj_over_ptH;
     // Error code :: classification was succesful or some error occured
     HTXS::ErrorCode errorCode;
   };
@@ -916,11 +916,11 @@ namespace HTXS {
     cat.isZ2vvDecay = htxs_cat_rivet.isZ2vvDecay;
     cat.isTHW = htxs_cat_rivet.isTHW;
     // HTXS classification variables (STXS 1.3)
-    cat.M_jj = htxs_cat_rivet.M_jj;
-    cat.pt_Hjj = htxs_cat_rivet.pt_Hjj;
-    cat.deltaphi_jj = htxs_cat_rivet.deltaphi_jj;
-    cat.pt_Hj_over_pt_H = htxs_cat_rivet.pt_Hj_over_pt_H;
-    cat.pt_V = htxs_cat_rivet.pt_V;
+    cat.V_pt = htxs_cat_rivet.V_pt;
+    cat.Mjj = htxs_cat_rivet.Mjj;
+    cat.ptHjj = htxs_cat_rivet.ptHjj;
+    cat.dPhijj = htxs_cat_rivet.dPhijj;
+    cat.ptHj_over_ptH = htxs_cat_rivet.ptHj_over_ptH;
     return cat;
   }
 
@@ -1232,11 +1232,11 @@ namespace Rivet {
     // Flag to distinguish tHW from tHq
     bool isTHW = false;
     // HTXS classification variables (STXS 1.3)
-    double M_jj;
-    double pt_Hjj;
-    double deltaphi_jj;
-    double pt_Hj_over_pt_H;
-    double pt_V;
+    double V_pt;
+    double Mjj;
+    double ptHjj;
+    double dPhijj;
+    double ptHj_over_ptH;
     /// Error code: Whether classification was succesful or some error occured
     HTXS::ErrorCode errorCode;
   };

--- a/SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h
+++ b/SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h
@@ -37,23 +37,23 @@ namespace HTXS {
     enum Category {
       UNKNOWN = 0,
       GG2H_FWDH = 10,
-      GG2H = 11,
+      GG2H_FID = 11,
       VBF_FWDH = 20,
-      VBF = 21,
+      VBF_FID = 21,
       VH2HQQ_FWDH = 22,
-      VH2HQQ = 23,
+      VH2HQQ_FID = 23,
       QQ2HLNU_FWDH = 30,
-      QQ2HLNU = 31,
+      QQ2HLNU_FID = 31,
       QQ2HLL_FWDH = 40,
-      QQ2HLL = 41,
+      QQ2HLL_FID = 41,
       GG2HLL_FWDH = 50,
-      GG2HLL = 51,
+      GG2HLL_FID = 51,
       TTH_FWDH = 60,
-      TTH = 61,
+      TTH_FID = 61,
       BBH_FWDH = 70,
-      BBH = 71,
+      BBH_FID = 71,
       TH_FWDH = 80,
-      TH = 81
+      TH_FID = 81
     };
   }  // namespace Stage0
 
@@ -77,7 +77,7 @@ namespace HTXS {
       GG2H_GE2J_PTH_60_120 = 109,
       GG2H_GE2J_PTH_120_200 = 110,
       GG2H_GE2J_PTH_GT200 = 111,
-      // "VBF"
+      // EW qqH
       QQ2HQQ_FWDH = 200,
       QQ2HQQ_VBFTOPO_JET3VETO = 201,
       QQ2HQQ_VBFTOPO_JET3 = 202,
@@ -103,13 +103,13 @@ namespace HTXS {
       GG2HLL_PTV_GT150_GE1J = 503,
       // ttH
       TTH_FWDH = 600,
-      TTH = 601,
+      TTH_FID = 601,
       // bbH
       BBH_FWDH = 700,
-      BBH = 701,
+      BBH_FID = 701,
       // tH
       TH_FWDH = 800,
-      TH = 801
+      TH_FID = 801
     };
   }  // namespace Stage1
 
@@ -131,7 +131,7 @@ namespace HTXS {
       GG2H_MJJ_350_700_PTHJJ_GT25 = 111,
       GG2H_MJJ_GT700_PTHJJ_0_25 = 112,
       GG2H_MJJ_GT700_PTHJJ_GT25 = 113,
-      // "VBF"
+      // EW qqH
       QQ2HQQ_FWDH = 200,
       QQ2HQQ_0J = 201,
       QQ2HQQ_1J = 202,
@@ -166,13 +166,13 @@ namespace HTXS {
       GG2HLL_PTV_GT250 = 505,
       // ttH
       TTH_FWDH = 600,
-      TTH = 601,
+      TTH_FID = 601,
       // bbH
       BBH_FWDH = 700,
-      BBH = 701,
+      BBH_FID = 701,
       // tH
       TH_FWDH = 800,
-      TH = 801
+      TH_FID = 801
     };
   }  // namespace Stage1_1
 
@@ -201,7 +201,7 @@ namespace HTXS {
       GG2H_MJJ_1000_1500_PTHJJ_GT25 = 118,
       GG2H_MJJ_GT1500_PTHJJ_0_25 = 119,
       GG2H_MJJ_GT1500_PTHJJ_GT25 = 120,
-      // "VBF"
+      // EW qqH
       QQ2HQQ_FWDH = 200,
       QQ2HQQ_0J = 201,
       QQ2HQQ_1J = 202,
@@ -280,13 +280,13 @@ namespace HTXS {
       GG2HLL_PTV_GT400_GE2J = 515,
       // ttH
       TTH_FWDH = 600,
-      TTH = 601,
+      TTH_FID = 601,
       // bbH
       BBH_FWDH = 700,
-      BBH = 701,
+      BBH_FID = 701,
       // tH
       TH_FWDH = 800,
-      TH = 801
+      TH_FID = 801
     };
   }  // namespace Stage1_1_Fine
 
@@ -315,7 +315,7 @@ namespace HTXS {
       GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25 = 114,
       GG2H_GE2J_MJJ_GT700_PTH_0_200_PTHJJ_0_25 = 115,
       GG2H_GE2J_MJJ_GT700_PTH_0_200_PTHJJ_GT25 = 116,
-      // "VBF"
+      // EW qqH
       QQ2HQQ_FWDH = 200,
       QQ2HQQ_0J = 201,
       QQ2HQQ_1J = 202,
@@ -357,10 +357,10 @@ namespace HTXS {
       TTH_PTH_GT300 = 605,
       // bbH
       BBH_FWDH = 700,
-      BBH = 701,
+      BBH_FID = 701,
       // tH
       TH_FWDH = 800,
-      TH = 801
+      TH_FID = 801
     };
   }  // namespace Stage1_2
 
@@ -396,7 +396,7 @@ namespace HTXS {
       GG2H_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_GT25 = 125,
       GG2H_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_0_25 = 126,
       GG2H_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_GT25 = 127,
-      // "VBF"
+      // EW qqH
       QQ2HQQ_FWDH = 200,
       QQ2HQQ_0J = 201,
       QQ2HQQ_1J = 202,
@@ -483,12 +483,343 @@ namespace HTXS {
       TTH_PTH_GT450 = 606,
       // bbH
       BBH_FWDH = 700,
-      BBH = 701,
+      BBH_FID = 701,
       // tH
       TH_FWDH = 800,
-      TH = 801
+      TH_FID = 801
     };
   }  // namespace Stage1_2_Fine
+
+  /// Categorization Stage 1.3:
+  /// Three digit integer of format PF
+  /// Where P is a digit representing the process
+  /// F is a unique integer ( F < 99 ) corresponding to each Stage1_3 phase-space region (bin)
+  namespace Stage1_3 {
+    enum Category {
+      UNKNOWN = 0,
+      // Gluon fusion
+      GG2H_FWDH = 100,
+      GG2H_PTH_200_300 = 101,
+      GG2H_PTH_300_450 = 102,
+      GG2H_PTH_450_650 = 103,
+      GG2H_PTH_650_1000 = 104,
+      GG2H_PTH_GT1000 = 105,
+      GG2H_0J_PTH_0_5 = 106,
+      GG2H_0J_PTH_5_10 = 107,
+      GG2H_0J_PTH_10_15 = 108,
+      GG2H_0J_PTH_15_20 = 109,
+      GG2H_0J_PTH_20_25 = 110,
+      GG2H_0J_PTH_25_30 = 111,
+      GG2H_0J_PTH_30_200 = 112,
+      GG2H_1J_PTH_0_30 = 113,
+      GG2H_1J_PTH_30_60 = 114,
+      GG2H_1J_PTH_60_120 = 115,
+      GG2H_1J_PTH_120_200 = 116,
+      GG2H_GE2J_MJJ_0_350_PTH_0_30 = 117,
+      GG2H_GE2J_MJJ_0_350_PTH_30_60 = 118,
+      GG2H_GE2J_MJJ_0_350_PTH_60_120 = 119,
+      GG2H_GE2J_MJJ_0_350_PTH_120_200 = 120,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25 = 121,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25 = 122,
+      GG2H_GE2J_MJJ_GT700_PTH_0_200_PTHJJ_0_25 = 123,
+      GG2H_GE2J_MJJ_GT700_PTH_0_200_PTHJJ_GT25 = 124,
+      // EW qqH
+      QQ2HQQ_FWDH = 200,
+      QQ2HQQ_0J = 201,
+      QQ2HQQ_1J = 202,
+      QQ2HQQ_GE2J_MJJ_0_60_PTH_0_200 = 203,
+      QQ2HQQ_GE2J_MJJ_60_120_PTH_0_200 = 204,
+      QQ2HQQ_GE2J_MJJ_120_350_PTH_0_200 = 205,
+      QQ2HQQ_GE2J_MJJ_0_60_PTH_GT200 = 206,
+      QQ2HQQ_GE2J_MJJ_60_120_PTH_GT200 = 207,
+      QQ2HQQ_GE2J_MJJ_120_350_PTH_GT200 = 208,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25 = 209,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25 = 210,
+      QQ2HQQ_GE2J_MJJ_GT700_PTH_0_200_PTHJJ_0_25 = 211,
+      QQ2HQQ_GE2J_MJJ_GT700_PTH_0_200_PTHJJ_GT25 = 212,
+      QQ2HQQ_GE2J_MJJ_GT350_PTH_200_450 = 213,
+      QQ2HQQ_GE2J_MJJ_GT350_PTH_GT450 = 214,
+      // qq -> WH
+      QQ2HLNU_FWDH = 300,
+      QQ2HLNU_PTV_0_75 = 301,
+      QQ2HLNU_PTV_75_150 = 302,
+      QQ2HLNU_PTV_150_250_0J = 303,
+      QQ2HLNU_PTV_150_250_GE1J = 304,
+      QQ2HLNU_PTV_250_400_0J = 305,
+      QQ2HLNU_PTV_250_400_GE1J = 306,
+      QQ2HLNU_PTV_400_600 = 307,
+      QQ2HLNU_PTV_GT600 = 308,
+      // qq -> ZH
+      QQ2HLL_FWDH = 400,
+      QQ2HLL_PTV_0_75 = 401,
+      QQ2HLL_PTV_75_150 = 402,
+      QQ2HLL_PTV_150_250_0J = 403,
+      QQ2HLL_PTV_150_250_GE1J = 404,
+      QQ2HLL_PTV_250_400_0J = 405,
+      QQ2HLL_PTV_250_400_GE1J = 406,
+      QQ2HLL_PTV_400_600 = 407,
+      QQ2HLL_PTV_GT600 = 408,
+      // gg -> ZH
+      GG2HLL_FWDH = 500,
+      GG2HLL_PTV_0_75 = 501,
+      GG2HLL_PTV_75_150 = 502,
+      GG2HLL_PTV_150_250_0J = 503,
+      GG2HLL_PTV_150_250_GE1J = 504,
+      GG2HLL_PTV_250_400_0J = 505,
+      GG2HLL_PTV_250_400_GE1J = 506,
+      GG2HLL_PTV_400_600 = 507,
+      GG2HLL_PTV_GT600 = 508,
+      // ttH
+      TTH_FWDH = 600,
+      TTH_PTH_0_60 = 601,
+      TTH_PTH_60_120 = 602,
+      TTH_PTH_120_200 = 603,
+      TTH_PTH_200_300 = 604,
+      TTH_PTH_300_450 = 605,
+      TTH_PTH_450_650 = 606,
+      TTH_PTH_GT650 = 607,
+      // bbH
+      BBH_FWDH = 700,
+      BBH_FID = 701,
+      // tH
+      TH_FWDH = 800,
+      TH_FID = 801
+
+    };
+  }  // namespace Stage1_3
+
+  namespace Stage1_3_Fine {
+    enum Category {
+      UNKNOWN = 0,
+      // Gluon fusion
+      GG2H_FWDH = 100,
+      GG2H_PTH_200_300_PTHJoverPTH_0_15 = 101,
+      GG2H_PTH_300_450_PTHJoverPTH_0_15 = 102,
+      GG2H_PTH_450_650_PTHJoverPTH_0_15 = 103,
+      GG2H_PTH_650_1000_PTHJoverPTH_0_15 = 104,
+      GG2H_PTH_GT1000_PTHJoverPTH_0_15 = 105,
+      GG2H_PTH_200_300_PTHJoverPTH_GT15 = 106,
+      GG2H_PTH_300_450_PTHJoverPTH_GT15 = 107,
+      GG2H_PTH_450_650_PTHJoverPTH_GT15 = 108,
+      GG2H_PTH_650_1000_PTHJoverPTH_GT15 = 109,
+      GG2H_PTH_GT1000_PTHJoverPTH_GT15 = 110,
+      GG2H_0J_PTH_0_5 = 111,
+      GG2H_0J_PTH_5_10 = 112,
+      GG2H_0J_PTH_10_15 = 113,
+      GG2H_0J_PTH_15_20 = 114,
+      GG2H_0J_PTH_20_25 = 115,
+      GG2H_0J_PTH_25_30 = 116,
+      GG2H_0J_PTH_30_200 = 117,
+      GG2H_1J_PTH_0_30 = 118,
+      GG2H_1J_PTH_30_60 = 119,
+      GG2H_1J_PTH_60_120 = 120,
+      GG2H_1J_PTH_120_200 = 121,
+      GG2H_GE2J_MJJ_0_350_PTH_0_30_PTHJJ_0_25 = 122,
+      GG2H_GE2J_MJJ_0_350_PTH_30_60_PTHJJ_0_25 = 123,
+      GG2H_GE2J_MJJ_0_350_PTH_60_120_PTHJJ_0_25 = 124,
+      GG2H_GE2J_MJJ_0_350_PTH_120_200_PTHJJ_0_25 = 125,
+      GG2H_GE2J_MJJ_0_350_PTH_0_30_PTHJJ_GT25 = 126,
+      GG2H_GE2J_MJJ_0_350_PTH_30_60_PTHJJ_GT25 = 127,
+      GG2H_GE2J_MJJ_0_350_PTH_60_120_PTHJJ_GT25 = 128,
+      GG2H_GE2J_MJJ_0_350_PTH_120_200_PTHJJ_GT25 = 129,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 = 130,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPI_MPIO2 = 131,
+      GG2H_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 = 132,
+      GG2H_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPI_MPIO2 = 133,
+      GG2H_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 = 134,
+      GG2H_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPI_MPIO2 = 135,
+      GG2H_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 = 136,
+      GG2H_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPI_MPIO2 = 137,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPIO2_0 = 138,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPIO2_0 = 139,
+      GG2H_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPIO2_0 = 140,
+      GG2H_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPIO2_0 = 141,
+      GG2H_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPIO2_0 = 142,
+      GG2H_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPIO2_0 = 143,
+      GG2H_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPIO2_0 = 144,
+      GG2H_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPIO2_0 = 145,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25_DPHIJJ_0_PIO2 = 146,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25_DPHIJJ_0_PIO2 = 147,
+      GG2H_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_0_25_DPHIJJ_0_PIO2 = 148,
+      GG2H_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_GT25_DPHIJJ_0_PIO2 = 149,
+      GG2H_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_0_PIO2 = 150,
+      GG2H_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_0_PIO2 = 151,
+      GG2H_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_0_PIO2 = 152,
+      GG2H_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_0_PIO2 = 153,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25_DPHIJJ_PIO2_PI = 154,
+      GG2H_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25_DPHIJJ_PIO2_PI = 155,
+      GG2H_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_0_25_DPHIJJ_PIO2_PI = 156,
+      GG2H_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_GT25_DPHIJJ_PIO2_PI = 157,
+      GG2H_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_PIO2_PI = 158,
+      GG2H_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_PIO2_PI = 159,
+      GG2H_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_PIO2_PI = 160,
+      GG2H_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_PIO2_PI = 161,
+      // EW qqH
+      QQ2HQQ_FWDH = 200,
+      QQ2HQQ_0J = 201,
+      QQ2HQQ_1J_PTH_0_200 = 202,
+      QQ2HQQ_1J_PTH_200_450 = 203,
+      QQ2HQQ_1J_PTH_450_650 = 204,
+      QQ2HQQ_1J_PTH_GT650 = 205,
+      QQ2HQQ_GE2J_MJJ_0_60_PTH_0_200_PTHJJ_0_25 = 206,
+      QQ2HQQ_GE2J_MJJ_60_120_PTH_0_200_PTHJJ_0_25 = 207,
+      QQ2HQQ_GE2J_MJJ_120_350_PTH_0_200_PTHJJ_0_25 = 208,
+      QQ2HQQ_GE2J_MJJ_0_60_PTH_0_200_PTHJJ_GT25 = 209,
+      QQ2HQQ_GE2J_MJJ_60_120_PTH_0_200_PTHJJ_GT25 = 210,
+      QQ2HQQ_GE2J_MJJ_120_350_PTH_0_200_PTHJJ_GT25 = 211,
+      QQ2HQQ_GE2J_MJJ_0_60_PTH_GT200_PTHJJ_0_25 = 212,
+      QQ2HQQ_GE2J_MJJ_60_120_PTH_GT200_PTHJJ_0_25 = 213,
+      QQ2HQQ_GE2J_MJJ_120_350_PTH_GT200_PTHJJ_0_25 = 214,
+      QQ2HQQ_GE2J_MJJ_0_60_PTH_GT200_PTHJJ_GT25 = 215,
+      QQ2HQQ_GE2J_MJJ_60_120_PTH_GT200_PTHJJ_GT25 = 216,
+      QQ2HQQ_GE2J_MJJ_120_350_PTH_GT200_PTHJJ_GT25 = 217,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 = 218,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPI_MPIO2 = 219,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 = 220,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPI_MPIO2 = 221,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 = 222,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPI_MPIO2 = 223,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 = 224,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPI_MPIO2 = 225,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPIO2_0 = 226,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPIO2_0 = 227,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPIO2_0 = 228,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPIO2_0 = 229,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPIO2_0 = 230,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPIO2_0 = 231,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_MPIO2_0 = 232,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_MPIO2_0 = 233,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25_DPHIJJ_0_PIO2 = 234,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25_DPHIJJ_0_PIO2 = 235,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_0_25_DPHIJJ_0_PIO2 = 236,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_GT25_DPHIJJ_0_PIO2 = 237,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_0_PIO2 = 238,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_0_PIO2 = 239,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_0_PIO2 = 240,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_0_PIO2 = 241,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_0_25_DPHIJJ_PIO2_PI = 242,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_0_200_PTHJJ_GT25_DPHIJJ_PIO2_PI = 243,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_0_25_DPHIJJ_PIO2_PI = 244,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_0_200_PTHJJ_GT25_DPHIJJ_PIO2_PI = 245,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_PIO2_PI = 246,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_PIO2_PI = 247,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_0_25_DPHIJJ_PIO2_PI = 248,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_0_200_PTHJJ_GT25_DPHIJJ_PIO2_PI = 249,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_200_450_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 = 250,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_200_450_PTHJJ_GT25_DPHIJJ_MPI_MPIO2 = 251,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_200_450_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 = 252,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_200_450_PTHJJ_GT25_DPHIJJ_MPI_MPIO2 = 253,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_200_450_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 = 254,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_200_450_PTHJJ_GT25_DPHIJJ_MPI_MPIO2 = 255,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_200_450_PTHJJ_0_25_DPHIJJ_MPI_MPIO2 = 256,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_200_450_PTHJJ_GT25_DPHIJJ_MPI_MPIO2 = 257,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_200_450_PTHJJ_0_25_DPHIJJ_MPIO2_0 = 258,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_200_450_PTHJJ_GT25_DPHIJJ_MPIO2_0 = 259,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_200_450_PTHJJ_0_25_DPHIJJ_MPIO2_0 = 260,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_200_450_PTHJJ_GT25_DPHIJJ_MPIO2_0 = 261,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_200_450_PTHJJ_0_25_DPHIJJ_MPIO2_0 = 262,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_200_450_PTHJJ_GT25_DPHIJJ_MPIO2_0 = 263,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_200_450_PTHJJ_0_25_DPHIJJ_MPIO2_0 = 264,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_200_450_PTHJJ_GT25_DPHIJJ_MPIO2_0 = 265,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_200_450_PTHJJ_0_25_DPHIJJ_0_PIO2 = 266,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_200_450_PTHJJ_GT25_DPHIJJ_0_PIO2 = 267,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_200_450_PTHJJ_0_25_DPHIJJ_0_PIO2 = 268,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_200_450_PTHJJ_GT25_DPHIJJ_0_PIO2 = 269,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_200_450_PTHJJ_0_25_DPHIJJ_0_PIO2 = 270,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_200_450_PTHJJ_GT25_DPHIJJ_0_PIO2 = 271,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_200_450_PTHJJ_0_25_DPHIJJ_0_PIO2 = 272,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_200_450_PTHJJ_GT25_DPHIJJ_0_PIO2 = 273,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_200_450_PTHJJ_0_25_DPHIJJ_PIO2_PI = 274,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_200_450_PTHJJ_GT25_DPHIJJ_PIO2_PI = 275,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_200_450_PTHJJ_0_25_DPHIJJ_PIO2_PI = 276,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_200_450_PTHJJ_GT25_DPHIJJ_PIO2_PI = 277,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_200_450_PTHJJ_0_25_DPHIJJ_PIO2_PI = 278,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_200_450_PTHJJ_GT25_DPHIJJ_PIO2_PI = 279,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_200_450_PTHJJ_0_25_DPHIJJ_PIO2_PI = 280,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_200_450_PTHJJ_GT25_DPHIJJ_PIO2_PI = 281,
+      QQ2HQQ_GE2J_MJJ_350_700_PTH_GT450 = 282,
+      QQ2HQQ_GE2J_MJJ_700_1000_PTH_GT450 = 283,
+      QQ2HQQ_GE2J_MJJ_1000_1500_PTH_GT450 = 284,
+      QQ2HQQ_GE2J_MJJ_GT1500_PTH_GT450 = 285,
+      // qq -> WH
+      QQ2HLNU_FWDH = 300,
+      QQ2HLNU_PTV_0_75_0J = 301,
+      QQ2HLNU_PTV_75_150_0J = 302,
+      QQ2HLNU_PTV_150_250_0J = 303,
+      QQ2HLNU_PTV_250_400_0J = 304,
+      QQ2HLNU_PTV_400_600_0J = 305,
+      QQ2HLNU_PTV_GT600_0J = 306,
+      QQ2HLNU_PTV_0_75_1J = 307,
+      QQ2HLNU_PTV_75_150_1J = 308,
+      QQ2HLNU_PTV_150_250_1J = 309,
+      QQ2HLNU_PTV_250_400_1J = 310,
+      QQ2HLNU_PTV_400_600_1J = 311,
+      QQ2HLNU_PTV_GT600_1J = 312,
+      QQ2HLNU_PTV_0_75_GE2J = 313,
+      QQ2HLNU_PTV_75_150_GE2J = 314,
+      QQ2HLNU_PTV_150_250_GE2J = 315,
+      QQ2HLNU_PTV_250_400_GE2J = 316,
+      QQ2HLNU_PTV_400_600_GE2J = 317,
+      QQ2HLNU_PTV_GT600_GE2J = 318,
+      // qq -> ZH
+      QQ2HLL_FWDH = 400,
+      QQ2HLL_PTV_0_75_0J = 401,
+      QQ2HLL_PTV_75_150_0J = 402,
+      QQ2HLL_PTV_150_250_0J = 403,
+      QQ2HLL_PTV_250_400_0J = 404,
+      QQ2HLL_PTV_400_600_0J = 405,
+      QQ2HLL_PTV_GT600_0J = 406,
+      QQ2HLL_PTV_0_75_1J = 407,
+      QQ2HLL_PTV_75_150_1J = 408,
+      QQ2HLL_PTV_150_250_1J = 409,
+      QQ2HLL_PTV_250_400_1J = 410,
+      QQ2HLL_PTV_400_600_1J = 411,
+      QQ2HLL_PTV_GT600_1J = 412,
+      QQ2HLL_PTV_0_75_GE2J = 413,
+      QQ2HLL_PTV_75_150_GE2J = 414,
+      QQ2HLL_PTV_150_250_GE2J = 415,
+      QQ2HLL_PTV_250_400_GE2J = 416,
+      QQ2HLL_PTV_400_600_GE2J = 417,
+      QQ2HLL_PTV_GT600_GE2J = 418,
+      // gg -> ZH
+      GG2HLL_FWDH = 500,
+      GG2HLL_PTV_0_75_0J = 501,
+      GG2HLL_PTV_75_150_0J = 502,
+      GG2HLL_PTV_150_250_0J = 503,
+      GG2HLL_PTV_250_400_0J = 504,
+      GG2HLL_PTV_400_600_0J = 505,
+      GG2HLL_PTV_GT600_0J = 506,
+      GG2HLL_PTV_0_75_1J = 507,
+      GG2HLL_PTV_75_150_1J = 508,
+      GG2HLL_PTV_150_250_1J = 509,
+      GG2HLL_PTV_250_400_1J = 510,
+      GG2HLL_PTV_400_600_1J = 511,
+      GG2HLL_PTV_GT600_1J = 512,
+      GG2HLL_PTV_0_75_GE2J = 513,
+      GG2HLL_PTV_75_150_GE2J = 514,
+      GG2HLL_PTV_150_250_GE2J = 515,
+      GG2HLL_PTV_250_400_GE2J = 516,
+      GG2HLL_PTV_400_600_GE2J = 517,
+      GG2HLL_PTV_GT600_GE2J = 518,
+      // ttH
+      TTH_FWDH = 600,
+      TTH_PTH_0_60 = 601,
+      TTH_PTH_60_120 = 602,
+      TTH_PTH_120_200 = 603,
+      TTH_PTH_200_300 = 604,
+      TTH_PTH_300_450 = 605,
+      TTH_PTH_450_650 = 606,
+      TTH_PTH_GT650 = 607,
+      // bbH
+      BBH_FWDH = 700,
+      BBH_FID = 701,
+      // tH
+      THQ_FWDH = 800,
+      THQ_FID = 801,
+      THW_FWDH = 802,
+      THW_FID = 803,
+    };
+  }  // namespace Stage1_3_Fine
 
   //#ifdef ROOT_TLorentzVector
   //typedef TLorentzVector TLV;
@@ -538,13 +869,20 @@ namespace HTXS {
     HTXS::Stage1_2::Category stage1_2_cat_pTjet30GeV;
     HTXS::Stage1_2_Fine::Category stage1_2_fine_cat_pTjet25GeV;
     HTXS::Stage1_2_Fine::Category stage1_2_fine_cat_pTjet30GeV;
+    HTXS::Stage1_3::Category stage1_3_cat_pTjet25GeV;
+    HTXS::Stage1_3::Category stage1_3_cat_pTjet30GeV;
+    HTXS::Stage1_3_Fine::Category stage1_3_fine_cat_pTjet25GeV;
+    HTXS::Stage1_3_Fine::Category stage1_3_fine_cat_pTjet30GeV;
     // Flag for Z->vv decay mode (needed to split QQ2ZH and GG2ZH)
     bool isZ2vvDecay = false;
-    // Temporary fix: add variables to perform STXS 1.3 classification with nanoAOD on-the-fly
-    double V_pt;
-    double Mjj;
-    double ptHjj;
-    double dPhijj;
+    // Flag to distinguish tHW from tHq
+    bool isTHW = false;
+    // HTXS classification variables (STXS 1.3)
+    double M_jj;
+    double pt_Hjj;
+    double deltaphi_jj;
+    double pt_Hj_over_pt_H;
+    double pt_V;
     // Error code :: classification was succesful or some error occured
     HTXS::ErrorCode errorCode;
   };
@@ -571,12 +909,18 @@ namespace HTXS {
     cat.stage1_2_cat_pTjet30GeV = htxs_cat_rivet.stage1_2_cat_pTjet30GeV;
     cat.stage1_2_fine_cat_pTjet25GeV = htxs_cat_rivet.stage1_2_fine_cat_pTjet25GeV;
     cat.stage1_2_fine_cat_pTjet30GeV = htxs_cat_rivet.stage1_2_fine_cat_pTjet30GeV;
+    cat.stage1_3_cat_pTjet25GeV = htxs_cat_rivet.stage1_3_cat_pTjet25GeV;
+    cat.stage1_3_cat_pTjet30GeV = htxs_cat_rivet.stage1_3_cat_pTjet30GeV;
+    cat.stage1_3_fine_cat_pTjet25GeV = htxs_cat_rivet.stage1_3_fine_cat_pTjet25GeV;
+    cat.stage1_3_fine_cat_pTjet30GeV = htxs_cat_rivet.stage1_3_fine_cat_pTjet30GeV;
     cat.isZ2vvDecay = htxs_cat_rivet.isZ2vvDecay;
-    // Temporary fix: add variables to perform STXS 1.3 classification with nanoAOD on-the-fly
-    cat.V_pt = htxs_cat_rivet.V_pt;
-    cat.Mjj = htxs_cat_rivet.Mjj;
-    cat.ptHjj = htxs_cat_rivet.ptHjj;
-    cat.dPhijj = htxs_cat_rivet.dPhijj;
+    cat.isTHW = htxs_cat_rivet.isTHW;
+    // HTXS classification variables (STXS 1.3)
+    cat.M_jj = htxs_cat_rivet.M_jj;
+    cat.pt_Hjj = htxs_cat_rivet.pt_Hjj;
+    cat.deltaphi_jj = htxs_cat_rivet.deltaphi_jj;
+    cat.pt_Hj_over_pt_H = htxs_cat_rivet.pt_Hj_over_pt_H;
+    cat.pt_V = htxs_cat_rivet.pt_V;
     return cat;
   }
 
@@ -726,6 +1070,107 @@ namespace HTXS {
     return (F + offset[P]);
   }
 
+  // Same for Stage1_3 categories
+  inline int HTXSstage1_3_to_HTXSstage1_3_FineIndex(HTXS::Stage1_3::Category stage1_3, HiggsProdMode prodMode,
+                                                    tH_type tH) {
+    if (stage1_3 == HTXS::Stage1_3::Category::UNKNOWN) 
+      return 0;
+    int P = (int)(stage1_3 / 100);
+    int F = (int)(stage1_3 % 100);
+    // 1.a split tH categories
+    if (prodMode == HiggsProdMode::TH) {
+      // check that tH splitting is valid for Stage-1 FineIndex
+      // else return unknown category
+      if (tH == tH_type::noTH) 
+        return 0;
+      // check if forward tH
+      int fwdH = F == 0 ? 0 : 1;
+      return (133 + 2 * (tH - 1) + fwdH);
+    }
+    // 1.b QQ2HQQ --> split into VBF, WH, ZH -> HQQ
+    // offset vector 1: input is the Higgs prodMode
+    // first two indicies are dummies, given that this is only called for prodMode=2,3,4
+    std::vector<int> pMode_offset = {0, 0, 51, 66, 81};
+    if (P == 2) 
+      return (F + pMode_offset[prodMode]);
+    // 1.c GG2ZH split into gg->ZH-had and gg->ZH-lep
+    if (prodMode == HiggsProdMode::GG2ZH && P == 1) 
+      return F + 26;
+    // 1.d remaining categories
+    // offset vector 2: input is the Stage-1 category P
+    // third index is dummy, given that this is called for category P=0,1,3,4,5,6,7
+    std::vector<int> catP_offset = {0, 1, 0, 96, 105, 114, 123, 131};
+    return (F + catP_offset[P]);
+  }
+
+  inline int HTXSstage1_3_to_HTXSstage1_3_FineIndex(const HiggsClassification &stxs, 
+                                                    tH_type tH = noTH,
+                                                    bool jets_pT25 = false) {
+    HTXS::Stage1_3::Category stage1_3 
+        = jets_pT25 == false ? stxs.stage1_3_cat_pTjet30GeV : stxs.stage1_3_cat_pTjet25GeV;
+    return HTXSstage1_3_to_HTXSstage1_3_FineIndex(stage1_3, stxs.prodMode, tH);
+  }
+
+  inline int HTXSstage1_3_to_index(HTXS::Stage1_3::Category stage1_3) {
+    // the Stage-1_3 categories
+    int P = (int)(stage1_3 / 100);
+    int F = (int)(stage1_3 % 100);
+    std::vector<int> offset{0, 1, 26, 41, 50, 59, 68, 76, 78, 80};
+    // convert to linear values
+    return (F + offset[P]);
+  }
+
+  // Same for Stage1_3_Fine categories
+  inline int HTXSstage1_3_Fine_to_HTXSstage1_3_Fine_FineIndex(HTXS::Stage1_3_Fine::Category Stage1_3_Fine,
+                                                              HiggsProdMode prodMode, 
+                                                              tH_type tH) {
+    if (Stage1_3_Fine == HTXS::Stage1_3_Fine::Category::UNKNOWN) 
+      return 0;
+    int P = (int)(Stage1_3_Fine / 100);
+    int F = (int)(Stage1_3_Fine % 100);
+    // 1.a split tH categories
+    if (prodMode == HiggsProdMode::TH) {
+      // check that tH splitting is valid for Stage-1 FineIndex
+      // else return unknown category
+      if (tH == tH_type::noTH) 
+        return 0;
+      // check if forward tH
+      int fwdH = F == 0 || F == 2 ? 0 : 1;
+      return (450 + 2 * (tH - 1) + fwdH);
+    }
+    // 1.b QQ2HQQ --> split into VBF, WH, ZH -> HQQ
+    // offset vector 1: input is the Higgs prodMode
+    // first two indicies are dummies, given that this is only called for prodMode=2,3,4
+    std::vector<int> pMode_offset = {0, 0, 125, 211, 297};
+    if (P == 2) 
+      return (F + pMode_offset[prodMode]);
+    // 1.c GG2ZH split into gg->ZH-had and gg->ZH-lep
+    if (prodMode == HiggsProdMode::GG2ZH && P == 1) 
+      return F + 63;
+    // 1.d remaining categories
+    // offset vector 2: input is the Stage-1 category P
+    // third index is dummy, given that this is called for category P=0,1,3,4,5,6,7
+    std::vector<int> catP_offset = {0, 1, 0, 383, 402, 421, 440, 448};
+    return (F + catP_offset[P]);
+  }
+
+  inline int HTXSstage1_3_Fine_to_HTXSstage1_3_Fine_FineIndex(const HiggsClassification &stxs, 
+                                                              tH_type tH = noTH,
+                                                              bool jets_pT25 = false) {
+    HTXS::Stage1_3_Fine::Category Stage1_3_Fine =
+        jets_pT25 == false ? stxs.stage1_3_fine_cat_pTjet30GeV : stxs.stage1_3_fine_cat_pTjet25GeV;
+    return HTXSstage1_3_Fine_to_HTXSstage1_3_Fine_FineIndex(Stage1_3_Fine, stxs.prodMode, tH);
+  }
+
+  inline int HTXSstage1_3_Fine_to_index(HTXS::Stage1_3_Fine::Category Stage1_3_Fine) {
+    // the Stage-1_3_Fine categories
+    int P = (int)(Stage1_3_Fine / 100);
+    int F = (int)(Stage1_3_Fine % 100);
+    std::vector<int> offset{0, 1, 63, 149, 168, 187, 206, 214, 216, 219};
+    // convert to linear values
+    return (F + offset[P]);
+  }
+
   // #endif
 
 }  // namespace HTXS
@@ -752,35 +1197,46 @@ namespace Rivet {
     Rivet::FourMomentum p4decay_V;
     /// Jets built ignoring Higgs decay products and leptons from V decays, pT thresholds at 25 GeV and 30 GeV
     Rivet::Jets jets25, jets30;
-    /// Stage-0 HTXS event classifcation, see: https://cds.cern.ch/record/2138079
+    /// Stage-0 HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_0
     HTXS::Stage0::Category stage0_cat;
-    /// Stage-1 HTXS event classifcation, see: https://cds.cern.ch/record/2138079
+    /// Stage-1 HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1
     HTXS::Stage1::Category stage1_cat_pTjet25GeV;
-    /// Stage-1 HTXS event classifcation, see: https://cds.cern.ch/record/2138079
+    /// Stage-1 HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1
     HTXS::Stage1::Category stage1_cat_pTjet30GeV;
-    /// Error code: Whether classification was succesful or some error occured
+    /// Stage-1_1 HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1_1
     HTXS::Stage1_1::Category stage1_1_cat_pTjet25GeV;
-    /// Stage-1 STXS event classifcation, see: https://cds.cern.ch/record/2138079
+    /// Stage-1_1 HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1_1
     HTXS::Stage1_1::Category stage1_1_cat_pTjet30GeV;
-    /// Stage-1_1 STXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWGFiducialAndSTXS#Stage_1_1
+    /// Stage-1_1 (fine)HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1_1
     HTXS::Stage1_1_Fine::Category stage1_1_fine_cat_pTjet25GeV;
-    /// Stage-1_1 STXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWGFiducialAndSTXS#Stage_1_1
+    /// Stage-1_1 (fine) HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1_1
     HTXS::Stage1_1_Fine::Category stage1_1_fine_cat_pTjet30GeV;
-    /// Stage-1 STXS event classifcation, see: https://cds.cern.ch/record/2138079
+    /// Stage-1_2 HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1_2_binning_used_at_Run_2
     HTXS::Stage1_2::Category stage1_2_cat_pTjet25GeV;
-    /// Stage-1 STXS event classifcation, see: https://cds.cern.ch/record/2138079
+    /// Stage-1_2 HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1_2_binning_used_at_Run_2
     HTXS::Stage1_2::Category stage1_2_cat_pTjet30GeV;
-    /// Stage-1_2 STXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWGFiducialAndSTXS#Stage_1_1
+    /// Stage-1_2 (fine) HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1_2_binning_used_at_Run_2
     HTXS::Stage1_2_Fine::Category stage1_2_fine_cat_pTjet25GeV;
-    /// Stage-1_2 STXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWGFiducialAndSTXS#Stage_1_1
+    /// Stage-1_2 (fine) HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1_2_binning_used_at_Run_2
     HTXS::Stage1_2_Fine::Category stage1_2_fine_cat_pTjet30GeV;
+    /// Stage-1_3 HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1_3_recommended_binning_fo
+    HTXS::Stage1_3::Category stage1_3_cat_pTjet25GeV;
+    /// Stage-1_3 HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1_3_recommended_binning_fo
+    HTXS::Stage1_3::Category stage1_3_cat_pTjet30GeV;
+    /// Stage-1_3 (fine) HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1_3_recommended_binning_fo
+    HTXS::Stage1_3_Fine::Category stage1_3_fine_cat_pTjet25GeV;
+    /// Stage-1_3 (fine) HTXS event classifcation, see: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGFiducialAndSTXS#Stage_1_3_recommended_binning_fo
+    HTXS::Stage1_3_Fine::Category stage1_3_fine_cat_pTjet30GeV;
     /// Flag to distiguish the Z->vv and Z->l+l- decay modes
     bool isZ2vvDecay = false;
-    // Temporary fix: add variables to perform STXS 1.3 classification with nanoAOD on-the-fly
-    double V_pt;
-    double Mjj;
-    double ptHjj;
-    double dPhijj;
+    // Flag to distinguish tHW from tHq
+    bool isTHW = false;
+    // HTXS classification variables (STXS 1.3)
+    double M_jj;
+    double pt_Hjj;
+    double deltaphi_jj;
+    double pt_Hj_over_pt_H;
+    double pt_V;
     /// Error code: Whether classification was succesful or some error occured
     HTXS::ErrorCode errorCode;
   };


### PR DESCRIPTION
PR is identical to: https://github.com/cms-sw/cmssw/pull/51499, which passed all checks/comments.

Now based on top of CMSSW master. After merging this we should close https://github.com/cms-sw/cmssw/pull/51499, and then backport to the relevant releases that are used for (Re)NanoAOD on Run 3 Higgs samples.