### PR TITLE
Phase-2 primary-vertex reconstruction with the vertex-slot GNN (Alpaka inference), behind the vertexSlotGNN process modifier

### DIFF
--- a/Configuration/ProcessModifiers/python/vertexSlotGNN_cff.py
+++ b/Configuration/ProcessModifiers/python/vertexSlotGNN_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+vertexSlotGNN = cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1093,6 +1093,29 @@ upgradeWFs['phase2L3MuonsOIFirst'].step2 = {'-s':'DIGI:pdigi_valid,L1TrackTrigge
 upgradeWFs['phase2L3MuonsOIFirst'].step3 = {'--procModifiers':'phase2L3MuonsOIFirst'}
 upgradeWFs['phase2L3MuonsOIFirst'].step4 = {'--procModifiers':'phase2L3MuonsOIFirst'}
 
+class UpgradeWorkflow_vertexSlotGNN(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'RecoGlobal' in step:
+            stepDict[stepName][k] = deepcopy(stepDict[step][k])
+            if '--procModifiers' in stepDict[stepName][k]:
+                stepDict[stepName][k]['--procModifiers'] += ',vertexSlotGNN'
+            else:
+                stepDict[stepName][k]['--procModifiers'] = 'vertexSlotGNN'
+
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return fragment == "TTbar_14TeV" and 'Run4' in key and 'FS' not in key
+
+upgradeWFs['vertexSlotGNN'] = UpgradeWorkflow_vertexSlotGNN(
+    steps = [
+        'RecoGlobal',
+    ],
+    PU = [
+        'RecoGlobal',
+    ],
+    suffix = '_vertexSlotGNN',
+    offset = 0.28,
+)
+
 # Track DNN workflows
 class UpgradeWorkflow_trackdnn(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):

--- a/DataFormats/VertexGNNReco/BuildFile.xml
+++ b/DataFormats/VertexGNNReco/BuildFile.xml
@@ -1,0 +1,10 @@
+<use name="rootcore"/>
+<use name="eigen"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/Portable"/>
+<use name="DataFormats/SoATemplate"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="!serial"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/DataFormats/VertexGNNReco/interface/VertexGNNHostCollection.h
+++ b/DataFormats/VertexGNNReco/interface/VertexGNNHostCollection.h
@@ -1,0 +1,14 @@
+#ifndef DataFormats_VertexGNNReco_interface_VertexGNNHostCollection_h
+#define DataFormats_VertexGNNReco_interface_VertexGNNHostCollection_h
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/VertexGNNReco/interface/VertexGNNSoA.h"
+
+namespace vertexgnn {
+
+  using TrackFeaturesHostCollection = PortableHostCollection<TrackFeaturesSoA>;
+  using GNNOutputHostCollection = PortableHostCollection<GNNOutputSoA>;
+
+}  // namespace vertexgnn
+
+#endif

--- a/DataFormats/VertexGNNReco/interface/VertexGNNSoA.h
+++ b/DataFormats/VertexGNNReco/interface/VertexGNNSoA.h
@@ -1,0 +1,46 @@
+#ifndef DataFormats_VertexGNNReco_interface_VertexGNNSoA_h
+#define DataFormats_VertexGNNReco_interface_VertexGNNSoA_h
+
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+namespace vertexgnn {
+
+  constexpr int kNumSlots = 220;
+  constexpr int kNumFeatures = 13;
+
+  using SlotVector = Eigen::Vector<float, kNumSlots>;
+  using PIDVector = Eigen::Vector<float, 3>;
+
+  GENERATE_SOA_LAYOUT(TrackFeaturesLayout,
+                      SOA_COLUMN(float, vz),
+                      SOA_COLUMN(float, dz),
+                      SOA_COLUMN(float, pt),
+                      SOA_COLUMN(float, eta),
+                      SOA_COLUMN(float, mva),
+                      SOA_COLUMN(float, pl),
+                      SOA_COLUMN(float, t_pi),
+                      SOA_COLUMN(float, t_k),
+                      SOA_COLUMN(float, t_p),
+                      SOA_COLUMN(float, s_pi),
+                      SOA_COLUMN(float, s_k),
+                      SOA_COLUMN(float, s_p),
+                      SOA_COLUMN(float, has_time))
+
+  using TrackFeaturesSoA = TrackFeaturesLayout<>;
+
+  GENERATE_SOA_LAYOUT(GNNOutputLayout,
+                      SOA_EIGEN_COLUMN(SlotVector, A),
+                      SOA_EIGEN_COLUMN(SlotVector, z_hat),
+                      SOA_EIGEN_COLUMN(SlotVector, t_hat),
+                      SOA_EIGEN_COLUMN(SlotVector, p),
+                      SOA_EIGEN_COLUMN(PIDVector, pi))
+
+  using GNNOutputSoA = GNNOutputLayout<>;
+
+}  // namespace vertexgnn
+
+#endif

--- a/DataFormats/VertexGNNReco/interface/alpaka/VertexGNNDeviceCollection.h
+++ b/DataFormats/VertexGNNReco/interface/alpaka/VertexGNNDeviceCollection.h
@@ -1,0 +1,17 @@
+#ifndef DataFormats_VertexGNNReco_interface_alpaka_VertexGNNDeviceCollection_h
+#define DataFormats_VertexGNNReco_interface_alpaka_VertexGNNDeviceCollection_h
+
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "DataFormats/VertexGNNReco/interface/VertexGNNSoA.h"
+#include "DataFormats/VertexGNNReco/interface/VertexGNNHostCollection.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexgnn {
+
+  using TrackFeaturesDeviceCollection = PortableCollection<::vertexgnn::TrackFeaturesSoA>;
+
+  using GNNOutputDeviceCollection = PortableCollection<::vertexgnn::GNNOutputSoA>;
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexgnn
+
+#endif

--- a/DataFormats/VertexGNNReco/src/alpaka/classes_cuda.h
+++ b/DataFormats/VertexGNNReco/src/alpaka/classes_cuda.h
@@ -1,0 +1,7 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/VertexGNNReco/interface/VertexGNNSoA.h"
+#include "DataFormats/VertexGNNReco/interface/alpaka/VertexGNNDeviceCollection.h"

--- a/DataFormats/VertexGNNReco/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/VertexGNNReco/src/alpaka/classes_cuda_def.xml
@@ -1,0 +1,10 @@
+<lcgdict>
+
+  <class name="alpaka_cuda_async::vertexgnn::TrackFeaturesDeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::vertexgnn::TrackFeaturesDeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::vertexgnn::TrackFeaturesDeviceCollection>>" persistent="false"/>
+
+  <class name="alpaka_cuda_async::vertexgnn::GNNOutputDeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::vertexgnn::GNNOutputDeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::vertexgnn::GNNOutputDeviceCollection>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/VertexGNNReco/src/alpaka/classes_rocm.h
+++ b/DataFormats/VertexGNNReco/src/alpaka/classes_rocm.h
@@ -1,0 +1,7 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/VertexGNNReco/interface/VertexGNNSoA.h"
+#include "DataFormats/VertexGNNReco/interface/alpaka/VertexGNNDeviceCollection.h"

--- a/DataFormats/VertexGNNReco/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/VertexGNNReco/src/alpaka/classes_rocm_def.xml
@@ -1,0 +1,10 @@
+<lcgdict>
+
+  <class name="alpaka_rocm_async::vertexgnn::TrackFeaturesDeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::vertexgnn::TrackFeaturesDeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::vertexgnn::TrackFeaturesDeviceCollection>>" persistent="false"/>
+
+  <class name="alpaka_rocm_async::vertexgnn::GNNOutputDeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::vertexgnn::GNNOutputDeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::vertexgnn::GNNOutputDeviceCollection>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/VertexGNNReco/src/classes.cc
+++ b/DataFormats/VertexGNNReco/src/classes.cc
@@ -1,0 +1,5 @@
+#include "DataFormats/Portable/interface/PortableHostCollectionReadRules.h"
+#include "DataFormats/VertexGNNReco/interface/VertexGNNHostCollection.h"
+
+SET_PORTABLEHOSTCOLLECTION_READ_RULES(vertexgnn::TrackFeaturesHostCollection);
+SET_PORTABLEHOSTCOLLECTION_READ_RULES(vertexgnn::GNNOutputHostCollection);

--- a/DataFormats/VertexGNNReco/src/classes.h
+++ b/DataFormats/VertexGNNReco/src/classes.h
@@ -1,0 +1,7 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/VertexGNNReco/interface/VertexGNNSoA.h"
+#include "DataFormats/VertexGNNReco/interface/VertexGNNHostCollection.h"

--- a/DataFormats/VertexGNNReco/src/classes_def.xml
+++ b/DataFormats/VertexGNNReco/src/classes_def.xml
@@ -1,0 +1,10 @@
+<lcgdict>
+
+  <class name="vertexgnn::TrackFeaturesLayout<128,false>"/>
+  <class name="PortableHostCollection<vertexgnn::TrackFeaturesLayout<128,false> >"/>
+  <class name="edm::Wrapper<PortableHostCollection<vertexgnn::TrackFeaturesLayout<128,false> > >" splitLevel="0"/>
+
+  <class name="vertexgnn::GNNOutputLayout<128,false>"/>
+  <class name="PortableHostCollection<vertexgnn::GNNOutputLayout<128,false> >"/>
+  <class name="edm::Wrapper<PortableHostCollection<vertexgnn::GNNOutputLayout<128,false> > >" splitLevel="0"/>
+</lcgdict>

--- a/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 #AOD content
 RecoVertexAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep  *_offlinePrimaryVertices__*', 
+    outputCommands = cms.untracked.vstring('keep  *_offlinePrimaryVertices__*',
         'keep *_offlinePrimaryVerticesWithBS_*_*',
         'keep *_offlinePrimaryVerticesFromCosmicTracks_*_*',
         'keep *_nuclearInteractionMaker_*_*',
-        'keep *_generalV0Candidates_*_*',                                           
+        'keep *_generalV0Candidates_*_*',
 	'keep *_inclusiveSecondaryVertices_*_*')
 )
 
@@ -23,6 +23,13 @@ phase2_timing.toModify( RecoVertexAOD,
 phase2_timing_layer.toModify( RecoVertexAOD,
      outputCommands = RecoVertexAOD.outputCommands + _phase2_tktiming_layer_RecoVertexEventContent)
 
+from Configuration.ProcessModifiers.vertexSlotGNN_cff import vertexSlotGNN
+_vertexSlotGNN_RecoVertexEventContent = [ 'keep *_offlinePrimaryVerticesGNN__*',
+                                          'keep *_unsortedOfflinePrimaryVerticesGNN_*_*',
+                                          'keep *_tofPIDGNN_*_*',
+                                          'keep *_tofPID3D_*_*' ]
+(phase2_timing_layer & vertexSlotGNN).toModify( RecoVertexAOD,
+     outputCommands = RecoVertexAOD.outputCommands + _vertexSlotGNN_RecoVertexEventContent)
 #RECO content
 RecoVertexRECO = cms.PSet(
     outputCommands = cms.untracked.vstring()

--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -15,11 +15,11 @@ from RecoJets.JetProducers.caloJetsForTrk_cff import *
 
 unsortedOfflinePrimaryVertices=offlinePrimaryVertices.clone()
 offlinePrimaryVertices=sortedPrimaryVertices.clone(
-    vertices="unsortedOfflinePrimaryVertices", 
+    vertices="unsortedOfflinePrimaryVertices",
     particles="trackRefsForJetsBeforeSorting"
 )
 offlinePrimaryVerticesWithBS=sortedPrimaryVertices.clone(
-    vertices="unsortedOfflinePrimaryVertices:WithBS", 
+    vertices="unsortedOfflinePrimaryVertices:WithBS",
     particles="trackRefsForJetsBeforeSorting"
 )
 trackWithVertexRefSelectorBeforeSorting = trackWithVertexRefSelector.clone(
@@ -28,7 +28,6 @@ trackWithVertexRefSelectorBeforeSorting = trackWithVertexRefSelector.clone(
     ptErrorCut=9e99
 )
 trackRefsForJetsBeforeSorting = trackRefsForJets.clone(src="trackWithVertexRefSelectorBeforeSorting")
-
 
 vertexrecoTask = cms.Task(unsortedOfflinePrimaryVertices,
                           trackWithVertexRefSelectorBeforeSorting,
@@ -89,6 +88,24 @@ phase2_timing_layer.toModify(unsortedOfflinePrimaryVertices,
                          1: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('fromTracksPID')))}
 )
 
+from RecoVertex.Configuration.RecoVertex_phase2_timing_cff import (trackFeatureProducer,
+                                                                  gnnVertexProducer,
+                                                                  unsortedOfflinePrimaryVerticesGNN,
+                                                                  trackWithVertexRefSelectorBeforeSortingGNN,
+                                                                  trackRefsForJetsBeforeSortingGNN,
+                                                                  offlinePrimaryVerticesGNN,
+                                                                  tofPIDGNN)
+_phase2_tktiming_layer_vertexSlotGNN_vertexrecoTask = cms.Task( _phase2_tktiming_layer_vertexrecoTask.copy(),
+                                            trackFeatureProducer,
+                                            gnnVertexProducer,
+                                            unsortedOfflinePrimaryVerticesGNN,
+                                            trackWithVertexRefSelectorBeforeSortingGNN,
+                                            trackRefsForJetsBeforeSortingGNN,
+                                            offlinePrimaryVerticesGNN,
+                                            tofPIDGNN,
+                                            )
+from Configuration.ProcessModifiers.vertexSlotGNN_cff import vertexSlotGNN
+(phase2_timing_layer & vertexSlotGNN).toReplaceWith(vertexrecoTask, _phase2_tktiming_layer_vertexSlotGNN_vertexrecoTask)
 from Configuration.ProcessModifiers.vertex4DTrackSelMVA_cff import vertex4DTrackSelMVA
 vertex4DTrackSelMVA.toModify(unsortedOfflinePrimaryVertices4D, useMVACut = True)
 vertex4DTrackSelMVA.toModify(unsortedOfflinePrimaryVertices4DwithPID, useMVACut = True)

--- a/RecoVertex/Configuration/python/RecoVertex_phase2_timing_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_phase2_timing_cff.py
@@ -70,3 +70,41 @@ tofPID3D=tofPIDProducer.clone(vtxsSrc='unsortedOfflinePrimaryVertices')
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
 phase2_timing_layer.toModify(tofPID, vtxsSrc='unsortedOfflinePrimaryVertices4D', vertexReassignment=False)
 phase2_timing_layer.toModify(tofPID3D, vertexReassignment=False)
+
+trackFeatureProducer = cms.EDProducer("vertexgnn::TrackFeatureProducer",
+    TkFilterParameters = unsortedOfflinePrimaryVertices.TkFilterParameters.clone()
+)
+gnnVertexProducer = cms.EDProducer("vertexgnn::GNNVertexProducerAlpaka@alpaka",
+    trackFeatures = cms.InputTag("trackFeatureProducer"),
+    model = cms.FileInPath("RecoVertex/PrimaryVertexProducer/data/vertexSlotGNN.pt"),
+)
+unsortedOfflinePrimaryVerticesGNN = unsortedOfflinePrimaryVertices4D.clone(
+    TkClusParameters = cms.PSet(algorithm = cms.string("GNN2D_alpaka"),
+        TkDAClusParameters = cms.PSet(
+            existenceThreshold = cms.double(0.01),
+            trackAssignmentThreshold = cms.double(0.5),
+            gnnOutput = cms.InputTag("gnnVertexProducer"),
+        )
+    ),
+    TrackTimesLabel = "tofPID4DnoPID:t0safe",
+    TrackTimeResosLabel = "tofPID4DnoPID:sigmat0safe",
+    vertexCollections = {0: dict(useClusterWeights = cms.bool(False)),
+                         1: dict(useClusterWeights = cms.bool(False))}
+)
+trackWithVertexRefSelectorBeforeSortingGNN = trackWithVertexRefSelector.clone(
+    vertexTag = "unsortedOfflinePrimaryVerticesGNN",
+    ptMax = 9e99,
+    ptErrorCut = 9e99
+)
+trackRefsForJetsBeforeSortingGNN = trackRefsForJets.clone(
+    src = "trackWithVertexRefSelectorBeforeSortingGNN"
+)
+offlinePrimaryVerticesGNN = sortedPrimaryVertices.clone(
+    vertices = "unsortedOfflinePrimaryVerticesGNN",
+    particles = "trackRefsForJetsBeforeSortingGNN",
+    trackTimeTag = "tofPID4DnoPID:t0safe",
+    trackTimeResoTag = "tofPID4DnoPID:sigmat0safe",
+    assignment = dict(useTiming = True)
+)
+tofPIDGNN = tofPIDProducer.clone(vtxsSrc = 'unsortedOfflinePrimaryVerticesGNN')
+phase2_timing_layer.toModify(tofPIDGNN, vertexReassignment = False)

--- a/RecoVertex/PrimaryVertexProducer/BuildFile.xml
+++ b/RecoVertex/PrimaryVertexProducer/BuildFile.xml
@@ -1,9 +1,16 @@
 <use name="ofast-flag"/>
+<use name="rootcore"/>
 <use name="DataFormats/BeamSpot"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/Portable"/>
+<use name="DataFormats/SoATemplate"/>
+<use name="DataFormats/VertexGNNReco"/>
 <use name="DataFormats/VertexReco"/>
+<use name="eigen"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
 <use name="RecoVertex/AdaptiveVertexFit"/>
 <use name="RecoVertex/KalmanVertexFit"/>
 <use name="RecoVertex/VertexPrimitives"/>

--- a/RecoVertex/PrimaryVertexProducer/README.md
+++ b/RecoVertex/PrimaryVertexProducer/README.md
@@ -1,0 +1,45 @@
+# Vertex-slot GNN primary-vertex reconstruction (Alpaka backend)
+
+Primary-vertex reconstruction for Phase-2 with MTD timing using the *vertex-slot* model: a
+graph/attention network that assigns every selected track to one of `K` vertex slots and predicts
+for every slot its z position, time and existence probability. The model runs through
+`PhysicsTools/PyTorchAlpaka` (GPU, or CPU with the serial Alpaka backend); the vertices are built and
+fitted by the standard `PrimaryVertexProducer`.
+
+## Modules (RecoVertex/PrimaryVertexProducer)
+
+| module | type | what it does |
+|---|---|---|
+| `trackFeatureProducer` | `vertexgnn::TrackFeatureProducer` (plugins/) | selects the tracks with the `TrackFilterForPVFinding` of the PV producer and fills the model inputs, one SoA row per track (`DataFormats/VertexGNNReco`, `TrackFeaturesLayout`) |
+| `gnnVertexProducer` | `vertexgnn::GNNVertexProducerAlpaka@alpaka` (plugins/alpaka/) | runs the TorchScript model on the feature SoA, output SoA `GNNOutputLayout`: `A[N,K]` assignment probabilities, `z_hat`, `t_hat`, `p` per slot (replicated per row), `pi[N,3]` PID weights |
+| `unsortedOfflinePrimaryVerticesGNN` | `PrimaryVertexProducer`, algorithm `GNN2D_alpaka` | per track the slot with the highest probability; slots with `p > existenceThreshold` and at least one track become vertex candidates at `z_hat`, tracks join their slot if the probability is at least `trackAssignmentThreshold` (`GNNClusterizerFromAlpaka`); candidates are fitted with the configured fitter (`useClusterWeights` keeps the GNN probabilities as track weights instead of the fitter's); per-track outputs stored as ValueMaps `gnnSlotAssignment`, `gnnMaxProb`, `gnnPiWeight0/1/2` |
+| `offlinePrimaryVerticesGNN`, `tofPIDGNN` | standard sorting and tofPID | as for the 4D vertices |
+| `GNNTrackInspector` | analyzer (test/ configs) | histograms of the per-track ValueMaps |
+
+The number of slots `K` is the compile-time constant `vertexgnn::kNumSlots`
+(`DataFormats/VertexGNNReco/interface/VertexGNNSoA.h`) and the model input features are the `kNumFeatures`
+columns of `TrackFeaturesLayout` in the same header, in that order. **A model can only be used with a build whose
+`kNumSlots` and feature list match it.**
+
+## Model file
+
+`RecoVertex/PrimaryVertexProducer/data/vertexSlotGNN.pt` (cms-data): TorchScript module that takes the
+`[N, kNumFeatures]` feature tensor and returns the five tensors `A[N,K]`, `z_hat[N,K]`, `t_hat[N,K]`,
+`p[N,K]`, `pi[N,3]`, every output with one row per track. `GNNVertexProducerAlpaka` runs the model once
+at construction on random input and stops with a configuration error when the model does not accept
+`kNumFeatures` features or does not return `kNumSlots` slots.
+
+## Configuration
+
+The vertex-slot vertices are added to the Phase-2 (timing layer) vertex reconstruction by the
+process modifier `vertexSlotGNN` (`Configuration/ProcessModifiers/python/vertexSlotGNN_cff.py`),
+see `RecoVertex/Configuration/python/RecoVertex_phase2_timing_cff.py` for the module definitions and
+`RecoVertex_cff.py` / `RecoVertex_EventContent_cff.py` for the task and the event content. Alpaka
+modules need the `ProcessAcceleratorAlpaka` service (`--procModifiers alpaka` with `cmsDriver`, or an
+explicit `process.load` as in the test configuration).
+
+`test/vertexTask_alpaka_cfg.py` re-runs the vertex reconstruction (3D, 4D and GNN) on a Phase-2
+GEN-SIM-RECO file; `test/mtdValidation_3way_cfg.py` and `test/mtdHarvesting_3way_cfg.py` run the MTD
+validation and harvesting for the three vertex collections into the DQM folders `MTD/Vertices/{3D,4D,GNN}`
+and `MTD/Tracks/{3D,4D,GNN}`. When merging several validation files, harvest each file first and
+`hadd` the harvested outputs.

--- a/RecoVertex/PrimaryVertexProducer/interface/GNNClusterizerFromAlpaka.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/GNNClusterizerFromAlpaka.h
@@ -1,0 +1,33 @@
+#ifndef RecoVertex_PrimaryVertexProducer_GNNClusterizerFromAlpaka_h
+#define RecoVertex_PrimaryVertexProducer_GNNClusterizerFromAlpaka_h
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+
+#include <vector>
+
+namespace vertexgnn {
+
+  class GNNClusterizerFromAlpaka {
+  public:
+    GNNClusterizerFromAlpaka(const edm::ParameterSet& conf);
+
+    std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>& tracks,
+                                          const std::vector<int>& trackSlot,
+                                          const std::vector<float>& trackMaxProb,
+                                          const std::vector<float>& z_hat,
+                                          const std::vector<float>& p) const;
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc);
+
+  private:
+    const double existenceThreshold_;
+    const double trackAssignmentThreshold_;
+    const bool verbose_;
+  };
+
+}  // namespace vertexgnn
+
+#endif

--- a/RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducer.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducer.h
@@ -39,6 +39,8 @@
 #include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/GapClusterizerInZ.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/GNNClusterizerFromAlpaka.h"
+#include "DataFormats/VertexGNNReco/interface/VertexGNNHostCollection.h"
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
 #include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexFitterBase.h"
@@ -108,4 +110,9 @@ private:
   edm::ValueMap<float> trackMTDTimeQualities_;
   edm::ValueMap<float> trackTimes_;
   double minTrackTimeQuality_;
+  std::vector<TransientVertex> clustersFromGNN(edm::Event& iEvent,
+                                               const std::vector<reco::TransientTrack>& seltks) const;
+  bool useAlpakaGNN_ = false;
+  std::unique_ptr<vertexgnn::GNNClusterizerFromAlpaka> alpakaClusterizer_;
+  edm::EDGetTokenT<vertexgnn::GNNOutputHostCollection> gnnOutputToken_;
 };

--- a/RecoVertex/PrimaryVertexProducer/interface/SequentialPrimaryVertexFitterAdapter.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/SequentialPrimaryVertexFitterAdapter.h
@@ -2,11 +2,12 @@
 #define SequentialPrimaryVertexFitterAdapter_h
 
 /**\class SequentialPrimaryVertexFitterAdapter
- 
-  Description: Adapter class for Kalman and Adaptive vertex fitters 
+
+  Description: Adapter class for Kalman and Adaptive vertex fitters
 
 */
 
+#include <map>
 #include <sstream>
 
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
@@ -17,7 +18,8 @@
 class SequentialPrimaryVertexFitterAdapter : public PrimaryVertexFitterBase {
 public:
   SequentialPrimaryVertexFitterAdapter() : fitter(nullptr) {}
-  SequentialPrimaryVertexFitterAdapter(const VertexFitter<5>* vertex_fitter) : fitter(vertex_fitter) {}
+  SequentialPrimaryVertexFitterAdapter(const VertexFitter<5>* vertex_fitter, bool useClusterWeights = false)
+      : fitter(vertex_fitter), useClusterWeights_(useClusterWeights) {}
   ~SequentialPrimaryVertexFitterAdapter() override = default;
 
   std::vector<TransientVertex> fit(const std::vector<reco::TransientTrack>& dummy,
@@ -43,6 +45,18 @@ public:
       }  // else: no fit ==> v.isValid()=False
 
       if (v.isValid()) {
+        if (useClusterWeights_ && cluster.hasTrackWeight()) {
+          std::map<const reco::Track*, float> clusterWeight;
+          for (const auto& kv : cluster.weightMap()) {
+            clusterWeight[&(kv.first.track())] = kv.second;
+          }
+          TransientVertex::TransientTrackToFloatMap weights;
+          for (const auto& tt : v.originalTracks()) {
+            auto it = clusterWeight.find(&(tt.track()));
+            weights[tt] = (it != clusterWeight.end()) ? it->second : 1.0f;
+          }
+          v.weightMap(weights);
+        }
         pvs.push_back(v);
       }
     }
@@ -52,5 +66,6 @@ public:
 protected:
   // configuration
   const VertexFitter<5>* fitter;  // Kalman or Adaptive
+  bool useClusterWeights_ = false;
 };
 #endif

--- a/RecoVertex/PrimaryVertexProducer/plugins/BuildFile.xml
+++ b/RecoVertex/PrimaryVertexProducer/plugins/BuildFile.xml
@@ -1,6 +1,30 @@
 <use name="FWCore/Framework"/>
-<use name="clhep"/>
+<use name="FWCore/ServiceRegistry"/>
+<use name="CommonTools/UtilAlgos"/>
 <use name="RecoVertex/PrimaryVertexProducer"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/TrackReco"/>
+<use name="DataFormats/VertexGNNReco"/>
+<use name="DataFormats/BeamSpot"/>
+<use name="TrackingTools/TransientTrack"/>
+<use name="TrackingTools/Records"/>
+<use name="root"/>
 <library file="*.cc" name="RecoVertexPrimaryVertexProducerPlugins">
+  <flags EDM_PLUGIN="1"/>
+</library>
+
+<library file="alpaka/*.cc" name="RecoVertexPrimaryVertexProducerPluginsPortable">
+  <use name="alpaka"/>
+  <use name="pytorch"/>
+  <use name="pytorch-cuda" for="alpaka/cuda"/>
+  <use name="DataFormats/Portable"/>
+  <use name="DataFormats/SoATemplate"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+  <use name="HeterogeneousCore/AlpakaCore"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="PhysicsTools/PyTorchAlpaka"/>
+  <flags ALPAKA_BACKENDS="1"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoVertex/PrimaryVertexProducer/plugins/GNNTrackInspector.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/GNNTrackInspector.cc
@@ -1,0 +1,130 @@
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/VertexGNNReco/interface/VertexGNNSoA.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "TH1F.h"
+
+class GNNTrackInspector : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit GNNTrackInspector(const edm::ParameterSet& iConfig);
+  ~GNNTrackInspector() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void beginJob() override;
+  void analyze(const edm::Event& iEvent, const edm::EventSetup&) override;
+
+  const edm::InputTag trackSrc_;
+  const edm::InputTag pvModule_;
+  const uint32_t printFirstN_;
+  const bool dropNaNs_;
+
+  edm::EDGetTokenT<reco::TrackCollection> tkTok_;
+  edm::EDGetTokenT<edm::ValueMap<float>> slotAssignTok_;
+  edm::EDGetTokenT<edm::ValueMap<float>> maxProbTok_;
+  edm::EDGetTokenT<edm::ValueMap<float>> piWeight0Tok_;
+  edm::EDGetTokenT<edm::ValueMap<float>> piWeight1Tok_;
+  edm::EDGetTokenT<edm::ValueMap<float>> piWeight2Tok_;
+
+  TH1F *h_slotAssign_, *h_maxProb_;
+  TH1F *h_piWeight0_, *h_piWeight1_, *h_piWeight2_;
+};
+
+GNNTrackInspector::GNNTrackInspector(const edm::ParameterSet& iConfig)
+    : trackSrc_(iConfig.getParameter<edm::InputTag>("trackSrc")),
+      pvModule_(iConfig.getParameter<edm::InputTag>("pvModule")),
+      printFirstN_(iConfig.getParameter<uint32_t>("printFirstN")),
+      dropNaNs_(iConfig.getParameter<bool>("dropNaNs")) {
+  usesResource("TFileService");
+
+  tkTok_ = consumes<reco::TrackCollection>(trackSrc_);
+
+  auto mkTag = [&](const std::string& instance) -> edm::InputTag {
+    return edm::InputTag(pvModule_.label(), instance, pvModule_.process());
+  };
+
+  slotAssignTok_ = consumes<edm::ValueMap<float>>(mkTag("gnnSlotAssignment"));
+  maxProbTok_ = consumes<edm::ValueMap<float>>(mkTag("gnnMaxProb"));
+  piWeight0Tok_ = consumes<edm::ValueMap<float>>(mkTag("gnnPiWeight0"));
+  piWeight1Tok_ = consumes<edm::ValueMap<float>>(mkTag("gnnPiWeight1"));
+  piWeight2Tok_ = consumes<edm::ValueMap<float>>(mkTag("gnnPiWeight2"));
+}
+
+void GNNTrackInspector::beginJob() {
+  edm::Service<TFileService> fs;
+  h_slotAssign_ =
+      fs->make<TH1F>("slotAssign", "GNN Slot Assignment;slot;tracks", vertexgnn::kNumSlots, 0, vertexgnn::kNumSlots);
+  h_maxProb_ = fs->make<TH1F>("maxProb", "GNN Max Assignment Prob;prob;tracks", 100, 0.0, 1.0);
+  h_piWeight0_ = fs->make<TH1F>("piWeight0", "PID Weight #pi;weight;tracks", 100, 0.0, 1.0);
+  h_piWeight1_ = fs->make<TH1F>("piWeight1", "PID Weight K;weight;tracks", 100, 0.0, 1.0);
+  h_piWeight2_ = fs->make<TH1F>("piWeight2", "PID Weight p;weight;tracks", 100, 0.0, 1.0);
+}
+
+void GNNTrackInspector::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
+  edm::Handle<reco::TrackCollection> hTracks;
+  iEvent.getByToken(tkTok_, hTracks);
+  auto const& tracks = *hTracks;
+  auto const& slotAssignVM = iEvent.get(slotAssignTok_);
+  auto const& maxProbVM = iEvent.get(maxProbTok_);
+  auto const& piWeight0VM = iEvent.get(piWeight0Tok_);
+  auto const& piWeight1VM = iEvent.get(piWeight1Tok_);
+  auto const& piWeight2VM = iEvent.get(piWeight2Tok_);
+
+  const size_t nTk = tracks.size();
+
+  auto get = [&](const edm::ValueMap<float>& vm, size_t i) -> float {
+    reco::TrackRef tref(hTracks, i);
+    float v = vm[tref];
+    return (dropNaNs_ && !std::isfinite(v)) ? 0.f : v;
+  };
+
+  for (size_t i = 0; i < std::min<size_t>(nTk, printFirstN_); ++i) {
+    float slot = get(slotAssignVM, i);
+    float maxP = get(maxProbVM, i);
+    float pw0 = get(piWeight0VM, i), pw1 = get(piWeight1VM, i), pw2 = get(piWeight2VM, i);
+
+    auto const& trk = tracks[i];
+    edm::LogInfo("GNNTrackInspector") << "track[" << i << "] pt=" << trk.pt() << " eta=" << trk.eta()
+                                      << " slot=" << slot << " maxProb=" << maxP << " piWeights=(" << pw0 << "," << pw1
+                                      << "," << pw2 << ")";
+  }
+
+  auto fillIf = [&](TH1F* h, const edm::ValueMap<float>& vm, size_t i) {
+    reco::TrackRef tref(hTracks, i);
+    float v = vm[tref];
+    if (dropNaNs_ && !std::isfinite(v))
+      return;
+    h->Fill(v);
+  };
+  for (size_t i = 0; i < nTk; ++i) {
+    fillIf(h_slotAssign_, slotAssignVM, i);
+    fillIf(h_maxProb_, maxProbVM, i);
+    fillIf(h_piWeight0_, piWeight0VM, i);
+    fillIf(h_piWeight1_, piWeight1VM, i);
+    fillIf(h_piWeight2_, piWeight2VM, i);
+  }
+}
+
+void GNNTrackInspector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("trackSrc", edm::InputTag("generalTracks"))
+      ->setComment("The TrackCollection these ValueMaps are keyed against.");
+  desc.add<edm::InputTag>("pvModule", edm::InputTag("unsortedOfflinePrimaryVerticesGNN"))
+      ->setComment("Module label of the PrimaryVertexProducer that produced gnn* ValueMaps.");
+  desc.add<uint32_t>("printFirstN", 10)->setComment("Print first N tracks per event to the Log.");
+  desc.add<bool>("dropNaNs", true)->setComment("If true, skip NaNs when filling histos.");
+  descriptions.add("GNNTrackInspector", desc);
+}
+DEFINE_FWK_MODULE(GNNTrackInspector);

--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -15,6 +15,7 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
 #include "RecoVertex/VertexTools/interface/GeometricAnnealing.h"
+#include <limits>
 
 PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf)
     : theTTBToken(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))), theConfig(conf) {
@@ -49,21 +50,34 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf)
     theTrackClusterizer = new DAClusterizerInZT_vect(
         conf.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkDAClusParameters"));
     useTransientTrackTime_ = true;
+  } else if (clusteringAlgorithm == "GNN2D_alpaka") {
+    const auto& clusParams =
+        conf.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkDAClusParameters");
+    useAlpakaGNN_ = true;
+    useTransientTrackTime_ = true;
+    theTrackClusterizer = nullptr;
+    gnnOutputToken_ = consumes<vertexgnn::GNNOutputHostCollection>(clusParams.getParameter<edm::InputTag>("gnnOutput"));
+    alpakaClusterizer_ = std::make_unique<vertexgnn::GNNClusterizerFromAlpaka>(clusParams);
+    produces<edm::ValueMap<float>>("gnnSlotAssignment");
+    produces<edm::ValueMap<float>>("gnnMaxProb");
+    produces<edm::ValueMap<float>>("gnnPiWeight0");
+    produces<edm::ValueMap<float>>("gnnPiWeight1");
+    produces<edm::ValueMap<float>>("gnnPiWeight2");
   } else {
     throw VertexException("PrimaryVertexProducer: unknown clustering algorithm: " + clusteringAlgorithm);
   }
 
   if (useTransientTrackTime_) {
-    trkTimesToken = consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("TrackTimesLabel"));
-    trkTimeResosToken = consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("TrackTimeResosLabel"));
+    trkTimesToken = consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("TrackTimesLabel"));
+    trkTimeResosToken = consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("TrackTimeResosLabel"));
     trackMTDTimeQualityToken =
-        consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("trackMTDTimeQualityVMapTag"));
+        consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackMTDTimeQualityVMapTag"));
     minTrackTimeQuality_ = conf.getParameter<double>("minTrackTimeQuality");
   }
 
   // select and configure the vertex fitters
   std::vector<edm::ParameterSet> vertexCollections =
-      conf.getParameter<std::vector<edm::ParameterSet> >("vertexCollections");
+      conf.getParameter<std::vector<edm::ParameterSet>>("vertexCollections");
 
   for (std::vector<edm::ParameterSet>::const_iterator algoconf = vertexCollections.begin();
        algoconf != vertexCollections.end();
@@ -74,11 +88,12 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf)
 
     // configure the fitter and selector
     std::string fitterAlgorithm = algoconf->getParameter<std::string>("algorithm");
+    const bool useClusterWeights = algoconf->getParameter<bool>("useClusterWeights");
     if (fitterAlgorithm == "KalmanVertexFitter") {
-      algorithm.pv_fitter = new SequentialPrimaryVertexFitterAdapter(new KalmanVertexFitter());
+      algorithm.pv_fitter = new SequentialPrimaryVertexFitterAdapter(new KalmanVertexFitter(), useClusterWeights);
     } else if (fitterAlgorithm == "AdaptiveVertexFitter") {
       auto fitter = new AdaptiveVertexFitter(GeometricAnnealing(algoconf->getParameter<double>("chi2cutoff")));
-      algorithm.pv_fitter = new SequentialPrimaryVertexFitterAdapter(fitter);
+      algorithm.pv_fitter = new SequentialPrimaryVertexFitterAdapter(fitter, useClusterWeights);
     } else if (fitterAlgorithm.empty()) {
       algorithm.pv_fitter = nullptr;
     } else if (fitterAlgorithm == "AdaptiveChisquareVertexFitter") {
@@ -261,7 +276,12 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   std::vector<reco::TransientTrack>&& seltks = theTrackFilter->select(t_tks);
 
   // clusterize tracks in Z
-  std::vector<TransientVertex>&& clusters = theTrackClusterizer->vertices(seltks);
+  std::vector<TransientVertex> clusters;
+  if (useAlpakaGNN_) {
+    clusters = clustersFromGNN(iEvent, seltks);
+  } else {
+    clusters = theTrackClusterizer->vertices(seltks);
+  }
 
   if (fVerbose) {
     edm::LogPrint("PrimaryVertexProducer")
@@ -356,6 +376,73 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   }
 }
 
+std::vector<TransientVertex> PrimaryVertexProducer::clustersFromGNN(
+    edm::Event& iEvent, const std::vector<reco::TransientTrack>& seltks) const {
+  constexpr int K = vertexgnn::kNumSlots;
+  const auto& gnnOutput = iEvent.get(gnnOutputToken_);
+  auto gnnView = gnnOutput.const_view();
+  const int nGNN = gnnView.metadata().size();
+  const int N = static_cast<int>(seltks.size());
+  if (nGNN != N) {
+    edm::LogWarning("PrimaryVertexProducer") << "GNN output has " << nGNN << " tracks but " << N
+                                             << " tracks were selected; tracks without GNN output are left unassigned";
+  }
+  const int nRead = std::min(nGNN, N);
+
+  std::vector<float> z_hat(K, 0.f), p(K, 0.f);
+  if (nRead > 0) {
+    auto elem = gnnView[0];
+    for (int k = 0; k < K; ++k) {
+      z_hat[k] = elem.z_hat()[k];
+      p[k] = elem.p()[k];
+    }
+  }
+
+  std::vector<int> trackSlot(N, -1);
+  std::vector<float> trackMaxProb(N, -1.f), pi0(N, 0.f), pi1(N, 0.f), pi2(N, 0.f);
+  for (int i = 0; i < nRead; ++i) {
+    auto elem = gnnView[i];
+    for (int k = 0; k < K; ++k) {
+      const float prob = elem.A()[k];
+      if (prob > trackMaxProb[i]) {
+        trackMaxProb[i] = prob;
+        trackSlot[i] = k;
+      }
+    }
+    pi0[i] = elem.pi()[0];
+    pi1[i] = elem.pi()[1];
+    pi2[i] = elem.pi()[2];
+  }
+
+  const auto& trkHandle = iEvent.getHandle(trkToken);
+  const size_t nAll = trkHandle->size();
+  const float nan = std::numeric_limits<float>::quiet_NaN();
+  std::vector<float> vmSlot(nAll, nan), vmMaxProb(nAll, nan), vmPi0(nAll, nan), vmPi1(nAll, nan), vmPi2(nAll, nan);
+  for (int i = 0; i < nRead; ++i) {
+    const reco::TrackRef ref = seltks[i].trackBaseRef().castTo<reco::TrackRef>();
+    if (ref.isNull() || ref.key() >= nAll)
+      continue;
+    vmSlot[ref.key()] = static_cast<float>(trackSlot[i]);
+    vmMaxProb[ref.key()] = trackMaxProb[i];
+    vmPi0[ref.key()] = pi0[i];
+    vmPi1[ref.key()] = pi1[i];
+    vmPi2[ref.key()] = pi2[i];
+  }
+  auto putValueMap = [&](const std::vector<float>& values, const std::string& label) {
+    auto out = std::make_unique<edm::ValueMap<float>>();
+    edm::ValueMap<float>::Filler filler(*out);
+    filler.insert(trkHandle, values.begin(), values.end());
+    filler.fill();
+    iEvent.put(std::move(out), label);
+  };
+  putValueMap(vmSlot, "gnnSlotAssignment");
+  putValueMap(vmMaxProb, "gnnMaxProb");
+  putValueMap(vmPi0, "gnnPiWeight0");
+  putValueMap(vmPi1, "gnnPiWeight1");
+  putValueMap(vmPi2, "gnnPiWeight2");
+
+  return alpakaClusterizer_->vertices(seltks, trackSlot, trackMaxProb, z_hat, p);
+}
 void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription psd_pv_time;
   {
@@ -381,6 +468,8 @@ void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& des
     vpsd1.add<double>("zcutoff", 1.0);
     vpsd1.add<double>("mintrkweight", 0.0);
     vpsd1.add<double>("minNdof", 0.0);
+    vpsd1.add<bool>("useClusterWeights", true)
+        ->setComment("keep the clusterizer's track weights (e.g. GNN probabilities) instead of the fitter's");
     vpsd1.add<edm::ParameterSetDescription>("vertexTimeParameters", psd_pv_time);
 
     // two default values : with- and without beam constraint
@@ -442,11 +531,17 @@ void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& des
       edm::ParameterSetDescription psd3;
       GapClusterizerInZ::fillPSetDescription(psd3);
 
+      edm::ParameterSetDescription psd4;
+      vertexgnn::GNNClusterizerFromAlpaka::fillPSetDescription(psd4);
+      psd4.add<edm::InputTag>("gnnOutput", edm::InputTag("gnnVertexProducer"))
+          ->setComment("GNNOutputHostCollection produced by GNNVertexProducerAlpaka");
       psd0.ifValue(
           edm::ParameterDescription<std::string>("algorithm", "DA_vect", true),
           "DA_vect" >> edm::ParameterDescription<edm::ParameterSetDescription>("TkDAClusParameters", psd1, true) or
               "DA2D_vect" >>
                   edm::ParameterDescription<edm::ParameterSetDescription>("TkDAClusParameters", psd2, true) or
+              "GNN2D_alpaka" >>
+                  edm::ParameterDescription<edm::ParameterSetDescription>("TkDAClusParameters", psd4, true) or
               "gap" >> edm::ParameterDescription<edm::ParameterSetDescription>("TkGapClusParameters", psd3, true));
     }
     desc.add<edm::ParameterSetDescription>("TkClusParameters", psd0);

--- a/RecoVertex/PrimaryVertexProducer/plugins/TrackFeatureProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/TrackFeatureProducer.cc
@@ -1,0 +1,157 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/VertexGNNReco/interface/VertexGNNHostCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+
+#include <cmath>
+
+namespace vertexgnn {
+
+  class TrackFeatureProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit TrackFeatureProducer(const edm::ParameterSet& params)
+        : trackToken_(consumes<reco::TrackCollection>(params.getParameter<edm::InputTag>("tracks"))),
+          beamSpotToken_(consumes<reco::BeamSpot>(params.getParameter<edm::InputTag>("beamSpot"))),
+          mvaToken_(consumes<edm::ValueMap<float>>(params.getParameter<edm::InputTag>("trackMTDTimeQualityVMapTag"))),
+          tmtdToken_(consumes<edm::ValueMap<float>>(params.getParameter<edm::InputTag>("tmtdSrc"))),
+          sigmatmtdToken_(consumes<edm::ValueMap<float>>(params.getParameter<edm::InputTag>("sigmatmtdSrc"))),
+          pathLengthToken_(consumes<edm::ValueMap<float>>(params.getParameter<edm::InputTag>("pathmtd"))),
+          tofPiToken_(consumes<edm::ValueMap<float>>(params.getParameter<edm::InputTag>("tofPi"))),
+          tofKToken_(consumes<edm::ValueMap<float>>(params.getParameter<edm::InputTag>("tofK"))),
+          tofPToken_(consumes<edm::ValueMap<float>>(params.getParameter<edm::InputTag>("tofP"))),
+          sigmaTofPiToken_(consumes<edm::ValueMap<float>>(params.getParameter<edm::InputTag>("sigmatofpiSrc"))),
+          sigmaTofKToken_(consumes<edm::ValueMap<float>>(params.getParameter<edm::InputTag>("sigmatofkSrc"))),
+          sigmaTofPToken_(consumes<edm::ValueMap<float>>(params.getParameter<edm::InputTag>("sigmatofpSrc"))),
+          ttbToken_(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))),
+          trackFilter_(params.getParameter<edm::ParameterSet>("TkFilterParameters")) {
+      produces<TrackFeaturesHostCollection>();
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
+      desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
+      desc.add<edm::InputTag>("trackMTDTimeQualityVMapTag", edm::InputTag("mtdTrackQualityMVA:mtdQualMVA"));
+      desc.add<edm::InputTag>("tmtdSrc", edm::InputTag("trackExtenderWithMTD:generalTracktmtd"));
+      desc.add<edm::InputTag>("sigmatmtdSrc", edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"));
+      desc.add<edm::InputTag>("pathmtd", edm::InputTag("trackExtenderWithMTD:generalTrackPathLength"));
+      desc.add<edm::InputTag>("tofPi", edm::InputTag("trackExtenderWithMTD:generalTrackTofPi"));
+      desc.add<edm::InputTag>("tofK", edm::InputTag("trackExtenderWithMTD:generalTrackTofK"));
+      desc.add<edm::InputTag>("tofP", edm::InputTag("trackExtenderWithMTD:generalTrackTofP"));
+      desc.add<edm::InputTag>("sigmatofpiSrc", edm::InputTag("trackExtenderWithMTD:generalTrackSigmaTofPi"));
+      desc.add<edm::InputTag>("sigmatofkSrc", edm::InputTag("trackExtenderWithMTD:generalTrackSigmaTofK"));
+      desc.add<edm::InputTag>("sigmatofpSrc", edm::InputTag("trackExtenderWithMTD:generalTrackSigmaTofP"));
+      edm::ParameterSetDescription filterDesc;
+      TrackFilterForPVFinding::fillPSetDescription(filterDesc);
+      desc.add<edm::ParameterSetDescription>("TkFilterParameters", filterDesc)
+          ->setComment("must be identical to the TkFilterParameters of the PrimaryVertexProducer using the GNN");
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+    void produce(edm::Event& event, const edm::EventSetup& eventSetup) override {
+      const auto trackHandle = event.getHandle(trackToken_);
+      const auto& beamSpot = event.get(beamSpotToken_);
+      const auto& mva = event.get(mvaToken_);
+      const auto& tmtd = event.get(tmtdToken_);
+      const auto& sigmatmtd = event.get(sigmatmtdToken_);
+      const auto& pathLength = event.get(pathLengthToken_);
+      const auto& tofPi = event.get(tofPiToken_);
+      const auto& tofK = event.get(tofKToken_);
+      const auto& tofP = event.get(tofPToken_);
+      const auto& sigmaTofPi = event.get(sigmaTofPiToken_);
+      const auto& sigmaTofK = event.get(sigmaTofKToken_);
+      const auto& sigmaTofP = event.get(sigmaTofPToken_);
+
+      const auto& ttBuilder = eventSetup.getData(ttbToken_);
+      const std::vector<reco::TransientTrack> selectedTracks =
+          trackFilter_.select(ttBuilder.build(trackHandle, beamSpot));
+      const int N = selectedTracks.size();
+
+      auto features = std::make_unique<TrackFeaturesHostCollection>(cms::alpakatools::host(), N);
+      auto view = features->view();
+      for (int i = 0; i < N; ++i) {
+        const reco::Track& track = selectedTracks[i].track();
+        const reco::TrackBaseRef ref = selectedTracks[i].trackBaseRef();
+
+        float trackMva = mva[ref];
+        float trackPathLength = pathLength[ref];
+        if (!std::isfinite(trackMva))
+          trackMva = -1.f;
+        if (!std::isfinite(trackPathLength))
+          trackPathLength = -1.f;
+
+        const float tMtd = tmtd[ref];
+        const float sigmaTMtd = sigmatmtd[ref];
+        const bool tmtdValid = (sigmaTMtd >= 0.f);
+        float t_pi = 0.f, t_k = 0.f, t_p = 0.f;
+        float s_pi = 0.2f, s_k = 0.2f, s_p = 0.2f;
+        if (tmtdValid && sigmaTofPi[ref] >= 0.f) {
+          t_pi = tMtd - tofPi[ref];
+          s_pi = combineSigma(sigmaTofPi[ref], sigmaTMtd);
+        }
+        if (tmtdValid && sigmaTofK[ref] >= 0.f) {
+          t_k = tMtd - tofK[ref];
+          s_k = combineSigma(sigmaTofK[ref], sigmaTMtd);
+        }
+        if (tmtdValid && sigmaTofP[ref] >= 0.f) {
+          t_p = tMtd - tofP[ref];
+          s_p = combineSigma(sigmaTofP[ref], sigmaTMtd);
+        }
+
+        view[i].vz() = sanitize(track.vz());
+        view[i].dz() = sanitize(track.dzError());
+        view[i].pt() = sanitize(track.pt());
+        view[i].eta() = sanitize(track.eta());
+        view[i].mva() = sanitize(trackMva);
+        view[i].pl() = sanitize(trackPathLength);
+        view[i].t_pi() = sanitize(t_pi);
+        view[i].t_k() = sanitize(t_k);
+        view[i].t_p() = sanitize(t_p);
+        view[i].s_pi() = sanitize(s_pi);
+        view[i].s_k() = sanitize(s_k);
+        view[i].s_p() = sanitize(s_p);
+        view[i].has_time() = (trackMva >= 0.f) ? 1.f : 0.f;
+      }
+      event.put(std::move(features));
+    }
+
+  private:
+    static float combineSigma(float sigmaTof, float sigmaTMtd) {
+      const float a = std::max(sigmaTof, 0.f);
+      const float b = std::max(sigmaTMtd, 0.f);
+      const float out = std::sqrt(a * a + b * b + 1e-12f);
+      return std::isfinite(out) ? out : 1e9f;
+    }
+    static float sanitize(float v) { return std::isfinite(v) ? v : 1e9f; }
+
+    const edm::EDGetTokenT<reco::TrackCollection> trackToken_;
+    const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> mvaToken_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> tmtdToken_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> sigmatmtdToken_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> tofPiToken_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> tofKToken_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> tofPToken_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> sigmaTofPiToken_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> sigmaTofKToken_;
+    const edm::EDGetTokenT<edm::ValueMap<float>> sigmaTofPToken_;
+    const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttbToken_;
+    const TrackFilterForPVFinding trackFilter_;
+  };
+
+}  // namespace vertexgnn
+
+DEFINE_FWK_MODULE(vertexgnn::TrackFeatureProducer);

--- a/RecoVertex/PrimaryVertexProducer/plugins/alpaka/GNNVertexProducerAlpaka.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/alpaka/GNNVertexProducerAlpaka.cc
@@ -1,0 +1,131 @@
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDPutToken.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "PhysicsTools/PyTorchAlpaka/interface/TensorCollection.h"
+#include "PhysicsTools/PyTorchAlpaka/interface/alpaka/AlpakaModel.h"
+#include "DataFormats/VertexGNNReco/interface/VertexGNNSoA.h"
+#include "DataFormats/VertexGNNReco/interface/VertexGNNHostCollection.h"
+#include "DataFormats/VertexGNNReco/interface/alpaka/VertexGNNDeviceCollection.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexgnn {
+
+  class GNNVertexProducerAlpaka : public stream::EDProducer<> {
+  public:
+    explicit GNNVertexProducerAlpaka(const edm::ParameterSet& params)
+        : EDProducer<>(params),
+
+          trackFeaturesToken_(
+              consumes<::vertexgnn::TrackFeaturesHostCollection>(params.getParameter<edm::InputTag>("trackFeatures"))),
+          gnnOutputToken_{produces()},
+          model_(params.getParameter<edm::FileInPath>("model").fullPath()),
+          verbose_(params.getUntrackedParameter<bool>("verbose", false)) {
+      checkModel();
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<edm::FileInPath>("model", edm::FileInPath("RecoVertex/PrimaryVertexProducer/data/vertexSlotGNN.pt"));
+      desc.add<edm::InputTag>("trackFeatures", edm::InputTag("trackFeatureProducer"));
+      desc.addUntracked<bool>("verbose", false);
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+    void produce(device::Event& event, const device::EventSetup& eventSetup) override {
+      const auto& hostInput = event.get(trackFeaturesToken_);
+      const auto N = hostInput.const_view().metadata().size();
+
+      if (verbose_) {
+        edm::LogInfo("GNNVertexProducerAlpaka")
+            << "N=" << N << " tracks (from HostCollection), K=" << ::vertexgnn::kNumSlots << " slots";
+      }
+
+      TrackFeaturesDeviceCollection deviceInput(event.queue(), N);
+      alpaka::memcpy(event.queue(), deviceInput.buffer(), hostInput.buffer());
+
+      GNNOutputDeviceCollection deviceOutput(event.queue(), N);
+
+      auto inputRecords = deviceInput.const_view().records();
+      auto outputRecords = deviceOutput.view().records();
+
+      cms::torch::alpakatools::TensorCollection<Queue> inputs(N);
+      inputs.add<::vertexgnn::TrackFeaturesSoA>("features",
+                                                inputRecords.vz(),
+                                                inputRecords.dz(),
+                                                inputRecords.pt(),
+                                                inputRecords.eta(),
+                                                inputRecords.mva(),
+                                                inputRecords.pl(),
+                                                inputRecords.t_pi(),
+                                                inputRecords.t_k(),
+                                                inputRecords.t_p(),
+                                                inputRecords.s_pi(),
+                                                inputRecords.s_k(),
+                                                inputRecords.s_p(),
+                                                inputRecords.has_time());
+
+      cms::torch::alpakatools::TensorCollection<Queue> outputs(N);
+      outputs.add<::vertexgnn::GNNOutputSoA>("A", outputRecords.A());
+      outputs.add<::vertexgnn::GNNOutputSoA>("z_hat", outputRecords.z_hat());
+      outputs.add<::vertexgnn::GNNOutputSoA>("t_hat", outputRecords.t_hat());
+      outputs.add<::vertexgnn::GNNOutputSoA>("p", outputRecords.p());
+      outputs.add<::vertexgnn::GNNOutputSoA>("pi", outputRecords.pi());
+
+      if (verbose_) {
+        edm::LogInfo("GNNVertexProducerAlpaka") << "Running model_.forward(queue, inputs, outputs) on device...";
+      }
+
+      model_.forward(event.queue(), inputs, outputs);
+
+      if (verbose_) {
+        edm::LogInfo("GNNVertexProducerAlpaka") << "Inference complete";
+      }
+
+      event.emplace(gnnOutputToken_, std::move(deviceOutput));
+    }
+
+  private:
+    void checkModel() {
+      constexpr int nTracks = 64;
+      std::vector<::torch::IValue> inputs{::torch::rand({nTracks, ::vertexgnn::kNumFeatures})};
+      ::torch::IValue result;
+      try {
+        result = model_.forward(inputs);
+      } catch (const std::exception& e) {
+        throw cms::Exception("Configuration")
+            << "GNNVertexProducerAlpaka: the model does not accept " << ::vertexgnn::kNumFeatures << " track features\n"
+            << e.what();
+      }
+      if (!result.isTuple() || result.toTuple()->elements().size() != 5) {
+        throw cms::Exception("Configuration")
+            << "GNNVertexProducerAlpaka: the model must return the 5 tensors A, z_hat, t_hat, p, pi";
+      }
+      const auto A = result.toTuple()->elements()[0].toTensor();
+      const auto slots = (A.dim() == 2) ? A.size(1) : -1;
+      if (slots != ::vertexgnn::kNumSlots) {
+        throw cms::Exception("Configuration")
+            << "GNNVertexProducerAlpaka: the model has " << slots
+            << " vertex slots, the build expects kNumSlots = " << ::vertexgnn::kNumSlots;
+      }
+    }
+
+    const edm::EDGetTokenT<::vertexgnn::TrackFeaturesHostCollection> trackFeaturesToken_;
+    const device::EDPutToken<GNNOutputDeviceCollection> gnnOutputToken_;
+    torch::AlpakaModel model_;
+    const bool verbose_;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::vertexgnn
+
+DEFINE_FWK_ALPAKA_MODULE(vertexgnn::GNNVertexProducerAlpaka);

--- a/RecoVertex/PrimaryVertexProducer/src/GNNClusterizerFromAlpaka.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/GNNClusterizerFromAlpaka.cc
@@ -1,0 +1,68 @@
+#include "RecoVertex/PrimaryVertexProducer/interface/GNNClusterizerFromAlpaka.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+namespace vertexgnn {
+
+  GNNClusterizerFromAlpaka::GNNClusterizerFromAlpaka(const edm::ParameterSet& conf)
+      : existenceThreshold_(conf.getParameter<double>("existenceThreshold")),
+        trackAssignmentThreshold_(conf.getParameter<double>("trackAssignmentThreshold")),
+        verbose_(conf.getUntrackedParameter<bool>("verbose", false)) {}
+
+  std::vector<TransientVertex> GNNClusterizerFromAlpaka::vertices(const std::vector<reco::TransientTrack>& tracks,
+                                                                  const std::vector<int>& trackSlot,
+                                                                  const std::vector<float>& trackMaxProb,
+                                                                  const std::vector<float>& z_hat,
+                                                                  const std::vector<float>& p) const {
+    std::vector<TransientVertex> clusters;
+    const int N = tracks.size();
+    const int K = z_hat.size();
+    if (N == 0 || K == 0) {
+      return clusters;
+    }
+
+    std::vector<int> slotTrackCount(K, 0);
+    for (int i = 0; i < N; ++i) {
+      if (trackSlot[i] >= 0 && trackSlot[i] < K) {
+        slotTrackCount[trackSlot[i]]++;
+      }
+    }
+
+    const GlobalError dummyError(0.01, 0, 0.01, 0., 0., 0.01);
+    for (int k = 0; k < K; ++k) {
+      if (!(p[k] > existenceThreshold_ && slotTrackCount[k] >= 1)) {
+        continue;
+      }
+      std::vector<reco::TransientTrack> clusterTracks;
+      std::vector<float> clusterWeights;
+      for (int i = 0; i < N; ++i) {
+        if (trackSlot[i] == k && trackMaxProb[i] >= trackAssignmentThreshold_) {
+          clusterTracks.push_back(tracks[i]);
+          clusterWeights.push_back(trackMaxProb[i]);
+        }
+      }
+      if (clusterTracks.empty()) {
+        continue;
+      }
+      TransientVertex vertex(GlobalPoint(0, 0, z_hat[k]), dummyError, clusterTracks, 0);
+      TransientVertex::TransientTrackToFloatMap weightMap;
+      for (size_t i = 0; i < clusterTracks.size(); ++i) {
+        weightMap[clusterTracks[i]] = clusterWeights[i];
+      }
+      vertex.weightMap(weightMap);
+      clusters.push_back(vertex);
+    }
+
+    if (verbose_) {
+      edm::LogPrint("GNNClusterizerFromAlpaka") << "vertex-slot GNN: " << clusters.size() << " vertex candidates from "
+                                                << N << " tracks and " << K << " slots";
+    }
+    return clusters;
+  }
+
+  void GNNClusterizerFromAlpaka::fillPSetDescription(edm::ParameterSetDescription& desc) {
+    desc.add<double>("existenceThreshold", 0.5)->setComment("minimum slot existence probability");
+    desc.add<double>("trackAssignmentThreshold", 0.5)->setComment("minimum track assignment probability");
+    desc.addUntracked<bool>("verbose", false);
+  }
+
+}  // namespace vertexgnn

--- a/RecoVertex/PrimaryVertexProducer/test/mtdHarvesting_3way_cfg.py
+++ b/RecoVertex/PrimaryVertexProducer/test/mtdHarvesting_3way_cfg.py
@@ -1,0 +1,80 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C22I13M9_cff import Phase2C22I13M9
+process = cms.Process('mtdHarvesting', Phase2C22I13M9)
+
+input_file = "file:mtdValidation_3way.root"
+
+print("=" * 60)
+print("MTD 3-way harvesting (3D + 4D + GNN)")
+print(f"Input: {input_file}")
+print("=" * 60)
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.StandardSequences.EDMtoMEAtRunEnd_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load("Configuration.Geometry.GeometryExtendedRun4D121Reco_cff")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
+
+process.MessageLogger.cerr.FwkReport = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32(-1),
+)
+
+process.source = cms.Source("DQMRootSource",
+    fileNames = cms.untracked.vstring(input_file)
+)
+
+process.edmtome_step = cms.Path(process.EDMtoME)
+process.dqmsave_step = cms.Path(process.DQMSaver)
+
+process.load("Validation.MtdValidation.btlSimHitsPostProcessor_cfi")
+process.load("Validation.MtdValidation.btlLocalRecoPostProcessor_cfi")
+process.load("Validation.MtdValidation.MtdEleIsoPostProcessor_cfi")
+process.load("Validation.MtdValidation.MtdTracksPostProcessor_cfi")
+process.load("Validation.MtdValidation.Primary4DVertexPostProcessor_cfi")
+
+process.Primary4DVertexPostProcessor3D = process.Primary4DVertexPostProcessor.clone(
+    folder = cms.string('MTD/Vertices/3D/')
+)
+process.MtdTracksPostProcessor3D = process.MtdTracksPostProcessor.clone(
+    folder = cms.string('MTD/Tracks/3D/')
+)
+
+process.Primary4DVertexPostProcessor.folder = cms.string('MTD/Vertices/4D/')
+process.MtdTracksPostProcessor.folder = cms.string('MTD/Tracks/4D/')
+
+process.Primary4DVertexPostProcessorGNN = process.Primary4DVertexPostProcessor.clone(
+    folder = cms.string('MTD/Vertices/GNN/')
+)
+process.MtdTracksPostProcessorGNN = process.MtdTracksPostProcessor.clone(
+    folder = cms.string('MTD/Tracks/GNN/')
+)
+
+process.harvesting = cms.Sequence(
+    process.btlSimHitsPostProcessor +
+    process.btlLocalRecoPostProcessor +
+    process.MtdEleIsoPostProcessor +
+
+    process.Primary4DVertexPostProcessor3D +
+    process.MtdTracksPostProcessor3D +
+
+    process.Primary4DVertexPostProcessor +
+    process.MtdTracksPostProcessor +
+
+    process.Primary4DVertexPostProcessorGNN +
+    process.MtdTracksPostProcessorGNN
+)
+
+process.p = cms.Path(process.harvesting)
+
+process.schedule = cms.Schedule(process.edmtome_step, process.p, process.dqmsave_step)
+
+print("\nHarvesting post-processors:")
+print("  - Primary4DVertexPostProcessor3D  -> MTD/Vertices/3D/")
+print("  - Primary4DVertexPostProcessor    -> MTD/Vertices/4D/")
+print("  - Primary4DVertexPostProcessorGNN -> MTD/Vertices/GNN/")
+print("  - MtdTracksPostProcessor3D        -> MTD/Tracks/3D/")
+print("  - MtdTracksPostProcessor          -> MTD/Tracks/4D/")
+print("  - MtdTracksPostProcessorGNN       -> MTD/Tracks/GNN/")

--- a/RecoVertex/PrimaryVertexProducer/test/mtdValidation_3way_cfg.py
+++ b/RecoVertex/PrimaryVertexProducer/test/mtdValidation_3way_cfg.py
@@ -1,0 +1,160 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C22I13M9_cff import Phase2C22I13M9
+process = cms.Process('mtdValidation', Phase2C22I13M9)
+
+input_file = "file:revtx_step3_alpaka.root"
+output_file = "file:mtdValidation_3way.root"
+
+print("=" * 60)
+print("MTD 3-way validation (3D + 4D + GNN)")
+print(f"Input:  {input_file}")
+print(f"Output: {output_file}")
+print("=" * 60)
+
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+
+process.load("Configuration.Geometry.GeometryExtendedRun4D121Reco_cff")
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T35', '')
+process.load('RecoLocalFastTime.FTLClusterizer.MTDCPEESProducer_cfi')
+process.load("Configuration.StandardSequences.Reconstruction_cff")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
+
+process.options.numberOfThreads = 1
+process.options.numberOfStreams = 0
+process.options.numberOfConcurrentLuminosityBlocks = 0
+process.options.eventSetup.numberOfConcurrentIOVs = 1
+
+process.MessageLogger.cerr.FwkReport = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32(10),
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(input_file)
+)
+
+process.mix.digitizers = cms.PSet()
+for a in process.aliases: delattr(process, a)
+
+process.load("Validation.MtdValidation.btlSimHitsValid_cfi")
+process.load("Validation.MtdValidation.btlDigiHitsValid_cfi")
+process.load("Validation.MtdValidation.btlLocalRecoValid_cfi")
+btlValidation = cms.Sequence(process.btlSimHitsValid + process.btlDigiHitsValid + process.btlLocalRecoValid)
+
+process.load("Validation.MtdValidation.etlSimHitsValid_cfi")
+process.load("Validation.MtdValidation.etlDigiHitsValid_cfi")
+process.load("Validation.MtdValidation.etlLocalRecoValid_cfi")
+etlValidation = cms.Sequence(process.etlSimHitsValid + process.etlDigiHitsValid + process.etlLocalRecoValid)
+
+process.load("Validation.MtdValidation.mtdEleIsoValid_cfi")
+
+process.load("Validation.MtdValidation.mtdTracksValid_cfi")
+process.load("Validation.MtdValidation.vertices4DValid_cfi")
+
+process.vertices3DValid = process.vertices4DValid.clone(
+    folder = cms.string('MTD/Vertices/3D/'),
+    offline4DPV = 'offlinePrimaryVertices',
+    t0PID = 'tofPID3D:t0',
+    t0SafePID = 'tofPID3D:t0safe',
+    sigmat0SafePID = 'tofPID3D:sigmat0safe',
+    probPi = 'tofPID3D:probPi',
+    probK = 'tofPID3D:probK',
+    probP = 'tofPID3D:probP',
+    optionalPlots = True,
+)
+
+process.mtdTracks3DValid = process.mtdTracksValid.clone(
+    folder = cms.string('MTD/Tracks/3D/'),
+    inputTagV = 'offlinePrimaryVertices',
+    t0PID = 'tofPID3D:t0',
+    t0SafePID = 'tofPID3D:t0safe',
+    sigmat0SafePID = 'tofPID3D:sigmat0safe',
+    sigmat0PID = 'tofPID3D:sigmat0',
+)
+
+process.vertices4DValid.folder = cms.string('MTD/Vertices/4D/')
+process.vertices4DValid.offline4DPV = 'offlinePrimaryVertices4D'
+process.vertices4DValid.t0PID = 'tofPID:t0'
+process.vertices4DValid.t0SafePID = 'tofPID:t0safe'
+process.vertices4DValid.sigmat0SafePID = 'tofPID:sigmat0safe'
+process.vertices4DValid.probPi = 'tofPID:probPi'
+process.vertices4DValid.probK = 'tofPID:probK'
+process.vertices4DValid.probP = 'tofPID:probP'
+process.vertices4DValid.optionalPlots = True
+
+process.mtdTracksValid.folder = cms.string('MTD/Tracks/4D/')
+process.mtdTracksValid.inputTagV = 'offlinePrimaryVertices4D'
+process.mtdTracksValid.t0PID = 'tofPID:t0'
+process.mtdTracksValid.t0SafePID = 'tofPID:t0safe'
+process.mtdTracksValid.sigmat0SafePID = 'tofPID:sigmat0safe'
+process.mtdTracksValid.sigmat0PID = 'tofPID:sigmat0'
+
+process.verticesGNNValid = process.vertices4DValid.clone(
+    folder = cms.string('MTD/Vertices/GNN/'),
+    offline4DPV = 'offlinePrimaryVerticesGNN',
+    t0PID = 'tofPIDGNN:t0',
+    t0SafePID = 'tofPIDGNN:t0safe',
+    sigmat0SafePID = 'tofPIDGNN:sigmat0safe',
+    probPi = 'unsortedOfflinePrimaryVerticesGNN:gnnPiWeight0',
+    probK = 'unsortedOfflinePrimaryVerticesGNN:gnnPiWeight1',
+    probP = 'unsortedOfflinePrimaryVerticesGNN:gnnPiWeight2',
+    trackweightTh = 0.0,
+    optionalPlots = True,
+)
+
+process.mtdTracksGNNValid = process.mtdTracksValid.clone(
+    folder = cms.string('MTD/Tracks/GNN/'),
+    inputTagV = 'offlinePrimaryVerticesGNN',
+    t0PID = 'tofPIDGNN:t0',
+    t0SafePID = 'tofPIDGNN:t0safe',
+    sigmat0SafePID = 'tofPIDGNN:sigmat0safe',
+    sigmat0PID = 'tofPIDGNN:sigmat0',
+)
+
+process.validation = cms.Sequence(
+    btlValidation +
+    etlValidation +
+
+    process.vertices3DValid +
+    process.mtdTracks3DValid +
+
+    process.mtdTracksValid +
+    process.vertices4DValid +
+
+    process.verticesGNNValid +
+    process.mtdTracksGNNValid +
+
+    process.mtdEleIsoValid
+)
+
+process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('DQMIO'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string(output_file),
+    outputCommands = process.DQMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+process.p = cms.Path(process.mix + process.mtdTrackingRecHits + process.validation)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+process.schedule = cms.Schedule(process.p, process.endjob_step, process.DQMoutput_step)
+
+print("\nValidation modules:")
+print("  - vertices3DValid    -> MTD/Vertices/3D/  (offlinePrimaryVertices)")
+print("  - vertices4DValid    -> MTD/Vertices/4D/  (offlinePrimaryVertices4D)")
+print("  - verticesGNNValid   -> MTD/Vertices/GNN/ (offlinePrimaryVerticesGNN)")
+print("  - mtdTracks3DValid   -> MTD/Tracks/3D/")
+print("  - mtdTracksValid     -> MTD/Tracks/4D/")
+print("  - mtdTracksGNNValid  -> MTD/Tracks/GNN/")

--- a/RecoVertex/PrimaryVertexProducer/test/vertexTask_alpaka_cfg.py
+++ b/RecoVertex/PrimaryVertexProducer/test/vertexTask_alpaka_cfg.py
@@ -1,0 +1,81 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Phase2C22I13M9_cff import Phase2C22I13M9
+from Configuration.ProcessModifiers.vertexSlotGNN_cff import vertexSlotGNN
+
+process = cms.Process('REVTX', Phase2C22I13M9, vertexSlotGNN)
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi')
+process.load('HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4D121Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T35', '')
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_20_0_0/RelValTTbar_14TeV/GEN-SIM-RECO/PU_150X_mcRun4_realistic_v1_STD_D121_RegeneratedGS_PU_16Aug26-v6/2590000/02886033-95df-4ef9-9bc6-b148f6aaf487.root',
+    ),
+    inputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_SimClusterToCaloParticleAssociation_*_*',
+        'drop *_allTrackstersToSimTrackstersAssociationsByLCs_*_*',
+        'drop *_allTrackstersToSimTrackstersAssociationsByHits_*_*',
+    ),
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(1),
+    wantSummary = cms.untracked.bool(True),
+)
+process.MessageLogger.cerr.FwkReport.reportEvery = 10
+
+process.exe = cms.Path(process.firstStepPrimaryVerticesUnsorted * process.vertexreco)
+
+process.TFileService = cms.Service("TFileService", fileName = cms.string("gnn_inspector.root"))
+process.gnnInspector = cms.EDAnalyzer("GNNTrackInspector",
+    pvModule = cms.InputTag("unsortedOfflinePrimaryVerticesGNN", "", "REVTX"),
+    trackSrc = cms.InputTag("generalTracks"),
+    printFirstN = cms.uint32(0),
+    dropNaNs = cms.bool(True),
+)
+process.inspect_path = cms.EndPath(process.gnnInspector)
+
+outputCommands = cms.untracked.vstring(list(process.FEVTDEBUGHLTEventContent.outputCommands) + [
+    'drop *_offlinePrimaryVertices_*_RECO',
+    'drop *_offlinePrimaryVertices4D_*_RECO',
+    'drop *_offlinePrimaryVertices4DWithBS_*_RECO',
+    'drop *_offlinePrimaryVerticesWithBS_*_RECO',
+    'drop *_TriggerResults_*_RECO',
+    'drop *_trackTimeValueMapProducer_generalTracksConfigurableFlatResolutionModel_RECO',
+    'drop *_trackTimeValueMapProducer_generalTracksConfigurableFlatResolutionModelResolution_RECO',
+    'drop *_trackTimeValueMapProducer_generalTracksPerfectResolutionModel_RECO',
+    'drop *_trackTimeValueMapProducer_generalTracksPerfectResolutionModelResolution_RECO',
+    'drop *_tofPID_probK_RECO',
+    'drop *_tofPID_probP_RECO',
+    'drop *_tofPID_probPi_RECO',
+    'drop *_tofPID_sigmat0_RECO',
+    'drop *_tofPID_sigmat0safe_RECO',
+    'drop *_tofPID_t0_RECO',
+    'drop *_tofPID_t0safe_RECO',
+    'drop *_ak4CaloJetsForTrk_*_RECO',
+    'drop *_inclusiveSecondaryVertices_*_RECO',
+    'drop *_generalV0Candidates_Kshort_RECO',
+    'drop *_generalV0Candidates_Lambda_RECO',
+])
+process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(dataTier = cms.untracked.string('GEN-SIM-RECO'), filterName = cms.untracked.string('')),
+    fileName = cms.untracked.string('file:revtx_step3_alpaka.root'),
+    outputCommands = outputCommands,
+    splitLevel = cms.untracked.int32(0),
+)
+process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
+
+from Validation.Performance.TimeMemorySummary import customiseWithTimeMemorySummary
+process = customiseWithTimeMemorySummary(process)

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -390,11 +390,18 @@ private:
   MonitorElement* meSimPVTvsZ_;
 
   MonitorElement* meVtxTrackMult_;
+  MonitorElement* meVtxTrackMultLin_;
   MonitorElement* meVtxTrackMultPassNdof_;
+  MonitorElement* meVtxTrackMultPassNdofLin_;
   MonitorElement* meVtxTrackMultFailNdof_;
   MonitorElement* meVtxTrackW_;
   MonitorElement* meVtxTrackWnt_;
   MonitorElement* meVtxTrackRecLVMult_;
+  MonitorElement* meVtxTrackRecLVMultLin_;
+  MonitorElement* meVtxTrackRecLVMult20_;
+  MonitorElement* meVtxTrackRecLVMultLin20_;
+  MonitorElement* meVtxTrackRecLVMult60_;
+  MonitorElement* meVtxTrackRecLVMultLin60_;
   MonitorElement* meVtxTrackRecLVW_;
   MonitorElement* meVtxTrackRecLVWnt_;
 
@@ -795,13 +802,26 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
   meSimPVTvsZ_ = ibook.bookProfile("simPVTvsZ", "PV Time vs Z", 30, -15., 15., 30, -0.75, 0.75);
 
   meVtxTrackMult_ = ibook.book1D("VtxTrackMult", "Log10(Vertex track multiplicity)", 80, 0.5, 2.5);
+  meVtxTrackMultLin_ = ibook.book1D("VtxTrackMultLin", "Vertex track multiplicity", 80, 3., 320.);
   meVtxTrackMultPassNdof_ =
       ibook.book1D("VtxTrackMultPassNdof", "Log10(Vertex track multiplicity for ndof>4)", 80, 0.5, 2.5);
+  meVtxTrackMultPassNdofLin_ =
+      ibook.book1D("VtxTrackMultPassNdofLin", "Vertex track multiplicity for ndof>4", 80, 3., 320.);
   meVtxTrackMultFailNdof_ = ibook.book1D("VtxTrackMultFailNdof", "Vertex track multiplicity for ndof<4", 10, 0., 10.);
   meVtxTrackW_ = ibook.book1D("VtxTrackW", "Vertex track weight (all)", 50, 0., 1.);
   meVtxTrackWnt_ = ibook.book1D("VtxTrackWnt", "Vertex track Wnt", 50, 0., 1.);
   meVtxTrackRecLVMult_ =
-      ibook.book1D("VtxTrackRecLVMult", "Log10(Vertex track multiplicity) for matched LV", 80, 0.5, 2.5);
+      ibook.book1D("VtxTrackRecLVMult", "Log10(Vertex track multiplicity) for matched LV", 40, 0.5, 2.5);
+  meVtxTrackRecLVMultLin_ =
+      ibook.book1D("VtxTrackRecLVMultLin", "Vertex track multiplicity for matched LV", 40, 3., 320.);
+  meVtxTrackRecLVMult20_ =
+      ibook.book1D("VtxTrackRecLVMult20", "Log10(Vertex track multiplicity) for matched LV (20 bins)", 20, 0.5, 2.5);
+  meVtxTrackRecLVMultLin20_ =
+      ibook.book1D("VtxTrackRecLVMultLin20", "Vertex track multiplicity for matched LV (20 bins)", 20, 3., 320.);
+  meVtxTrackRecLVMult60_ =
+      ibook.book1D("VtxTrackRecLVMult60", "Log10(Vertex track multiplicity) for matched LV (60 bins)", 60, 0.5, 2.5);
+  meVtxTrackRecLVMultLin60_ =
+      ibook.book1D("VtxTrackRecLVMultLin60", "Vertex track multiplicity for matched LV (60 bins)", 60, 3., 320.);
   meVtxTrackRecLVW_ = ibook.book1D("VtxTrackRecLVW", "Vertex track weight for matched LV (all)", 50, 0., 1.);
   meVtxTrackRecLVWnt_ = ibook.book1D("VtxTrackRecLVWnt", "Vertex track Wnt for matched LV", 50, 0., 1.);
 
@@ -2901,6 +2921,7 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
         }  // loop on reco tracks
         if (selectedVtxMatching) {
           meVtxTrackMult_->Fill(log10(nt));
+          meVtxTrackMultLin_->Fill(nt);
           mePUTrackRelMult_->Fill(static_cast<double>(PUnt) / nt);
           meFakeTrackRelMult_->Fill(static_cast<double>(Fakent) / nt);
           mePUTrackRelSumWnt_->Fill(PUsumWnt / sumWnt);
@@ -2973,6 +2994,11 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
           }
           if (selectedLV) {
             meVtxTrackRecLVMult_->Fill(log10(nt));
+            meVtxTrackRecLVMultLin_->Fill(nt);
+            meVtxTrackRecLVMult20_->Fill(log10(nt));
+            meVtxTrackRecLVMultLin20_->Fill(nt);
+            meVtxTrackRecLVMult60_->Fill(log10(nt));
+            meVtxTrackRecLVMultLin60_->Fill(nt);
             mePUTrackRecLVRelMult_->Fill(static_cast<double>(PUnt) / nt);
             meFakeTrackRecLVRelMult_->Fill(static_cast<double>(Fakent) / nt);
             mePUTrackRecLVRelSumWnt_->Fill(PUsumWnt / sumWnt);
@@ -3055,6 +3081,7 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
     if (recopv.at(ir).ndof > selNdof_) {
       meRecPVZ_->Fill(recopv.at(ir).z);
       meVtxTrackMultPassNdof_->Fill(log10(vertex->tracksSize()));
+      meVtxTrackMultPassNdofLin_->Fill(vertex->tracksSize());
 
       if (recopv.at(ir).recVtx->tError() > 0.) {
         meRecPVT_->Fill(recopv.at(ir).recVtx->t());


### PR DESCRIPTION
#### PR description:

This PR adds the vertex-slot GNN primary-vertex reconstruction for Phase-2 with MTD timing.
A graph network with slot attention assigns every selected track to one of K vertex slots and
predicts for every slot its z position, time and existence probability. The vertices are built
from the slot assignments and fitted by the standard `PrimaryVertexProducer`. Inference runs
through `PhysicsTools/PyTorchAlpaka`, on GPU or on the CPU serial backend. The method and its
performance on Phase-2 TTbar PU200 samples are documented in the detector performance note
CMS-DP-2026-042, "GNN based Primary Vertex Reconstruction with Slot Attention",
https://cds.cern.ch/record/2961848.

What is added:

- New package `DataFormats/VertexGNNReco`: the track-feature and GNN-output SoA layouts and
  their portable collections. The number of slots `kNumSlots` and the number of input features
  `kNumFeatures` are compile-time constants of the layout.
- `RecoVertex/PrimaryVertexProducer`:
  - `vertexgnn::TrackFeatureProducer` fills the feature SoA for the tracks selected by the
    standard `TrackFilterForPVFinding`, from the track and MTD ValueMaps.
  - `vertexgnn::GNNVertexProducerAlpaka` runs the TorchScript model. At construction it runs
    the model once on random input and throws a configuration exception if the model does not
    match `kNumFeatures` and `kNumSlots`.
  - `PrimaryVertexProducer` gets the `GNN2D_alpaka` clusterizer option
    (`GNNClusterizerFromAlpaka`) with per-track ValueMaps for the slot, the assignment
    probability and the PID weights, and a `useClusterWeights` parameter of the vertex
    collections that keeps the clusterizer track weights in the fit
    (`SequentialPrimaryVertexFitterAdapter`).
  - `GNNTrackInspector` and the test configurations (reconstruction, 3-way MTD validation and
    harvesting for the 3D, 4D and GNN vertex collections).
- Process modifier `vertexSlotGNN` (`Configuration/ProcessModifiers`). With the modifier the
  `phase2_timing_layer` vertex task additionally runs `trackFeatureProducer`,
  `gnnVertexProducer`, `unsortedOfflinePrimaryVerticesGNN`, `offlinePrimaryVerticesGNN` and
  `tofPIDGNN`, and the new products are kept in the AOD, RECO and FEVT event content. Without
  the modifier nothing changes.
- Relval workflow variant `.28` (offset 0.28) that runs the TTbar Run4 workflows with the
  modifier on the RecoGlobal step, e.g. 34434.28 and 34634.28.
- `Validation/MtdValidation`: linear-scale vertex track multiplicity histograms and rebinned
  variants of the matched leading-vertex multiplicity in `Primary4DVertexValidation`. These are
  booked unconditionally, so they appear in all Phase-2 workflows.

The TorchScript model `RecoVertex/PrimaryVertexProducer/data/vertexSlotGNN.pt` comes from
cms-data: repository `cms-data/RecoVertex-PrimaryVertexProducer`, requested in
cms-sw/cmssw#51863. The training is done outside CMSSW; the model interface is described in
`RecoVertex/PrimaryVertexProducer/README.md`.

Notes for the reviewers:

- `DataFormats/VertexGNNReco` is a new package and needs a category in cms-bot.
- The GNN output depends on the CPU generation or GPU used for the inference at the level of
  floating-point rounding, as for the other PyTorch-based modules; this affects only the GNN
  vertex collections.

#### PR validation:

- `scram b`, `scram b code-checks` and `scram b code-format` clean.
- Relval workflows 34434.0 and 34434.28 (D121 TTbar, no PU) run through all steps in
  CMSSW_20_1_0_pre3. The reco step with and without the modifier, run single-threaded on the
  same step2 input, gives identical standard products; the modifier only adds the new GNN
  branches.
- The reconstruction on a D121 TTbar PU200 RelVal sample reproduces the results of the code
  used for CMS-DP-2026-042 bit for bit when run on the same hardware; the standard 3D and 4D
  vertex collections and the tofPID products are unchanged.
- Timing and physics performance on D121 TTbar PU200 samples are shown in CMS-DP-2026-042.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport; no backport planned.