### PR TITLE
Addition of a HGCal-only reco, validation, harvesting sequence and workflow

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1375,6 +1375,29 @@ upgradeWFs['HCALOnlyCPU'] = PatatrackWorkflow(
     offset = 0.521,
 )
 
+# HGCal-only local reconstruction and validation, without general tracking
+#  - Phase-2 only (HGCal does not exist in Run3)
+#  - RAW2DIGI + HGCal-only reconstruction, with DQM and validation
+#  - harvesting
+class UpgradeWorkflow_HGCalOnly(PatatrackWorkflow):
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return ('Run4' in key) and (fragment == "TTbar_14TeV") and hasHarvest
+
+upgradeWFs['HGCalOnly'] = UpgradeWorkflow_HGCalOnly(
+    digi = {
+        # nothing special needed for the HGCal-only reconstruction
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi,RECO:reconstruction_hgcalOnly,VALIDATION:@HGCalOnlyValidation',
+        '--customise': 'Validation/Configuration/customiseHGCalOnly.customiseHGCalOnly',
+    },
+    harvest = {
+        '-s': 'HARVESTING:@HGCalOnlyValidation'
+    },
+    suffix = 'HGCalOnly',
+    offset = 0.531,
+)
+
 ###############################################################################################################
 ### Alpaka workflows
 ###

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -270,6 +270,22 @@ reconstruction_hcalOnlyLegacyTask = cms.Task(
 reconstruction_hcalOnly = cms.Sequence(reconstruction_hcalOnlyTask)
 reconstruction_hcalOnlyLegacy = cms.Sequence(reconstruction_hcalOnlyLegacyTask)
 
+# define a sequence to run the HGCal local reco without the tracking step, for HGCalOnly workflows
+particleFlowClusterHGCalNoTracks = particleFlowClusterHGCal.clone(
+    initialClusteringStep=dict(tracksterSrc='ticlTrackstersCLUE3DHigh')
+)
+hgcalLocalRecoTask_hgcalOnly = hgcalLocalRecoTask.copyAndExclude([particleFlowClusterHGCal])
+hgcalLocalRecoTask_hgcalOnly.add(particleFlowClusterHGCalNoTracks)
+
+reconstruction_hgcalOnlyTask = cms.Task(
+    bunchSpacingProducer,
+    offlineBeamSpot,
+    hgcalLocalRecoTask_hgcalOnly,
+    mergeTICLTask,
+    pfClusteringHGCalTask
+)
+reconstruction_hgcalOnly = cms.Sequence(reconstruction_hgcalOnlyTask)
+
 #need a fully expanded sequence copy
 modulesToRemove = list() # copy does not work well
 noTrackingAndDependent = list()

--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -19,6 +19,7 @@ autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLite
                    'standardValidationHiMix' : ['prevalidation','validationHiMix','validationHarvesting'],
                    'standardValidationNoHLTHiMix' : ['prevalidationNoHLT','validationNoHLTHiMix','validationHarvestingNoHLT'],
                    'HGCalValidation' : ['globalPrevalidationHGCal', 'globalValidationHGCal', 'hgcalValidatorPostProcessor'],
+                   'HGCalOnlyValidation' : ['globalPrevalidationHGCal', 'globalValidationHGCalOnly', 'hgcalValidatorPostProcessor'],
                    'BarrelValidation' : ['globalPrevalidationBarrel', 'globalValidationBarrel', 'barrelValidatorPostProcessor'],
                    'MTDValidation' : ['', 'globalValidationMTD', 'mtdValidationPostProcessor'],
                    'ecalValidation_phase2' : ['', 'validationECALPhase2', ''],

--- a/Validation/Configuration/python/customiseHGCalOnly.py
+++ b/Validation/Configuration/python/customiseHGCalOnly.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+
+def customiseHGCalOnly(process):
+    ## avoid crash due to missing track collection in HGCalOnly workflows
+    process.trackingParticleGsfTrackAssociation.ignoremissingtrackcollection = cms.untracked.bool(True)
+    return process

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -271,6 +271,11 @@ globalPrevalidationHGCal = cms.Sequence(hgcalAssociators, ticlSimTrackstersTask)
 
 globalValidationHGCal = cms.Sequence(hgcalValidation)
 
+## remove the DQM modules depending on tracks from the HGCalOnly validation workflows
+globalValidationHGCalOnly = globalValidationHGCal.copy()
+globalValidationHGCalOnly.remove(hgcalTiclPFValidation)
+globalValidationHGCalOnly.remove(hgcalPFJetValidation)
+
 globalPrevalidationBarrel = cms.Sequence()
 _globalPrevalidationBarrel = globalPrevalidationBarrel.copy()
 _globalPrevalidationBarrel += cms.Sequence(barrelAssociators)


### PR DESCRIPTION
#### PR description:

In the context of NGT Task 3.3,  where we are investigating the replacement of HGCal raw data with low-level reconstructed data, we found that CMSSW currently lacks an HGCal-only workflow that runs the HGCal reconstruction and DQM without the full reconstruction chain, analogous to the existing Pixel-, HCAL-, and ECAL-only workflows.

Such a workflow allows the HGCal reconstruction to be exercised very quickly by skipping the full general tracking.

This PR adds HGCal-only reconstruction, validation, and harvesting sequences, together with an upgrade workflow available through `runTheMatrix.py`:

```
runTheMatrix.py -w upgrade -l 37634.531 --extended --showMatrix

37634.531 TTbar_14TeV_TuneCP5_Run4D127_GenSimHLBeamSpot14+DigiTrigger_HGCalOnly_Run4D127+RecoGlobal_HGCalOnly_Run4D127+HARVESTGlobal_HGCalOnly_Run4D127 

[1]: cmsDriver.py TTbar_14TeV_TuneCP5_cfi  -s GEN,SIM -n 10 --conditions auto:phase2_realistic_T35 --beamspot DBrealisticHLLHC --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry ExtendedRun4D127 --era Phase2C26I13M9 --relval 9000,100 

[2]: cmsDriver.py step2  -s DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:@relvalRun4 --conditions auto:phase2_realistic_T35 --datatier GEN-SIM-DIGI-RAW -n 10 --eventcontent FEVTDEBUGHLT --geometry ExtendedRun4D127 --era Phase2C26I13M9

[3]: cmsDriver.py step3  -s RAW2DIGI:RawToDigi,RECO:reconstruction_hgcalOnly,VALIDATION:@HGCalValidationOnly --conditions auto:phase2_realistic_T35 --datatier GEN-SIM-RECO,MINIAODSIM,DQMIO -n 10 --eventcontent FEVTDEBUGHLT,MINIAODSIM,DQM --geometry ExtendedRun4D127 --era Phase2C26I13M9 --customise Validation/Configuration/customiseHGCalOnly.customiseHGCalOnly

[4]: cmsDriver.py step4  -s HARVESTING:@HGCalValidationOnly --conditions auto:phase2_realistic_T35 --mc  --geometry ExtendedRun4D127 --scenario pp --filetype DQM --era Phase2C26I13M9 -n 100 
```

Caveat: 
#### Caveats:

1. `particleFlowClusterHGCalNoTracks` is configured with    `tracksterSrc = 'ticlTrackstersCLUE3DHigh'`, so that PF clustering uses   the CLUE3D tracksters and does not require `generalTracks`.

2. The `customiseHGCalOnly` customisation sets  `trackingParticleGsfTrackAssociation.ignoremissingtrackcollection`   to `True`. This is needed because `trackingParticleGsfTrackAssociation`  is still scheduled through the simulation-truth association dependency  chain and otherwise attempts to consume the unavailable `quickTrackAssociatorByHits` product:
```
----- Begin Fatal Exception 10-Sep-2026 17:50:05 CEST-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 1 stream: 5
   [1] Running path 'validation_step'
   [2] Prefetching for module HGCalValidator/'hgcalValidator'
   [3] Prefetching for module SimTrackstersProducer/'ticlSimTracksters'
   [4] Calling method for module TrackAssociatorEDProducer/'trackingParticleGsfTrackAssociation'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: reco::TrackToTrackingParticleAssociator
Looking for module label: quickTrackAssociatorByHits
Looking for productInstanceName: 

   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "TryToContinue = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.

----- End Fatal Exception -------------------------------------------------
```
I could use a Modifier to fix this, rather than a customization function, but it seems to me better to avoid adding a Modifier for a single workflow.

#### PR validation:

```
runTheMatrix.py -w upgrade -l 37634.531 
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Yes, it would be useful to have it also in 20_0_X cycle, if possible, as it will be used for this kind of studies.