### PR TITLE
[PY314] Fix unit tests by avoiding lambda function which is not pickle-able

### DIFF
--- a/Validation/HGCalValidation/test/test_makeHGCalValidationPlots.sh
+++ b/Validation/HGCalValidation/test/test_makeHGCalValidationPlots.sh
@@ -7,3 +7,6 @@ function die { cat 29690*/*.log; echo $1: status $2; exit $2; }
 runTheMatrix.py -w upgrade -l 29690.0 --startFrom HARVESTING --maxSteps 4 --recycle das:/RelValTTbar_14TeV/CMSSW_15_1_0-150X_mcRun4_realistic_v1_STD_RecycledGS_Run4D110_noPU-v2/DQMIO --command="-s HARVESTING:@HGCalValidation" || die "Could not run HARVESTING" $?
 
 (makeHGCalValidationPlots.py --collection all --jobs 4 29690.0*/DQM*.root) || die "makeHGCalValidationPlots.py failed" $?
+
+#dump workflow log so that bot can cache the opened input datafile
+die "makeHGCalValidationPlots.py Passed" 0

--- a/Validation/RecoTrack/python/plotting/html.py
+++ b/Validation/RecoTrack/python/plotting/html.py
@@ -697,7 +697,8 @@ class TrackingPageSet(PageSet):
         ret.extend(algos)
         return ret
 
-
+def _dqmSubFolderTranslatedToSectionName(algoQuality):
+    return algoQuality[0]
 
 class IndexSection:
     def __init__(self, sample, title, fastVsFull, pileupComparison):
@@ -731,7 +732,7 @@ class IndexSection:
         self._miniaodPage = PageSet(*params)
         self._timingPage = PageSet(*params)
         self._pfPages = PageSet(*params)
-        self._hltPages = PageSet(*params, dqmSubFolderTranslatedToSectionName=lambda algoQuality: algoQuality[0])
+        self._hltPages = PageSet(*params, dqmSubFolderTranslatedToSectionName=_dqmSubFolderTranslatedToSectionName)
         self._pixelPages = TrackingPageSet(*params)
         self._otherPages = PageSet(*params)
 

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -1,4 +1,5 @@
 from builtins import range
+from functools import partial
 import os
 import copy
 import collections
@@ -129,6 +130,9 @@ def _makeDistSimPlots(postfix, quantity, common={}):
         Plot("num_assoc(simToReco)_"+p, ytitle="Reconstructed TPs", **args),
     ]
 
+def _oneMinus(x):
+   return 1 - x
+
 def _makeMVAPlots(num, hp=False):
     pfix = "_hp" if hp else ""
     pfix2 = "Hp" if hp else ""
@@ -167,7 +171,7 @@ def _makeMVAPlots(num, hp=False):
             # Same signal efficiency, background efficiency, and ROC definitions as in TMVA
             Plot(true_cuteff, xtitle=xtitlecut, ytitle="True track selection efficiency", ymax=_maxEff),
             Plot(fake_cuteff, xtitle=xtitlecut, ytitle="Fake track selection efficiency", ymax=_maxEff),
-            Plot(ROC("true_eff_vs_fake_rej_mva%d%s"%(num,pfix), true_cuteff, Transform("fake_rej_mva%d%s"%(num,pfix), fake_cuteff, lambda x: 1-x)), xtitle="True track selection efficiency", ytitle="Fake track rejection", xmax=_maxEff, ymax=_maxEff),
+            Plot(ROC("true_eff_vs_fake_rej_mva%d%s"%(num,pfix), true_cuteff, Transform("fake_rej_mva%d%s"%(num,pfix), fake_cuteff, _oneMinus)), xtitle="True track selection efficiency", ytitle="Fake track rejection", xmax=_maxEff, ymax=_maxEff),
         ], ncols=3, legendDy=_legendDy_1row),
         PlotGroup("mva%d%sPtEta"%(num,pfix2), [
             Plot("mva_assoc(recoToSim)_mva%d%s_pT"%(num,pfix), xtitle="Track p_{T} (GeV)", ytitle=xtitle+" for true tracks", xlog=True, **argsprofile),
@@ -695,10 +699,18 @@ def _constructSummary(mapping=None, highPurity=False, byOriginalAlgo=False, byAl
                     normalizeToNumberOfEvents=True,
     )
     _commonN.update(_common)
-    _commonAB = dict(mapping=mapping,
-                     renameBin=lambda bl: _summaryBinRename(bl, highPurity, byOriginalAlgo, byAlgoMask, ptCut, seeds),
-                     ignoreMissingBins=True,
-                     originalOrder=True,
+    _commonAB = dict(
+        mapping=mapping,
+        renameBin=partial(
+            _summaryBinRename,
+            highPurity=highPurity,
+            byOriginalAlgo=byOriginalAlgo,
+            byAlgoMask=byAlgoMask,
+            ptCut=ptCut,
+            seeds=seeds,
+      ),
+      ignoreMissingBins=True,
+      originalOrder=True,
     )
     if byOriginalAlgo or byAlgoMask:
         _commonAB["minExistingBins"] = 2

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -22,6 +22,10 @@ class LimitTrackAlgo:
 def limitRelVal(algo, quality):
     return quality in ["", "highPurity", "ByOriginalAlgo", "highPurityByOriginalAlgo"]
 
+
+def ignore(_a, _b):
+    return False
+
 def main(opts):
     sample = SimpleSample(opts.subdirprefix, opts.html_sample, [(f, f.replace(".root", "")) for f in opts.files])
 
@@ -54,7 +58,6 @@ def main(opts):
         }
     }
     if opts.limit_relval:
-        ignore = lambda a,q: False
         kwargs_tracking["limitSubFoldersOnlyTo"] = {
             "": limitRelVal,
             "allTPEffic": ignore,


### PR DESCRIPTION
This fixes the failing 2 unit tests in Python 3.14 IBs
https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el9_amd64_gcc14/www/wed/20.1.PY314-wed-11/CMSSW_20_1_PY314_X_2026-09-09-1100?utests
```
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02958/el9_amd64_gcc14/cms/cmssw/CMSSW_20_1_PY314_X_2026-09-09-1100/bin/el9_amd64_gcc14/makeHGCalValidationPlots.py", line 328, in <module>
    main(opts)
    ~~~~^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02958/el9_amd64_gcc14/cms/cmssw/CMSSW_20_1_PY314_X_2026-09-09-1100/bin/el9_amd64_gcc14/makeHGCalValidationPlots.py", line 266, in main
    task()
    ~~~~^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02958/el9_amd64_gcc14/cms/cmssw/CMSSW_20_1_PY314_X_2026-09-09-1100/bin/el9_amd64_gcc14/makeHGCalValidationPlots.py", line 236, in plot_hitCal
    val.doPlots(hgchitcalib, plotterDrawArgs=drawArgs)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02958/el9_amd64_gcc14/cms/cmssw/CMSSW_20_1_PY314_X_2026-09-09-1100/src/Validation/RecoTrack/python/plotting/validation.py", line 1268, in doPlots
    self._doPlotsForPlotter(plotter, sample, **kwargs) # which in turn launches _doPlots()
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02958/el9_amd64_gcc14/cms/cmssw/CMSSW_20_1_PY314_X_2026-09-09-1100/src/Validation/RecoTrack/python/plotting/validation.py", line 1312, in _doPlotsForPlotter
    p.start()
    ~~~~~~~^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02958/el9_amd64_gcc14/external/python3/3.14.6-6981a5f57097289f5ca7aac624c1350d/lib/python3.14/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
                  ~~~~~~~~~~~^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02958/el9_amd64_gcc14/external/python3/3.14.6-6981a5f57097289f5ca7aac624c1350d/lib/python3.14/multiprocessing/context.py", line 230, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02958/el9_amd64_gcc14/external/python3/3.14.6-6981a5f57097289f5ca7aac624c1350d/lib/python3.14/multiprocessing/context.py", line 306, in _Popen
    return Popen(process_obj)
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02958/el9_amd64_gcc14/external/python3/3.14.6-6981a5f57097289f5ca7aac624c1350d/lib/python3.14/multiprocessing/popen_forkserver.py", line 35, in __init__
    super().__init__(process_obj)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02958/el9_amd64_gcc14/external/python3/3.14.6-6981a5f57097289f5ca7aac624c1350d/lib/python3.14/multiprocessing/popen_fork.py", line 20, in __init__
    self._launch(process_obj)
    ~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02958/el9_amd64_gcc14/external/python3/3.14.6-6981a5f57097289f5ca7aac624c1350d/lib/python3.14/multiprocessing/popen_forkserver.py", line 47, in _launch
    reduction.dump(process_obj, buf)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02958/el9_amd64_gcc14/external/python3/3.14.6-6981a5f57097289f5ca7aac624c1350d/lib/python3.14/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
_pickle.PicklingError: Can't pickle local object <function IndexSection.__init__.<locals>.<lambda> at 0x1464cf8d1220>
```