### PR TITLE
Define UniqueSimTrackId as a type alias instead of a class for dictionaries

### DIFF
--- a/SimDataFormats/TrackingAnalysis/src/classes_def.xml
+++ b/SimDataFormats/TrackingAnalysis/src/classes_def.xml
@@ -34,7 +34,7 @@
 
   <class name="std::vector<std::pair<edm::Ref<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle> >,double> >" />
   <class name="std::pair<edm::Ref<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<io_v1::TrackingParticle>,io_v1::TrackingParticle> >,double>" />
-  <class name="UniqueSimTrackId"/>
+  <typedef name="UniqueSimTrackId"/>
   <class name="std::pair<UniqueSimTrackId, edm::Ref<std::vector<io_v1::TrackingParticle>, io_v1::TrackingParticle, edm::refhelper::FindUsingAdvance<std::vector<io_v1::TrackingParticle>, io_v1::TrackingParticle> > >"/>
   <class name="std::unordered_map<UniqueSimTrackId, TrackingParticleRef, UniqueSimTrackIdHash>"/>
   <class name="edm::Wrapper<std::unordered_map<UniqueSimTrackId, TrackingParticleRef, UniqueSimTrackIdHash>>"/>


### PR DESCRIPTION
#### PR description:

This PR fixes the problem reported in https://github.com/cms-sw/cmssw/pull/51761#issuecomment-5623454249.

The `UniqueSimTrackId` is an alias for `std::pair<unsigned int, EncodedEventId>` whose dictionary is defined in
`SimDataFormats/EncodedEventId`. 

Resolves https://github.com/cms-sw/framework-team/issues/2432

#### PR validation:

The unit tests failing in the IBs with the duplicate dictionary error now succeed.