### PR TITLE
Do not throw when a track crosses more than 5 muon stations

### DIFF
--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -208,9 +208,16 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
           // 	LogTrace("MuonIdentification")<<"            // Message: A muon candidate track has more than 4 stations with matching segments.";
           // 	LogTrace("MuonIdentification")<<"            // Did not expect this - please let me know: ibloch@fnal.gov";
           // for all other cases
-          if (nr_of_stations_crossed > 5)
+          // nr_of_stations_crossed counts the stations the track was propagated
+          // close to, over the n_muon_stations the arrays are sized for, so any
+          // value up to n_muon_stations is reachable: a prompt muon stays within
+          // 5 (1 ME0 + 4 CSC), but a heavy long-lived charged particle need not.
+          // 1/n is the correct generalisation of the weights above, so only a
+          // count that cannot come from the loop is a logic error.
+          if (nr_of_stations_crossed > n_muon_stations)
             throw cms::Exception("LogicError")
-                << "A muon candidate track has more than 5 stations with matching segments. This should not happen.";
+                << "A muon candidate track crossed " << nr_of_stations_crossed << " muon stations, but only "
+                << n_muon_stations << " exist. This should not happen.";
           station_weight[i - 1] = 1.f / nr_of_stations_crossed;
       }
 


### PR DESCRIPTION
#### PR description:

`muon::segmentCompatibility` ends its station-weight switch with a `default` branch that throws if `nr_of_stations_crossed > 5`. That limit does not match the code around it: the arrays are sized for `n_muon_stations = 9` (4 DT + 1 ME0 + 4 CSC) and the counter is incremented in all three branches of the loop, so values above 5 are reachable. Five is the maximum for a *prompt* muon (1 ME0 + 4 CSC), which is what the comment at `case 5` describes.

A heavy long-lived charged particle is not bound by that. Running NanoAOD over an HSCP GEN-SIM sample (smuon, m = 1 TeV, ctau = 500 mm, generated from EXO-RunIII2024Summer24HSCPGS-00648), one muon in 2000 events crosses 6 stations and the job dies with
```
    An exception of category 'LogicError' occurred while
       [3] Calling method for module SimplePATMuonFlatTableProducer/'muonTable'
    A muon candidate track has more than 5 stations with matching segments. This should not happen.
```

after SIM, DIGI, RECO and MiniAOD have all run cleanly.

The `1.f / nr_of_stations_crossed` immediately below the throw is already the correct generalization of the hand-tuned weights in cases 1 to 5, so this PR restricts the exception to a count that cannot come from the loop at all (`> n_muon_stations`), and leaves the weight as it was.

The message is also corrected: the counter counts stations the track was propagated close to (`trackDist < 999999`), not stations with a matched segment, which is tracked separately in `station_has_segmentmatch[]` and never read by the counter.

Expected changes in the output: none for any track crossing 5 or fewer stations, which is every track in a Standard Model sample (checked below). Tracks crossing 6 to 9 stations now get the `1/n` weight instead of aborting the job. 

#### PR validation:

Reproducer: NanoAOD over 2000 events of the HSCP smuon sample above fails without this patch and completes with it, producing the full table with no branches dropped. The one offending muon is at |eta| = 1.55, pT = 590 GeV, with `Muon_nStations = 6`.

No-change check on Standard Model samples: `Muon_nStations` never exceeds 5 in either of two locally produced NanoAOD samples in the same release, DY (9494 events, 5035 muons) and ttbar (2000 events, 1345 muons), so the modified branch is not reached and their output is unaffected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. 



resolves https://github.com/cms-sw/cmssw/issues/51354