### PR TITLE
MuonID merge crossing track legs

### DIFF
--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -11,6 +11,8 @@
 // user include files
 #include "RecoMuon/MuonIdentification/plugins/MuonIdProducer.h"
 
+#include <algorithm>
+
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
@@ -30,6 +32,18 @@
 
 #include "RecoMuon/MuonIdentification/interface/MuonMesh.h"
 #include "RecoMuon/MuonIdentification/interface/MuonKinkFinder.h"
+
+namespace {
+  // add the chambers of another propagation, skipping the ones already matched
+  void appendMatches(std::vector<reco::MuonChamberMatch>& matches, const std::vector<reco::MuonChamberMatch>& extra) {
+    for (const auto& match : extra) {
+      const bool alreadyThere =
+          std::any_of(matches.begin(), matches.end(), [&match](const auto& kept) { return kept.id == match.id; });
+      if (!alreadyThere)
+        matches.push_back(match);
+    }
+  }
+}  // namespace
 
 MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
     : geomTokenRun_(esConsumes<edm::Transition::BeginRun>()),
@@ -65,6 +79,7 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
   fillGlobalTrackQuality_ = iConfig.getParameter<bool>("fillGlobalTrackQuality");
   fillGlobalTrackRefits_ = iConfig.getParameter<bool>("fillGlobalTrackRefits");
   arbitrateTrackerMuons_ = iConfig.getParameter<bool>("arbitrateTrackerMuons");
+  mergeCrossingTrackLegs_ = iConfig.getParameter<bool>("mergeCrossingTrackLegs");
   selectHighPurity_ = iConfig.getParameter<bool>("selectHighPurity");
   //SK: (maybe temporary) run it only if the global is also run
   fillTrackerKink_ = false;
@@ -578,12 +593,30 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
       bool splitTrack = false;
       if (track.extra().isAvailable() && TrackDetectorAssociator::crossedIP(track))
         splitTrack = true;
-      const auto& directions = splitTrack ? directions1 : directions2;
-      for (const auto direction : directions) {
-        // make muon
-        reco::Muon trackerMuon(makeMuon(iEvent, iSetup, trackRef, reco::Muon::InnerTrack));
-        fillMuonId(iEvent, iSetup, trackerMuon, direction);
+      const bool mergeLegs = splitTrack && mergeCrossingTrackLegs_;
 
+      std::vector<reco::Muon> candidates;
+      if (mergeLegs) {
+        // both legs share the track, so keep one muon holding the matches of both
+        reco::Muon trackerMuon(makeMuon(iEvent, iSetup, trackRef, reco::Muon::InnerTrack));
+        fillMuonId(iEvent, iSetup, trackerMuon, TrackDetectorAssociator::InsideOut);
+        reco::Muon otherLeg(makeMuon(iEvent, iSetup, trackRef, reco::Muon::InnerTrack));
+        fillMuonId(iEvent, iSetup, otherLeg, TrackDetectorAssociator::OutsideIn);
+        auto mergedMatches = trackerMuon.matches();
+        appendMatches(mergedMatches, otherLeg.matches());
+        trackerMuon.setMatches(mergedMatches);
+        candidates.push_back(std::move(trackerMuon));
+      } else {
+        const auto& directions = splitTrack ? directions1 : directions2;
+        for (const auto direction : directions) {
+          // make muon
+          reco::Muon trackerMuon(makeMuon(iEvent, iSetup, trackRef, reco::Muon::InnerTrack));
+          fillMuonId(iEvent, iSetup, trackerMuon, direction);
+          candidates.push_back(std::move(trackerMuon));
+        }
+      }
+
+      for (auto& trackerMuon : candidates) {
         if (debugWithTruthMatching_) {
           // add MC hits to a list of matched segments.
           // Since it's debugging mode - code is slow
@@ -608,26 +641,44 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
           trackerMuon.setType(trackerMuon.type() | reco::Muon::ME0Muon);
 
         for (auto& muon : *outputMuons) {
-          if (muon.innerTrack().get() == trackerMuon.innerTrack().get() &&
-              std::abs(reco::deltaPhi(phiOfMuonInteractionRegion(muon), phiOfMuonInteractionRegion(trackerMuon))) <
-                  M_PI_2) {
-            newMuon = false;
+          if (muon.innerTrack().get() != trackerMuon.innerTrack().get())
+            continue;
+          // sharing the tracker track already makes the two the same object; the phi test only
+          // says whether they were reconstructed from the same hemisphere
+          const bool sameRegion = std::abs(reco::deltaPhi(phiOfMuonInteractionRegion(muon),
+                                                          phiOfMuonInteractionRegion(trackerMuon))) < M_PI_2;
+          if (!sameRegion && !mergeCrossingTrackLegs_)
+            continue;
+          newMuon = false;
+          if (sameRegion) {
             muon.setMatches(trackerMuon.matches());
-            if (trackerMuon.isTimeValid())
-              muon.setTime(trackerMuon.time());
-            if (trackerMuon.isEnergyValid())
-              muon.setCalEnergy(trackerMuon.calEnergy());
-            if (goodTrackerMuon)
-              muon.setType(muon.type() | reco::Muon::TrackerMuon);
-            if (goodRPCMuon)
-              muon.setType(muon.type() | reco::Muon::RPCMuon);
-            if (goodGEMMuon)
-              muon.setType(muon.type() | reco::Muon::GEMMuon);
-            if (goodME0Muon)
-              muon.setType(muon.type() | reco::Muon::ME0Muon);
-            LogTrace("MuonIdentification") << "Found a corresponding global muon. Set energy, matches and move on";
-            break;
+          } else {
+            // fill the muon's own leg first, so the merge keeps the chambers of both
+            if (!muon.isMatchesValid() && muon.isStandAloneMuon())
+              fillMuonId(iEvent,
+                         iSetup,
+                         muon,
+                         std::abs(reco::deltaPhi(phiOfMuonInteractionRegion(muon), muon.phi())) < M_PI_2
+                             ? TrackDetectorAssociator::InsideOut
+                             : TrackDetectorAssociator::OutsideIn);
+            auto mergedMatches = muon.matches();
+            appendMatches(mergedMatches, trackerMuon.matches());
+            muon.setMatches(mergedMatches);
           }
+          if (trackerMuon.isTimeValid())
+            muon.setTime(trackerMuon.time());
+          if (trackerMuon.isEnergyValid())
+            muon.setCalEnergy(trackerMuon.calEnergy());
+          if (goodTrackerMuon)
+            muon.setType(muon.type() | reco::Muon::TrackerMuon);
+          if (goodRPCMuon)
+            muon.setType(muon.type() | reco::Muon::RPCMuon);
+          if (goodGEMMuon)
+            muon.setType(muon.type() | reco::Muon::GEMMuon);
+          if (goodME0Muon)
+            muon.setType(muon.type() | reco::Muon::ME0Muon);
+          LogTrace("MuonIdentification") << "Found a corresponding global muon. Set energy, matches and move on";
+          break;
         }
         if (newMuon) {
           if (goodTrackerMuon || goodRPCMuon || goodGEMMuon || goodME0Muon) {
@@ -1607,6 +1658,7 @@ void MuonIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.setAllowAnything();
 
   desc.add<bool>("arbitrateTrackerMuons", false);
+  desc.add<bool>("mergeCrossingTrackLegs", false);
   desc.add<bool>("storeCrossedHcalRecHits", false);
   desc.add<bool>("fillShowerDigis", false);
   desc.add<bool>("isPhase2", false);

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -14,6 +14,8 @@
 #include <algorithm>
 
 #include "DataFormats/Math/interface/deltaPhi.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
+#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
@@ -297,6 +299,7 @@ void MuonIdProducer::init(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     iEvent.getByToken(pvToken_, pvHandle_);
   if (gemHitHandle_.isValid())
     gemgeom = &iSetup.getData(gemgeomToken_);
+  globalGeom_ = &iSetup.getData(globalGeomToken_);
 }
 
 reco::Muon MuonIdProducer::makeMuon(edm::Event& iEvent,
@@ -656,6 +659,10 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
           if (sameRegion) {
             muon.setMatches(trackerMuon.matches());
           } else {
+            LogTrace("MuonIdentification")
+                << "merging legs at (eta,phi) " << etaOfMuonInteractionRegion(muon) << ","
+                << phiOfMuonInteractionRegion(muon) << " and " << etaOfMuonInteractionRegion(trackerMuon) << ","
+                << phiOfMuonInteractionRegion(trackerMuon);
             // fill the muon's own leg first, so the merge keeps the chambers of both
             if (!muon.isMatchesValid() && muon.isStandAloneMuon())
               fillMuonId(iEvent,
@@ -1620,6 +1627,25 @@ double MuonIdProducer::phiOfMuonInteractionRegion(const reco::Muon& muon) const 
       return muon.phi();  // makes little sense, but what else can I use
   }
   return sectorPhi(muon.matches().at(0).id);
+}
+
+double MuonIdProducer::etaOfMuonInteractionRegion(const reco::Muon& muon) const {
+  if (muon.isStandAloneMuon())
+    return muon.standAloneMuon()->innerPosition().eta();
+  // the rest is tracker muon only
+  if (muon.matches().empty()) {
+    if (muon.innerTrack().isAvailable() && muon.innerTrack()->extra().isAvailable())
+      return muon.innerTrack()->outerPosition().eta();
+    else
+      return muon.eta();
+  }
+  // where the track crossed the first matched chamber
+  const auto& match = muon.matches().at(0);
+  if (globalGeom_) {
+    if (const GeomDet* det = globalGeom_->idToDet(match.id))
+      return det->toGlobal(LocalPoint(match.x, match.y, 0)).eta();
+  }
+  return muon.eta();
 }
 
 void MuonIdProducer::fillGlbQuality(edm::Event& iEvent, const edm::EventSetup& iSetup, reco::Muon& aMuon) {

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -643,6 +643,9 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
         for (auto& muon : *outputMuons) {
           if (muon.innerTrack().get() != trackerMuon.innerTrack().get())
             continue;
+          // a candidate without matches has nothing to contribute and must not wipe the muon's
+          if (trackerMuon.matches().empty())
+            continue;
           // sharing the tracker track already makes the two the same object; the phi test only
           // says whether they were reconstructed from the same hemisphere
           const bool sameRegion = std::abs(reco::deltaPhi(phiOfMuonInteractionRegion(muon),

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -228,6 +228,12 @@ private:
 
   bool arbitrateTrackerMuons_;
 
+  // A tracker track that crosses the interaction point is propagated twice, once in each
+  // direction, so that both hemispheres of muon chambers are reachable. With this flag the
+  // two propagations produce a single muon carrying the chamber matches of both legs,
+  // instead of two muons sharing the track and hence having an identical four-vector.
+  bool mergeCrossingTrackLegs_;
+
   bool isPhase2_;
   bool debugWithTruthMatching_;
 

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -129,6 +129,7 @@ private:
   unsigned int chamberId(const DetId&);
 
   double phiOfMuonInteractionRegion(const reco::Muon& muon) const;
+  double etaOfMuonInteractionRegion(const reco::Muon& muon) const;
 
   bool checkLinks(const reco::MuonTrackLinks*) const;
   inline bool approxEqual(const double a, const double b, const double tol = 1E-3) const {
@@ -297,6 +298,7 @@ private:
   std::unique_ptr<MuonMesh> meshAlgo_;
   edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemgeomToken_;
   const GEMGeometry* gemgeom;
+  const GlobalTrackingGeometry* globalGeom_ = nullptr;
   double GEM_edgecut_;
 };
 #endif

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -93,6 +93,8 @@ muons1stStep = cms.EDProducer("MuonIdProducer",
 
     # tracker muon arbitration
     arbitrateTrackerMuons = cms.bool(True),
+    # one muon, not two, for a tracker track crossing the interaction point
+    mergeCrossingTrackLegs = cms.bool(True),
     # normalization parameter for ME0 tracker muon arbitration
     dxNorm = cms.double(0.45),
     dDphiDzNorm = cms.double(0.00003)


### PR DESCRIPTION
#### PR description:

In https://indico.cern.ch/event/1716929/#17-cosmic-background-for-run-3
on slide13 the analyzers reported a muon duplication for cosmics data.

`MuonIdProducer` can emit two `reco::Muon` with a **identical four-vector** for a single tracker track, because both take their momentum from the same `innerTrack`. The DisMuon analysis sees this in **20.7%** of two-muon cosmic MC events and **17.7%** of NoBPTX data events in `slimmedDisplacedMuons`.

There are two mechanisms:

1. A tracker track that crosses the interaction point is propagated in **both** directions (so that both hemispheres of muon chambers are reachable), and each propagation builds its own muon.
2. The "already in the list" test can fail between a global muon and its own tracker candidate on a **non-crossing** traversing track, because the test compares the $\phi$ of the muon interaction regions and the two legs land in opposite hemispheres.

This PR adds a `mergeCrossingTrackLegs` parameter. When it is on, the tracker-muon loop builds **one** merged candidate for an IP-crossing track, holding the chamber matches of both propagation directions de-duplicated by chamber `DetId`, and the "already in the list" test keys on **`innerTrack` identity alone** rather than on the $\phi$ test. Opposite-hemisphere merges fill the existing muon's own leg first, so no chamber match is lost.

**Defaults are deliberately asymmetric.** `muons1stStep_cfi.py` sets the parameter **`True`**, so offline reconstruction gets the fix. The `fillDescriptions` default stays **`False`**, and the `MuonIdProducer` instances in the HLT menus do not set the parameter, so **HLT is unchanged by construction**. 

Note that `muons1stStep_cfi.py` must carry the parameter explicitly: `desc.setAllowAnything()` means the `fillDescriptions` default is never injected into the hand-written cfi, so `clone()` would otherwise raise `TypeError: mergeCrossingTrackLegs does not already exist`.

#### PR validation:

**Offline, from the same `step2.root` in each A/B pair**

| sample | setup | result |
|---|---|---|
| cosmics relval 7.3 | flag off | identical to baseline |
| cosmics relval 7.3 | default on | `muons` 2 → **0** duplicate groups, `splitMuons` 1 → 0, `muons1Leg` 3 → 0 |
| DY→µµ relval 16850.0 (`-w upgrade`) | default on, incl. `earlyMuons` | **identical** to flag off |

A "duplicate group" is one tracker track that produced more than one `reco::Muon`, bucketed by the `innerTrack` `(product id, key)`.

`splitMuons` is included on purpose: it has the same *within-leg* duplicates, so "splitMuons already gives per-leg muons" does not rescue it. The two *genuine* legs of a split muon have distinct `innerTrack` refs and are never merged.

**`runTheMatrix.py -l limited`**: all **33/33** non-data workflows pass, including `7.3 CosmicsSPLoose2018`. 

**HLT.** The `fillDescriptions` default of `False` is load-bearing. Running the GRun menu twice over identical events at `nThreads=1`, once stock and once with `mergeCrossingTrackLegs=True` forced on all 12 instances, and comparing every path's accept bit plus every muon:

| sample | events | pairs sharing one `innerTrack` (off → on) | events differing | trigger decisions changed |
|---|---|---|---|---|
| NoBPTX Run2023B (data) | 5000 | 12 → **0** | 5 | **1** |
| RelValTTbarToDilepton_14TeV (Run3 MC) | 1500 | 0 → 0 | 0 | 0 |

So the fix removes every one-track duplicate at HLT and creates none: but in one NoBPTX event it also flips **nine jet paths** (`HLT_AK8PFJet40`, `AlCa_AK8PFJet40`, `MC_PFHT`, `MC_AK4PFJets`, `MC_AK8PFJets`, `MC_AK8PFHT`) and, importantly, the **dataset assignments** `Dataset_JetMET0`, `Dataset_JetMET1`, `Dataset_AlCaLowPtJet`. `hltMuons` feeds HLT particle flow, so a duplicated 98 GeV muon is double-counted into PF jets and HT; merging it removes the phantom energy and the event drops below threshold. The direction is arguably the correct physics, but it is a jet-trigger rate change and a stream-routing change, ~~so it is left to a follow-up under TSG review rather than being taken here.~~

EDIT: After the comments from Marco, I've changed the default here too.

The effect is confined to cosmic-like topologies: the merge requires an IP-crossing or opposite-hemisphere track. The $t\bar{t}$ sample carries more muons per event (1.13 vs 0.65) and shows no differences at all. The NoBPTX number is therefore an upper bound rather than a menu-wide rate, and it rests on a single event.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport.
