### PR TITLE
Reset GenEventData before write_data in HepMC3Product

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/HepMC3Product.cc
+++ b/SimDataFormats/GeneratorProducts/src/HepMC3Product.cc
@@ -23,7 +23,12 @@ HepMC3Product::HepMC3Product(const HepMC3::GenEvent& evt)
 
 HepMC3Product::~HepMC3Product() = default;
 
-void HepMC3Product::addHepMCData(const HepMC3::GenEvent& evt) { evt.write_data(evt_); }
+// GenEvent::write_data appends to the GenEventData vectors, so the target
+// has to be emptied first or every particle, vertex and link is stored twice.
+void HepMC3Product::addHepMCData(const HepMC3::GenEvent& evt) {
+  evt_ = HepMC3::GenEventData();
+  evt.write_data(evt_);
+}
 
 void HepMC3Product::applyVtxGen(HepMC3::FourVector const& vtxShift) {
   //std::cout<< " applyVtxGen called " << isVtxGenApplied_ << endl;
@@ -33,7 +38,7 @@ void HepMC3Product::applyVtxGen(HepMC3::FourVector const& vtxShift) {
   HepMC3::GenEvent evt;
   evt.read_data(evt_);
   evt.shift_position_by(vtxShift);
-  evt.write_data(evt_);
+  addHepMCData(evt);
   isVtxGenApplied_ = true;
   return;
 }
@@ -101,6 +106,6 @@ void HepMC3Product::boostToLab(TMatrixD const* lorentz, std::string const& type)
     //  << "no type found for boostToLab(std::string), options are vertex or momentum \n";
   }
 
-  evt.write_data(evt_);
+  addHepMCData(evt);
   return;
 }


### PR DESCRIPTION
#### PR description:

`HepMC3Product::applyVtxGen` and `boostToLab` call `evt.read_data(evt_)`, modify the event, and `evt.write_data(evt_)` back into the same `GenEventData` member. `HepMC3::GenEvent::write_data` appends to the data vectors rather than clearing them, so every vertex-smeared `HepMC3Product` stores each particle, vertex and link twice. The second copy's links point at the first copy's ids, which leaves the duplicates present but unlinked (no production vertex).

Observed with `Pythia8HepMC3GeneratorFilter` + `VtxSmeared` in CMSSW_20_1_0_pre3: the `generator:unsmeared` product holds 1672 particles and 964 vertices in an event, `generatorSmeared` holds exactly 3344 and 1928. Any consumer that rebuilds the event with `read_data` sees the duplicates (`GenParticleProducer`, SIM, a HepMC3 ascii dump shows them as mother-less particles).

Fix: `addHepMCData` resets `evt_` before writing; `applyVtxGen` and `boostToLab` use it.

Expected changes in output: every vertex-smeared (or boosted) `HepMC3Product` shrinks to the unsmeared particle and vertex count. HepMC2 workflows are not touched. 

#### PR validation:

Diagnosed by dumping both products of the same events to HepMC3 ascii with a small EDAnalyzer wrapping `HepMC3::WriterAscii`: `generator:unsmeared` 1672 particles / 964 vertices, `generatorSmeared` 3344 / 1928, the second half of the particle list carrying mother 0. [After the fix, a 20-event `DYToLL_M-50_13TeV_pythia8` GEN with `Pythia8HepMC3GeneratorFilter` gives identical particle and vertex counts for the unsmeared and smeared products: N / M.] Code compiles in CMSSW_20_1_0_pre3, el8_amd64_gcc14.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. Any release cycle carrying HepMC3 generator support is
affected; a backport to 15_1_X / 16_0_X can follow if wanted. Probably not needed tho.
